### PR TITLE
Various ttml subtitles fixes

### DIFF
--- a/src/parsers/texttracks/ttml/html/createElement.ts
+++ b/src/parsers/texttracks/ttml/html/createElement.ts
@@ -121,12 +121,6 @@ function applyTextStyle(
   }
 
   // applies to span
-  const wrapOption = style.wrapOption;
-  if (wrapOption && wrapOption === "noWrap") {
-    element.style.whiteSpace = "nowrap";
-  }
-
-  // applies to span
   const textOutline = style.textOutline;
   if (textOutline) {
     const outlineData = textOutline.trim().replace(/\s+/g, " ").split(" ");
@@ -260,9 +254,10 @@ function applyTextStyle(
   }
 
   // applies to body, div, p, region, span
-  if (!shouldTrimWhiteSpace) {
-    element.style.whiteSpace = "pre";
-  }
+  const wrapOption = style.wrapOption;
+  element.style.whiteSpace = wrapOption === "noWrap" ?
+    (shouldTrimWhiteSpace ? "nowrap" : "pre") :
+    (shouldTrimWhiteSpace ? "normal" : "pre-wrap");
 }
 
 /**

--- a/src/parsers/texttracks/ttml/html/createElement.ts
+++ b/src/parsers/texttracks/ttml/html/createElement.ts
@@ -514,7 +514,7 @@ export default function createElement(
   regions : IStyleObject[],
   styles : IStyleObject[],
   paragraphStyle : IStyleList,
-  shouldTrimWhiteSpaceOnParagraph : boolean
+  shouldTrimWhiteSpace : boolean
 ) : HTMLElement {
   const divs = getParentElementsByTagName(paragraph, "div");
 
@@ -537,7 +537,7 @@ export default function createElement(
   applyPStyle(pElement, paragraphStyle);
 
   const textContent = generateTextContent(
-    paragraph, regions, styles, paragraphStyle, shouldTrimWhiteSpaceOnParagraph);
+    paragraph, regions, styles, paragraphStyle, shouldTrimWhiteSpace);
 
   for (let i = 0; i < textContent.length; i++) {
     pElement.appendChild(textContent[i]);

--- a/src/parsers/texttracks/ttml/html/createElement.ts
+++ b/src/parsers/texttracks/ttml/html/createElement.ts
@@ -480,12 +480,12 @@ function generateTextContent(
         elements.push(br);
       } else if (
         currentNode.nodeName === "span" &&
+        currentNode.nodeType === Node.ELEMENT_NODE &&
         currentNode.childNodes.length > 0
       ) {
         const spaceAttribute = (currentNode as Element).getAttribute("xml:space");
         const shouldTrimWhiteSpaceOnSpan = spaceAttribute ?
           spaceAttribute === "default" : shouldTrimWhiteSpaceFromParent;
-        style.whiteSpace = shouldTrimWhiteSpaceOnSpan ? "normal" : "pre";
 
         // compute the new applyable style
         const newStyle = objectAssign({}, style, getStylingAttributes(

--- a/src/parsers/texttracks/ttml/html/createElement.ts
+++ b/src/parsers/texttracks/ttml/html/createElement.ts
@@ -105,7 +105,8 @@ function generateCSSTextOutline(
  */
 function applyTextStyle(
   element : HTMLElement,
-  style : Partial<Record<string, string>>
+  style : Partial<Record<string, string>>,
+  shouldTrimWhiteSpace : boolean
 ) {
   // applies to span
   const color = style.color;
@@ -259,8 +260,7 @@ function applyTextStyle(
   }
 
   // applies to body, div, p, region, span
-  const whiteSpace = style.whiteSpace;
-  if (whiteSpace === "pre") {
+  if (!shouldTrimWhiteSpace) {
     element.style.whiteSpace = "pre";
   }
 }
@@ -348,12 +348,6 @@ function applyGeneralStyle(
   if (display === "none") {
     element.style.display = "none";
   }
-
-  // applies to body, div, p, region, span
-  const whiteSpace = style.whiteSpace;
-  if (whiteSpace === "pre") {
-    element.style.whiteSpace = whiteSpace;
-  }
 }
 
 /**
@@ -397,12 +391,6 @@ function applyPStyle(
         break;
     }
   }
-
-  // applies to p
-  const whiteSpace = style.whiteSpace;
-  if (whiteSpace === "pre") {
-    element.style.whiteSpace = whiteSpace;
-  }
 }
 
 /**
@@ -412,20 +400,20 @@ function applyPStyle(
  * @param {Element} el - the #text element, which text content should be
  * displayed
  * @param {Object} style - the style object for the given text
- * @param {Boolean} shouldTrimWhiteSpaceFromParent - True if the space should be
- * trimmed by default. From the parent xml:space parameter.
+ * @param {Boolean} shouldTrimWhiteSpace - True if the space should be
+ * trimmed.
  * @returns {HTMLElement}
  */
 function createTextElement(
   el : Node,
   style : Partial<Record<string, string>>,
-  shouldTrimWhiteSpaceFromParent : boolean
+  shouldTrimWhiteSpace : boolean
 ) : HTMLElement {
   const textElement = document.createElement("span");
 
   let textContent = el.textContent || "";
 
-  if (shouldTrimWhiteSpaceFromParent) {
+  if (shouldTrimWhiteSpace) {
     // 1. Trim leading and trailing whitespace.
     // 2. Collapse multiple spaces into one.
     let trimmed = textContent.trim();
@@ -436,7 +424,7 @@ function createTextElement(
   textElement.innerHTML = textContent;
   textElement.className = "rxp-texttrack-span";
 
-  applyTextStyle(textElement, style);
+  applyTextStyle(textElement, style, shouldTrimWhiteSpace);
   return textElement;
 }
 

--- a/src/parsers/texttracks/ttml/html/createElement.ts
+++ b/src/parsers/texttracks/ttml/html/createElement.ts
@@ -522,7 +522,7 @@ function generateTextContent(
  * @param {Array.<Object>} regions
  * @param {Array.<Object>} styles
  * @param {Object} paragraphStyle
- * @param {Boolean} shouldTrimWhiteSpace
+ * @param {Boolean} shouldTrimWhiteSpaceOnParagraph
  * @returns {HTMLElement}
  */
 export default function createElement(

--- a/src/parsers/texttracks/ttml/html/index.ts
+++ b/src/parsers/texttracks/ttml/html/index.ts
@@ -132,9 +132,7 @@ export default function parseTTMLStringToDIV(
     const shouldTrimWhiteSpaceOnBody =
       bodySpaceAttribute === "default" || params.spaceStyle === "default";
 
-    const paragraphNodes = body ?
-      body.querySelectorAll("div")[0].children :
-      getTextNodes(tt);
+    const paragraphNodes = getTextNodes(tt);
 
     for (let i = 0; i < paragraphNodes.length; i++) {
       const paragraph = paragraphNodes[i];

--- a/src/parsers/texttracks/ttml/html/index.ts
+++ b/src/parsers/texttracks/ttml/html/index.ts
@@ -74,6 +74,7 @@ export default function parseTTMLStringToDIV(
     const body = getBodyNode(tt);
     const styleNodes = getStyleNodes(tt);
     const regionNodes = getRegionNodes(tt);
+    const paragraphNodes = getTextNodes(tt);
     const params = getParameters(tt);
 
     // construct styles array based on the xml as an optimization
@@ -131,8 +132,6 @@ export default function parseTTMLStringToDIV(
     const bodySpaceAttribute = body ? body.getAttribute("xml:space") : undefined;
     const shouldTrimWhiteSpaceOnBody =
       bodySpaceAttribute === "default" || params.spaceStyle === "default";
-
-    const paragraphNodes = getTextNodes(tt);
 
     for (let i = 0; i < paragraphNodes.length; i++) {
       const paragraph = paragraphNodes[i];

--- a/src/parsers/texttracks/ttml/html/index.ts
+++ b/src/parsers/texttracks/ttml/html/index.ts
@@ -138,6 +138,10 @@ export default function parseTTMLStringToDIV(
             STYLE_ATTRIBUTES, [paragraph, ...divs], styles, regions)
         );
 
+        const paragraphSpaceAttribute = paragraph.getAttribute("xml:space");
+        const shouldTrimWhiteSpaceOnParagraph = paragraphSpaceAttribute ?
+          paragraphSpaceAttribute === "default" : params.spaceStyle === "default";
+
         const cue = parseCue(
           paragraph,
           timeOffset,
@@ -145,7 +149,8 @@ export default function parseTTMLStringToDIV(
           regions,
           body,
           paragraphStyle,
-          params
+          params,
+          shouldTrimWhiteSpaceOnParagraph
         );
         if (cue) {
           ret.push(cue);

--- a/src/parsers/texttracks/ttml/html/index.ts
+++ b/src/parsers/texttracks/ttml/html/index.ts
@@ -74,7 +74,6 @@ export default function parseTTMLStringToDIV(
     const body = getBodyNode(tt);
     const styleNodes = getStyleNodes(tt);
     const regionNodes = getRegionNodes(tt);
-    const textNodes = getTextNodes(tt);
     const params = getParameters(tt);
 
     // construct styles array based on the xml as an optimization
@@ -129,8 +128,16 @@ export default function parseTTMLStringToDIV(
       getStylingAttributes(STYLE_ATTRIBUTES, [body], styles, regions) :
       getStylingAttributes(STYLE_ATTRIBUTES, [], styles, regions);
 
-    for (let i = 0; i < textNodes.length; i++) {
-      const paragraph = textNodes[i];
+    const bodySpaceAttribute = body ? body.getAttribute("xml:space") : undefined;
+    const shouldTrimWhiteSpaceOnBody =
+      bodySpaceAttribute === "default" || params.spaceStyle === "default";
+
+    const paragraphNodes = body ?
+      body.querySelectorAll("div")[0].children :
+      getTextNodes(tt);
+
+    for (let i = 0; i < paragraphNodes.length; i++) {
+      const paragraph = paragraphNodes[i];
       if (paragraph instanceof Element) {
         const divs = getParentElementsByTagName(paragraph , "div");
         const paragraphStyle = objectAssign({}, bodyStyle,
@@ -140,7 +147,7 @@ export default function parseTTMLStringToDIV(
 
         const paragraphSpaceAttribute = paragraph.getAttribute("xml:space");
         const shouldTrimWhiteSpaceOnParagraph = paragraphSpaceAttribute ?
-          paragraphSpaceAttribute === "default" : params.spaceStyle === "default";
+          paragraphSpaceAttribute === "default" : shouldTrimWhiteSpaceOnBody;
 
         const cue = parseCue(
           paragraph,

--- a/src/parsers/texttracks/ttml/html/parseCue.ts
+++ b/src/parsers/texttracks/ttml/html/parseCue.ts
@@ -47,7 +47,7 @@ export default function parseCue(
   body : Element|null,
   styleBase : IStyleList,
   ttParams : ITTParameters,
-  shouldTrimWhiteSpaceOnParagraph : boolean
+  shouldTrimWhiteSpace : boolean
 ) : ITTMLHTMLCue|null {
   // Disregard empty elements:
   // TTML allows for empty elements like <div></div>.
@@ -66,7 +66,7 @@ export default function parseCue(
     regions,
     styles,
     styleBase,
-    shouldTrimWhiteSpaceOnParagraph
+    shouldTrimWhiteSpace
   );
   return {
     start: start + offset,

--- a/src/parsers/texttracks/ttml/html/parseCue.ts
+++ b/src/parsers/texttracks/ttml/html/parseCue.ts
@@ -36,6 +36,7 @@ export interface ITTMLHTMLCue {
  * @param {Element} body
  * @param {Object} styleBase
  * @param {Object} ttParams
+ * @param {Boolean} shouldTrimWhiteSpaceOnParagraph
  * @returns {Object|null}
  */
 export default function parseCue(
@@ -45,7 +46,8 @@ export default function parseCue(
   regions : IStyleObject[],
   body : Element|null,
   styleBase : IStyleList,
-  ttParams : ITTParameters
+  ttParams : ITTParameters,
+  shouldTrimWhiteSpaceOnParagraph : boolean
 ) : ITTMLHTMLCue|null {
   // Disregard empty elements:
   // TTML allows for empty elements like <div></div>.
@@ -64,7 +66,7 @@ export default function parseCue(
     regions,
     styles,
     styleBase,
-    ttParams.spaceStyle === "default"
+    shouldTrimWhiteSpaceOnParagraph
   );
   return {
     start: start + offset,

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -253,7 +253,20 @@ function generateTextContent(
           trimmed = trimmed.replace(/\s+/g, " ");
           textContent = trimmed;
         }
-        text += textContent;
+
+        // DOM Parser turns HTML escape caracters into caracters,
+        // that may be misinterpreted by VTTCue API (typically, less-than sign
+        // and greater-than sign can be interpreted as HTML tags signs).
+        // Original escaped caracters must be conserved.
+        const escapedTextContent = textContent
+          .replace(/&|\u0026/g, "&amp;")
+          .replace(/<|\u003C/g, "&lt;")
+          .replace(/>|\u2265/g, "&gt;")
+          .replace(/\u200E/g, "&lrm;")
+          .replace(/\u200F/g, "&rlm;")
+          .replace(/\u00A0/g, "&nbsp;");
+
+        text += escapedTextContent;
       } else if (currentNode.nodeName === "br") {
         text += "\n";
       } else if (

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -146,9 +146,7 @@ function parseTTMLStringToVTT(
     const shouldTrimWhiteSpaceOnBody =
       bodySpaceAttribute === "default" || params.spaceStyle === "default";
 
-    const paragraphNodes = body ?
-      body.querySelectorAll("div")[0].children :
-      getTextNodes(tt);
+    const paragraphNodes = getTextNodes(tt);
 
     for (let i = 0; i < paragraphNodes.length; i++) {
       const paragraph = paragraphNodes[i];

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -93,7 +93,6 @@ function parseTTMLStringToVTT(
     const body = getBodyNode(tt);
     const styleNodes = getStyleNodes(tt);
     const regionNodes = getRegionNodes(tt);
-    const textNodes = getTextNodes(tt);
     const params = getParameters(tt);
 
     // construct styles array based on the xml as an optimization
@@ -143,8 +142,16 @@ function parseTTMLStringToVTT(
       getStylingAttributes(WANTED_STYLE_ATTRIBUTES, [body], styles, regions) :
       getStylingAttributes(WANTED_STYLE_ATTRIBUTES, [], styles, regions);
 
-    for (let i = 0; i < textNodes.length; i++) {
-      const paragraph = textNodes[i];
+    const bodySpaceAttribute = body ? body.getAttribute("xml:space") : undefined;
+    const shouldTrimWhiteSpaceOnBody =
+      bodySpaceAttribute === "default" || params.spaceStyle === "default";
+
+    const paragraphNodes = body ?
+      body.querySelectorAll("div")[0].children :
+      getTextNodes(tt);
+
+    for (let i = 0; i < paragraphNodes.length; i++) {
+      const paragraph = paragraphNodes[i];
       if (paragraph instanceof Element) {
         const divs = getParentElementsByTagName(paragraph , "div");
         const paragraphStyle = objectAssign({}, bodyStyle,
@@ -154,8 +161,7 @@ function parseTTMLStringToVTT(
 
         const paragraphSpaceAttribute = paragraph.getAttribute("xml:space");
         const shouldTrimWhiteSpaceOnParagraph = paragraphSpaceAttribute ?
-          paragraphSpaceAttribute === "default" :
-          params.spaceStyle === "default";
+          paragraphSpaceAttribute === "default" : shouldTrimWhiteSpaceOnBody;
 
         const cue = parseCue(
           paragraph,

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -198,7 +198,7 @@ function parseCue(
   _regions : IStyleObject[],
   paragraphStyle : IStyleList,
   params : ITTParameters,
-  shouldTrimWhiteSpaceOnParagraph : boolean
+  shouldTrimWhiteSpace : boolean
 ) : VTTCue|TextTrackCue|null {
   // Disregard empty elements:
   // TTML allows for empty elements like <div></div>.
@@ -211,7 +211,7 @@ function parseCue(
   }
 
   const { start, end } = getTimeDelimiters(paragraph, params);
-  const text = generateTextContent(paragraph, shouldTrimWhiteSpaceOnParagraph);
+  const text = generateTextContent(paragraph, shouldTrimWhiteSpace);
   const cue = makeCue(start + offset, end + offset, text);
   if (!cue) {
     return null;

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -277,6 +277,7 @@ function generateTextContent(
         text += "\n";
       } else if (
         currentNode.nodeName === "span" &&
+        currentNode.nodeType === Node.ELEMENT_NODE &&
         currentNode.childNodes.length > 0
       ) {
         const spaceAttribute = (currentNode as Element).getAttribute("xml:space");

--- a/src/parsers/texttracks/ttml/native/index.ts
+++ b/src/parsers/texttracks/ttml/native/index.ts
@@ -93,6 +93,7 @@ function parseTTMLStringToVTT(
     const body = getBodyNode(tt);
     const styleNodes = getStyleNodes(tt);
     const regionNodes = getRegionNodes(tt);
+    const paragraphNodes = getTextNodes(tt);
     const params = getParameters(tt);
 
     // construct styles array based on the xml as an optimization
@@ -145,8 +146,6 @@ function parseTTMLStringToVTT(
     const bodySpaceAttribute = body ? body.getAttribute("xml:space") : undefined;
     const shouldTrimWhiteSpaceOnBody =
       bodySpaceAttribute === "default" || params.spaceStyle === "default";
-
-    const paragraphNodes = getTextNodes(tt);
 
     for (let i = 0; i < paragraphNodes.length; i++) {
       const paragraph = paragraphNodes[i];


### PR DESCRIPTION
- Keep HTML escape caracters on ttml content:
DOMParser turn HTML escape caracters into caracters, that can be misunderstood by VTTCue API (typically, a less-than sign can be interpreted as the beginning of a HTML tag). After being parsed, all the concerned caracters are know turned back into HTML escape caracters.

- Parse xml:space attribute in all nodes from tt to text tag:
Before, we parsed the attribute in the style tag from ttml. We know look for it at every node level, so we can apply it to subtitle style-sheet (in HTML and native mode).

- Consider paragraph parent div: 
We check for style attributes in the parent div of paragraphs.