### PR TITLE
Avoid video element by default in full screen in iOS devices.

### DIFF
--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -506,6 +506,10 @@ class Player extends EventEmitter<PLAYER_EVENT_STRINGS, any> {
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1194624
     videoElement.preload = "auto";
 
+    // For iOS > 10, avoid displaying video element by default in full screen
+    // when playing content.
+    videoElement.setAttribute("playsinline", "true");
+
     this.version = /*PLAYER_VERSION*/"3.5.1";
     this.log = log;
     this.state = "STOPPED";


### PR DESCRIPTION
Add `playsinline` attribute to video element.