### PR TITLE
codec-switching with sourceBuffer.changeType

### DIFF
--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -58,6 +58,21 @@ import {
   setMediaKeys,
 } from "./eme";
 
+export interface ICustomSourceBuffer<T> {
+  addEventListener : (eventName : string, cb : (arg : any) => void) => void;
+  removeEventListener : (
+    eventName : string,
+    callback : (arg : any) => void
+  ) => void;
+  buffered : TimeRanges;
+  changeType? : (type: string) => void;
+  updating : boolean;
+  timestampOffset : number;
+  appendBuffer(data : T) : void;
+  remove(from : number, to : number) : void;
+  abort() : void;
+}
+
 /**
  * Returns true if the given codec is supported by the browser's MediaSource
  * implementation.
@@ -402,6 +417,25 @@ function play$(mediaElement : HTMLMediaElement) : Observable<void> {
   );
 }
 
+/**
+ * If the changeType MSE API is implemented, update the current codec of the
+ * SourceBuffer and return true.
+ * Else, return false.
+ * @param {Object} sourceBuffer
+ * @param {string} codec
+ * @returns {boolean}
+ */
+function tryToChangeSourceBufferType(
+  sourceBuffer : ICustomSourceBuffer<unknown>,
+  codec : string
+) : boolean {
+  if (typeof sourceBuffer.changeType === "function") {
+    sourceBuffer.changeType(codec);
+    return true;
+  }
+  return false;
+}
+
 export {
   CustomMediaKeySystemAccess,
   ICompatMediaKeySystemAccess,
@@ -437,4 +471,5 @@ export {
   setMediaKeys,
   shouldRenewMediaKeys,
   shouldUnsetMediaKeys,
+  tryToChangeSourceBufferType,
 };

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -419,8 +419,8 @@ function play$(mediaElement : HTMLMediaElement) : Observable<void> {
 
 /**
  * If the changeType MSE API is implemented, update the current codec of the
- * SourceBuffer and return true.
- * Else, return false.
+ * SourceBuffer and return true if it succeeded.
+ * In any other cases, return false.
  * @param {Object} sourceBuffer
  * @param {string} codec
  * @returns {boolean}
@@ -430,7 +430,12 @@ function tryToChangeSourceBufferType(
   codec : string
 ) : boolean {
   if (typeof sourceBuffer.changeType === "function") {
-    sourceBuffer.changeType(codec);
+    try {
+      sourceBuffer.changeType(codec);
+    } catch (e) {
+      log.warn("Could not call 'changeType' on the given SourceBuffer:", e);
+      return false;
+    }
     return true;
   }
   return false;

--- a/src/core/buffer/append_data.ts
+++ b/src/core/buffer/append_data.ts
@@ -35,6 +35,7 @@ export interface IAppendedSegmentInfos<T> {
   segment : ISegment;
   initSegmentData : T|null;
   segmentData : T;
+  codec : string;
   segmentOffset : number;
 }
 
@@ -49,18 +50,24 @@ export interface IAppendedSegmentInfos<T> {
  */
 function appendDataToSourceBuffer<T>(
   queuedSourceBuffer : QueuedSourceBuffer<T>,
-  { segment, initSegmentData, segmentData, segmentOffset } : IAppendedSegmentInfos<T>
+  {
+    segment,
+    initSegmentData,
+    segmentData,
+    segmentOffset,
+    codec,
+  } : IAppendedSegmentInfos<T>
 ) : Observable<void> {
 
   let append$ : Observable<void>;
   if (segment.isInit) {
     append$ = initSegmentData == null ?
       observableOf(undefined) :
-      queuedSourceBuffer.appendBuffer(initSegmentData, null, segmentOffset);
+      queuedSourceBuffer.appendBuffer(codec, initSegmentData, null, segmentOffset);
   } else {
     append$ = segmentData == null ?
       observableOf(undefined) :
-      queuedSourceBuffer.appendBuffer(initSegmentData, segmentData, segmentOffset);
+      queuedSourceBuffer.appendBuffer(codec, initSegmentData, segmentData, segmentOffset);
   }
   return append$;
 }

--- a/src/core/buffer/representation_buffer.ts
+++ b/src/core/buffer/representation_buffer.ts
@@ -395,10 +395,9 @@ export default function RepresentationBuffer<T>({
       }
 
       const append$ = appendDataInSourceBuffer(clock$, queuedSourceBuffer, {
-        initSegmentData: initSegmentObject && initSegmentObject.segmentData,
-        segmentData,
-        segment,
-        segmentOffset,
+        initSegment: initSegmentObject && initSegmentObject.segmentData,
+        segment: segment.isInit ? null : segmentData,
+        timestampOffset: segmentOffset,
         codec,
       });
 

--- a/src/core/buffer/representation_buffer.ts
+++ b/src/core/buffer/representation_buffer.ts
@@ -161,6 +161,7 @@ export default function RepresentationBuffer<T>({
 } : IRepresentationBufferArguments<T>) : Observable<IRepresentationBufferEvent<T>> {
   // unwrap components of the content
   const { manifest, period, adaptation, representation } = content;
+  const codec = representation.getMimeTypeString();
   const bufferType = adaptation.type;
   const initSegment = representation.index.getInitSegment();
 
@@ -393,9 +394,13 @@ export default function RepresentationBuffer<T>({
         return EMPTY;
       }
 
-      const initSegmentData = initSegmentObject && initSegmentObject.segmentData;
-      const dataToAppend = { initSegmentData, segmentData, segment, segmentOffset };
-      const append$ = appendDataInSourceBuffer(clock$, queuedSourceBuffer, dataToAppend);
+      const append$ = appendDataInSourceBuffer(clock$, queuedSourceBuffer, {
+        initSegmentData: initSegmentObject && initSegmentObject.segmentData,
+        segmentData,
+        segment,
+        segmentOffset,
+        codec,
+      });
 
       sourceBufferWaitingQueue.add(segment.id);
 

--- a/src/core/source_buffers/abstract_source_buffer.ts
+++ b/src/core/source_buffers/abstract_source_buffer.ts
@@ -19,23 +19,10 @@ import {
   Observable,
   of as observableOf,
 } from "rxjs";
+import { ICustomSourceBuffer } from "../../compat";
 import EventEmitter from "../../utils/eventemitter";
 import tryCatch from "../../utils/rx-tryCatch";
 import ManualTimeRanges from "./time_ranges";
-
-export interface ICustomSourceBuffer<T> {
-  addEventListener : (eventName : string, cb : (arg : any) => void) => void;
-  removeEventListener : (
-    eventName : string,
-    callback : (arg : any) => void
-  ) => void;
-  buffered : TimeRanges;
-  updating : boolean;
-  timestampOffset : number;
-  appendBuffer(data : T) : void;
-  remove(from : number, to : number) : void;
-  abort() : void;
-}
 
 /**
  * Abstract class for a custom SourceBuffer implementation.

--- a/src/core/source_buffers/index.ts
+++ b/src/core/source_buffers/index.ts
@@ -20,6 +20,7 @@ import features from "../../features";
 import log from "../../log";
 import BufferGarbageCollector from "./garbage_collector";
 import QueuedSourceBuffer, {
+  IAppendBufferInfos,
   IBufferType,
 } from "./queued_source_buffer";
 
@@ -305,6 +306,7 @@ function shouldHaveNativeSourceBuffer(
 
 export {
   BufferGarbageCollector,
+  IAppendBufferInfos,
   IBufferType,
   QueuedSourceBuffer,
 };

--- a/src/core/source_buffers/index.ts
+++ b/src/core/source_buffers/index.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import { ICustomSourceBuffer } from "../../compat";
 import MediaError from "../../errors/MediaError";
 import features from "../../features";
 import log from "../../log";
-import { ICustomSourceBuffer } from "./abstract_source_buffer";
 import BufferGarbageCollector from "./garbage_collector";
 import QueuedSourceBuffer, {
   IBufferType,
@@ -214,7 +214,8 @@ export default class SourceBufferManager {
           .nativeTextTracksBuffer(this._mediaElement, !!options.hideNativeSubtitle);
       }
 
-      const queuedSourceBuffer = new QueuedSourceBuffer<unknown>("text", sourceBuffer);
+      const queuedSourceBuffer =
+        new QueuedSourceBuffer<unknown>("text", codec, sourceBuffer);
 
       this._initializedSourceBuffers.text = {
         codec,
@@ -227,7 +228,8 @@ export default class SourceBufferManager {
       }
       log.info("SB: Creating a new image SourceBuffer with codec", codec);
       const sourceBuffer = new features.imageBuffer();
-      const queuedSourceBuffer = new QueuedSourceBuffer<unknown>("image", sourceBuffer);
+      const queuedSourceBuffer =
+        new QueuedSourceBuffer<unknown>("image", codec, sourceBuffer);
       this._initializedSourceBuffers.image = {
         codec,
         sourceBuffer: queuedSourceBuffer,
@@ -286,7 +288,7 @@ function createNativeQueuedSourceBuffer(
   codec : string
 ) : QueuedSourceBuffer<ArrayBuffer|ArrayBufferView|TypedArray|DataView|null> {
   const sourceBuffer = mediaSource.addSourceBuffer(codec);
-  return new QueuedSourceBuffer(bufferType, sourceBuffer);
+  return new QueuedSourceBuffer(bufferType, codec, sourceBuffer);
 }
 
 /**

--- a/src/core/source_buffers/queued_source_buffer.ts
+++ b/src/core/source_buffers/queued_source_buffer.ts
@@ -385,8 +385,10 @@ export default class QueuedSourceBuffer<T> {
         case SourceBufferAction.Append:
           const { segment, timestampOffset = 0, codec } = queueItem.args;
           if (this._currentCodec !== codec) {
-            tryToChangeSourceBufferType(this._buffer, codec);
-            this._currentCodec = codec;
+            const couldUpdateType = tryToChangeSourceBufferType(this._buffer, codec);
+            if (couldUpdateType) {
+              this._currentCodec = codec;
+            }
           }
           if (this._buffer.timestampOffset !== timestampOffset) {
             const newTimestampOffset = timestampOffset || 0;

--- a/src/core/source_buffers/queued_source_buffer.ts
+++ b/src/core/source_buffers/queued_source_buffer.ts
@@ -385,9 +385,12 @@ export default class QueuedSourceBuffer<T> {
         case SourceBufferAction.Append:
           const { segment, timestampOffset = 0, codec } = queueItem.args;
           if (this._currentCodec !== codec) {
+            log.debug("QSB: updating codec");
             const couldUpdateType = tryToChangeSourceBufferType(this._buffer, codec);
             if (couldUpdateType) {
               this._currentCodec = codec;
+            } else {
+              log.warn("QSB: could not update codec", codec, this._currentCodec);
             }
           }
           if (this._buffer.timestampOffset !== timestampOffset) {

--- a/src/core/source_buffers/queued_source_buffer.ts
+++ b/src/core/source_buffers/queued_source_buffer.ts
@@ -232,19 +232,6 @@ export default class QueuedSourceBuffer<T> {
   }
 
   /**
-   * Abort the linked SourceBuffer and dispose of the ressources used by this
-   * QueuedSourceBuffer.
-   *
-   * /!\ You won't be able to use the QueuedSourceBuffer after calling this
-   * function.
-   * @private
-   */
-  public abort() : void {
-    this.dispose();
-    this._buffer.abort();
-  }
-
-  /**
    * Returns the currently buffered data, in a TimeRanges object.
    * @returns {TimeRanges}
    */
@@ -253,17 +240,20 @@ export default class QueuedSourceBuffer<T> {
   }
 
   /**
-   * Free up ressources used by this class.
+   * Abort the linked SourceBuffer and dispose of the ressources used by this
+   * QueuedSourceBuffer.
    *
    * /!\ You won't be able to use the QueuedSourceBuffer after calling this
    * function.
+   * @private
    */
-  public dispose() : void {
+  public abort() : void {
     this._buffer.removeEventListener("update", this.__onUpdate);
     this._buffer.removeEventListener("error", this.__onError);
     this._buffer.removeEventListener("updateend", this.__flush);
     this._queue.length = 0;
     this._flushing = null;
+    this._buffer.abort();
   }
 
   /**

--- a/src/core/source_buffers/text/native/index.ts
+++ b/src/core/source_buffers/text/native/index.ts
@@ -22,11 +22,10 @@
 import {
   addTextTrack,
   ICompatTextTrack,
+  ICustomSourceBuffer,
 } from "../../../../compat";
 import log from "../../../../log";
-import AbstractSourceBuffer, {
-  ICustomSourceBuffer,
-} from "../../abstract_source_buffer";
+import AbstractSourceBuffer from "../../abstract_source_buffer";
 import parseTextTrackToCues from "./parsers";
 
 export interface INativeTextTrackData {

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -15,9 +15,9 @@
  */
 
 import { Observable } from "rxjs";
+import { ICustomSourceBuffer } from "../compat";
 import { IEMEManagerEvent } from "../core/eme";
 import { IKeySystemOption } from "../core/eme/types";
-import { ICustomSourceBuffer } from "../core/source_buffers/abstract_source_buffer";
 import {
   IDirectfileEvent,
   IDirectFileStreamOptions,


### PR DESCRIPTION
Use the very new [1] [sourceBuffer.changeType](https://developer.mozilla.org/en-US/docs/Web/API/SourceBuffer/changeType) API to allow codec-switching.

For now, if the current browser does not have this API, push the content with another codec without doing anything (which might crash, but was the previous behavior).

[1] Chromium 70; Firefox 63 and that's all for now