### PR TITLE
Prefer WebKit EME API on Safari

### DIFF
--- a/src/compat/__tests__/should_use_webkit_media_keys.test.ts
+++ b/src/compat/__tests__/should_use_webkit_media_keys.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const originalWebKitMediaKeys = (window as any).WebKitMediaKeys;
+
+describe("compat - shouldUseWebKitMediaKeys", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    (window as any).WebKitMediaKeys = originalWebKitMediaKeys;
+  });
+
+  it("should return false if we are not on Safari", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true,
+               isSafari: false };
+    });
+    const shouldUseWebKitMediaKeys = require("../should_use_webkit_media_keys");
+    expect(shouldUseWebKitMediaKeys.default()).toBe(false);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should return false if we are on Safari but WekitMediaKeys is not available", () => {
+  /* tslint:enable max-line-length */
+
+    (window as any).WebKitMediaKeys = undefined;
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true,
+               isSafari: true };
+    });
+    const shouldUseWebKitMediaKeys = require("../should_use_webkit_media_keys");
+    expect(shouldUseWebKitMediaKeys.default()).toBe(false);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should return true if we are on Safari and a WebKitMediaKeys implementation is available", () => {
+  /* tslint:enable max-line-length */
+
+    (window as any).WebKitMediaKeys = {};
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true,
+               isSafari: true };
+    });
+    const shouldUseWebKitMediaKeys = require("../should_use_webkit_media_keys");
+    expect(shouldUseWebKitMediaKeys.default()).toBe(true);
+  });
+});

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -15,7 +15,7 @@
  */
 
 import { MediaError } from "../errors";
