### PR TITLE
code/utils: replace `ignoreProgressEvents` `request` option by `sendProgressEvents` option

### DIFF
--- a/src/transports/dash/pipelines.ts
+++ b/src/transports/dash/pipelines.ts
@@ -67,7 +67,6 @@ function requestStringResource(url : string) : Observable<string> {
   return request({
     url,
     responseType: "text",
-    ignoreProgressEvents: true,
   }).pipe(
     filter((e) => e.type === "response"),
     map((e) => e.value.responseData)
@@ -214,7 +213,11 @@ export default function(
         });
       }
       const { mediaURL } = segment;
-      return request({ url: mediaURL, responseType: "arraybuffer" });
+      return request({
+        url: mediaURL,
+        responseType: "arraybuffer",
+        sendProgressEvents: true,
+      });
     },
 
     parser(

--- a/src/transports/dash/pipelines_text.ts
+++ b/src/transports/dash/pipelines_text.ts
@@ -77,6 +77,7 @@ function TextTrackLoader(
           Math.max(range[1], indexRange[1]),
         ]),
       },
+      sendProgressEvents: true,
     });
   }
   return request<ArrayBuffer|string>({
@@ -85,6 +86,7 @@ function TextTrackLoader(
     headers: range ? {
       Range: byteRange(range),
     } : null,
+    sendProgressEvents: true,
   });
 }
 

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -52,12 +52,14 @@ function regularSegmentLoader(
           Math.max(range[1], indexRange[1]),
         ]),
       },
