### PR TITLE
smooth: fix first time reference calculation

### DIFF
--- a/src/parsers/manifest/smooth/index.ts
+++ b/src/parsers/manifest/smooth/index.ts
@@ -479,7 +479,7 @@ function createSmoothStreamingParser(
 
       if (manifestDuration != null && +manifestDuration !== 0) {
         duration = lastTimeReference == null ?
-          (+manifestDuration + (firstTimeReference || 0)) / timescale :
+          (+manifestDuration / timescale) + (firstTimeReference || 0) :
           lastTimeReference;
       } else {
         duration = Infinity;
@@ -488,7 +488,7 @@ function createSmoothStreamingParser(
     }
 
     const minimumTime = firstTimeReference != null ?
-      firstTimeReference / timescale : undefined;
+      firstTimeReference : undefined;
 
     const manifest = {
       id: "gen-smooth-manifest-" + generateNewId(),


### PR DESCRIPTION
Easy fix on the HSS manifest parser:
The ``firstTimeReference`` variable was already a value expressed in seconds.

We previously divided it by the timescale a second time. This behaviour led to the following problems:
  - The duration for HSS VOD contents not starting at a `0` time was too high.
  - The default initial position for HSS VOD contents not starting at a `0` time was before the actual first segment of the manifest.
  - ``getMinimumPosition`` for HSS VOD contents not starting at a `0` time returned a time inferior to what it should be