### PR TITLE
fix: directfile playback on samsung browser

### DIFF
--- a/src/compat/constants.ts
+++ b/src/compat/constants.ts
@@ -117,14 +117,6 @@ const MediaKeys_ : ICompatMediaKeysConstructor|undefined =
     }
   };
 
-// true for IE / Edge
-const isIE : boolean =
-  navigator.appName === "Microsoft Internet Explorer" ||
-  navigator.appName === "Netscape" && /(Trident|Edge)\//.test(navigator.userAgent);
-
-const isFirefox : boolean =
-  navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
-
 const READY_STATES = {
   HAVE_NOTHING: 0,
   HAVE_METADATA: 1,
@@ -147,6 +139,4 @@ export {
   MediaSource_,
   READY_STATES,
   VTTCue_,
-  isFirefox,
-  isIE,
 };

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -34,12 +34,16 @@ import {
   ICompatMediaKeySystemConfiguration,
   ICompatTextTrack,
   ICompatVTTCue,
-  isFirefox,
-  isIE,
   MediaSource_,
   READY_STATES,
   VTTCue_,
 } from "./constants";
+import {
+  isFirefox,
+  isIE,
+  isSamsungBrowser,
+  getFirefoxMajorVersion,
+} from "./userAgents";
 import * as events from "./events";
 import {
   exitFullscreen,
@@ -417,6 +421,7 @@ export {
   clearElementSrc,
   events,
   exitFullscreen,
+  getFirefoxMajorVersion,
   getInitData,
   hasEMEAPIs,
   hasLoadedMetadata,
@@ -424,6 +429,7 @@ export {
   isFirefox,
   isFullscreen,
   isIE,
+  isSamsungBrowser,
   isOffline,
   isPlaybackStuck,
   isVTTCue,

--- a/src/compat/userAgents.ts
+++ b/src/compat/userAgents.ts
@@ -1,0 +1,31 @@
+// true for IE / Edge
+const isIE : boolean =
+  navigator.appName === "Microsoft Internet Explorer" ||
+  navigator.appName === "Netscape" && /(Trident|Edge)\//.test(navigator.userAgent);
+
+const isFirefox : boolean =
+  navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
+
+const isSamsungBrowser : boolean =
+  navigator.userAgent.toLowerCase().indexOf("samsungbrowser") !== -1;
+
+const getFirefoxMajorVersion = (): number|null => {
+  const result = navigator.userAgent.toLowerCase().match(/firefox\/(\d+)/);
+  if (!result || result.length < 2) {
+    return null;
+  }
+
+  const majorVersion = parseInt(result[1]);
+  if (isNaN(majorVersion)) {
+    return null;
+  }
+
+  return majorVersion;
+};
+
+export {
+  isFirefox,
+  isIE,
+  isSamsungBrowser,
+  getFirefoxMajorVersion
+};


### PR DESCRIPTION
### Problem Description

Samsung Internet emit loadedmetadata and canplay before it has loaded the manifest. Note that Samsung Internet does not support MediaSource by default, so directfile is used. In our case we play a HLS-stream with directfile.

The screenshot below show that rx-player will set player state to ENDED. That is because `getLoadedContentState` in `get_player_state.ts` find that the `gapBetweenDurationAndCurrentTime` is 0 because to `mediaElement.duration` is 0.

So the current flow for Samsung Internet is:
1. `loadedmetadata` recognized in `initialSeekAndPlay.ts`
1. Initial seek is triggered
1. `getLoadedContentState` get a `stalledStatus` but `media.duration` is still 0
1. PlayerState is set to ENDED

### Changes

- Moved `isIE` and `isFirefox` to `compat/userAgents.ts`, accompanied with the
new `isSamsungBrowser` and `getFirefoxMajorVersion`
- Only apply Firefox preload fix to affected versions
- Apply samsung browser preload fix for directfile
- preload is no longer set by rx-player for other browser, thus relying on the browser default which should be "auto"

By forcing preload to none for Samsung Internet, it will not emit loadedmetadata and canplay too early. We also moved some userAgent related code to its own file. 

Thoughts?

![screenshot_20181107-160916_samsung internet](https://user-images.githubusercontent.com/1225694/48139825-b93d0580-e2a7-11e8-8666-f0f6feb738fb.jpg)
