### PR TITLE
Feat/abr switch without cancelling

### DIFF
--- a/src/core/abr/representation_chooser.ts
+++ b/src/core/abr/representation_chooser.ts
@@ -122,29 +122,6 @@ interface IRepresentationChooserOptions {
 }
 
 /**
- * Returns an observable emitting only the representation concerned by the
- * bitrate ceil given.
- * @param {Array.<Representation>} representations
- * @param {number} bitrate
- * @returns {Observable}
- */
-function setManualRepresentation(
-  representations : Representation[],
-  bitrate : number
-) : Observable<IABREstimation> {
-  const chosenRepresentation =
-    fromBitrateCeil(representations, bitrate) ||
-    representations[0];
-
-  return observableOf({
-    bitrate: undefined, // Bitrate estimation is deactivated here
-    representation: chosenRepresentation,
-    manual: true,
-    urgent: true, // a manual bitrate switch should happen immediately
-  });
-}
-
-/**
  * Get the pending request starting with the asked segment position.
  * @param {Object} requests
  * @param {number} position
@@ -401,7 +378,13 @@ export default class RepresentationChooser {
     return manualBitrate$.pipe(switchMap(manualBitrate => {
       if (manualBitrate >= 0) {
         // -- MANUAL mode --
-        return setManualRepresentation(representations, manualBitrate);
+        return observableOf({
+          bitrate: undefined, // Bitrate estimation is deactivated here
+          representation: fromBitrateCeil(representations, manualBitrate) ||
+            representations[0],
+          manual: true,
+          urgent: true, // a manual bitrate switch should happen immediately
+        });
       }
 
       // -- AUTO mode --

--- a/src/core/abr/representation_chooser.ts
+++ b/src/core/abr/representation_chooser.ts
@@ -129,20 +129,18 @@ interface IRepresentationChooserOptions {
  */
 function getConcernedRequest(
   requests : Partial<Record<string, IRequestInfo>>,
-  position : number
+  neededPosition : number
 ) : IRequestInfo|undefined {
   const currentRequestIds = Object.keys(requests);
   const len = currentRequestIds.length;
 
   for (let i = 0; i < len; i++) {
     const request = requests[currentRequestIds[i]];
-
-    // We check that this chunk has a high probability of being the one we want
-    if (
-      request != null &&
-      Math.abs(request.time - position) < request.duration * 0.3
-    ) {
-      return request;
+    if (request != null && request.duration > 0) {
+      const segmentEnd = request.time + request.duration;
+      if (segmentEnd > neededPosition && neededPosition - request.time > -0.3) {
+        return request;
+      }
     }
   }
 }

--- a/src/core/buffer/adaptation_buffer.ts
+++ b/src/core/buffer/adaptation_buffer.ts
@@ -154,8 +154,10 @@ export default function AdaptationBuffer<T>(
 
     tap((estimation) => {
       if (estimation.urgent) {
+        log.info("AdaptationBuffer: urgent Representation switch");
         killCurrentBuffer$.next();
       } else {
+        log.info("AdaptationBuffer: non-urgent Representation switch");
         terminateCurrentBuffer$.next();
       }
     }),


### PR DESCRIPTION
# ABR Switch without cancelling

This PR brings the possibility to switch the current `RepresentationBuffer` (i.e. because of a higher or lower bandwidth estimation) without aborting the previous one's pending requests.