### PR TITLE
eme/api: add disableMediaKeysAttachmentLock keySystem option

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -198,12 +198,35 @@ This property is an array of objects with the following properties (only
     directly the license or `null` if it can be done synchronously.
 
   - ``closeSessionsOnStop`` (``Boolean|undefined``): If set to ``true``, the
-    ``MediaKeySession`` created for a content will be immediately closed when the
-    content stops its playback. This might be required by your key system
+    ``MediaKeySession`` created for a content will be immediately closed when
+    the content stops its playback. This might be required by your key system
     implementation (most often, it is not).
 
     If set to ``false`` or not set, the ``MediaKeySession`` can be reused if the
     same content needs to be re-decrypted.
+
+  - ``disableMediaKeysAttachmentLock`` (``Boolean|undefined``):
+    In regular conditions, we might want to wait for the media element to have
+    decryption capabilities (what we call here "MediaKeys attachment") before
+    beginning to load the actual content.
+
+    Waiting for that capability validation allows for example to play a content
+    which contains both encrypted and unencrypted data on the Chrome browser.
+
+    However, we found that in some peculiar devices (like some set-top boxes)
+    this can create a deadlock: the browser sometimes wait for some
+    content to be loaded before validating the media element's decryption
+    capabilities.
+
+    Because we didn't find a good enough compromise for now, we added the
+    `disableMediaKeysAttachmentLock` boolean.
+    By setting it to `true`, we won't wait for "MediaKeys attachment" before
+    pushing the first content. The downside being that content of mixed
+    unencrypted/encrypted data might not be playable with that configuration.
+
+    You can try that property if your encrypted contents seems to load
+    indefinitely on "exotic" targets.
+
 
 #### Example
 

--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -225,7 +225,7 @@ This property is an array of objects with the following properties (only
     unencrypted/encrypted data might not be playable with that configuration.
 
     You can try that property if your encrypted contents seems to load
-    indefinitely on "exotic" targets.
+    indefinitely on peculiar targets.
 
 
 #### Example

--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -41,18 +41,20 @@ type MediaKeysRequirement = "optional" |
                             "required" |
                             "not-allowed";
 
+export interface IMediaKeySystemAccessInfos {
+  mediaKeySystemAccess: ICompatMediaKeySystemAccess |
+                        ICustomMediaKeySystemAccess;
+  options: IKeySystemOption;
+}
+
 export interface IReuseMediaKeySystemAccessEvent {
   type: "reuse-media-key-system-access";
-  value: { mediaKeySystemAccess: ICompatMediaKeySystemAccess |
-                                 ICustomMediaKeySystemAccess;
-           options: IKeySystemOption; };
+  value: IMediaKeySystemAccessInfos;
 }
 
 export interface ICreateMediaKeySystemAccessEvent {
   type: "create-media-key-system-access";
-  value: { mediaKeySystemAccess: ICompatMediaKeySystemAccess |
-                                 ICustomMediaKeySystemAccess;
-           options: IKeySystemOption; };
+  value: IMediaKeySystemAccessInfos;
 }
 
 export type IFoundMediaKeySystemAccessEvent = IReuseMediaKeySystemAccessEvent |

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -31,6 +31,16 @@ export interface IEMEWarningEvent { type : "warning";
 
 export interface IEMEInitEvent { type: "eme-init"; }
 
+export interface ICreatedMediaKeysEvent { type: "created-media-keys";
+                                          value: IMediaKeysInfos; }
+
+export interface IAttachedMediaKeysEvent { type: "attached-media-keys";
+                                           value: IMediaKeysInfos; }
+
+export type IEMEManagerEvent = IEMEWarningEvent |
+                               ICreatedMediaKeysEvent |
+                               IAttachedMediaKeysEvent;
+
 // Infos indentifying a MediaKeySystemAccess
 export interface IKeySystemAccessInfos {
   keySystemAccess: ICompatMediaKeySystemAccess |
@@ -95,6 +105,7 @@ export interface IKeySystemOption {
   videoRobustnesses?: Array<string|undefined>;
   audioRobustnesses?: Array<string|undefined>;
   throwOnLicenseExpiration? : boolean;
+  disableMediaKeysAttachmentLock? : boolean;
 }
 
 // Keys are the different key statuses possible.

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -29,8 +29,6 @@ export interface IEMEWarningEvent { type : "warning";
                                     value : ICustomError |
                                             Error; }
 
-export interface IEMEInitEvent { type: "eme-init"; }
-
 export interface ICreatedMediaKeysEvent { type: "created-media-keys";
                                           value: IMediaKeysInfos; }
 

--- a/src/core/init/__tests__/is_eme_ready.test.ts
+++ b/src/core/init/__tests__/is_eme_ready.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import isEMEReadyEvent from "../is_eme_ready";
+
+describe("core - init - isEMEReadyEvent", () => {
+  it("should return false for a warning event", () => {
+    expect(isEMEReadyEvent({
+      type: "warning",
+      value: new Error(),
+    })).toBe(false);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should return false for a `created-media-keys` event without `disableMediaKeysAttachmentLock`", () => {
+  /* tslint:enable max-line-length */
+    expect(isEMEReadyEvent({
+      type: "created-media-keys",
+      value: {
+        mediaKeySystemAccess: {} as any,
+        keySystemOptions: {
+          type: "blabla",
+          getLicense() : never { throw new Error(); },
+        },
+        mediaKeys: {} as any,
+        sessionsStore: {} as any,
+        sessionStorage: null,
+      },
+    })).toBe(false);
+    expect(isEMEReadyEvent({
+      type: "created-media-keys",
+      value: {
+        mediaKeySystemAccess: {} as any,
+        keySystemOptions: {
+          type: "blabla",
+          getLicense() : never { throw new Error(); },
+          disableMediaKeysAttachmentLock: false,
+        },
+        mediaKeys: {} as any,
+        sessionsStore: {} as any,
+        sessionStorage: null,
+      },
+    })).toBe(false);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should return true for a `created-media-keys` event with `disableMediaKeysAttachmentLock`", () => {
+  /* tslint:enable max-line-length */
+    expect(isEMEReadyEvent({
+      type: "created-media-keys",
+      value: {
+        mediaKeySystemAccess: {} as any,
+        keySystemOptions: {
+          type: "blabla",
+          getLicense() : never { throw new Error(); },
+          disableMediaKeysAttachmentLock: true,
+        },
+        mediaKeys: {} as any,
+        sessionsStore: {} as any,
+        sessionStorage: null,
+      },
+    })).toBe(true);
+  });
+
+  it("should return true for any `attached-media-keys` event", () => {
+    expect(isEMEReadyEvent({
+      type: "attached-media-keys",
+      value: {
+        mediaKeySystemAccess: {} as any,
+        keySystemOptions: {
+          type: "blabla",
+          getLicense() : never { throw new Error(); },
+        },
+        mediaKeys: {} as any,
+        sessionsStore: {} as any,
+        sessionStorage: null,
+      },
+    })).toBe(true);
+    expect(isEMEReadyEvent({
+      type: "attached-media-keys",
+      value: {
+        mediaKeySystemAccess: {} as any,
+        keySystemOptions: {
+          type: "blabla",
+          getLicense() : never { throw new Error(); },
+          disableMediaKeysAttachmentLock: true,
+        },
+        mediaKeys: {} as any,
+        sessionsStore: {} as any,
+        sessionStorage: null,
+      },
+    })).toBe(true);
+  });
+});

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -50,6 +50,7 @@ import EVENTS from "./events_generators";
 import { IInitialTimeOptions } from "./get_initial_time";
 import getStalledEvents from "./get_stalled_events";
 import seekAndLoadOnMediaEvents from "./initial_seek_and_play";
+import isEMEReadyEvent from "./is_eme_ready";
 import throwOnMediaError from "./throw_on_media_error";
 import {
   IInitClockTick,
@@ -174,7 +175,7 @@ export default function initializeDirectfileContent({
 
   // Manage "loaded" event and warn if autoplay is blocked on the current browser
   const loadedEvent$ = emeManager$.pipe(
-    filter(({ type }) => type === "eme-init" || type === "eme-disabled"),
+    filter(isEMEReadyEvent),
     take(1),
     mergeMapTo(load$),
     mergeMap((evt) => {

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -70,6 +70,7 @@ import EVENTS from "./events_generators";
 import getInitialTime, {
   IInitialTimeOptions,
 } from "./get_initial_time";
+import isEMEReadyEvent from "./is_eme_ready";
 import createMediaSourceLoader, {
   IMediaSourceLoaderEvent,
 } from "./load_on_media_source";
@@ -210,15 +211,10 @@ export default function InitializeOnMediaSource({
   const manifestRefreshed$ =
     new ReplaySubject<{ manifest : Manifest; sendingTime? : number }>(1);
 
-  const emeInitialized$ = emeManager$.pipe(
-    filter(({ type }) => type === "eme-init" || type === "eme-disabled"),
-    take(1)
-  );
-
   const loadContent$ = observableCombineLatest(
     openMediaSource$,
     fetchManifest({ url, hasClockSynchronization: false }),
-    emeInitialized$
+    emeManager$.pipe(filter(isEMEReadyEvent), take(1))
   ).pipe(mergeMap(([ mediaSource, { manifest, sendingTime } ]) => {
 
     /**

--- a/src/core/init/is_eme_ready.ts
+++ b/src/core/init/is_eme_ready.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IEMEManagerEvent } from "../eme";
+import { IEMEDisabledEvent } from "./create_eme_manager";
+
+/**
+ * Returns true if the received EME-related event indicate that we can begin to
+ * load the content.
+ * @param {Object} emeEvent
+ * @returns {Boolean}
+ */
+export default function isEMEReadyEvent(
+  emeEvent : IEMEManagerEvent|IEMEDisabledEvent
+) : boolean {
+  return emeEvent.type === "eme-disabled" ||
+         emeEvent.type === "attached-media-keys" ||
+         (emeEvent.type === "created-media-keys" &&
+          emeEvent.value.keySystemOptions.disableMediaKeysAttachmentLock === true);
+}


### PR DESCRIPTION
# add disableMediaKeysAttachmentLock keySystem option

# Overview

Implement ``disableMediaKeysAttachmentLock`` keySystem option, to allow user to opt-out the lock we made in the release `v3.11.0` to be able to load content with both encrypted and unencrypted data in Chrome desktop.

We couldn't find a solution that worked both ways so I had to fall back to one or the other type of deal.
As this only causes problem on some STBs, I choose to let this lock on by default.

I'm still unsure whether this should just be an "experimental" feature or a plain announced, maintained and documented feature. I choose to do all that for now and we will see what to really do before releasing.

# Implementation

I updated the `EMEManager` to communicate more clearly about what it does. More precizely, it now sends two more events:
  - `ICreatedMediaKeysEvent`
  - `IAttachedMediaKeysEvent`

Those two are respectively for when we have called `createMediaKeys` on the `MediaKeySystemAccess` and after we succesfully attached the `MediaKeys` instance to the `HTMLMediaElement`.

In Init, I listen to both events:
  - If the `ICreatedMediaKeysEvent` is received for a key system where ``disableMediaKeysAttachmentLock`` is set, we continue
  - if it was not set or set to `false`, we wait for the `IAttachedMediaKeysEvent` to continue
  - of course, we continue immediately if a `"eme-disabled"` event is received.

# Notes

I also looked at what our other friends were doing:
  - shaka player just seem to always wait for MediaKeys attachment: https://github.com/google/shaka-player/blob/e8a12ed7a5005355a91e4157800b97ff05c938a1/lib/player.js#L1657
  - dash.js doesn't seem to wait for anything EME (though I found that part hard to read).