### PR TITLE
misc: make manualBitrateSwitchingMode optional

### DIFF
--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -148,7 +148,7 @@ export interface ILoadVideoOptions {
   textTrackMode? : "native"|"html";
   hideNativeSubtitle? : boolean;
   textTrackElement? : HTMLElement;
-  manualBitrateSwitchingMode : "seamless"|"direct";
+  manualBitrateSwitchingMode? : "seamless"|"direct";
 }
 
 interface IParsedLoadVideoOptionsBase {


### PR DESCRIPTION
Documentation states that `manualBitrateSwitchingMode` should be optional. This change makes `manualBitrateSwitchingMode` optional in `ILoadVideoOptions`.