### PR TITLE
Feat/get average bitrates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+  - abr: add ``bitrateEstimationChange`` event
   - api: a Date object can now be given to the ``loadVideo`` argument ``startAt.wallClockTime``. It will be automatically converted into seconds.
   - languages: add ``normalizedLanguage`` property in manifest-related-APIs to expose the ISO 639-3 language code of the audio and text tracks
   - languages: add ``normalized`` property in language-related-API to expose the ISO 639-3 language code of the audio and text tracks

--- a/doc/api/player_events.md
+++ b/doc/api/player_events.md
@@ -12,6 +12,7 @@
     - [videoBitrateChange](#events-videoBitrateChange)
     - [imageTrackUpdate](#events-imageTrackUpdate)
     - [fullscreenChange](#events-fullscreenChange)
+    - [bitrateEstimationChange](#events-bitrateEstimationChange)
     - [warning](#events-warning)
     - [error](#events-error)
     - [nativeTextTrackChange](#events-nativeTextTrackChange)
@@ -108,6 +109,18 @@ _payload type_: ``Boolean``
 Triggered each time the video player goes/exits fullscreen mode.
 
 The payload is ``true`` if the player entered fullscreen, ``false`` if it exited it.
+
+### <a name="events-bitrateEstimationChange"></a>bitrateEstimationChange
+
+_payload type_: ``Object``
+
+Information about the last bitrate estimation performed, by type of buffer (``audio``, ``video`` etc.).
+
+Note that this event is sent only if the corresponding buffer type has multiple representation for the given content (as bitrate estimations are only useful in that case).
+
+The payload is an object with the following properties:
+  - ``type`` (``string``): The buffer type
+  - ``bitrate`` (``Number``): The last estimated bandwidth for this buffer type, in bits per seconds. This bitrate is smoothed by doing a (complex) mean on an extended period of time, so it often does not link directly to the current calculated bitrate.
 
 ### <a name="events-warning"></a>warning
 

--- a/src/core/api/private.js
+++ b/src/core/api/private.js
@@ -95,6 +95,9 @@ export default (self) => ({
     case "adaptationChange":
       self._priv.onAdaptationChange(value);
       break;
+    case "bitrateEstimationChange":
+      self._priv.onBitrateEstimationChange(value);
+      break;
     case "manifestChange":
       self._priv.onManifestChange(value);
       break;
@@ -244,6 +247,14 @@ export default (self) => ({
     } else if (type == "audio") {
       self._priv.recordState("audioBitrate", bitrate != null ? bitrate : -1);
     }
+  },
+
+  onBitrateEstimationChange({ type, bitrate }) {
+    if (__DEV__) {
+      assert(type != null);
+      assert(bitrate != null);
+    }
+    self._priv.recordState("bitrateEstimation", { type, bitrate });
   },
 
   /**


### PR DESCRIPTION
Add ``bitrateEstimationChange`` event:


Information about the last bitrate estimation performed, by type of buffer (``audio``, ``video`` etc.).

Note that this event is sent only if the corresponding buffer type has multiple representation for the given content (as bitrate estimations are only useful in that case).

The payload is an object with the following properties:
  - ``type`` (``string``): The buffer type
  - ``bitrate`` (``Number``): The last estimated bandwidth for this buffer type, in bits per seconds. This bitrate is smoothed by doing a (complex) mean on an extended period of time, so it often does not link directly to the current calculated bitrate.