### PR TITLE
Smooth vod contents with start timestamp != 0, implementation 2, start at manifest

### DIFF
--- a/src/core/manifest.js
+++ b/src/core/manifest.js
@@ -74,6 +74,7 @@ function normalizeManifest(location, manifest, subtitles, images) {
 
   manifest.id = manifest.id || uniqueId++;
   manifest.type = manifest.type || "static";
+  manifest.minimumTime = manifest.minimumTime;
 
   const locations = manifest.locations;
   if (!locations || !locations.length) {
@@ -361,6 +362,7 @@ function updateManifest(oldManifest, newManifest) {
   const oldAdaptations = oldManifest.getAdaptations();
   const newAdaptations = newManifest.getAdaptations();
 
+  oldManifest.minimumTime = newManifest.minimumTime;
   for (let i = 0; i < oldAdaptations.length; i++) {
     const newAdaptation =
       findElementFromId(oldAdaptations[i].id, newAdaptations);

--- a/src/core/timings.js
+++ b/src/core/timings.js
@@ -370,7 +370,7 @@ function getBufferLimits(manifest) {
   const BUFFER_DEPTH_SECURITY = 5;
 
   if (!manifest.isLive) {
-    return [0, manifest.getDuration()];
+    return [manifest.minimumTime || 0, manifest.getDuration()];
   }
 
   const {
@@ -381,8 +381,15 @@ function getBufferLimits(manifest) {
 
   const now = Date.now() / 1000;
   const max = now - availabilityStartTime - presentationLiveGap;
+
   return [
-    Math.min(max, max - timeShiftBufferDepth + BUFFER_DEPTH_SECURITY),
+    Math.min(
+      max,
+      Math.max(
+        manifest.minimumTime != null ? manifest.minimumTime : 0,
+        max - timeShiftBufferDepth + BUFFER_DEPTH_SECURITY
+      )
+    ),
     max,
   ];
 }

--- a/src/manifest/manifest.js
+++ b/src/manifest/manifest.js
@@ -32,6 +32,7 @@ class Manifest {
    * @param {string} args.type
    * @param {Array.<string>} args.locations
    * @param {Number} args.duration
+   * @param {Number} [args.minimumTime]
    */
   constructor(args = {}) {
     const nId = generateNewId();
@@ -50,6 +51,7 @@ class Manifest {
       },
     ];
 
+    this.minimumTime = args.minimumTime;
     this.isLive = args.type === "dynamic";
     this.uris = args.locations || [];
 


### PR DESCRIPTION
Feature needed by NCP.

With this implementation, non-live Smooth Streaming Manifest will begin at a specific timestamp, which is the max between:
  - The first time Reference of the first video adaptation
  - The first time Reference of the first audio adaptation

The Duration defined in the manifest will be added to this timestamp to define the "real" duration of the content.

I'm still hesitating between this or always push the content at a 0 timestamp with Smooth static content.

This implementation is closer to the Manifest and the ISOBMFF's tfrf and tfxd but:
  - I don't think that's what NCP want
  - that's not how the hasplayer handle it