### PR TITLE
Misc/manifest tolerance improvements

### DIFF
--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -120,7 +120,8 @@ export default function createMediaSourceLoader({
     const manifest = manifest$.getValue();
 
     // TODO Update the duration if it evolves?
-    setDurationToMediaSource(mediaSource, manifest.getDuration());
+    const duration = manifest.getDuration() || Infinity;
+    setDurationToMediaSource(mediaSource, duration);
 
     const initialPeriod = manifest.getPeriodForTime(initialTime);
     if (initialPeriod == null) {

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -121,7 +121,8 @@ export default function createMediaSourceLoader({
 
     // TODO Update the duration if it evolves?
     const duration = manifest.getDuration();
-    setDurationToMediaSource(mediaSource, duration == null ? Infinity : 0);
+    setDurationToMediaSource(mediaSource,
+      duration == null ?  Infinity : duration);
 
     const initialPeriod = manifest.getPeriodForTime(initialTime);
     if (initialPeriod == null) {

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -120,8 +120,8 @@ export default function createMediaSourceLoader({
     const manifest = manifest$.getValue();
 
     // TODO Update the duration if it evolves?
-    const duration = manifest.getDuration() || Infinity;
-    setDurationToMediaSource(mediaSource, duration);
+    const duration = manifest.getDuration();
+    setDurationToMediaSource(mediaSource, duration == null ? Infinity : 0);
 
     const initialPeriod = manifest.getPeriodForTime(initialTime);
     if (initialPeriod == null) {

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -22,6 +22,7 @@ import { ICustomError } from "../errors";
 import MediaError from "../errors/MediaError";
 import log from "../log";
 import generateNewId from "../utils/id";
+import { normalize as normalizeLang } from "../utils/languages";
 import uniq from "../utils/uniq";
 import Representation, {
   IRepresentationArguments,
@@ -56,7 +57,6 @@ export interface IAdaptationArguments {
   closedCaption? : boolean;
   language? : string;
   manuallyAdded? : boolean;
-  normalizedLanguage? : string;
 }
 
 /**
@@ -147,10 +147,7 @@ export default class Adaptation {
 
     if (args.language != null) {
       this.language = args.language;
-    }
-
-    if (args.normalizedLanguage != null) {
-      this.normalizedLanguage = args.normalizedLanguage;
+      this.normalizedLanguage = normalizeLang(args.language);
     }
 
     if (args.closedCaption != null) {

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -47,13 +47,13 @@ export type IRepresentationFilter = (
 
 export interface IAdaptationArguments {
   // -- required
+  id : string;
   representations : IRepresentationArguments[];
   type : IAdaptationType;
 
   // -- optional
   audioDescription? : boolean;
   closedCaption? : boolean;
-  id? : number|string;
   language? : string;
   manuallyAdded? : boolean;
   normalizedLanguage? : string;

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -53,19 +53,22 @@ interface ISupplementaryTextTrack {
 }
 
 interface IManifestArguments {
+  // required
+  id : string;
+  isLive : boolean;
+  periods : IPeriodArguments[];
+  transportType : string;
+
+  // optional
   availabilityStartTime? : number;
   baseURL? : string;
   duration? : number;
-  isLive : boolean;
-  minimumTime? : number;
   lifetime? : number;
-  id : string;
-  periods : IPeriodArguments[];
+  minimumTime? : number;
   presentationLiveGap? : number;
   suggestedPresentationDelay? : number;
   timeShiftBufferDepth? : number;
-  transportType : string;
-  uris : string[];
+  uris? : string[];
 }
 
 interface IManifestParsingOptions {
@@ -215,7 +218,7 @@ export default class Manifest {
 
     this.minimumTime = args.minimumTime;
     this.isLive = args.isLive;
-    this.uris = args.uris;
+    this.uris = args.uris || [];
 
     this.lifetime = args.lifetime;
     this.suggestedPresentationDelay = args.suggestedPresentationDelay;

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -20,7 +20,6 @@ import { ICustomError } from "../errors";
 import log from "../log";
 import assert from "../utils/assert";
 import generateNewId from "../utils/id";
-import { normalize as normalizeLang } from "../utils/languages";
 import warnOnce from "../utils/warnOnce";
 import Adaptation, {
   IAdaptationType,
@@ -557,7 +556,6 @@ export default class Manifest {
           id: adaptationID,
           type: "text",
           language: _language,
-          normalizedLanguage: normalizeLang(_language),
           closedCaption,
           manuallyAdded: true,
           representations: [{

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -472,10 +472,11 @@ export default class Manifest {
     // TODO use RTT for the manifest request? (+ 3 or something)
     const BUFFER_DEPTH_SECURITY = 5;
 
+    const minimumTime = this.minimumTime != null ? this.minimumTime : 0;
     if (!this.isLive) {
       const duration = this.getDuration();
-      return duration == null ?
-        [minimumTime, Infinity] : [minimumTime, duration];
+      const maximumTime = duration == null ? Infinity : duration;
+      return [minimumTime, maximumTime];
     }
 
     const ast = this.availabilityStartTime || 0;
@@ -487,10 +488,7 @@ export default class Manifest {
     return [
       Math.min(
         max,
-        Math.max(
-          this.minimumTime != null ? this.minimumTime : 0,
-          max - tsbd + BUFFER_DEPTH_SECURITY
-        )
+        Math.max(minimumTime, max - tsbd + BUFFER_DEPTH_SECURITY)
       ),
       max,
     ];

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -34,9 +34,12 @@ export type IAdaptationsArguments =
 
 // Arguments constitutive of a new Period.
 export interface IPeriodArguments {
+  // required
   id : string; // unique ID for that Period.
   adaptations : IAdaptationsArguments; // "Tracks" in that Period.
   start : number; // start time of the Period, in seconds.
+
+  // optional
   duration? : number; // duration of the Period, in seconds.
                       // Can be undefined for a still-running one.
 }

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -25,13 +25,13 @@ interface IContentProtection {
 export interface IRepresentationArguments {
   // -- required
   bitrate : number;
+  id : string;
   index : IRepresentationIndex;
 
   // -- optional
   frameRate? : string;
   codecs? : string;
   height? : number;
-  id? : string|number;
   mimeType? : string;
   width? : number;
   contentProtections? : IContentProtection[];

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -29,12 +29,12 @@ export interface IRepresentationArguments {
   index : IRepresentationIndex;
 
   // -- optional
-  frameRate? : string;
   codecs? : string;
+  contentProtections? : IContentProtection[];
+  frameRate? : string;
   height? : number;
   mimeType? : string;
   width? : number;
-  contentProtections? : IContentProtection[];
 }
 
 /**

--- a/src/parsers/manifest/dash/get_presentation_live_gap.ts
+++ b/src/parsers/manifest/dash/get_presentation_live_gap.ts
@@ -78,7 +78,6 @@ export default function getPresentationLiveGap(
   }
   const firstAdaptationFromLastPeriod = firstAdaptationsFromLastPeriod[0];
   const lastRef = getLastLiveTimeReference(firstAdaptationFromLastPeriod);
-  return lastRef != null ?
-    Date.now() / 1000 - (lastRef + manifest.availabilityStartTime) :
-    10;
+  const ast = manifest.availabilityStartTime || 0;
+  return lastRef != null ? Date.now() / 1000 - (lastRef + ast) : 10;
 }

--- a/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
@@ -87,7 +87,6 @@ export interface IAdaptationSetAttributes {
   minFrameRate? : string;
   minHeight? : number;
   minWidth? : number;
-  normalizedLanguage? : string;
   par? : string;
   profiles? : string;
   segmentAlignment? : number|boolean;

--- a/src/parsers/manifest/dash/parseAdaptationSets.ts
+++ b/src/parsers/manifest/dash/parseAdaptationSets.ts
@@ -17,7 +17,6 @@
 import arrayFind from "array-find";
 import log from "../../../log";
 import arrayIncludes from "../../../utils/array-includes";
-import { normalize as normalizeLang } from "../../../utils/languages";
 import { resolveURL } from "../../../utils/url";
 import {
   IParsedAdaptation,
@@ -191,8 +190,6 @@ export default function parseAdaptationSets(
         };
         if (adaptation.attributes.language != null) {
           parsedAdaptationSet.language = adaptation.attributes.language;
-          parsedAdaptationSet.normalizedLanguage =
-            normalizeLang(adaptation.attributes.language);
         }
         if (isClosedCaption != null) {
           parsedAdaptationSet.closedCaption = isClosedCaption;

--- a/src/parsers/manifest/dash/parseMPD.ts
+++ b/src/parsers/manifest/dash/parseMPD.ts
@@ -184,26 +184,11 @@ function parseCompleteIntermediateRepresentation(
 
   // -- add optional fields --
 
-  if (rootAttributes.profiles != null) {
-    parsedMPD.profiles = rootAttributes.profiles;
-  }
   if (rootAttributes.type !== "static" && rootAttributes.availabilityEndTime != null) {
     parsedMPD.availabilityEndTime = rootAttributes.availabilityEndTime;
   }
-  if (rootAttributes.publishTime != null) {
-    parsedMPD.publishTime = rootAttributes.publishTime;
-  }
-  if (rootAttributes.minBufferTime != null) {
-    parsedMPD.minBufferTime = rootAttributes.minBufferTime;
-  }
   if (rootAttributes.timeShiftBufferDepth != null) {
     parsedMPD.timeShiftBufferDepth = rootAttributes.timeShiftBufferDepth;
-  }
-  if (rootAttributes.maxSegmentDuration != null) {
-    parsedMPD.maxSegmentDuration = rootAttributes.maxSegmentDuration;
-  }
-  if (rootAttributes.maxSubsegmentDuration != null) {
-    parsedMPD.maxSubsegmentDuration = rootAttributes.maxSubsegmentDuration;
   }
 
   checkManifestIDs(parsedMPD);

--- a/src/parsers/manifest/dash/parseMPD.ts
+++ b/src/parsers/manifest/dash/parseMPD.ts
@@ -149,12 +149,12 @@ function parseCompleteIntermediateRepresentation(
     baseURL,
   });
 
-  const duration : number = (() => {
+  const duration : number|undefined = (() => {
     if (rootAttributes.duration != null) {
       return rootAttributes.duration;
     }
     if (isDynamic) {
-      return Infinity;
+      return undefined;
     }
     if (parsedPeriods.length) {
       const lastPeriod = parsedPeriods[parsedPeriods.length - 1];
@@ -164,7 +164,7 @@ function parseCompleteIntermediateRepresentation(
         return lastPeriod.start + lastPeriod.duration;
       }
     }
-    return Infinity;
+    return undefined;
   })();
 
   const parsedMPD : IParsedManifest = {
@@ -192,9 +192,6 @@ function parseCompleteIntermediateRepresentation(
   }
   if (rootAttributes.publishTime != null) {
     parsedMPD.publishTime = rootAttributes.publishTime;
-  }
-  if (rootAttributes.duration != null) {
-    parsedMPD.duration = rootAttributes.duration;
   }
   if (rootAttributes.minBufferTime != null) {
     parsedMPD.minBufferTime = rootAttributes.minBufferTime;

--- a/src/parsers/manifest/dash/parseRepresentations.ts
+++ b/src/parsers/manifest/dash/parseRepresentations.ts
@@ -172,20 +172,6 @@ export default function parseRepresentations(
       codecs = codecs === "mp4a.40.02" ? "mp4a.40.2" : codecs;
       parsedRepresentation.codecs = codecs;
     }
-    if (representation.attributes.audioSamplingRate != null) {
-      parsedRepresentation.audioSamplingRate =
-        representation.attributes.audioSamplingRate;
-    } else if (adaptation.attributes.audioSamplingRate != null) {
-      parsedRepresentation.audioSamplingRate =
-        adaptation.attributes.audioSamplingRate;
-    }
-    if (representation.attributes.codingDependency != null) {
-      parsedRepresentation.codingDependency =
-        representation.attributes.codingDependency;
-    } else if (adaptation.attributes.codingDependency != null) {
-      parsedRepresentation.codingDependency =
-        adaptation.attributes.codingDependency;
-    }
     if (representation.attributes.frameRate != null) {
       parsedRepresentation.frameRate =
         representation.attributes.frameRate;
@@ -200,44 +186,12 @@ export default function parseRepresentations(
       parsedRepresentation.height =
         adaptation.attributes.height;
     }
-    if (representation.attributes.maxPlayoutRate != null) {
-      parsedRepresentation.maxPlayoutRate =
-        representation.attributes.maxPlayoutRate;
-    } else if (adaptation.attributes.maxPlayoutRate != null) {
-      parsedRepresentation.maxPlayoutRate =
-        adaptation.attributes.maxPlayoutRate;
-    }
-    if (representation.attributes.maximumSAPPeriod != null) {
-      parsedRepresentation.maximumSAPPeriod =
-        representation.attributes.maximumSAPPeriod;
-    } else if (adaptation.attributes.maximumSAPPeriod != null) {
-      parsedRepresentation.maximumSAPPeriod =
-        adaptation.attributes.maximumSAPPeriod;
-    }
     if (representation.attributes.mimeType != null) {
       parsedRepresentation.mimeType =
         representation.attributes.mimeType;
     } else if (adaptation.attributes.mimeType != null) {
       parsedRepresentation.mimeType =
         adaptation.attributes.mimeType;
-    }
-    if (representation.attributes.profiles != null) {
-      parsedRepresentation.profiles =
-        representation.attributes.profiles;
-    } else if (adaptation.attributes.profiles != null) {
-      parsedRepresentation.profiles =
-        adaptation.attributes.profiles;
-    }
-    if (representation.attributes.qualityRanking != null) {
-      parsedRepresentation.qualityRanking =
-        representation.attributes.qualityRanking;
-    }
-    if (representation.attributes.segmentProfiles != null) {
-      parsedRepresentation.segmentProfiles =
-        representation.attributes.segmentProfiles;
-    } else if (adaptation.attributes.segmentProfiles != null) {
-      parsedRepresentation.segmentProfiles =
-        adaptation.attributes.segmentProfiles;
     }
     if (representation.attributes.width != null) {
       parsedRepresentation.width =

--- a/src/parsers/manifest/smooth/index.ts
+++ b/src/parsers/manifest/smooth/index.ts
@@ -438,7 +438,6 @@ function createSmoothStreamingParser(
     let suggestedPresentationDelay : number|undefined;
     let presentationLiveGap : number|undefined;
     let availabilityStartTime : number|undefined;
-    let duration : number;
 
     const firstVideoAdaptation = adaptations.video ? adaptations.video[0] : undefined;
     const firstAudioAdaptation = adaptations.audio ? adaptations.audio[0] : undefined;
@@ -494,6 +493,7 @@ function createSmoothStreamingParser(
       }
     }
 
+    let duration : number|undefined;
     if (isLive) {
       suggestedPresentationDelay = SUGGESTED_PERSENTATION_DELAY;
       availabilityStartTime = REFERENCE_DATE_TIME;
@@ -502,7 +502,7 @@ function createSmoothStreamingParser(
           (lastTimeReference + availabilityStartTime) : 10);
       const manifestDuration = root.getAttribute("Duration");
       duration = (manifestDuration != null && +manifestDuration !== 0) ?
-        (+manifestDuration / timescale) : Infinity;
+        (+manifestDuration / timescale) : undefined;
     } else {
       // if non-live and first time reference different than 0. Add first time reference
       // to duration
@@ -513,7 +513,7 @@ function createSmoothStreamingParser(
           (+manifestDuration / timescale) + (firstTimeReference || 0) :
           lastTimeReference;
       } else {
-        duration = Infinity;
+        duration = undefined;
       }
 
     }

--- a/src/parsers/manifest/smooth/index.ts
+++ b/src/parsers/manifest/smooth/index.ts
@@ -18,7 +18,6 @@ import objectAssign from "object-assign";
 import config from "../../../config";
 import assert from "../../../utils/assert";
 import generateNewId from "../../../utils/id";
-import { normalize as normalizeLang } from "../../../utils/languages";
 import {
   normalizeBaseURL,
   resolveURL,
@@ -226,8 +225,6 @@ function createSmoothStreamingParser(
 
     const subType = root.getAttribute("Subtype");
     const language = root.getAttribute("Language");
-    const normalizedLanguage = language == null ?
-      language : normalizeLang(language);
     const baseURL = root.getAttribute("Url") || "";
     if (__DEV__) {
       assert(baseURL !== "");
@@ -349,10 +346,7 @@ function createSmoothStreamingParser(
       id: adaptationID,
       type: adaptationType,
       representations,
-      language: language == null ?
-        undefined : language,
-      normalizedLanguage: normalizedLanguage == null ?
-        undefined : normalizedLanguage,
+      language: language == null ?  undefined : language,
     };
 
     if (adaptationType === "text" && subType === "DESC") {

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -79,7 +79,7 @@ export interface IParsedPeriod {
 export interface IParsedManifest {
   // required
   availabilityStartTime : number;
-  duration: number;
+  duration? : number;
   id: string;
   periods: IParsedPeriod[];
   transportType: string; // "smooth", "dash" etc.

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -62,7 +62,6 @@ export interface IParsedAdaptation {
   audioDescription? : boolean;
   closedCaption? : boolean;
   language?: string;
-  normalizedLanguage? : string;
 }
 
 export interface IParsedPeriod {

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -28,24 +28,11 @@ export interface IParsedRepresentation {
   id: string;
 
   // optional
-  audioSamplingRate?: string;
-  audiotag? : number;
-  bitsPerSample? : number;
-  channels? : number;
-  codecPrivateData? : string;
   codecs?: string;
-  codingDependency?: boolean;
   contentProtections? : IContentProtection[];
   frameRate?: string;
   height?: number;
-  maxPlayoutRate?: number;
-  maximumSAPPeriod?: number;
   mimeType?: string;
-  packetSize? : number;
-  profiles?: string;
-  qualityRanking?: number;
-  samplingRate? : number;
-  segmentProfiles?: string;
   width?: number;
 }
 
@@ -68,34 +55,29 @@ export interface IParsedPeriod {
   // required
   id : string;
   start : number;
-  end? : number;
   adaptations : IParsedAdaptations;
 
   // optional
   duration? : number;
+  end? : number;
 }
 
 export interface IParsedManifest {
   // required
-  availabilityStartTime : number;
-  duration? : number;
   id: string;
+  isLive : boolean;
   periods: IParsedPeriod[];
   transportType: string; // "smooth", "dash" etc.
-  isLive : boolean;
-  uris: string[]; // uris where the manifest can be refreshed
 
   // optional
-  availabilityEndTime?: number;
+  availabilityEndTime? : number;
+  availabilityStartTime? : number;
   baseURL? : string;
-  maxSegmentDuration?: number;
-  maxSubsegmentDuration?: number;
-  minBufferTime?: number;
-  minimumTime? : number;
+  duration? : number;
   lifetime?: number;
+  minimumTime? : number;
   presentationLiveGap?: number;
-  profiles?: string;
-  publishTime?: number;
   suggestedPresentationDelay?: number;
   timeShiftBufferDepth?: number;
+  uris?: string[]; // uris where the manifest can be refreshed
 }

--- a/tests/integration/scenarios/dash_live.js
+++ b/tests/integration/scenarios/dash_live.js
@@ -38,7 +38,7 @@ describe("DASH live content (SegmentTimeline)", function () {
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);
     expect(typeof manifest).to.equal("object");
-    expect(manifest.getDuration()).to.equal(Infinity);
+    expect(manifest.getDuration()).to.equal(undefined);
     expect(manifest.transport)
       .to.equal(manifestInfos.transport);
     expect(typeof manifest.id).to.equal("string");


### PR DESCRIPTION
Simplify much more manifest creation:
  - allow `duration` to be undefined (ex: for live contents). This means that the content's duration is not known. In most places where it was used, we consider the duration as infinite (example, when setting the duration on the `MediaSource` or when we want to know the seeking limits)
  - move `normalizedLanguage` entirely on the `src/manifest`-side
  - all `id` properties are `string`
  - `Manifest`, `Period`, `Adaptation` and `Representation` all require an `id` property to be set
  - remove from `src/parsers` most properties that are not reflected in `src/manifest`