### PR TITLE
misc: use substring instead of substr

### DIFF
--- a/src/parsers/manifest/dash/node_parsers/index.ts
+++ b/src/parsers/manifest/dash/node_parsers/index.ts
@@ -110,7 +110,7 @@ function inferAdaptationType(
   }
 
   function fromCodecs(codecs : string) {
-    switch (codecs.substr(0, 3)) {
+    switch (codecs.substring(0, 3)) {
       case "avc":
       case "hev":
       case "hvc":
@@ -124,7 +124,7 @@ function inferAdaptationType(
         return "image";
     }
 
-    switch (codecs.substr(0, 4)) {
+    switch (codecs.substring(0, 4)) {
       case "mp4a":
         return "audio";
       case "wvtt":

--- a/src/parsers/manifest/smooth/get_codecs.ts
+++ b/src/parsers/manifest/smooth/get_codecs.ts
@@ -28,7 +28,7 @@ export function getAudioCodecs(
     mpProfile = 5; // High Efficiency AAC Profile
   } else {
     mpProfile = codecPrivateData ?
-      (parseInt(codecPrivateData.substr(0, 2), 16) & 0xF8) >> 3 : 2;
+      (parseInt(codecPrivateData.substring(0, 2), 16) & 0xF8) >> 3 : 2;
   }
   return mpProfile ? ("mp4a.40." + mpProfile) : "";
 }

--- a/src/parsers/texttracks/ttml/style.ts
+++ b/src/parsers/texttracks/ttml/style.ts
@@ -64,7 +64,7 @@ export function getStylingAttributes(
           } else if (name === "region") {
             regionID = attribute.value;
           } else {
-            const nameWithoutTTS = name.substr(4);
+            const nameWithoutTTS = name.substring(4);
             if (arrayIncludes(leftAttributes, nameWithoutTTS)) {
               currentStyle[nameWithoutTTS] = attribute.value;
               leftAttributes.splice(j, 1);
@@ -137,7 +137,7 @@ export function getStylingFromElement(node : Node) : IStyleList {
   for (let i = 0; i <= element.attributes.length - 1; i++) {
     const styleAttribute = element.attributes[i];
     if (startsWith(styleAttribute.name, "tts")) {
-      const nameWithoutTTS = styleAttribute.name.substr(4);
+      const nameWithoutTTS = styleAttribute.name.substring(4);
       currentStyle[nameWithoutTTS] = styleAttribute.value;
     }
   }

--- a/src/utils/__tests__/starts-with.test.ts
+++ b/src/utils/__tests__/starts-with.test.ts
@@ -39,14 +39,7 @@ describe("utils - starts-with", () => {
     expect(startsWith("Hiders", "Hid", 1)).to.eql(false);
 
     expect(startsWith("Come Down To Us", "")).to.eql(true);
+    expect(startsWith("Rough Sleeper", "Ro", -5)).to.eql(true);
     expect(startsWith("", "")).to.eql(true);
-  });
-
-  it("should take a starting index as first argument", () => {
-    expect(startsWith("Shaka-Player", "Shaka", 0)).to.eql(true);
-    expect(startsWith("Shaka-Player", "Shaka", 1)).to.eql(false);
-    expect(startsWith("Shaka-Player", "haka", 0)).to.eql(false);
-    expect(startsWith("Shaka-Player", "haka", 1)).to.eql(true);
-    expect(startsWith("Shaka-Player", "haka", 2)).to.eql(false);
   });
 });

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -78,7 +78,7 @@ function hexToBytes(str : string) : Uint8Array {
   const len = str.length;
   const arr = new Uint8Array(len / 2);
   for (let i = 0, j = 0; i < len; i += 2, j++) {
-    arr[j] = parseInt(str.substr(i, 2), 16) & 0xFF;
+    arr[j] = parseInt(str.substring(i, i + 2), 16) & 0xFF;
   }
   return arr;
 }

--- a/src/utils/starts-with.ts
+++ b/src/utils/starts-with.ts
@@ -36,6 +36,7 @@ export default function startsWith(
     return completeString.startsWith(searchString, position);
     /* tslint:enable ban */
   }
+  const initialPosition = position || 0;
   return completeString
-    .substr(position || 0, searchString.length) === searchString;
+    .substring(initialPosition, initialPosition + searchString.length) === searchString;
 }

--- a/src/utils/starts-with.ts
+++ b/src/utils/starts-with.ts
@@ -36,7 +36,7 @@ export default function startsWith(
     return completeString.startsWith(searchString, position);
     /* tslint:enable ban */
   }
-  const initialPosition = position || 0;
+  const initialPosition = typeof position === "number" ? Math.max(position, 0) : 0;
   return completeString
     .substring(initialPosition, initialPosition + searchString.length) === searchString;
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -75,12 +75,12 @@ function resolveURL(...args : Array<string|undefined>) : string {
     else {
       // trim if begins with "/"
       if (part[0] === "/") {
-        part = part.substr(1);
+        part = part.substring(1);
       }
 
       // trim if ends with "/"
       if (base[base.length - 1] === "/") {
-        base = base.substr(0, base.length - 1);
+        base = base.substring(0, base.length - 1);
       }
 
       base = base + "/" + part;

--- a/tslint.json
+++ b/tslint.json
@@ -21,6 +21,7 @@
       ["*", "find"],
       ["*", "findIndex"],
       ["*", "startsWith"],
+      ["*", "substr"],
       ["Promise"],
       ["Promise", "reject"],
       ["Promise", "resolve"]


### PR DESCRIPTION
Using both `substr` and `substring` in the code is confusing.

Also, MDN [tells us](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) that `substr` is now considered a legacy function (even if I didn't find any other source on that one.

What I did there:
  - ban `substr` from being used
  - use `substring` instead in any part of the code where `substr` was used.