### PR TITLE
Create and add standard vtt style elements.

### DIFF
--- a/src/parsers/texttracks/webvtt/create_default_style_elements.ts
+++ b/src/parsers/texttracks/webvtt/create_default_style_elements.ts
@@ -1,0 +1,36 @@
+import { IStyleElement } from "./html/parse_style_block";
+
+/**
+ * Creates default classes defined in the W3 specification
+ * 
+ * https://www.w3.org/TR/webvtt1/#default-classes
+ */
+
+const colorMap: { [colorName: string]: string } = {
+    "white": "#ffffff",
+    "lime": "#00ff00",
+    "cyan": "#00ffff",
+    "red": "#ff0000",
+    "yellow": "#ffff00",
+    "magenta": "#ff00ff",
+    "blue": "#0000ff",
+    "black": "#000000"
+};
+
+export default function createDefaultStyleElements() { 
+    return Object.keys(colorMap).reduce((result, key) => {
+        result.push({
+            className: key,
+            isGlobalStyle: false,
+            styleContent: `color: ${colorMap[key]}`
+        });
+
+        result.push({
+            className: `bg_${key}`,
+            isGlobalStyle: false,
+            styleContent: `background-color: ${colorMap[key]}`
+        });
+
+        return result;
+    }, [] as IStyleElement[]);
+}

--- a/src/parsers/texttracks/webvtt/html/parse_webvtt_to_div.ts
+++ b/src/parsers/texttracks/webvtt/html/parse_webvtt_to_div.ts
@@ -22,6 +22,7 @@ import convertPayloadToHTML from "./convert_payload_to_html";
 import parseStyleBlock, {
   IStyleElement,
 } from "./parse_style_block";
+import createDefaultStyleElements from "../create_default_style_elements";
 
 export interface IVTTHTMLCue {
   start : number;
@@ -54,7 +55,7 @@ export default function parseWebVTT(
   }
 
   const cuesArray : IVTTHTMLCue[] = [];
-  const styleElements : IStyleElement[] = [];
+  const styleElements : IStyleElement[] = [...createDefaultStyleElements()];
   if (!linified[0].match(/^WEBVTT( |\t|\n|\r|$)/)) {
     throw new Error("Can't parse WebVTT: Invalid File.");
   }


### PR DESCRIPTION
Hi!

W3 has defined some default classes for VTT styling. However, when using the VTT->HTML parser shipped with RX-player, these classes are ignored if they're not manually defined in the VTT file. In this PR we've mapped the W3 defined classes to the corresponding default styling.

The list of classes can be found here: https://www.w3.org/TR/webvtt1/#default-classes

