### PR TITLE
Net/return manifest directly

### DIFF
--- a/doc/architecture/pipelines/index.md
+++ b/doc/architecture/pipelines/index.md
@@ -25,8 +25,6 @@ current transport protocol to return an unified Manifest object.
 This is the part of the code that interacts with `transports` to perform the
 request and parsing  of the Manifest file.
 
-It can also add multiple supplementary Image or Text tracks to a given Manifest.
-
 
 
 ## The SegmentPipelinesManager #################################################

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -728,8 +728,10 @@ class Player extends EventEmitter<PLAYER_EVENT_STRINGS, any> {
         throw new Error(`transport "${transport}" not supported`);
       }
 
-      const pipelines = transportFn(transportOptions);
-      const { representationFilter } = transportOptions;
+      const pipelines = transportFn(objectAssign({
+        supplementaryTextTracks,
+        supplementaryImageTracks,
+      }, transportOptions));
 
       // Options used by the ABR Manager.
       const adaptiveOptions = {
@@ -769,17 +771,10 @@ class Player extends EventEmitter<PLAYER_EVENT_STRINGS, any> {
         keySystems,
         mediaElement: videoElement,
         networkConfig,
+        pipelines,
         speed$: this._priv_speed$,
         startAt,
         textTrackOptions,
-        transport: {
-          pipelines,
-          options: {
-            representationFilter,
-            supplementaryImageTracks,
-            supplementaryTextTracks,
-          },
-        },
         url,
       })
         .pipe(takeUntil(contentIsStopped$))

