### PR TITLE
feat/Partial Periods

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -78,7 +78,7 @@ import {
 import features from "../../features";
 import Manifest, {
   Adaptation,
-  Period,
+  IFetchedPeriod,
   Representation,
 } from "../../manifest";
 import { IBifThumbnail } from "../../parsers/images/bif";
@@ -161,7 +161,7 @@ interface IPublicAPIEvent {
   error : ICustomError | Error;
   warning : ICustomError | Error;
   nativeTextTracksChange : TextTrack[];
-  periodChange : Period;
+  periodChange : IFetchedPeriod;
   availableAudioBitratesChange : number[];
   availableVideoBitratesChange : number[];
   availableAudioTracksChange : ITMAudioTrackListItem[];
@@ -363,7 +363,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      * null if no Period is being played.
      * @type {Object}
      */
-    currentPeriod : Period|null;
+    currentPeriod : IFetchedPeriod|null;
 
     /**
      * Store currently considered adaptations, per active period.
@@ -1996,7 +1996,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @param {Object} value
    * @private
    */
-  private _priv_onActivePeriodChanged({ period } : { period : Period }) : void {
+  private _priv_onActivePeriodChanged({ period } : { period : IFetchedPeriod }) : void {
     if (!this._priv_contentInfos) {
       log.error("API: The active period changed but no content is loaded");
       return;
@@ -2058,7 +2058,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   private _priv_onPeriodBufferReady(value : {
     type : IBufferType;
-    period : Period;
+    period : IFetchedPeriod;
     adaptation$ : Subject<Adaptation|null>;
   }) : void {
     const { type, period, adaptation$ } = value;
@@ -2113,7 +2113,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   private _priv_onPeriodBufferCleared(value : {
     type : IBufferType;
-    period : Period;
+    period : IFetchedPeriod;
   }) : void {
     const { type, period } = value;
 
@@ -2173,7 +2173,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   } : {
     type : IBufferType;
     adaptation : Adaptation|null;
-    period : Period;
+    period : IFetchedPeriod;
   }) : void {
     if (!this._priv_contentInfos) {
       log.error("API: The adaptations changed but no content is loaded");
@@ -2232,7 +2232,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     representation,
   }: {
     type : IBufferType;
-    period : Period;
+    period : IFetchedPeriod;
     representation : Representation|null;
   }) : void {
     if (!this._priv_contentInfos) {

--- a/src/core/api/track_manager.ts
+++ b/src/core/api/track_manager.ts
@@ -26,7 +26,7 @@ import {
 import log from "../../log";
 import {
   Adaptation,
-  Period,
+  IFetchedPeriod,
   Representation,
 } from "../../manifest";
 import arrayFind from "../../utils/array_find";
@@ -92,7 +92,7 @@ interface ITMPeriodVideoInfos { adaptations : Adaptation[];
                                 adaptation$ : Subject<Adaptation|null>; }
 
 // stored informations for a single period
-interface ITMPeriodInfos { period : Period;
+interface ITMPeriodInfos { period : IFetchedPeriod;
                            audio? : ITMPeriodAudioInfos;
                            text? : ITMPeriodTextInfos;
                            video? : ITMPeriodVideoInfos; }
@@ -138,13 +138,13 @@ export default class TrackManager {
   private _preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
 
   // Memoization of the previously-chosen audio Adaptation for each Period.
-  private _audioChoiceMemory : WeakMap<Period, Adaptation|null>;
+  private _audioChoiceMemory : WeakMap<IFetchedPeriod, Adaptation|null>;
 
   // Memoization of the previously-chosen text Adaptation for each Period.
-  private _textChoiceMemory : WeakMap<Period, Adaptation|null>;
+  private _textChoiceMemory : WeakMap<IFetchedPeriod, Adaptation|null>;
 
   // Memoization of the previously-chosen video Adaptation for each Period.
-  private _videoChoiceMemory : WeakMap<Period, Adaptation|null>;
+  private _videoChoiceMemory : WeakMap<IFetchedPeriod, Adaptation|null>;
 
   /**
    * @param {BehaviorSubject<Array.<Object|null>>} preferredAudioTracks - Array
@@ -176,7 +176,7 @@ export default class TrackManager {
    */
   public addPeriod(
     bufferType : "audio" | "text"| "video",
-    period : Period,
+    period : IFetchedPeriod,
     adaptation$ : Subject<Adaptation|null>
   ) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -204,7 +204,7 @@ export default class TrackManager {
    */
   public removePeriod(
     bufferType : "audio" | "text" | "video",
-    period : Period
+    period : IFetchedPeriod
   ) : void {
     const periodIndex = findPeriodIndex(this._periods, period);
     if (periodIndex == null) {
@@ -246,7 +246,7 @@ export default class TrackManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialAudioTrack(period : Period) : void {
+  public setInitialAudioTrack(period : IFetchedPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem && periodItem.audio;
     if (!audioInfos || !periodItem) {
@@ -277,7 +277,7 @@ export default class TrackManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialTextTrack(period : Period) : void {
+  public setInitialTextTrack(period : IFetchedPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem && periodItem.text;
     if (!textInfos || !periodItem) {
@@ -306,7 +306,7 @@ export default class TrackManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialVideoTrack(period : Period) : void {
+  public setInitialVideoTrack(period : IFetchedPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem && periodItem.video;
     if (!videoInfos || !periodItem) {
@@ -333,7 +333,7 @@ export default class TrackManager {
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
    */
-  public setAudioTrackByID(period : Period, wantedId : string) : void {
+  public setAudioTrackByID(period : IFetchedPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem && periodItem.audio;
     if (!audioInfos) {
@@ -360,7 +360,7 @@ export default class TrackManager {
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
    */
-  public setTextTrackByID(period : Period, wantedId : string) : void {
+  public setTextTrackByID(period : IFetchedPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem && periodItem.text;
     if (!textInfos) {
@@ -390,7 +390,7 @@ export default class TrackManager {
    * @throws Error - Throws if the given id is not found in any video adaptation
    * of the given Period.
    */
-  public setVideoTrackByID(period : Period, wantedId : string) : void {
+  public setVideoTrackByID(period : IFetchedPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem && periodItem.video;
     if (!videoInfos) {
@@ -419,7 +419,7 @@ export default class TrackManager {
    *
    * @throws Error - Throws if the period given has not been added
    */
-  public disableAudioTrack(period : Period) : void {
+  public disableAudioTrack(period : IFetchedPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem && periodItem.audio;
     if (!audioInfos) {
@@ -441,7 +441,7 @@ export default class TrackManager {
    *
    * @throws Error - Throws if the period given has not been added
    */
-  public disableTextTrack(period : Period) : void {
+  public disableTextTrack(period : IFetchedPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem && periodItem.text;
     if (!textInfos) {
@@ -466,7 +466,7 @@ export default class TrackManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The audio track chosen for this Period
    */
-  public getChosenAudioTrack(period : Period) : ITMAudioTrack|null {
+  public getChosenAudioTrack(period : IFetchedPeriod) : ITMAudioTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem && periodItem.audio;
     if (audioInfos == null) {
@@ -494,7 +494,7 @@ export default class TrackManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The text track chosen for this Period
    */
-  public getChosenTextTrack(period : Period) : ITMTextTrack|null {
+  public getChosenTextTrack(period : IFetchedPeriod) : ITMTextTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem && periodItem.text;
     if (textInfos == null) {
@@ -522,7 +522,7 @@ export default class TrackManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The video track chosen for this Period
    */
-  public getChosenVideoTrack(period : Period) : ITMVideoTrack|null {
+  public getChosenVideoTrack(period : IFetchedPeriod) : ITMVideoTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem && periodItem.video;
     if (videoInfos == null) {
@@ -546,7 +546,7 @@ export default class TrackManager {
    *
    * @returns {Array.<Object>}
    */
-  public getAvailableAudioTracks(period : Period) : ITMAudioTrackListItem[] {
+  public getAvailableAudioTracks(period : IFetchedPeriod) : ITMAudioTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem && periodItem.audio;
     if (audioInfos == null) {
@@ -573,7 +573,7 @@ export default class TrackManager {
    * @param {Period} period
    * @returns {Array.<Object>}
    */
-  public getAvailableTextTracks(period : Period) : ITMTextTrackListItem[] {
+  public getAvailableTextTracks(period : IFetchedPeriod) : ITMTextTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem && periodItem.text;
     if (textInfos == null) {
@@ -599,7 +599,7 @@ export default class TrackManager {
    *
    * @returns {Array.<Object>}
    */
-  public getAvailableVideoTracks(period : Period) : ITMVideoTrackListItem[] {
+  public getAvailableVideoTracks(period : IFetchedPeriod) : ITMVideoTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem && periodItem.video;
     if (videoInfos == null) {
@@ -832,7 +832,7 @@ function findFirstOptimalTextAdaptation(
 
 function findPeriodIndex(
   periods : SortedList<ITMPeriodInfos>,
-  period : Period
+  period : IFetchedPeriod
 ) : number|undefined {
   for (let i = 0; i < periods.length(); i++) {
     const periodI = periods.get(i);
@@ -844,7 +844,7 @@ function findPeriodIndex(
 
 function getPeriodItem(
   periods : SortedList<ITMPeriodInfos>,
-  period : Period
+  period : IFetchedPeriod
 ) : ITMPeriodInfos|undefined {
   for (let i = 0; i < periods.length(); i++) {
     const periodI = periods.get(i);

--- a/src/core/buffers/active_period_emitter.ts
+++ b/src/core/buffers/active_period_emitter.ts
@@ -32,19 +32,19 @@ import {
   tap,
 } from "rxjs/operators";
 import log from "../../log";
-import { Period } from "../../manifest";
+import { IFetchedPeriod } from "../../manifest";
 import SortedList from "../../utils/sorted_list";
 import {
   IBufferType,
 } from "../source_buffers";
 
 // PeriodBuffer informations emitted to the ActivePeriodEmitted
-export interface IPeriodBufferInfos { period: Period;
+export interface IPeriodBufferInfos { period: IFetchedPeriod;
                                       type: IBufferType; }
 
 // structure used internally to keep track of which Period has which
 // PeriodBuffer
-interface IPeriodItem { period: Period;
+interface IPeriodItem { period: IFetchedPeriod;
                         buffers: Set<IBufferType>; }
 
 /**
@@ -88,7 +88,7 @@ export default function ActivePeriodEmitter(
   bufferTypes: IBufferType[],
   addPeriodBuffer$ : Observable<IPeriodBufferInfos>,
   removePeriodBuffer$ : Observable<IPeriodBufferInfos>
-) : Observable<Period|null> {
+) : Observable<IFetchedPeriod|null> {
   const periodsList : SortedList<IPeriodItem> =
     new SortedList((a, b) => a.period.start - b.period.start);
 
@@ -129,7 +129,7 @@ export default function ActivePeriodEmitter(
     }));
 
   return observableMerge(onItemAdd$, onItemRemove$).pipe(
-    map(() : Period|null => {
+    map(() : IFetchedPeriod|null => {
       const head = periodsList.head();
       if (!head) {
         return null;

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -46,7 +46,7 @@ import {
 import log from "../../../log";
 import Manifest, {
   Adaptation,
-  Period,
+  IFetchedPeriod,
   Representation,
 } from "../../../manifest";
 import concatMapLatest from "../../../utils/concat_map_latest";
@@ -107,7 +107,8 @@ export default function AdaptationBuffer<T>(
   segmentFetcher : IPrioritizedSegmentFetcher<T>,
   wantedBufferAhead$ : Observable<number>,
   content : { manifest : Manifest;
-              period : Period; adaptation : Adaptation; },
+              period : IFetchedPeriod;
+              adaptation : Adaptation; },
   abrManager : ABRManager,
   options : { manualBitrateSwitchingMode : "seamless" | "direct" }
 ) : Observable<IAdaptationBufferEvent<T>> {

--- a/src/core/buffers/buffer_orchestrator.ts
+++ b/src/core/buffers/buffer_orchestrator.ts
@@ -37,6 +37,7 @@ import config from "../../config";
 import { MediaError } from "../../errors";
 import log from "../../log";
 import Manifest, {
+  IFetchedPeriod,
   Period,
 } from "../../manifest";
 import SortedList from "../../utils/sorted_list";
@@ -187,7 +188,7 @@ export default function BufferOrchestrator(
   // Emits the activePeriodChanged events every time the active Period changes.
   const activePeriodChanged$ =
     ActivePeriodEmitter(bufferTypes, addPeriodBuffer$, removePeriodBuffer$).pipe(
-      filter((period) : period is Period => !!period),
+      filter((period) : period is IFetchedPeriod => !!period),
       map(period => {
         log.info("Buffer: New active period", period);
         return EVENTS.activePeriodChanged(period);
@@ -329,6 +330,12 @@ export default function BufferOrchestrator(
     destroy$ : Observable<void>
   ) : Observable<IMultiplePeriodBuffersEvent> {
     log.info("Buffer: Creating new Buffer for", bufferType, basePeriod);
+
+    // XXX TODO
+    if (!basePeriod.isFetched()) {
+      throw new MediaError("MEDIA_TIME_NOT_FOUND",
+        "The first Period was not fetched", true);
+    }
 
     // Emits the Period of the next Period Buffer when it can be created.
     const createNextPeriodBuffer$ = new Subject<Period>();

--- a/src/core/buffers/events_generators.ts
+++ b/src/core/buffers/events_generators.ts
@@ -18,8 +18,8 @@ import { Subject } from "rxjs";
 import { ICustomError } from "../../errors";
 import {
   Adaptation,
+  IFetchedPeriod,
   ISegment,
-  Period,
   Representation,
 } from "../../manifest";
 import { IBufferType } from "../source_buffers";
@@ -48,7 +48,7 @@ const EVENTS = {
              value: { bufferType } };
   },
 
-  activePeriodChanged(period : Period) : IActivePeriodChangedEvent {
+  activePeriodChanged(period : IFetchedPeriod) : IActivePeriodChangedEvent {
     return { type : "activePeriodChanged",
              value : { period } };
   },
@@ -56,7 +56,7 @@ const EVENTS = {
   adaptationChange(
     bufferType : IBufferType,
     adaptation : Adaptation|null,
-    period : Period
+    period : IFetchedPeriod
   ) : IAdaptationChangeEvent {
     return { type: "adaptationChange",
              value : { type: bufferType,
@@ -115,7 +115,7 @@ const EVENTS = {
 
   periodBufferReady(
     type : IBufferType,
-    period : Period,
+    period : IFetchedPeriod,
     adaptation$ : Subject<Adaptation|null>
   ) : IPeriodBufferReadyEvent {
     return { type: "periodBufferReady",
@@ -124,7 +124,7 @@ const EVENTS = {
 
   periodBufferCleared(
     type : IBufferType,
-    period : Period
+    period : IFetchedPeriod
   ) : IPeriodBufferClearedEvent {
     return { type: "periodBufferCleared",
              value: { type, period } };
@@ -132,7 +132,7 @@ const EVENTS = {
 
   representationChange(
     type : IBufferType,
-    period : Period,
+    period : IFetchedPeriod,
     representation : Representation
   ) : IRepresentationChangeEvent {
     return { type: "representationChange",

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -37,7 +37,7 @@ import config from "../../../config";
 import log from "../../../log";
 import Manifest, {
   Adaptation,
-  Period,
+  IFetchedPeriod,
 } from "../../../manifest";
 import arrayIncludes from "../../../utils/array_includes";
 import InitializationSegmentCache from "../../../utils/initialization_segment_cache";
@@ -85,7 +85,7 @@ export interface IPeriodBufferArguments {
   bufferType : IBufferType;
   clock$ : Observable<IPeriodBufferClockTick>;
   content : { manifest : Manifest;
-              period : Period; };
+              period : IFetchedPeriod; };
   garbageCollectors : WeakMapMemory<QueuedSourceBuffer<unknown>, Observable<never>>;
   segmentBookkeepers : WeakMapMemory<QueuedSourceBuffer<unknown>, SegmentBookkeeper>;
   segmentPipelinesManager : SegmentPipelinesManager<any>;

--- a/src/core/buffers/types.ts
+++ b/src/core/buffers/types.ts
@@ -18,8 +18,8 @@ import { Subject } from "rxjs";
 import { ICustomError } from "../../errors";
 import {
   Adaptation,
+  IFetchedPeriod,
   ISegment,
-  Period,
   Representation,
 } from "../../manifest";
 import { IBufferType } from "../source_buffers";
@@ -91,10 +91,11 @@ export interface IBitrateEstimationChangeEvent {
 // Emitted when the current Representation considered changes
 export interface IRepresentationChangeEvent {
   type : "representationChange";
-  value : { type : IBufferType;
-            period : Period;
-            representation : Representation |
-                             null; };
+  value : {
+    type : IBufferType;
+    period : IFetchedPeriod;
+    representation : Representation|null;
+  };
 }
 
 // Every events sent by the AdaptationBuffer
@@ -106,18 +107,19 @@ export type IAdaptationBufferEvent<T> = IRepresentationBufferEvent<T> |
 // The currently-downloaded Adaptation changed.
 export interface IAdaptationChangeEvent { type : "adaptationChange";
                                           value : { type : IBufferType;
-                                                    period : Period;
+                                                    period : IFetchedPeriod;
                                                     adaptation : Adaptation |
                                                                  null; }; }
+
 // Currently-playing Period changed.
 export interface IActivePeriodChangedEvent { type: "activePeriodChanged";
-                                             value : { period: Period }; }
+                                             value : { period: IFetchedPeriod }; }
 
 // a new PeriodBuffer is ready, waiting for an adaptation/track choice.
 export interface IPeriodBufferReadyEvent {
   type : "periodBufferReady";
   value : { type : IBufferType;
-            period : Period;
+            period : IFetchedPeriod;
             adaptation$ : Subject<Adaptation|null>; };
 }
 
@@ -125,7 +127,7 @@ export interface IPeriodBufferReadyEvent {
 // cleaning-up resources.
 export interface IPeriodBufferClearedEvent { type : "periodBufferCleared";
                                              value : { type : IBufferType;
-                                                       period : Period; }; }
+                                                       period : IFetchedPeriod; }; }
 
 // The last PeriodBuffers from every type are full.
 export interface IEndOfStreamEvent { type: "end-of-stream";

--- a/src/core/init/events_generators.ts
+++ b/src/core/init/events_generators.ts
@@ -16,7 +16,7 @@
 
 import { ICustomError } from "../../errors";
 import Manifest, {
-  Period,
+  IFetchedPeriod,
 } from "../../manifest";
 import ABRManager from "../abr";
 import { IRepresentationChangeEvent } from "../buffers";
@@ -79,7 +79,7 @@ function speedChanged(speed : number) : ISpeedChangedEvent {
  */
 function nullRepresentation(
   type : IBufferType,
-  period : Period
+  period : IFetchedPeriod
 ) : IRepresentationChangeEvent {
   return { type: "representationChange",
            value: { type,

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -31,7 +31,7 @@ import {
 import { MediaError } from "../../errors";
 import log from "../../log";
 import Manifest, {
-  Period,
+  IFetchedPeriod,
 } from "../../manifest";
 import ABRManager from "../abr";
 import BufferOrchestrator, {
@@ -121,7 +121,7 @@ export default function createMediaSourceLoader({
                                                              duration);
 
     const initialPeriod = manifest.getPeriodForTime(initialTime);
-    if (initialPeriod == null) {
+    if (initialPeriod == null || !initialPeriod.isFetched()) { // XXX TODO
       throw new MediaError("MEDIA_STARTING_TIME_NOT_FOUND",
                            "Wanted starting time not found in the Manifest.",
                            true);
@@ -232,7 +232,7 @@ export default function createMediaSourceLoader({
  */
 function createNativeSourceBuffersForPeriod(
   sourceBuffersManager : SourceBuffersManager,
-  period : Period
+  period : IFetchedPeriod
 ) : void {
   Object.keys(period.adaptations).forEach(bufferType => {
     if (SourceBuffersManager.isNative(bufferType)) {

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -25,7 +25,10 @@ import Manifest, {
   ISupplementaryImageTrack,
   ISupplementaryTextTrack,
 } from "./manifest";
-import Period from "./period";
+import Period, {
+  IFetchedPeriod,
+  IPartialPeriod,
+} from "./period";
 import Representation from "./representation";
 import IRepresentationIndex, {
   ISegment,
@@ -40,8 +43,10 @@ export {
 
   // types
   IAdaptationType,
+  IFetchedPeriod,
   IManifestArguments,
   IManifestParsingOptions,
+  IPartialPeriod,
   IRepresentationFilter,
   IRepresentationIndex,
   ISegment,

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -25,6 +25,8 @@ import Adaptation, {
   IRepresentationFilter,
 } from "./adaptation";
 import Period, {
+  IFetchedPeriod,
+  IPartialPeriod,
   IPeriodArguments,
 } from "./period";
 import { StaticRepresentationIndex } from "./representation_index";
@@ -269,7 +271,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     warnOnce("manifest.getAdaptations() is deprecated." +
              " Please use manifest.period[].getAdaptations() instead");
     const firstPeriod = this.periods[0];
-    if (!firstPeriod) {
+    if (!firstPeriod || !firstPeriod.isFetched()) {
       return [];
     }
     const adaptationsByType = firstPeriod.adaptations;
@@ -292,7 +294,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     warnOnce("manifest.getAdaptationsForType(type) is deprecated." +
              " Please use manifest.period[].getAdaptationsForType(type) instead");
     const firstPeriod = this.periods[0];
-    if (!firstPeriod) {
+    if (!firstPeriod || !firstPeriod.isFetched()) {
       return [];
     }
     return firstPeriod.adaptations[adaptationType] || [];
@@ -443,10 +445,14 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     });
 
     if (newImageTracks.length && this.periods.length) {
-      const { adaptations } = this.periods[0];
-      adaptations.image =
-        adaptations.image ? adaptations.image.concat(newImageTracks) :
-                            newImageTracks;
+      const firstPeriod = this.periods[0];
+      if (firstPeriod.adaptations == null) {
+        firstPeriod.adaptations = {};
+      }
+      const { adaptations } = firstPeriod;
+      adaptations.image = adaptations.image ? adaptations.image
+                                                         .concat(newImageTracks) :
+                                              newImageTracks;
     }
   }
 
@@ -492,17 +498,23 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     }, []);
 
     if (newTextAdaptations.length && this.periods.length) {
-      const { adaptations } = this.periods[0];
-      adaptations.text =
-        adaptations.text ? adaptations.text.concat(newTextAdaptations) :
-                           newTextAdaptations;
+      const firstPeriod = this.periods[0];
+      if (firstPeriod.adaptations == null) {
+        firstPeriod.adaptations = {};
+      }
+      const { adaptations } = firstPeriod;
+      adaptations.text = adaptations.text ? adaptations.text
+                                                       .concat(newTextAdaptations) :
+                                            newTextAdaptations;
     }
   }
 }
 
 export {
+  IFetchedPeriod,
   IManifestArguments,
   IManifestParsingOptions,
+  IPartialPeriod,
   ISupplementaryImageTrack,
   ISupplementaryTextTrack,
 };

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -52,6 +52,7 @@ export interface IPartialPeriod {
   start : number;
   duration? : number;
   end? : number;
+  url? : string;
   getAdaptation(wantedId : number|string) : Adaptation|undefined;
   getAdaptations() : Adaptation[];
   getAdaptationsForType(adaptationType : IAdaptationType) : Adaptation[];

--- a/src/parsers/manifest/dash/get_last_time_reference.ts
+++ b/src/parsers/manifest/dash/get_last_time_reference.ts
@@ -73,6 +73,11 @@ export default function getLastTimeReference(
   }
   const lastPeriodAdaptations =
     manifest.periods[manifest.periods.length - 1].adaptations;
+
+  if (lastPeriodAdaptations == null) {
+    // XXX TODO?
+    throw new Error("DASH Parser: the last period is not fetched for a live content.");
+  }
   const firstAdaptationsFromLastPeriod =
     lastPeriodAdaptations.video || lastPeriodAdaptations.audio;
   if (!firstAdaptationsFromLastPeriod || !firstAdaptationsFromLastPeriod.length) {

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -69,6 +69,7 @@ export interface IParsedPartialPeriod {
   start : number;
 
   // optional
+  url? : string;
   adaptations? : IParsedAdaptations;
   duration? : number;
   end? : number;

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -62,11 +62,24 @@ export interface IParsedPeriod {
   end? : number;
 }
 
+// Period for which the adaptations are not yet known
+export interface IParsedPartialPeriod {
+  // required
+  id : string;
+  start : number;
+
+  // optional
+  adaptations? : IParsedAdaptations;
+  duration? : number;
+  end? : number;
+}
+
 export interface IParsedManifest {
   // required
   id: string; // Unique ID for the manifest.
   isLive : boolean; // If true, this Manifest describes a content not finished yet.
-  periods: IParsedPeriod[]; // Periods contained in this manifest.
+  periods: Array<IParsedPeriod|IParsedPartialPeriod>;  // Periods contained in
+                                                       // this manifest.
   transportType: string; // "smooth", "dash" etc.
 
   // optional

--- a/src/parsers/manifest/utils/check_manifest_ids.ts
+++ b/src/parsers/manifest/utils/check_manifest_ids.ts
@@ -42,6 +42,9 @@ export default function checkManifestIDs(
       periodIDS.push(periodID);
     }
     const { adaptations } = period;
+    if (adaptations == null) {
+      return;
+    }
     const adaptationIDs : string[] = [];
     Object.keys(adaptations).forEach((type) => {
       (adaptations[type] || []).forEach(adaptation => {


### PR DESCRIPTION
Add the possibility to have a partial period we can lazy-load only when needed.

Useful for:
  - DASH xlinks in onRequest mode
  - the metaplaylist transport

What is done:
  - [x] set IPartialPeriod type
  - [ ] perform manifest update when the periods are loaded
  - [x] load the partial period when needed
  - [ ] apply to DASH's xlinks
  - [ ] apply to metaplaylist periods