### PR TITLE
MediaKeySession usage fix

### DIFF
--- a/src/core/compat.js
+++ b/src/core/compat.js
@@ -367,7 +367,7 @@ else if (MediaKeys_ && !requestMediaKeySystemAccess) {
 
     update: wrapUpdate(function(license, sessionId) {
       assert(this._ss);
-      this._ss.update(license, sessionId);
+      this._ss.update(ArrayBuffer.isView(license) ? license : new Uint8Array(license));
       this.sessionId = sessionId;
     }, function() {
       return this._ss;


### PR DESCRIPTION
According to https://www.w3.org/TR/encrypted-media/#idl-def-MediaKeySession update method takes only one argument.
Additional fix for IE11 where license needs to be changed to Uint8Array.
