### PR TITLE
JSON specific loader

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -63,6 +63,7 @@ var DemoZapper = React.createClass({
     });
 
     this.player = player;
+    this.player.log.setLevel("DEBUG");
     this.player.addEventListener("error", function(error) {
       alert(error.message);
     });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rx-player",
   "author": "Canal+",
-  "version": "1.3.1",
+  "version": "1.4.0-rxnext17",
   "description": "Canal+ HTML5 Video Player",
   "keywords": [
     "video",
@@ -21,7 +21,7 @@
     "url": "git://github.com/canalplus/rx-player.git"
   },
   "dependencies": {
-    "canal-js-utils": "^2.0.0"
+    "canal-js-utils": "3.0.0-rxnext12"
   },
   "devDependencies": {
     "babel-core": "^5.2.15",

--- a/src/adaptive/index.js
+++ b/src/adaptive/index.js
@@ -16,7 +16,7 @@
 
 var _ = require("canal-js-utils/misc");
 var log = require("canal-js-utils/log");
-var { Observable, BehaviorSubject, CompositeDisposable } = require("canal-js-utils/rx");
+var { Observable, BehaviorSubject, Subscription } = require("canal-js-utils/rx");
 var { combineLatest } = Observable;
 var { only } = require("canal-js-utils/rx-ext");
 
@@ -80,7 +80,8 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
     video: AverageBitrate(filterByType(metrics, "video"), { alpha: 0.6 }).publishValue(initVideoBitrate || 0),
   };
 
-  var conns = new CompositeDisposable(_.map(_.values($averageBitrates), a => a.connect()));
+  var conns = new Subscription();
+  _.each(_.values($averageBitrates), a => conns.add(a.connect()));
 
   var $usrBitrates = {
     audio: new BehaviorSubject(Infinity),
@@ -99,12 +100,12 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
   };
 
   function audioAdaptationChoice(adaptations) {
-    return $languages.changes()
+    return $languages.distinctUntilChanged()
       .map(lang => findByLang(adaptations, lang) || adaptations[0]);
   }
 
   function textAdaptationChoice(adaptations) {
-    return $subtitles.changes()
+    return $subtitles.distinctUntilChanged()
       .map(lang => findByLang(adaptations, lang));
   }
 
@@ -143,7 +144,7 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
 
           return getClosestBitrate(bitrates, avrBitrate, bufThreshold);
         })
-        .changes()
+        .distinctUntilChanged()
         .customDebounce(2000, { leading: true });
 
       if (type == "video") {
@@ -179,7 +180,7 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
           return avr;
         })
         .map(b => _.find(representations, rep => rep.bitrate === getClosestBitrate(bitrates, b)))
