### PR TITLE
feat: trigger endOfStream + removed END_OF_PLAY

### DIFF
--- a/demo/full/scripts/controllers/ControlBar.jsx
+++ b/demo/full/scripts/controllers/ControlBar.jsx
@@ -16,8 +16,9 @@ const ControlBar = ({
   hasEnded,
   isLive,
   player,
+  stopAtEnd,
 }) => {
-  const displayControls = hasLoadedContent && !hasEnded;
+  const displayControls = !stopAtEnd || (hasLoadedContent && !hasEnded);
 
   let positionElement;
   if (!displayControls) {
@@ -70,5 +71,6 @@ export default withModulesState({
     hasLoadedContent: "hasLoadedContent",
     hasEnded: "hasEnded",
     isLive: "isLive",
+    stopAtEnd: "stopAtEnd",
   },
 })(ControlBar);

--- a/demo/full/scripts/controllers/PlayPauseButton.jsx
+++ b/demo/full/scripts/controllers/PlayPauseButton.jsx
@@ -20,8 +20,9 @@ const PlayPauseButton = ({
   isPaused,
   hasLoadedContent,
   hasEnded,
+  stopAtEnd,
 }) => {
-  const disabled = !hasLoadedContent || hasEnded;
+  const disabled = (!hasLoadedContent || hasEnded) && stopAtEnd;
   const displayPause = !isPaused && hasLoadedContent &&
     !hasEnded;
 
@@ -47,5 +48,6 @@ export default withModulesState({
     isPaused: "isPaused",
     hasLoadedContent: "hasLoadedContent",
     hasEnded: "hasEnded",
+    stopAtEnd: "stopAtEnd",
   },
 })(PlayPauseButton);

--- a/demo/full/scripts/modules/player/events.js
+++ b/demo/full/scripts/modules/player/events.js
@@ -84,7 +84,7 @@ const linkPlayerEventsToState = (player, state, $destroy) => {
           player.getAvailableAudioTracks();
         stateUpdates.availableSubtitles =
           player.getAvailableTextTracks();
-      } else if (arg === "STOPPED" || arg === "ENDED") {
+      } else if (arg === "STOPPED") {
         stateUpdates.audioBitrate = undefined;
         stateUpdates.videoBitrate = undefined;
         stateUpdates.availableAudioBitrates = [];

--- a/demo/full/scripts/modules/player/index.js
+++ b/demo/full/scripts/modules/player/index.js
@@ -9,12 +9,14 @@
 import { linkPlayerEventsToState } from "./events.js";
 
 const RxPlayer = window.RxPlayer;
+const stopAtEnd = false;
 
 const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
   const player = new RxPlayer({
     limitVideoWidth: false,
     throttleWhenHidden: true,
     videoElement,
+    stopAtEnd,
   });
 
   // facilitate DEV mode
@@ -51,6 +53,7 @@ const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
     videoBitrateAuto: true,
     videoBitrate: undefined,
     volume: player.getVolume(),
+    stopAtEnd,
   });
 
   linkPlayerEventsToState(player, state, $destroy);

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -14,6 +14,7 @@
     - [maxBufferBehind](#prop-maxBufferBehind)
     - [limitVideoWidth](#prop-limitVideoWidth)
     - [throttleWhenHidden](#prop-throttleWhenHidden)
+    - [stopAtEnd](#prop-stopAtEnd)
 
 
 ## <a name="overview"></a>Overview
@@ -204,5 +205,24 @@ To activate this feature, set it to ``true``.
 ```js
 const player = Player({
   throttleWhenHidden: true
+});
+```
+
+### <a name="prop-stopAtEnd"></a>stopAtEnd
+
+_type_: ``Boolean``
+
+_defaults_: ``true``
+
+If some cases, you may want the player to stop current playback when content is ended.
+At this point, the player is idle, and the content is no more loaded.
+
+If players doesn't stop at end, it means that current content is still loaded. 
+You can perform trickmode.
+
+To activate this feature, set it to ``true``.
+```js
+const player = Player({
+  stopAtEnd: true
 });
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,15 +166,6 @@ export default {
   DISCONTINUITY_THRESHOLD: 1,
 
   /**
-   * Time before the end of a video (in seconds) at which the player should
-   * automatically stop.
-   * It happens often that the video gets stuck 100 to 300 ms before the end,
-   * especially on IE11 and Edge
-   * @type {Number}
-   */
-  END_OF_PLAY: 0.5,
-
-  /**
    * Ratio used to know if an already loaded segment should be re-buffered.
    * We re-load the given segment if the current one times that ratio is
    * inferior to the new one.

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -88,6 +88,7 @@ export interface IConstructorOptions {
   initialAudioBitrate? : number;
   maxAudioBitrate? : number;
   maxVideoBitrate? : number;
+  stopAtEnd? : boolean;
 }
 
 export interface IParsedConstructorOptions {
@@ -103,6 +104,7 @@ export interface IParsedConstructorOptions {
   initialAudioBitrate : number;
   maxAudioBitrate : number;
   maxVideoBitrate : number;
+  stopAtEnd : boolean;
 }
 
 interface ILoadVideoOptionsBase {
@@ -182,6 +184,7 @@ function parseConstructorOptions(
   let initialAudioBitrate : number;
   let maxAudioBitrate : number;
   let maxVideoBitrate : number;
+  let stopAtEnd : boolean;
 
   if (options.maxBufferAhead == null) {
     maxBufferAhead = DEFAULT_MAX_BUFFER_AHEAD;
@@ -268,6 +271,14 @@ function parseConstructorOptions(
     }
   }
 
+  if (options.stopAtEnd == null) {
+    stopAtEnd = true;
+  } else if(typeof options.stopAtEnd === "boolean"){
+    stopAtEnd = options.stopAtEnd;
+  } else {
+    throw new Error("Invalid stopAtEnd parameter. Should be a boolean.");
+  }
+
   return {
     maxBufferAhead,
     maxBufferBehind,
@@ -279,6 +290,7 @@ function parseConstructorOptions(
     initialVideoBitrate,
     maxAudioBitrate,
     maxVideoBitrate,
+    stopAtEnd,
   };
 }
 

--- a/src/core/buffer/types.ts
+++ b/src/core/buffer/types.ts
@@ -21,6 +21,7 @@ import { ICustomSourceBuffer } from "../stream/source_buffers";
 import { SupportedBufferTypes } from "../types";
 
 export interface IBufferClockTick {
+  buffered : TimeRanges;
   currentTime : number;
   readyState : number;
   timeOffset : number;

--- a/src/core/buffer/types.ts
+++ b/src/core/buffer/types.ts
@@ -28,6 +28,7 @@ export interface IBufferClockTick {
   duration? : number;
   liveGap? : number;
   stalled : object|null;
+  currentRange : {start : number; end: number}|null;
 }
 
 export interface IBufferSegmentInfos {

--- a/src/core/stream/index.ts
+++ b/src/core/stream/index.ts
@@ -20,8 +20,6 @@ import { Observable } from "rxjs/Observable";
 import { ReplaySubject } from "rxjs/ReplaySubject";
 import { Subject } from "rxjs/Subject";
 
-import config from "../../config";
-
 import arrayIncludes from "../../utils/array-includes";
 import InitializationSegmentCache from "../../utils/initialization_segment_cache";
 import log from "../../utils/log";

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,9 @@ import "rxjs/add/operator/switchMap";
 import "rxjs/add/operator/switchMapTo";
 import "rxjs/add/operator/take";
 import "rxjs/add/operator/takeUntil";
+import "rxjs/add/operator/takeWhile";
 import "rxjs/add/operator/timeout";
+import "rxjs/add/operator/withLatestFrom";
 
 import logger from "./utils/log";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import "rxjs/add/observable/throw";
 import "rxjs/add/observable/timer";
 
 import "rxjs/add/operator/catch";
+import "rxjs/add/operator/combineLatest";
 import "rxjs/add/operator/concat";
 import "rxjs/add/operator/concatAll";
 import "rxjs/add/operator/concatMap";

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -114,6 +114,7 @@ class Manifest {
     this.availabilityStartTime = args.availabilityStartTime;
     this.presentationLiveGap = args.presentationLiveGap;
     this.timeShiftBufferDepth = args.timeShiftBufferDepth;
+    this.updatePresentationTimelineDuration();
 
     if (__DEV__ && this.isLive) {
       assert(this.suggestedPresentationDelay != null);
@@ -147,7 +148,9 @@ class Manifest {
             if(lastPosition && minimumAdaptationsDuration[type] == null) {
               minimumAdaptationsDuration[type] = lastPosition;
             } else if(lastPosition && minimumAdaptationsDuration[type] !== lastPosition) {
-              throw new Error("VALID_MANIFEST_ERROR");
+              throw new Error(
+                "Unauthorized manifest. Representations should have the same duration."
+              );
             }
           });
         });

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -69,7 +69,8 @@ class Manifest {
   public presentationLiveGap? : number;
   public timeShiftBufferDepth? : number;
 
-  private _duration : number;
+  private _presentationTimelineDuration: number;
+  private _duration: number;
 
   /**
    * @constructor
@@ -129,7 +130,46 @@ class Manifest {
     return this._duration;
   }
 
-  getUrl() : string {
+  /**
+   * Update presentation timeline duration
+   */
+  updatePresentationTimelineDuration() {
+    const minimumAdaptationsDuration: IDictionary<number> = {};
+
+    // Browse adaptations to find minimum duration
+    ["audio","video"].forEach((type) => {
+      const adaptations = (this.adaptations as any)[type];
+      if (adaptations) {
+        adaptations.forEach((adaptation: Adaptation) => {
+          const representations = adaptation.representations;
+          representations.forEach((representation) => {
+            const lastPosition = representation.index.getLastPosition();
+            if(lastPosition && minimumAdaptationsDuration[type] == null) {
+              minimumAdaptationsDuration[type] = lastPosition;
+            } else if(lastPosition && minimumAdaptationsDuration[type] !== lastPosition) {
+              throw new Error("VALID_MANIFEST_ERROR");
+            }
+          });
+        });
+      }
+    });
+
+    this._presentationTimelineDuration = Math.min(
+      this._duration,
+      minimumAdaptationsDuration.video || Infinity,
+      minimumAdaptationsDuration.audio|| Infinity
+    );
+  }
+
+  /**
+   * Get current presentation timeline duration.
+   * @returns {number}
+   */
+  getPresentationTimelineDuration(): number {
+    return this._presentationTimelineDuration;
+  }
+
+  getUrl(): string {
     return this.uris[0];
   }
 

--- a/src/manifest/indexes/helpers.ts
+++ b/src/manifest/indexes/helpers.ts
@@ -51,7 +51,7 @@ interface IListIndex {
 
 export interface IListIndexListItem {
   media : string;
-  range? : [ number, number ];
+  mediaRange? : [ number, number ];
 }
 
 /**

--- a/src/manifest/indexes/list.ts
+++ b/src/manifest/indexes/list.ts
@@ -57,7 +57,7 @@ const ListIndexHelpers: ISegmentHelpers<IListIndex> = {
     const segments : Segment[] = [];
     let i = Math.floor(up / duration);
     while (i <= length) {
-      const range = list[i].range;
+      const range = list[i].mediaRange;
       const media = list[i].media;
       const args = {
         id: "" + repId + "_" + i,

--- a/src/net/dash/index.ts
+++ b/src/net/dash/index.ts
@@ -124,6 +124,7 @@ export default function(
       representation,
       response,
       init,
+      manifest,
     } : ISegmentParserArguments<Uint8Array|ArrayBuffer>
     ) : SegmentParserObservable {
 
@@ -152,9 +153,9 @@ export default function(
         segmentInfos =
           getISOBMFFTimingInfos(segment, responseData, sidxSegments, init);
       }
-
       if (nextSegments) {
         addNextSegments(representation, segmentInfos, nextSegments);
+        manifest.updatePresentationTimelineDuration();
       }
       return Observable.of({ segmentData, segmentInfos });
     },


### PR DESCRIPTION
The MediaSource API endOfStream() notify video element and media sources that we have complete buffering. It improves video element behavior, including the behavior when current time is around the content's ending. User can seek until the last video frame, and the video element triggers the "ended" event.

With the latter, we can stop the video player without working around the expected video behavior. The player may be frame accurate.