### PR TITLE
fix(state): fix paused event emitted right before the ended event

### DIFF
--- a/src/core/player.js
+++ b/src/core/player.js
@@ -440,7 +440,9 @@ class Player extends EventEmitter {
   }
 
   _playPauseNext(evt) {
-    this.playing.next(evt.type == "play");
+    if (this.video.ended !== true) {
+      this.playing.next(evt.type == "play");
+    }
   }
 
   _setPlayerState(s) {


### PR DESCRIPTION
A paused event was emitted before the ended event