### PR TITLE
Escape dot in RegExp

### DIFF
--- a/webpack-demo.config.js
+++ b/webpack-demo.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, loader: "babel", exclude: [/rx.lite.js$/] },
+      { test: /\.js$/, loader: "babel", exclude: [/rx\.lite\.js$/] },
       { test: /\.css$/, loader: "style-loader!css-loader" },
       {
         test: /\.(otf|eot|svg|ttf|woff)/,


### PR DESCRIPTION
Without antislash, the period allow any character