### PR TITLE
fix: replace native 'find' with 'arrayFind'

### DIFF
--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -204,8 +204,8 @@ export default class Manifest {
    * @returns {Period|undefined}
    */
   getPeriodForTime(time : number) : Period|undefined {
-    return this.periods.find(period => {
-     return time >= period.start &&
+    return arrayFind(this.periods, period => {
+      return time >= period.start &&
         (period.end == null || period.end > time);
     });
   }
@@ -221,9 +221,9 @@ export default class Manifest {
     if (endOfPeriod == null) {
       return null;
     }
-    return this.periods.find(_period => {
+    return arrayFind(this.periods, _period => {
       return _period.end == null || endOfPeriod < _period.end;
-    }) || null;
+    }) || null;
   }
 
   /**


### PR DESCRIPTION
`find` method is not supported in IE11.