### PR TITLE
add missing dev dependency - webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "script-loader": "^0.6.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.5",
-    "webpack": "^1.12.12"
+    "webpack": "^1.12.12",
+    "webpack-dev-server": "^1.14.1"
   }
 }


### PR DESCRIPTION
Without webpack-dev-server `make test` fails