### PR TITLE
fix(playerState): fix playerStateChange events when directFile=true

### DIFF
--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -534,9 +534,7 @@ function Stream({
     const { timings, seekings } = createTimings(manifest);
     const justManifest = Observable.of({ type: "manifest", value: manifest });
     const emeHandler = createEMEIfKeySystems();
-    const stalled = createStalled(timings, {
-      changePlayback: pipelines.requiresMediaSource(),
-    });
+    const stalled = createStalled(timings, true);
     const canPlay = createLoadedMetadata(manifest).concat(stalled);
     const buffers = createAdaptationsBuffers(mediaSource,
                                              manifest,

--- a/src/core/stream.js
+++ b/src/core/stream.js
@@ -534,7 +534,7 @@ function Stream({
     const { timings, seekings } = createTimings(manifest);
     const justManifest = Observable.of({ type: "manifest", value: manifest });
     const emeHandler = createEMEIfKeySystems();
-    const stalled = createStalled(timings, true);
+    const stalled = createStalled(timings, { changePlayback: true });
     const canPlay = createLoadedMetadata(manifest).concat(stalled);
     const buffers = createAdaptationsBuffers(mediaSource,
                                              manifest,


### PR DESCRIPTION
When using a direct file, the video could sometime pause / play when it had no more / new data to play, without changing the player state as those pause/play events were not controlled by our algorithm.

This PR adds the detection of those "unexpected" events + makes the timings be managed the same way, wether your using a directFile or not.

I also added the detection of the element canPlay, which sets the stalled attribute as null, as the observable stalled in stream.js is initiated with a null value.