+      sendProgressEvents: true,
     });
   }
   return request({
     url,
     responseType: "arraybuffer",
     headers: range ? { Range: byteRange(range) } : null,
+    sendProgressEvents: true,
   });
 }
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -83,10 +83,7 @@ export default function(
   const smoothManifestParser = createSmoothManifestParser(options);
   const segmentLoader = generateSegmentLoader(options.segmentLoader);
 
-  const manifestLoaderOptions = {
-    customManifestLoader: options.manifestLoader,
-    ignoreProgressEvents: true as true,
-  };
+  const manifestLoaderOptions = { customManifestLoader: options.manifestLoader };
   const manifestLoader = generateManifestLoader(manifestLoaderOptions);
 
   const manifestPipeline = {
@@ -103,7 +100,6 @@ export default function(
         resolving = request({
           url: replaceToken(url, ""),
           responseType: "document",
-          ignoreProgressEvents: true,
         }).pipe(
           map(({ value }) : string => {
             const extractedURL = extractISML(value.responseData);
@@ -218,7 +214,11 @@ export default function(
         });
       }
       const responseType = isMP4EmbeddedTrack(representation) ? "arraybuffer" : "text";
-      return request({ url: segment.mediaURL, responseType });
+      return request({
+        url: segment.mediaURL,
+        responseType,
+        sendProgressEvents: true,
+      });
     },
 
     parser({
@@ -378,7 +378,11 @@ export default function(
         });
       }
 
-      return request({ url: segment.mediaURL, responseType: "arraybuffer" });
+      return request({
+        url: segment.mediaURL,
+        responseType: "arraybuffer",
+        sendProgressEvents: true,
+      });
     },
 
     parser(

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -56,6 +56,7 @@ function regularSegmentLoader(
     url,
     responseType: "arraybuffer",
     headers,
+    sendProgressEvents: true,
   });
 }
 

--- a/src/transports/utils/manifest_loader.ts
+++ b/src/transports/utils/manifest_loader.ts
@@ -27,15 +27,8 @@ import {
  * Manifest loader triggered if there was no custom-defined one in the API.
  * @param {string} url
  */
-function regularManifestLoader(
-  url: string,
-  ignoreProgressEvents?: true
-) {
-  return request({
-    url,
-    responseType: "document",
-    ignoreProgressEvents,
-  });
+function regularManifestLoader(url: string) {
+  return request({ url, responseType: "document" });
 }
 
 /**
@@ -44,13 +37,10 @@ function regularManifestLoader(
  * @returns {Function}
  */
 const manifestPreLoader = (
-  options: {
-    customManifestLoader?: CustomManifestLoader;
-    ignoreProgressEvents?: true;
-  }) => (url: string) : ILoaderObservable<Document|string> => {
-    const { customManifestLoader, ignoreProgressEvents } = options;
+  { customManifestLoader } : { customManifestLoader?: CustomManifestLoader }
+) => (url: string) : ILoaderObservable<Document|string> => {
     if (!customManifestLoader) {
-      return regularManifestLoader(url, ignoreProgressEvents);
+      return regularManifestLoader(url);
     }
 
     const timeAPIsDelta = Date.now() - performance.now();
@@ -98,10 +88,10 @@ const manifestPreLoader = (
        * Callback triggered when the custom manifest loader fails
        * @param {*} err - The corresponding error encountered
        */
-      const reject = (err = {}) => {
+      const reject = (err : unknown) => {
         if (!hasFallbacked) {
           hasFinished = true;
-          obs.error(err);
+          obs.error(err == null ? {} : err);
         }
       };
 

--- a/src/utils/request/xhr_request.ts
+++ b/src/utils/request/xhr_request.ts
@@ -56,7 +56,7 @@ export interface IRequestOptions<T, U> {
   headers? : { [ header: string ] : string }|null;
   responseType? : T;
   timeout? : number;
-  ignoreProgressEvents? : U;
+  sendProgressEvents? : U;
 }
 
 /**
@@ -154,37 +154,40 @@ function toJSONForIE(data : string) : unknown|null {
  */
 
 // overloading to the max
-function request(options :
-  IRequestOptions<undefined|null|""|"text", false|undefined>
-) : Observable<IRequestResponse<string, "text">|IRequestProgress>;
-function request(options : IRequestOptions<undefined|null|""|"text", true>) :
+function request(options : IRequestOptions<undefined|null|""|"text", false|undefined>) :
   Observable<IRequestResponse<string, "text">>;
+function request(options :
+  IRequestOptions<undefined|null|""|"text", true>
+) : Observable<IRequestResponse<string, "text">|IRequestProgress>;
+
 function request(options : IRequestOptions<"arraybuffer", false|undefined>) :
-  Observable<IRequestResponse<ArrayBuffer, "arraybuffer">|IRequestProgress>;
-function request(options : IRequestOptions<"arraybuffer", true>) :
   Observable<IRequestResponse<ArrayBuffer, "arraybuffer">>;
+function request(options : IRequestOptions<"arraybuffer", true>) :
+  Observable<IRequestResponse<ArrayBuffer, "arraybuffer">|IRequestProgress>;
+
 function request(options : IRequestOptions<"document", false|undefined>) :
-  Observable<IRequestResponse<Document, "document">|IRequestProgress>;
-function request(options : IRequestOptions<"document", true>) :
   Observable<IRequestResponse<Document, "document">>;
+function request(options : IRequestOptions<"document", true>) :
+  Observable<IRequestResponse<Document, "document">|IRequestProgress>;
+
 function request(options : IRequestOptions<"json", false|undefined>) :
-  Observable<IRequestResponse<object, "json">|IRequestProgress>;
-function request(options : IRequestOptions<"json", true>) :
   Observable<IRequestResponse<object, "json">>;
+function request(options : IRequestOptions<"json", true>) :
+  Observable<IRequestResponse<object, "json">|IRequestProgress>;
+
 function request(options : IRequestOptions<"blob", false|undefined>) :
-  Observable<IRequestResponse<Blob, "blob">|IRequestProgress>;
-function request(options : IRequestOptions<"blob", true>) :
   Observable<IRequestResponse<Blob, "blob">>;
+function request(options : IRequestOptions<"blob", true>) :
+  Observable<IRequestResponse<Blob, "blob">|IRequestProgress>;
+
 function request<T>(
-  options : IRequestOptions<
-    XMLHttpRequestResponseType|null|undefined, false|undefined
-  >
+  options : IRequestOptions<XMLHttpRequestResponseType|null|undefined, false|undefined>
+) : Observable<IRequestResponse<T, XMLHttpRequestResponseType>>;
+function request<T>(
+  options : IRequestOptions<XMLHttpRequestResponseType|null|undefined, true>
 ) : Observable<
   IRequestResponse<T, XMLHttpRequestResponseType>|IRequestProgress
 >;
-function request<T>(
-  options : IRequestOptions<XMLHttpRequestResponseType|null|undefined, true>
-) : Observable<IRequestResponse<T, XMLHttpRequestResponseType>>;
 
 function request<T>(
   options : IRequestOptions<
@@ -243,7 +246,7 @@ function request<T>(
       obs.error(new RequestError(xhr, url, errorCode));
     };
 
-    if (!options.ignoreProgressEvents) {
+    if (options.sendProgressEvents === true) {
       xhr.onprogress = function onXHRProgress(event) {
         const currentTime = performance.now();
         obs.next({


### PR DESCRIPTION
This helps to simplify the usage of the `xhrRequest` utils, which now will only emit the response by default. This simplification helps encouraging future tools to use the same function to perform XHR request.