-import { shouldUseWebKitMediaKeys } from "./eme/custom_media_keys";
+import shouldUseWebKitMediaKeys from "./should_use_webkit_media_keys";
 
 // regular MediaKeys type + optional functions present in IE11
 interface ICompatMediaKeysConstructor {

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -96,10 +96,10 @@ const MediaSource_ : typeof MediaSource|undefined = win.MediaSource ||
                                                     win.MSMediaSource;
 
 const MediaKeys_ : ICompatMediaKeysConstructor|undefined =
-  win.MediaKeys ||
+  win.MSMediaKeys ||
   win.MozMediaKeys ||
   win.WebKitMediaKeys ||
-  win.MSMediaKeys ||
+  win.MediaKeys ||
   class {
     public readonly create : () => never;
     public readonly isTypeSupported : () => never;

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -15,7 +15,7 @@
  */
 
 import { MediaError } from "../errors";
-import { isSafari } from "./browser_detection";
+import { shouldUseWebKitMediaKeys } from "./eme/custom_media_keys";
 
 // regular MediaKeys type + optional functions present in IE11
 interface ICompatMediaKeysConstructor {
@@ -97,11 +97,7 @@ const MediaSource_ : typeof MediaSource|undefined = win.MediaSource ||
                                                     win.MSMediaSource;
 
 const MediaKeys_ : ICompatMediaKeysConstructor|undefined = (() => {
-  // On Safari 12.1, it seems that since fairplay CDM implementation
-  // within the browser is not standard with EME w3c current spec, the
-  // requestMediaKeySystemAccess API doesn't resolve positively, even
-  // if the drm (fairplay in most cases) is supported.
-  if (isSafari && win.WebKitMediaKeys != null && win.MediaKeys != null) {
+  if (shouldUseWebKitMediaKeys()) {
     return win.WebKitMediaKeys;
   }
   return win.MediaKeys ||

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -29,9 +29,12 @@ const isFirefox : boolean = navigator.userAgent.toLowerCase()
 
 const isSamsungBrowser : boolean = /SamsungBrowser/.test(navigator.userAgent);
 
+const isSafari : boolean = /Safari/i.test(navigator.userAgent);
+
 export {
   isIE11,
   isIEOrEdge,
   isFirefox,
+  isSafari,
   isSamsungBrowser,
 };

--- a/src/compat/eme/custom_media_keys.ts
+++ b/src/compat/eme/custom_media_keys.ts
@@ -36,23 +36,12 @@ import {
   // https://github.com/Microsoft/TypeScript/issues/19189
   ICompatMediaKeySystemAccess,
   ICompatMediaKeySystemConfiguration,
-
   MediaKeys_,
 } from "../browser_compatibility_types";
-import {
-  isIE11,
-  isSafari,
-} from "../browser_detection";
+import { isIE11 } from "../browser_detection";
 import * as events from "../event_listeners";
+import shouldUseWebKitMediaKeys from "../should_use_webkit_media_keys";
 import CustomMediaKeySystemAccess from "./custom_key_system_access";
-
-// On Safari 12.1, it seems that since fairplay CDM implementation
-// within the browser is not standard with EME w3c current spec, the
-// requestMediaKeySystemAccess API doesn't resolve positively, even
-// if the drm (fairplay in most cases) is supported.
-export function shouldUseWebKitMediaKeys() {
-  return isSafari && (window as any).WebKitMediaKeys != null;
-}
 
 let requestMediaKeySystemAccess : null |
                                   ((keyType : string,

--- a/src/compat/eme/custom_media_keys.ts
+++ b/src/compat/eme/custom_media_keys.ts
@@ -167,11 +167,10 @@ let CustomMediaKeys : IMockMediaKeysConstructor =
  * Therefore, we prefer not to use requestMediaKeySystemAccess on Safari when webkit API
  * is available.
  */
-const preferWebKitAPIForSafari = isSafari &&
-  (window as any).WebKitMediaKeys &&
-  MediaKeys_ === (window as any).WebKitMediaKeys;
-
-if (navigator.requestMediaKeySystemAccess && !preferWebKitAPIForSafari) {
+if (navigator.requestMediaKeySystemAccess &&
+    !isSafari ||
+    MediaKeys_ === (window as any).WebKitMediaKeys
+) {
   requestMediaKeySystemAccess = (a : string, b : ICompatMediaKeySystemConfiguration[]) =>
     castToObservable(
       navigator.requestMediaKeySystemAccess(a, b) as Promise<ICompatMediaKeySystemAccess>

--- a/src/compat/eme/custom_media_keys.ts
+++ b/src/compat/eme/custom_media_keys.ts
@@ -46,6 +46,14 @@ import {
 import * as events from "../event_listeners";
 import CustomMediaKeySystemAccess from "./custom_key_system_access";
 
+// On Safari 12.1, it seems that since fairplay CDM implementation
+// within the browser is not standard with EME w3c current spec, the
+// requestMediaKeySystemAccess API doesn't resolve positively, even
+// if the drm (fairplay in most cases) is supported.
+export function shouldUseWebKitMediaKeys() {
+  return isSafari && (window as any).WebKitMediaKeys != null;
+}
+
 let requestMediaKeySystemAccess : null |
                                   ((keyType : string,
                                     config : ICompatMediaKeySystemConfiguration[])
@@ -168,8 +176,7 @@ let CustomMediaKeys : IMockMediaKeysConstructor =
  * is available.
  */
 if (navigator.requestMediaKeySystemAccess &&
-    !isSafari ||
-    MediaKeys_ === (window as any).WebKitMediaKeys
+    !shouldUseWebKitMediaKeys()
 ) {
   requestMediaKeySystemAccess = (a : string, b : ICompatMediaKeySystemConfiguration[]) =>
     castToObservable(

--- a/src/compat/should_use_webkit_media_keys.ts
+++ b/src/compat/should_use_webkit_media_keys.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSafari } from "./browser_detection";
+
+// On Safari 12.1, it seems that since fairplay CDM implementation
+// within the browser is not standard with EME w3c current spec, the
+// requestMediaKeySystemAccess API doesn't resolve positively, even
+// if the drm (fairplay in most cases) is supported.
+export default function shouldUseWebKitMediaKeys() {
+  return isSafari && (window as any).WebKitMediaKeys != null;
+}


### PR DESCRIPTION
Since Safari 12.1, EME APIs are available without webkit prefix.
However, it seems that since fairplay CDM implementation within the browser is not standard with EME w3c current spec, the requestMediaKeySystemAccess API doesn't resolve positively, even if the drm (fairplay in most cases) is supported.
 
Therefore, we prefer not to use requestMediaKeySystemAccess on Safari when webkit API is available.