### PR TITLE
direct: fix loadedEvent

### DIFF
--- a/src/core/stream/directfile.ts
+++ b/src/core/stream/directfile.ts
@@ -169,7 +169,7 @@ export default function StreamDirectFile({
         const error = new MediaError("MEDIA_ERR_BLOCKED_AUTOPLAY", null, false);
         return observableOf(EVENTS.warning(error), EVENTS.loaded());
       }
-      return observableOf(EVENTS.loaded);
+      return observableOf(EVENTS.loaded());
     }));
 
   // Start everything! (Just put the URL in the element's src).


### PR DESCRIPTION
Fixes a bug introduced in 64eafd4b, that cause the loadedEvent to emit
the loaded function instead of the loaded event object.

Reproducible at http://developers.canal-plus.com/rx-player/. Try to start a directfile. The video starts, but the spinner is still visible.