### PR TITLE
misc: fix server side support

### DIFF
--- a/src/compat/constants.ts
+++ b/src/compat/constants.ts
@@ -18,22 +18,26 @@ import MediaError from "../errors/MediaError";
 
 const BROWSER_PREFIXES = ["", "webkit", "moz", "ms"];
 
-const win = window;
-const HTMLElement_ : HTMLElementConstructor = win.HTMLElement;
-const VTTCue_ : VTTCueConstructor|undefined = win.VTTCue || win.TextTrackCue;
+const win = typeof window !== "undefined" ? window : undefined;
+const HTMLElement_ : HTMLElementConstructor|undefined = win && win.HTMLElement;
+const VTTCue_ : VTTCueConstructor|undefined = win && (win.VTTCue || win.TextTrackCue);
 
 const MediaSource_ : MediaSourceConstructor|undefined = (
-  win.MediaSource ||
-  win.MozMediaSource ||
-  win.WebKitMediaSource ||
-  win.MSMediaSource
+  win && (
+    win.MediaSource ||
+    win.MozMediaSource ||
+    win.WebKitMediaSource ||
+    win.MSMediaSource
+  )
 );
 
 let MediaKeys_ : MediaKeysConstructor|undefined = (
-  win.MediaKeys ||
-  win.MozMediaKeys ||
-  win.WebKitMediaKeys ||
-  win.MSMediaKeys
+  win && (
+    win.MediaKeys ||
+    win.MozMediaKeys ||
+    win.WebKitMediaKeys ||
+    win.MSMediaKeys
+  )
 );
 
 if (!MediaKeys_) {
@@ -57,11 +61,14 @@ if (!MediaKeys_) {
 
 // true for IE / Edge
 const isIE : boolean = (
-  navigator.appName === "Microsoft Internet Explorer" ||
-  navigator.appName === "Netscape" && /(Trident|Edge)\//.test(navigator.userAgent)
+  typeof navigator !== "undefined" && (
+    navigator.appName === "Microsoft Internet Explorer" ||
+    navigator.appName === "Netscape" && /(Trident|Edge)\//.test(navigator.userAgent)
+  )
 );
 
 const isFirefox : boolean = (
+  typeof navigator !== "undefined" &&
   navigator.userAgent.toLowerCase().indexOf("firefox") !== -1
 );
 

--- a/src/compat/eme/MediaKeys.ts
+++ b/src/compat/eme/MediaKeys.ts
@@ -308,7 +308,9 @@ let MockMediaKeys : IMockMediaKeysConstructor =
     }
   };
 
-if (navigator.requestMediaKeySystemAccess) {
+if (typeof navigator === "undefined") {
+  requestMediaKeySystemAccess = null;
+} else if (navigator.requestMediaKeySystemAccess) {
   requestMediaKeySystemAccess = (a : string, b : MediaKeySystemConfiguration[]) =>
     castToObservable(navigator.requestMediaKeySystemAccess(a, b));
 } else {

--- a/src/compat/events.ts
+++ b/src/compat/events.ts
@@ -34,7 +34,7 @@ import {
 } from "./constants";
 
 const INACTIVITY_DELAY = config.INACTIVITY_DELAY;
-const pixelRatio = window.devicePixelRatio || 1;
+const pixelRatio = (typeof window !== "undefined" && window.devicePixelRatio) || 1;
 
 /**
  * Find the first supported event from the list given.
@@ -92,10 +92,11 @@ function compatibleListener<T extends Event>(
 ) : (element : IEventTargetLike) => Observable<T> {
   let mem : string|undefined;
   const prefixedEvents = eventPrefixed(eventNames, prefixes);
+
   return (element) => {
     // if the element is a HTMLElement we can detect
     // the supported event, and memoize it in `mem`
-    if (element instanceof HTMLElement_) {
+    if (HTMLElement_ && element instanceof HTMLElement_) {
       if (typeof mem === "undefined") {
         mem = findSupportedEvent(element, prefixedEvents);
       }
@@ -127,6 +128,10 @@ function compatibleListener<T extends Event>(
  * @returns {Observable}
  */
 function visibilityChange() : Observable<boolean> {
+  if (typeof document === "undefined") {
+    return Observable.never();
+  }
+
   let prefix;
   if (document.hidden != null) {
     prefix = "";

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -143,6 +143,7 @@ function canPlay(
 // old WebKit SourceBuffer implementation,
 // where a synchronous append is used instead of appendBuffer
 if (
+  typeof window !== "undefined" &&
   window.WebKitSourceBuffer &&
   !window.WebKitSourceBuffer.prototype.addEventListener
 ) {


### PR DESCRIPTION
We use server-side rendering in our react app, and have some trouble importing rx-player. There are a few lines that use window/document which are executed in an import.

This PR adds a few additional undefined checks when window/document are used in the global scope.

Some tests do not pass, but its the same in master.

Thoughts?