### PR TITLE
fix: get loaded size from xhr instead of totalsize

### DIFF
--- a/src/utils/request/index.ts
+++ b/src/utils/request/index.ts
@@ -257,7 +257,7 @@ function request<T>(
       if (xhr.readyState === 4) {
         if (xhr.status >= 200 && xhr.status < 300) {
           const receivedTime = Date.now();
-          const totalSize = event.total;
+          const totalSize = event.loaded;
           const status = xhr.status;
           const loadedResponseType = xhr.responseType;
           const _url = xhr.responseURL || url;


### PR DESCRIPTION
In case of having to download into a fmp4 file, you didn't get the loaded size, but the whole file size.
So ABR was wrong, was estimating too large bitrates and wasn't picking the correct representation. 