--- a/src/core/buffer/period_buffer_manager.ts
+++ b/src/core/buffer/period_buffer_manager.ts
@@ -360,10 +360,9 @@ export default function PeriodBufferManager(
 
     // Create Period Buffer for the next Period.
     const nextPeriodBuffer$ = createNextPeriodBuffer$
-      .pipe(exhaustMap((nextPeriod) => {
-        return manageConsecutivePeriodBuffers(
-          bufferType, nextPeriod, destroyNextBuffers$);
-      }));
+      .pipe(exhaustMap((nextPeriod) =>
+        manageConsecutivePeriodBuffers(bufferType, nextPeriod, destroyNextBuffers$)
+      ));
 
     // Allows to destroy each created Buffer, from the newest to the oldest,
     // once destroy$ emits.

--- a/src/core/init/index.ts
+++ b/src/core/init/index.ts
@@ -41,6 +41,7 @@ import config from "../../config";
 import { ICustomError } from "../../errors";
 import log from "../../log";
 import Manifest from "../../manifest";
+import { ITransportPipelines } from "../../net/types";
 import throttle from "../../utils/rx-throttle";
 import ABRManager, {
   IABRMetric,
@@ -49,7 +50,6 @@ import ABRManager, {
 import { IKeySystemOption } from "../eme/types";
 import {
   createManifestPipeline,
-  IManifestTransportInfos,
   IPipelineOptions,
   SegmentPipelinesManager,
 } from "../pipelines";
@@ -122,7 +122,7 @@ export interface IInitializeOptions {
   speed$ : Observable<number>;
   startAt? : IInitialTimeOptions;
   textTrackOptions : ITextTrackSourceBufferOptions;
-  transport : IManifestTransportInfos;
+  pipelines : ITransportPipelines;
   url : string;
 }
 
@@ -160,7 +160,7 @@ export default function Initialize({
   speed$,
   startAt,
   textTrackOptions,
-  transport,
+  pipelines,
   url,
 } : IInitializeOptions) : Observable<IInitEvent> {
   // Subject through which warnings will be sent
@@ -169,7 +169,7 @@ export default function Initialize({
   // Fetch and parse the manifest from the URL given.
   // Throttled to avoid doing multiple simultaneous requests.
   const fetchManifest = throttle(createManifestPipeline(
-    transport,
+    pipelines,
     getManifestPipelineOptions(networkConfig),
     warning$
   ));
@@ -184,7 +184,7 @@ export default function Initialize({
 
   // Creates pipelines for downloading segments.
   const segmentPipelinesManager = new SegmentPipelinesManager<any>(
-    transport.pipelines, requestsInfos$, network$, warning$);
+    pipelines, requestsInfos$, network$, warning$);
 
   // Create ABR Manager, which will choose the right "Representation" for a
   // given "Adaptation".

--- a/src/core/pipelines/index.ts
+++ b/src/core/pipelines/index.ts
@@ -16,7 +16,6 @@
 
 import createManifestPipeline, {
   IFetchManifestResult,
-  IManifestTransportInfos,
 } from "./manifest";
 import SegmentPipelinesManager, {
   IFetchedSegment,
@@ -27,7 +26,6 @@ import SegmentPipelinesManager, {
 export {
   createManifestPipeline,
   IFetchManifestResult,
-  IManifestTransportInfos,
   IFetchedSegment,
   IPipelineOptions,
   SegmentPipelinesManager,

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -16,7 +16,6 @@
 
 import arrayFind from "array-find";
 import objectAssign from "object-assign";
-import { Subject } from "rxjs";
 import { isCodecSupported } from "../compat";
 import { ICustomError } from "../errors";
 import MediaError from "../errors/MediaError";
@@ -121,16 +120,22 @@ export default class Adaptation {
   public manuallyAdded? : boolean;
 
   /**
+   * Array containing every errors that happened when the Adaptation has been
+   * created, in the order they have happened.
+   * @type {Array.<Error>}
+   */
+  public readonly parsingErrors : Array<Error|ICustomError>;
+
+  /**
    * @constructor
    * @param {Object} args
-   * @param {Subject} warning$
    * @param {Function|undefined} [representationFilter]
    */
   constructor(
     args : IAdaptationArguments,
-    warning$ : Subject<Error|ICustomError>,
     representationFilter? : IRepresentationFilter
   ) {
+    this.parsingErrors = [];
     const nId = generateNewId();
     this.id = args.id == null ? nId : "" + args.id;
     this.type = args.type;
@@ -142,7 +147,7 @@ export default class Adaptation {
     if (hadRepresentations && argsRepresentations.length === 0) {
       log.warn("Incompatible codecs for adaptation", args);
       const error = new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR", null, false);
-      warning$.next(error);
+      this.parsingErrors.push(error);
     }
 
     if (args.language != null) {

--- a/src/transports/dash/index.ts
+++ b/src/transports/dash/index.ts
@@ -109,7 +109,6 @@ export default function(
       const data = typeof response.responseData === "string" ?
         new DOMParser().parseFromString(response.responseData, "text/xml") :
         response.responseData;
-
       const parsedManifest = dashManifestParser(data, url);
       return loadExternalRessources(parsedManifest);
 
@@ -117,11 +116,7 @@ export default function(
         parserResponse : IMPDParserResponse
       ) : IManifestParserObservable {
         if (parserResponse.type === "done") {
-          const manifest = new Manifest(parserResponse.value, {
-            representationFilter: options.representationFilter,
-            supplementaryImageTracks: options.supplementaryImageTracks,
-            supplementaryTextTracks: options.supplementaryTextTracks,
-          });
+          const manifest = new Manifest(parserResponse.value, options);
           return observableOf({ manifest, url });
         }
 

--- a/src/transports/dash/index.ts
+++ b/src/transports/dash/index.ts
@@ -30,6 +30,7 @@ import {
   mergeMap,
 } from "rxjs/operators";
 import features from "../../features";
+import Manifest from "../../manifest";
 import {
   getMDHDTimescale,
   getSegmentsFromSidx,
@@ -42,6 +43,18 @@ import dashManifestParser, {
   IMPDParserResponse,
 } from "../../parsers/manifest/dash";
 import request from "../../utils/request";
+import {
+  ILoaderObservable,
+  ImageParserObservable,
+  IManifestLoaderArguments,
+  IManifestParserArguments,
+  IManifestParserObservable,
+  ISegmentLoaderArguments,
+  ISegmentParserArguments,
+  ITransportOptions,
+  ITransportPipelines,
+  SegmentParserObservable,
+} from "../types";
 import generateManifestLoader from "../utils/manifest_loader";
 import getISOBMFFTimingInfos from "./isobmff_timing_infos";
 import generateSegmentLoader from "./segment_loader";
@@ -50,25 +63,6 @@ import {
   parser as TextTrackParser,
 } from "./texttracks";
 import { addNextSegments } from "./utils";
-
-import {
-  CustomManifestLoader,
-  CustomSegmentLoader,
-  ILoaderObservable,
-  ImageParserObservable,
-  IManifestLoaderArguments,
-  IManifestParserArguments,
-  IManifestParserObservable,
-  ISegmentLoaderArguments,
-  ISegmentParserArguments,
-  ITransportPipelines,
-  SegmentParserObservable,
-} from "../types";
-
-interface IDASHOptions {
-  manifestLoader? : CustomManifestLoader;
-  segmentLoader? : CustomSegmentLoader;
-}
 
 /**
  * Request external "xlink" ressource from a MPD.
@@ -93,7 +87,7 @@ function requestXLink(xlinkURL : string) : Observable<string> {
  * @returns {Object}
  */
 export default function(
-  options : IDASHOptions = {}
+  options : ITransportOptions = {}
 ) : ITransportPipelines {
   const manifestLoader = generateManifestLoader({
     customManifestLoader: options.manifestLoader,
@@ -115,13 +109,20 @@ export default function(
       const data = typeof response.responseData === "string" ?
         new DOMParser().parseFromString(response.responseData, "text/xml") :
         response.responseData;
+
       const parsedManifest = dashManifestParser(data, url);
+      return loadExternalRessources(parsedManifest);
 
       function loadExternalRessources(
         parserResponse : IMPDParserResponse
       ) : IManifestParserObservable {
         if (parserResponse.type === "done") {
-          return observableOf({ manifest: parserResponse.value, url });
+          const manifest = new Manifest(parserResponse.value, {
+            representationFilter: options.representationFilter,
+            supplementaryImageTracks: options.supplementaryImageTracks,
+            supplementaryTextTracks: options.supplementaryTextTracks,
+          });
+          return observableOf({ manifest, url });
         }
 
         const { ressources, continue: continueParsing } = parserResponse.value;
@@ -133,7 +134,6 @@ export default function(
             loadExternalRessources(continueParsing(loadedRessources))
           ));
       }
-      return loadExternalRessources(parsedManifest);
     },
   };
 

--- a/src/transports/smooth/index.ts
+++ b/src/transports/smooth/index.ts
@@ -26,7 +26,7 @@ import {
 import { map } from "rxjs/operators";
 import features from "../../features";
 import log from "../../log";
-import {
+import Manifest, {
   Adaptation,
   Representation,
 } from "../../manifest";
@@ -146,7 +146,12 @@ export default function(
         new DOMParser().parseFromString(response.responseData, "text/xml") :
         response.responseData;
       const { receivedTime: manifestReceivedTime } = response;
-      const manifest = smoothManifestParser(data, url, manifestReceivedTime);
+      const parserResult = smoothManifestParser(data, url, manifestReceivedTime);
+      const manifest = new Manifest(parserResult, {
+        representationFilter: options.representationFilter,
+        supplementaryImageTracks: options.supplementaryImageTracks,
+        supplementaryTextTracks: options.supplementaryTextTracks,
+      });
       return observableOf({ manifest, url });
     },
   };

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -20,12 +20,14 @@ import {
 } from "rxjs";
 import Manifest, {
   Adaptation,
+  IRepresentationFilter,
   ISegment,
+  ISupplementaryImageTrack,
+  ISupplementaryTextTrack,
   Period,
   Representation,
 } from "../manifest";
 import { IBifThumbnail } from "../parsers/images/bif";
-import { IParsedManifest } from "../parsers/manifest/types";
 
 // Contains timings informations on a single segment.
 // Those variables expose the best guess we have on the effective duration and
@@ -145,12 +147,13 @@ export interface ISegmentParserArguments<T> {
 
 // -- response
 
-export interface IManifestResult {
-  manifest: IParsedManifest; // the manifest itself
+// Result from the Manifest parser
+export interface IManifestParserResult {
+  manifest: Manifest; // the manifest itself
   url? : string; // final URL of the manifest
 }
 
-export type IManifestParserObservable = Observable<IManifestResult>;
+export type IManifestParserObservable = Observable<IManifestParserResult>;
 
 export type SegmentParserObservable = Observable<{
   segmentData : Uint8Array|ArrayBuffer|null; // Data to decode
@@ -273,6 +276,9 @@ export interface ITransportOptions {
   referenceDateTime? : number;
   minRepresentationBitrate? : number;
   keySystems? : (hex? : Uint8Array) => IParsedKeySystem[];
+  representationFilter? : IRepresentationFilter;
+  supplementaryImageTracks? : ISupplementaryImageTrack[];
+  supplementaryTextTracks? : ISupplementaryTextTrack[];
 }
 
 export type ITransportFunction = (options? : ITransportOptions) =>


### PR DESCRIPTION
The manifest parser from the net pipelines should now return a `Manifest` instance directly and not a `IParsedManifest` used to generate a Manifest instance.

This makes more sense and helps us if we want to include MetaPlaylist support.

Note: we could also directly return a Manifest instance in the parser though, I let you be the judge. This would completely obliterate the need of a `IParsedManifest` to be defined in `src/parsers/manifest`.

I also added a special `parsingErrors` property to `Manifest`, `Period` and `Adaptation` and removed the warning subject. This property will contain, after the parsing, every non-fatal error that happened during it in chronological order.

We should get rid of this kinds of Subjects in general: Because a library user can bind a callback to any of those warnings. If they do an action that lead to other effects (like stopping the player on a specific warning), continuing to parse after that callback can lead us to weird half-stopped states.