### PR TITLE
vtt: set cue line property as number

### DIFF
--- a/src/parsers/texttracks/webvtt/native.ts
+++ b/src/parsers/texttracks/webvtt/native.ts
@@ -104,7 +104,7 @@ function setSettingsOnCue(
     const percentagePosition = /^(\d+(\.\d+)?)%(,([a-z]+))?/;
     const percentageMatches = settings.line.match(percentagePosition);
     if (percentageMatches) {
-      cue.line = percentageMatches[1];
+      cue.line = Number(percentageMatches[1]);
       cue.snapToLines = false;
       if (arrayIncludes(["start", "center", "end"], percentageMatches[4])) {
         cue.lineAlign = percentageMatches[4];
@@ -121,7 +121,7 @@ function setSettingsOnCue(
       const lineMatches = settings.line.match(linePosition);
 
       if (lineMatches) {
-        cue.line = lineMatches[1];
+        cue.line = Number(lineMatches[1]);
         cue.snapToLines = true;
 
         if (arrayIncludes(["start", "center", "end"], lineMatches[3])) {

--- a/src/typings/browser.d.ts
+++ b/src/typings/browser.d.ts
@@ -144,9 +144,9 @@ declare class VTTCue {
   align : string;
   endTime : number;
   id : string;
-  line : string;
+  line : number|"auto";
   lineAlign : string;
-  position : number|string;
+  position : number|"auto";
   positionAlign : string;
   size : number|string;
   snapToLines : boolean;


### PR DESCRIPTION
Fix for _"Failed to set the 'line' property on 'VTTCue': The provided value '44' is not a valid enum value of type AutoKeyword."_

VTTCue line property must be double or AutoKeyword. This PR fixes a
crash when attempting to set line as string.

https://w3c.github.io/webvtt/#typedefdef-lineandpositionsetting