### PR TITLE
parsers: fixed time computation in template index

### DIFF
--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -135,7 +135,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
       const number = Math.floor((periodRelativeNumber / duration)) +
         (startNumber == null ? 1 : startNumber);
 
-      const time = (number * duration) / timescale;
+      const time = (number * duration);
 
       const args = {
         id: "" + number,


### PR DESCRIPTION
Time as miscalculated from number in Template Index, provocating:
-> Re-downloading of already bufferized segments
-> Impossible to find segment being requested in ABR.

One line fix.