### PR TITLE
Feat/static smooth manifest minimum position

### DIFF
--- a/src/core/stream/initial_time.ts
+++ b/src/core/stream/initial_time.ts
@@ -19,6 +19,7 @@ import Manifest from "../../manifest";
 import {
   getBufferLimits,
   getMaximumBufferPosition,
+  getMinimumBufferPosition,
 } from "../../manifest/timings";
 
 const { DEFAULT_LIVE_GAP } = config;
@@ -38,7 +39,7 @@ export interface IInitialTimeOptions {
  *      the manifest informations
  *   2. else if the video is live, use the live edge and suggested delays from
  *      it
- *   3. else returns 0 (beginning)
+ *   3. else returns the minimum time announced in the manifest
  *
  * @param {Manifest} manifest
  * @param {Object} startAt
@@ -87,5 +88,6 @@ export default function getInitialTime(
     return getMaximumBufferPosition(manifest) -
       (sgp == null ? DEFAULT_LIVE_GAP : sgp);
   }
-  return 0;
+
+  return getMinimumBufferPosition(manifest);
 }

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -33,6 +33,7 @@ export interface IManifestArguments {
   adaptations : Partial<Record<AdaptationType, IAdaptationArguments[]>>;
   type? : string;
   locations : string[];
+  minimumTime? : number;
   suggestedPresentationDelay? : number;
   availabilityStartTime? : number;
   presentationLiveGap? : number;
@@ -66,6 +67,7 @@ class Manifest {
   public uris : string[];
   public suggestedPresentationDelay? : number;
   public availabilityStartTime? : number;
+  public minimumTime? : number;
   public presentationLiveGap? : number;
   public timeShiftBufferDepth? : number;
 
@@ -73,13 +75,7 @@ class Manifest {
 
   /**
    * @constructor
-   * @param {Object} [args={}]
-   * @param {string|Number} [args.id]
-   * @param {string} args.transportType
-   * @param {Array.<Object>} args.adaptations
-   * @param {string} args.type
-   * @param {Array.<string>} args.locations
-   * @param {Number} args.duration
+   * @param {Object} args
    */
   constructor(args : IManifestArguments) {
     const nId = generateNewId();
@@ -102,6 +98,7 @@ class Manifest {
       },
     ];
 
+    this.minimumTime = args.minimumTime;
     this.isLive = args.type === "dynamic";
     this.uris = args.locations || [];
 

--- a/src/manifest/timings.ts
+++ b/src/manifest/timings.ts
@@ -87,7 +87,7 @@ function getBufferLimits(manifest : Manifest) : [number, number] {
   const BUFFER_DEPTH_SECURITY = 5;
 
   if (!manifest.isLive) {
-    return [0, manifest.getDuration()];
+    return [manifest.minimumTime || 0, manifest.getDuration()];
   }
 
   const ast = manifest.availabilityStartTime || 0;
@@ -97,7 +97,13 @@ function getBufferLimits(manifest : Manifest) : [number, number] {
   const now = Date.now() / 1000;
   const max = now - ast - plg;
   return [
-    Math.min(max, max - tsbd + BUFFER_DEPTH_SECURITY),
+    Math.min(
+      max,
+      Math.max(
+        manifest.minimumTime != null ? manifest.minimumTime : 0,
+        max - tsbd + BUFFER_DEPTH_SECURITY
+      )
+    ),
     max,
   ];
 }

--- a/src/net/types.ts
+++ b/src/net/types.ts
@@ -233,6 +233,7 @@ export interface IParsedManifest {
   publishTime?: Date|number;
   mediaPresentationDuration?: number;
   minimumUpdatePeriod?: number;
+  minimumTime? : number;
   minBufferTime?: number;
   timeShiftBufferDepth?: number;
   suggestedPresentationDelay?: number;


### PR DESCRIPTION
Allows to play HSS VODs with a first chunk not being at a 0 timestamp.

The player will play at the timestamp indicated by the first chunk in the manifest. The duration will be this timestamp added to the ``Duration`` indicated in the manifest.

To completely work with NCP's stream, we have to merge the ``endOfStream`` fix (issue described in #128)