### PR TITLE
manifest: redefine Manifest to be an EventEmitter

### DIFF
--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -26,7 +26,6 @@
 
 import objectAssign from "object-assign";
 import {
-  BehaviorSubject,
   concat as observableConcat,
   defer as observableDefer,
   merge as observableMerge,
@@ -111,14 +110,14 @@ export default function AdaptationBuffer<T>(
   segmentFetcher : IPrioritizedSegmentFetcher<T>,
   wantedBufferAhead$ : Observable<number>,
   content : {
-    manifest$ : BehaviorSubject<Manifest>;
+    manifest : Manifest;
     period : Period; adaptation : Adaptation;
   },
   abrManager : ABRManager,
   options : { manualBitrateSwitchingMode : "seamless"|"direct" }
 ) : Observable<IAdaptationBufferEvent<T>> {
   const directManualBitrateSwitching = options.manualBitrateSwitchingMode === "direct";
-  const { manifest$, period, adaptation } = content;
+  const { manifest, period, adaptation } = content;
 
   // Keep track of the currently considered representation to add informations
   // to the ABR clock.
@@ -206,7 +205,7 @@ export default function AdaptationBuffer<T>(
           representation,
           adaptation,
           period,
-          manifest$,
+          manifest,
         },
         queuedSourceBuffer,
         segmentBookkeeper,
@@ -221,7 +220,6 @@ export default function AdaptationBuffer<T>(
           // exist
           // (In case of smooth streaming, 412 errors are requests that are
           // performed to early).
-          const manifest = manifest$.getValue();
           if (
             !manifest.isLive ||
             error.type !== ErrorTypes.NETWORK_ERROR ||

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  BehaviorSubject,
   concat as observableConcat,
   EMPTY,
   merge as observableMerge,
@@ -76,7 +75,7 @@ export interface IPeriodBufferArguments {
   bufferType : IBufferType;
   clock$ : Observable<IPeriodBufferClockTick>;
   content : {
-    manifest$ : BehaviorSubject<Manifest>;
+    manifest : Manifest;
     period : Period;
   };
   garbageCollectors : WeakMapMemory<QueuedSourceBuffer<unknown>, Observable<never>>;
@@ -186,7 +185,7 @@ export default function PeriodBuffer({
     adaptation : Adaptation,
     qSourceBuffer : QueuedSourceBuffer<T>
   ) : Observable<IAdaptationBufferEvent<T>|IBufferWarningEvent> {
-    const { manifest$ } = content;
+    const { manifest } = content;
     const segmentBookkeeper = segmentBookkeepers.get(qSourceBuffer);
     const pipelineOptions = getPipelineOptions(
       bufferType, options.segmentRetry, options.offlineRetry);
@@ -198,7 +197,7 @@ export default function PeriodBuffer({
       segmentBookkeeper,
       pipeline,
       wantedBufferAhead$,
-      { manifest$, period, adaptation },
+      { manifest, period, adaptation },
       abrManager,
       options
     ).pipe(catchError((error : Error) => {

--- a/src/core/init/create_buffer_clock.ts
+++ b/src/core/init/create_buffer_clock.ts
@@ -16,7 +16,6 @@
 
 import objectAssign from "object-assign";
 import {
-  BehaviorSubject,
   combineLatest as observableCombineLatest,
   merge as observableMerge,
   Observable,
@@ -40,7 +39,7 @@ import { IInitClockTick } from "./types";
  * @returns {Observable}
  */
 export default function createBufferClock(
-  manifest$ : BehaviorSubject<Manifest>,
+  manifest : Manifest,
   initClock$ : Observable<IInitClockTick>,
   initialSeek$ : Observable<unknown>,
   speed$ : Observable<number>,
@@ -65,7 +64,6 @@ export default function createBufferClock(
   const clock$ : Observable<IBufferOrchestratorClockTick> =
     observableCombineLatest(initClock$, speed$)
       .pipe(map(([tick, speed]) => {
-        const manifest = manifest$.getValue();
         return objectAssign({
           isLive: manifest.isLive,
           liveGap: manifest.isLive ?

--- a/src/core/init/events_generators.ts
+++ b/src/core/init/events_generators.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { BehaviorSubject } from "rxjs";
 import { ICustomError } from "../../errors";
 import Manifest, {
   Period,
@@ -57,11 +56,11 @@ function stalled(stalling : IStallingItem|null) : IStalledEvent {
  */
 function manifestReady(
   abrManager : ABRManager,
-  manifest$ : BehaviorSubject<Manifest>
+  manifest : Manifest
 ) : IManifestReadyEvent {
   return {
     type: "manifestReady",
-    value: { abrManager, manifest$ },
+    value: { abrManager, manifest },
   };
 }
 

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  BehaviorSubject,
   EMPTY,
   merge as observableMerge,
   Observable,
@@ -61,7 +60,7 @@ import updatePlaybackRate from "./update_playback_rate";
 export interface IMediaSourceLoaderArguments {
   mediaElement : HTMLMediaElement; // Media Element on which the content will be
                                    // played
-  manifest$ : BehaviorSubject<Manifest>; // Manifest of the content we want to
+  manifest : Manifest; // Manifest of the content we want to
                                          // play
   clock$ : Observable<IInitClockTick>; // Emit position informations
   speed$ : Observable<number>; // Emit the speed.
@@ -95,7 +94,7 @@ export type IMediaSourceLoaderEvent =
  */
 export default function createMediaSourceLoader({
   mediaElement,
-  manifest$,
+  manifest,
   clock$,
   speed$,
   bufferOptions,
@@ -117,8 +116,6 @@ export default function createMediaSourceLoader({
     initialTime : number,
     autoPlay : boolean
   ) {
-    const manifest = manifest$.getValue();
-
     // TODO Update the duration if it evolves?
     const duration = manifest.getDuration();
     setDurationToMediaSource(mediaSource, duration == null ?  Infinity : duration);
@@ -147,14 +144,14 @@ export default function createMediaSourceLoader({
     const { seek$, load$ } =
       seekAndLoadOnMediaEvents(clock$, mediaElement, initialTime, autoPlay);
 
-    const bufferClock$ = createBufferClock(manifest$, clock$, seek$, speed$, initialTime);
+    const bufferClock$ = createBufferClock(manifest, clock$, seek$, speed$, initialTime);
 
     // Will be used to cancel any endOfStream tries when the contents resume
     const cancelEndOfStream$ = new Subject<null>();
 
     // Creates Observable which will manage every Buffer for the given Content.
     const buffers$ = BufferOrchestrator(
-      { manifest$, initialPeriod },
+      { manifest, initialPeriod },
       bufferClock$,
       abrManager,
       sourceBufferManager,

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { BehaviorSubject } from "rxjs";
 import { ICustomError } from "../../errors";
 import Manifest from "../../manifest";
 import ABRManager from "../abr";
@@ -47,7 +46,7 @@ export interface IManifestReadyEvent {
   type : "manifestReady";
   value : {
     abrManager : ABRManager;
-    manifest$ : BehaviorSubject<Manifest>;
+    manifest : Manifest;
   };
 }
 

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -17,6 +17,7 @@
 import arrayFind from "array-find";
 import { ICustomError } from "../errors";
 import log from "../log";
+import EventEmitter from "../utils/eventemitter";
 import generateNewId from "../utils/id";
 import warnOnce from "../utils/warnOnce";
 import Adaptation, {
@@ -78,7 +79,7 @@ interface IManifestParsingOptions {
  * Normalized Manifest structure.
  * @class Manifest
  */
-export default class Manifest {
+export default class Manifest extends EventEmitter<"manifestUpdate", null> {
   /**
    * ID uniquely identifying this Manifest.
    * @type {string}
@@ -195,6 +196,7 @@ export default class Manifest {
    * @param {Object} args
    */
   constructor(args : IManifestArguments, options : IManifestParsingOptions) {
+    super();
     const {
       supplementaryTextTracks = [],
       supplementaryImageTracks = [],
@@ -339,6 +341,7 @@ export default class Manifest {
 
   /**
    * @param {number} delta
+   * TODO Remove?
    */
   updateLiveGap(delta : number) : void {
     if (this.isLive) {
@@ -354,7 +357,7 @@ export default class Manifest {
    * Update the current manifest properties
    * @param {Object} Manifest
    */
-  update(newManifest : Manifest) : Manifest {
+  update(newManifest : Manifest) : void {
     this._duration = newManifest.getDuration();
     this.availabilityStartTime = newManifest.availabilityStartTime;
     this.lifetime = newManifest.lifetime;
@@ -400,7 +403,7 @@ export default class Manifest {
         }
       }
     }
-    return this;
+    this.trigger("manifestUpdate", null);
   }
 
   /**

--- a/src/utils/eventemitter.ts
+++ b/src/utils/eventemitter.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import {
+  Observable,
+  Observer,
+} from "rxjs";
 import log from "../log";
 
 type IListeners<T extends string, U> =
@@ -116,4 +120,26 @@ export default class EventEmitter<T extends string, U>
       }
     });
   }
+}
+
+/**
+ * Simple redefinition of the fromEvent from rxjs to also work on our
+ * implementation of EventEmitter with type-checked strings
+ * @param {Object} target
+ * @param {string} eventName
+ * @returns {Observable}
+ */
+export function fromEvent<T extends string, U>(
+  target : IEventEmitter<T, U>,
+  eventName : T
+) : Observable<U> {
+  return Observable.create((obs : Observer<U>) => {
+    function handler(event : U) {
+      obs.next(event);
+    }
+    target.addEventListener(eventName, handler);
+    return () => {
+      target.removeEventListener(eventName, handler);
+    };
+  });
 }


### PR DESCRIPTION
The previous redefinition of Manifest as a BehaviorSubject() was ideal but made no real-world sense:
  - The API still communicates the Manifest. It would be better for the user if it updated in place
  - Never mutating the manifest would complexify the whole chain of buffers where everything from the Manifest to the Segment might need to be re-defined as a BehaviorSubject
  - Each part of the code updating the manifest had to use the subject to communicate the change to the rest of the code.

Now, the Manifest itself is an EventEmitter, and trigger a `manifestUpdate` event each time it is mutated (through its `update` method).
Each part of the code that wants to react to those updates now just need to add an event listener to the Manifest.

Unfortunately, the `fromEvent` function from `rxjs` was not type-compatible with our EventEmitter, as we defined a much more precize type than `string` for its events. This led me to redefine that function, which is the cause for most of the additions here.