### PR TITLE
Gauge initial bandwidth to display a better first quality to the user

### DIFF
--- a/demo/full/scripts/contents.js
+++ b/demo/full/scripts/contents.js
@@ -1,11 +1,5 @@
 export default [
   {
-    "name": "DASH-IF - SegmentTimeline live stream",
-    "url": "https://vm2.dashif.org/livesim-dev/segtimeline_1/testpic_6s/Manifest.mpd",
-    "transport": "dash",
-    "live": true,
-  },
-  {
     "name": "Tears of Steal (clear)",
     "url": "https://www.bok.net/dash/tears_of_steel/cleartext/stream.mpd",
     "transport": "dash",

--- a/src/core/abr/bandwidth_estimator.ts
+++ b/src/core/abr/bandwidth_estimator.ts
@@ -18,11 +18,15 @@ import config from "../../config";
 import EWMA from "./ewma";
 
 const {
-  ABR_MINIMUM_TOTAL_BYTES,
   ABR_MINIMUM_CHUNK_SIZE,
   ABR_FAST_EMA,
   ABR_SLOW_EMA,
 } = config;
+
+export interface IBandwidthEstimatorEstimate {
+  bitrate : number|undefined; // The calculated bitrate
+  bytesSampled : number; // the number of bytes at the basis of this estimate
+}
 
 /**
  * Calculate a mean bandwidth based on the bytes downloaded and the amount
@@ -81,14 +85,21 @@ export default class BandwidthEstimator {
    * Get estimate of the bandwidth, in bits per seconds.
    * @returns {Number|undefined}
    */
-  public getEstimate() : number|undefined {
-    if (this._bytesSampled < ABR_MINIMUM_TOTAL_BYTES) {
-      return undefined;
+  public getEstimate() : IBandwidthEstimatorEstimate {
+    const fastEstimate = this._fastEWMA.getEstimate();
+    if (fastEstimate == null) {
+      return { bitrate: undefined, bytesSampled: this._bytesSampled };
+    }
+
+    const slowEstimate = this._slowEWMA.getEstimate();
+    if (slowEstimate == null) {
+      return { bitrate: undefined, bytesSampled: this._bytesSampled };
     }
 
     // Take the minimum of these two estimates.  This should have the effect of
     // adapting down quickly, but up more slowly.
-    return Math.min(this._fastEWMA.getEstimate(), this._slowEWMA.getEstimate());
+    const bitrate = Math.min(fastEstimate, slowEstimate);
+    return { bitrate, bytesSampled: this._bytesSampled };
   }
 
   /**

--- a/src/core/abr/ewma.ts
+++ b/src/core/abr/ewma.ts
@@ -50,8 +50,8 @@ export default class EWMA {
   /**
    * @returns {number} value
    */
-  public getEstimate() : number {
+  public getEstimate() : number|undefined {
     const zeroFactor = 1 - Math.pow(this._alpha, this._totalWeight);
-    return this._lastEstimate / zeroFactor;
+    return zeroFactor ? this._lastEstimate / zeroFactor : undefined;
   }
 }

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -667,6 +667,13 @@ class Player extends EventEmitter<PLAYER_EVENT_STRINGS, any> {
    * @throws Error - throws if the asked transport does not exist
    */
   loadVideo(opts : ILoadVideoOptions) : void {
+    console.time("loadVideo");
+    this.addEventListener("playerStateChange", (state) => {
+      if (state === "LOADED") {
+        console.timeEnd("loadVideo");
+        console.timeEnd("manifest");
+      }
+    });
     const options = parseLoadVideoOptions(opts);
     log.info("API: Calling loadvideo", options);
 

--- a/src/core/source_buffers/queued_source_buffer.ts
+++ b/src/core/source_buffers/queued_source_buffer.ts
@@ -316,9 +316,7 @@ export default class QueuedSourceBuffer<T> {
    * @private
    */
   private _onUpdateEnd() : void {
-    if (!this.isLocked()) {
-      this._flush();
-    }
+    this._flush();
   }
 
   /**
@@ -344,8 +342,7 @@ export default class QueuedSourceBuffer<T> {
    */
   private _addToQueue(order : IQSBOrders<T>) : Observable<unknown> {
     return Observable.create((obs : Observer<unknown>) => {
-      const shouldRestartQueue = !this.isLocked() &&
-        this._queue.length === 0 && this._currentOrder == null;
+      const shouldRestartQueue = this._queue.length === 0 && this._currentOrder == null;
       let queueItem : IQSBQueueItems<T>;
       const subject = new Subject<unknown>();
 


### PR DESCRIPTION
# Better initial quality (PR name and title in progress!)

## The problem

Right now, the first pushed segments are the ones with the lowest quality by default.
This means that even for people with very good bandwidth, the first seconds of content might be of very poor quality.

From feedbacks, we realized that we could profit a lot from doing a better first estimation, even if this means longer load times.

## The (possible) solution

The current solution we try to implement is - in that order:
  1. download the first lower-level segments
  2. if (and only if) the bandwidth allow for much better segments, throw those and re-download them in a better quality.
  3. push the initial segments to the SourceBuffer

## The conditions

The problems are:
  - the first segments seen by the user should be of a bandwidth-correlated enough quality
  - we should not initially push to the SourceBuffer if we are not confident enough on the correlation between the user's bandwidth and the first downloaded segments
  - we should have an initial calculation of the bitrate fast enough to limit load time to an acceptable level

## Current implementation

Right now, we chose to take the following steps:

  - [x] add to the QueuedSourceBuffer (SourceBuffer abstraction) methods to "lock" and "unlock" segment-pushing.
    Basically, when the lock is active, segments will be bufferised in a queue.
 
  - [x] Give the possibility to empty the QueuedSourceBuffer's queue (if bufferised segments are not of an optimal quality)

  - [ ] Better estimate the initial bitrate in the ABRManager (which does bandwidth estimations)

  - [ ] initially lock the QueuedSourceBuffer (before the content is loaded)

  - [ ] Empty the QueuedSourceBuffer's queue when the ABRManager select another Representation

  - [ ] Unlock the QueuedSourceBuffer once the quality is sufficient

  - [ ] Unlock the QueuedSourceBuffer if the corresponding buffer is idle

## Notes

As it might only be needed for some VOD contents (and rarely for live contents), this feature should be opt-in (e.g. with an added ``loadVideo`` option).