-        .changes(r => r.id)
+        .distinctUntilChanged((a, b) => a.id === b.id)
         .tap(r => log.info("bitrate", type, r.bitrate));
     }
     else {
@@ -193,8 +194,8 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
   }
 
   return {
-    setLanguage(lng) { $languages.onNext(lng); },
-    setSubtitle(sub) { $subtitles.onNext(sub); },
+    setLanguage(lng) { $languages.next(lng); },
+    setSubtitle(sub) { $subtitles.next(sub); },
     getLanguage() { return $languages.value; },
     getSubtitle() { return $subtitles.value; },
 
@@ -205,12 +206,12 @@ module.exports = function(metrics, timings, deviceEvents, options={}) {
     getAudioBufferSize() { return $bufSizes.audio.value; },
     getVideoBufferSize() { return $bufSizes.video.value; },
 
-    setAudioBitrate(x)    { $usrBitrates.audio.onNext(def(x, Infinity)); },
-    setVideoBitrate(x)    { $usrBitrates.video.onNext(def(x, Infinity)); },
-    setAudioMaxBitrate(x) { $maxBitrates.audio.onNext(def(x, Infinity)); },
-    setVideoMaxBitrate(x) { $maxBitrates.video.onNext(def(x, Infinity)); },
-    setAudioBufferSize(x) { $bufSizes.audio.onNext(def(x, defaultBufferSize)); },
-    setVideoBufferSize(x) { $bufSizes.video.onNext(def(x, defaultBufferSize)); },
+    setAudioBitrate(x)    { $usrBitrates.audio.next(def(x, Infinity)); },
+    setVideoBitrate(x)    { $usrBitrates.video.next(def(x, Infinity)); },
+    setAudioMaxBitrate(x) { $maxBitrates.audio.next(def(x, Infinity)); },
+    setVideoMaxBitrate(x) { $maxBitrates.video.next(def(x, Infinity)); },
+    setAudioBufferSize(x) { $bufSizes.audio.next(def(x, defaultBufferSize)); },
+    setVideoBufferSize(x) { $bufSizes.video.next(def(x, defaultBufferSize)); },
 
     getBufferAdapters,
     getAdaptationsChoice,

--- a/src/core/buffer.js
+++ b/src/core/buffer.js
@@ -190,7 +190,7 @@ function Buffer({
           // into the main buffer observable so that it can be treated
           // upstream
           if (err instanceof OutOfIndexError) {
-            outOfIndexStream.onNext({ type: "out-of-index", value: err });
+            outOfIndexStream.next({ type: "out-of-index", value: err });
             return empty();
           }
           else {

--- a/src/core/compat.js
+++ b/src/core/compat.js
@@ -241,7 +241,7 @@ if (!requestMediaKeySystemAccess && HTMLVideoElement_.prototype.webkitGenerateKe
     }),
     close: wrap(function() {
       if (this._con)
-        this._con.dispose();
+        this._con.unsubscribe();
       this._con = null;
       this._vid = null;
     }),
@@ -343,7 +343,7 @@ else if (MediaKeys_ && !requestMediaKeySystemAccess) {
       if (this._ss) {
         this._ss.close();
         this._ss = null;
-        this._con.dispose();
+        this._con.unsubscribe();
         this._con = null;
       }
     }),
@@ -406,18 +406,25 @@ if (!MediaKeys_) {
 }
 
 function _setMediaKeys(elt, mk) {
-  if (mk instanceof MockMediaKeys) return mk._setVideo(elt);
-  if (elt.setMediaKeys)
+  if (mk instanceof MockMediaKeys) {
+    return mk._setVideo(elt);
+  }
+
+  if (elt.setMediaKeys) {
     return elt.setMediaKeys(mk);
+  }
 
-  if (mk === null)
+  if (mk === null) {
     return;
+  }
 
-  if (elt.WebkitSetMediaKeys)
+  if (elt.WebkitSetMediaKeys) {
     return elt.WebkitSetMediaKeys(mk);
+  }
 
-  if (elt.mozSetMediaKeys)
+  if (elt.mozSetMediaKeys) {
     return elt.mozSetMediaKeys(mk);
+  }
 
   // IE11 requires that the video has received metadata
   // (readyState>=1) before setting metadata.

--- a/src/core/device-events.js
+++ b/src/core/device-events.js
@@ -39,7 +39,7 @@ function DeviceEvents(videoElement) {
   )
     .startWith("init")
     .map(() => videoElement.clientWidth * pixelRatio)
-    .changes();
+    .distinctUntilChanged();
 
   return {
     videoWidth,

--- a/src/core/eme.js
+++ b/src/core/eme.js
@@ -379,8 +379,8 @@ function findCompatibleKeySystem(keySystems) {
               };
             }
 
-            obs.onNext({ keySystem, keySystemAccess });
-            obs.onCompleted();
+            obs.next({ keySystem, keySystemAccess });
+            obs.complete();
           },
           () => {
             log.debug("eme: rejected access to keysystem", keyType, keySystemConfigurations);
@@ -776,8 +776,7 @@ function EME(video, keySystems) {
 
   return combineLatest(
     onEncrypted(video),
-    findCompatibleKeySystem(keySystems),
-    (evt, ks) => ([evt, ks])
+    findCompatibleKeySystem(keySystems)
   )
     .take(1)
     .flatMap(([evt, ks]) => handleEncryptedEvents(evt, ks));

--- a/src/core/pipelines.js
+++ b/src/core/pipelines.js
@@ -17,7 +17,9 @@
 var _ = require("canal-js-utils/misc");
 var { Subject, Observable } = require("canal-js-utils/rx");
 var { retryWithBackoff } = require("canal-js-utils/rx-ext");
-var { fromPromise, just } = Observable;
+var { just } = Observable;
+
+var timeoutError = new Error("timeout");
 
 var noCache = {
   add() {},
@@ -59,7 +61,7 @@ function createPipeline(type, { resolver, loader, parser }, metrics, opts={}) {
 
   function callLoader(resolvedInfos) {
     return loader(resolvedInfos)
-      .simpleTimeout(timeout, "timeout")
+      .timeout(timeout, timeoutError)
       .map((response) => {
         var loadedInfos = _.extend({ response }, resolvedInfos);
 
@@ -67,7 +69,7 @@ function createPipeline(type, { resolver, loader, parser }, metrics, opts={}) {
         cache.add(resolvedInfos, loadedInfos);
 
         // emit loadedInfos in the metrics observer
-        metrics.onNext({ type, value: loadedInfos });
+        metrics.next({ type, value: loadedInfos });
 
         return loadedInfos;
       });
@@ -80,7 +82,7 @@ function createPipeline(type, { resolver, loader, parser }, metrics, opts={}) {
 
         var fromCache = cache.get(resolvedInfos);
         if (_.isPromise(fromCache))
-          return fromPromise(fromCache).catch(backedOffLoader);
+          return Observable.from(fromCache).catch(backedOffLoader);
 
         if (fromCache === null)
           return backedOffLoader();

--- a/src/core/player.js
+++ b/src/core/player.js
@@ -18,7 +18,7 @@ var Promise_ = require("canal-js-utils/promise");
 
 var _ = require("canal-js-utils/misc");
 var log = require("canal-js-utils/log");
-var { CompositeDisposable, BehaviorSubject, Observable, Subject } = require("canal-js-utils/rx");
+var { Subscription, BehaviorSubject, Observable, Subject } = require("canal-js-utils/rx");
 var { combineLatest, defer, zip } = Observable;
 var { on } = require("canal-js-utils/rx-ext");
 var EventEmitter = require("canal-js-utils/eventemitter");
@@ -153,7 +153,7 @@ class Player extends EventEmitter {
 
   _clear() {
     if (this.subscriptions) {
-      this.subscriptions.dispose();
+      this.subscriptions.unsubscribe();
       this.subscriptions = null;
     }
   }
@@ -168,10 +168,10 @@ class Player extends EventEmitter {
 
   dispose() {
     this.stop();
-    this.metrics.dispose();
-    this.adaptive.dispose();
-    this.fullscreen.dispose();
-    this.stream.dispose();
+    this.metrics.unsubscribe();
+    this.adaptive.unsubscribe();
+    this.fullscreen.unsubscribe();
+    this.stream.unsubscribe();
 
     this.metrics = null;
     this.adaptive = null;
@@ -254,7 +254,7 @@ class Player extends EventEmitter {
 
     this.stop();
     this.frag = timeFragment;
-    this.playing.onNext(autoPlay);
+    this.playing.next(autoPlay);
 
     var pipelines = this.createPipelines(transport, {
       audio: { cache: new InitializationSegmentCache() },
@@ -317,13 +317,13 @@ class Player extends EventEmitter {
           return PLAYER_PAUSED;
         })
       )
-      .changes()
+      .distinctUntilChanged()
       .startWith(PLAYER_LOADING);
 
-    var subscriptions = this.subscriptions = new CompositeDisposable();
+    var subscriptions = this.subscriptions = new Subscription();
     var subs = [
       on(video, ["play", "pause"])
-        .each(evt => this.playing.onNext(evt.type == "play")),
+        .each(evt => this.playing.next(evt.type == "play")),
 
       segments.each((segment) => {
         var type = segment.adaptation.type;
@@ -373,8 +373,8 @@ class Player extends EventEmitter {
       ),
 
       stream.subscribe(
-        n => this.stream.onNext(n),
-        e => this.stream.onNext({ type: "error", value: e })
+        n => this.stream.next(n),
+        e => this.stream.next({ type: "error", value: e })
       ),
 
       stream.connect()
@@ -384,7 +384,7 @@ class Player extends EventEmitter {
 
     // _clear may have been called synchronously on early disposable
     if (!this.subscriptions) {
-      subscriptions.dispose();
+      subscriptions.unsubscribe();
     }
 
     this._triggerTimeChange();
@@ -395,6 +395,7 @@ class Player extends EventEmitter {
   _setState(s) {
     if (this.state !== s) {
       this.state = s;
+      log.info("playerStateChange", s);
       this.trigger("playerStateChange", s);
     }
   }

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -46,7 +46,7 @@ var DISCONTINUITY_THRESHOLD = 1;
 function plugDirectFile(url, video) {
   return Observable.create((observer) => {
     video.src = url;
-    observer.onNext({ url });
+    observer.next({ url });
     return () => {
       video.src = "";
     };
@@ -165,7 +165,7 @@ function Stream({
       var mediaSource = new MediaSource_();
       var objectURL = video.src = URL.createObjectURL(mediaSource);
 
-      observer.onNext({ url, mediaSource });
+      observer.next({ url, mediaSource });
       log.info("create mediasource object", objectURL);
 
       return () => {
@@ -381,7 +381,7 @@ function Stream({
    */
   function createStalled(timings, changePlaybackRate=true) {
     return timings
-      .distinctUntilChanged(null, (prevTiming, timing) => {
+      .distinctUntilChanged((prevTiming, timing) => {
         var isStalled = timing.stalled;
         var wasStalled = prevTiming.stalled;
 
@@ -458,7 +458,7 @@ function Stream({
     var adaptationsBuffers = _.map(getAdaptations(manifest),
       adaptation => createBuffer(mediaSource, adaptation, timings, seekings));
 
-    var buffers = merge(adaptationsBuffers);
+    var buffers = merge.apply(null, adaptationsBuffers);
 
     if (!manifest.isLive)
       return buffers;
@@ -469,7 +469,7 @@ function Stream({
     return buffers
       // do not throw multiple times OutOfIndexErrors in order to have
       // only one manifest reload for each error.
-      .distinctUntilChanged(null, (a, b) =>
+      .distinctUntilChanged((a, b) =>
         isOutOfIndexError(b) &&
         isOutOfIndexError(a))
       .concatMap((message) => manifestAdapter(manifest, message));

--- a/src/core/timings.js
+++ b/src/core/timings.js
@@ -142,7 +142,7 @@ function timingsSampler(video) {
     function emitSample(evt) {
       var timingEventType = evt && evt.type || "timeupdate";
       prevTimings = scanTimingsSamples(prevTimings, timingEventType);
-      obs.onNext(prevTimings);
+      obs.next(prevTimings);
     }
 
     var samplerInterval = setInterval(emitSample, TIMINGS_SAMPLING_INTERVAL);
@@ -153,7 +153,7 @@ function timingsSampler(video) {
     video.addEventListener("seeked", emitSample);
     video.addEventListener("loadedmetadata", emitSample);
 
-    obs.onNext(prevTimings);
+    obs.next(prevTimings);
 
     return () => {
       clearInterval(samplerInterval);

--- a/src/net/smooth/index.js
+++ b/src/net/smooth/index.js
@@ -46,6 +46,7 @@ var TT_PARSERS = {
 
 var ISM_REG = /\.(isml?)(\?token=\S+)?$/;
 var WSX_REG = /\.wsx?(\?token=\S+)?/;
+var JSON_REG = /\.json?(\?token=\S+)?/;
 var TOKEN_REG = /\?token=(\S+)/;
 
 function byteRange([start, end]) {
@@ -58,6 +59,10 @@ function byteRange([start, end]) {
 
 function extractISML(doc) {
   return doc.getElementsByTagName("media")[0].getAttribute("src");
+}
+
+function extractJSON(json) {
+  return json.primary.src || json.backup.src || json.failover.src;
 }
 
 function extractToken(url) {
@@ -106,8 +111,12 @@ module.exports = function(options={}) {
           url: replaceToken(url, ""),
           format: "document"
         }).map(({ blob }) => extractISML(blob));
-      }
-      else {
+      } else if (JSON_REG.test(url)) {
+        resolving = req({
+          url: replaceToken(url, ""),
+          format: "json"
+        }).map(({ blob }) => extractJSON(blob));
+      } else {
         resolving = just(url);
       }
 

--- a/webpack-demo.config.js
+++ b/webpack-demo.config.js
@@ -13,7 +13,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, loader: "babel?loose=all", exclude: [/rx\.lite\.js$/] },
+      { test: /\.js$/, loader: "babel?loose=all" },
       { test: /\.css$/, loader: "style-loader!css-loader" },
       {
         test: /\.(otf|eot|svg|ttf|woff)/,
@@ -34,6 +34,6 @@ module.exports = {
     }),
   ],
   resolveLoader: {
-    fallback: path.join(__dirname, "node_modules")
+    root: path.join(__dirname, "node_modules")
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, exclude: [/rx\.lite\.js$/,/es6-promise\.js/], loader: "babel?loose=all" },
+      { test: /\.js$/, loader: "babel?loose=all" },
     ]
   },
   resolve: {
@@ -34,6 +34,6 @@ module.exports = {
     }),
   ],
   resolveLoader: {
-    fallback: path.join(__dirname, "node_modules")
+    root: path.join(__dirname, "node_modules")
   }
 };


### PR DESCRIPTION
Some editors, such as `CANAL+` may use `.json`loader, similar to `.wsx` already handled by `rx-player`.
I added this loader to handle json loaders. By the way, maybe we should consider a better API to allow any type of loader. 

This PR needs #16 `RxNext` features