### PR TITLE
buffer: perform discontinuity seeks only for native source buffers

### DIFF
--- a/src/core/buffer/create_fake_buffer.ts
+++ b/src/core/buffer/create_fake_buffer.ts
@@ -18,6 +18,7 @@ import { Observable } from "rxjs/Observable";
 import Manifest, {
   Period,
 } from "../../manifest";
+import { IBufferType } from "../source_buffers";
 import {
   IBufferClockTick,
   IBufferStateFull,
@@ -31,15 +32,17 @@ import {
  *
  * @param {Observable} bufferClock$
  * @param {Observable} wantedBufferAhead$
+ * @param {string} bufferType
  * @param {Object} content
  * @returns {Observable}
  */
 export default function createFakeBuffer(
   bufferClock$ : Observable<IBufferClockTick>,
   wantedBufferAhead$ : Observable<number>,
+  bufferType : IBufferType,
   content : { manifest : Manifest; period : Period }
 ) : Observable<IBufferStateFull> {
-  const period = content.period;
+  const { period } = content;
   return Observable.combineLatest(bufferClock$, wantedBufferAhead$)
     .filter(([clockTick, wantedBufferAhead]) =>
       period.end != null && clockTick.currentTime + wantedBufferAhead >= period.end
@@ -47,7 +50,7 @@ export default function createFakeBuffer(
     .map(() => {
       return {
         type: "full-buffer" as "full-buffer",
-        value: undefined,
+        value: { bufferType },
       };
     });
 }

--- a/src/core/stream/buffers_handler.ts
+++ b/src/core/stream/buffers_handler.ts
@@ -481,7 +481,8 @@ export default function BuffersHandler(
 
         return cleanBuffer$
           .mapTo(EVENTS.adaptationChange(bufferType, null, period))
-          .concat(createFakeBuffer(clock$, wantedBufferAhead$, { manifest, period }));
+          .concat(createFakeBuffer(
+            clock$, wantedBufferAhead$, bufferType, { manifest, period }));
       }
 
       log.info(`updating ${bufferType} adaptation`, adaptation, period);
@@ -534,7 +535,8 @@ export default function BuffersHandler(
             "has crashed. Aborting it.", error);
           sourceBufferManager.disposeSourceBuffer(bufferType);
           errorStream.next(error);
-          return createFakeBuffer(clock$, wantedBufferAhead$, { manifest, period });
+          return createFakeBuffer(
+            clock$, wantedBufferAhead$, bufferType, { manifest, period });
         }
 
         log.error(

--- a/src/core/stream/live_events_handler.ts
+++ b/src/core/stream/live_events_handler.ts
@@ -17,6 +17,7 @@
 import { Observable } from "rxjs/Observable";
 import Manifest from "../../manifest";
 import log from "../../utils/log";
+import SourceBufferManager from "../source_buffers";
 import EVENTS, {
   IManifestUpdateEvent,
   IStreamEvent,
@@ -67,8 +68,10 @@ export default function liveEventsHandler(
   return function handleLiveEvents(message) {
     switch (message.type) {
       case "discontinuity-encountered":
-        log.warn("explicit discontinuity seek", message.value.nextTime);
-        videoElement.currentTime = message.value.nextTime;
+        if (SourceBufferManager.isNative(message.value.bufferType)) {
+          log.warn("explicit discontinuity seek", message.value.nextTime);
+          videoElement.currentTime = message.value.nextTime;
+        }
         break;
 
       case "needs-manifest-refresh":


### PR DESCRIPTION
The title says it all, we do not care enough for discontinuities in subtitles or images to seek past them when encountered. We do however for audio and video segments.

To simplify the exploitation of the different events emitted by the RepresentationBuffer, we add bufferType information to all of them.

This could be added by higher-layers such as the BufferHandler but it would be too redundant to do so (we would have to re-declare the types) so this can be seen as a middle-level solution.