### PR TITLE
fix: consider main adaptation when it is the first parsed

### DIFF
--- a/src/parsers/manifest/dash/node_parsers/index.ts
+++ b/src/parsers/manifest/dash/node_parsers/index.ts
@@ -648,6 +648,9 @@ export default function parseManifest(
           const parsedAdaptation = parsedAdaptations[type];
           if (!parsedAdaptation) {
             parsedAdaptations[type] = [parsedAdaptationSet];
+            if (isMainAdaptation) {
+              acc.mainAdaptations[type] = parsedAdaptationSet;
+            }
           } else if (isMainAdaptation) {
             // put "main" adaptation as the first
             parsedAdaptation.unshift(parsedAdaptationSet);


### PR DESCRIPTION
When the first parsed adaptation is a main adaptation, we ignored it.