### PR TITLE
text/ttml: apply correctly a style if directly set on an attribute

### DIFF
--- a/src/parsers/texttracks/ttml/style.ts
+++ b/src/parsers/texttracks/ttml/style.ts
@@ -65,7 +65,7 @@ export function getStylingAttributes(
         } else {
           const nameWithoutTTS = name.substr(4);
           if (arrayIncludes(leftAttributes, nameWithoutTTS)) {
-            currentStyle[attribute.name] = attribute.value;
+            currentStyle[nameWithoutTTS] = attribute.value;
             leftAttributes.splice(j, 1);
             if (!leftAttributes.length) {
               return currentStyle;


### PR DESCRIPTION
Easy fix for when a style was set directly on a an attribute of a corresponding element (not on a style).

The issue was that the ``currentStyle`` object, which is a dictionary of every styling values to apply to our elements, contained the string ``tts:nameOfTheStyle`` - which is the attribute name in the ttml spec - instead of just ``nameOfTheStyle`` - which is what we go with in the code.

The attribute name without the ``tts:`` part was already computed, but the original name was put in the ``currentStyle`` object instead of it by mistake.