### PR TITLE
compat: safely remove track elements on stop on firefox

### DIFF
--- a/src/compat/__tests__/clear_element_src.test.ts
+++ b/src/compat/__tests__/clear_element_src.test.ts
@@ -14,18 +14,200 @@
  * limitations under the License.
  */
 
-import clearElementSrc from "../clear_element_src";
+import arrayFindIndex from "../../utils/array_find_index";
 
 describe("Compat - clearElementSrc", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
   it("should empty the src and remove the Attribute for a given Element", () => {
     const fakeElement : any = {
       src: "foo",
       removeAttribute() { return null; },
     };
-    const spy = jest.spyOn(fakeElement, "removeAttribute");
+    jest.mock("../browser_detection.ts", () => ({
+      isFirefox: false,
+    }));
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
     clearElementSrc(fakeElement);
     expect(fakeElement.src).toBe("");
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy).toHaveBeenCalledWith("src");
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+  });
+
+  it("should throw if failed to remove the Attribute for a given Element", () => {
+    const fakeElement : any = {
+      src: "foo",
+      removeAttribute() { throw new Error("Oups, can't remove attribute."); },
+    };
+    jest.mock("../browser_detection.ts", () => ({
+      isFirefox: false,
+    }));
+    const clearElementSrc = require("../clear_element_src").default;
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+
+    expect(() => clearElementSrc(fakeElement))
+      .toThrowError("Oups, can't remove attribute.");
+    expect(fakeElement.src).toBe("");
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+  });
+
+  it("should disable text tracks and remove childs if on firefox", () => {
+    const fakeElement : any = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: [
+        { mode: "showing" },
+        { mode: "showing" },
+      ],
+      childNodes: [
+        { nodeName: "audio" },
+        { nodeName: "track" },
+        { nodeName: "track" },
+      ],
+      hasChildNodes: () => true,
+      removeChild: (node: { nodeName: string }) => {
+        const { childNodes } = fakeElement;
+        const idx = arrayFindIndex(childNodes, (n: any) => n.nodeName === node.nodeName);
+        childNodes.splice(idx, 1);
+      },
+    };
+
+    jest.mock("../browser_detection.ts", () => ({
+      isFirefox: true,
+    }));
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.textTracks[0].mode).toBe("disabled");
+    expect(fakeElement.textTracks[1].mode).toBe("disabled");
+    expect(fakeElement.childNodes).toEqual([{ nodeName: "audio" }]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(1);
+    expect(spyRemoveChild).toHaveBeenCalledTimes(2);
+    expect(spyRemoveChild).toHaveBeenCalledWith({ nodeName: "track"});
+  });
+
+  it("should log when failed to remove text track child node if on firefox", () => {
+    const fakeElement : any = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: [
+        { mode: "showing" },
+        { mode: "showing" },
+      ],
+      childNodes: [
+        { nodeName: "audio" },
+        { nodeName: "track" },
+        { nodeName: "track" },
+      ],
+      hasChildNodes: () => true,
+      removeChild: () => {
+        throw new Error();
+      },
+    };
+
+    jest.mock("../browser_detection", () => ({
+      isFirefox: true,
+    }));
+
+    const mockLogWarn = jest.fn((message) => message);
+    jest.mock("../../log", () => ({
+      default: { warn: mockLogWarn },
+    }));
+
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.textTracks[0].mode).toBe("disabled");
+    expect(fakeElement.textTracks[1].mode).toBe("disabled");
+    expect(fakeElement.childNodes).toEqual([
+      { nodeName: "audio" },
+      { nodeName: "track" },
+      { nodeName: "track" },
+    ]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(1);
+    expect(spyRemoveChild).toHaveBeenCalledTimes(2);
+    expect(mockLogWarn).toHaveBeenCalledTimes(2);
+    expect(mockLogWarn)
+      .toHaveBeenCalledWith("Could not remove text track child from element.");
+  });
+
+  it("should not remove audio child node if on firefox and no text tracks", () => {
+    const fakeElement : any = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: [],
+      childNodes: [
+        { nodeName: "audio" },
+      ],
+      hasChildNodes: () => true,
+      removeChild: () => null,
+    };
+
+    jest.mock("../browser_detection.ts", () => ({
+      isFirefox: true,
+    }));
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.childNodes).toEqual([{ nodeName: "audio" }]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(1);
+    expect(spyRemoveChild).not.toHaveBeenCalled();
+  });
+
+  it("should not handle text tracks nodes is has no child nodes if on firefox", () => {
+    const fakeElement : any = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: [],
+      childNodes: [],
+      hasChildNodes: () => false,
+      removeChild: () => null,
+    };
+
+    jest.mock("../browser_detection.ts", () => ({
+      isFirefox: true,
+    }));
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.childNodes).toEqual([]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(1);
+    expect(spyRemoveChild).not.toHaveBeenCalled();
   });
 });

--- a/src/compat/clear_element_src.ts
+++ b/src/compat/clear_element_src.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import log from "../log";
 import { isFirefox } from "./browser_detection";
 
 /**
@@ -34,7 +35,11 @@ export default function clearElementSrc(element : HTMLMediaElement) : void {
       const { childNodes } = element;
       for (let j = childNodes.length - 1; j >= 0; j--) {
         if (childNodes[j].nodeName === "track") {
-          element.removeChild(childNodes[j]);
+          try {
+            element.removeChild(childNodes[j]);
+          } catch (err) {
+            log.warn("Could not remove text track child from element.");
+          }
         }
       }
     }

--- a/src/compat/clear_element_src.ts
+++ b/src/compat/clear_element_src.ts
@@ -28,12 +28,15 @@ export default function clearElementSrc(element : HTMLMediaElement) : void {
   if (isFirefox) {
     const { textTracks } = element;
     for (let i = 0; i < textTracks.length; i++) {
-      element.childNodes.forEach((node) => {
-        if (node.nodeName === "track") {
-          element.removeChild(node);
-        }
-      });
       textTracks[i].mode = "disabled";
+    }
+    if (element.hasChildNodes()) {
+      const { childNodes } = element;
+      for (let j = childNodes.length - 1; j >= 0; j--) {
+        if (childNodes[j].nodeName === "track") {
+          element.removeChild(childNodes[j]);
+        }
+      }
     }
   }
   element.src = "";


### PR DESCRIPTION
Reduce the risk to throw when clearing element source on firefox