### PR TITLE
Manifest: better infer the minimum time of a manifest

### DIFF
--- a/src/core/api/from_wallclock_time.ts
+++ b/src/core/api/from_wallclock_time.ts
@@ -43,13 +43,15 @@ function normalizeWallClockTime(
   }
   const spd = manifest.suggestedPresentationDelay || 0;
   const plg = manifest.presentationLiveGap || 0;
-  const tsbd = manifest.timeShiftBufferDepth || 0;
+  const tsbd = manifest.timeShiftBufferDepth;
 
   const timeInMs = typeof _time === "number" ?
     _time : +_time;
 
   const now = Date.now();
   const max = now - (plg + spd) * 1000;
-  const min = now - (tsbd) * 1000;
+  const min = tsbd == null ?
+    (manifest.minimumTime || manifest.availabilityStartTime || 0) :
+    now - (tsbd) * 1000;
   return Math.max(Math.min(timeInMs, max), min);
 }

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -17,7 +17,6 @@
 import arrayFind from "array-find";
 import { ICustomError } from "../errors";
 import log from "../log";
-import assert from "../utils/assert";
 import generateNewId from "../utils/id";
 import warnOnce from "../utils/warnOnce";
 import Adaptation, {
@@ -235,11 +234,6 @@ export default class Manifest {
       log.warn("Manifest: non live content and duration is null.");
     }
     this._duration = args.duration;
-
-    if (__DEV__ && this.isLive) {
-      assert(this.availabilityStartTime != null);
-      assert(this.timeShiftBufferDepth != null);
-    }
 
     if (supplementaryImageTracks.length) {
       this.addSupplementaryImageAdaptations(supplementaryImageTracks);

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -182,7 +182,7 @@ export default class Manifest {
    * created, in the order they have happened.
    * @type {Array.<Error>}
    */
-  public readonly parsingErrors : Array<Error|ICustomError>;
+  public parsingErrors : Array<Error|ICustomError>;
 
   /**
    * Whole duration anounced in the Manifest.
@@ -362,10 +362,12 @@ export default class Manifest {
    */
   update(newManifest : Manifest) : Manifest {
     this._duration = newManifest.getDuration();
-    this.lifetime = newManifest.lifetime;
-    this.timeShiftBufferDepth = newManifest.timeShiftBufferDepth;
     this.availabilityStartTime = newManifest.availabilityStartTime;
+    this.lifetime = newManifest.lifetime;
+    this.minimumTime = newManifest.minimumTime;
+    this.parsingErrors = newManifest.parsingErrors;
     this.suggestedPresentationDelay = newManifest.suggestedPresentationDelay;
+    this.timeShiftBufferDepth = newManifest.timeShiftBufferDepth;
     this.uris = newManifest.uris;
 
     const oldPeriods = this.periods;

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -479,14 +479,14 @@ export default class Manifest {
     // TODO use RTT for the manifest request? (+ 3 or something)
     const BUFFER_DEPTH_SECURITY = 5;
 
-    const minimumTime = this.minimumTime != null ? this.minimumTime : 0;
+    const ast = this.availabilityStartTime || 0;
+    const minimumTime = this.minimumTime != null ? this.minimumTime : ast;
     if (!this.isLive) {
       const duration = this.getDuration();
       const maximumTime = duration == null ? Infinity : duration;
       return [minimumTime, maximumTime];
     }
 
-    const ast = this.availabilityStartTime || 0;
     const plg = this.presentationLiveGap || 0;
     const tsbd = this.timeShiftBufferDepth || 0;
 


### PR DESCRIPTION
- use availabilityStartTime when it exists to fallback on in case the `minimumTime` property is not set.
- update `minimumTime` on Manifest updates

Also stop throwing in ``__DEV__`` mode for missing live properties.