### PR TITLE
fix: use response url in create_loader

### DIFF
--- a/src/core/pipelines/create_loader.ts
+++ b/src/core/pipelines/create_loader.ts
@@ -283,6 +283,7 @@ export default function createLoader<T, U>(
                 const response$ = observableOf({
                   type: "response" as "response",
                   value: objectAssign({}, resolverResponse, {
+                    url: arg.type === "response" ? arg.value.url : undefined,
                     responseData: arg.value.responseData,
                     sendingTime: arg.type === "response" ?
                       arg.value.sendingTime : undefined,


### PR DESCRIPTION
Hi,

It's currently not possible to play manifest urls that have been redirected, because the `xhr.responseUrl` is lost in `create_loader.ts`. Not sure if this worked before.

See: https://switcher.cdn.svt.se/1383013-001A_072aba30.mpd

This change will modify the response value from the pipeline. Previously the url was assigned from `resolverResponse` (which is { url: '...' } in dash).

Also not sure if this is the best fix. Thoughts?

P.S. do you want PRs to master or release branches?