### PR TITLE
manifest: fix update mechanism due to inversion of arguments

### DIFF
--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -376,7 +376,7 @@ export default class Manifest extends EventEmitter<"manifestUpdate", null> {
         oldPeriods.splice(i, 1);
         i--;
       } else {
-        updatePeriodInPlace(newPeriod, oldPeriod);
+        updatePeriodInPlace(oldPeriod, newPeriod);
       }
     }
 


### PR DESCRIPTION
A __really__ dumb typo made most DASH dynamic contents based on SegmentTimeline not "updatable".

This is a major issue.