### PR TITLE
dash: set manifest lifetime to minimumUpdatePeriod

### DIFF
--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -176,6 +176,7 @@ function parseCompleteIntermediateRepresentation(
       rootAttributes.id : "gen-dash-manifest-" + generateManifestID(),
     periods: parsedPeriods,
     transportType: "dash",
+    lifetime: rootAttributes.minimumUpdatePeriod,
     isLive: isDynamic,
     uris: [uri, ...rootChildren.locations],
     suggestedPresentationDelay: rootAttributes.suggestedPresentationDelay != null ?

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -176,7 +176,6 @@ function parseCompleteIntermediateRepresentation(
       rootAttributes.id : "gen-dash-manifest-" + generateManifestID(),
     periods: parsedPeriods,
     transportType: "dash",
-    lifetime: rootAttributes.minimumUpdatePeriod,
     isLive: isDynamic,
     uris: [uri, ...rootChildren.locations],
     suggestedPresentationDelay: rootAttributes.suggestedPresentationDelay != null ?
@@ -191,6 +190,9 @@ function parseCompleteIntermediateRepresentation(
   }
   if (rootAttributes.timeShiftBufferDepth != null) {
     parsedMPD.timeShiftBufferDepth = rootAttributes.timeShiftBufferDepth;
+  }
+  if (rootAttributes.minimumUpdatePeriod != null && rootAttributes.minimumUpdatePeriod > 0) {
+    parsedMPD.lifetime = rootAttributes.minimumUpdatePeriod;
   }
 
   checkManifestIDs(parsedMPD);

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -191,7 +191,8 @@ function parseCompleteIntermediateRepresentation(
   if (rootAttributes.timeShiftBufferDepth != null) {
     parsedMPD.timeShiftBufferDepth = rootAttributes.timeShiftBufferDepth;
   }
-  if (rootAttributes.minimumUpdatePeriod != null && rootAttributes.minimumUpdatePeriod > 0) {
+  if (rootAttributes.minimumUpdatePeriod != null
+      && rootAttributes.minimumUpdatePeriod > 0) {
     parsedMPD.lifetime = rootAttributes.minimumUpdatePeriod;
   }
 


### PR DESCRIPTION
Hi!

We noticed that the manifest didn't refresh on our live streams (segment template without segment timeline) as it did before. If you specify a `minimumUpdatePeriod` in the manifest, it should be reflected in the manifest lifetime property.

Thanks!