### PR TITLE
Smooth vod contents with start timestamp != 0, implementation 1: start at 0

### DIFF
--- a/src/manifest/indexes/helpers.js
+++ b/src/manifest/indexes/helpers.js
@@ -60,10 +60,59 @@ const scale = (index, time)  => {
   return time / index.timescale;
 };
 
+const getSegmentIndex = (index, ts) => {
+  const { timeline } = index;
+
+  let low = 0;
+  let high = timeline.length;
+
+  while (low < high) {
+    const mid = (low + high) >>> 1;
+    if (timeline[mid].ts < ts) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+
+  return (low > 0)
+    ? low - 1
+    : low;
+};
+
+const getSegmentNumber = (ts, up, duration) => {
+  const diff = up - ts;
+  if (diff > 0) {
+    return Math.floor(diff / duration);
+  } else {
+    return 0;
+  }
+};
+
+const calculateRepeat = (seg, nextSeg) => {
+  let rep = seg.r || 0;
+
+  // A negative value of the @r attribute of the S element indicates
+  // that the duration indicated in @d attribute repeats until the
+  // start of the next S element, the end of the Period or until the
+  // next MPD update.
+  if (rep < 0) {
+    const repEnd = nextSeg
+      ? nextSeg.t
+      : Infinity;
+    rep = Math.ceil((repEnd - seg.ts) / seg.d) - 1;
+  }
+
+  return rep;
+};
+
 export {
   normalizeRange,
   getTimelineRangeEnd,
   getInitSegment,
   setTimescale,
+  getSegmentIndex,
+  getSegmentNumber,
+  calculateRepeat,
   scale,
 };

--- a/src/manifest/indexes/smooth.js
+++ b/src/manifest/indexes/smooth.js
@@ -1,18 +1,111 @@
+import Segment from "../segment.js";
 import TimelineIndex from "./timeline.js";
 import {
+  calculateRepeat,
+  getSegmentIndex,
+  getSegmentNumber,
   getTimelineRangeEnd,
   getInitSegment,
   setTimescale,
   scale,
 } from "./helpers.js";
 
+
+/**
+ * Convert from a time and duration in seconds to a beginning and end
+ * timestamp in the scale of the smooth timeline array.
+ * @param {Object} index
+ * @param {number} [index.presentationTimeOffset=0]
+ * @param {number} [index.timescale=0]
+ * @param {number} [index.segmentTimeOffset=0]
+ * @returns {Object}
+ */
+function normalizeSmoothRange(index, ts, duration) {
+  const pto = index.presentationTimeOffset || 0;
+  const timescale = index.timescale || 1;
+  const segmentTimeOffset = index.segmentTimeOffset || 0;
+
+  return {
+    up: ((ts) * timescale - pto) + segmentTimeOffset,
+    to: ((ts + duration) * timescale - pto) + segmentTimeOffset,
+  };
+}
+
 export default {
-  getSegments: TimelineIndex.getSegments, // TODO Re-implement?
   getInitSegment,
   checkDiscontinuity: TimelineIndex.checkDiscontinuity, // TODO Re-implement?
   _addSegmentInfos: TimelineIndex._addSegmentInfos,
   setTimescale,
   scale,
+
+  getSegments(repId, index, _up, _to) {
+    const { up, to } = normalizeSmoothRange(index, _up, _to);
+    const segmentTimeOffset = index.segmentTimeOffset || 0;
+
+    const { timeline, timescale, media } = index;
+    const segments = [];
+
+    const timelineLength = timeline.length;
+    let timelineIndex = getSegmentIndex(index, up) - 1;
+    // TODO(pierre): use @maxSegmentDuration if possible
+    let maxDuration = (timeline.length && timeline[0].d) || 0;
+
+    loop:
+    for(;;) {
+      if (++timelineIndex >= timelineLength) {
+        break;
+      }
+
+      const segmentRange = timeline[timelineIndex];
+      const { d, ts, range } = segmentRange;
+      maxDuration = Math.max(maxDuration, d);
+
+      // live-added segments have @d attribute equals to -1
+      if (d < 0) {
+        if (ts + maxDuration < to) {
+          const time = ts - segmentTimeOffset;
+          const args = {
+            id: "" + repId + "_" + ts,
+            time,
+            init: false,
+            range: range,
+            duration: undefined,
+            indexRange: null,
+            timescale,
+            media,
+          };
+          segments.push(new Segment(args));
+        }
+        break;
+      }
+
+      const repeat = calculateRepeat(segmentRange, timeline[timelineIndex + 1]);
+      let segmentNumber = getSegmentNumber(ts, up, d);
+      let segmentTime;
+      while ((segmentTime = ts + segmentNumber * d) < to) {
+        if (segmentNumber++ <= repeat) {
+          const time = segmentTime - segmentTimeOffset;
+          const args = {
+            id: "" + repId + "_" + segmentTime,
+            time,
+            init: false,
+            range: range,
+            duration: d,
+            indexRange: null,
+            timescale,
+            media,
+          };
+          segments.push(new Segment(args));
+        } else {
+          continue loop;
+        }
+      }
+
+      break;
+    }
+
+    return segments;
+  },
 
   shouldRefresh(index, time) {
     const {

--- a/src/manifest/indexes/timeline.js
+++ b/src/manifest/indexes/timeline.js
@@ -1,57 +1,14 @@
 import Segment from "../segment.js";
 import {
+  calculateRepeat,
+  getSegmentIndex,
+  getSegmentNumber,
   normalizeRange,
   getTimelineRangeEnd,
   getInitSegment,
   setTimescale,
   scale,
 } from "./helpers.js";
-
-const getSegmentIndex = (index, ts) => {
-  const { timeline } = index;
-
-  let low = 0;
-  let high = timeline.length;
-
-  while (low < high) {
-    const mid = (low + high) >>> 1;
-    if (timeline[mid].ts < ts) {
-      low = mid + 1;
-    } else {
-      high = mid;
-    }
-  }
-
-  return (low > 0)
-    ? low - 1
-    : low;
-};
-
-const getSegmentNumber = (ts, up, duration) => {
-  const diff = up - ts;
-  if (diff > 0) {
-    return Math.floor(diff / duration);
-  } else {
-    return 0;
-  }
-};
-
-const calculateRepeat = (seg, nextSeg) => {
-  let rep = seg.r || 0;
-
-  // A negative value of the @r attribute of the S element indicates
-  // that the duration indicated in @d attribute repeats until the
-  // start of the next S element, the end of the Period or until the
-  // next MPD update.
-  if (rep < 0) {
-    const repEnd = nextSeg
-      ? nextSeg.t
-      : Infinity;
-    rep = Math.ceil((repEnd - seg.ts) / seg.d) - 1;
-  }
-
-  return rep;
-};
 
 const SegmentTimelineHelpers = {
   getInitSegment,


### PR DESCRIPTION
Feature needed by  NCP.

With this implementation, non-live Smooth Streaming Manifest beginning with a segment having a timestamp different than 0 will be automatically re-scaled to 0 before being pushed to a SourceBuffer.

I'm still hesitating between this or respecting the Manifest and pushing segments at the timestamp announced in it.

However, this is how it works on the hasplayer and it also seems to be the wanted behavior for NCP.