### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/src/core/eme.js
+++ b/src/core/eme.js
@@ -398,7 +398,7 @@ function findCompatibleKeySystem(keySystems) {
 
     testKeySystem(0);
 
-    () => {
+    return () => {
       disposed = true;
       if (sub) {
         sub.unsubscribe();


### PR DESCRIPTION
When no compatible keySystem was found there was Uncaught TypeError in  line 371: obs.error