### PR TITLE
fix/api: make sure the LOADED state change is sent after the initial seek

### DIFF
--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -17,7 +17,6 @@
 import nextTick from "next-tick";
 import {
   defer as observableDefer,
-  fromEvent as observableFromEvent,
   Observable,
   Observer,
   of as observableOf,
@@ -169,22 +168,6 @@ function hasLoadedMetadata(
     return observableOf(null);
   } else {
     return events.onLoadedMetadata$(mediaElement)
-      .pipe(take(1));
-  }
-}
-
-/**
- * Returns ane observable emitting a single time, as soon as a play is possible.
- * @param {HTMLMediaElement} mediaElement
- * @returns {Observable}
- */
-function canPlay(
-  mediaElement : HTMLMediaElement
-) : Observable<unknown> {
-  if (mediaElement.readyState >= READY_STATES.HAVE_ENOUGH_DATA) {
-    return observableOf(null);
-  } else {
-    return observableFromEvent(mediaElement, "canplay")
       .pipe(take(1));
   }
 }
@@ -460,7 +443,6 @@ export {
   VTTCue_,
   addTextTrack,
   canPatchISOBMFFSegment,
-  canPlay,
   clearElementSrc,
   events,
   exitFullscreen,

--- a/src/core/stream/directfile.ts
+++ b/src/core/stream/directfile.ts
@@ -137,10 +137,8 @@ export default function StreamDirectFile({
     getDirectFileInitialTime(mediaElement, startAt);
   log.debug("Stream: Initial time calculated:", initialTime);
 
-  const {
-    seek$,
-    load$,
-  } = seekAndLoadOnMediaEvents(mediaElement, initialTime, autoPlay);
+  const { seek$, load$ } =
+    seekAndLoadOnMediaEvents(clock$, mediaElement, initialTime, autoPlay);
 
   // Create EME Manager, an observable which will manage every EME-related
   // issue.

--- a/src/core/stream/initial_seek_and_play.ts
+++ b/src/core/stream/initial_seek_and_play.ts
@@ -76,7 +76,7 @@ function doInitialSeek(
  */
 function canPlay(clock$ : Observable<IStreamClockTick>) {
   return clock$.pipe(filter(tick => {
-    return tick.seeking !== true && tick.stalled == null &&
+    return !tick.seeking && tick.stalled == null &&
       (tick.readyState === 4 || tick.readyState === 3 && tick.currentRange != null);
   }), take(1));
 }

--- a/src/core/stream/initial_seek_and_play.ts
+++ b/src/core/stream/initial_seek_and_play.ts
@@ -75,10 +75,13 @@ function doInitialSeek(
  * @returns {Observable}
  */
 function canPlay(clock$ : Observable<IStreamClockTick>) {
-  return clock$.pipe(filter(tick => {
-    return !tick.seeking && tick.stalled == null &&
-      (tick.readyState === 4 || tick.readyState === 3 && tick.currentRange != null);
-  }), take(1));
+  return clock$.pipe(
+    filter((tick) => {
+      return !tick.seeking && tick.stalled == null &&
+        (tick.readyState === 4 || tick.readyState === 3 && tick.currentRange != null);
+    }),
+    take(1)
+  );
 }
 
 /**

--- a/src/core/stream/stream_loader.ts
+++ b/src/core/stream/stream_loader.ts
@@ -141,7 +141,7 @@ export default function StreamLoader({
     createNativeSourceBuffersForPeriod(sourceBufferManager, initialPeriod);
 
     const { seek$, load$ } =
-      seekAndLoadOnMediaEvents(mediaElement, initialTime, autoPlay);
+      seekAndLoadOnMediaEvents(clock$, mediaElement, initialTime, autoPlay);
 
     const bufferClock$ = createBufferClock(manifest, clock$, seek$, speed$, initialTime);
 

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -38,6 +38,7 @@ export interface IStreamClockTick {
     reason : "seeking" | "not-ready" | "buffering";
     timestamp : number;
   } | null;
+  seeking : boolean;
 }
 
 // The manifest has been downloaded and parsed for the first time


### PR DESCRIPTION
This fix #386 

I'll copy paste my solution here.

---

This PR redefine the time when we declare the content as `LOADED`.
Basically it is now when all those conditions are met:
  - the media element is not currently "seeking" (when the media element announce that a seeking action is still taking place)
  - the media element is not considered as stalled (when we force the content to pause while we wait for more data to come)
  - the media element has a readyState of ``4`` or of ``3`` but with the current range bufferised (basically, this means that the content can begin to play immediately)