### PR TITLE
Propose new indentation style

### DIFF
--- a/src/compat/add_text_track.ts
+++ b/src/compat/add_text_track.ts
@@ -40,9 +40,10 @@ export default function addTextTrack(
   const kind = "subtitles";
   if (isIEOrEdge) {
     const tracksLength = mediaElement.textTracks.length;
-    track = tracksLength > 0 ?
-      mediaElement.textTracks[tracksLength - 1] : mediaElement.addTextTrack(kind);
-    track.mode = hidden ? track.HIDDEN : track.SHOWING;
+    track = tracksLength > 0 ? mediaElement.textTracks[tracksLength - 1] :
+                               mediaElement.addTextTrack(kind);
+    track.mode = hidden ? track.HIDDEN :
+                          track.SHOWING;
   } else {
     trackElement = document.createElement("track");
     mediaElement.appendChild(trackElement);

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -24,22 +24,21 @@ interface ICompatMediaKeysConstructor {
 
 // Regular VTTCue as present in most browsers
 // TODO open TypeScript issue about it?
-type ICompatVTTCueConstructor =
-  new(start : number, end : number, cueText : string) => ICompatVTTCue;
+type ICompatVTTCueConstructor = new(start : number,
+                                    end : number,
+                                    cueText : string) => ICompatVTTCue;
 
-interface ICompatVTTCue {
-  align : string;
-  endTime : number;
-  id : string;
-  line : number|"auto";
-  lineAlign : string;
-  position : number|"auto";
-  positionAlign : string;
-  size : number|string;
-  snapToLines : boolean;
-  startTime : number;
-  vertical : string;
-}
+interface ICompatVTTCue { align : string;
+                          endTime : number;
+                          id : string;
+                          line : number|"auto";
+                          lineAlign : string;
+                          position : number|"auto";
+                          positionAlign : string;
+                          size : number|string;
+                          snapToLines : boolean;
+                          startTime : number;
+                          vertical : string; }
 
 // surcharge TextTrack to allow adding ICompatVTTCue to it
 interface ICompatTextTrack extends TextTrack {
@@ -48,18 +47,16 @@ interface ICompatTextTrack extends TextTrack {
 }
 
 // Document with added optional functions for old browsers
-interface ICompatDocument extends Document {
-  mozCancelFullScreen? : () => void;
-  mozFullScreenElement? : HTMLElement;
-  mozHidden? : boolean;
-  msExitFullscreen? : () => void;
-  webkitExitFullscreen : () => void;
-  fullscreenElement : Element|null;
-  msFullscreenElement? : Element|null;
-  webkitFullscreenElement : Element|null;
-  msHidden? : boolean;
-  webkitHidden? : boolean;
-}
+interface ICompatDocument extends Document { mozCancelFullScreen? : () => void;
+                                             mozFullScreenElement? : HTMLElement;
+                                             mozHidden? : boolean;
+                                             msExitFullscreen? : () => void;
+                                             webkitExitFullscreen : () => void;
+                                             fullscreenElement : Element|null;
+                                             msFullscreenElement? : Element|null;
+                                             webkitFullscreenElement : Element|null;
+                                             msHidden? : boolean;
+                                             webkitHidden? : boolean; }
 
 // Element with added optional functions for old browsers
 interface ICompatHTMLMediaElement extends HTMLMediaElement {
@@ -85,15 +82,13 @@ interface ICompatMediaKeySystemConfiguration {
 
 const win = window as any;
 const HTMLElement_ : typeof HTMLElement = win.HTMLElement;
-const VTTCue_ : ICompatVTTCueConstructor|undefined =
-  win.VTTCue ||
-  win.TextTrackCue;
+const VTTCue_ : ICompatVTTCueConstructor|undefined = win.VTTCue ||
+                                                     win.TextTrackCue;
 
-const MediaSource_ : typeof MediaSource|undefined =
-  win.MediaSource ||
-  win.MozMediaSource ||
-  win.WebKitMediaSource ||
-  win.MSMediaSource;
+const MediaSource_ : typeof MediaSource|undefined = win.MediaSource ||
+                                                    win.MozMediaSource ||
+                                                    win.WebKitMediaSource ||
+                                                    win.MSMediaSource;
 
 const MediaKeys_ : ICompatMediaKeysConstructor|undefined =
   win.MediaKeys ||
@@ -117,13 +112,11 @@ const MediaKeys_ : ICompatMediaKeysConstructor|undefined =
     }
   };
 
-const READY_STATES = {
-  HAVE_NOTHING: 0,
-  HAVE_METADATA: 1,
-  HAVE_CURRENT_DATA: 2,
-  HAVE_FUTURE_DATA: 3,
-  HAVE_ENOUGH_DATA: 4,
-};
+const READY_STATES = { HAVE_NOTHING: 0,
+                       HAVE_METADATA: 1,
+                       HAVE_CURRENT_DATA: 2,
+                       HAVE_FUTURE_DATA: 3,
+                       HAVE_ENOUGH_DATA: 4 };
 
 export {
   HTMLElement_,

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -16,19 +16,18 @@
 
 // true on IE11
 // false on Edge and other IEs/browsers.
-const isIE11 : boolean =
-  !!(window as any).MSInputMethodContext && !!(document as any).documentMode;
+const isIE11 : boolean = !!(window as any).MSInputMethodContext &&
+                         !!(document as any).documentMode;
 
 // true for IE / Edge
-const isIEOrEdge : boolean =
-  navigator.appName === "Microsoft Internet Explorer" ||
-  navigator.appName === "Netscape" && /(Trident|Edge)\//.test(navigator.userAgent);
+const isIEOrEdge : boolean = navigator.appName === "Microsoft Internet Explorer" ||
+                             navigator.appName === "Netscape" &&
+                             /(Trident|Edge)\//.test(navigator.userAgent);
 
-const isFirefox : boolean =
-  navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
+const isFirefox : boolean = navigator.userAgent.toLowerCase()
+                                               .indexOf("firefox") !== -1;
 
-const isSamsungBrowser : boolean =
-  /SamsungBrowser/.test(navigator.userAgent);
+const isSamsungBrowser : boolean = /SamsungBrowser/.test(navigator.userAgent);
 
 export {
   isIE11,

--- a/src/compat/can_patch_isobmff.ts
+++ b/src/compat/can_patch_isobmff.ts
@@ -23,10 +23,8 @@ import { isIEOrEdge } from "./browser_detection";
  * Returns true if the current target is tolerant enough for us to
  * simply be able to "patch" an ISOBMFF segment or if we have to create a
  * new one from scratch instead.
- *
- * TODO understand what the fudge Pierre meant here
  * @returns {Boolean}
  */
-export default function canPatchISOBMFFSegment() {
+export default function canPatchISOBMFFSegment() : boolean {
   return !isIEOrEdge;
 }

--- a/src/compat/change_source_buffer_type.ts
+++ b/src/compat/change_source_buffer_type.ts
@@ -17,23 +17,21 @@
 import log from "../log";
 import { IEventEmitter } from "../utils/event_emitter";
 
-interface ICustomSourceBufferEvents {
-  updatestart : Event|undefined;
-  update : Event|undefined;
-  updateend : Event|undefined;
-  error : Event;
-}
+interface ICustomSourceBufferEvents { updatestart : Event|undefined;
+                                      update : Event|undefined;
+                                      updateend : Event|undefined;
+                                      error : Event; }
 
 export interface ICustomSourceBuffer<T>
   extends IEventEmitter<ICustomSourceBufferEvents> {
-  buffered : TimeRanges;
-  changeType? : (type: string) => void;
-  updating : boolean;
-  timestampOffset : number;
-  appendBuffer(data : T) : void;
-  remove(from : number, to : number) : void;
-  abort() : void;
-}
+    buffered : TimeRanges;
+    changeType? : (type: string) => void;
+    updating : boolean;
+    timestampOffset : number;
+    appendBuffer(data : T) : void;
+    remove(from : number, to : number) : void;
+    abort() : void;
+  }
 
 /**
  * If the changeType MSE API is implemented, update the current codec of the

--- a/src/compat/eme/constants.ts
+++ b/src/compat/eme/constants.ts
@@ -20,4 +20,4 @@ import {
 } from "../../utils/byte_parsing";
 
 // The way "pssh" will be written in ISOBMFF files
-export const PSSH_TO_INTEGER = be4toi(strToBytes("pssh"), 0);
+export const PSSH_TO_INTEGER : number = be4toi(strToBytes("pssh"), 0);

--- a/src/compat/eme/custom_key_system_access.ts
+++ b/src/compat/eme/custom_key_system_access.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import PPromise from "../../utils/promise";
 
 // XXX TODO remove when the issue is resolved
 // https://github.com/Microsoft/TypeScript/issues/19189
-import PPromise from "../../utils/promise";
 import { ICompatMediaKeySystemConfiguration } from "../browser_compatibility_types";
 import { ICustomMediaKeys } from "./custom_media_keys";
 
+// MediaKeySystemAccess implementation
 export interface ICustomMediaKeySystemAccess {
   readonly keySystem : string;
   getConfiguration() : ICompatMediaKeySystemConfiguration;
@@ -34,9 +35,11 @@ export interface ICustomMediaKeySystemAccess {
  */
 export default class CustomMediaKeySystemAccess implements ICustomMediaKeySystemAccess {
   /**
-   * @param {string} _keyType
-   * @param {Object} _mediaKeys
-   * @param {Object} _configuration
+   * @param {string} _keyType - type of key system (e.g. "widevine" or
+   * "com.widevine.alpha").
+   * @param {Object} _mediaKeys - MediaKeys implementation
+   * @param {Object} _configuration - Configuration accepted for this
+   * MediaKeySystemAccess.
    */
   constructor(
     private readonly _keyType : string,
@@ -45,21 +48,23 @@ export default class CustomMediaKeySystemAccess implements ICustomMediaKeySystem
   ) {}
 
   /**
-   * @returns {string}
+   * @returns {string} - current key system type (e.g. "widevine" or
+   * "com.widevine.alpha").
    */
   get keySystem() : string {
     return this._keyType;
   }
 
   /**
-   * @returns {Promise}
+   * @returns {Promise.<Object>} - Promise wrapping the MediaKeys for this
+   * MediaKeySystemAccess. Never rejects.
    */
   public createMediaKeys() : Promise<ICustomMediaKeys|MediaKeys> {
     return new PPromise((res) => res(this._mediaKeys));
   }
 
   /**
-   * @returns {Object}
+   * @returns {Object} - Configuration accepted for this MediaKeySystemAccess.
    */
   public getConfiguration() : ICompatMediaKeySystemConfiguration {
     return this._configuration;

--- a/src/compat/eme/generate_key_request.ts
+++ b/src/compat/eme/generate_key_request.ts
@@ -37,8 +37,8 @@ import { ICustomMediaKeySession } from "./custom_media_keys";
  *
  * If the initData is unrecognized or if a CENC PSSH is not found, this function
  * throws.
- * @param {Uint8Array} initData
- * @returns {Uint8Array}
+ * @param {Uint8Array} initData - Initialization data you want to patch
+ * @returns {Uint8Array} - Initialization data, patched
  */
 export function patchInitData(initData : Uint8Array) : Uint8Array {
   const initialLength = initData.byteLength;
@@ -48,9 +48,8 @@ export function patchInitData(initData : Uint8Array) : Uint8Array {
 
   let offset = 0;
   while (offset < initData.length) {
-    if (
-      initData.length < offset + 8 ||
-      be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
+    if (initData.length < offset + 8 ||
+        be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
     ) {
       log.warn("Compat: unrecognized initialization data. Cannot patch it.");
       throw new Error("Compat: unrecognized initialization data. Cannot patch it.");
@@ -63,24 +62,23 @@ export function patchInitData(initData : Uint8Array) : Uint8Array {
     }
 
     const currentPSSH = initData.subarray(offset, offset + len);
-    if (
-      // yep
-      initData[offset + 12] === 0x10 &&
-      initData[offset + 13] === 0x77 &&
-      initData[offset + 14] === 0xef &&
-      initData[offset + 15] === 0xec &&
-      initData[offset + 16] === 0xc0 &&
-      initData[offset + 17] === 0xb2 &&
-      initData[offset + 18] === 0x4d &&
-      initData[offset + 19] === 0x02 &&
-      initData[offset + 20] === 0xac &&
-      initData[offset + 21] === 0xe3 &&
-      initData[offset + 22] === 0x3c &&
-      initData[offset + 23] === 0x1e &&
-      initData[offset + 24] === 0x52 &&
-      initData[offset + 25] === 0xe2 &&
-      initData[offset + 26] === 0xfb &&
-      initData[offset + 27] === 0x4b
+    // yep
+    if (initData[offset + 12] === 0x10 &&
+        initData[offset + 13] === 0x77 &&
+        initData[offset + 14] === 0xef &&
+        initData[offset + 15] === 0xec &&
+        initData[offset + 16] === 0xc0 &&
+        initData[offset + 17] === 0xb2 &&
+        initData[offset + 18] === 0x4d &&
+        initData[offset + 19] === 0x02 &&
+        initData[offset + 20] === 0xac &&
+        initData[offset + 21] === 0xe3 &&
+        initData[offset + 22] === 0x3c &&
+        initData[offset + 23] === 0x1e &&
+        initData[offset + 24] === 0x52 &&
+        initData[offset + 25] === 0xe2 &&
+        initData[offset + 26] === 0xfb &&
+        initData[offset + 27] === 0x4b
     ) {
       log.info("Compat: CENC PSSH found.");
       cencs = concat(cencs, currentPSSH);
@@ -104,11 +102,15 @@ export function patchInitData(initData : Uint8Array) : Uint8Array {
 
 /**
  * Generate a request from session.
- * @param {MediaKeySession} session
- * @param {Uint8Array} initData
- * @param {string} initDataType
- * @param {string} sessionType
- * @returns {Observable}
+ * @param {MediaKeySession} session - MediaKeySession on which the request will
+ * be done.
+ * @param {Uint8Array} initData - Initialization data given e.g. by the
+ * "encrypted" event for the corresponding request.
+ * @param {string} initDataType - Initialization data type given e.g. by the
+ * "encrypted" event for the corresponding request.
+ * @param {string} sessionType - Type of session you want to generate. Consult
+ * EME Specification for more information on session types.
+ * @returns {Observable} - Emit when done. Errors if fails.
  */
 export default function generateKeyRequest(
   session: MediaKeySession|ICustomMediaKeySession,
@@ -127,8 +129,7 @@ export default function generateKeyRequest(
     } else {
       patchedInit = initData;
     }
-    return castToObservable(
-      session.generateRequest(initDataType || "", patchedInit)
-    );
+    return castToObservable(session.generateRequest(initDataType || "",
+                                                    patchedInit));
   });
 }

--- a/src/compat/eme/get_init_data.ts
+++ b/src/compat/eme/get_init_data.ts
@@ -33,8 +33,8 @@ import { PSSH_TO_INTEGER } from "./constants";
  * concatenated (as it is usually the case).
  * If that's the case, it will filter duplicated PSSHs from it.
  *
- * @param {Uint8Array} initData
- * @returns {Uint8Array}
+ * @param {Uint8Array} initData - Raw initialization data
+ * @returns {Uint8Array} - Initialization data, "cleaned"
  */
 function cleanEncryptedEvent(initData : Uint8Array) : Uint8Array {
   let resInitData = new Uint8Array();
@@ -42,9 +42,8 @@ function cleanEncryptedEvent(initData : Uint8Array) : Uint8Array {
 
   let offset = 0;
   while (offset < initData.length) {
-    if (
-      initData.length < offset + 8 ||
-      be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
+    if (initData.length < offset + 8 ||
+        be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
     ) {
       log.warn("Compat: Unrecognized initialization data. Use as is.");
       return initData;
@@ -78,8 +77,9 @@ function cleanEncryptedEvent(initData : Uint8Array) : Uint8Array {
  *   - the initialization Data
  *   - the initialization Data type
  *
- * @param {MediaEncryptedEvent} encryptedEvent
- * @returns {Object}
+ * @param {MediaEncryptedEvent} encryptedEvent - Payload received with an
+ * "encrypted" event.
+ * @returns {Object} - Initialization data and Initialization data type.
  * @throws {EncryptedMediaError} - Throws if no initialization data is
  * encountered in the given event.
  */
@@ -91,15 +91,12 @@ export default function getInitData(
 } {
   const initData = encryptedEvent.initData;
   if (initData == null) {
-    throw new EncryptedMediaError(
-      "INVALID_ENCRYPTED_EVENT",
-      "Compat: No init data found on media encrypted event.",
-      true
-    );
+    throw new EncryptedMediaError("INVALID_ENCRYPTED_EVENT",
+                                  "Compat: No init data found on media encrypted event.",
+                                  true);
   }
+
   const initDataBytes = new Uint8Array(initData);
-  return {
-    initData: cleanEncryptedEvent(initDataBytes),
-    initDataType: encryptedEvent.initDataType,
-  };
+  return { initData: cleanEncryptedEvent(initDataBytes),
+           initDataType: encryptedEvent.initDataType };
 }

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -87,9 +87,8 @@ function findSupportedEvent(
  */
 function eventPrefixed(eventNames : string[], prefixes? : string[]) : string[] {
   return eventNames.reduce((parent : string[], name : string) =>
-    parent
-      .concat((prefixes || BROWSER_PREFIXES)
-      .map((p) => p + name)), []);
+    parent.concat((prefixes || BROWSER_PREFIXES)
+          .map((p) => p + name)), []);
 }
 
 export interface IEventEmitterLike {
@@ -97,10 +96,9 @@ export interface IEventEmitterLike {
   removeEventListener: (eventName: string, handler: () => void) => void;
 }
 
-export type IEventTargetLike =
-  HTMLElement |
-  IEventEmitterLike |
-  IEventEmitter<any>;
+export type IEventTargetLike = HTMLElement |
+                               IEventEmitterLike |
+                               IEventEmitter<any>;
 
 /**
  * @param {Array.<string>} eventNames
@@ -125,11 +123,9 @@ function compatibleListener<T extends Event>(
         return observableFromEvent(element, mem) as Observable<T>;
       } else {
         if (__DEV__) {
-          /* tslint:disable:max-line-length */
-          log.warn(
-            `compat: element <${element.tagName}> does not support any of these events: ${prefixedEvents.join(", ")}`
-            /* tslint:enable:max-line-length */
-          );
+          log.warn(`compat: element ${element.tagName}` +
+                   " does not support any of these events: " +
+                   prefixedEvents.join(", "));
         }
         return NEVER;
       }
@@ -137,9 +133,8 @@ function compatibleListener<T extends Event>(
 
     // otherwise, we need to listen to all the events
     // and merge them into one observable sequence
-    return observableMerge(
-      ...prefixedEvents
-        .map(eventName => observableFromEvent(element, eventName))
+    return observableMerge(...prefixedEvents.map(eventName =>
+                             observableFromEvent(element, eventName))
     );
   };
 }
@@ -151,7 +146,7 @@ function compatibleListener<T extends Event>(
  * @returns {Observable}
  */
 function visibilityChange() : Observable<boolean> {
-  let prefix;
+  let prefix : string|undefined;
 
   const doc = document as ICompatDocument;
   if (doc.hidden != null) {
@@ -164,9 +159,10 @@ function visibilityChange() : Observable<boolean> {
     prefix = "webkit";
   }
 
-  const hidden = prefix ? prefix + "Hidden" : "hidden";
-  const visibilityChangeEvent = prefix + "visibilitychange";
-
+  const hidden = prefix ? prefix + "Hidden" :
+                          "hidden";
+  const visibilityChangeEvent = prefix ? prefix + "visibilitychange" :
+                                         "visibilitychange";
   return observableFromEvent(document, visibilityChangeEvent)
     .pipe(map(() => document[hidden as "hidden"]));
 }
@@ -191,7 +187,7 @@ const isHidden$ = visibilityChange()
 /**
  * @returns {Observable}
  */
-function isInBackground$() {
+function isInBackground$() : Observable<boolean> {
   return observableMerge(isVisible$, isHidden$)
     .pipe(startWith(false));
 }
@@ -257,10 +253,8 @@ const onFullscreenChange$ = compatibleListener(
  * @returns {Observable}
  */
 const onPlayPause$ = (mediaElement : HTMLMediaElement) : Observable<Event> =>
-  observableMerge(
-    compatibleListener(["play"])(mediaElement),
-    compatibleListener(["pause"])(mediaElement)
-  );
+  observableMerge(compatibleListener(["play"])(mediaElement),
+                  compatibleListener(["pause"])(mediaElement));
 
 /**
  * @param {HTMLMediaElement} mediaElement
@@ -268,10 +262,8 @@ const onPlayPause$ = (mediaElement : HTMLMediaElement) : Observable<Event> =>
  */
 const onTextTrackChanges$ =
   (textTrackList : TextTrackList) : Observable<TrackEvent> =>
-    observableMerge(
-      compatibleListener<TrackEvent>(["addtrack"])(textTrackList),
-      compatibleListener<TrackEvent>(["removetrack"])(textTrackList)
-    );
+    observableMerge(compatibleListener<TrackEvent>(["addtrack"])(textTrackList),
+                    compatibleListener<TrackEvent>(["removetrack"])(textTrackList));
 
 /**
  * @param {MediaSource} mediaSource

--- a/src/compat/fullscreen.ts
+++ b/src/compat/fullscreen.ts
@@ -71,12 +71,10 @@ function exitFullscreen() : void {
  */
 function isFullscreen() : boolean {
   const doc = document as ICompatDocument;
-  return !!(
-    doc.fullscreenElement ||
-    doc.mozFullScreenElement ||
-    doc.webkitFullscreenElement ||
-    doc.msFullscreenElement
-  );
+  return !!(doc.fullscreenElement ||
+            doc.mozFullScreenElement ||
+            doc.webkitFullscreenElement ||
+            doc.msFullscreenElement);
 }
 
 export {

--- a/src/compat/is_playback_stuck.ts
+++ b/src/compat/is_playback_stuck.ts
@@ -27,16 +27,16 @@ import { isFirefox } from "./browser_detection";
  */
 export default function isPlaybackStuck(
   time : number,
-  currentRange : {
-    start: number;
-    end: number;
-  }|null,
+  currentRange : { start: number;
+                   end: number; } |
+                 null,
   state : string,
   isStalled : boolean
 ) : boolean {
   const FREEZE_THRESHOLD = 10; // freeze threshold in seconds
-  return (
-    isFirefox && isStalled && state === "timeupdate" &&
-    !!currentRange && currentRange.end - time > FREEZE_THRESHOLD
-  );
+  return (isFirefox &&
+          isStalled &&
+          state === "timeupdate" &&
+          !!currentRange &&
+          currentRange.end - time > FREEZE_THRESHOLD);
 }

--- a/src/compat/is_vtt_cue.ts
+++ b/src/compat/is_vtt_cue.ts
@@ -25,5 +25,5 @@ export default function isVTTCue(
   cue : ICompatVTTCue|TextTrackCue
 ) : cue is ICompatVTTCue {
   return typeof (window as any).VTTCue === "function" &&
-    cue instanceof (window as any).VTTCue;
+         cue instanceof (window as any).VTTCue;
 }

--- a/src/compat/patch_webkit_source_buffer.ts
+++ b/src/compat/patch_webkit_source_buffer.ts
@@ -17,22 +17,18 @@
 import nextTick from "next-tick";
 import EventEmitter from "../utils/event_emitter";
 
-type IWebKitSourceBufferConstructor =
-  new() => IWebKitSourceBuffer;
+type IWebKitSourceBufferConstructor = new() => IWebKitSourceBuffer;
 
-interface IWebKitSourceBuffer {
-  append(data : ArrayBuffer) : void;
-  remove(from : number, to : number) : void;
-}
+interface IWebKitSourceBuffer { append(data : ArrayBuffer) : void;
+                                remove(from : number, to : number) : void; }
 
 // TODO This is the last ugly side-effect here.
 // Either remove it or find the best way to implement that
 export default function patchWebkitSourceBuffer() {
   // old WebKit SourceBuffer implementation,
   // where a synchronous append is used instead of appendBuffer
-  if (
-    (window as any).WebKitSourceBuffer &&
-    !(window as any).WebKitSourceBuffer.prototype.addEventListener
+  if ((window as any).WebKitSourceBuffer &&
+      !(window as any).WebKitSourceBuffer.prototype.addEventListener
   ) {
 
     const sourceBufferWebkitRef : IWebKitSourceBufferConstructor =

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,7 +46,8 @@ export default {
    *     element. Can be useful to display richer TTML subtitles, for example.
    * @type {Object|null}
    */
-  DEFAULT_TEXT_TRACK_MODE: "native" as "native"|"html",
+  DEFAULT_TEXT_TRACK_MODE: "native" as "native" |
+                                       "html",
 
   /**
    * Strategy to adopt when manually setting the current bitrate.
@@ -58,7 +59,8 @@ export default {
    *     during a short moment.
    * @type {string}
    */
-  DEFAULT_MANUAL_BITRATE_SWITCHING_MODE: "seamless" as "seamless"|"direct",
+  DEFAULT_MANUAL_BITRATE_SWITCHING_MODE: "seamless" as "seamless" |
+                                                       "direct",
 
   /**
    * If set to true, video through loadVideo will auto play by default
@@ -578,18 +580,12 @@ export default {
    * @type {Object}
    */
   BUFFER_PADDING: {
-    audio: {
-      high: 1,
-      low: 1,
-    }, // only "audio" segments
-    video: {
-      high: 3,
-      low: 2,
-    }, // only "video" segments
-    other: {
-      high: 1,
-      low: 1,
-    }, // tracks which are not audio/video (text images).
+    audio: { high: 1,
+             low: 1 }, // only "audio" segments
+    video: { high: 3,
+             low: 2 }, // only "video" segments
+    other: { high: 1,
+             low: 1 }, // tracks which are not audio/video (text images).
   },
 
   /**
@@ -661,13 +657,11 @@ export default {
    * Defined in order of importance (first will be tested first etc.)
    * @type {Array.<string>}
    */
-  EME_DEFAULT_WIDEVINE_ROBUSTNESSES: [
-    "HW_SECURE_ALL",
-    "HW_SECURE_DECODE",
-    "HW_SECURE_CRYPTO",
-    "SW_SECURE_DECODE",
-    "SW_SECURE_CRYPTO",
-  ],
+  EME_DEFAULT_WIDEVINE_ROBUSTNESSES: [ "HW_SECURE_ALL",
+                                       "HW_SECURE_DECODE",
+                                       "HW_SECURE_CRYPTO",
+                                       "SW_SECURE_DECODE",
+                                       "SW_SECURE_CRYPTO" ],
 
   /**
    * Link canonical key systems names to their respective reverse domain name,
@@ -678,18 +672,12 @@ export default {
    */
   /* tslint:disable no-object-literal-type-assertion */
   EME_KEY_SYSTEMS: {
-    clearkey:  [
-      "webkit-org.w3.clearkey",
-      "org.w3.clearkey",
-    ],
-    widevine:  [
-      "com.widevine.alpha",
-    ],
-    playready: [
-      "com.microsoft.playready",
-      "com.chromecast.playready",
-      "com.youtube.playready",
-    ],
+    clearkey:  [ "webkit-org.w3.clearkey",
+                 "org.w3.clearkey" ],
+    widevine:  [ "com.widevine.alpha" ],
+    playready: [ "com.microsoft.playready",
+                 "com.chromecast.playready",
+                 "com.youtube.playready" ],
   } as Partial<Record<string, string[]>>,
   /* tslint:enable no-object-literal-type-assertion */
 

--- a/src/core/abr/abr_manager.ts
+++ b/src/core/abr/abr_manager.ts
@@ -31,15 +31,11 @@ import RepresentationChooser, {
   IRequest,
 } from "./representation_chooser";
 
-interface IMetricValue {
-  duration: number;
-  size: number;
-}
+interface IMetricValue { duration: number;
+                         size: number; }
 
-interface IMetric {
-  type : IBufferType;
-  value : IMetricValue;
-}
+interface IMetric { type : IBufferType;
+                    value : IMetricValue; }
 
 export type IABRClockTick = IRepresentationChooserClockTick;
 
@@ -52,13 +48,11 @@ interface IRepresentationChoosersOptions {
   maxAutoBitrates: Partial<Record<IBufferType, number>>;
 }
 
-const defaultChooserOptions = {
-  limitWidth: {},
-  throttle: {},
-  initialBitrates: {},
-  manualBitrates: {},
-  maxAutoBitrates: {},
-};
+const defaultChooserOptions = { limitWidth: {},
+                                throttle: {},
+                                initialBitrates: {},
+                                manualBitrates: {},
+                                maxAutoBitrates: {} };
 
 /**
  * Create the right RepresentationChooser instance, from the given data.
@@ -70,13 +64,11 @@ const createChooser = (
   type : IBufferType,
   options : IRepresentationChoosersOptions
 ) : RepresentationChooser => {
-  return new RepresentationChooser({
-    limitWidth$: options.limitWidth[type],
-    throttle$: options.throttle[type],
-    initialBitrate: options.initialBitrates[type],
-    manualBitrate: options.manualBitrates[type],
-    maxAutoBitrate: options.maxAutoBitrates[type],
-  });
+  return new RepresentationChooser({ limitWidth$: options.limitWidth[type],
+                                     throttle$: options.throttle[type],
+                                     initialBitrate: options.initialBitrates[type],
+                                     manualBitrate: options.manualBitrates[type],
+                                     maxAutoBitrate: options.maxAutoBitrates[type] });
 };
 
 /**
@@ -324,8 +316,8 @@ export default class ABRManager {
   private _lazilyCreateChooser(bufferType : IBufferType) : RepresentationChooser {
     if (!this._choosers[bufferType]) {
       log.debug("ABR: Creating new buffer for ", bufferType);
-      this._choosers[bufferType] =
-        createChooser(bufferType, this._chooserInstanceOptions);
+      this._choosers[bufferType] = createChooser(bufferType,
+                                                 this._chooserInstanceOptions);
     }
     return this._choosers[bufferType] as RepresentationChooser;
   }

--- a/src/core/abr/bandwidth_estimator.ts
+++ b/src/core/abr/bandwidth_estimator.ts
@@ -17,12 +17,10 @@
 import config from "../../config";
 import EWMA from "./ewma";
 
-const {
-  ABR_MINIMUM_TOTAL_BYTES,
-  ABR_MINIMUM_CHUNK_SIZE,
-  ABR_FAST_EMA,
-  ABR_SLOW_EMA,
-} = config;
+const { ABR_MINIMUM_TOTAL_BYTES,
+        ABR_MINIMUM_CHUNK_SIZE,
+        ABR_FAST_EMA,
+        ABR_SLOW_EMA } = config;
 
 /**
  * Calculate a mean bandwidth based on the bytes downloaded and the amount
@@ -88,7 +86,8 @@ export default class BandwidthEstimator {
 
     // Take the minimum of these two estimates.  This should have the effect of
     // adapting down quickly, but up more slowly.
-    return Math.min(this._fastEWMA.getEstimate(), this._slowEWMA.getEstimate());
+    return Math.min(this._fastEWMA.getEstimate(),
+                    this._slowEWMA.getEstimate());
   }
 
   /**

--- a/src/core/abr/ewma.ts
+++ b/src/core/abr/ewma.ts
@@ -40,7 +40,8 @@ export default class EWMA {
    */
   public addSample(weight : number, value : number) : void {
     const adjAlpha = Math.pow(this._alpha, weight);
-    const newEstimate = value * (1 - adjAlpha) + adjAlpha * this._lastEstimate;
+    const newEstimate = value * (1 - adjAlpha) +
+                        adjAlpha * this._lastEstimate;
     if (!isNaN(newEstimate)) {
       this._lastEstimate = newEstimate;
       this._totalWeight += weight;

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -38,80 +38,71 @@ import {
   getRange,
 } from "../../utils/ranges";
 
-export type IMediaInfosState =
-  "init" |
-  "canplay" |
-  "play" |
-  "progress" |
-  "seeking" |
-  "seeked" |
-  "loadedmetadata" |
-  "ratechange" |
-  "timeupdate";
+export type IMediaInfosState = "init" |
+                               "canplay" |
+                               "play" |
+                               "progress" |
+                               "seeking" |
+                               "seeked" |
+                               "loadedmetadata" |
+                               "ratechange" |
+                               "timeupdate";
 
 // Informations recuperated on the media element on each clock
 // tick
-interface IMediaInfos {
-  bufferGap : number;
-  buffered : TimeRanges;
-  currentRange : {
-    start : number;
-    end : number;
-  }|null;
-  currentTime : number;
-  duration : number;
-  ended: boolean;
-  paused : boolean;
-  playbackRate : number;
-  readyState : number;
-  seeking : boolean;
-  state : IMediaInfosState;
-}
+interface IMediaInfos { bufferGap : number;
+                        buffered : TimeRanges;
+                        currentRange : { start : number;
+                                         end : number; } |
+                                       null;
+                        currentTime : number;
+                        duration : number;
+                        ended: boolean;
+                        paused : boolean;
+                        playbackRate : number;
+                        readyState : number;
+                        seeking : boolean;
+                        state : IMediaInfosState; }
 
 type stalledStatus = {
-  reason : "seeking" | "not-ready" | "buffering";
-  timestamp : number;
-} | null;
+                       reason : "seeking" | "not-ready" | "buffering";
+                       timestamp : number;
+                     } |
+                     null;
 
 // Global informations emitted on each clock tick
-export interface IClockTick extends IMediaInfos {
-  stalled : stalledStatus;
-}
+export interface IClockTick extends IMediaInfos { stalled : stalledStatus; }
 
 function isMediaInfoState(state : string) : state is IMediaInfosState {
   return state === "init" ||
-    state === "canplay" ||
-    state === "play" ||
-    state === "progress" ||
-    state === "seeking" ||
-    state === "seeked" ||
-    state === "loadedmetadata" ||
-    state === "ratechange" ||
-    state ===   "timeupdate";
+         state === "canplay" ||
+         state === "play" ||
+         state === "progress" ||
+         state === "seeking" ||
+         state === "seeked" ||
+         state === "loadedmetadata" ||
+         state === "ratechange" ||
+         state ===   "timeupdate";
 }
 
-const {
-  SAMPLING_INTERVAL_MEDIASOURCE,
-  SAMPLING_INTERVAL_NO_MEDIASOURCE,
-  RESUME_GAP_AFTER_SEEKING,
-  RESUME_GAP_AFTER_NOT_ENOUGH_DATA,
-  RESUME_GAP_AFTER_BUFFERING,
-  STALL_GAP,
-} = config;
+const { SAMPLING_INTERVAL_MEDIASOURCE,
+        SAMPLING_INTERVAL_NO_MEDIASOURCE,
+        RESUME_GAP_AFTER_SEEKING,
+        RESUME_GAP_AFTER_NOT_ENOUGH_DATA,
+        RESUME_GAP_AFTER_BUFFERING,
+        STALL_GAP } = config;
 
 /**
  * HTMLMediaElement Events for which timings are calculated and emitted.
  * @type {Array.<string>}
  */
-const SCANNED_MEDIA_ELEMENTS_EVENTS = [
-  "canplay",
-  "play",
-  "progress",
-  "seeking",
-  "seeked",
-  "loadedmetadata",
-  "ratechange",
-];
+const SCANNED_MEDIA_ELEMENTS_EVENTS = [ "canplay",
+                                        "play",
+                                        "progress",
+                                        "seeking",
+                                        "seeked",
+                                        "loadedmetadata",
+                                        "ratechange" ];
 
 /**
  * Returns the amount of time in seconds the buffer should have ahead of the
@@ -144,7 +135,8 @@ function hasLoadedUntilTheEnd(
   currentRange : { start : number; end : number }|null,
   duration : number
 ) : boolean {
-  return currentRange != null && (duration - currentRange.end) <= STALL_GAP;
+  return currentRange != null &&
+         (duration - currentRange.end) <= STALL_GAP;
 }
 
 /**
@@ -158,30 +150,26 @@ function getMediaInfos(
   mediaElement : HTMLMediaElement,
   currentState : IMediaInfosState
 ) : IMediaInfos {
-  const {
-    buffered,
-    currentTime,
-    duration,
-    ended,
-    paused,
-    playbackRate,
-    readyState,
-    seeking,
-  } = mediaElement;
+  const { buffered,
+          currentTime,
+          duration,
+          ended,
+          paused,
+          playbackRate,
+          readyState,
+          seeking } = mediaElement;
 
-  return {
-    bufferGap: getLeftSizeOfRange(buffered, currentTime),
-    buffered,
-    currentRange: getRange(buffered, currentTime),
-    currentTime,
-    duration,
-    ended,
-    paused,
-    playbackRate,
-    readyState,
-    seeking,
-    state: currentState,
-  };
+  return { bufferGap: getLeftSizeOfRange(buffered, currentTime),
+           buffered,
+           currentRange: getRange(buffered, currentTime),
+           currentTime,
+           duration,
+           ended,
+           paused,
+           playbackRate,
+           readyState,
+           seeking,
+           state: currentState };
 }
 
 /**
@@ -201,46 +189,38 @@ function getStalledStatus(
   currentTimings : IMediaInfos,
   withMediaSource : boolean
 ) : stalledStatus {
-  const {
-    state: currentState,
-    currentTime,
-    bufferGap,
-    currentRange,
-    duration,
-    paused,
-    readyState,
-    ended,
-  } = currentTimings;
+  const { state: currentState,
+          currentTime,
+          bufferGap,
+          currentRange,
+          duration,
+          paused,
+          readyState,
+          ended } = currentTimings;
 
-  const {
-    stalled: prevStalled,
-    state: prevState,
-    currentTime: prevTime,
-  } = prevTimings;
+  const { stalled: prevStalled,
+          state: prevState,
+          currentTime: prevTime } = prevTimings;
 
   const fullyLoaded = hasLoadedUntilTheEnd(currentRange, duration);
 
-  const canStall = (
-    readyState >= 1 &&
-    currentState !== "loadedmetadata" &&
-    !prevStalled &&
-    !(fullyLoaded || ended)
-  );
+  const canStall = (readyState >= 1 &&
+                    currentState !== "loadedmetadata" &&
+                    !prevStalled &&
+                    !(fullyLoaded || ended));
 
   let shouldStall;
   let shouldUnstall;
 
   if (withMediaSource) {
-    if (
-      canStall &&
-      (bufferGap <= STALL_GAP || bufferGap === Infinity || readyState === 1)
+    if (canStall &&
+        (bufferGap <= STALL_GAP || bufferGap === Infinity || readyState === 1)
     ) {
       shouldStall = true;
-    } else if (
-      prevStalled &&
-      readyState > 1 &&
-      bufferGap < Infinity &&
-      (bufferGap > getResumeGap(prevStalled) || fullyLoaded || ended)
+    } else if (prevStalled &&
+               readyState > 1 &&
+               bufferGap < Infinity &&
+               (bufferGap > getResumeGap(prevStalled) || fullyLoaded || ended)
     ) {
       shouldUnstall = true;
     }
@@ -250,20 +230,17 @@ function getStalledStatus(
   // own, so we only try to detect when the media timestamp has not changed
   // between two consecutive timeupdates
   else {
-    if (
-      canStall &&
-      (!paused && currentState === "timeupdate" &&
-        prevState === "timeupdate" && currentTime === prevTime ||
-        currentState === "seeking" && bufferGap === Infinity)
+    if (canStall &&
+        (!paused && currentState === "timeupdate" &&
+         prevState === "timeupdate" && currentTime === prevTime ||
+         currentState === "seeking" && bufferGap === Infinity)
     ) {
       shouldStall = true;
-    } else if (
-      prevStalled &&
-      (currentState !== "seeking" && currentTime !== prevTime ||
-        currentState === "canplay" ||
-        bufferGap < Infinity &&
-        (bufferGap > getResumeGap(prevStalled) || fullyLoaded || ended)
-      )
+    } else if (prevStalled &&
+               (currentState !== "seeking" && currentTime !== prevTime ||
+                currentState === "canplay" ||
+                bufferGap < Infinity &&
+                (bufferGap > getResumeGap(prevStalled) || fullyLoaded || ended))
     ) {
       shouldUnstall = true;
     }
@@ -278,10 +255,8 @@ function getStalledStatus(
     } else {
       reason = "buffering";
     }
-    return {
-      reason,
-      timestamp: performance.now(),
-    };
+    return { reason,
+             timestamp: performance.now() };
   }
   else if (shouldUnstall) {
     return null;
@@ -320,8 +295,7 @@ function createClock(
 ) : Observable<IClockTick> {
   return new Observable((obs : Observer<IClockTick>) => {
     let lastTimings : IClockTick = objectAssign(getMediaInfos(mediaElement, "init"),
-      { stalled: null }
-    );
+                                                { stalled: null });
 
     /**
      * Emit timings sample.
@@ -329,33 +303,34 @@ function createClock(
      * @param {Event} [evt] - The Event which triggered the callback, if one.
      */
     function emitSample(evt? : Event) {
-      const state : IMediaInfosState = evt && isMediaInfoState(evt.type) ?
-        evt.type : "timeupdate";
+      const state : IMediaInfosState = evt &&
+                                       isMediaInfoState(evt.type) ? evt.type :
+                                                                    "timeupdate";
       const mediaTimings = getMediaInfos(mediaElement, state);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, withMediaSource);
 
       // /!\ Mutate mediaTimings
       lastTimings = objectAssign(mediaTimings,
-        { stalled: stalledState }
-      );
+                                 { stalled: stalledState });
       log.debug("API: new clock tick", lastTimings);
       obs.next(lastTimings);
     }
 
-    const interval = withMediaSource
-      ? SAMPLING_INTERVAL_MEDIASOURCE
-      : SAMPLING_INTERVAL_NO_MEDIASOURCE;
+    const interval = withMediaSource ? SAMPLING_INTERVAL_MEDIASOURCE :
+                                       SAMPLING_INTERVAL_NO_MEDIASOURCE;
 
     const intervalID = setInterval(emitSample, interval);
-    SCANNED_MEDIA_ELEMENTS_EVENTS.forEach((eventName) =>
-      mediaElement.addEventListener(eventName, emitSample));
+    SCANNED_MEDIA_ELEMENTS_EVENTS
+      .forEach((eventName) =>
+        mediaElement.addEventListener(eventName, emitSample));
 
     obs.next(lastTimings);
 
     return () => {
       clearInterval(intervalID);
-      SCANNED_MEDIA_ELEMENTS_EVENTS.forEach((eventName) =>
-        mediaElement.removeEventListener(eventName, emitSample));
+      SCANNED_MEDIA_ELEMENTS_EVENTS
+        .forEach((eventName) =>
+          mediaElement.removeEventListener(eventName, emitSample));
     };
   }).pipe(
     multicast(() => new ReplaySubject<IClockTick>(1)), // Always emit the last

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -22,17 +22,15 @@ const { FORCED_ENDED_THRESHOLD } = config;
  * Player state dictionnary
  * @type {Object}
  */
-export const PLAYER_STATES = {
-  STOPPED: "STOPPED",
-  LOADED: "LOADED",
-  LOADING: "LOADING",
-  PLAYING: "PLAYING",
-  PAUSED: "PAUSED",
-  ENDED: "ENDED",
-  BUFFERING: "BUFFERING",
-  SEEKING: "SEEKING",
-  RELOADING: "RELOADING",
-};
+export const PLAYER_STATES = { STOPPED: "STOPPED",
+                               LOADED: "LOADED",
+                               LOADING: "LOADING",
+                               PLAYING: "PLAYING",
+                               PAUSED: "PAUSED",
+                               ENDED: "ENDED",
+                               BUFFERING: "BUFFERING",
+                               SEEKING: "SEEKING",
+                               RELOADING: "RELOADING" };
 
 /**
  * Get state string for a _loaded_ content.
@@ -46,7 +44,10 @@ export const PLAYER_STATES = {
 export default function getLoadedContentState(
   mediaElement : HTMLMediaElement,
   isPlaying : boolean,
-  stalledStatus : { reason : "seeking" | "not-ready" | "buffering" }|null
+  stalledStatus : { reason : "seeking" |
+                             "not-ready" |
+                             "buffering"; } |
+                  null
 ) : string {
   if (mediaElement.ended) {
     return PLAYER_STATES.ENDED;
@@ -57,19 +58,17 @@ export default function getLoadedContentState(
     // emit an 'ended' event in some conditions. Detect if we
     // reached the end by comparing the current position and the
     // duration instead.
-    const gapBetweenDurationAndCurrentTime =
-      Math.abs(mediaElement.duration - mediaElement.currentTime);
-    if (
-      FORCED_ENDED_THRESHOLD != null &&
-      gapBetweenDurationAndCurrentTime < FORCED_ENDED_THRESHOLD
+    const gapBetweenDurationAndCurrentTime = Math.abs(mediaElement.duration -
+                                                      mediaElement.currentTime);
+    if (FORCED_ENDED_THRESHOLD != null &&
+        gapBetweenDurationAndCurrentTime < FORCED_ENDED_THRESHOLD
     ) {
       return PLAYER_STATES.ENDED;
     }
 
-    return stalledStatus.reason === "seeking" ?
-      PLAYER_STATES.SEEKING :
-      PLAYER_STATES.BUFFERING;
+    return stalledStatus.reason === "seeking" ? PLAYER_STATES.SEEKING :
+                                                PLAYER_STATES.BUFFERING;
   }
-  return isPlaying ? PLAYER_STATES.PLAYING : PLAYER_STATES.PAUSED;
-
+  return isPlaying ? PLAYER_STATES.PLAYING :
+                     PLAYER_STATES.PAUSED;
 }

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -38,99 +38,80 @@ import {
   ITextTrackPreference,
 } from "./track_manager";
 
-const {
-  DEFAULT_AUTO_PLAY,
-  DEFAULT_INITIAL_BITRATES,
-  DEFAULT_LIMIT_VIDEO_WIDTH,
-  DEFAULT_MANUAL_BITRATE_SWITCHING_MODE,
-  DEFAULT_MAX_BITRATES,
-  DEFAULT_MAX_BUFFER_AHEAD,
-  DEFAULT_MAX_BUFFER_BEHIND,
-  DEFAULT_SHOW_NATIVE_SUBTITLE,
-  DEFAULT_STOP_AT_END,
-  DEFAULT_TEXT_TRACK_MODE,
-  DEFAULT_THROTTLE_WHEN_HIDDEN,
-  DEFAULT_WANTED_BUFFER_AHEAD,
-} = config;
+const { DEFAULT_AUTO_PLAY,
+        DEFAULT_INITIAL_BITRATES,
+        DEFAULT_LIMIT_VIDEO_WIDTH,
+        DEFAULT_MANUAL_BITRATE_SWITCHING_MODE,
+        DEFAULT_MAX_BITRATES,
+        DEFAULT_MAX_BUFFER_AHEAD,
+        DEFAULT_MAX_BUFFER_BEHIND,
+        DEFAULT_SHOW_NATIVE_SUBTITLE,
+        DEFAULT_STOP_AT_END,
+        DEFAULT_TEXT_TRACK_MODE,
+        DEFAULT_THROTTLE_WHEN_HIDDEN,
+        DEFAULT_WANTED_BUFFER_AHEAD } = config;
 
 export { IKeySystemOption };
 
-export interface ITransportOptions {
-  aggressiveMode? : boolean;
-  manifestLoader? : CustomManifestLoader;
-  segmentLoader? : CustomSegmentLoader;
-  representationFilter? : IRepresentationFilter;
-  referenceDateTime? : number;
-}
+export interface ITransportOptions { aggressiveMode? : boolean;
+                                     manifestLoader? : CustomManifestLoader;
+                                     segmentLoader? : CustomSegmentLoader;
+                                     representationFilter? : IRepresentationFilter;
+                                     referenceDateTime? : number; }
 
-export interface ISupplementaryTextTrackOption {
-  url : string;
-  language : string;
-  closedCaption : boolean;
-  mimeType : string;
-  codecs? : string;
-}
+export interface ISupplementaryTextTrackOption { url : string;
+                                                 language : string;
+                                                 closedCaption : boolean;
+                                                 mimeType : string;
+                                                 codecs? : string; }
 
-export interface ISupplementaryImageTrackOption {
-  url : string;
-  mimeType : string;
-}
+export interface ISupplementaryImageTrackOption { url : string;
+                                                  mimeType : string; }
 
-export interface IDefaultAudioTrackOption {
-  language : string;
-  normalized : string;
-  audioDescription : boolean;
-}
+export interface IDefaultAudioTrackOption { language : string;
+                                            normalized : string;
+                                            audioDescription : boolean; }
 
-export interface IDefaultTextTrackOption {
-  language : string;
-  normalized : string;
-  closedCaption : boolean;
-}
+export interface IDefaultTextTrackOption { language : string;
+                                           normalized : string;
+                                           closedCaption : boolean; }
 
-export type ITextTrackPreference = null | {
-  language : string;
-  closedCaption : boolean;
-};
+export type ITextTrackPreference = null |
+                                   { language : string;
+                                     closedCaption : boolean; };
 
-export interface INetworkConfigOption {
-  manifestRetry? : number;
-  offlineRetry? : number;
-  segmentRetry? : number;
-}
+export interface INetworkConfigOption { manifestRetry? : number;
+                                        offlineRetry? : number;
+                                        segmentRetry? : number; }
 
-export type IStartAtOption =
-  { position : number } |
-  { wallClockTime : Date|number } |
-  { percentage : number } |
-  { fromLastPosition : number } |
-  { fromFirstPosition : number };
+export type IStartAtOption = { position : number } |
+                             { wallClockTime : Date|number } |
+                             { percentage : number } |
+                             { fromLastPosition : number } |
+                             { fromFirstPosition : number };
 
-type IParsedStartAtOption =
-  { position : number } |
-  { wallClockTime : number } |
-  { percentage : number } |
-  { fromLastPosition : number } |
-  { fromFirstPosition : number };
+type IParsedStartAtOption = { position : number } |
+                            { wallClockTime : number } |
+                            { percentage : number } |
+                            { fromLastPosition : number } |
+                            { fromFirstPosition : number };
 
-export interface IConstructorOptions {
-  maxBufferAhead? : number;
-  maxBufferBehind? : number;
-  wantedBufferAhead? : number;
+export interface IConstructorOptions { maxBufferAhead? : number;
+                                       maxBufferBehind? : number;
+                                       wantedBufferAhead? : number;
 
-  limitVideoWidth? : boolean;
-  throttleWhenHidden? : boolean;
+                                       limitVideoWidth? : boolean;
+                                       throttleWhenHidden? : boolean;
 
-  preferredAudioTracks? : IAudioTrackPreference[];
-  preferredTextTracks? : ITextTrackPreference[];
+                                       preferredAudioTracks? : IAudioTrackPreference[];
+                                       preferredTextTracks? : ITextTrackPreference[];
 
-  videoElement? : HTMLMediaElement;
-  initialVideoBitrate? : number;
-  initialAudioBitrate? : number;
-  maxAudioBitrate? : number;
-  maxVideoBitrate? : number;
-  stopAtEnd? : boolean;
-}
+                                       videoElement? : HTMLMediaElement;
+                                       initialVideoBitrate? : number;
+                                       initialAudioBitrate? : number;
+                                       maxAudioBitrate? : number;
+                                       maxVideoBitrate? : number;
+                                       stopAtEnd? : boolean; }
 
 export interface IParsedConstructorOptions {
   maxBufferAhead : number;
@@ -185,15 +166,13 @@ interface IParsedLoadVideoOptionsBase {
   manualBitrateSwitchingMode : "seamless"|"direct";
 }
 
-interface IParsedLoadVideoOptionsNative extends IParsedLoadVideoOptionsBase {
-  textTrackMode : "native";
-  hideNativeSubtitle : boolean;
-}
+interface IParsedLoadVideoOptionsNative
+          extends IParsedLoadVideoOptionsBase { textTrackMode : "native";
+                                                hideNativeSubtitle : boolean; }
 
-interface IParsedLoadVideoOptionsHTML extends IParsedLoadVideoOptionsBase {
-  textTrackMode : "html";
-  textTrackElement : HTMLElement;
-}
+interface IParsedLoadVideoOptionsHTML
+          extends IParsedLoadVideoOptionsBase { textTrackMode : "html";
+                                                textTrackElement : HTMLElement; }
 
 export type IParsedLoadVideoOptions =
   IParsedLoadVideoOptionsNative |
@@ -257,17 +236,20 @@ function parseConstructorOptions(
     }
   }
 
-  limitVideoWidth = options.limitVideoWidth == null ?
-    DEFAULT_LIMIT_VIDEO_WIDTH : !!options.limitVideoWidth;
+  limitVideoWidth = options.limitVideoWidth == null ? DEFAULT_LIMIT_VIDEO_WIDTH :
+                                                      !!options.limitVideoWidth;
 
   throttleWhenHidden = options.throttleWhenHidden == null ?
-    DEFAULT_THROTTLE_WHEN_HIDDEN : !!options.throttleWhenHidden;
+    DEFAULT_THROTTLE_WHEN_HIDDEN :
+    !!options.throttleWhenHidden;
 
   preferredAudioTracks = options.preferredAudioTracks == null ?
-    [] : options.preferredAudioTracks;
+    [] :
+    options.preferredAudioTracks;
 
   preferredTextTracks = options.preferredTextTracks == null ?
-    [] : options.preferredTextTracks;
+    [] :
+    options.preferredTextTracks;
 
   if (options.videoElement == null) {
     videoElement = document.createElement("video");
@@ -319,24 +301,22 @@ function parseConstructorOptions(
     }
   }
 
-  stopAtEnd = options.stopAtEnd == null ?
-    DEFAULT_STOP_AT_END : !!options.stopAtEnd;
+  stopAtEnd = options.stopAtEnd == null ? DEFAULT_STOP_AT_END :
+                                          !!options.stopAtEnd;
 
-  return {
-    maxBufferAhead,
-    maxBufferBehind,
-    limitVideoWidth,
-    videoElement,
-    wantedBufferAhead,
-    throttleWhenHidden,
-    preferredAudioTracks,
-    preferredTextTracks,
-    initialAudioBitrate,
-    initialVideoBitrate,
-    maxAudioBitrate,
-    maxVideoBitrate,
-    stopAtEnd,
-  };
+  return { maxBufferAhead,
+           maxBufferBehind,
+           limitVideoWidth,
+           videoElement,
+           wantedBufferAhead,
+           throttleWhenHidden,
+           preferredAudioTracks,
+           preferredTextTracks,
+           initialAudioBitrate,
+           initialVideoBitrate,
+           maxAudioBitrate,
+           maxVideoBitrate,
+           stopAtEnd };
 }
 
 /**
@@ -375,21 +355,20 @@ function parseLoadVideoOptions(
     transport = String(options.transport);
   }
 
-  const autoPlay = options.autoPlay == null ?
-    DEFAULT_AUTO_PLAY : !!options.autoPlay;
+  const autoPlay = options.autoPlay == null ? DEFAULT_AUTO_PLAY :
+                                              !!options.autoPlay;
 
   if (options.keySystems == null) {
     keySystems = [];
   } else {
-    keySystems = Array.isArray(options.keySystems) ?
-      options.keySystems : [options.keySystems];
+    keySystems = Array.isArray(options.keySystems) ? options.keySystems :
+                                                     [options.keySystems];
     for (const keySystem of keySystems) {
-      if (
-        typeof keySystem.type !== "string" ||
-        typeof keySystem.getLicense !== "function"
+      if (typeof keySystem.type !== "string" ||
+          typeof keySystem.getLicense !== "function"
       ) {
         throw new Error("Invalid key system given: Missing type string or " +
-          "getLicense callback");
+                        "getLicense callback");
       }
     }
   }
@@ -407,14 +386,12 @@ function parseLoadVideoOptions(
       if (typeof supplementaryTextTrack.closedCaption !== "boolean") {
         supplementaryTextTrack.closedCaption = !!supplementaryTextTrack.closedCaption;
       }
-      if (
-        typeof supplementaryTextTrack.language !== "string" ||
-        typeof supplementaryTextTrack.mimeType !== "string" ||
-        typeof supplementaryTextTrack.url !== "string"
+      if (typeof supplementaryTextTrack.language !== "string" ||
+          typeof supplementaryTextTrack.mimeType !== "string" ||
+          typeof supplementaryTextTrack.url !== "string"
       ) {
-        /* tslint:disable:max-line-length */
-        throw new Error("Invalid supplementary text track given. Missing either language, mimetype or url");
-        /* tslint:enable:max-line-length */
+        throw new Error("Invalid supplementary text track given. " +
+                        "Missing either language, mimetype or url");
       }
     }
   }
@@ -426,13 +403,11 @@ function parseLoadVideoOptions(
       Array.isArray(options.supplementaryImageTracks) ?
         options.supplementaryImageTracks : [options.supplementaryImageTracks];
     for (const supplementaryImageTrack of supplementaryImageTracks) {
-      if (
-        typeof supplementaryImageTrack.mimeType !== "string" ||
-        typeof supplementaryImageTrack.url !== "string"
+      if (typeof supplementaryImageTrack.mimeType !== "string" ||
+          typeof supplementaryImageTrack.url !== "string"
       ) {
-        /* tslint:disable:max-line-length */
-        throw new Error("Invalid supplementary image track given. Missing either mimetype or url");
-        /* tslint:enable:max-line-length */
+        throw new Error("Invalid supplementary image track given. " +
+                        "Missing either mimetype or url");
       }
     }
   }
@@ -440,9 +415,7 @@ function parseLoadVideoOptions(
   if (options.textTrackMode == null) {
     textTrackMode = DEFAULT_TEXT_TRACK_MODE;
   } else {
-    if (
-      options.textTrackMode !== "native" && options.textTrackMode !== "html"
-    ) {
+    if (options.textTrackMode !== "native" && options.textTrackMode !== "html") {
       throw new Error("Invalid textTrackMode.");
     }
     textTrackMode = options.textTrackMode;
@@ -450,19 +423,20 @@ function parseLoadVideoOptions(
 
   if (options.defaultAudioTrack != null) {
     warnOnce("The `defaultAudioTrack` loadVideo option is deprecated.\n" +
-      "Please use the `preferredAudioTracks` constructor option or the" +
-      "`setPreferredAudioTracks` method instead");
+             "Please use the `preferredAudioTracks` constructor option or the" +
+             "`setPreferredAudioTracks` method instead");
   }
   const defaultAudioTrack = normalizeAudioTrack(options.defaultAudioTrack);
 
   if (options.defaultTextTrack != null) {
     warnOnce("The `defaultTextTrack` loadVideo option is deprecated.\n" +
-      "Please use the `preferredTextTracks` constructor option or the" +
-      "`setPreferredTextTracks` method instead");
+             "Please use the `preferredTextTracks` constructor option or the" +
+             "`setPreferredTextTracks` method instead");
   }
   const defaultTextTrack = normalizeTextTrack(options.defaultTextTrack);
   const hideNativeSubtitle = (options as any).hideNativeSubtitle == null ?
-    !DEFAULT_SHOW_NATIVE_SUBTITLE : !!(options as any).hideNativeSubtitle;
+    !DEFAULT_SHOW_NATIVE_SUBTITLE :
+    !!(options as any).hideNativeSubtitle;
   const manualBitrateSwitchingMode =
     (options as any).manualBitrateSwitchingMode == null ?
       !DEFAULT_MANUAL_BITRATE_SWITCHING_MODE :
@@ -471,59 +445,56 @@ function parseLoadVideoOptions(
   if (textTrackMode === "html") {
     // TODO Better way to express that in TypeScript?
     if ((options as any).textTrackElement == null) {
-      /* tslint:disable:max-line-length */
-      throw new Error("You have to provide a textTrackElement in \"html\" textTrackMode.");
-      /* tslint:enable:max-line-length */
+      throw new Error("You have to provide a textTrackElement " +
+                      "in \"html\" textTrackMode.");
     } else if (!((options as any).textTrackElement instanceof HTMLElement)) {
       throw new Error("textTrackElement should be an HTMLElement.");
     } else {
       textTrackElement = (options as any).textTrackElement;
     }
   } else if ((options as any).textTrackElement != null) {
-    /* tslint:disable:max-line-length */
-    log.warn("API: You have set a textTrackElement without being in an \"html\" textTrackMode. It will be ignored.");
-    /* tslint:enable:max-line-length */
+    log.warn("API: You have set a textTrackElement without being in " +
+             "an \"html\" textTrackMode. It will be ignored.");
   }
 
   if (options.startAt != null) {
     // TODO Better way to express that in TypeScript?
-    if (
-      (options.startAt as { wallClockTime? : Date|number }).wallClockTime
-      instanceof Date
+    if ((options.startAt as { wallClockTime? : Date|number }).wallClockTime
+           instanceof Date
     ) {
       const wallClockTime = (options.startAt as { wallClockTime : Date })
         .wallClockTime.getTime() / 1000;
-      startAt = objectAssign({}, options.startAt, { wallClockTime });
+      startAt = objectAssign({},
+                             options.startAt,
+                             { wallClockTime });
     } else {
       startAt = options.startAt as IParsedStartAtOption;
     }
   }
 
-  const networkConfig = options.networkConfig == null ? {} : {
-    manifestRetry: options.networkConfig.manifestRetry,
-    offlineRetry: options.networkConfig.offlineRetry,
-    segmentRetry: options.networkConfig.segmentRetry,
-  };
+  const networkConfig = options.networkConfig == null ?
+    {} :
+    { manifestRetry: options.networkConfig.manifestRetry,
+      offlineRetry: options.networkConfig.offlineRetry,
+      segmentRetry: options.networkConfig.segmentRetry };
 
   // TODO without cast
   /* tslint:disable no-object-literal-type-assertion */
-  return {
-    autoPlay,
-    defaultAudioTrack,
-    defaultTextTrack,
-    hideNativeSubtitle,
-    keySystems,
-    manualBitrateSwitchingMode,
-    networkConfig,
-    startAt,
-    supplementaryImageTracks,
-    supplementaryTextTracks,
-    textTrackElement,
-    textTrackMode,
-    transport,
-    transportOptions,
-    url,
-  } as IParsedLoadVideoOptions;
+  return { autoPlay,
+           defaultAudioTrack,
+           defaultTextTrack,
+           hideNativeSubtitle,
+           keySystems,
+           manualBitrateSwitchingMode,
+           networkConfig,
+           startAt,
+           supplementaryImageTracks,
+           supplementaryTextTracks,
+           textTrackElement,
+           textTrackMode,
+           transport,
+           transportOptions,
+           url } as IParsedLoadVideoOptions;
   /* tslint:enable no-object-literal-type-assertion */
 }
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -511,21 +511,19 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   constructor(options : IConstructorOptions = {}) {
     super();
-    const {
-      initialAudioBitrate,
-      initialVideoBitrate,
-      limitVideoWidth,
-      maxAudioBitrate,
-      maxBufferAhead,
-      maxBufferBehind,
-      maxVideoBitrate,
-      preferredAudioTracks,
-      preferredTextTracks,
-      throttleWhenHidden,
-      videoElement,
-      wantedBufferAhead,
-      stopAtEnd,
-    } = parseConstructorOptions(options);
+    const { initialAudioBitrate,
+            initialVideoBitrate,
+            limitVideoWidth,
+            maxAudioBitrate,
+            maxBufferAhead,
+            maxBufferBehind,
+            maxVideoBitrate,
+            preferredAudioTracks,
+            preferredTextTracks,
+            throttleWhenHidden,
+            videoElement,
+            wantedBufferAhead,
+            stopAtEnd } = parseConstructorOptions(options);
 
     // Workaround to support Firefox autoplay on FF 42.
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1194624
@@ -589,18 +587,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     };
 
     this._priv_bitrateInfos = {
-      lastBitrates: {
-        audio: initialAudioBitrate,
-        video: initialVideoBitrate,
-      },
-      initialMaxAutoBitrates: {
-        audio: maxAudioBitrate,
-        video: maxVideoBitrate,
-      },
-      manualBitrates: {
-        audio: -1,
-        video: -1,
-      },
+      lastBitrates: { audio: initialAudioBitrate,
+                      video: initialVideoBitrate },
+      initialMaxAutoBitrates: { audio: maxAudioBitrate,
+                                video: maxVideoBitrate },
+      manualBitrates: { audio: -1,
+                        video: -1 },
     };
 
     this._priv_throttleWhenHidden = throttleWhenHidden;
@@ -676,20 +668,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const options = parseLoadVideoOptions(opts);
     log.info("API: Calling loadvideo", options);
 
-    const {
-      autoPlay,
-      defaultAudioTrack,
-      defaultTextTrack,
-      keySystems,
-      manualBitrateSwitchingMode,
-      networkConfig,
-      startAt,
-      supplementaryImageTracks,
-      supplementaryTextTracks,
-      transport,
-      transportOptions,
-      url,
-    } = options;
+    const { autoPlay,
+            defaultAudioTrack,
+            defaultTextTrack,
+            keySystems,
+            manualBitrateSwitchingMode,
+            networkConfig,
+            startAt,
+            supplementaryImageTracks,
+            supplementaryTextTracks,
+            transport,
+            transportOptions,
+            url } = options;
 
     // Perform multiple checks on the given options
     if (!this.videoElement) {
@@ -702,17 +692,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const isDirectFile = transport === "directfile";
 
     this._priv_currentError = null;
-    this._priv_contentInfos = {
-      url,
-      isDirectFile,
-      thumbnails: null,
-      manifest: null,
-      currentPeriod: null,
-      activeAdaptations: null,
-      activeRepresentations: null,
-      initialAudioTrack: defaultAudioTrack,
-      initialTextTrack: defaultTextTrack,
-    };
+    this._priv_contentInfos = { url,
+                                isDirectFile,
+                                thumbnails: null,
+                                manifest: null,
+                                currentPeriod: null,
+                                activeAdaptations: null,
+                                activeRepresentations: null,
+                                initialAudioTrack: defaultAudioTrack,
+                                initialTextTrack: defaultTextTrack };
 
     // inilialize to false
     this._priv_playing$.next(false);
@@ -725,7 +713,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     const contentIsStopped$ = observableMerge(
       this._priv_stopCurrentContent$,
-      this._priv_stopAtEnd ? onEnded$(videoElement) : EMPTY
+      this._priv_stopAtEnd ? onEnded$(videoElement) :
+                             EMPTY
     ).pipe(take(1));
 
     let playback$ : ConnectableObservable<IInitEvent>;
@@ -736,45 +725,42 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         throw new Error(`transport "${transport}" not supported`);
       }
 
-      const pipelines = transportFn(objectAssign({
-        supplementaryTextTracks,
-        supplementaryImageTracks,
-      }, transportOptions));
+      const pipelines = transportFn(objectAssign({ supplementaryTextTracks,
+                                                   supplementaryImageTracks },
+                                                 transportOptions));
 
       // Options used by the ABR Manager.
       const adaptiveOptions = {
         initialBitrates: this._priv_bitrateInfos.lastBitrates,
         manualBitrates: this._priv_bitrateInfos.manualBitrates,
         maxAutoBitrates: this._priv_bitrateInfos.initialMaxAutoBitrates,
-        throttle: this._priv_throttleWhenHidden ? {
-          video: isInBackground$()
-          .pipe(
-            map(isBg => isBg ? 0 : Infinity),
-            takeUntil(this._priv_stopCurrentContent$)
-          ),
-        } : {},
-        limitWidth: this._priv_limitVideoWidth ? {
-          video: videoWidth$(videoElement)
-            .pipe(takeUntil(this._priv_stopCurrentContent$)),
-        } : {},
+        throttle: this._priv_throttleWhenHidden ?
+        { video: isInBackground$()
+            .pipe(
+              map(isBg => isBg ? 0 :
+                                 Infinity),
+              takeUntil(this._priv_stopCurrentContent$)
+            ), } :
+        {},
+        limitWidth: this._priv_limitVideoWidth ?
+        { video: videoWidth$(videoElement)
+            .pipe(takeUntil(this._priv_stopCurrentContent$)), } :
+        {},
       };
 
       // Options used by the TextTrack SourceBuffer
-      const textTrackOptions = options.textTrackMode === "native" ? {
-        textTrackMode: "native" as "native",
-        hideNativeSubtitle: options.hideNativeSubtitle,
-      } : {
-        textTrackMode: "html" as "html",
-        textTrackElement: options.textTrackElement,
-      };
+      const textTrackOptions = options.textTrackMode === "native" ?
+        { textTrackMode: "native" as "native",
+          hideNativeSubtitle: options.hideNativeSubtitle } :
+        { textTrackMode: "html" as "html",
+          textTrackElement: options.textTrackElement };
 
       // playback$ Observable, through which the content will be launched.
       playback$ = initializeMediaSourcePlayback({
         adaptiveOptions,
         autoPlay,
-        bufferOptions: objectAssign({
-          manualBitrateSwitchingMode,
-        }, this._priv_bufferOptions),
+        bufferOptions: objectAssign({ manualBitrateSwitchingMode },
+                                    this._priv_bufferOptions),
         clock$,
         keySystems,
         mediaElement: videoElement,
@@ -791,17 +777,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (features.directfile == null) {
         throw new Error("DirectFile feature not activated in your build.");
       }
-      playback$ = features.directfile({
-        autoPlay,
-        clock$,
-        keySystems,
-        mediaElement: videoElement,
-        speed$: this._priv_speed$,
-        startAt,
-        url,
-      })
-        .pipe(takeUntil(contentIsStopped$))
-        .pipe(publish()) as ConnectableObservable<IInitEvent>;
+      playback$ = features.directfile({ autoPlay,
+                                        clock$,
+                                        keySystems,
+                                        mediaElement: videoElement,
+                                        speed$: this._priv_speed$,
+                                        startAt,
+                                        url }
+      ).pipe(takeUntil(contentIsStopped$))
+       .pipe(publish()) as ConnectableObservable<IInitEvent>;
     }
 
     // Emit an object when the player stalls and null when it unstall
@@ -836,8 +820,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       stalled$.pipe(startWith(null)),
       endedEvent$.pipe(startWith(null)),
       seekingEvent$.pipe(startWith(null))
-    )
-    .pipe(
+    ).pipe(
       takeUntil(this._priv_stopCurrentContent$),
       map(([isPlaying, stalledStatus]) =>
         getPlayerState(videoElement, isPlaying, stalledStatus)
@@ -927,7 +910,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   getManifest() : Manifest|null {
     return this._priv_contentInfos &&
-      this._priv_contentInfos.manifest;
+           this._priv_contentInfos.manifest;
   }
 
   /**
@@ -961,7 +944,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (!currentPeriod || !activeRepresentations) {
       return null;
     }
-    return activeRepresentations[currentPeriod.id] || null;
+    return activeRepresentations[currentPeriod.id] ||
+           null;
   }
 
   /**
@@ -981,7 +965,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   getNativeTextTrack() : TextTrack|null {
     warnOnce("getNativeTextTrack is deprecated." +
-      " Please open an issue if you used this API.");
+             " Please open an issue if you used this API.");
     if (!this.videoElement) {
       throw new Error("Disposed player");
     }
@@ -1119,9 +1103,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     if (manifest != null) {
       const currentTime = this.videoElement.currentTime;
-      return this.isLive() ?
-        (currentTime + (manifest.availabilityStartTime || 0)) :
-        currentTime;
+      return this.isLive() ? (currentTime + (manifest.availabilityStartTime || 0)) :
+                             currentTime;
     }
     return 0;
   }
@@ -1281,8 +1264,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     return playPromise.catch((error: Error) => {
       if (error.name === "NotAllowedError") {
-        const warning =
-          new MediaError("MEDIA_ERR_PLAY_NOT_ALLOWED", error.toString(), false);
+        const warning = new MediaError("MEDIA_ERR_PLAY_NOT_ALLOWED",
+                                       error.toString(),
+                                       false);
         this.trigger("warning", warning);
       }
       throw error;
@@ -1340,8 +1324,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           );
       } else {
         throw new Error("invalid time object. You must set one of the " +
-          "following properties: \"relative\", \"position\" or " +
-          "\"wallClockTime\"");
+                        "following properties: \"relative\", \"position\" or " +
+                        "\"wallClockTime\"");
       }
     }
 
@@ -1359,7 +1343,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   isFullscreen() : boolean {
     warnOnce("isFullscreen is deprecated." +
-      " Fullscreen management should now be managed by the application");
+             " Fullscreen management should now be managed by the application");
     return isFullscreen();
   }
 
@@ -1370,7 +1354,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   setFullscreen(goFull : boolean = true) : void {
     warnOnce("setFullscreen is deprecated." +
-      " Fullscreen management should now be managed by the application");
+             " Fullscreen management should now be managed by the application");
     if (!this.videoElement) {
       throw new Error("Disposed player");
     }
@@ -1388,7 +1372,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   exitFullscreen() : void {
     warnOnce("exitFullscreen is deprecated." +
-      " Fullscreen management should now be managed by the application");
+             " Fullscreen management should now be managed by the application");
     exitFullscreen();
   }
 
@@ -1919,9 +1903,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
             // TODO merge multiple data from the same track together
             this._priv_contentInfos.thumbnails = imageData;
-            this.trigger("imageTrackUpdate", {
-              data: this._priv_contentInfos.thumbnails,
-            });
+            this.trigger("imageTrackUpdate",
+                         { data: this._priv_contentInfos.thumbnails });
           }
         }
     }
@@ -1992,9 +1975,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const { initialAudioTrack, initialTextTrack } = this._priv_contentInfos;
     this._priv_trackManager = new TrackManager({
       preferredAudioTracks: initialAudioTrack === undefined ?
-        this._priv_preferredAudioTracks : new BehaviorSubject([initialAudioTrack]),
+        this._priv_preferredAudioTracks :
+        new BehaviorSubject([initialAudioTrack]),
       preferredTextTracks: initialTextTrack === undefined ?
-        this._priv_preferredTextTracks : new BehaviorSubject([initialTextTrack]),
+        this._priv_preferredTextTracks :
+        new BehaviorSubject([initialTextTrack]),
     });
 
     fromEvent(manifest, "manifestUpdate")
@@ -2023,11 +2008,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     this._priv_triggerContentEvent("periodChange", period);
     this._priv_triggerContentEvent("availableAudioTracksChange",
-      this.getAvailableAudioTracks());
+                                   this.getAvailableAudioTracks());
     this._priv_triggerContentEvent("availableTextTracksChange",
-      this.getAvailableTextTracks());
+                                   this.getAvailableTextTracks());
     this._priv_triggerContentEvent("availableVideoTracksChange",
-      this.getAvailableVideoTracks());
+                                    this.getAvailableVideoTracks());
 
     // Emit intial events for the Period
     if (this._priv_trackManager) {
@@ -2045,15 +2030,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     this._priv_triggerContentEvent("availableAudioBitratesChange",
-      this.getAvailableAudioBitrates());
+                                   this.getAvailableAudioBitrates());
     this._priv_triggerContentEvent("availableVideoBitratesChange",
-      this.getAvailableVideoBitrates());
+                                   this.getAvailableVideoBitrates());
 
     const activeAudioRepresentations = this.getCurrentRepresentations();
     if (activeAudioRepresentations && activeAudioRepresentations.audio != null) {
       const bitrate = activeAudioRepresentations.audio.bitrate;
       this._priv_triggerContentEvent("audioBitrateChange",
-        bitrate != null ? bitrate : -1);
+                                     bitrate != null ? bitrate : -1);
     } else {
       this._priv_triggerContentEvent("audioBitrateChange", -1);
     }
@@ -2062,7 +2047,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (activeVideoRepresentations && activeVideoRepresentations.video != null) {
       const bitrate = activeVideoRepresentations.video.bitrate;
       this._priv_triggerContentEvent("videoBitrateChange",
-        bitrate != null ? bitrate : -1);
+                                     bitrate != null ? bitrate : -1);
     } else {
       this._priv_triggerContentEvent("videoBitrateChange", -1);
     }
@@ -2203,17 +2188,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       activePeriodAdaptations[type] = adaptation;
     }
 
-    if (
-      this._priv_trackManager &&
-      currentPeriod != null && period != null &&
-      period.id === currentPeriod.id
+    if (this._priv_trackManager &&
+        currentPeriod != null && period != null &&
+        period.id === currentPeriod.id
     ) {
       switch (type) {
         case "audio":
           const audioTrack = this._priv_trackManager.getChosenAudioTrack(currentPeriod);
           this._priv_triggerContentEvent("audioTrackChange", audioTrack);
           this._priv_triggerContentEvent("availableAudioBitratesChange",
-            this.getAvailableVideoBitrates());
+                                         this.getAvailableVideoBitrates());
           break;
         case "text":
           const textTrack = this._priv_trackManager.getChosenTextTrack(currentPeriod);
@@ -2223,7 +2207,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           const videoTrack = this._priv_trackManager.getChosenVideoTrack(currentPeriod);
           this._priv_triggerContentEvent("videoTrackChange", videoTrack);
           this._priv_triggerContentEvent("availableVideoBitratesChange",
-            this.getAvailableVideoBitrates());
+                                         this.getAvailableVideoBitrates());
           break;
       }
     }
@@ -2273,10 +2257,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (period != null && currentPeriod != null && currentPeriod.id === period.id) {
       if (type === "video") {
         this._priv_triggerContentEvent("videoBitrateChange",
-          bitrate != null ? bitrate : -1);
+                                       bitrate != null ? bitrate : -1);
       } else if (type === "audio") {
         this._priv_triggerContentEvent("audioBitrateChange",
-          bitrate != null ? bitrate : -1);
+                                       bitrate != null ? bitrate : -1);
       }
     }
   }
@@ -2292,10 +2276,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_onBitrateEstimationChange({
     type,
     bitrate,
-  } : {
-    type : IBufferType;
-    bitrate : number|undefined;
-  }) : void {
+  } : { type : IBufferType;
+        bitrate : number|undefined; }
+  ) : void {
     this._priv_triggerContentEvent("bitrateEstimationChange", { type, bitrate });
   }
 
@@ -2372,16 +2355,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       playbackRate: clockTick.playbackRate,
 
       // TODO fix higher up?
-      bufferGap: isFinite(clockTick.bufferGap) ? clockTick.bufferGap : 0,
+      bufferGap: isFinite(clockTick.bufferGap) ? clockTick.bufferGap :
+                                                 0,
     };
 
-    if (
-      manifest != null &&
-      manifest.isLive &&
-      clockTick.currentTime > 0
+    if (manifest != null &&
+        manifest.isLive &&
+        clockTick.currentTime > 0
     ) {
-      positionData.wallClockTime =
-        clockTick.currentTime + (manifest.availabilityStartTime || 0);
+      positionData.wallClockTime = clockTick.currentTime +
+                                   (manifest.availabilityStartTime || 0);
       positionData.liveGap = manifest.getMaximumPosition() - clockTick.currentTime;
     }
 

--- a/src/core/api/track_manager.ts
+++ b/src/core/api/track_manager.ts
@@ -35,123 +35,88 @@ import normalizeLanguage from "../../utils/languages";
 import SortedList from "../../utils/sorted_list";
 
 // single preference for an audio track Adaptation
-export type IAudioTrackPreference = null | {
-  language : string;
-  audioDescription : boolean;
-};
+export type IAudioTrackPreference = null |
+                                    { language : string;
+                                      audioDescription : boolean; };
 
 // single preference for a text track Adaptation
-export type ITextTrackPreference = null | {
-  language : string;
-  closedCaption : boolean;
-};
+export type ITextTrackPreference = null |
+                                   { language : string;
+                                     closedCaption : boolean; };
 
 // audio track returned by the TrackManager
-export interface ITMAudioTrack {
-  language : string;
-  normalized : string;
-  audioDescription : boolean;
-  id : number|string;
-}
+export interface ITMAudioTrack { language : string;
+                                 normalized : string;
+                                 audioDescription : boolean;
+                                 id : number|string; }
 
 // text track returned by the TrackManager
-export interface ITMTextTrack {
-  language : string;
-  normalized : string;
-  closedCaption : boolean;
-  id : number|string;
-}
+export interface ITMTextTrack { language : string;
+                                normalized : string;
+                                closedCaption : boolean;
+                                id : number|string; }
 
-interface ITMVideoRepresentation {
-  id : string|number;
-  bitrate : number;
-  width? : number;
-  height? : number;
-  codec? : string;
-  frameRate? : string;
-}
+interface ITMVideoRepresentation { id : string|number;
+                                   bitrate : number;
+                                   width? : number;
+                                   height? : number;
+                                   codec? : string;
+                                   frameRate? : string; }
 
 // video track returned by the TrackManager
-export interface ITMVideoTrack {
-  id : number|string;
-  representations: ITMVideoRepresentation[];
-}
+export interface ITMVideoTrack { id : number|string;
+                                 representations: ITMVideoRepresentation[]; }
 
 // audio track from a list of audio tracks returned by the TrackManager
-export interface ITMAudioTrackListItem extends ITMAudioTrack {
-  active : boolean;
-}
+export interface ITMAudioTrackListItem
+  extends ITMAudioTrack { active : boolean; }
 
 // text track from a list of text tracks returned by the TrackManager
-export interface ITMTextTrackListItem extends ITMTextTrack {
-  active : boolean;
-}
+export interface ITMTextTrackListItem
+  extends ITMTextTrack { active : boolean; }
 
 // video track from a list of video tracks returned by the TrackManager
-export interface ITMVideoTrackListItem extends ITMVideoTrack {
-  active : boolean;
-}
+export interface ITMVideoTrackListItem
+  extends ITMVideoTrack { active : boolean; }
 
 // stored audio informations for a single period
-interface ITMPeriodAudioInfos {
-  adaptations : Adaptation[];
-  adaptation$ : Subject<Adaptation|null> ;
-}
+interface ITMPeriodAudioInfos { adaptations : Adaptation[];
+                                adaptation$ : Subject<Adaptation|null>; }
 
 // stored text informations for a single period
-interface ITMPeriodTextInfos {
-  adaptations : Adaptation[];
-  adaptation$ : Subject<Adaptation|null> ;
-}
+interface ITMPeriodTextInfos { adaptations : Adaptation[];
+                               adaptation$ : Subject<Adaptation|null>; }
 
 // stored video informations for a single period
-interface ITMPeriodVideoInfos {
-  adaptations : Adaptation[];
-  adaptation$ : Subject<Adaptation|null> ;
-}
+interface ITMPeriodVideoInfos { adaptations : Adaptation[];
+                                adaptation$ : Subject<Adaptation|null>; }
 
 // stored informations for a single period
-interface ITMPeriodInfos {
-  period : Period;
-  audio? : ITMPeriodAudioInfos;
-  text? : ITMPeriodTextInfos;
-  video? : ITMPeriodVideoInfos;
-}
+interface ITMPeriodInfos { period : Period;
+                           audio? : ITMPeriodAudioInfos;
+                           text? : ITMPeriodTextInfos;
+                           video? : ITMPeriodVideoInfos; }
 
-type INormalizedAudioTrack = null | {
-  normalized : string;
-  audioDescription : boolean;
-};
+type INormalizedAudioTrack = null |
+                             { normalized : string;
+                               audioDescription : boolean; };
 
-type INormalizedTextTrack = null | {
-  normalized : string;
-  closedCaption : boolean;
-};
+type INormalizedTextTrack = null |
+                            { normalized : string;
+                              closedCaption : boolean; };
 
-/**
- * @param {Array.<Object>}
- * @returns {Array.<Object>}
- */
 function normalizeAudioTracks(
   tracks : IAudioTrackPreference[]
 ) : INormalizedAudioTrack[] {
-  return tracks.map(t => t && {
-    normalized: normalizeLanguage(t.language),
-    audioDescription: t.audioDescription,
-  });
+  return tracks.map(t => t && { normalized: normalizeLanguage(t.language),
+                                audioDescription: t.audioDescription });
 }
 
-/**
- * @param {Array.<Object>}
- * @returns {Array.<Object>}
- */
 function normalizeTextTracks(
   tracks : ITextTrackPreference[]
 ) : INormalizedTextTrack[] {
-  return tracks.map(t => t && {
-    normalized: normalizeLanguage(t.language),
-    closedCaption: t.closedCaption,
-  });
+  return tracks.map(t => t && { normalized: normalizeLanguage(t.language),
+                                closedCaption: t.closedCaption, });
 }
 
 /**
@@ -160,50 +125,32 @@ function normalizeTextTracks(
  * @class TrackManager
  */
 export default class TrackManager {
-  /**
-   * Current Periods considered by the TrackManager.
-   * Sorted by start time ascending
-   * @type {SortedList}
-   * @private
-   */
+  // Current Periods considered by the TrackManager.
+  // Sorted by start time ascending
   private _periods : SortedList<ITMPeriodInfos>;
 
-  /**
-   * Array of preferred languages for audio tracks.
-   * Sorted by order of preference descending.
-   * @type {Array.<Object>}
-   * @private
-   */
+  // Array of preferred languages for audio tracks.
+  // Sorted by order of preference descending.
   private _preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
 
-  /**
-   * Array of preferred languages for text tracks.
-   * Sorted by order of preference descending.
-   * @type {Array.<Object>}
-   * @private
-   */
+  // Array of preferred languages for text tracks.
+  // Sorted by order of preference descending.
   private _preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
 
-  /**
-   * Memoization of the previously-chosen audio Adaptation for each Period.
-   * @type {WeakMap}
-   */
+  // Memoization of the previously-chosen audio Adaptation for each Period.
   private _audioChoiceMemory : WeakMap<Period, Adaptation|null>;
 
-  /**
-   * Memoization of the previously-chosen text Adaptation for each Period.
-   * @type {WeakMap}
-   */
+  // Memoization of the previously-chosen text Adaptation for each Period.
   private _textChoiceMemory : WeakMap<Period, Adaptation|null>;
 
-  /**
-   * Memoization of the previously-chosen video Adaptation for each Period.
-   * @type {WeakMap}
-   */
+  // Memoization of the previously-chosen video Adaptation for each Period.
   private _videoChoiceMemory : WeakMap<Period, Adaptation|null>;
 
   /**
-   * @param {Object} defaults
+   * @param {BehaviorSubject<Array.<Object|null>>} preferredAudioTracks - Array
+   * of audio track preferences
+   * @param {BehaviorSubject<Array.<Object|null>>} preferredAudioTracks - Array
+   * of text track preferences
    */
   constructor(defaults : {
     preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
@@ -222,9 +169,10 @@ export default class TrackManager {
 
   /**
    * Add Subject to choose Adaptation for new "audio" or "text" Period.
-   * @param {string} bufferType
-   * @param {Period} period
-   * @param {Subject} adaptations
+   * @param {string} bufferType - The concerned buffer type
+   * @param {Period} period - The concerned Period.
+   * @param {Subject.<Object|null>} adaptation$ - A subject through which the
+   * choice will be given
    */
   public addPeriod(
     bufferType : "audio" | "text"| "video",
@@ -237,26 +185,22 @@ export default class TrackManager {
         log.warn(`TrackManager: ${bufferType} already added for period`, period);
         return;
       } else {
-        periodItem[bufferType] = {
-          adaptations: period.adaptations[bufferType] || [],
-          adaptation$,
-        };
+        periodItem[bufferType] = { adaptations: period.adaptations[bufferType] || [],
+                                   adaptation$ };
       }
     } else {
-      this._periods.add({
-        period,
-        [bufferType]: {
-          adaptations: period.adaptations[bufferType] || [],
-          adaptation$,
-        },
+      this._periods.add({ period,
+                          [bufferType]: { adaptations: period.adaptations[bufferType] ||
+                                                       [],
+                                          adaptation$, },
       });
     }
   }
 
   /**
    * Remove Subject to choose an "audio" or "text" Adaptation for a Period.
-   * @param {string} bufferType
-   * @param {Period} period
+   * @param {string} bufferType - The concerned buffer type
+   * @param {Period} period - The concerned Period.
    */
   public removePeriod(
     bufferType : "audio" | "text" | "video",
@@ -300,9 +244,7 @@ export default class TrackManager {
    * Emit initial audio Adaptation through the given Subject based on:
    *   - the preferred audio tracks
    *   - the last choice for this period, if one
-   * @param {Period} period
-   *
-   * @throws Error - Throws if the period given has not been added
+   * @param {Period} period - The concerned Period.
    */
   public setInitialAudioTrack(period : Period) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -315,13 +257,12 @@ export default class TrackManager {
     const audioAdaptations = period.adaptations.audio || [];
     const chosenAudioAdaptation = this._audioChoiceMemory.get(period);
 
-    if (
-      chosenAudioAdaptation === undefined ||
-      !arrayIncludes(audioAdaptations, chosenAudioAdaptation)
+    if (chosenAudioAdaptation === undefined ||
+        !arrayIncludes(audioAdaptations, chosenAudioAdaptation)
     ) {
       const normalizedTracks = normalizeAudioTracks(preferredAudioTracks);
-      const optimalAdaptation =
-        findFirstOptimalAudioAdaptation(audioAdaptations, normalizedTracks);
+      const optimalAdaptation = findFirstOptimalAudioAdaptation(audioAdaptations,
+                                                                normalizedTracks);
 
       this._audioChoiceMemory.set(period, optimalAdaptation);
       audioInfos.adaptation$.next(optimalAdaptation);
@@ -334,9 +275,7 @@ export default class TrackManager {
    * Emit initial text Adaptation through the given Subject based on:
    *   - the preferred text tracks
    *   - the last choice for this period, if one
-   * @param {Period} period
-   *
-   * @throws Error - Throws if the period given has not been added
+   * @param {Period} period - The concerned Period.
    */
   public setInitialTextTrack(period : Period) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -348,14 +287,12 @@ export default class TrackManager {
     const preferredTextTracks = this._preferredTextTracks.getValue();
     const textAdaptations = period.adaptations.text || [];
     const chosenTextAdaptation = this._textChoiceMemory.get(period);
-    if (
-      chosenTextAdaptation === undefined ||
-      !arrayIncludes(textAdaptations, chosenTextAdaptation)
+    if (chosenTextAdaptation === undefined ||
+        !arrayIncludes(textAdaptations, chosenTextAdaptation)
     ) {
       const normalizedTracks = normalizeTextTracks(preferredTextTracks);
-      const optimalAdaptation =
-        findFirstOptimalTextAdaptation(textAdaptations, normalizedTracks);
-
+      const optimalAdaptation = findFirstOptimalTextAdaptation(textAdaptations,
+                                                               normalizedTracks);
       this._textChoiceMemory.set(period, optimalAdaptation);
       textInfos.adaptation$.next(optimalAdaptation);
     } else {
@@ -367,9 +304,7 @@ export default class TrackManager {
    * Emit initial video Adaptation through the given Subject based on:
    *   - the preferred video tracks
    *   - the last choice for this period, if one
-   * @param {Period} period
-   *
-   * @throws Error - Throws if the period given has not been added
+   * @param {Period} period - The concerned Period.
    */
   public setInitialVideoTrack(period : Period) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -381,9 +316,8 @@ export default class TrackManager {
     const videoAdaptations = period.adaptations.video || [];
     const chosenVideoAdaptation = this._videoChoiceMemory.get(period);
 
-    if (
-        chosenVideoAdaptation === undefined ||
-      !arrayIncludes(videoAdaptations, chosenVideoAdaptation)
+    if (chosenVideoAdaptation === undefined ||
+        !arrayIncludes(videoAdaptations, chosenVideoAdaptation)
     ) {
       const optimalAdaptation = videoAdaptations[0];
 
@@ -396,13 +330,8 @@ export default class TrackManager {
 
   /**
    * Set audio track based on the ID of its adaptation for a given added Period.
-   *
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
-   *
-   * @throws Error - Throws if the period given has not been added
-   * @throws Error - Throws if the given id is not found in any audio adaptation
-   * of the given Period.
    */
   public setAudioTrackByID(period : Period, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -411,8 +340,8 @@ export default class TrackManager {
       throw new Error("TrackManager: Given Period not found.");
     }
 
-    const wantedAdaptation = arrayFind(audioInfos.adaptations, ({ id }) =>
-      id === wantedId);
+    const wantedAdaptation = arrayFind(audioInfos.adaptations,
+                                       ({ id }) => id === wantedId);
 
     if (wantedAdaptation === undefined) {
       throw new Error("Audio Track not found.");
@@ -428,13 +357,8 @@ export default class TrackManager {
 
   /**
    * Set text track based on the ID of its adaptation for a given added Period.
-   *
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
-   *
-   * @throws Error - Throws if the period given has not been added
-   * @throws Error - Throws if the given id is not found in any text adaptation
-   * of the given Period.
    */
   public setTextTrackByID(period : Period, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
@@ -442,8 +366,8 @@ export default class TrackManager {
     if (!textInfos) {
       throw new Error("TrackManager: Given Period not found.");
     }
-    const wantedAdaptation = arrayFind(textInfos.adaptations, ({ id }) =>
-      id === wantedId);
+    const wantedAdaptation = arrayFind(textInfos.adaptations,
+                                       ({ id }) => id === wantedId);
 
     if (wantedAdaptation === undefined) {
       throw new Error("Text Track not found.");
@@ -459,7 +383,6 @@ export default class TrackManager {
 
   /**
    * Set video track based on the ID of its adaptation for a given added Period.
-   *
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
    *
@@ -474,8 +397,8 @@ export default class TrackManager {
       throw new Error("LanguageManager: Given Period not found.");
     }
 
-    const wantedAdaptation = arrayFind(videoInfos.adaptations, ({ id }) =>
-      id === wantedId);
+    const wantedAdaptation = arrayFind(videoInfos.adaptations,
+                                       ({ id }) => id === wantedId);
 
     if (wantedAdaptation === undefined) {
       throw new Error("Video Track not found.");
@@ -540,8 +463,8 @@ export default class TrackManager {
    * Returns null is the the current audio track is disabled or not
    * set yet.
    *
-   * @param {Period} period
-   * @returns {Object|null}
+   * @param {Period} period - The concerned Period.
+   * @returns {Object|null} - The audio track chosen for this Period
    */
   public getChosenAudioTrack(period : Period) : ITMAudioTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
@@ -555,12 +478,10 @@ export default class TrackManager {
       return null;
     }
 
-    return {
-      language: chosenAudioAdaptation.language || "",
-      normalized: chosenAudioAdaptation.normalizedLanguage || "",
-      audioDescription: !!chosenAudioAdaptation.isAudioDescription,
-      id: chosenAudioAdaptation.id,
-    };
+    return { language: chosenAudioAdaptation.language || "",
+             normalized: chosenAudioAdaptation.normalizedLanguage || "",
+             audioDescription: !!chosenAudioAdaptation.isAudioDescription,
+             id: chosenAudioAdaptation.id };
   }
 
   /**
@@ -570,8 +491,8 @@ export default class TrackManager {
    * Returns null is the the current text track is disabled or not
    * set yet.
    *
-   * @param {Period} period
-   * @returns {Object|null}
+   * @param {Period} period - The concerned Period.
+   * @returns {Object|null} - The text track chosen for this Period
    */
   public getChosenTextTrack(period : Period) : ITMTextTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
@@ -585,12 +506,10 @@ export default class TrackManager {
       return null;
     }
 
-    return {
-      language: chosenTextAdaptation.language || "",
-      normalized: chosenTextAdaptation.normalizedLanguage || "",
-      closedCaption: !!chosenTextAdaptation.isClosedCaption,
-      id: chosenTextAdaptation.id,
-    };
+    return { language: chosenTextAdaptation.language || "",
+             normalized: chosenTextAdaptation.normalizedLanguage || "",
+             closedCaption: !!chosenTextAdaptation.isClosedCaption,
+             id: chosenTextAdaptation.id };
   }
 
   /**
@@ -600,8 +519,8 @@ export default class TrackManager {
    * Returns null is the the current video track is disabled or not
    * set yet.
    *
-   * @param {Period} period
-   * @returns {Object|null}
+   * @param {Period} period - The concerned Period.
+   * @returns {Object|null} - The video track chosen for this Period
    */
   public getChosenVideoTrack(period : Period) : ITMVideoTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
@@ -717,27 +636,24 @@ export default class TrackManager {
         return;
       }
 
-      const {
-        period,
-        audio: audioItem,
-      } = periodItem;
+      const { period,
+              audio: audioItem } = periodItem;
       const audioAdaptations = period.adaptations.audio || [];
       const chosenAudioAdaptation = this._audioChoiceMemory.get(period);
 
-      if (
-        chosenAudioAdaptation === null ||
-        (
-          chosenAudioAdaptation !== undefined &&
-          arrayIncludes(audioAdaptations, chosenAudioAdaptation)
-        )
+      if (chosenAudioAdaptation === null ||
+          (
+            chosenAudioAdaptation !== undefined &&
+            arrayIncludes(audioAdaptations, chosenAudioAdaptation)
+          )
       ) {
         // Already best audio for this Buffer, check next one
         recursiveUpdateAudioTrack(index + 1);
         return;
       }
 
-      const optimalAdaptation =
-        findFirstOptimalAudioAdaptation(audioAdaptations, normalizedTracks);
+      const optimalAdaptation = findFirstOptimalAudioAdaptation(audioAdaptations,
+                                                                normalizedTracks);
 
       this._audioChoiceMemory.set(period, optimalAdaptation);
       audioItem.adaptation$.next(optimalAdaptation);
@@ -766,27 +682,24 @@ export default class TrackManager {
         return;
       }
 
-      const {
-        period,
-        text: textItem,
-      } = periodItem;
+      const { period,
+              text: textItem } = periodItem;
       const textAdaptations = period.adaptations.text || [];
       const chosenTextAdaptation = this._textChoiceMemory.get(period);
 
-      if (
-        chosenTextAdaptation === null ||
-        (
-          chosenTextAdaptation !== undefined &&
-          arrayIncludes(textAdaptations, chosenTextAdaptation)
-        )
+      if (chosenTextAdaptation === null ||
+          (
+            chosenTextAdaptation !== undefined &&
+            arrayIncludes(textAdaptations, chosenTextAdaptation)
+          )
       ) {
         // Already best text for this Buffer, check next one
         recursiveUpdateTextTrack(index + 1);
         return;
       }
 
-      const optimalAdaptation =
-        findFirstOptimalTextAdaptation(textAdaptations, normalizedTracks);
+      const optimalAdaptation = findFirstOptimalTextAdaptation(textAdaptations,
+                                                               normalizedTracks);
 
       this._textChoiceMemory.set(period, optimalAdaptation);
       textItem.adaptation$.next(optimalAdaptation);
@@ -812,19 +725,16 @@ export default class TrackManager {
         return;
       }
 
-      const {
-        period,
-        video: videoItem,
-      } = periodItem;
+      const { period,
+              video: videoItem, } = periodItem;
       const videoAdaptations = period.adaptations.video || [];
       const chosenVideoAdaptation = this._videoChoiceMemory.get(period);
 
-      if (
-        chosenVideoAdaptation === null ||
-        (
-          chosenVideoAdaptation !== undefined &&
-          arrayIncludes(videoAdaptations, chosenVideoAdaptation)
-        )
+      if (chosenVideoAdaptation === null ||
+          (
+            chosenVideoAdaptation !== undefined &&
+            arrayIncludes(videoAdaptations, chosenVideoAdaptation)
+          )
       ) {
         // Already best video for this Buffer, check next one
         recursiveUpdateVideoTrack(index + 1);
@@ -952,5 +862,10 @@ function getPeriodItem(
 function parseVideoRepresentation(
   { id, bitrate, frameRate, width, height, codec } : Representation
 ) : ITMVideoRepresentation {
-  return { id, bitrate, frameRate, width, height, codec };
+  return { id,
+           bitrate,
+           frameRate,
+           width,
+           height,
+           codec };
 }

--- a/src/core/buffers/active_period_emitter.ts
+++ b/src/core/buffers/active_period_emitter.ts
@@ -39,17 +39,13 @@ import {
 } from "../source_buffers";
 
 // PeriodBuffer informations emitted to the ActivePeriodEmitted
-export interface IPeriodBufferInfos {
-  period: Period;
-  type: IBufferType;
-}
+export interface IPeriodBufferInfos { period: Period;
+                                      type: IBufferType; }
 
 // structure used internally to keep track of which Period has which
 // PeriodBuffer
-interface IPeriodItem {
-  period: Period;
-  buffers: Set<IBufferType>;
-}
+interface IPeriodItem { period: Period;
+                        buffers: Set<IBufferType>; }
 
 /**
  * Emit the active Period each times it changes.
@@ -101,10 +97,8 @@ export default function ActivePeriodEmitter(
       // add or update the periodItem
       let periodItem = periodsList.findFirst(p => p.period === period);
       if (!periodItem) {
-        periodItem = {
-          period,
-          buffers: new Set<IBufferType>(),
-        };
+        periodItem = { period,
+                       buffers: new Set<IBufferType>() };
         periodsList.add(periodItem);
       }
 

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -105,12 +105,10 @@ export default function AdaptationBuffer<T>(
   segmentBookkeeper : SegmentBookkeeper,
   segmentFetcher : IPrioritizedSegmentFetcher<T>,
   wantedBufferAhead$ : Observable<number>,
-  content : {
-    manifest : Manifest;
-    period : Period; adaptation : Adaptation;
-  },
+  content : { manifest : Manifest;
+              period : Period; adaptation : Adaptation; },
   abrManager : ABRManager,
-  options : { manualBitrateSwitchingMode : "seamless"|"direct" }
+  options : { manualBitrateSwitchingMode : "seamless" | "direct" }
 ) : Observable<IAdaptationBufferEvent<T>> {
   const directManualBitrateSwitching = options.manualBitrateSwitchingMode === "direct";
   const { manifest, period, adaptation } = content;
@@ -120,8 +118,8 @@ export default function AdaptationBuffer<T>(
   let currentRepresentation : Representation|null = null;
 
   const abrClock$ = clock$.pipe(map((tick) => {
-    const downloadBitrate = currentRepresentation ?
-      currentRepresentation.bitrate : undefined;
+    const downloadBitrate = currentRepresentation ? currentRepresentation.bitrate :
+                                                    undefined;
     return objectAssign({ downloadBitrate }, tick);
   }));
 
@@ -146,9 +144,8 @@ export default function AdaptationBuffer<T>(
   );
 
   const newRepresentation$ = abr$
-    .pipe(distinctUntilChanged((a, b) =>
-      a.manual === b.manual && a.representation.id === b.representation.id
-    ));
+    .pipe(distinctUntilChanged((a, b) => a.manual === b.manual &&
+                                         a.representation.id === b.representation.id));
 
   const adaptationBuffer$ = observableMerge(
     newRepresentation$
@@ -198,20 +195,16 @@ export default function AdaptationBuffer<T>(
   ) : Observable<IRepresentationBufferEvent<T>> {
     return observableDefer(() => {
       log.info("Buffer: changing representation", adaptation.type, representation);
-      return RepresentationBuffer({
-        clock$,
-        content: {
-          representation,
-          adaptation,
-          period,
-          manifest,
-        },
-        queuedSourceBuffer,
-        segmentBookkeeper,
-        segmentFetcher,
-        terminate$: terminateCurrentBuffer$,
-        wantedBufferAhead$,
-      });
+      return RepresentationBuffer({ clock$,
+                                    content: { representation,
+                                               adaptation,
+                                               period,
+                                               manifest },
+                                    queuedSourceBuffer,
+                                    segmentBookkeeper,
+                                    segmentFetcher,
+                                    terminate$: terminateCurrentBuffer$,
+                                    wantedBufferAhead$, });
     });
   }
 }

--- a/src/core/buffers/adaptation/index.ts
+++ b/src/core/buffers/adaptation/index.ts
@@ -19,6 +19,4 @@ import AdaptationBuffer, {
 } from "./adaptation_buffer";
 
 export default AdaptationBuffer;
-export {
-  IAdaptationBufferClockTick,
-};
+export { IAdaptationBufferClockTick };

--- a/src/core/buffers/are_buffers_complete.ts
+++ b/src/core/buffers/are_buffers_complete.ts
@@ -56,7 +56,8 @@ export default function areBuffersComplete(
     .map((buffer) => {
       return buffer.pipe(
         filter((evt) => {
-          return evt.type === "complete-buffer" || evt.type === "active-buffer";
+          return evt.type === "complete-buffer" ||
+                 evt.type === "active-buffer";
         }),
         map((evt) => evt.type === "complete-buffer"),
         startWith(false),

--- a/src/core/buffers/events_generators.ts
+++ b/src/core/buffers/events_generators.ts
@@ -44,19 +44,13 @@ import {
 
 const EVENTS = {
   activeBuffer(bufferType: IBufferType) : IBufferStateActive {
-    return {
-      type: "active-buffer",
-      value: { bufferType },
-    };
+    return { type: "active-buffer",
+             value: { bufferType } };
   },
 
   activePeriodChanged(period : Period) : IActivePeriodChangedEvent {
-    return {
-      type : "activePeriodChanged",
-      value : {
-        period,
-      },
-    };
+    return { type : "activePeriodChanged",
+             value : { period } };
   },
 
   adaptationChange(
@@ -64,14 +58,10 @@ const EVENTS = {
     adaptation : Adaptation|null,
     period : Period
   ) : IAdaptationChangeEvent {
-    return {
-      type: "adaptationChange",
-      value : {
-        type: bufferType,
-        adaptation,
-        period,
-      },
-    };
+    return { type: "adaptationChange",
+             value : { type: bufferType,
+                       adaptation,
+                       period } };
   },
 
   addedSegment<T>(
@@ -79,63 +69,44 @@ const EVENTS = {
     segment : ISegment,
     segmentData : T
   ) : IBufferEventAddedSegment<T> {
-    return {
-      type : "added-segment",
-      value : { bufferType, segment, segmentData },
-    };
+    return { type : "added-segment",
+             value : { bufferType, segment, segmentData } };
   },
 
   bitrateEstimationChange(
     type : IBufferType,
     bitrate : number|undefined
   ) : IBitrateEstimationChangeEvent {
-    return {
-      type: "bitrateEstimationChange",
-      value: {
-        type,
-        bitrate,
-      },
-    };
+    return { type: "bitrateEstimationChange",
+             value: { type, bitrate } };
   },
 
   bufferComplete(bufferType: IBufferType) : ICompletedBufferEvent {
-    return {
-      type: "complete-buffer",
-      value: {
-        type: bufferType,
-      },
-    };
+    return { type: "complete-buffer",
+             value: { type: bufferType } };
   },
 
   discontinuityEncountered(
     bufferType : IBufferType,
     nextTime : number
   ) : IBufferNeedsDiscontinuitySeek {
-    return {
-      type : "discontinuity-encountered",
-      value : { bufferType, nextTime },
-    };
+    return { type : "discontinuity-encountered",
+             value : { bufferType, nextTime } };
   },
 
   endOfStream() : IEndOfStreamEvent {
-    return {
-      type: "end-of-stream",
-      value: undefined,
-    };
+    return { type: "end-of-stream",
+             value: undefined };
   },
 
   fullBuffer(bufferType : IBufferType) : IBufferStateFull {
-    return {
-      type: "full-buffer",
-      value: { bufferType },
-    };
+    return { type: "full-buffer",
+             value: { bufferType } };
   },
 
   needsManifestRefresh(bufferType : IBufferType) : IBufferNeedsManifestRefresh {
-    return {
-      type : "needs-manifest-refresh",
-      value : { bufferType },
-    };
+    return { type : "needs-manifest-refresh",
+             value : { bufferType } };
   },
 
   needsMediaSourceReload() : INeedsMediaSourceReload {
@@ -147,27 +118,16 @@ const EVENTS = {
     period : Period,
     adaptation$ : Subject<Adaptation|null>
   ) : IPeriodBufferReadyEvent {
-    return {
-      type: "periodBufferReady",
-      value: {
-        type,
-        period,
-        adaptation$,
-      },
-    };
+    return { type: "periodBufferReady",
+             value: { type, period, adaptation$ } };
   },
 
   periodBufferCleared(
     type : IBufferType,
     period : Period
   ) : IPeriodBufferClearedEvent {
-    return {
-      type: "periodBufferCleared",
-      value: {
-        type,
-        period,
-      },
-    };
+    return { type: "periodBufferCleared",
+             value: { type, period } };
   },
 
   representationChange(
@@ -175,28 +135,18 @@ const EVENTS = {
     period : Period,
     representation : Representation
   ) : IRepresentationChangeEvent {
-    return {
-      type: "representationChange",
-      value: {
-        type,
-        period,
-        representation,
-      },
-    };
+    return { type: "representationChange",
+             value: { type, period, representation } };
   },
 
   resumeStream() : IResumeStreamEvent {
-    return {
-      type: "resume-stream",
-      value: undefined,
-    };
+    return { type: "resume-stream",
+             value: undefined };
   },
 
   warning(value : Error | ICustomError) : IBufferWarningEvent {
-    return {
-      type: "warning",
-      value,
-    };
+    return { type: "warning",
+             value };
   },
 };
 

--- a/src/core/buffers/index.ts
+++ b/src/core/buffers/index.ts
@@ -20,6 +20,4 @@ import BufferOrchestrator, {
 export * from "./types";
 
 export default BufferOrchestrator;
-export {
-  IBufferOrchestratorClockTick,
-};
+export { IBufferOrchestratorClockTick };

--- a/src/core/buffers/period/create_fake_buffer.ts
+++ b/src/core/buffers/period/create_fake_buffer.ts
@@ -52,10 +52,8 @@ export default function createFakeAdaptationBuffer(
     ),
     map(() => {
       log.debug("Buffer: full FakeBuffer", bufferType);
-      return {
-        type: "full-buffer" as "full-buffer",
-        value: { bufferType },
-      };
+      return { type: "full-buffer" as "full-buffer",
+               value: { bufferType } };
     })
   );
 }

--- a/src/core/buffers/period/get_adaptation_switch_strategy.ts
+++ b/src/core/buffers/period/get_adaptation_switch_strategy.ts
@@ -57,40 +57,39 @@ export default function getAdaptationSwitchStrategy(
   }
 
   const { currentTime } = clockTick;
-  if (
-    bufferType === "video" &&
-    clockTick.readyState > 1 &&
-    isTimeInRange({ start, end }, currentTime)
+  if (bufferType === "video" &&
+      clockTick.readyState > 1 &&
+      isTimeInRange({ start, end }, currentTime)
   ) {
     return { type: "needs-reload", value: undefined };
   }
 
   const paddingBefore = ADAPTATION_SWITCH_BUFFER_PADDINGS[bufferType].before || 0;
   const paddingAfter = ADAPTATION_SWITCH_BUFFER_PADDINGS[bufferType].after || 0;
-  if (
-    !paddingAfter && !paddingBefore ||
-    (currentTime - paddingBefore) >= end ||
-    (currentTime + paddingAfter) <= start
+
+  if (!paddingAfter && !paddingBefore ||
+      (currentTime - paddingBefore) >= end ||
+      (currentTime + paddingAfter) <= start
   ) {
-    return { type: "clean-buffer", value: [{ start, end }]};
+    return { type: "clean-buffer",
+             value: [{ start, end }]};
   }
+
   if (currentTime - paddingBefore <= start) {
-    return {
-      type: "clean-buffer",
-      value: [{ start: currentTime + paddingAfter, end }],
-    };
+    return { type: "clean-buffer",
+             value: [{ start: currentTime + paddingAfter,
+                       end }] };
   }
+
   if (currentTime + paddingAfter >= end) {
-    return {
-      type: "clean-buffer",
-      value: [{ start, end: currentTime - paddingBefore }],
-    };
+    return { type: "clean-buffer",
+             value: [{ start,
+                       end: currentTime - paddingBefore }] };
   }
-  return {
-    type: "clean-buffer",
-    value: [
-      { start, end: currentTime - paddingBefore },
-      { start: currentTime + paddingAfter, end },
-    ],
-  };
+
+  return { type: "clean-buffer",
+           value: [ { start,
+                      end: currentTime - paddingBefore },
+                    { start: currentTime + paddingAfter,
+                      end } ] };
 }

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -64,10 +64,8 @@ import {
 import createFakeBuffer from "./create_fake_buffer";
 import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
 
-const {
-  DEFAULT_MAX_PIPELINES_RETRY_ON_ERROR,
-  DEFAULT_MAX_PIPELINES_RETRY_ON_OFFLINE,
-} = config;
+const { DEFAULT_MAX_PIPELINES_RETRY_ON_ERROR,
+        DEFAULT_MAX_PIPELINES_RETRY_ON_OFFLINE } = config;
 
 export interface IPeriodBufferClockTick {
   currentTime : number; // the current position we are in the video in s
@@ -86,17 +84,16 @@ export interface IPeriodBufferArguments {
   abrManager : ABRManager;
   bufferType : IBufferType;
   clock$ : Observable<IPeriodBufferClockTick>;
-  content : { manifest : Manifest; period : Period };
+  content : { manifest : Manifest;
+              period : Period; };
   garbageCollectors : WeakMapMemory<QueuedSourceBuffer<unknown>, Observable<never>>;
   segmentBookkeepers : WeakMapMemory<QueuedSourceBuffer<unknown>, SegmentBookkeeper>;
   segmentPipelinesManager : SegmentPipelinesManager<any>;
   sourceBuffersManager : SourceBuffersManager;
-  options: {
-    manualBitrateSwitchingMode : "seamless"|"direct";
-    offlineRetry? : number;
-    segmentRetry? : number;
-    textTrackOptions? : ITextTrackSourceBufferOptions;
-  };
+  options: { manualBitrateSwitchingMode : "seamless" | "direct";
+             offlineRetry? : number;
+             segmentRetry? : number;
+             textTrackOptions? : ITextTrackSourceBufferOptions; };
   wantedBufferAhead$ : Observable<number>;
 }
 
@@ -169,10 +166,9 @@ export default function PeriodBuffer({
           const bufferGarbageCollector$ = garbageCollectors.get(qSourceBuffer);
           const adaptationBuffer$ = createAdaptationBuffer(adaptation, qSourceBuffer);
 
-          return observableConcat(
-            cleanBuffer$,
-            observableMerge(adaptationBuffer$, bufferGarbageCollector$)
-          );
+          return observableConcat(cleanBuffer$,
+                                  observableMerge(adaptationBuffer$,
+                                                  bufferGarbageCollector$));
         }));
 
       return observableConcat<IPeriodBufferEvent>(
@@ -203,19 +199,19 @@ export default function PeriodBuffer({
 
     const adaptationBufferClock$ = clock$.pipe(map(tick => {
       const buffered = qSourceBuffer.getBuffered();
-      return objectAssign({}, tick, {
-        bufferGap: getLeftSizeOfRange(buffered, tick.currentTime),
-      });
+      return objectAssign({},
+                          tick,
+                          { bufferGap: getLeftSizeOfRange(buffered,
+                                                          tick.currentTime) });
     }));
-    return AdaptationBuffer(
-      adaptationBufferClock$,
-      qSourceBuffer,
-      segmentBookkeeper,
-      pipeline,
-      wantedBufferAhead$,
-      { manifest, period, adaptation },
-      abrManager,
-      options
+    return AdaptationBuffer(adaptationBufferClock$,
+                            qSourceBuffer,
+                            segmentBookkeeper,
+                            pipeline,
+                            wantedBufferAhead$,
+                            { manifest, period, adaptation },
+                            abrManager,
+                            options
     ).pipe(catchError((error : Error) => {
       // non native buffer should not impact the stability of the
       // player. ie: if a text buffer sends an error, we want to
@@ -275,13 +271,11 @@ function getPipelineOptions(
   if (bufferType === "image") {
     maxRetry = 0; // Deactivate BIF fetching if it fails
   } else {
-    maxRetry = retry != null ?
-      retry : DEFAULT_MAX_PIPELINES_RETRY_ON_ERROR;
+    maxRetry = retry != null ? retry :
+                               DEFAULT_MAX_PIPELINES_RETRY_ON_ERROR;
   }
-
-  maxRetryOffline = offlineRetry != null ?
-    offlineRetry : DEFAULT_MAX_PIPELINES_RETRY_ON_OFFLINE;
-
+  maxRetryOffline = offlineRetry != null ? offlineRetry :
+                                           DEFAULT_MAX_PIPELINES_RETRY_ON_OFFLINE;
   return { cache, maxRetry, maxRetryOffline };
 }
 

--- a/src/core/buffers/representation/force_garbage_collection.ts
+++ b/src/core/buffers/representation/force_garbage_collection.ts
@@ -51,13 +51,11 @@ export default function forceGarbageCollection(
     mergeMap((timing) => {
       log.warn("Buffer: Running garbage collector");
       const buffered = bufferingQueue.getBuffered();
-      let cleanedupRanges =
-        selectGCedRanges(timing.currentTime, buffered, GC_GAP_CALM);
+      let cleanedupRanges = selectGCedRanges(timing.currentTime, buffered, GC_GAP_CALM);
 
       // more aggressive GC if we could not find any range to clean
       if (cleanedupRanges.length === 0) {
-        cleanedupRanges =
-          selectGCedRanges(timing.currentTime, buffered, GC_GAP_BEEFY);
+        cleanedupRanges = selectGCedRanges(timing.currentTime, buffered, GC_GAP_BEEFY);
       }
 
       log.debug("Buffer: GC cleaning", cleanedupRanges);
@@ -85,19 +83,11 @@ function selectGCedRanges(
   currentTime : number,
   buffered : TimeRanges,
   gcGap : number
-) : Array<{
-  start : number;
-  end : number;
-}> {
-  const { innerRange, outerRanges } = getInnerAndOuterTimeRanges(
-    buffered,
-    currentTime
-  );
-
-  const cleanedupRanges : Array<{
-    start : number;
-    end: number;
-  }> = [];
+) : Array<{ start : number; end : number }> {
+  const { innerRange, outerRanges } = getInnerAndOuterTimeRanges(buffered,
+                                                                 currentTime);
+  const cleanedupRanges : Array<{ start : number;
+                                  end: number; }> = [];
 
   // start by trying to remove all ranges that do not contain the
   // current time and respect the gcGap
@@ -116,19 +106,14 @@ function selectGCedRanges(
   if (innerRange) {
     log.debug("Buffer: GC removing part of inner range", cleanedupRanges);
     if (currentTime - gcGap > innerRange.start) {
-      cleanedupRanges.push({
-        start: innerRange.start,
-        end: currentTime - gcGap,
-      });
+      cleanedupRanges.push({ start: innerRange.start,
+                             end: currentTime - gcGap });
     }
 
     if (currentTime + gcGap < innerRange.end) {
-      cleanedupRanges.push({
-        start: currentTime + gcGap,
-        end: innerRange.end,
-      });
+      cleanedupRanges.push({ start: currentTime + gcGap,
+                             end: innerRange.end });
     }
   }
-
   return cleanedupRanges;
 }

--- a/src/core/buffers/representation/get_segment_priority.ts
+++ b/src/core/buffers/representation/get_segment_priority.ts
@@ -31,19 +31,16 @@ const { SEGMENT_PRIORITIES_STEPS } = config;
  */
 export default function getSegmentPriority(
   segment : ISegment,
-  clockTick : {
-    currentTime : number;
-    wantedTimeOffset : number;
-  }
+  clockTick : { currentTime : number;
+                wantedTimeOffset : number; }
 ) : number {
   const currentTime = clockTick.currentTime + clockTick.wantedTimeOffset;
   const segmentStart = segment.time / segment.timescale;
   const distance = segmentStart - currentTime;
 
-  for (
-    let priority = 0;
-    priority < SEGMENT_PRIORITIES_STEPS.length;
-    priority++
+  for (let priority = 0;
+       priority < SEGMENT_PRIORITIES_STEPS.length;
+       priority++
   ) {
     if (distance < SEGMENT_PRIORITIES_STEPS[priority]) {
       return priority;

--- a/src/core/buffers/representation/segment_filter.ts
+++ b/src/core/buffers/representation/segment_filter.ts
@@ -51,12 +51,9 @@ export default function shouldDownloadSegment(
   wantedRange : { start : number; end : number },
   segmentIDsToIgnore : SimpleSet
 ) : boolean {
-  const {
-    period,
-    adaptation,
-    representation,
-  } = content;
+  const { period, adaptation, representation } = content;
   const shouldIgnore = segmentIDsToIgnore.test(segment.id);
+
   if (shouldIgnore) {
     return false;
   }
@@ -94,6 +91,7 @@ export default function shouldDownloadSegment(
 
   // only re-load comparatively-poor bitrates for the same adaptation.
   const bitrateCeil = currentSegment.infos.representation.bitrate *
-    BITRATE_REBUFFERING_RATIO;
+                      BITRATE_REBUFFERING_RATIO;
+
   return representation.bitrate > bitrateCeil;
 }

--- a/src/core/buffers/segment_bookkeeper.ts
+++ b/src/core/buffers/segment_bookkeeper.ts
@@ -25,18 +25,14 @@ import {
 import { convertToRanges } from "../../utils/ranges";
 import takeFirstSet from "../../utils/take_first_set";
 
-const {
-  MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT,
-  MAX_BUFFERED_DISTANCE,
-  MINIMUM_SEGMENT_SIZE,
-} = config;
+const { MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT,
+        MAX_BUFFERED_DISTANCE,
+        MINIMUM_SEGMENT_SIZE } = config;
 
-interface IBufferedSegmentInfos {
-  adaptation : Adaptation;
-  period : Period;
-  representation : Representation;
-  segment : ISegment;
-}
+interface IBufferedSegmentInfos { adaptation : Adaptation;
+                                  period : Period;
+                                  representation : Representation;
+                                  segment : ISegment; }
 
 interface IBufferedSegment {
   bufferedEnd : number|undefined; // Last inferred end in the SourceBuffer
@@ -110,13 +106,12 @@ export default class SegmentBookkeeper {
       // Find the first segment either within this TimeRange or past it:
       // skip until first segment with at least MINIMUM_SEGMENT_SIZE past the
       // start of that range.
-      while (
-        thisSegment &&
+      while (thisSegment &&
 
-        // TODO better way to indicate to typescript that all is well here
-        (takeFirstSet(thisSegment.bufferedEnd, thisSegment.end) as number
-          - rangeStart)
-        < MINIMUM_SEGMENT_SIZE
+             // TODO better way to indicate to typescript that all is well here
+            (takeFirstSet(thisSegment.bufferedEnd, thisSegment.end) as number
+              - rangeStart
+            ) < MINIMUM_SEGMENT_SIZE
       ) {
         thisSegment = inventory[++inventoryIndex];
       }
@@ -137,9 +132,8 @@ export default class SegmentBookkeeper {
           inventory[indexBefore + numberOfSegmentToDelete - 1];
 
         // TODO better way to indicate to typescript that all is well here
-        lastDeletedSegmentEnd = takeFirstSet(
-          lastDeletedSegment.bufferedEnd, lastDeletedSegment.end) as number;
-
+        lastDeletedSegmentEnd = takeFirstSet(lastDeletedSegment.bufferedEnd,
+                                             lastDeletedSegment.end) as number;
         // mutate inventory
         inventory.splice(indexBefore, numberOfSegmentToDelete);
         inventoryIndex = indexBefore;
@@ -155,12 +149,11 @@ export default class SegmentBookkeeper {
       //
       // If the current segment is actually completely outside that range (it
       // is contained in one of the next one), skip that part.
-      if (
-        rangeEnd -
+      if (rangeEnd -
 
-        // TODO better way to indicate to typescript that all is well here
-        (takeFirstSet(thisSegment.bufferedStart, thisSegment.start) as number)
-        >= MINIMUM_SEGMENT_SIZE
+          // TODO better way to indicate to typescript that all is well here
+          (takeFirstSet(thisSegment.bufferedStart, thisSegment.start) as number)
+            >= MINIMUM_SEGMENT_SIZE
       ) {
         // set the bufferedStart of the first segment in that range
         if (
@@ -171,10 +164,9 @@ export default class SegmentBookkeeper {
           // Update bufferedStart
           thisSegment.bufferedStart = rangeStart;
         } else if (thisSegment.bufferedStart == null) {
-          if (
-            lastDeletedSegmentEnd !== -1 &&
-            lastDeletedSegmentEnd > rangeStart &&
-            thisSegment.start - lastDeletedSegmentEnd <= MAX_BUFFERED_DISTANCE
+          if (lastDeletedSegmentEnd !== -1 &&
+              lastDeletedSegmentEnd > rangeStart &&
+              thisSegment.start - lastDeletedSegmentEnd <= MAX_BUFFERED_DISTANCE
           ) {
             thisSegment.bufferedStart = lastDeletedSegmentEnd;
           } else if (thisSegment.start - rangeStart <= MAX_BUFFERED_DISTANCE) {
@@ -189,16 +181,12 @@ export default class SegmentBookkeeper {
         // Make contiguous until first segment outside that range
         // (i.e until the start of the next segment can not constitute a segment
         // in that range == less than MINIMUM_SEGMENT_SIZE into that range)
-        while (
-          thisSegment &&
-          (
-            rangeEnd -
-
-            // TODO better way to indicate to typescript that all is well here
-            (takeFirstSet(thisSegment.bufferedStart, thisSegment.start) as
-              number)
-          )
-          >= MINIMUM_SEGMENT_SIZE
+        while (thisSegment &&
+               (
+                 rangeEnd -
+                    // TODO better way to indicate to typescript that all is well here
+                   (takeFirstSet(thisSegment.bufferedStart, thisSegment.start) as number)
+                ) >= MINIMUM_SEGMENT_SIZE
         ) {
           const prevSegment = inventory[inventoryIndex - 1];
 
@@ -216,9 +204,8 @@ export default class SegmentBookkeeper {
       // update the bufferedEnd of the last segment in that range
       const lastSegmentInRange = inventory[inventoryIndex - 1];
       if (lastSegmentInRange) {
-        if (
-          lastSegmentInRange.bufferedEnd != null &&
-          lastSegmentInRange.bufferedEnd > rangeEnd
+        if (lastSegmentInRange.bufferedEnd != null &&
+            lastSegmentInRange.bufferedEnd > rangeEnd
         ) {
           // the segment appears to have been partially garbage collected:
           // Update bufferedEnd
@@ -282,18 +269,14 @@ export default class SegmentBookkeeper {
     // const start = segment.time / segment.timescale;
     // const end = (segment.time + segment.duration) / segment.timescale;
 
-    const newSegment = {
-      start,
-      end,
-      bufferedStart: undefined,
-      bufferedEnd: undefined,
-      infos: {
-        segment,
-        period,
-        adaptation,
-        representation,
-      },
-    };
+    const newSegment = { start,
+                         end,
+                         bufferedStart: undefined,
+                         bufferedEnd: undefined,
+                         infos: { segment,
+                                  period,
+                                  adaptation,
+                                  representation } };
 
     // begin by the end as in most use cases this will be faster
     for (let i = inventory.length - 1; i >= 0; i--) {
@@ -492,11 +475,7 @@ export default class SegmentBookkeeper {
       timescale : number;
     }
   ) : IBufferedSegment|null {
-    const {
-      time,
-      duration,
-      timescale,
-    } = segmentInfos;
+    const { time, duration, timescale } = segmentInfos;
     const { inventory } = this;
 
     for (let i = inventory.length - 1; i >= 0; i--) {
@@ -518,13 +497,10 @@ export default class SegmentBookkeeper {
         // false negatives are better than false positives here.
         // When impossible to know, say the segment is not complete
         if (hasEnoughInfos(currentSegmentI, prevSegmentI, nextSegmentI)) {
-          if (
-            hasWantedRange(
-              wantedRange,
-              currentSegmentI,
-              prevSegmentI,
-              nextSegmentI
-            )
+          if (hasWantedRange(wantedRange,
+                             currentSegmentI,
+                             prevSegmentI,
+                             nextSegmentI)
           ) {
             return currentSegmentI;
           }
@@ -548,13 +524,13 @@ export default class SegmentBookkeeper {
       nextSegmentI : IBufferedSegment
     ) : boolean {
       if ((prevSegmentI && prevSegmentI.bufferedEnd == null) ||
-        currentSegmentI.bufferedStart == null
+          currentSegmentI.bufferedStart == null
       ) {
         return false;
       }
 
       if ((nextSegmentI && nextSegmentI.bufferedStart == null) ||
-        currentSegmentI.bufferedEnd == null
+          currentSegmentI.bufferedEnd == null
       ) {
         return false;
       }
@@ -579,11 +555,10 @@ export default class SegmentBookkeeper {
       prevSegmentI : IBufferedSegment,
       nextSegmentI : IBufferedSegment
     ) : boolean {
-      if (
-        !prevSegmentI ||
-        prevSegmentI.bufferedEnd == null ||
-        currentSegmentI.bufferedStart == null ||
-        prevSegmentI.bufferedEnd < currentSegmentI.bufferedStart
+      if (!prevSegmentI ||
+          prevSegmentI.bufferedEnd == null ||
+          currentSegmentI.bufferedStart == null ||
+          prevSegmentI.bufferedEnd < currentSegmentI.bufferedStart
       ) {
         if (currentSegmentI.bufferedStart == null) {
           return false;
@@ -594,13 +569,13 @@ export default class SegmentBookkeeper {
           if (wantedDiff > 0 && timeDiff
             > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT) {
             log.debug("SB: The wanted segment has been garbage collected",
-              currentSegmentI);
+                      currentSegmentI);
             return false;
           }
         } else {
           if (timeDiff > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT) {
             log.debug("SB: The wanted segment has been garbage collected",
-              currentSegmentI);
+                      currentSegmentI);
             return false;
           }
         }
@@ -608,11 +583,10 @@ export default class SegmentBookkeeper {
 
       if (currentSegmentI.end === null) {
         return false;
-      } else if (
-          !nextSegmentI ||
-          nextSegmentI.bufferedStart == null ||
-          currentSegmentI.bufferedEnd == null ||
-          nextSegmentI.bufferedStart > currentSegmentI.bufferedEnd
+      } else if (!nextSegmentI ||
+                 nextSegmentI.bufferedStart == null ||
+                 currentSegmentI.bufferedEnd == null ||
+                 nextSegmentI.bufferedStart > currentSegmentI.bufferedEnd
       ) {
         if (currentSegmentI.bufferedEnd == null) {
           return false;
@@ -623,13 +597,13 @@ export default class SegmentBookkeeper {
           if (wantedDiff > 0 && timeDiff
             > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT) {
             log.debug("SB: The wanted segment has been garbage collected",
-              currentSegmentI);
+                      currentSegmentI);
             return false;
           }
         } else {
           if (timeDiff > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT) {
             log.debug("SB: The wanted segment has been garbage collected",
-              currentSegmentI);
+                      currentSegmentI);
             return false;
           }
         }

--- a/src/core/buffers/types.ts
+++ b/src/core/buffers/types.ts
@@ -53,9 +53,8 @@ export interface IBufferNeedsDiscontinuitySeek {
 }
 
 // Events communicating about actions that need to be taken
-export type IBufferNeededActions =
-  IBufferNeedsManifestRefresh |
-  IBufferNeedsDiscontinuitySeek;
+export type IBufferNeededActions = IBufferNeedsManifestRefresh |
+                                   IBufferNeedsDiscontinuitySeek;
 
 // State emitted when the Buffer is scheduling segments
 export interface IBufferStateActive {
@@ -74,129 +73,94 @@ export interface IBufferStateFull {
 }
 
 // State emitted when the buffer waits
-export type IRepresentationBufferStateEvent =
-  IBufferNeededActions |
-  IBufferStateFull |
-  IBufferStateActive;
+export type IRepresentationBufferStateEvent = IBufferNeededActions |
+                                              IBufferStateFull |
+                                              IBufferStateActive;
 
 // Events emitted by the Buffer
-export type IRepresentationBufferEvent<T> =
-  IBufferEventAddedSegment<T> |
-  IRepresentationBufferStateEvent;
+export type IRepresentationBufferEvent<T> = IBufferEventAddedSegment<T> |
+                                            IRepresentationBufferStateEvent;
 
 // Emitted as new bitrate estimations are done
 export interface IBitrateEstimationChangeEvent {
   type : "bitrateEstimationChange";
-  value : {
-    type : IBufferType;
-    bitrate : number|undefined;
-  };
+  value : { type : IBufferType;
+            bitrate : number|undefined; };
 }
 
 // Emitted when the current Representation considered changes
 export interface IRepresentationChangeEvent {
   type : "representationChange";
-  value : {
-    type : IBufferType;
-    period : Period;
-    representation : Representation|null;
-  };
+  value : { type : IBufferType;
+            period : Period;
+            representation : Representation |
+                             null; };
 }
 
 // Every events sent by the AdaptationBuffer
-export type IAdaptationBufferEvent<T> =
-  IRepresentationBufferEvent<T> |
-  IBitrateEstimationChangeEvent |
-  INeedsMediaSourceReload |
-  IRepresentationChangeEvent;
+export type IAdaptationBufferEvent<T> = IRepresentationBufferEvent<T> |
+                                        IBitrateEstimationChangeEvent |
+                                        INeedsMediaSourceReload |
+                                        IRepresentationChangeEvent;
 
 // The currently-downloaded Adaptation changed.
-export interface IAdaptationChangeEvent {
-  type : "adaptationChange";
-  value : {
-    type : IBufferType;
-    period : Period;
-    adaptation : Adaptation|null;
-  };
-}
-
+export interface IAdaptationChangeEvent { type : "adaptationChange";
+                                          value : { type : IBufferType;
+                                                    period : Period;
+                                                    adaptation : Adaptation |
+                                                                 null; }; }
 // Currently-playing Period changed.
-export interface IActivePeriodChangedEvent {
-  type: "activePeriodChanged";
-  value : {
-    period: Period;
-  };
-}
+export interface IActivePeriodChangedEvent { type: "activePeriodChanged";
+                                             value : { period: Period }; }
 
 // a new PeriodBuffer is ready, waiting for an adaptation/track choice.
 export interface IPeriodBufferReadyEvent {
   type : "periodBufferReady";
-  value : {
-    type : IBufferType;
-    period : Period;
-    adaptation$ : Subject<Adaptation|null>;
-  };
+  value : { type : IBufferType;
+            period : Period;
+            adaptation$ : Subject<Adaptation|null>; };
 }
 
 // A PeriodBuffer has been cleared (it is not used anymore). Can be used for
 // cleaning-up resources.
-export interface IPeriodBufferClearedEvent {
-  type : "periodBufferCleared";
-  value : {
-    type : IBufferType;
-    period : Period;
-  };
-}
+export interface IPeriodBufferClearedEvent { type : "periodBufferCleared";
+                                             value : { type : IBufferType;
+                                                       period : Period; }; }
 
 // The last PeriodBuffers from every type are full.
-export interface IEndOfStreamEvent {
-  type: "end-of-stream";
-  value: undefined;
-}
+export interface IEndOfStreamEvent { type: "end-of-stream";
+                                     value: undefined; }
 
 // A previously non-existent or full last PeriodBuffer resumed.
-export interface IResumeStreamEvent {
-  type: "resume-stream";
-  value: undefined;
-}
+export interface IResumeStreamEvent { type: "resume-stream";
+                                      value: undefined; }
 
 // The last PeriodBuffer of a given type is full.
-export interface ICompletedBufferEvent {
-  type: "complete-buffer";
-  value : {
-    type: IBufferType;
-  };
-}
+export interface ICompletedBufferEvent { type: "complete-buffer";
+                                         value : { type: IBufferType }; }
 
 // The MediaSource needs to be reloaded to continue
-export interface INeedsMediaSourceReload {
-  type: "needs-media-source-reload";
-  value: undefined;
-}
+export interface INeedsMediaSourceReload { type: "needs-media-source-reload";
+                                           value: undefined; }
 
 // Events coming from single PeriodBuffer
-export type IPeriodBufferEvent =
-  IPeriodBufferReadyEvent |
-  IAdaptationBufferEvent<unknown> |
-  IBufferWarningEvent |
-  INeedsMediaSourceReload |
-  IAdaptationChangeEvent;
+export type IPeriodBufferEvent = IPeriodBufferReadyEvent |
+                                 IAdaptationBufferEvent<unknown> |
+                                 IBufferWarningEvent |
+                                 INeedsMediaSourceReload |
+                                 IAdaptationChangeEvent;
 
 // Events coming from function(s) managing multiple PeriodBuffers.
-export type IMultiplePeriodBuffersEvent =
-  IPeriodBufferEvent |
-  IPeriodBufferClearedEvent |
-  ICompletedBufferEvent;
+export type IMultiplePeriodBuffersEvent = IPeriodBufferEvent |
+                                          IPeriodBufferClearedEvent |
+                                          ICompletedBufferEvent;
 
 // Every events sent by the BufferOrchestrator exported here.
-export type IBufferOrchestratorEvent =
-  IActivePeriodChangedEvent |
-  IMultiplePeriodBuffersEvent |
-  IEndOfStreamEvent |
-  IResumeStreamEvent;
+export type IBufferOrchestratorEvent = IActivePeriodChangedEvent |
+                                       IMultiplePeriodBuffersEvent |
+                                       IEndOfStreamEvent |
+                                       IResumeStreamEvent;
 
 // A minor error happened
-export interface IBufferWarningEvent {
-  type : "warning";
-  value : Error|ICustomError;
-}
+export interface IBufferWarningEvent { type : "warning";
+                                       value : Error | ICustomError; }

--- a/src/core/eme/attach_media_keys.ts
+++ b/src/core/eme/attach_media_keys.ts
@@ -44,24 +44,21 @@ export default function attachMediaKeys(
 ) : Observable<unknown> {
   return observableDefer(() => {
     const previousState = currentMediaKeysInfos.getState(mediaElement);
-    const {
-      keySystemOptions,
-      mediaKeySystemAccess,
-      mediaKeys,
-      sessionsStore,
-    } = mediaKeysInfos;
+    const { keySystemOptions,
+            mediaKeySystemAccess,
+            mediaKeys,
+            sessionsStore } = mediaKeysInfos;
 
-    currentMediaKeysInfos.setState(mediaElement, {
-      keySystemOptions,
-      mediaKeySystemAccess,
-      mediaKeys,
-      sessionsStore,
-    });
+    currentMediaKeysInfos.setState(mediaElement,
+                                   { keySystemOptions,
+                                     mediaKeySystemAccess,
+                                     mediaKeys,
+                                     sessionsStore });
 
-    return (
-      previousState && previousState.sessionsStore !== sessionsStore ?
-        previousState.sessionsStore.closeAllSessions() :
-        observableOf(null)
+    return (previousState &&
+            previousState.sessionsStore !== sessionsStore ?
+              previousState.sessionsStore.closeAllSessions() :
+              observableOf(null)
     ).pipe(mergeMap(() => {
       if (mediaElement.mediaKeys === mediaKeys) {
         return observableOf(null);

--- a/src/core/eme/get_media_keys.ts
+++ b/src/core/eme/get_media_keys.ts
@@ -50,8 +50,9 @@ function createSessionStorage(
 
   const { licenseStorage } = keySystemOptions;
   if (!licenseStorage) {
-    throw new EncryptedMediaError(
-      "INVALID_KEY_SYSTEM", "No license storage found for persistent license.", true);
+    throw new EncryptedMediaError("INVALID_KEY_SYSTEM",
+                                  "No license storage found for persistent license.",
+                                  true);
   }
 
   log.info("EME: Set the given license storage");
@@ -63,10 +64,9 @@ export default function getMediaKeysInfos(
   keySystemsConfigs: IKeySystemOption[],
   currentMediaKeysInfos : MediaKeysInfosStore
 ) : Observable<IMediaKeysInfos> {
-    return getMediaKeySystemAccess(
-      mediaElement,
-      keySystemsConfigs,
-      currentMediaKeysInfos
+    return getMediaKeySystemAccess(mediaElement,
+                                   keySystemsConfigs,
+                                   currentMediaKeysInfos
     ).pipe(mergeMap((evt) => {
       const { options, mediaKeySystemAccess } = evt.value;
       const currentState = currentMediaKeysInfos.getState(mediaElement);
@@ -74,23 +74,19 @@ export default function getMediaKeysInfos(
 
       if (currentState != null && evt.type === "reuse-media-key-system-access") {
         const { mediaKeys, sessionsStore } = currentState;
-        return observableOf({
-          mediaKeys,
-          sessionsStore,
-          mediaKeySystemAccess,
-          keySystemOptions: options,
-          sessionStorage,
-        });
+        return observableOf({ mediaKeys,
+                              sessionsStore,
+                              mediaKeySystemAccess,
+                              keySystemOptions: options,
+                              sessionStorage });
       }
 
       log.debug("EME: Calling createMediaKeys on the MediaKeySystemAccess");
       return castToObservable(mediaKeySystemAccess.createMediaKeys())
-        .pipe(map((mediaKeys) => ({
-          mediaKeys,
-          sessionsStore: new SessionsStore(mediaKeys),
-          mediaKeySystemAccess,
-          keySystemOptions: options,
-          sessionStorage,
-        })));
+        .pipe(map((mediaKeys) => ({ mediaKeys,
+                                    sessionsStore: new SessionsStore(mediaKeys),
+                                    mediaKeySystemAccess,
+                                    keySystemOptions: options,
+                                    sessionStorage })));
     }));
 }

--- a/src/core/eme/get_session.ts
+++ b/src/core/eme/get_session.ts
@@ -40,19 +40,16 @@ import isSessionUsable from "./utils/is_session_usable";
 
 export interface IHandledEncryptedEvent {
   type : "created-session" |
-    "loaded-open-session" |
-    "loaded-persistent-session";
-  value : {
-    mediaKeySession : MediaKeySession|ICustomMediaKeySession;
-    sessionType : MediaKeySessionType;
-    initData : Uint8Array; // assiociated initialization data
-    initDataType : string|undefined; // type of the associated initialization data
-  };
-}
+         "loaded-open-session" |
+         "loaded-persistent-session";
+  value : { mediaKeySession : MediaKeySession |
+                              ICustomMediaKeySession;
+            sessionType : MediaKeySessionType;
+            initData : Uint8Array; // assiociated initialization data
+            initDataType : string | // type of the associated initialization data
+                           undefined; }; }
 
-const {
-  EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS: MAX_SESSIONS,
-} = config;
+const { EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS: MAX_SESSIONS } = config;
 
 /**
  * Handle MediaEncryptedEvents sent by a HTMLMediaElement:
@@ -69,10 +66,8 @@ export default function getSession(
   mediaKeysInfos : IMediaKeysInfos
 ) : Observable<IHandledEncryptedEvent> {
   return observableDefer(() => {
-    const {
-      initData,
-      initDataType,
-    } = getInitData(encryptedEvent);
+    const { initData,
+            initDataType } = getInitData(encryptedEvent);
 
     if (handledInitData.has(initData, initDataType)) {
       log.debug("EME: Init data already received. Skipping it.");
@@ -88,15 +83,11 @@ export default function getSession(
       previousLoadedSession = entry.session;
       if (isSessionUsable(previousLoadedSession)) {
         log.debug("EME: Reuse loaded session", previousLoadedSession.sessionId);
-        return observableOf({
-          type: "loaded-open-session" as "loaded-open-session",
-          value: {
-            mediaKeySession: previousLoadedSession,
-            sessionType: entry.sessionType,
-            initData,
-            initDataType,
-          },
-        });
+        return observableOf({ type: "loaded-open-session" as "loaded-open-session",
+                              value: { mediaKeySession: previousLoadedSession,
+                                       sessionType: entry.sessionType,
+                                       initData,
+                                       initDataType } });
       } else if (mediaKeysInfos.sessionStorage) {
         mediaKeysInfos.sessionStorage.delete(new Uint8Array(initData), initDataType);
       }
@@ -119,15 +110,12 @@ export default function getSession(
       return observableConcat(
         observableMerge(...cleaningOldSessions$).pipe(ignoreElements()),
         createSession(initData, initDataType, mediaKeysInfos)
-          .pipe(map((evt) => ({
-            type: evt.type,
-            value: {
-              mediaKeySession: evt.value.mediaKeySession,
-              sessionType: evt.value.sessionType,
-              initData,
-              initDataType,
-            },
-          })))
+          .pipe(map((evt) => ({ type: evt.type,
+                                value: {
+                                  mediaKeySession: evt.value.mediaKeySession,
+                                  sessionType: evt.value.sessionType,
+                                  initData,
+                                  initDataType, } })))
       );
     }));
   });

--- a/src/core/eme/media_keys_infos_store.ts
+++ b/src/core/eme/media_keys_infos_store.ts
@@ -22,12 +22,18 @@ import {
 import { IKeySystemOption } from "./types";
 import SessionsStore from "./utils/open_sessions_store";
 
-export type IMediaElementMediaKeysInfos = {
-  keySystemOptions : IKeySystemOption;
-  mediaKeySystemAccess : ICustomMediaKeySystemAccess|ICompatMediaKeySystemAccess;
-  mediaKeys : MediaKeys|ICustomMediaKeys;
-  sessionsStore : SessionsStore;
-}|null;
+export type IMediaElementMediaKeysInfos =
+  { keySystemOptions : IKeySystemOption;
+
+    mediaKeySystemAccess : ICustomMediaKeySystemAccess |
+                           ICompatMediaKeySystemAccess;
+
+    mediaKeys : MediaKeys |
+                ICustomMediaKeys;
+
+    sessionsStore : SessionsStore;
+  } |
+  null;
 
 /**
  * Store the MediaKeys infos attached to a media element.

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -32,16 +32,15 @@ import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
 import { IEMEWarningEvent } from "./types";
 
-type TypedArray =
-  Int8Array |
-  Int16Array |
-  Int32Array |
-  Uint8Array |
-  Uint16Array |
-  Uint32Array |
-  Uint8ClampedArray |
-  Float32Array |
-  Float64Array;
+type TypedArray = Int8Array |
+                  Int16Array |
+                  Int32Array |
+                  Uint8Array |
+                  Uint16Array |
+                  Uint32Array |
+                  Uint8ClampedArray |
+                  Float32Array |
+                  Float64Array;
 
 /**
  * Call the setServerCertificate API with the given certificate.
@@ -66,8 +65,9 @@ function setServerCertificate(
       (mediaKeys as MediaKeys).setServerCertificate(serverCertificate)
     ).pipe(catchError((error: Error) => {
       log.warn("EME: mediaKeys.setServerCertificate returned an error", error);
-      throw new EncryptedMediaError(
-        "LICENSE_SERVER_CERTIFICATE_ERROR", error.toString(), true);
+      throw new EncryptedMediaError("LICENSE_SERVER_CERTIFICATE_ERROR",
+                                    error.toString(),
+                                    true);
     }));
   });
 }
@@ -93,7 +93,7 @@ export default function trySettingServerCertificate(
       }));
   }
   log.warn("EME: Could not set the server certificate." +
-    " mediaKeys.setServerCertificate is not a function");
+           " mediaKeys.setServerCertificate is not a function");
   return EMPTY;
 }
 

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -25,67 +25,73 @@ import SessionsStore from "./utils/open_sessions_store";
 import PersistedSessionsStore from "./utils/persisted_session_store";
 
 // A minor error happened
-export interface IEMEWarningEvent {
-  type : "warning";
-  value : ICustomError|Error;
-}
+export interface IEMEWarningEvent { type : "warning";
+                                    value : ICustomError |
+                                            Error; }
 
-export interface IEMEInitEvent {
-  type: "eme-init";
-}
+export interface IEMEInitEvent { type: "eme-init"; }
 
 // Infos indentifying a MediaKeySystemAccess
 export interface IKeySystemAccessInfos {
-  keySystemAccess: ICompatMediaKeySystemAccess|ICustomMediaKeySystemAccess;
+  keySystemAccess: ICompatMediaKeySystemAccess |
+                   ICustomMediaKeySystemAccess;
   keySystemOptions: IKeySystemOption;
 }
 
 // Infos identyfing a single MediaKey
 export interface IMediaKeysInfos {
-  mediaKeySystemAccess: ICompatMediaKeySystemAccess|ICustomMediaKeySystemAccess;
+  mediaKeySystemAccess: ICompatMediaKeySystemAccess |
+                        ICustomMediaKeySystemAccess;
   keySystemOptions: IKeySystemOption; // options set by the user
-  mediaKeys : MediaKeys|ICustomMediaKeys;
+  mediaKeys : MediaKeys |
+              ICustomMediaKeys;
   sessionsStore : SessionsStore;
   sessionStorage : PersistedSessionsStore|null;
 }
 
 // Data stored in a persistent MediaKeySession storage
-export interface IPersistedSessionData {
-  sessionId : string;
-  initData : number;
-  initDataType : string|undefined;
-}
+export interface IPersistedSessionData { sessionId : string;
+                                         initData : number;
+                                         initDataType : string|undefined; }
 
 // MediaKeySession storage interface
-export interface IPersistedSessionStorage {
-  load() : IPersistedSessionData[];
-  save(x : IPersistedSessionData[]) : void;
-}
+export interface IPersistedSessionStorage { load() : IPersistedSessionData[];
+                                            save(x : IPersistedSessionData[]) : void; }
 
-type TypedArray =
-  Int8Array |
-  Int16Array |
-  Int32Array |
-  Uint8Array |
-  Uint16Array |
-  Uint32Array |
-  Uint8ClampedArray |
-  Float32Array |
-  Float64Array;
+type TypedArray = Int8Array |
+                  Int16Array |
+                  Int32Array |
+                  Uint8Array |
+                  Uint16Array |
+                  Uint32Array |
+                  Uint8ClampedArray |
+                  Float32Array |
+                  Float64Array;
 
 // Options given by the caller
 export interface IKeySystemOption {
   type : string;
   getLicense : (message : Uint8Array, messageType : string)
-    => Promise<TypedArray|ArrayBuffer|null>|TypedArray|ArrayBuffer|null;
-  serverCertificate? : ArrayBuffer|TypedArray;
+                 => Promise<TypedArray |
+                            ArrayBuffer |
+                            null> |
+                    TypedArray |
+                    ArrayBuffer |
+                    null;
+  serverCertificate? : ArrayBuffer | TypedArray;
   persistentLicense? : boolean;
   licenseStorage? : IPersistedSessionStorage;
   persistentStateRequired? : boolean;
   distinctiveIdentifierRequired? : boolean;
   closeSessionsOnStop? : boolean;
-  onKeyStatusesChange? : (evt : Event, session : MediaKeySession|ICustomMediaKeySession)
-    => Promise<TypedArray|ArrayBuffer|null>|TypedArray|ArrayBuffer|null;
+  onKeyStatusesChange? : (evt : Event, session : MediaKeySession |
+                                                 ICustomMediaKeySession)
+                           => Promise<TypedArray |
+                                      ArrayBuffer |
+                                      null> |
+                              TypedArray |
+                              ArrayBuffer |
+                              null;
   videoRobustnesses?: Array<string|undefined>;
   audioRobustnesses?: Array<string|undefined>;
   throwOnLicenseExpiration? : boolean;
@@ -94,12 +100,11 @@ export interface IKeySystemOption {
 // Keys are the different key statuses possible.
 // Values are ``true`` if such key status defines an error
 /* tslint:disable no-object-literal-type-assertion */
-export const KEY_STATUS_ERRORS = {
-  "internal-error": true,
-  expired: false,
-  released: false,
-  "output-restricted": false,
-  "output-downscaled": false,
-  "status-pending": false,
-} as Partial<Record<string, boolean>>;
+export const KEY_STATUS_ERRORS = { "internal-error": true,
+                                   expired: false,
+                                   released: false,
+                                   "output-restricted": false,
+                                   "output-downscaled": false,
+                                   "status-pending": false,
+                                 } as Partial<Record<string, boolean>>;
 /* tslint:enable no-object-literal-type-assertion */

--- a/src/core/eme/utils/is_session_usable.ts
+++ b/src/core/eme/utils/is_session_usable.ts
@@ -41,12 +41,11 @@ export default function isSessionUsable(
     keyStatuses.push(keyStatus);
   });
 
-  if (
-    keyStatuses.length > 0 &&
-    (
-      !arrayIncludes(keyStatuses, "expired") &&
-      !arrayIncludes(keyStatuses, "internal-error")
-    )
+  if (keyStatuses.length > 0 &&
+      (
+        !arrayIncludes(keyStatuses, "expired") &&
+        !arrayIncludes(keyStatuses, "internal-error")
+      )
   ) {
     log.debug("EME: Reuse loaded session", loadedSession.sessionId);
     return true;

--- a/src/core/eme/utils/open_sessions_store.ts
+++ b/src/core/eme/utils/open_sessions_store.ts
@@ -37,18 +37,15 @@ import castToObservable from "../../../utils/cast_to_observable";
 import hashBuffer from "../../../utils/hash_buffer";
 
 // Cached data for a single MediaKeySession
-interface IStoreSessionEntry {
-  initData : number;
-  initDataType: string|undefined;
-  session : MediaKeySession|ICustomMediaKeySession;
-  sessionType : MediaKeySessionType;
-}
+interface IStoreSessionEntry { initData : number;
+                               initDataType: string|undefined;
+                               session : MediaKeySession|ICustomMediaKeySession;
+                               sessionType : MediaKeySessionType; }
 
 // What is returned by the cache
-export interface IStoreSessionData {
-  session : MediaKeySession|ICustomMediaKeySession;
-  sessionType : MediaKeySessionType;
-}
+export interface IStoreSessionData { session : MediaKeySession |
+                                               ICustomMediaKeySession;
+                                     sessionType : MediaKeySessionType; }
 
 /**
  * Create and store MediaKeySessions linked to a single MediaKeys
@@ -123,12 +120,10 @@ export default class MediaKeySessionsStore {
     }
 
     const session = createSession(this._mediaKeys, sessionType);
-    const entry = {
-      session,
-      sessionType,
-      initData: hashBuffer(initData),
-      initDataType,
-    };
+    const entry = { session,
+                    sessionType,
+                    initData: hashBuffer(initData),
+                    initDataType };
     if (session.closed !== null) {
       session.closed
         .then(() => {

--- a/src/core/eme/utils/persisted_session_store.ts
+++ b/src/core/eme/utils/persisted_session_store.ts
@@ -27,11 +27,9 @@ import {
 } from "../types";
 
 function checkStorage(storage : IPersistedSessionStorage) : void {
-  assertInterface(
-    storage,
-    { save: "function", load: "function" },
-    "licenseStorage"
-  );
+  assertInterface(storage,
+                  { save: "function", load: "function" },
+                  "licenseStorage");
 }
 
 /**
@@ -77,9 +75,9 @@ export default class PersistedSessionsStore {
   ) : IPersistedSessionData|null {
     const hash = hashBuffer(initData);
     const entry = arrayFind(this._entries, (e) =>
-      e.initData === hash &&
-      e.initDataType === initDataType
-    );
+                    e.initData === hash &&
+                    e.initDataType === initDataType
+                  );
     return entry || null;
   }
 
@@ -107,11 +105,9 @@ export default class PersistedSessionsStore {
     }
 
     log.info("EME-PSS: Add new session", sessionId, session);
-    this._entries.push({
-      sessionId,
-      initData: hashBuffer(initData),
-      initDataType,
-    });
+    this._entries.push({ sessionId,
+                         initData: hashBuffer(initData),
+                         initDataType });
     this._save();
   }
 
@@ -127,9 +123,9 @@ export default class PersistedSessionsStore {
     const hash = hashBuffer(initData);
 
     const entry = arrayFind(this._entries, (e) =>
-      e.initData === hash &&
-      e.initDataType === initDataType
-    );
+                    e.initData === hash &&
+                    e.initDataType === initDataType
+                  );
     if (entry) {
       log.warn("EME-PSS: Delete session from store", entry);
 

--- a/src/core/init/create_buffer_clock.ts
+++ b/src/core/init/create_buffer_clock.ts
@@ -46,9 +46,7 @@ export default function createBufferClock(
 ) : Observable<IBufferOrchestratorClockTick> {
   let initialSeekPerformed = false;
   const updateTimeOffset$ = initialSeek$.pipe(
-    tap(() => {
-      initialSeekPerformed = true;
-    }),
+    tap(() => { initialSeekPerformed = true; }),
     ignoreElements()
   );
 
@@ -67,7 +65,8 @@ export default function createBufferClock(
           // initial position, the currentTime will most probably be 0 where the
           // effective starting position will be _startTime_.
           // Thus we initially set a wantedTimeOffset equal to startTime.
-          wantedTimeOffset: initialSeekPerformed ? 0 : startTime - tick.currentTime,
+          wantedTimeOffset: initialSeekPerformed ? 0 :
+                                                   startTime - tick.currentTime,
           speed,
         }, tick);
       }));

--- a/src/core/init/create_eme_manager.ts
+++ b/src/core/init/create_eme_manager.ts
@@ -34,9 +34,7 @@ import {
 
 const { onEncrypted$ } = events;
 
-export interface IEMEDisabledEvent {
-  type: "eme-disabled";
-}
+export interface IEMEDisabledEvent { type: "eme-disabled"; }
 
 /**
  * Create EMEManager if possible (has the APIs and configuration).
@@ -54,7 +52,8 @@ export default function createEMEManager(
       onEncrypted$(mediaElement).pipe(map(() => {
         log.error("Init: Encrypted event but EME feature not activated");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
-          "EME feature not activated.", true);
+                                      "EME feature not activated.",
+                                      true);
       })),
       observableOf({ type: "eme-disabled" as "eme-disabled" }));
   }
@@ -64,7 +63,8 @@ export default function createEMEManager(
       onEncrypted$(mediaElement).pipe(map(() => {
         log.error("Init: Ciphered media and no keySystem passed");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
-          "Media is encrypted and no `keySystems` given", true);
+                                      "Media is encrypted and no `keySystems` given",
+                                      true);
       })),
       observableOf({ type: "eme-disabled" as "eme-disabled" }));
   }
@@ -74,7 +74,8 @@ export default function createEMEManager(
       onEncrypted$(mediaElement).pipe(map(() => {
         log.error("Init: Encrypted event but no EME API available");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
-          "Encryption APIs not found.", true);
+                                      "Encryption APIs not found.",
+                                      true);
       })),
       observableOf({ type: "eme-disabled" as "eme-disabled" }));
   }

--- a/src/core/init/create_media_source.ts
+++ b/src/core/init/create_media_source.ts
@@ -42,9 +42,8 @@ export function setDurationToMediaSource(
   mediaSource : MediaSource,
   duration : number
 ) : void {
-  const newDuration : number = duration === Infinity ?
-    Number.MAX_VALUE : duration;
-
+  const newDuration = duration === Infinity ? Number.MAX_VALUE :
+                                              duration;
   if (mediaSource.duration !== newDuration) {
     log.info("Init: Setting duration", newDuration);
     mediaSource.duration = newDuration;
@@ -74,7 +73,6 @@ function resetMediaSource(
           log.info("Init: Removing SourceBuffer from mediaSource", sourceBuffer);
           sourceBuffer.abort();
         }
-
         mediaSource.removeSourceBuffer(sourceBuffer);
       }
       catch (e) {
@@ -119,7 +117,8 @@ function createMediaSource(
   return new Observable((observer : Observer<MediaSource>) => {
     if (!MediaSource_) {
       throw new MediaError("MEDIA_SOURCE_NOT_SUPPORTED",
-        "No MediaSource Object was found in the current browser.", true);
+                           "No MediaSource Object was found in the current browser.",
+                           true);
     }
 
     // make sure the media has been correctly reset

--- a/src/core/init/end_of_stream.ts
+++ b/src/core/init/end_of_stream.ts
@@ -31,20 +31,16 @@ import {
 import { events } from "../../compat";
 import log from "../../log";
 
-const {
-  onRemoveSourceBuffers$,
-  onSourceOpen$,
-  onUpdate$,
-} = events;
+const { onRemoveSourceBuffers$,
+        onSourceOpen$,
+        onUpdate$ } = events;
 
 /**
  * Get "updating" SourceBuffers from a SourceBufferList.
  * @param {SourceBufferList} sourceBuffers
  * @returns {Array.<SourceBuffer>}
  */
-function getUpdatingSourceBuffers(
-  sourceBuffers : SourceBufferList
-) : SourceBuffer[] {
+function getUpdatingSourceBuffers(sourceBuffers : SourceBufferList) : SourceBuffer[] {
   const updatingSourceBuffers : SourceBuffer[] = [];
   for (let i = 0; i < sourceBuffers.length; i++) {
     const SourceBuffer = sourceBuffers[i];
@@ -52,7 +48,6 @@ function getUpdatingSourceBuffers(
         updatingSourceBuffers.push(SourceBuffer);
     }
   }
-
   return updatingSourceBuffers;
 }
 

--- a/src/core/init/events_generators.ts
+++ b/src/core/init/events_generators.ts
@@ -58,10 +58,8 @@ function manifestReady(
   abrManager : ABRManager,
   manifest : Manifest
 ) : IManifestReadyEvent {
-  return {
-    type: "manifestReady",
-    value: { abrManager, manifest },
-  };
+  return { type: "manifestReady",
+           value: { abrManager, manifest } };
 }
 
 /**
@@ -83,14 +81,10 @@ function nullRepresentation(
   type : IBufferType,
   period : Period
 ) : IRepresentationChangeEvent {
-  return {
-    type: "representationChange",
-    value: {
-      type,
-      representation: null,
-      period,
-    },
-  };
+  return { type: "representationChange",
+           value: { type,
+                    representation: null,
+                    period } };
 }
 
 /**
@@ -106,14 +100,12 @@ function reloadingMediaSource() : IReloadingMediaSourceEvent {
   return { type: "reloading-media-source", value: undefined };
 }
 
-const INIT_EVENTS = {
-  loaded,
-  manifestReady,
-  nullRepresentation,
-  reloadingMediaSource,
-  speedChanged,
-  stalled,
-  warning,
-};
+const INIT_EVENTS = { loaded,
+                      manifestReady,
+                      nullRepresentation,
+                      reloadingMediaSource,
+                      speedChanged,
+                      stalled,
+                      warning };
 
 export default INIT_EVENTS;

--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -19,13 +19,11 @@ import Manifest from "../../manifest";
 
 const { DEFAULT_LIVE_GAP } = config;
 
-export interface IInitialTimeOptions {
-  position? : number;
-  wallClockTime? : number;
-  fromFirstPosition? : number;
-  fromLastPosition? : number;
-  percentage? : number;
-}
+export interface IInitialTimeOptions { position? : number;
+                                       wallClockTime? : number;
+                                       fromFirstPosition? : number;
+                                       fromLastPosition? : number;
+                                       percentage? : number; }
 
 /**
  * Returns the calculated initial time for the content described by the given
@@ -57,13 +55,13 @@ export default function getInitialTime(
     }
     else if (startAt.fromFirstPosition != null) {
       const { fromFirstPosition } = startAt;
-      return fromFirstPosition <= 0 ?
-        min : Math.min(min + fromFirstPosition, max);
+      return fromFirstPosition <= 0 ? min :
+                                      Math.min(max, min + fromFirstPosition);
     }
     else if (startAt.fromLastPosition != null) {
       const { fromLastPosition } = startAt;
-      return fromLastPosition >= 0 ?
-        max : Math.max(min, max + fromLastPosition);
+      return fromLastPosition >= 0 ? max :
+                                     Math.max(min, max + fromLastPosition);
     } else if (startAt.percentage != null) {
       const { percentage } = startAt;
       if (percentage > 100) {
@@ -79,8 +77,8 @@ export default function getInitialTime(
 
   if (manifest.isLive) {
     const sgp = manifest.suggestedPresentationDelay;
-    return manifest.getMaximumPosition() -
-      (sgp == null ? DEFAULT_LIVE_GAP : sgp);
+    return manifest.getMaximumPosition() - (sgp == null ? DEFAULT_LIVE_GAP :
+                                                          sgp);
   }
 
   return manifest.getMinimumPosition();

--- a/src/core/init/get_stalled_events.ts
+++ b/src/core/init/get_stalled_events.ts
@@ -62,8 +62,10 @@ export default function getStalledEvents(
       // calculate a stalled state. This is useful for some
       // implementation that might drop an injected segment, or in
       // case of small discontinuity in the content.
-      if (
-        isPlaybackStuck(tick.currentTime, tick.currentRange, tick.state, !!tick.stalled)
+      if (isPlaybackStuck(tick.currentTime,
+                          tick.currentRange,
+                          tick.state,
+                          !!tick.stalled)
       ) {
         log.warn("Init: After freeze seek", currentTime, tick.currentRange);
         mediaElement.currentTime = currentTime;
@@ -76,8 +78,11 @@ export default function getStalledEvents(
     share(),
     map(tick => tick.stalled),
     distinctUntilChanged((wasStalled, isStalled) => {
-      return !wasStalled && !isStalled ||
-        (!!wasStalled && !!isStalled && wasStalled.reason === isStalled.reason);
+      return !wasStalled &&
+             !isStalled ||
+             (!!wasStalled &&
+              !!isStalled &&
+              wasStalled.reason === isStalled.reason);
     })
   );
 }

--- a/src/core/init/initial_seek_and_play.ts
+++ b/src/core/init/initial_seek_and_play.ts
@@ -59,9 +59,14 @@ function canPlay(
     filter((tick) => {
       const { seeking, stalled, readyState, currentRange } = tick;
       return !seeking &&
-        stalled == null &&
-        (readyState === 4 || readyState === 3 && currentRange != null) &&
-        (!shouldValidateMetadata() || mediaElement.duration > 0);
+             stalled == null &&
+            (
+              readyState === 4 ||
+              readyState === 3 &&
+              currentRange != null) &&
+            (
+              !shouldValidateMetadata() ||
+              mediaElement.duration > 0);
     }),
     take(1),
     mapTo("can-play" as "can-play")
@@ -91,7 +96,7 @@ function autoPlay$(
       if (error.name === "NotAllowedError") {
         // auto-play was probably prevented.
         log.warn("Init: Media element can't play." +
-          " It may be due to browser auto-play policies.");
+                 " It may be due to browser auto-play policies.");
         return observableOf("autoplay-blocked" as "autoplay-blocked");
       } else {
         throw error;
@@ -127,8 +132,8 @@ export default function seekAndLoadOnMediaEvents(
     take(1),
     tap(() => {
       log.info("Init: Set initial time", startTime);
-      mediaElement.currentTime = typeof startTime === "function" ?
-        startTime() : startTime;
+      mediaElement.currentTime = typeof startTime === "function" ? startTime() :
+                                                                   startTime;
     }),
     shareReplay({ refCount: true })
   );

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -85,7 +85,7 @@ function getDirectFileInitialTime(
   const duration = mediaElement.duration;
   if (!duration || !isFinite(duration)) {
     log.warn("startAt.fromLastPosition set but no known duration, " +
-      "beginning at 0.");
+             "beginning at 0.");
     return 0;
   }
 
@@ -106,24 +106,21 @@ function getDirectFileInitialTime(
 }
 
 // Argument used by `initializeDirectfileContent`
-export interface IDirectFileOptions {
-  autoPlay : boolean;
-  clock$ : Observable<IInitClockTick>;
-  keySystems : IKeySystemOption[];
-  mediaElement : HTMLMediaElement;
-  speed$ : Observable<number>;
-  startAt? : IInitialTimeOptions;
-  url : string;
-}
+export interface IDirectFileOptions { autoPlay : boolean;
+                                      clock$ : Observable<IInitClockTick>;
+                                      keySystems : IKeySystemOption[];
+                                      mediaElement : HTMLMediaElement;
+                                      speed$ : Observable<number>;
+                                      startAt? : IInitialTimeOptions;
+                                      url : string; }
 
 // Events emitted by `initializeDirectfileContent`
-export type IDirectfileEvent =
-  ISpeedChangedEvent |
-  IStalledEvent |
-  ILoadedEvent |
-  IWarningEvent |
-  IEMEManagerEvent |
-  IEMEDisabledEvent;
+export type IDirectfileEvent = ISpeedChangedEvent |
+                               IStalledEvent |
+                               ILoadedEvent |
+                               IWarningEvent |
+                               IEMEManagerEvent |
+                               IEMEDisabledEvent;
 
 /**
  * Launch a content in "Directfile mode".
@@ -139,14 +136,14 @@ export default function initializeDirectfileContent({
   startAt,
   url,
 } : IDirectFileOptions) : Observable<IDirectfileEvent> {
+
   clearElementSrc(mediaElement);
 
   // Start everything! (Just put the URL in the element's src).
   const linkURL$ = setElementSrc$(mediaElement, url);
 
   log.debug("Init: Calculating initial time");
-  const initialTime = () =>
-    getDirectFileInitialTime(mediaElement, startAt);
+  const initialTime = () => getDirectFileInitialTime(mediaElement, startAt);
   log.debug("Init: Initial time calculated:", initialTime);
 
   const { seek$, load$ } =
@@ -166,9 +163,9 @@ export default function initializeDirectfileContent({
 
   // Set the speed set by the user on the media element while pausing a
   // little longer while the buffer is empty.
-  const playbackRate$ = updatePlaybackRate(mediaElement, speed$, clock$, {
-    pauseWhenStalled: true,
-  }).pipe(map(EVENTS.speedChanged));
+  const playbackRate$ =
+    updatePlaybackRate(mediaElement, speed$, clock$, { pauseWhenStalled: true })
+      .pipe(map(EVENTS.speedChanged));
 
   // Create Stalling Manager, an observable which will try to get out of
   // various infinite stalling issues
@@ -183,13 +180,15 @@ export default function initializeDirectfileContent({
     mergeMap((evt) => {
       if (evt === "autoplay-blocked") {
         const error = new MediaError("MEDIA_ERR_BLOCKED_AUTOPLAY",
-          "Cannot trigger auto-play automatically: your browser does not allow it.",
-          false);
+                                     "Cannot trigger auto-play automatically: " +
+                                     "your browser does not allow it.",
+                                     false);
         return observableOf(EVENTS.warning(error), EVENTS.loaded());
       } else if (evt === "not-loaded-metadata") {
         const error = new MediaError("MEDIA_ERR_NOT_LOADED_METADATA",
-          "Cannot load automatically: your browser falsely announced having loaded " +
-          "the content.", false);
+                                     "Cannot load automatically: your browser " +
+                                     "falsely announced having loaded the content.",
+                                     false);
         return observableOf(EVENTS.warning(error));
       }
       return observableOf(EVENTS.loaded());
@@ -197,12 +196,10 @@ export default function initializeDirectfileContent({
 
   const initialSeek$ = seek$.pipe(ignoreElements());
 
-  return observableMerge(
-    loadedEvent$,
-    initialSeek$,
-    emeManager$,
-    mediaError$,
-    playbackRate$,
-    stalled$
-  );
+  return observableMerge(loadedEvent$,
+                         initialSeek$,
+                         emeManager$,
+                         mediaError$,
+                         playbackRate$,
+                         stalled$);
 }

--- a/src/core/init/throw_on_media_error.ts
+++ b/src/core/init/throw_on_media_error.ts
@@ -37,21 +37,27 @@ export default function throwOnMediaError(
       switch (errorCode) {
         case 1:
           throw new MediaError("MEDIA_ERR_ABORTED",
-            "The fetching of the associated resource was aborted by the " +
-            "user's request.", true);
+                               "The fetching of the associated resource was aborted " +
+                               "by the user's request.",
+                               true);
         case 2:
           throw new MediaError("MEDIA_ERR_NETWORK",
-            "A network error occurred which prevented the media from being " +
-            "successfully fetched", true);
+                               "A network error occurred which prevented the media " +
+                               "from being successfully fetched",
+                               true);
         case 3:
           throw new MediaError("MEDIA_ERR_DECODE",
-            "An error occurred while trying to decode the media resource", true);
+                               "An error occurred while trying to decode the media " +
+                               "resource",
+                               true);
         case 4:
           throw new MediaError("MEDIA_ERR_SRC_NOT_SUPPORTED",
-            "The media resource has been found to be unsuitable.", true);
+                               "The media resource has been found to be unsuitable.",
+                               true);
         default:
           throw new MediaError("MEDIA_ERR_UNKNOWN",
-            "The HTMLMediaElement errored due to an unknown reason.", true);
+                               "The HTMLMediaElement errored due to an unknown reason.",
+                               true);
       }
     }));
 }

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -21,64 +21,48 @@ import { IRepresentationChangeEvent } from "../buffers";
 import { IStallingItem } from "./get_stalled_events";
 
 // Object emitted when the clock ticks
-export interface IInitClockTick {
-  currentTime : number;
-  buffered : TimeRanges;
-  duration : number;
-  bufferGap : number;
-  state : string;
-  playbackRate : number;
-  currentRange : {
-    start : number;
-      end : number;
-  } | null;
-  readyState : number;
-  paused : boolean;
-  stalled : {
-    reason : "seeking" | "not-ready" | "buffering";
-    timestamp : number;
-  } | null;
-  seeking : boolean;
-}
+export interface IInitClockTick { currentTime : number;
+                                  buffered : TimeRanges;
+                                  duration : number;
+                                  bufferGap : number;
+                                  state : string;
+                                  playbackRate : number;
+                                  currentRange : { start : number;
+                                                   end : number; } |
+                                                 null;
+                                  readyState : number;
+                                  paused : boolean;
+                                  stalled : { reason : "seeking" |
+                                                       "not-ready" |
+                                                       "buffering";
+                                              timestamp : number; } |
+                                            null;
+                                  seeking : boolean; }
 
 // The manifest has been downloaded and parsed for the first time
-export interface IManifestReadyEvent {
-  type : "manifestReady";
-  value : {
-    abrManager : ABRManager;
-    manifest : Manifest;
-  };
-}
+export interface IManifestReadyEvent { type : "manifestReady";
+                                       value : { abrManager : ABRManager;
+                                                 manifest : Manifest; }; }
 
 // A minor error happened
-export interface IWarningEvent {
-  type : "warning";
-  value : Error|ICustomError;
-}
+export interface IWarningEvent { type : "warning";
+                                 value : Error | ICustomError; }
 
-export interface IReloadingMediaSourceEvent {
-  type: "reloading-media-source";
-  value: undefined;
-}
+export interface IReloadingMediaSourceEvent { type: "reloading-media-source";
+                                              value: undefined; }
 
 // The current playback rate changed.
 // Note: it can be a change wanted by the user or even a manual `0` speed
 // setting to build a buffer.
-export interface ISpeedChangedEvent {
-  type : "speedChanged";
-  value : number;
-}
+export interface ISpeedChangedEvent { type : "speedChanged";
+                                      value : number; }
 
 // The player stalled, leading to buffering.
-export interface IStalledEvent {
-  type : "stalled";
-  value : IStallingItem|null;
-}
+export interface IStalledEvent { type : "stalled";
+                                 value : IStallingItem|null; }
 
 // The content loaded
-export interface ILoadedEvent {
-  type : "loaded";
-  value : true;
-}
+export interface ILoadedEvent { type : "loaded";
+                                value : true; }
 
 export { IRepresentationChangeEvent };

--- a/src/core/init/update_playback_rate.ts
+++ b/src/core/init/update_playback_rate.ts
@@ -30,9 +30,7 @@ import {
 import log from "../../log";
 import { IInitClockTick } from "./types";
 
-export interface IPlaybackRateOptions {
-  pauseWhenStalled? : boolean;
-}
+export interface IPlaybackRateOptions { pauseWhenStalled? : boolean; }
 
 /**
  * Manage playback speed.
@@ -66,9 +64,8 @@ export default function updatePlaybackRate(
         map(([prevTiming, timing]) => {
           const isStalled = timing.stalled;
           const wasStalled = prevTiming.stalled;
-          if (
-            !wasStalled !== !isStalled || // xor
-            (wasStalled && isStalled && wasStalled.reason !== isStalled.reason)
+          if (!wasStalled !== !isStalled || // xor
+              (wasStalled && isStalled && wasStalled.reason !== isStalled.reason)
           ) {
             return !wasStalled;
           }

--- a/src/core/pipelines/manifest/create_manifest_pipeline.ts
+++ b/src/core/pipelines/manifest/create_manifest_pipeline.ts
@@ -46,15 +46,11 @@ import createLoader, {
   IPipelineLoaderResponse,
 } from "../utils/create_loader";
 
-const {
-  MAX_BACKOFF_DELAY_BASE,
-  INITIAL_BACKOFF_DELAY_BASE,
-} = config;
+const { MAX_BACKOFF_DELAY_BASE,
+        INITIAL_BACKOFF_DELAY_BASE } = config;
 
-export interface IRequestSchedulerOptions {
-  maxRetry : number;
-  maxRetryOffline : number;
-}
+export interface IRequestSchedulerOptions { maxRetry : number;
+                                            maxRetryOffline : number; }
 
 export interface IFetchManifestOptions {
   url : string; // URL from which the manifest was requested
@@ -65,10 +61,8 @@ export interface IFetchManifestOptions {
 type IPipelineManifestOptions =
   IPipelineLoaderOptions<IManifestLoaderArguments, Document|string>;
 
-export interface IFetchManifestResult {
-  manifest : Manifest;
-  sendingTime? : number;
-}
+export interface IFetchManifestResult { manifest : Manifest;
+                                        sendingTime? : number; }
 
 /**
  * Generate a new error from the infos given.
@@ -123,15 +117,15 @@ export default function createManifestPipeline(
   function scheduleRequest<T>(request : () => Observable<T>) : Observable<T> {
     const { maxRetry, maxRetryOffline } = pipelineOptions;
 
-    const backoffOptions = {
-      baseDelay: INITIAL_BACKOFF_DELAY_BASE,
-      maxDelay: MAX_BACKOFF_DELAY_BASE,
-      maxRetryRegular: maxRetry,
-      maxRetryOffline,
-      onRetry: (error : Error) => {
-        warning$.next(errorSelector("PIPELINE_LOAD_ERROR", error, false));
-      },
-    };
+    const backoffOptions = { baseDelay: INITIAL_BACKOFF_DELAY_BASE,
+                             maxDelay: MAX_BACKOFF_DELAY_BASE,
+                             maxRetryRegular: maxRetry,
+                             maxRetryOffline,
+                             onRetry: (error : Error) => {
+                               warning$.next(errorSelector("PIPELINE_LOAD_ERROR",
+                                                           error,
+                                                           false)); } };
+
     return downloadingBackoff(tryCatch(request, undefined), backoffOptions).pipe(
       catchError((error : Error) : Observable<never> => {
         throw errorSelector("PIPELINE_LOAD_ERROR", error, true);
@@ -160,15 +154,17 @@ export default function createManifestPipeline(
 
       mergeMap(({ value }) => {
         const { sendingTime } = value;
-        return parser({
-          response: value,
-          url,
-          hasClockSynchronization,
-          scheduleRequest,
-        }).pipe(
+        return parser({ response: value,
+                        url,
+                        hasClockSynchronization,
+                        scheduleRequest }
+        ).pipe(
           catchError((error: Error) => {
             const formattedError = isKnownError(error) ?
-              error : new OtherError("PIPELINE_PARSING_ERROR", error.toString(), true);
+                                     error :
+                                     new OtherError("PIPELINE_PARSING_ERROR",
+                                                    error.toString(),
+                                                    true);
             throw formattedError;
           }),
           map(({ manifest }) => {

--- a/src/core/pipelines/segment/prioritized_segment_fetcher.ts
+++ b/src/core/pipelines/segment/prioritized_segment_fetcher.ts
@@ -25,15 +25,11 @@ import {
 // Defines what is returned by the SegmentPipeline
 // See the function definition for documentation
 export interface IPrioritizedSegmentFetcher<T> {
-  createRequest : (
-    content : ISegmentLoaderArguments,
-    priority? : number
-  ) => Observable<IFetchedSegment<T>>;
+  createRequest : (content : ISegmentLoaderArguments,
+                   priority? : number) => Observable<IFetchedSegment<T>>;
 
-  updatePriority : (
-    observable : Observable<IFetchedSegment<T>>,
-    priority : number
-  ) => void;
+  updatePriority : (observable : Observable<IFetchedSegment<T>>,
+                    priority : number) => void;
 }
 
 /**

--- a/src/core/pipelines/segment/prioritizer.ts
+++ b/src/core/pipelines/segment/prioritizer.ts
@@ -107,11 +107,9 @@ export default class ObservablePrioritizer<T> {
    * @type {Array.<Object>}
    * @private
    */
-  private _queue : Array<{
-    observable : Observable<T>;
-    trigger : Subject<void>;
-    priority : number;
-  }>;
+  private _queue : Array<{ observable : Observable<T>;
+                           trigger : Subject<void>;
+                           priority : number; }>;
 
   constructor() {
     this._pendingPriority = null;
@@ -167,10 +165,8 @@ export default class ObservablePrioritizer<T> {
    * @param {number} priority
    */
   public updatePriority(obs : Observable<T>, priority : number) : void {
-    const index = arrayFindIndex(
-      this._queue,
-      (elt) => elt.observable === obs
-    );
+    const index = arrayFindIndex(this._queue,
+                                 (elt) => elt.observable === obs);
 
     if (index < 0) {
       return;
@@ -203,8 +199,8 @@ export default class ObservablePrioritizer<T> {
 
       this._pendingPriority = this._queue
         .reduce((acc : number | null, elt) => {
-          return acc == null || acc > elt.priority ?
-            elt.priority : acc;
+          return acc == null || acc > elt.priority ? elt.priority :
+                                                     acc;
         }, null);
 
       for (let i = 0; i < this._queue.length; i++) {
@@ -220,6 +216,6 @@ export default class ObservablePrioritizer<T> {
 
     this._numberOfPendingObservables++;
     return obs
-      .pipe(finalize(onObservableFinish));
+             .pipe(finalize(onObservableFinish));
   }
 }

--- a/src/core/pipelines/segment/segment_fetcher.ts
+++ b/src/core/pipelines/segment/segment_fetcher.ts
@@ -126,13 +126,9 @@ export default function createSegmentFetcher<T>(
 
             // format it for ABR Handling
             if (size != null && duration != null) {
-              network$.next({
-                type: bufferType,
-                value: {
-                  size,
-                  duration,
-                },
-              });
+              network$.next({ type: bufferType,
+                              value: { size,
+                                       duration } });
             }
             break;
           }
@@ -149,39 +145,30 @@ export default function createSegmentFetcher<T>(
               const duration = segment.duration / segment.timescale;
               const time = segment.time / segment.timescale;
               id = generateRequestID();
-              request$.next({
-                type: bufferType,
-                event: "requestBegin",
-                value: {
-                  duration,
-                  time,
-                  requestTimestamp: performance.now(),
-                  id,
-                },
-              });
+              request$.next({ type: bufferType,
+                              event: "requestBegin",
+                              value: { duration,
+                                       time,
+                                       requestTimestamp: performance.now(),
+                                       id } });
             }
             break;
           }
 
           case "progress": {
             const { value } = arg;
-            if (
-              value.totalSize != null &&
-              value.size < value.totalSize &&
-              id != null &&
-              request$ != null
+            if (value.totalSize != null &&
+                value.size < value.totalSize &&
+                id != null &&
+                request$ != null
             ) {
-              request$.next({
-                type: bufferType,
-                event: "progress",
-                value: {
-                  duration: value.duration,
-                  size: value.size,
-                  totalSize: value.totalSize,
-                  timestamp: performance.now(),
-                  id,
-                },
-              });
+              request$.next({ type: bufferType,
+                              event: "progress",
+                              value: { duration: value.duration,
+                                       size: value.size,
+                                       totalSize: value.totalSize,
+                                       timestamp: performance.now(),
+                                       id } });
             }
             break;
           }
@@ -195,11 +182,9 @@ export default function createSegmentFetcher<T>(
       finalize(() => {
         if (request$ != null) {
           if (id != null) {
-            request$.next({
-              type: bufferType,
-              event: "requestEnd",
-              value: { id },
-            });
+            request$.next({ type: bufferType,
+                            event: "requestEnd",
+                            value: { id } });
           }
           request$.complete();
         }
@@ -217,8 +202,10 @@ export default function createSegmentFetcher<T>(
             return segmentParser(parserArg)
               .pipe(catchError((error: Error) => {
                 const formattedError = isKnownError(error) ?
-                  error : new OtherError(
-                    "PIPELINE_PARSING_ERROR", error.toString(), true);
+                                         error :
+                                         new OtherError("PIPELINE_PARSING_ERROR",
+                                                        error.toString(),
+                                                        true);
                   throw formattedError;
               }));
           },

--- a/src/core/pipelines/segment/segment_pipelines_manager.ts
+++ b/src/core/pipelines/segment/segment_pipelines_manager.ts
@@ -26,7 +26,9 @@ import {
 } from "../../abr";
 import { IBufferType } from "../../source_buffers";
 import { IPipelineLoaderOptions } from "../utils/create_loader";
-import applyPrioritizerToSegmentFetcher from "./prioritized_segment_fetcher";
+import applyPrioritizerToSegmentFetcher, {
+  IPrioritizedSegmentFetcher,
+} from "./prioritized_segment_fetcher";
 import ObservablePrioritizer from "./prioritizer";
 import createSegmentFetcher, {
   IFetchedSegment,
@@ -107,20 +109,16 @@ export default class SegmentPipelinesManager<T> {
   createPipeline(
     bufferType : IBufferType,
     options : IPipelineLoaderOptions<ISegmentLoaderArguments, T>
-  ) {
-    const segmentFetcher = createSegmentFetcher<T>(
-      bufferType,
-      this._transport,
-      this._metrics$,
-      this._requestsInfos$,
-      this._warning$,
-      options
-    );
+  ) : IPrioritizedSegmentFetcher<T> {
+    const segmentFetcher = createSegmentFetcher<T>(bufferType,
+                                                   this._transport,
+                                                   this._metrics$,
+                                                   this._requestsInfos$,
+                                                   this._warning$,
+                                                   options);
 
     return applyPrioritizerToSegmentFetcher<T>(this._prioritizer, segmentFetcher);
   }
 }
 
-export {
-  IPipelineLoaderOptions as IPipelineOptions,
-};
+export { IPipelineLoaderOptions as IPipelineOptions };

--- a/src/core/pipelines/utils/backoff.ts
+++ b/src/core/pipelines/utils/backoff.ts
@@ -33,19 +33,19 @@ import { getFuzzedDelay } from "../../../utils/backoff_delay";
  * Called on a pipeline's loader error.
  * Returns whether the loader request should be retried.
  * @param {Error} error
- * @returns {Boolean}
+ * @returns {Boolean} - If true, the request can be retried.
  */
 function shouldRetry(error : Error) : boolean {
   if (!(error instanceof RequestError)) {
     return false;
   }
   if (error.type === RequestErrorTypes.ERROR_HTTP_CODE) {
-    return error.status >= 500 || error.status === 404 || error.status === 412;
+    return error.status >= 500 ||
+           error.status === 404 ||
+           error.status === 412;
   }
-  return (
-    error.type === RequestErrorTypes.TIMEOUT ||
-    error.type === RequestErrorTypes.ERROR_EVENT
-  );
+  return error.type === RequestErrorTypes.TIMEOUT ||
+         error.type === RequestErrorTypes.ERROR_EVENT;
 }
 
 /**
@@ -55,16 +55,16 @@ function shouldRetry(error : Error) : boolean {
  * @returns {Boolean}
  */
 function isOfflineRequestError(error : RequestError) : boolean {
-  return error.type === RequestErrorTypes.ERROR_EVENT && isOffline();
+  return error.type === RequestErrorTypes.ERROR_EVENT &&
+         isOffline();
 }
 
-interface IDownloadingBackoffOptions {
-  baseDelay : number;
-  maxDelay : number;
-  maxRetryRegular : number;
-  maxRetryOffline : number;
-  onRetry? : (error : Error, retryCount : number) => void;
-}
+interface IDownloadingBackoffOptions { baseDelay : number;
+                                       maxDelay : number;
+                                       maxRetryRegular : number;
+                                       maxRetryOffline : number;
+                                       onRetry? : (error : Error,
+                                                   retryCount : number) => void; }
 
 /**
  * Specific exponential backoff algorithm used for segments/manifest
@@ -83,55 +83,51 @@ function downloadingBackoff<T>(
   obs$ : Observable<T>,
   options : IDownloadingBackoffOptions
 ) : Observable<T> {
-  const {
-    baseDelay,
-    maxDelay,
-    maxRetryRegular,
-    maxRetryOffline,
-    onRetry,
-  } = options;
+  const { baseDelay,
+          maxDelay,
+          maxRetryRegular,
+          maxRetryOffline,
+          onRetry } = options;
+
   let retryCount = 0;
 
-  const ERROR_TYPES = {
-    NONE: 0,
-    REGULAR: 1,
-    OFFLINE: 2,
-  };
+  const ERROR_TYPES = { NONE: 0,
+                        REGULAR: 1,
+                        OFFLINE: 2 };
 
   let lastError = ERROR_TYPES.NONE;
-  return obs$
-    .pipe(catchError((error : Error, source) => {
-      if (!shouldRetry(error)) {
-        throw error;
-      }
-      const currentError = error instanceof RequestError &&
-        isOfflineRequestError(error) ?  ERROR_TYPES.OFFLINE : ERROR_TYPES.REGULAR;
 
-      const maxRetry = currentError === ERROR_TYPES.OFFLINE ?
-        maxRetryOffline : maxRetryRegular;
+  return obs$.pipe(catchError((error : Error, source) => {
+    if (!shouldRetry(error)) {
+      throw error;
+    }
+    const currentError = error instanceof RequestError &&
+                         isOfflineRequestError(error) ? ERROR_TYPES.OFFLINE :
+                                                        ERROR_TYPES.REGULAR;
 
-      if (currentError !== lastError) {
-        retryCount = 0;
-        lastError = currentError;
-      }
+    const maxRetry = currentError === ERROR_TYPES.OFFLINE ? maxRetryOffline :
+                                                            maxRetryRegular;
 
-      if (++retryCount > maxRetry) {
-        throw error;
-      }
+    if (currentError !== lastError) {
+      retryCount = 0;
+      lastError = currentError;
+    }
 
-      if (onRetry) {
-        onRetry(error, retryCount);
-      }
+    if (++retryCount > maxRetry) {
+      throw error;
+    }
 
-      const delay = Math.min(
-        baseDelay * Math.pow(2, retryCount - 1),
-        maxDelay
-      );
+    if (onRetry) {
+      onRetry(error, retryCount);
+    }
 
-      const fuzzedDelay = getFuzzedDelay(delay);
-      return observableTimer(fuzzedDelay).pipe(
-        mergeMap(() => source));
-    }));
+    const delay = Math.min(baseDelay * Math.pow(2, retryCount - 1),
+                           maxDelay);
+
+    const fuzzedDelay = getFuzzedDelay(delay);
+    return observableTimer(fuzzedDelay)
+             .pipe(mergeMap(() => source));
+  }));
 }
 
 export default downloadingBackoff;

--- a/src/core/source_buffers/abstract_source_buffer.ts
+++ b/src/core/source_buffers/abstract_source_buffer.ts
@@ -24,12 +24,10 @@ import EventEmitter from "../../utils/event_emitter";
 import tryCatch from "../../utils/rx-try_catch";
 import ManualTimeRanges from "./time_ranges";
 
-interface IAbstractSourceBufferEvent {
-  updatestart : undefined;
-  update : undefined;
-  updateend : undefined;
-  error : Event;
-}
+interface IAbstractSourceBufferEvent { updatestart : undefined;
+                                       update : undefined;
+                                       updateend : undefined;
+                                       error : Event; }
 
 /**
  * Abstract class for a custom SourceBuffer implementation.
@@ -37,8 +35,8 @@ interface IAbstractSourceBufferEvent {
  * @extends EventEmitter
  */
 export default abstract class AbstractSourceBuffer<T>
-  extends EventEmitter<IAbstractSourceBufferEvent>
-  implements ICustomSourceBuffer<T>
+                        extends EventEmitter<IAbstractSourceBufferEvent>
+                        implements ICustomSourceBuffer<T>
 {
   public timestampOffset : number;
   public updating : boolean;
@@ -101,17 +99,15 @@ export default abstract class AbstractSourceBuffer<T>
       func();
       return observableOf(undefined);
     }, undefined);
-    result.subscribe(
-      ()  => nextTick(() => {
-        this.updating = false;
-        this.trigger("update", undefined);
-        this.trigger("updateend", undefined);
-      }),
-      (e) => nextTick(() => {
-        this.updating = false;
-        this.trigger("error", e);
-        this.trigger("updateend", undefined);
-      })
-    );
+    result.subscribe(()  => nextTick(() => {
+                       this.updating = false;
+                       this.trigger("update", undefined);
+                       this.trigger("updateend", undefined);
+                     }),
+                     (e) => nextTick(() => {
+                       this.updating = false;
+                       this.trigger("error", e);
+                       this.trigger("updateend", undefined);
+                     }));
   }
 }

--- a/src/core/source_buffers/garbage_collector.ts
+++ b/src/core/source_buffers/garbage_collector.ts
@@ -50,12 +50,10 @@ export default function BufferGarbageCollector({
 }) : Observable<never> {
   return observableCombineLatest(clock$, maxBufferBehind$, maxBufferAhead$).pipe(
     mergeMap(([currentTime, maxBufferBehind, maxBufferAhead]) => {
-      return clearBuffer(
-        queuedSourceBuffer,
-        currentTime,
-        maxBufferBehind,
-        maxBufferAhead
-      );
+      return clearBuffer(queuedSourceBuffer,
+                         currentTime,
+                         maxBufferBehind,
+                         maxBufferAhead);
     }));
 }
 
@@ -85,14 +83,11 @@ function clearBuffer(
     return EMPTY;
   }
 
-  const cleanedupRanges : Array<{
-    start : number;
-    end: number;
-  }> = [];
-  const { innerRange, outerRanges } = getInnerAndOuterTimeRanges(
-    qSourceBuffer.getBuffered(),
-    position
-  );
+  const cleanedupRanges : Array<{ start : number;
+                                  end: number; }> = [];
+  const { innerRange, outerRanges } =
+    getInnerAndOuterTimeRanges(qSourceBuffer.getBuffered(),
+                               position);
 
   const collectBufferBehind = () => {
     if (!isFinite(maxBufferBehind)) {
@@ -105,23 +100,18 @@ function clearBuffer(
       if (position - maxBufferBehind >= outerRange.end) {
         cleanedupRanges.push(outerRange);
       }
-      else if (
-        position >= outerRange.end &&
-        position - maxBufferBehind > outerRange.start &&
-        position - maxBufferBehind < outerRange.end
+      else if (position >= outerRange.end &&
+               position - maxBufferBehind > outerRange.start &&
+               position - maxBufferBehind < outerRange.end
       ) {
-        cleanedupRanges.push({
-          start: outerRange.start,
-          end: position - maxBufferBehind,
-        });
+        cleanedupRanges.push({ start: outerRange.start,
+                               end: position - maxBufferBehind });
       }
     }
     if (innerRange) {
       if (position - maxBufferBehind > innerRange.start) {
-        cleanedupRanges.push({
-          start: innerRange.start,
-          end: position - maxBufferBehind,
-        });
+        cleanedupRanges.push({ start: innerRange.start,
+                               end: position - maxBufferBehind });
       }
     }
   };
@@ -137,23 +127,18 @@ function clearBuffer(
       if (position + maxBufferAhead <= outerRange.start) {
         cleanedupRanges.push(outerRange);
       }
-      else if (
-        position <= outerRange.start &&
-        position + maxBufferAhead < outerRange.end &&
-        position + maxBufferAhead > outerRange.start
+      else if (position <= outerRange.start &&
+               position + maxBufferAhead < outerRange.end &&
+               position + maxBufferAhead > outerRange.start
       ) {
-        cleanedupRanges.push({
-          start: position + maxBufferAhead,
-          end: outerRange.end,
-        });
+        cleanedupRanges.push({ start: position + maxBufferAhead,
+                               end: outerRange.end });
       }
     }
     if (innerRange) {
       if (position + maxBufferAhead < innerRange.end) {
-        cleanedupRanges.push({
-          start: position + maxBufferAhead,
-          end: innerRange.end,
-        });
+        cleanedupRanges.push({ start: position + maxBufferAhead,
+                               end: innerRange.end });
       }
     }
   };

--- a/src/core/source_buffers/image/image_source_buffer.ts
+++ b/src/core/source_buffers/image/image_source_buffer.ts
@@ -36,7 +36,7 @@ export interface IImageTrackSegmentData {
  * @class ImageSourceBuffer
  */
 class ImageSourceBuffer
-  extends AbstractSourceBuffer<IImageTrackSegmentData>
+      extends AbstractSourceBuffer<IImageTrackSegmentData>
 {
   /**
    * @param {Object} data
@@ -44,10 +44,9 @@ class ImageSourceBuffer
   _append(data : IImageTrackSegmentData) {
     log.debug("ImageSourceBuffer: appending new data.");
     const { start, end, timescale } = data;
-    this.buffered.insert(
-      start / timescale,
-      end == null ? Number.MAX_VALUE : end / timescale
-    );
+    this.buffered.insert(start / timescale,
+                         end == null ? Number.MAX_VALUE :
+                                       end / timescale);
   }
 
   /**

--- a/src/core/source_buffers/image/index.ts
+++ b/src/core/source_buffers/image/index.ts
@@ -24,6 +24,4 @@ import ImageSourceBuffer, {
 } from "./image_source_buffer";
 
 export default ImageSourceBuffer;
-export {
-  IImageTrackSegmentData,
-};
+export { IImageTrackSegmentData };

--- a/src/core/source_buffers/source_buffers_manager.ts
+++ b/src/core/source_buffers/source_buffers_manager.ts
@@ -22,19 +22,20 @@ import QueuedSourceBuffer, {
   IBufferType,
 } from "./queued_source_buffer";
 
-type TypedArray =
-  Int8Array |
-  Int16Array |
-  Int32Array |
-  Uint8Array |
-  Uint16Array |
-  Uint32Array |
-  Uint8ClampedArray |
-  Float32Array |
-  Float64Array;
+type TypedArray = Int8Array |
+                  Int16Array |
+                  Int32Array |
+                  Uint8Array |
+                  Uint16Array |
+                  Uint32Array |
+                  Uint8ClampedArray |
+                  Float32Array |
+                  Float64Array;
 
-const POSSIBLE_BUFFER_TYPES : IBufferType[] =
-  ["audio", "video", "text", "image"];
+const POSSIBLE_BUFFER_TYPES : IBufferType[] = [ "audio",
+                                                "video",
+                                                "text",
+                                                "image" ];
 
 /**
  * Get all currently available buffer types.
@@ -43,9 +44,8 @@ const POSSIBLE_BUFFER_TYPES : IBufferType[] =
  */
 export function getBufferTypes() : IBufferType[] {
   const bufferTypes : IBufferType[] = ["audio", "video"];
-  if (
-    features.nativeTextTracksBuffer != null ||
-    features.htmlTextTracksBuffer != null
+  if (features.nativeTextTracksBuffer != null ||
+      features.htmlTextTracksBuffer != null
   ) {
     bufferTypes.push("text");
   }
@@ -56,19 +56,13 @@ export function getBufferTypes() : IBufferType[] {
 }
 
 // Options available for a "text" SourceBuffer
-export type ITextTrackSourceBufferOptions =
-  {
-    textTrackMode? : "native";
-    hideNativeSubtitle? : boolean;
-  } |
-  {
-    textTrackMode : "html";
-    textTrackElement : HTMLElement;
-  };
+export type ITextTrackSourceBufferOptions = { textTrackMode? : "native";
+                                              hideNativeSubtitle? : boolean; } |
+                                            { textTrackMode : "html";
+                                              textTrackElement : HTMLElement; };
 
 // General Options available for any SourceBuffer
-export type ISourceBufferOptions =
-  ITextTrackSourceBufferOptions;
+export type ISourceBufferOptions = ITextTrackSourceBufferOptions;
 
 // Types of "native" SourceBuffers
 type INativeSourceBufferType = "audio" | "video";
@@ -152,15 +146,16 @@ export default class SourceBuffersManager {
       if (memorizedSourceBuffer) {
         if (memorizedSourceBuffer.codec !== codec) {
           log.warn("SB: Reusing native SourceBuffer with codec",
-            memorizedSourceBuffer.codec, "for codec", codec);
+                   memorizedSourceBuffer.codec, "for codec", codec);
         } else {
           log.info("SB: Reusing native SourceBuffer with codec", codec);
         }
         return memorizedSourceBuffer;
       }
       log.info("SB: Adding native SourceBuffer with codec", codec);
-      const nativeSourceBuffer =
-        createNativeQueuedSourceBuffer(bufferType, this._mediaSource, codec);
+      const nativeSourceBuffer = createNativeQueuedSourceBuffer(bufferType,
+                                                                this._mediaSource,
+                                                                codec);
       this._initializedSourceBuffers[bufferType] = nativeSourceBuffer;
       return nativeSourceBuffer;
     }
@@ -178,18 +173,19 @@ export default class SourceBuffersManager {
         if (features.htmlTextTracksBuffer == null) {
           throw new Error("HTML Text track feature not activated");
         }
-        sourceBuffer = new features
-          .htmlTextTracksBuffer(this._mediaElement, options.textTrackElement);
+        sourceBuffer = new features.htmlTextTracksBuffer(this._mediaElement,
+                                                         options.textTrackElement);
       } else {
         if (features.nativeTextTracksBuffer == null) {
           throw new Error("Native Text track feature not activated");
         }
-        sourceBuffer = new features
-          .nativeTextTracksBuffer(this._mediaElement, !!options.hideNativeSubtitle);
+        sourceBuffer = new features.nativeTextTracksBuffer(this._mediaElement,
+                                                           !!options.hideNativeSubtitle);
       }
 
-      const queuedSourceBuffer =
-        new QueuedSourceBuffer<unknown>("text", codec, sourceBuffer);
+      const queuedSourceBuffer = new QueuedSourceBuffer<unknown>("text",
+                                                                 codec,
+                                                                 sourceBuffer);
       this._initializedSourceBuffers.text = queuedSourceBuffer;
       return queuedSourceBuffer;
     } else if (bufferType === "image") {
@@ -198,15 +194,17 @@ export default class SourceBuffersManager {
       }
       log.info("SB: Creating a new image SourceBuffer with codec", codec);
       const sourceBuffer = new features.imageBuffer();
-      const queuedSourceBuffer =
-        new QueuedSourceBuffer<unknown>("image", codec, sourceBuffer);
+      const queuedSourceBuffer = new QueuedSourceBuffer<unknown>("image",
+                                                                 codec,
+                                                                 sourceBuffer);
       this._initializedSourceBuffers.image = queuedSourceBuffer;
       return queuedSourceBuffer;
     }
 
     log.error("SB: Unknown buffer type:", bufferType);
     throw new MediaError("BUFFER_TYPE_UNKNOWN",
-      "The player wants to create a SourceBuffer of an unknown type.", true);
+                         "The player wants to create a SourceBuffer of an unknown type.",
+                         true);
   }
 
   /**
@@ -222,9 +220,8 @@ export default class SourceBuffersManager {
 
     log.info("SB: Aborting SourceBuffer", bufferType);
     memorizedSourceBuffer.dispose();
-    if (
-      !shouldHaveNativeSourceBuffer(bufferType) ||
-      this._mediaSource.readyState === "open"
+    if (!shouldHaveNativeSourceBuffer(bufferType) ||
+        this._mediaSource.readyState === "open"
     ) {
       try {
         memorizedSourceBuffer.abort();

--- a/src/core/source_buffers/text/html/buffer_manager.ts
+++ b/src/core/source_buffers/text/html/buffer_manager.ts
@@ -103,10 +103,8 @@ export default class TextBufferManager {
 
         // ``to`` is within this segment
         if (startCuesInfos.end >= to) {
-          const [
-            cuesInfos1,
-            cuesInfos2,
-          ] = removeCuesInfosBetween(startCuesInfos, from, to);
+          const [ cuesInfos1,
+                  cuesInfos2 ] = removeCuesInfosBetween(startCuesInfos, from, to);
           this._cuesBuffer[i] = cuesInfos1;
           cuesBuffer.splice(i + 1, 0, cuesInfos2);
           return;
@@ -283,10 +281,8 @@ export default class TextBufferManager {
         // Which means:
         //   1. split current one in two parts based on our cue.
         //   2. insert our cue into it.
-        const [
-          cuesInfos1,
-          cuesInfos2,
-        ] = removeCuesInfosBetween(cuesInfos, start, end);
+        const [ cuesInfos1,
+                cuesInfos2 ] = removeCuesInfosBetween(cuesInfos, start, end);
         this._cuesBuffer[i] = cuesInfos1;
         cuesBuffer.splice(i + 1, 0, cuesInfosToInsert);
         cuesBuffer.splice(i + 2, 0, cuesInfos2);

--- a/src/core/source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/core/source_buffers/text/html/html_text_source_buffer.ts
@@ -35,24 +35,18 @@ import AbstractSourceBuffer from "../../abstract_source_buffer";
 import TextBufferManager from "./buffer_manager";
 import parseTextTrackToElements from "./parsers";
 
-const {
-  onEnded$,
-  onSeeked$,
-  onSeeking$,
-} = events;
+const { onEnded$,
+        onSeeked$,
+        onSeeking$ } = events;
 
-export interface IHTMLTextTrackData {
-  timescale : number;
-  start : number;
-  end? : number;
-  data : string;
-  type : string;
-  language : string;
-}
+export interface IHTMLTextTrackData { timescale : number;
+                                      start : number;
+                                      end? : number;
+                                      data : string;
+                                      type : string;
+                                      language : string; }
 
-const {
-  MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL,
-} = config;
+const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config;
 
 /**
  * Generate the clock at which TextTrack HTML Cues should be refreshed.
@@ -66,18 +60,13 @@ function generateClock(videoElement : HTMLMediaElement) : Observable<boolean> {
 
   const manualRefresh$ = observableMerge(seeked$, ended$);
   const autoRefresh$ = observableInterval(MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL)
-    .pipe(startWith(null));
+                         .pipe(startWith(null));
 
   return manualRefresh$.pipe(
     startWith(null),
-    switchMapTo(
-      observableConcat(
-        autoRefresh$
-          .pipe(mapTo(true), takeUntil(seeking$)),
-        observableOf(false)
-      )
-    )
-  );
+    switchMapTo(observableConcat(autoRefresh$
+                                   .pipe(mapTo(true), takeUntil(seeking$)),
+                                 observableOf(false))));
 }
 
 /**
@@ -99,7 +88,7 @@ function safelyRemoveChild(element : Element, child : Element|null) {
  * @class HTMLTextSourceBuffer
  */
 export default class HTMLTextSourceBuffer
-  extends AbstractSourceBuffer<IHTMLTextTrackData>
+               extends AbstractSourceBuffer<IHTMLTextTrackData>
 {
   private readonly _videoElement : HTMLMediaElement;
   private readonly _destroy$ : Subject<void>;
@@ -137,7 +126,8 @@ export default class HTMLTextSourceBuffer
         // As the clock is also based on real video events, we cannot just
         // divide by two the regular interval.
         const time = Math.max(this._videoElement.currentTime -
-          MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 2000, 0);
+                              MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 2000,
+                              0);
         const cue = this._buffer.get(time);
         if (!cue) {
           safelyRemoveChild(textTrackElement, this._currentElement);
@@ -175,13 +165,16 @@ export default class HTMLTextSourceBuffer
     }
 
     const startTime = timescaledStart / timescale;
-    const endTime = timescaledEnd != null ?
-      timescaledEnd / timescale : undefined;
+    const endTime = timescaledEnd != null ? timescaledEnd / timescale :
+                                            undefined;
 
-    const cues = parseTextTrackToElements(
-      type, dataString, this.timestampOffset, language);
+    const cues = parseTextTrackToElements(type,
+                                          dataString,
+                                          this.timestampOffset,
+                                          language);
     const start = startTime;
-    const end = endTime != null ? endTime : cues[cues.length - 1].end;
+    const end = endTime != null ? endTime :
+                                  cues[cues.length - 1].end;
     this._buffer.insert(cues, start, end);
     this.buffered.insert(start, end);
   }

--- a/src/core/source_buffers/text/html/index.ts
+++ b/src/core/source_buffers/text/html/index.ts
@@ -24,6 +24,4 @@ import HTMLTextSourceBuffer, {
 } from "./html_text_source_buffer";
 
 export default HTMLTextSourceBuffer;
-export {
-  IHTMLTextTrackData,
-};
+export { IHTMLTextTrackData };

--- a/src/core/source_buffers/text/html/parsers.ts
+++ b/src/core/source_buffers/text/html/parsers.ts
@@ -17,11 +17,9 @@
 import features from "../../../../features";
 import log from "../../../../log";
 
-export interface IHTMLCue {
-  start : number;
-  end: number;
-  element : HTMLElement;
-}
+export interface IHTMLCue { start : number;
+                            end: number;
+                            element : HTMLElement; }
 
 /**
  * Convert text track data into timed HTML Cues.

--- a/src/core/source_buffers/text/html/types.ts
+++ b/src/core/source_buffers/text/html/types.ts
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-export interface IHTMLCue {
-  start : number;
-  end : number;
-  element : HTMLElement;
-}
+export interface IHTMLCue { start : number;
+                            end : number;
+                            element : HTMLElement; }
 
-export interface ICuesGroup {
-  start : number;
-  end : number;
-  cues : IHTMLCue[];
-}
+export interface ICuesGroup { start : number;
+                              end : number;
+                              cues : IHTMLCue[]; }

--- a/src/core/source_buffers/text/html/utils.ts
+++ b/src/core/source_buffers/text/html/utils.ts
@@ -108,17 +108,15 @@ export function removeCuesInfosBetween(
   end : number
 ) : [ICuesGroup, ICuesGroup] {
   const end1 = Math.max(cuesInfos.start, start);
-  const cuesInfos1 = {
-    start: cuesInfos.start,
-    end: end1,
-    cues: getCuesBefore(cuesInfos.cues, start),
-  };
+  const cues1 = getCuesBefore(cuesInfos.cues, start);
+  const cuesInfos1 = { start: cuesInfos.start,
+                       end: end1,
+                       cues: cues1 };
 
   const start2 = Math.min(end, cuesInfos.end);
-  const cuesInfos2 = {
-    start: start2,
-    end: cuesInfos.end,
-    cues: getCuesAfter(cuesInfos.cues, end),
-  };
+  const cues2 = getCuesAfter(cuesInfos.cues, end);
+  const cuesInfos2 = { start: start2,
+                       end: cuesInfos.end,
+                       cues: cues2 };
   return [cuesInfos1, cuesInfos2];
 }

--- a/src/core/source_buffers/text/native/index.ts
+++ b/src/core/source_buffers/text/native/index.ts
@@ -24,6 +24,4 @@ import NativeTextSourceBuffer, {
 } from "./native_text_source_buffer";
 
 export default NativeTextSourceBuffer;
-export {
-  INativeTextTrackData,
-};
+export { INativeTextTrackData };

--- a/src/core/source_buffers/text/native/native_text_source_buffer.ts
+++ b/src/core/source_buffers/text/native/native_text_source_buffer.ts
@@ -24,14 +24,12 @@ import log from "../../../../log";
 import AbstractSourceBuffer from "../../abstract_source_buffer";
 import parseTextTrackToCues from "./parsers";
 
-export interface INativeTextTrackData {
-  data : string;
-  language : string;
-  timescale : number;
-  start: number;
-  end? : number;
-  type : string;
-}
+export interface INativeTextTrackData { data : string;
+                                        language : string;
+                                        timescale : number;
+                                        start: number;
+                                        end? : number;
+                                        type : string; }
 
 /**
  * SourceBuffer to display TextTracks in a <track> element, in the given
@@ -40,8 +38,8 @@ export interface INativeTextTrackData {
  * @extends AbstractSourceBuffer
  */
 export default class NativeTextSourceBuffer
-  extends AbstractSourceBuffer<INativeTextTrackData>
-  implements ICustomSourceBuffer<INativeTextTrackData>
+               extends AbstractSourceBuffer<INativeTextTrackData>
+               implements ICustomSourceBuffer<INativeTextTrackData>
 {
   private readonly _videoElement : HTMLMediaElement;
   private readonly _track : ICompatTextTrack;
@@ -57,10 +55,8 @@ export default class NativeTextSourceBuffer
   ) {
     log.debug("NTSB: Creating native text track SourceBuffer");
     super();
-    const {
-      track,
-      trackElement,
-    } = addTextTrack(videoElement, hideNativeSubtitle);
+    const { track,
+            trackElement } = addTextTrack(videoElement, hideNativeSubtitle);
 
     this._videoElement = videoElement;
     this._track = track;
@@ -88,9 +84,13 @@ export default class NativeTextSourceBuffer
     }
 
     const startTime = timescaledStart / timescale;
-    const endTime = timescaledEnd != null ? timescaledEnd / timescale : undefined;
+    const endTime = timescaledEnd != null ? timescaledEnd / timescale :
+                                            undefined;
 
-    const cues = parseTextTrackToCues(type, dataString, this.timestampOffset, language);
+    const cues = parseTextTrackToCues(type,
+                                      dataString,
+                                      this.timestampOffset,
+                                      language);
     if (cues.length > 0) {
       const firstCue = cues[0];
 
@@ -109,10 +109,9 @@ export default class NativeTextSourceBuffer
       for (let i = 0; i < cues.length; i++) {
         this._track.addCue(cues[i]);
       }
-      this.buffered.insert(
-        startTime,
-        endTime != null ? endTime : cues[cues.length - 1].endTime
-      );
+      this.buffered.insert(startTime,
+                           endTime != null ? endTime :
+                                             cues[cues.length - 1].endTime);
     } else if (endTime != null) {
       this.buffered.insert(startTime, endTime);
     }
@@ -141,14 +140,11 @@ export default class NativeTextSourceBuffer
   _abort() : void {
     log.debug("NTSB: Aborting native text track SourceBuffer");
     this._remove(0, Infinity);
-    const {
-      _trackElement,
-      _videoElement,
-    } = this;
+    const { _trackElement,
+            _videoElement } = this;
 
-    if (
-      _trackElement && _videoElement &&
-      _videoElement.hasChildNodes()
+    if (_trackElement && _videoElement &&
+        _videoElement.hasChildNodes()
     ) {
       try {
         _videoElement.removeChild(_trackElement);

--- a/src/core/source_buffers/time_ranges.ts
+++ b/src/core/source_buffers/time_ranges.ts
@@ -52,10 +52,8 @@ export default class ManualTimeRanges implements TimeRanges {
       assert(start >= 0, "invalid start time");
       assert(end - start > 0, "invalid end time");
     }
-    const rangesToIntersect : Array<{
-      start : number;
-      end: number;
-    }> = [];
+    const rangesToIntersect : Array<{ start : number;
+                                      end: number; }> = [];
     if (start > 0) {
       rangesToIntersect.push({ start: 0, end: start });
     }

--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -47,7 +47,8 @@ export default class EncryptedMediaError extends Error {
     this.type = ErrorTypes.ENCRYPTED_MEDIA_ERROR;
 
     this.code = ErrorCodes.hasOwnProperty(code) ?
-      (ErrorCodes as Record<string, string>)[code] : "";
+                  (ErrorCodes as Record<string, string>)[code] :
+                  "";
     this.fatal = !!fatal;
     this.message = errorMessage(this.name, this.code, reason);
   }

--- a/src/errors/is_known_error.ts
+++ b/src/errors/is_known_error.ts
@@ -20,11 +20,10 @@ import MediaError from "./media_error";
 import NetworkError from "./network_error";
 import OtherError from "./other_error";
 
-export type ICustomError =
-  EncryptedMediaError |
-  MediaError |
-  OtherError |
-  NetworkError;
+export type ICustomError = EncryptedMediaError |
+                           MediaError |
+                           OtherError |
+                           NetworkError;
 
 /**
  * Whether the error given is a ICustomError.
@@ -32,9 +31,7 @@ export type ICustomError =
  * @returns {Boolean}
  */
 export default function isKnownError(error : any) : error is ICustomError {
-  return (
-    !!error &&
-    !!error.type &&
-    Object.keys(ErrorTypes).indexOf(error.type) >= 0
-  );
+  return !!error &&
+         !!error.type &&
+         Object.keys(ErrorTypes).indexOf(error.type) >= 0;
 }

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -47,7 +47,8 @@ export default class MediaError extends Error {
     this.type = ErrorTypes.MEDIA_ERROR;
 
     this.code = ErrorCodes.hasOwnProperty(code) ?
-      (ErrorCodes as Record<string, string>)[code] : "";
+                  (ErrorCodes as Record<string, string>)[code] :
+                  "";
     this.fatal = !!fatal;
     this.message = errorMessage(this.name, this.code, reason);
   }

--- a/src/errors/network_error.ts
+++ b/src/errors/network_error.ts
@@ -58,7 +58,8 @@ export default class NetworkError extends Error {
     this.errorType = requestError.type;
 
     this.code = ErrorCodes.hasOwnProperty(code) ?
-      (ErrorCodes as Record<string, string>)[code] : "";
+                  (ErrorCodes as Record<string, string>)[code] :
+                  "";
     this.fatal = !!fatal;
     this.message = errorMessage(this.name, this.code, requestError.message);
   }
@@ -69,9 +70,7 @@ export default class NetworkError extends Error {
    * @returns {Boolean}
    */
   isHttpError(httpErrorCode : number) : boolean {
-    return (
-      this.errorType === RequestErrorTypes.ERROR_HTTP_CODE &&
-      this.status === httpErrorCode
-    );
+    return this.errorType === RequestErrorTypes.ERROR_HTTP_CODE &&
+           this.status === httpErrorCode;
   }
 }

--- a/src/errors/other_error.ts
+++ b/src/errors/other_error.ts
@@ -45,7 +45,8 @@ export default class OtherError extends Error {
     this.type = ErrorTypes.OTHER_ERROR;
 
     this.code = ErrorCodes.hasOwnProperty(code) ?
-      (ErrorCodes as Record<string, string>)[code] : "";
+                  (ErrorCodes as Record<string, string>)[code] :
+                  "";
     this.fatal = !!fatal;
     this.message = errorMessage(this.name, this.code, reason);
   }

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -39,17 +39,15 @@ import {
  * Initial features object, with no feature activated by default.
  * @type {Object}
  */
-const features : IFeaturesObject = {
-  transports: {},
-  imageBuffer: null,
-  imageParser: null,
-  nativeTextTracksBuffer: null,
-  nativeTextTracksParsers: {},
-  htmlTextTracksBuffer: null,
-  htmlTextTracksParsers: {},
-  emeManager: null,
-  directfile: null,
-};
+const features : IFeaturesObject = { transports: {},
+                                     imageBuffer: null,
+                                     imageParser: null,
+                                     nativeTextTracksBuffer: null,
+                                     nativeTextTracksParsers: {},
+                                     htmlTextTracksBuffer: null,
+                                     htmlTextTracksParsers: {},
+                                     emeManager: null,
+                                     directfile: null };
 
 export default features;
 export {

--- a/src/features/initialize_features.ts
+++ b/src/features/initialize_features.ts
@@ -36,11 +36,10 @@ export default function initializeFeaturesObject() : void {
   /* tslint:enable no-var-requires */
 
   // Feature switching the Native TextTrack implementation
-  const HAS_NATIVE_MODE =
-    __FEATURES__.NATIVE_VTT ||
-    __FEATURES__.NATIVE_SAMI ||
-    __FEATURES__.NATIVE_TTML ||
-    __FEATURES__.NATIVE_SRT;
+  const HAS_NATIVE_MODE = __FEATURES__.NATIVE_VTT ||
+                          __FEATURES__.NATIVE_SAMI ||
+                          __FEATURES__.NATIVE_TTML ||
+                          __FEATURES__.NATIVE_SRT;
 
   /* tslint:disable no-var-requires */
   if (__FEATURES__.SMOOTH) {
@@ -78,11 +77,10 @@ export default function initializeFeaturesObject() : void {
   /* tslint:enable no-var-requires */
 
   // Feature switching the HTML TextTrack implementation
-  const HAS_HTML_MODE =
-    __FEATURES__.HTML_VTT ||
-    __FEATURES__.HTML_SAMI ||
-    __FEATURES__.HTML_TTML ||
-    __FEATURES__.HTML_SRT;
+  const HAS_HTML_MODE = __FEATURES__.HTML_VTT ||
+                        __FEATURES__.HTML_SAMI ||
+                        __FEATURES__.HTML_TTML ||
+                        __FEATURES__.HTML_SRT;
 
   /* tslint:disable no-var-requires */
   if (HAS_HTML_MODE) {

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -30,32 +30,25 @@ import {
 } from "../parsers/texttracks";
 import { ITransportFunction } from "../transports";
 
-export type IDirectFileInit =
-  (args : IDirectFileOptions) => Observable<IDirectfileEvent>;
+export type IDirectFileInit = (args : IDirectFileOptions) =>
+                                Observable<IDirectfileEvent>;
 
-export type IEMEManager = (
-  mediaElement : HTMLMediaElement,
-  keySystems: IKeySystemOption[]
-) => Observable<IEMEManagerEvent>;
+export type IEMEManager = (mediaElement : HTMLMediaElement,
+                           keySystems: IKeySystemOption[]) =>
+                             Observable<IEMEManagerEvent>;
 
 export type INativeTextTracksBuffer =
-  new(
-    mediaElement : HTMLMediaElement,
-    hideNativeSubtitle: boolean
-  ) => ICustomSourceBuffer<unknown>;
+  new(mediaElement : HTMLMediaElement,
+      hideNativeSubtitle: boolean) => ICustomSourceBuffer<unknown>;
 
 export type IHTMLTextTracksBuffer =
-  new(
-    mediaElement : HTMLMediaElement,
-    textTrackElement: HTMLElement
-  ) => ICustomSourceBuffer<unknown>;
+  new(mediaElement : HTMLMediaElement,
+      textTrackElement: HTMLElement) => ICustomSourceBuffer<unknown>;
 
-interface IBifThumbnail {
-  index : number;
-  duration : number;
-  ts : number;
-  data : Uint8Array;
-}
+interface IBifThumbnail { index : number;
+                          duration : number;
+                          ts : number;
+                          data : Uint8Array; }
 
 interface IImageTrackSegmentData {
   data : IBifThumbnail[]; // image track data, in the given type
@@ -65,21 +58,18 @@ interface IImageTrackSegmentData {
   type : string; // the type of the data (example: "bif")
 }
 
-interface IBifObject {
-  fileFormat : string;
-  version : string;
-  imageCount : number;
-  timescale : number;
-  format : string;
-  width : number;
-  height : number;
-  aspectRatio : string;
-  isVod : boolean;
-  thumbs : IBifThumbnail[];
-}
+interface IBifObject { fileFormat : string;
+                       version : string;
+                       imageCount : number;
+                       timescale : number;
+                       format : string;
+                       width : number;
+                       height : number;
+                       aspectRatio : string;
+                       isVod : boolean;
+                       thumbs : IBifThumbnail[]; }
 
-export type IImageBuffer =
-  new() => ICustomSourceBuffer<IImageTrackSegmentData>;
+export type IImageBuffer = new() => ICustomSourceBuffer<IImageTrackSegmentData>;
 
 export type IImageParser =
   ((buffer : Uint8Array) => IBifObject);

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -27,36 +27,31 @@ import Representation, {
   IRepresentationArguments,
 } from "./representation";
 
-export type IAdaptationType = "video"|"audio"|"text"|"image";
+export type IAdaptationType = "video" | "audio" | "text" | "image";
 
-export const SUPPORTED_ADAPTATIONS_TYPE: IAdaptationType[] =
-  ["audio", "video", "text", "image"];
+export const SUPPORTED_ADAPTATIONS_TYPE: IAdaptationType[] = [ "audio",
+                                                               "video",
+                                                               "text",
+                                                               "image" ];
 
-export interface IRepresentationInfos {
-  bufferType: IAdaptationType;
-  language?: string;
-  isAudioDescription? : boolean;
-  isClosedCaption? : boolean;
-  normalizedLanguage? : string;
-}
+export interface IRepresentationInfos { bufferType: IAdaptationType;
+                                        language?: string;
+                                        isAudioDescription? : boolean;
+                                        isClosedCaption? : boolean;
+                                        normalizedLanguage? : string; }
 
-export type IRepresentationFilter = (
-  representation: Representation,
-  adaptationInfos: IRepresentationInfos
-) => boolean;
+export type IRepresentationFilter = (representation: Representation,
+                                     adaptationInfos: IRepresentationInfos) => boolean;
 
-export interface IAdaptationArguments {
-  // -- required
-  id : string;
-  representations : IRepresentationArguments[];
-  type : IAdaptationType;
+export interface IAdaptationArguments { id : string;
+                                        representations : IRepresentationArguments[];
+                                        type : IAdaptationType;
 
-  // -- optional
-  audioDescription? : boolean;
-  closedCaption? : boolean;
-  language? : string;
-  manuallyAdded? : boolean;
-}
+                                        // -- optional
+                                        audioDescription? : boolean;
+                                        closedCaption? : boolean;
+                                        language? : string;
+                                        manuallyAdded? : boolean; }
 
 /**
  * Normalized Adaptation structure.
@@ -68,66 +63,37 @@ export interface IAdaptationArguments {
  */
 export default class Adaptation {
 
-  /**
-   * ID uniquely identifying the Adaptation in the Period.
-   * TODO in the Manifest instead?
-   * @type {string}
-   */
+  // ID uniquely identifying the Adaptation in the Period.
   public readonly id : string;
 
-  /**
-   * Different `Representations` (e.g. qualities) this Adaptation is available
-   * in.
-   * @type {Array.<Object>}
-   */
+  // Different `Representations` (e.g. qualities) this Adaptation is available
+  // in.
   public readonly representations : Representation[];
 
-  /**
-   * Type of this Adaptation.
-   * @type {string}
-   */
+  // Type of this Adaptation.
   public readonly type : IAdaptationType;
 
-  /**
-   * Whether this track contains an audio description for the visually impaired.
-   * @type {Boolean}
-   */
+  // Whether this track contains an audio description for the visually impaired.
   public isAudioDescription? : boolean;
 
-  /**
-   * Whether this Adaptation contains closed captions for the hard-of-hearing.
-   * @type {Boolean}
-   */
+  // Whether this Adaptation contains closed captions for the hard-of-hearing.
   public isClosedCaption? : boolean;
 
-  /**
-   * Language this Adaptation is in, as announced in the original Manifest.
-   * @type {string|undefined}
-   */
+  // Language this Adaptation is in, as announced in the original Manifest.
   public language? : string;
 
-  /**
-   * Language this Adaptation is in, when translated into an ISO639-3 code.
-   * @type {string|undefined}
-   */
+  // Language this Adaptation is in, when translated into an ISO639-3 code.
   public normalizedLanguage? : string;
 
-  /**
-   * `true` if this Adaptation was not present in the original Manifest, but was
-   * manually added after through the corresponding APIs.
-   * @type {boolean}
-   */
+  // `true` if this Adaptation was not present in the original Manifest, but was
+  // manually added after through the corresponding APIs.
   public manuallyAdded : boolean;
 
-  /**
-   * Array containing every errors that happened when the Adaptation has been
-   * created, in the order they have happened.
-   * @type {Array.<Error>}
-   */
+  // Array containing every errors that happened when the Adaptation has been
+  // created, in the order they have happened.
   public readonly parsingErrors : Array<Error|ICustomError>;
 
   /**
-   * @constructor
    * @param {Object} args
    * @param {Function|undefined} [representationFilter]
    */
@@ -140,13 +106,14 @@ export default class Adaptation {
     this.type = args.type;
 
     const hadRepresentations = !!args.representations.length;
-    const argsRepresentations =
-      filterSupportedRepresentations(args.type, args.representations);
+    const argsRepresentations = filterSupportedRepresentations(args.type,
+                                                               args.representations);
 
     if (hadRepresentations && argsRepresentations.length === 0) {
       log.warn("Incompatible codecs for adaptation", args);
       const error = new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-        "An Adaptation contains only incompatible codecs.", false);
+                                   "An Adaptation contains only incompatible codecs.",
+                                   false);
       this.parsingErrors.push(error);
     }
 
@@ -169,13 +136,12 @@ export default class Adaptation {
         if (representationFilter == null) {
           return true;
         }
-        return representationFilter(representation, {
-          bufferType: this.type,
-          language: this.language,
-          normalizedLanguage: this.normalizedLanguage,
-          isClosedCaption: this.isClosedCaption,
-          isAudioDescription: this.isAudioDescription,
-        });
+        return representationFilter(representation,
+                                    { bufferType: this.type,
+                                      language: this.language,
+                                      normalizedLanguage: this.normalizedLanguage,
+                                      isClosedCaption: this.isClosedCaption,
+                                      isAudioDescription: this.isAudioDescription });
       });
 
     // for manuallyAdded adaptations (not in the manifest)
@@ -187,8 +153,7 @@ export default class Adaptation {
    * @returns {Array.<Number>}
    */
   getAvailableBitrates() : number[] {
-    const bitrates = this.representations
-      .map(representation => representation.bitrate);
+    const bitrates = this.representations.map(r => r.bitrate);
     return uniq(bitrates);
   }
 

--- a/src/manifest/filter_supported_representations.ts
+++ b/src/manifest/filter_supported_representations.ts
@@ -28,9 +28,8 @@ export default function filterSupportedRepresentations(
   representations : IRepresentationArguments[]
 ) : IRepresentationArguments[] {
   if (adaptationType === "audio" || adaptationType === "video") {
-    return representations.filter((representation) => {
-      return isCodecSupported(getCodec(representation));
-    });
+    return representations
+      .filter((representation) => isCodecSupported(getCodec(representation)));
   }
 
   return representations; // TODO for the other types?

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -83,131 +83,85 @@ export interface IManifestEvents {
  * @class Manifest
  */
 export default class Manifest extends EventEmitter<IManifestEvents> {
-  /**
-   * ID uniquely identifying this Manifest.
-   * @type {string}
-   */
+  // ID uniquely identifying this Manifest.
   public id : string;
 
-  /**
-   * Type of transport used by this Manifest (e.g. `"dash"` or `"smooth"`.
-   * @type {string}
-   */
+  // Type of transport used by this Manifest (e.g. `"dash"` or `"smooth"`.
   public transport : string;
 
-  /**
-   * Every `Adaptations` for the first `Period` of the Manifest.
-   * Deprecated. Please use manifest.periods[0].adaptations instead.
-   * @deprecated
-   * @type {Object}
-   */
+  // Every `Adaptations` for the first `Period` of the Manifest.
+  // Deprecated. Please use manifest.periods[0].adaptations instead.
+  // @deprecated
   public adaptations : ManifestAdaptations;
 
-  /**
-   * List every `Period` in that Manifest chronologically (from its start time).
-   * A `Period` contains content informations about the content available for
-   * a specific period in time.
-   * @type {Array.<Object>}
-   */
+  // List every `Period` in that Manifest chronologically (from its start time).
+  // A `Period` contains content informations about the content available for
+  // a specific period in time.
   public readonly periods : Period[];
 
-  /**
-   * If true, this Manifest describes a content still running live.
-   * If false, this Manifest describes a finished content.
-   * At the moment this specificity cannot change with time.
-   * TODO Handle that case?
-   * @type {Boolean}
-   */
+  // If true, this Manifest describes a content still running live.
+  // If false, this Manifest describes a finished content.
+  // At the moment this specificity cannot change with time.
+  // TODO Handle that case?
   public isLive : boolean;
 
-  /**
-   * Every URI linking to that Manifest, used for refreshing it.
-   * Listed from the most important to the least important.
-   * @type {Array.<string>}
-   */
+  // Every URI linking to that Manifest, used for refreshing it.
+  // Listed from the most important to the least important.
   public uris : string[];
 
-  /**
-   * Suggested delay from the "live edge" the content is suggested to start
-   * from.
-   * This only applies to live contents.
-   * @type {number|undefined}
-   */
+  // Suggested delay from the "live edge" the content is suggested to start
+  // from.
+  // This only applies to live contents.
   public suggestedPresentationDelay? : number;
 
-  /**
-   * Base URL from which relative segment's URLs will be relative to.
-   * @param {string}
-   */
+  // Base URL from which relative segment's URLs will be relative to.
+  // @param {string}
   public baseURL? : string;
 
-  /**
-   * Amount of time, in seconds, this Manifest is valid from its fetching time.
-   * If not valid, you will need to refresh and update this Manifest (the latter
-   * can be done through the `update` method).
-   * If no lifetime is set, this Manifest does not become invalid after an
-   * amount of time.
-   * @type {number|undefined}
-   */
+  // Amount of time, in seconds, this Manifest is valid from its fetching time.
+  // If not valid, you will need to refresh and update this Manifest (the latter
+  // can be done through the `update` method).
+  // If no lifetime is set, this Manifest does not become invalid after an
+  // amount of time.
   public lifetime? : number;
 
-  /**
-   * Minimum time, in seconds, at which the segment defined in the Manifest
-   * begins.
-   * @type {number|undefined}
-   */
+  // Minimum time, in seconds, at which the segment defined in the Manifest
+  // begins.
   public availabilityStartTime? : number;
 
-  /**
-   * Minimum time in this Manifest we can seek to, in seconds.
-   * @type {number|undefined}
-   */
+  // Minimum time in this Manifest we can seek to, in seconds.
   public minimumTime? : number;
 
-  /**
-   * Estimated difference between Date.now() and the real live edge of the
-   * content.
-   * Note: this is sometimes really hard to estimate.
-   * @type {number|undefined}
-   */
+  // Estimated difference between Date.now() and the real live edge of the
+  // content.
+  // Note: this is sometimes really hard to estimate.
   public presentationLiveGap? : number;
 
-  /**
-   * Time - relative to the last available position - in seconds from when
-   * the first segment is available.
-   * Every segments before that time can be considered as unavailable.
-   * This is also sometimes called the `TimeShift window`.
-   * @type {number|undefined}
-   */
+  // Time - relative to the last available position - in seconds from when
+  // the first segment is available.
+  // Every segments before that time can be considered as unavailable.
+  // This is also sometimes called the `TimeShift window`.
+  // @type {number|undefined}
   public timeShiftBufferDepth? : number;
 
-  /**
-   * Array containing every errors that happened when the Manifest has been
-   * created, in the order they have happened.
-   * @type {Array.<Error>}
-   */
+  // Array containing every errors that happened when the Manifest has been
+  // created, in the order they have happened.
   public parsingErrors : Array<Error|ICustomError>;
 
-  /**
-   * Whole duration anounced in the Manifest.
-   * @private
-   * @type {number}
-   */
+  // Whole duration anounced in the Manifest.
   private _duration : number|undefined;
 
+  // Offset the client's clock has over the server's, in milliseconds
   private _clockOffset : number|undefined;
 
   /**
-   * @constructor
    * @param {Object} args
    */
   constructor(args : IManifestArguments, options : IManifestParsingOptions) {
     super();
-    const {
-      supplementaryTextTracks = [],
-      supplementaryImageTracks = [],
-      representationFilter,
-    } = options;
+    const { supplementaryTextTracks = [],
+            supplementaryImageTracks = [],
+            representationFilter } = options;
     this.parsingErrors = [];
     this.id = args.id;
     this.transport = args.transportType;
@@ -260,7 +214,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   getPeriodForTime(time : number) : Period|undefined {
     return arrayFind(this.periods, (period) => {
       return time >= period.start &&
-        (period.end == null || period.end > time);
+             (period.end == null || period.end > time);
     });
   }
 
@@ -302,7 +256,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    */
   getAdaptations() : Adaptation[] {
     warnOnce("manifest.getAdaptations() is deprecated." +
-      " Please use manifest.period[].getAdaptations() instead");
+             " Please use manifest.period[].getAdaptations() instead");
     const firstPeriod = this.periods[0];
     if (!firstPeriod) {
       return [];
@@ -325,7 +279,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    */
   getAdaptationsForType(adaptationType : IAdaptationType) : Adaptation[] {
     warnOnce("manifest.getAdaptationsForType(type) is deprecated." +
-      " Please use manifest.period[].getAdaptationsForType(type) instead");
+             " Please use manifest.period[].getAdaptationsForType(type) instead");
     const firstPeriod = this.periods[0];
     if (!firstPeriod) {
       return [];
@@ -339,7 +293,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    */
   getAdaptation(wantedId : number|string) : Adaptation|undefined {
     warnOnce("manifest.getAdaptation(id) is deprecated." +
-      " Please use manifest.period[].getAdaptation(id) instead");
+             " Please use manifest.period[].getAdaptation(id) instead");
     /* tslint:disable:deprecation */
     return arrayFind(this.getAdaptations(), ({ id }) => wantedId === id);
     /* tslint:enable:deprecation */
@@ -479,25 +433,25 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     const newImageTracks = _imageTracks.map(({ mimeType, url }) => {
       const adaptationID = "gen-image-ada-" + generateNewId();
       const representationID = "gen-image-rep-" + generateNewId();
-      const newAdaptation = new Adaptation({
-        id: adaptationID,
-        type: "image",
-        manuallyAdded: true,
-        representations: [{
-          bitrate: 0,
-          id: representationID,
-          mimeType,
-          index: new StaticRepresentationIndex({ media: url }),
-        }],
-      });
+      const newAdaptation =
+        new Adaptation({ id: adaptationID,
+                         type: "image",
+                         manuallyAdded: true,
+                         representations: [{
+                           bitrate: 0,
+                           id: representationID,
+                           mimeType,
+                           index: new StaticRepresentationIndex({ media: url }),
+                         }], });
       this.parsingErrors.push(...newAdaptation.parsingErrors);
       return newAdaptation;
     });
 
     if (newImageTracks.length && this.periods.length) {
       const { adaptations } = this.periods[0];
-      adaptations.image = adaptations.image ?
-        adaptations.image.concat(newImageTracks) : newImageTracks;
+      adaptations.image =
+        adaptations.image ? adaptations.image.concat(newImageTracks) :
+                            newImageTracks;
     }
   }
 
@@ -518,25 +472,25 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
       languages,
       closedCaption,
     }) => {
-      const langsToMapOn : string[] = language ? [language] : languages || [];
+      const langsToMapOn : string[] = language ? [language] :
+                                                 languages || [];
 
       return allSubs.concat(langsToMapOn.map((_language) => {
         const adaptationID = "gen-text-ada-" + generateNewId();
         const representationID = "gen-text-rep-" + generateNewId();
-        const newAdaptation = new Adaptation({
-          id: adaptationID,
-          type: "text",
-          language: _language,
-          closedCaption,
-          manuallyAdded: true,
-          representations: [{
-            bitrate: 0,
-            id: representationID,
-            mimeType,
-            codecs,
-            index: new StaticRepresentationIndex({ media: url }),
-          }],
-        });
+        const newAdaptation =
+          new Adaptation({ id: adaptationID,
+                           type: "text",
+                           language: _language,
+                           closedCaption,
+                           manuallyAdded: true,
+                           representations: [{
+                             bitrate: 0,
+                             id: representationID,
+                             mimeType,
+                             codecs,
+                             index: new StaticRepresentationIndex({ media: url }),
+                           }], });
         this.parsingErrors.push(...newAdaptation.parsingErrors);
         return newAdaptation;
       }));
@@ -544,8 +498,9 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
 
     if (newTextAdaptations.length && this.periods.length) {
       const { adaptations } = this.periods[0];
-      adaptations.text = adaptations.text ?
-        adaptations.text.concat(newTextAdaptations) : newTextAdaptations;
+      adaptations.text =
+        adaptations.text ? adaptations.text.concat(newTextAdaptations) :
+                           newTextAdaptations;
     }
   }
 }

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -53,43 +53,25 @@ export interface IPeriodArguments {
  * @class Period
  */
 export default class Period {
-  /**
-   * ID uniquely identifying the Period in the Manifest.
-   * @type {string}
-   */
+  // ID uniquely identifying the Period in the Manifest.
   public readonly id : string;
 
-  /**
-   * Every 'Adaptation' in that Period, per type of Adaptation.
-   * @type {Object}
-   */
+  // Every 'Adaptation' in that Period, per type of Adaptation.
   public adaptations : IManifestAdaptations;
 
-  /**
-   * Duration of this Period, in seconds.
-   * `undefined` for still-running Periods.
-   * @type {number|undefined}
-   */
+  // Duration of this Period, in seconds.
+  // `undefined` for still-running Periods.
   public duration? : number;
 
-  /**
-   * Absolute start time of the Period, in seconds.
-   * @type {number}
-   */
+  // Absolute start time of the Period, in seconds.
   public start : number;
 
-  /**
-   * Absolute end time of the Period, in seconds.
-   * `undefined` for still-running Periods.
-   * @type {number|undefined}
-   */
+  // Absolute end time of the Period, in seconds.
+  // `undefined` for still-running Periods.
   public end? : number;
 
-  /**
-   * Array containing every errors that happened when the Period has been
-   * created, in the order they have happened.
-   * @type {Array.<Error>}
-   */
+  // Array containing every errors that happened when the Period has been
+  // created, in the order they have happened.
   public readonly parsingErrors : Array<Error|ICustomError>;
 
   /**
@@ -97,10 +79,7 @@ export default class Period {
    * @param {Object} args
    * @param {function|undefined} [representationFilter]
    */
-  constructor(
-    args : IPeriodArguments,
-    representationFilter? : IRepresentationFilter
-  ) {
+  constructor(args : IPeriodArguments, representationFilter? : IRepresentationFilter) {
     this.parsingErrors = [];
     this.id = args.id;
     this.adaptations = (Object.keys(args.adaptations) as IAdaptationType[])
@@ -113,10 +92,11 @@ export default class Period {
           .filter((adaptation) => {
             if (!arrayIncludes(SUPPORTED_ADAPTATIONS_TYPE, adaptation.type)) {
               log.info("not supported adaptation type", adaptation.type);
-              const error =
-                new MediaError("MANIFEST_UNSUPPORTED_ADAPTATION_TYPE",
-                  "An Adaptation has an unknown and unsupported type: " +
-                  adaptation.type, false);
+              const error = new MediaError("MANIFEST_UNSUPPORTED_ADAPTATION_TYPE",
+                                           "An Adaptation has an unknown and " +
+                                           "unsupported type: " +
+                                           adaptation.type,
+                                           false);
               this.parsingErrors.push(error);
               return false;
             } else {
@@ -129,13 +109,13 @@ export default class Period {
             return newAdaptation;
           })
           .filter((adaptation) => adaptation.representations.length);
-        if (
-          filteredAdaptations.length === 0 &&
-          adaptationsForType.length > 0 &&
-          (type === "video" || type === "audio")
+        if (filteredAdaptations.length === 0 &&
+            adaptationsForType.length > 0 &&
+            (type === "video" || type === "audio")
         ) {
-          throw new MediaError(
-            "MANIFEST_PARSE_ERROR", "No supported " + type + " adaptations", true);
+          throw new MediaError("MANIFEST_PARSE_ERROR",
+                               "No supported " + type + " adaptations",
+                               true);
         }
 
         if (filteredAdaptations.length) {
@@ -145,8 +125,9 @@ export default class Period {
       }, {});
 
     if (!this.adaptations.video && !this.adaptations.audio) {
-      throw new MediaError(
-        "MANIFEST_PARSE_ERROR", "No supported audio and video tracks.", true);
+      throw new MediaError("MANIFEST_PARSE_ERROR",
+                           "No supported audio and video tracks.",
+                           true);
     }
 
     this.duration = args.duration;
@@ -167,7 +148,8 @@ export default class Period {
     return objectValues(adaptationsByType)
       .reduce<Adaptation[]>((acc, adaptations) =>
         // Note: the second case cannot happen. TS is just being dumb here
-        adaptations != null ? acc.concat(adaptations) : acc,
+        adaptations != null ? acc.concat(adaptations) :
+                              acc,
         []
     );
   }

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -16,55 +16,38 @@
 
 import IRepresentationIndex from "./representation_index";
 
-interface IContentProtection {
-  keyId?: string;
-  systemId?: string;
-}
+interface IContentProtection { keyId?: string;
+                               systemId?: string; }
 
-export interface IRepresentationArguments {
-  // -- required
-  bitrate : number;
-  id : string;
-  index : IRepresentationIndex;
+export interface IRepresentationArguments { bitrate : number;
+                                            id : string;
+                                            index : IRepresentationIndex;
 
-  // -- optional
-  codecs? : string;
-  contentProtections? : IContentProtection[];
-  frameRate? : string;
-  height? : number;
-  mimeType? : string;
-  width? : number;
-}
+                                            // -- optional
+                                            codecs? : string;
+                                            contentProtections? : IContentProtection[];
+                                            frameRate? : string;
+                                            height? : number;
+                                            mimeType? : string;
+                                            width? : number; }
 
 /**
  * Normalized Representation structure.
  * @class Representation
  */
 class Representation {
-  /**
-   * ID uniquely identifying the Representation in the Adaptation.
-   * TODO unique for the whole manifest?
-   * @type {string}
-   */
+  // ID uniquely identifying the Representation in the Adaptation.
+  // TODO unique for the whole manifest?
   public readonly id : string|number;
 
-  /**
-   * Interface allowing to request segments for specific times.
-   * @type {Object}
-   */
+  // Interface allowing to request segments for specific times.
   public index : IRepresentationIndex;
 
-  /**
-   * Bitrate this Representation is in, in bits per seconds.
-   * @type {number}
-   */
+  // Bitrate this Representation is in, in bits per seconds.
   public bitrate : number;
 
-  /**
-   * Frame-rate, when it can be applied, of this Representation, in any textual
-   * indication possible (often under a ratio form).
-   * @type {string}
-   */
+  // Frame-rate, when it can be applied, of this Representation, in any textual
+  // indication possible (often under a ratio form).
   public frameRate? : string;
 
   public codec? : string;
@@ -72,14 +55,10 @@ class Representation {
   public width? : number;
   public height? : number;
 
-  /**
-   * DRM Informations for this Representation.
-   * @type {Array.<Object>}
-   */
+  // DRM Informations for this Representation.
   public contentProtections? : IContentProtection[];
 
   /**
-   * @constructor
    * @param {Object} args
    */
   constructor(args : IRepresentationArguments) {

--- a/src/manifest/representation_index/static.ts
+++ b/src/manifest/representation_index/static.ts
@@ -19,22 +19,21 @@ import IRepresentationIndex, {
   ISegment,
 } from "./types";
 
-export interface IStaticRepresentationIndexInfos {
-  media: string;
-}
+export interface IStaticRepresentationIndexInfos { media: string; }
 
 /**
  * Simple RepresentationIndex implementation for static files.
  * @class StaticRepresentationIndex
  */
 export default class StaticRepresentationIndex implements IRepresentationIndex {
-  private readonly _media: string;
+  // URL of the content
+  private readonly _mediaURL: string;
 
   /**
    * @param {Object} infos
    */
   constructor(infos : IStaticRepresentationIndexInfos) {
-    this._media = infos.media;
+    this._mediaURL = infos.media;
   }
 
   /**
@@ -51,15 +50,13 @@ export default class StaticRepresentationIndex implements IRepresentationIndex {
    * @returns {Array.<Object>}
    */
   getSegments() : ISegment[] {
-    return [{
-      id: "0",
-      isInit: false,
-      number: 0,
-      time: 0,
-      duration: Number.MAX_VALUE,
-      timescale: 1,
-      mediaURL: this._media,
-    }];
+    return [{ id: "0",
+              isInit: false,
+              number: 0,
+              time: 0,
+              duration: Number.MAX_VALUE,
+              timescale: 1,
+              mediaURL: this._mediaURL }];
   }
 
   /**

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -15,24 +15,20 @@
  */
 
 // privateInfos specific to Smooth Initialization Segments
-export interface ISmoothInitSegmentPrivateInfos {
-  codecPrivateData? : string;
-  bitsPerSample? : number;
-  channels? : number;
-  packetSize? : number;
-  samplingRate? : number;
-  protection? : {
-    keyId : string;
-    keySystems : Array<{
-      systemId : string;
-      privateData : Uint8Array;
-    }>;
-  };
-}
+export interface ISmoothInitSegmentPrivateInfos { codecPrivateData? : string;
+                                                  bitsPerSample? : number;
+                                                  channels? : number;
+                                                  packetSize? : number;
+                                                  samplingRate? : number;
+                                                  protection? : {
+                                                    keyId : string;
+                                                    keySystems : Array<{
+                                                      systemId : string;
+                                                      privateData : Uint8Array;
+                                                    }>;
+                                                  }; }
 
-export interface IPrivateInfos {
-  smoothInit? : ISmoothInitSegmentPrivateInfos;
-}
+export interface IPrivateInfos { smoothInit? : ISmoothInitSegmentPrivateInfos; }
 
 // ISegment Object.
 // Represent a single Segment from a Representation.
@@ -58,11 +54,9 @@ export interface ISegment {
                                  // Segment for later downloading/parsing
 }
 
-export interface IRepresentationIndexSegmentInfos {
-  duration : number;
-  time : number;
-  timescale : number;
-}
+export interface IRepresentationIndexSegmentInfos { duration : number;
+                                                    time : number;
+                                                    timescale : number; }
 
 // Interface that should be implemented by any Representation's index
 export default interface IRepresentationIndex {
@@ -136,17 +130,13 @@ export default interface IRepresentationIndex {
    * @param {Object} currentSegment
    */
   _addSegments(
-    nextSegments : Array<{
-      time : number;
-      duration : number;
-      timescale : number;
-      count? : number;
-      range? : [number, number];
-    }>,
-    currentSegment? : {
-      duration? : number;
-      time : number;
-      timescale? : number;
-    }
+    nextSegments : Array<{ time : number;
+                           duration : number;
+                           timescale : number;
+                           count? : number;
+                           range? : [number, number]; }>,
+    currentSegment? : { duration? : number;
+                        time : number;
+                        timescale? : number; }
   ) : void;
 }

--- a/src/manifest/update_period.ts
+++ b/src/manifest/update_period.ts
@@ -24,10 +24,9 @@ import Period from "./period";
  * @param {Object} oldPeriod
  * @param {Object} newPeriod
  */
-export default function updatePeriodInPlace(
-  oldPeriod : Period,
-  newPeriod : Period
-) : void {
+export default function updatePeriodInPlace(oldPeriod : Period,
+                                            newPeriod : Period) : void
+{
   oldPeriod.start = newPeriod.start;
   oldPeriod.end = newPeriod.end;
   oldPeriod.duration = newPeriod.duration;
@@ -37,28 +36,26 @@ export default function updatePeriodInPlace(
 
   for (let j = 0; j < oldAdaptations.length; j++) {
     const oldAdaptation = oldAdaptations[j];
-    const newAdaptation =
-      arrayFind(newAdaptations, a => a.id === oldAdaptation.id);
-
+    const newAdaptation = arrayFind(newAdaptations,
+                                    a => a.id === oldAdaptation.id);
     if (!newAdaptation) {
-      log.warn(
-        `Manifest: Adaptation "${oldAdaptations[j].id}" not found when merging.`
-      );
+      log.warn("Manifest: Adaptation \"" +
+               oldAdaptations[j].id +
+               "\" not found when merging.");
     } else {
       const oldRepresentations = oldAdaptations[j].representations;
       const newRepresentations = newAdaptation.representations;
 
       for (let k = 0; k < oldRepresentations.length; k++) {
         const oldRepresentation = oldRepresentations[k];
-        const newRepresentation = arrayFind(newRepresentations,
-          representation => representation.id === oldRepresentation.id);
+        const newRepresentation =
+          arrayFind(newRepresentations,
+                    representation => representation.id === oldRepresentation.id);
 
         if (!newRepresentation) {
-          /* tslint:disable:max-line-length */
-          log.warn(
-            `Manifest: Representation "${oldRepresentations[k].id}" not found when merging.`
-          );
-          /* tslint:enable:max-line-length */
+          log.warn("Manifest: Representation \"" +
+                   oldRepresentations[k].id +
+                   "\" not found when merging.");
         } else {
           oldRepresentation.index._update(newRepresentation.index);
         }

--- a/src/transports/dash/isobmff_timing_infos.ts
+++ b/src/transports/dash/isobmff_timing_infos.ts
@@ -51,8 +51,8 @@ function getISOBMFFTimingInfos(
   const baseDecodeTime = getTrackFragmentDecodeTime(buffer);
   const trunDuration = getDurationFromTrun(buffer);
 
-  const timescale = initInfos && initInfos.timescale ?
-    initInfos.timescale : segment.timescale;
+  const timescale = initInfos && initInfos.timescale ? initInfos.timescale :
+                                                       segment.timescale;
 
   // we could always make a mistake when reading a container.
   // If the estimate is too far from what the segment seems to imply, take
@@ -64,36 +64,36 @@ function getISOBMFFTimingInfos(
   let segmentStart : number|undefined;
 
   if (timescale === segment.timescale) {
-    maxDecodeTimeDelta = Math.min(
-      timescale * 0.9,
-      segment.duration != null ? segment.duration / 4 : 0.25
-    );
+    maxDecodeTimeDelta = Math.min(timescale * 0.9,
+                                  segment.duration != null ? segment.duration / 4 :
+                                                             0.25);
     segmentStart = segment.time;
     segmentDuration = segment.duration;
   } else {
-    maxDecodeTimeDelta = Math.min(
-      timescale * 0.9,
-      segment.duration != null ?
-        ((segment.duration / segment.timescale) * timescale) / 4 : 0.25
+    maxDecodeTimeDelta =
+      Math.min(timescale * 0.9,
+               segment.duration != null ?
+                 ((segment.duration / segment.timescale) * timescale) / 4 :
+                   0.25
     );
     segmentStart = ((segment.time || 0) / segment.timescale) * timescale;
     segmentDuration = segment.duration != null ?
-      (segment.duration / segment.timescale) * timescale : undefined;
+                        (segment.duration / segment.timescale) * timescale :
+                        undefined;
   }
 
   if (baseDecodeTime >= 0) {
     startTime = segment.timestampOffset != null ?
-      baseDecodeTime + (segment.timestampOffset * timescale) :
-      baseDecodeTime;
+                  baseDecodeTime + (segment.timestampOffset * timescale) :
+                  baseDecodeTime;
   }
 
-  if (
-    trunDuration >= 0 &&
-    (
-      segmentDuration == null ||
-      Math.abs(trunDuration - segmentDuration) <= maxDecodeTimeDelta
-    )
-  ) {
+  if (trunDuration >= 0 &&
+      (
+        segmentDuration == null ||
+        Math.abs(trunDuration - segmentDuration) <= maxDecodeTimeDelta
+      ))
+  {
     duration = trunDuration;
   }
 
@@ -104,11 +104,13 @@ function getISOBMFFTimingInfos(
       const sidxStart = _sidxSegments[0].time;
       if (sidxStart >= 0) {
         const sidxTimescale = _sidxSegments[0].timescale;
-        const baseStartTime = sidxTimescale != null && sidxTimescale !== timescale ?
-          (sidxStart / sidxTimescale) * timescale : sidxStart;
+        const baseStartTime = sidxTimescale != null &&
+                              sidxTimescale !== timescale ?
+                                (sidxStart / sidxTimescale) * timescale :
+                                sidxStart;
         startTime = segment.timestampOffset != null ?
-          baseStartTime + (segment.timestampOffset * timescale) :
-          baseStartTime;
+                      baseStartTime + (segment.timestampOffset * timescale) :
+                      baseStartTime;
       } else {
         startTime = segmentStart;
       }
@@ -118,7 +120,8 @@ function getISOBMFFTimingInfos(
   if (duration == null) {
     if (_sidxSegments.length) {
       const sidxDuration = _sidxSegments.reduce((a, b) => a + (b.duration || 0), 0);
-      duration = sidxDuration >= 0 ? sidxDuration : segmentDuration;
+      duration = sidxDuration >= 0 ? sidxDuration :
+                                     segmentDuration;
     } else {
       duration = segmentDuration;
     }
@@ -129,11 +132,9 @@ function getISOBMFFTimingInfos(
     assert(duration != null);
   }
 
-  return {
-    timescale,
-    time: startTime || 0,
-    duration: duration || 0,
-  };
+  return { timescale,
+           time: startTime || 0,
+           duration: duration || 0 };
 }
 
 export default getISOBMFFTimingInfos;

--- a/src/transports/dash/pipelines.ts
+++ b/src/transports/dash/pipelines.ts
@@ -64,10 +64,9 @@ import generateSegmentLoader from "./segment_loader";
  * @returns {Observable}
  */
 function requestStringResource(url : string) : Observable<string> {
-  return request({
-    url,
-    responseType: "text",
-  }).pipe(
+  return request({ url,
+                   responseType: "text" })
+  .pipe(
     filter((e) => e.type === "response"),
     map((e) => e.value.responseData)
   );
@@ -101,14 +100,14 @@ export default function(
     ) : IManifestParserObservable {
       const url = response.url == null ? loaderURL : response.url;
       const data = typeof response.responseData === "string" ?
-        new DOMParser().parseFromString(response.responseData, "text/xml") :
-        response.responseData;
+                     new DOMParser().parseFromString(response.responseData,
+                                                     "text/xml") :
+                     response.responseData;
 
-      const parsedManifest = parseMPD(data, {
-        url,
-        referenceDateTime,
-        loadExternalClock: !hasClockSynchronization,
-      });
+      const parsedManifest = parseMPD(data,
+                                      { url,
+                                        referenceDateTime,
+                                        loadExternalClock: !hasClockSynchronization });
       return loadExternalResources(parsedManifest);
 
       function loadExternalResources(

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -83,18 +83,12 @@ export interface ILoaderResponseValue<T> {
 }
 
 // A loader gave a response after a request
-export interface ILoaderResponse<T> {
-  type : "response";
-  value : ILoaderResponseValue<T>;
-}
+export interface ILoaderResponse<T> { type : "response";
+                                      value : ILoaderResponseValue<T>; }
 
 // A loader gave a response without doing any request
-interface ILoaderData<T> {
-  type : "data";
-  value : {
-    responseData : T;
-  };
-}
+interface ILoaderData<T> { type : "data";
+                           value : { responseData : T }; }
 
 // items emitted by loaders on xhr progress events
 export interface ILoaderProgress {
@@ -102,21 +96,18 @@ export interface ILoaderProgress {
   value : {
     duration : number;
     size : number;
-    totalSize? : number; // undefined if the total size is not known
     url : string;
+    totalSize? : number; // undefined if the total size is not known
   };
 }
 
 // items emitted by loaders on xhr response events
-interface ILoaderData<T> {
-  type : "data";
-  value : {
-    responseData : T;
-  };
-}
+interface ILoaderData<T> { type : "data";
+                           value : { responseData : T }; }
 
-export type ILoaderEvent<T> =
-  ILoaderProgress|ILoaderResponse<T>|ILoaderData<T>;
+export type ILoaderEvent<T> = ILoaderProgress |
+                              ILoaderResponse<T> |
+                              ILoaderData<T>;
 
 export type ILoaderObserver<T> = Observer<ILoaderEvent<T>>;
 
@@ -216,12 +207,10 @@ export type ImageParserObservable = Observable<{
 
 export interface ITransportManifestPipeline {
   // TODO Remove resolver
-  resolver? : (x : IManifestLoaderArguments) =>
-    Observable<IManifestLoaderArguments>;
-  loader : (x : IManifestLoaderArguments) =>
-    ILoaderObservable<Document|string>;
-  parser : (x : IManifestParserArguments<Document|string, string>) =>
-    IManifestParserObservable;
+  resolver? : (x : IManifestLoaderArguments) => Observable<IManifestLoaderArguments>;
+  loader : (x : IManifestLoaderArguments) => ILoaderObservable<Document|string>;
+  parser : (x : IManifestParserArguments< Document |
+                                          string, string>) => IManifestParserObservable;
 }
 
 interface ITransportSegmentPipelineBase<T> {
@@ -237,42 +226,42 @@ export type ITransportAudioSegmentPipeline =
 
 export interface ITransportTextSegmentPipeline {
   // Note: The segment's data can be null for init segments
-  loader : (x : ISegmentLoaderArguments) =>
-    ILoaderObservable<Uint8Array|ArrayBuffer|string|null>;
-  parser : (x : ISegmentParserArguments<Uint8Array|ArrayBuffer|string|null>) =>
-    TextTrackParserObservable;
+  loader : (x : ISegmentLoaderArguments) => ILoaderObservable< Uint8Array |
+                                                               ArrayBuffer |
+                                                               string |
+                                                               null >;
+  parser : (x : ISegmentParserArguments< Uint8Array |
+                                         ArrayBuffer |
+                                         string |
+                                         null >) => TextTrackParserObservable;
 }
 
 export interface ITransportImageSegmentPipeline {
   // Note: The segment's data can be null for init segments
-  loader : (x : ISegmentLoaderArguments) =>
-    ILoaderObservable<Uint8Array|ArrayBuffer|null>;
-  parser : (x : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>) =>
-    ImageParserObservable;
+  loader : (x : ISegmentLoaderArguments) => ILoaderObservable< Uint8Array |
+                                                               ArrayBuffer |
+                                                               null >;
+  parser : (x : ISegmentParserArguments< Uint8Array |
+                                         ArrayBuffer |
+                                         null >) => ImageParserObservable;
 }
 
-export type ITransportSegmentPipeline =
-  ITransportAudioSegmentPipeline |
-  ITransportVideoSegmentPipeline |
-  ITransportTextSegmentPipeline |
-  ITransportImageSegmentPipeline;
+export type ITransportSegmentPipeline = ITransportAudioSegmentPipeline |
+                                        ITransportVideoSegmentPipeline |
+                                        ITransportTextSegmentPipeline |
+                                        ITransportImageSegmentPipeline;
 
-export type ITransportPipeline =
-  ITransportManifestPipeline |
-  ITransportSegmentPipeline;
+export type ITransportPipeline = ITransportManifestPipeline |
+                                 ITransportSegmentPipeline;
 
-export interface ITransportPipelines {
-  manifest : ITransportManifestPipeline;
-  audio : ITransportAudioSegmentPipeline;
-  video : ITransportVideoSegmentPipeline;
-  text : ITransportTextSegmentPipeline;
-  image : ITransportImageSegmentPipeline;
-}
+export interface ITransportPipelines { manifest : ITransportManifestPipeline;
+                                       audio : ITransportAudioSegmentPipeline;
+                                       video : ITransportVideoSegmentPipeline;
+                                       text : ITransportTextSegmentPipeline;
+                                       image : ITransportImageSegmentPipeline; }
 
-interface IParsedKeySystem {
-  systemId : string;
-  privateData : Uint8Array;
-}
+interface IParsedKeySystem { systemId : string;
+                             privateData : Uint8Array; }
 
 export interface ITransportOptions {
   aggressiveMode? : boolean;
@@ -288,30 +277,24 @@ export interface ITransportOptions {
 }
 
 export type ITransportFunction = (options? : ITransportOptions) =>
-  ITransportPipelines;
+                                   ITransportPipelines;
 
 export type CustomSegmentLoader = (
   // first argument: infos on the segment
-  args : {
-    adaptation : Adaptation;
-    representation : Representation;
-    segment : ISegment;
-    transport : string;
-    url : string;
-    manifest : Manifest;
-  },
+  args : { adaptation : Adaptation;
+           representation : Representation;
+           segment : ISegment;
+           transport : string;
+           url : string;
+           manifest : Manifest; },
 
   // second argument: callbacks
-  callbacks : {
-    resolve : (args : {
-      data : ArrayBuffer|Uint8Array;
-      size : number;
-      duration : number;
-    }) => void;
+  callbacks : { resolve : (args : { data : ArrayBuffer|Uint8Array;
+                                    size : number;
+                                    duration : number; }) => void;
 
-    reject : (err? : Error) => void;
-    fallback? : () => void;
-  }
+                reject : (err? : Error) => void;
+                fallback? : () => void; }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;
@@ -321,16 +304,12 @@ export type CustomManifestLoader = (
   url : string,
 
   // second argument: callbacks
-  callbacks : {
-    resolve : (args : {
-      data : Document|string;
-      size : number;
-      duration : number;
-    }) => void;
+  callbacks : { resolve : (args : { data : Document|string;
+                                    size : number;
+                                    duration : number; }) => void;
 
-    reject : (err? : Error) => void;
-    fallback? : () => void;
-  }
+                 reject : (err? : Error) => void;
+                 fallback? : () => void; }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;

--- a/src/transports/utils/byte_range.ts
+++ b/src/transports/utils/byte_range.ts
@@ -20,7 +20,6 @@
  * @returns {string}
  */
 export default function byteRange([start, end] : [number, number]) : string {
-  return end === Infinity ?
-    "bytes=" + (+start) + "-" :
-    "bytes=" + (+start) + "-" + (+end);
+  return end === Infinity ?  "bytes=" + (+start) + "-" :
+                             "bytes=" + (+start) + "-" + (+end);
 }

--- a/src/utils/array_includes.ts
+++ b/src/utils/array_includes.ts
@@ -76,10 +76,12 @@ export default function arrayIncludes<T>(
     Math.max(len + n, 0);
 
   const areTheSame = (x : T, y : T) =>
-    x === y ||
-      // Viva las JavaScriptas!
-      (typeof x === "number" && typeof y === "number"
-        && isNaN(x) && isNaN(y));
+                       x === y ||
+                       // Viva las JavaScriptas!
+                       (
+                         typeof x === "number" &&
+                         typeof y === "number" &&
+                         isNaN(x) && isNaN(y));
 
   while (k < len) {
     if (areTheSame(arr[k], searchElement)) {

--- a/src/utils/byte_parsing.ts
+++ b/src/utils/byte_parsing.ts
@@ -16,16 +16,15 @@
 
 import assert from "./assert";
 
-type TypedArray =
-  Int8Array |
-  Int16Array |
-  Int32Array |
-  Uint8Array |
-  Uint16Array |
-  Uint32Array |
-  Uint8ClampedArray |
-  Float32Array |
-  Float64Array;
+type TypedArray = Int8Array |
+                  Int16Array |
+                  Int32Array |
+                  Uint8Array |
+                  Uint16Array |
+                  Uint32Array |
+                  Uint8ClampedArray |
+                  Float32Array |
+                  Float64Array;
 
 /**
  * Convert a simple string to an Uint8Array containing the corresponding
@@ -144,9 +143,8 @@ function concat(...args : Array<TypedArray|number[]|number>) : Uint8Array {
  * @returns {Number}
  */
 function be2toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0] << 8) +
-    (bytes[offset + 1] << 0));
+  return ((bytes[offset + 0] << 8) +
+          (bytes[offset + 1] << 0));
 }
 
 /**
@@ -156,11 +154,9 @@ function be2toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Number}
  */
 function be3toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0] * 0x0010000) +
-    (bytes[offset + 1] * 0x0000100) +
-    (bytes[offset + 2])
-  );
+  return ((bytes[offset + 0] * 0x0010000) +
+          (bytes[offset + 1] * 0x0000100) +
+          (bytes[offset + 2]));
 }
 
 /**
@@ -170,11 +166,10 @@ function be3toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Number}
  */
 function be4toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0] * 0x1000000) +
-    (bytes[offset + 1] * 0x0010000) +
-    (bytes[offset + 2] * 0x0000100) +
-    (bytes[offset + 3]));
+  return ((bytes[offset + 0] * 0x1000000) +
+          (bytes[offset + 1] * 0x0010000) +
+          (bytes[offset + 2] * 0x0000100) +
+          (bytes[offset + 3]));
 }
 
 /**
@@ -184,17 +179,16 @@ function be4toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Number}
  */
 function be8toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (
-      (bytes[offset + 0] * 0x1000000) +
-      (bytes[offset + 1] * 0x0010000) +
-      (bytes[offset + 2] * 0x0000100) +
-       (bytes[offset + 3])
-     ) * 0x100000000 +
-     (bytes[offset + 4] * 0x1000000) +
-     (bytes[offset + 5] * 0x0010000) +
-     (bytes[offset + 6] * 0x0000100) +
-     (bytes[offset + 7]));
+  return (((bytes[offset + 0] * 0x1000000) +
+           (bytes[offset + 1] * 0x0010000) +
+           (bytes[offset + 2] * 0x0000100) +
+           (bytes[offset + 3])
+          ) * 0x100000000 +
+
+         (bytes[offset + 4] * 0x1000000) +
+         (bytes[offset + 5] * 0x0010000) +
+         (bytes[offset + 6] * 0x0000100) +
+         (bytes[offset + 7]));
 }
 
 /**
@@ -204,10 +198,8 @@ function be8toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Uint8Array}
  */
 function itobe2(num : number) : Uint8Array {
-  return new Uint8Array([
-    (num >>> 8) & 0xFF,
-    (num)       & 0xFF,
-  ]);
+  return new Uint8Array([ (num >>> 8) & 0xFF,
+                          (num)       & 0xFF ]);
 }
 
 /**
@@ -217,12 +209,10 @@ function itobe2(num : number) : Uint8Array {
  * @returns {Uint8Array}
  */
 function itobe4(num : number) : Uint8Array {
-  return new Uint8Array([
-    (num >>> 24) & 0xFF,
-    (num >>> 16) & 0xFF,
-    (num >>>  8) & 0xFF,
-    (num)        & 0xFF,
-  ]);
+  return new Uint8Array([ (num >>> 24) & 0xFF,
+                          (num >>> 16) & 0xFF,
+                          (num >>>  8) & 0xFF,
+                          (num)        & 0xFF ]);
 }
 
 /**
@@ -236,16 +226,14 @@ function itobe4(num : number) : Uint8Array {
 function itobe8(num : number) : Uint8Array {
   const l = (num % 0x100000000);
   const h = (num - l) / 0x100000000;
-  return new Uint8Array([
-    (h >>> 24) & 0xFF,
-    (h >>> 16) & 0xFF,
-    (h >>>  8) & 0xFF,
-    (h)        & 0xFF,
-    (l >>> 24) & 0xFF,
-    (l >>> 16) & 0xFF,
-    (l >>>  8) & 0xFF,
-    (l)        & 0xFF,
-  ]);
+  return new Uint8Array([ (h >>> 24) & 0xFF,
+                          (h >>> 16) & 0xFF,
+                          (h >>>  8) & 0xFF,
+                          (h)        & 0xFF,
+                          (l >>> 24) & 0xFF,
+                          (l >>> 16) & 0xFF,
+                          (l >>>  8) & 0xFF,
+                          (l)        & 0xFF ]);
 }
 
 /**
@@ -255,9 +243,8 @@ function itobe8(num : number) : Uint8Array {
  * @returns {Number}
  */
 function le2toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0] << 0) +
-    (bytes[offset + 1] << 8));
+  return ((bytes[offset + 0] << 0) +
+          (bytes[offset + 1] << 8));
 }
 
 /**
@@ -267,11 +254,10 @@ function le2toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Number}
  */
 function le4toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0]) +
-    (bytes[offset + 1] * 0x0000100) +
-    (bytes[offset + 2] * 0x0010000) +
-    (bytes[offset + 3] * 0x1000000));
+  return ((bytes[offset + 0]) +
+          (bytes[offset + 1] * 0x0000100) +
+          (bytes[offset + 2] * 0x0010000) +
+          (bytes[offset + 3] * 0x1000000));
 }
 
 /**
@@ -281,16 +267,16 @@ function le4toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Number}
  */
 function le8toi(bytes : Uint8Array, offset : number) : number {
-  return (
-    (bytes[offset + 0]) +
-    (bytes[offset + 1] * 0x0000100) +
-    (bytes[offset + 2] * 0x0010000) +
-    (bytes[offset + 3] * 0x1000000) +
-   ((bytes[offset + 4]) +
-    (bytes[offset + 5] * 0x0000100) +
-    (bytes[offset + 6] * 0x0010000) +
-     (bytes[offset + 7] * 0x1000000)
-   ) * 0x100000000);
+  return (bytes[offset + 0]) +
+         (bytes[offset + 1] * 0x0000100) +
+         (bytes[offset + 2] * 0x0010000) +
+         (bytes[offset + 3] * 0x1000000) +
+         (
+           (bytes[offset + 4]) +
+           (bytes[offset + 5] * 0x0000100) +
+           (bytes[offset + 6] * 0x0010000) +
+           (bytes[offset + 7] * 0x1000000)
+         ) * 0x100000000;
 }
 
 /**
@@ -300,10 +286,8 @@ function le8toi(bytes : Uint8Array, offset : number) : number {
  * @returns {Uint8Array}
  */
 function itole2(num : number) : Uint8Array {
-  return new Uint8Array([
-    (num)       & 0xFF,
-    (num >>> 8) & 0xFF,
-  ]);
+  return new Uint8Array([ (num)       & 0xFF,
+                          (num >>> 8) & 0xFF ]);
 }
 
 /**
@@ -313,12 +297,10 @@ function itole2(num : number) : Uint8Array {
  * @returns {Uint8Array}
  */
 function itole4(num : number) : Uint8Array {
-  return new Uint8Array([
-    (num)        & 0xFF,
-    (num >>>  8) & 0xFF,
-    (num >>> 16) & 0xFF,
-    (num >>> 24) & 0xFF,
-  ]);
+  return new Uint8Array([ (num)        & 0xFF,
+                          (num >>>  8) & 0xFF,
+                          (num >>> 16) & 0xFF,
+                          (num >>> 24) & 0xFF ]);
 }
 
 /**

--- a/src/utils/cast_to_observable.ts
+++ b/src/utils/cast_to_observable.ts
@@ -20,16 +20,13 @@ import {
   of as observableOf,
 } from "rxjs";
 
-interface IObservableLike<T> {
-  subscribe(
-    next : (i: T) => void,
-    error : (e: any) => void,
-    complete : () => void
-  ) : ({
-    dispose? : () => void;
-    unsubscribe? : () => void;
-  }|void);
-}
+interface IObservableLike<T> { subscribe(next : (i: T) => void,
+                                         error : (e: any) => void,
+                                         complete : () => void) :
+                                 (
+                                   { dispose? : () => void;
+                                     unsubscribe? : () => void; } |
+                                   void); }
 
 /**
  * Try to cast the given value into an observable.
@@ -48,12 +45,9 @@ function castToObservable<T>(value? : any) : Observable<T> {
   if (value && typeof value.subscribe === "function") {
     const valObsLike = value as IObservableLike<T>;
     return new Observable((obs) => {
-      const sub = valObsLike.subscribe(
-        (val : T)   => { obs.next(val); },
-        (err : any) => { obs.error(err); },
-        ()          => { obs.complete(); }
-      );
-
+      const sub = valObsLike.subscribe((val : T)   => { obs.next(val); },
+                                       (err : unknown) => { obs.error(err); },
+                                       () => { obs.complete(); });
       return () => {
         if (sub && sub.dispose) {
           sub.dispose();

--- a/src/utils/concat_map_latest.ts
+++ b/src/utils/concat_map_latest.ts
@@ -50,9 +50,11 @@ export default function concatMapLatest<T, U>(
         isExhausting = true;
         return callback(value, counter++).pipe(
           tap({ complete: () => isExhausting = false }),
-          (s: Observable<U>) => observableConcat(s, observableDefer(() =>
-            hasValuePending ? next(valuePending) : EMPTY
-          ))
+          (s: Observable<U>) =>
+            observableConcat(s,
+                             observableDefer(() =>
+                               hasValuePending ? next(valuePending) :
+                                                 EMPTY))
         );
       });
     }

--- a/src/utils/event_emitter.ts
+++ b/src/utils/event_emitter.ts
@@ -21,27 +21,23 @@ import {
 import log from "../log";
 
 export interface IEventEmitter<T> {
-  addEventListener<TEventName extends keyof T>(
-    evt : TEventName,
-    fn : IListener<T, TEventName>
-  ) : void;
-  removeEventListener<TEventName extends keyof T>(
-    evt : TEventName,
-    fn : IListener<T, TEventName>
-  ) : void;
-  trigger?<TEventName extends keyof T>(
-    evt : TEventName,
-    arg : IArgs<T, TEventName>
-  ) : void;
+  addEventListener<TEventName extends keyof T>(evt : TEventName,
+                                               fn : IListener<T, TEventName>) :
+                                                void;
+  removeEventListener<TEventName extends keyof T>(evt : TEventName,
+                                                  fn : IListener<T, TEventName>) :
+                                                   void;
+  trigger?<TEventName extends keyof T>(evt : TEventName,
+                                       arg : IArgs<T, TEventName>) : void;
 }
 
 // Type of the argument in the listener's callback
-type IArgs<TEventRecord, TEventName extends keyof TEventRecord> =
-  TEventRecord[TEventName];
+type IArgs<TEventRecord, TEventName
+     extends keyof TEventRecord> = TEventRecord[TEventName];
 
 // Type of the listener function
-type IListener<TEventRecord, TEventName extends keyof TEventRecord> =
-  (args: IArgs<TEventRecord, TEventName>) => void;
+type IListener<TEventRecord, TEventName
+     extends keyof TEventRecord> = (args: IArgs<TEventRecord, TEventName>) => void;
 
 type IListeners<TEventRecord> = {
   [P in keyof TEventRecord]? : Array<IListener<TEventRecord, P>>

--- a/src/utils/initialization_segment_cache.ts
+++ b/src/utils/initialization_segment_cache.ts
@@ -36,13 +36,9 @@ class InitializationSegmentCache<T> {
    * @param {*} response
    */
   public add(
-    {
-      representation,
-      segment,
-    } : {
-      representation : Representation;
-      segment : ISegment;
-    },
+    { representation,
+      segment } : { representation : Representation;
+                    segment : ISegment; },
     response : T
   ) : void {
     if (segment.isInit) {
@@ -55,13 +51,9 @@ class InitializationSegmentCache<T> {
    * @returns {*} response
    */
   public get(
-    {
-      representation,
-      segment,
-    } : {
-      representation : Representation;
-      segment : ISegment;
-    }
+    { representation,
+      segment } : { representation : Representation;
+                    segment : ISegment; }
   ) : T|null {
     if (segment.isInit) {
       const value = this._cache.get(representation);

--- a/src/utils/languages/normalize.ts
+++ b/src/utils/languages/normalize.ts
@@ -17,26 +17,19 @@
 import ISO_MAP_1_TO_3 from "./ISO_639-1_to_ISO_639-3";
 import ISO_MAP_2_TO_3 from "./ISO_639-2_to_ISO_639-3";
 
-interface IMinimalAudioTrackObject {
-  language: string;
-  audioDescription?: boolean;
-}
+interface IMinimalAudioTrackObject { language: string;
+                                     audioDescription?: boolean; }
 
-interface IMinimalTextTrackObject {
-  language: string;
-  closedCaption?: boolean;
-}
+interface IMinimalTextTrackObject { language: string;
+                                    closedCaption?: boolean; }
 
-interface INormalizedAudioTrackObject extends IMinimalAudioTrackObject {
-  normalized: string;
-  audioDescription : boolean;
-}
+interface INormalizedAudioTrackObject
+          extends IMinimalAudioTrackObject { normalized: string;
+                                             audioDescription : boolean; }
 
-interface INormalizedTextTrackObject extends IMinimalTextTrackObject {
-  normalized: string;
-  closedCaption : boolean;
-}
-
+interface INormalizedTextTrackObject
+          extends IMinimalTextTrackObject { normalized: string;
+                                            closedCaption : boolean; }
 /**
  * Normalize language given.
  * Basically:
@@ -102,11 +95,9 @@ function normalizeTextTrack(
       closedCaption = !!_language.closedCaption;
     }
 
-    return {
-      language,
-      closedCaption,
-      normalized: normalizeLanguage(language),
-    };
+    return { language,
+             closedCaption,
+             normalized: normalizeLanguage(language) };
   }
 
   return _language;
@@ -136,11 +127,9 @@ function normalizeAudioTrack(
       audioDescription = !!_language.audioDescription;
     }
 
-    return {
-      language,
-      audioDescription,
-      normalized: normalizeLanguage(language),
-    };
+    return { language,
+             audioDescription,
+             normalized: normalizeLanguage(language) };
   }
 
   return _language;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,12 +16,11 @@
 
 import noop from "./noop";
 
-export type ILoggerLevel =
-  "NONE" |
-  "ERROR" |
-  "WARNING" |
-  "INFO" |
-  "DEBUG";
+export type ILoggerLevel = "NONE" |
+                           "ERROR" |
+                           "WARNING" |
+                           "INFO" |
+                           "DEBUG";
 
 type tConsoleFn = (...args : unknown[]) => void;
 
@@ -44,13 +43,11 @@ export default class Logger {
     this.warn = noop;
     this.info = noop;
     this.debug = noop;
-    this.LEVELS = {
-      NONE: 0,
-      ERROR: 1,
-      WARNING: 2,
-      INFO: 3,
-      DEBUG: 4,
-    };
+    this.LEVELS = { NONE: 0,
+                    ERROR: 1,
+                    WARNING: 2,
+                    INFO: 3,
+                    DEBUG: 4 };
     this.currentLevel = DEFAULT_LOG_LEVEL;
   }
 
@@ -70,14 +67,14 @@ export default class Logger {
 
     /* tslint:disable no-invalid-this */
     /* tslint:disable no-console */
-    this.error = (level >= this.LEVELS.ERROR) ?
-      console.error.bind(console) : noop;
-    this.warn = (level >= this.LEVELS.WARNING) ?
-      console.warn.bind(console) : noop;
-    this.info = (level >= this.LEVELS.INFO) ?
-      console.info.bind(console) : noop;
-    this.debug = (level >= this.LEVELS.DEBUG) ?
-      console.log.bind(console) : noop;
+    this.error = (level >= this.LEVELS.ERROR) ? console.error.bind(console) :
+                                                noop;
+    this.warn = (level >= this.LEVELS.WARNING) ? console.warn.bind(console) :
+                                                 noop;
+    this.info = (level >= this.LEVELS.INFO) ? console.info.bind(console) :
+                                              noop;
+    this.debug = (level >= this.LEVELS.DEBUG) ? console.log.bind(console) :
+                                                noop;
     /* tslint:enable no-console */
     /* tslint:enable no-invalid-this */
   }

--- a/src/utils/object_values.ts
+++ b/src/utils/object_values.ts
@@ -23,8 +23,8 @@ function objectValues<T>(o : { [s: string] : T } | ArrayLike<T>) : T[] {
 }
 
 /* tslint:disable no-unbound-method */
-export default typeof Object.values === "function" ?
-  Object.values : objectValues;
+export default typeof Object.values === "function" ? Object.values :
+                                                     objectValues;
 /* tslint:enable no-unbound-method */
 
 export {

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -16,5 +16,5 @@
 
 import pinkie from "pinkie";
 
-export default typeof Promise === "function" ?
-  Promise : pinkie;
+export default typeof Promise === "function" ? Promise :
+                                               pinkie;

--- a/src/utils/ranges.ts
+++ b/src/utils/ranges.ts
@@ -32,10 +32,8 @@
 // Factor for rounding errors
 const EPSILON = 1 / 60;
 
-interface IRange {
-  start : number;
-  end : number;
-}
+interface IRange { start : number;
+                   end : number; }
 
 /**
  * Check equality with a tolerance of EPSILON.
@@ -134,8 +132,8 @@ function isTimeInRange({ start, end } : IRange, time : number) : boolean {
  */
 function areRangesOverlapping(range1 : IRange, range2 : IRange) : boolean {
   return isTimeInRange(range1, range2.start) ||
-    range1.start < range2.end && range2.end < range1.end ||
-    isTimeInRange(range2, range1.start);
+         range1.start < range2.end && range2.end < range1.end ||
+         isTimeInRange(range2, range1.start);
 }
 
 /**
@@ -146,7 +144,7 @@ function areRangesOverlapping(range1 : IRange, range2 : IRange) : boolean {
  */
 function areRangesNearlyContiguous(range1 : IRange, range2 : IRange) : boolean {
   return nearlyEqual(range2.start, range1.end) ||
-    nearlyEqual(range2.end, range1.start);
+         nearlyEqual(range2.end, range1.start);
 }
 
 /**
@@ -157,10 +155,8 @@ function areRangesNearlyContiguous(range1 : IRange, range2 : IRange) : boolean {
 function convertToRanges(timeRanges : TimeRanges) : IRange[] {
   const ranges : IRange[] = [];
   for (let i = 0; i < timeRanges.length; i++) {
-    ranges.push({
-      start: timeRanges.start(i),
-      end: timeRanges.end(i),
-    });
+    ranges.push({ start: timeRanges.start(i),
+                  end: timeRanges.end(i) });
   }
   return ranges;
 }
@@ -176,10 +172,8 @@ function getRange(timeRanges : TimeRanges, time : number) : IRange|null {
     if (time >= start) {
       const end = timeRanges.end(i);
       if (time < end) {
-        return {
-          start,
-          end,
-        };
+        return { start,
+                 end };
       }
     }
   }
@@ -241,9 +235,8 @@ function getSizeOfRange(
   currentTime : number
 ) : number {
   const range = getRange(timeRanges, currentTime);
-  return range
-    ? range.end - range.start
-    : 0;
+  return range ? range.end - range.start :
+                 0;
 }
 
 /**
@@ -258,9 +251,8 @@ function getPlayedSizeOfRange(
   currentTime : number
 ) : number {
   const range = getRange(timeRanges, currentTime);
-  return range
-    ? currentTime - range.start
-    : 0;
+  return range ? currentTime - range.start :
+                 0;
 }
 
 /**
@@ -275,9 +267,8 @@ function getLeftSizeOfRange(
   currentTime : number
 ) : number {
   const range = getRange(timeRanges, currentTime);
-  return range
-    ? range.end - currentTime
-    : Infinity;
+  return range ? range.end - currentTime :
+                 Infinity;
 }
 
 /**
@@ -377,10 +368,8 @@ function keepRangeIntersection(
     if (overlappingRanges.length) {
       for (let j = 0; j < overlappingRanges.length; j++) {
         const overlappingRange = overlappingRanges[j];
-        result.push({
-          start: Math.max(range.start, overlappingRange.start),
-          end: Math.min(range.end, overlappingRange.end),
-        });
+        result.push({ start: Math.max(range.start, overlappingRange.start),
+                      end: Math.min(range.end, overlappingRange.end) });
       }
     }
   }

--- a/src/utils/request/xhr_request.ts
+++ b/src/utils/request/xhr_request.ts
@@ -23,41 +23,33 @@ const { DEFAULT_REQUEST_TIMEOUT } = config;
 const DEFAULT_RESPONSE_TYPE : XMLHttpRequestResponseType = "json";
 
 // Interface for "progress" events
-export interface IRequestProgress {
-  type : "progress";
-  value : {
-    currentTime : number;
-    duration : number;
-    size : number;
-    sendingTime : number;
-    url : string;
-    totalSize? : number;
-  };
+export interface IRequestProgress { type : "progress";
+                                    value : { currentTime : number;
+                                              duration : number;
+                                              size : number;
+                                              sendingTime : number;
+                                              url : string;
+                                              totalSize? : number; };
 }
 
 // Interface for "response" events
-export interface IRequestResponse<T, U> {
-  type : "response";
-  value : {
-    duration : number;
-    receivedTime : number;
-    responseData : T;
-    responseType : U;
-    sendingTime : number;
-    size : number;
-    status : number;
-    url : string;
-  };
-}
+export interface IRequestResponse<T, U> { type : "response";
+                                          value : { duration : number;
+                                                    receivedTime : number;
+                                                    responseData : T;
+                                                    responseType : U;
+                                                    sendingTime : number;
+                                                    size : number;
+                                                    status : number;
+                                                    url : string; }; }
 
 // Arguments for the "request" utils
-export interface IRequestOptions<T, U> {
-  url : string;
-  headers? : { [ header: string ] : string }|null;
-  responseType? : T;
-  timeout? : number;
-  sendProgressEvents? : U;
-}
+export interface IRequestOptions<T, U> { url : string;
+                                         headers? : { [ header: string ] : string } |
+                                                    null;
+                                         responseType? : T;
+                                         timeout? : number;
+                                         sendProgressEvents? : U; }
 
 /**
  * @param {string} data
@@ -154,64 +146,69 @@ function toJSONForIE(data : string) : unknown|null {
  */
 
 // overloading to the max
-function request(options : IRequestOptions<undefined|null|""|"text", false|undefined>) :
-  Observable<IRequestResponse<string, "text">>;
-function request(options :
-  IRequestOptions<undefined|null|""|"text", true>
-) : Observable<IRequestResponse<string, "text">|IRequestProgress>;
+function request(options : IRequestOptions<undefined|null|""|"text", false|undefined>)
+                : Observable<IRequestResponse<string, "text">>;
+function request(options : IRequestOptions<undefined|null|""|"text", true>)
+                : Observable<IRequestResponse<string, "text"> |
+                             IRequestProgress>;
 
-function request(options : IRequestOptions<"arraybuffer", false|undefined>) :
-  Observable<IRequestResponse<ArrayBuffer, "arraybuffer">>;
-function request(options : IRequestOptions<"arraybuffer", true>) :
-  Observable<IRequestResponse<ArrayBuffer, "arraybuffer">|IRequestProgress>;
+function request(options : IRequestOptions<"arraybuffer", false|undefined>)
+                : Observable<IRequestResponse<ArrayBuffer, "arraybuffer">>;
+function request(options : IRequestOptions<"arraybuffer", true>)
+                : Observable<IRequestResponse<ArrayBuffer, "arraybuffer"> |
+                             IRequestProgress>;
 
-function request(options : IRequestOptions<"document", false|undefined>) :
-  Observable<IRequestResponse<Document, "document">>;
-function request(options : IRequestOptions<"document", true>) :
-  Observable<IRequestResponse<Document, "document">|IRequestProgress>;
+function request(options : IRequestOptions<"document", false|undefined>)
+                : Observable<IRequestResponse<Document, "document">>;
+function request(options : IRequestOptions<"document", true>)
+                : Observable<IRequestResponse<Document, "document"> |
+                             IRequestProgress>;
 
-function request(options : IRequestOptions<"json", false|undefined>) :
-  Observable<IRequestResponse<object, "json">>;
-function request(options : IRequestOptions<"json", true>) :
-  Observable<IRequestResponse<object, "json">|IRequestProgress>;
+function request(options : IRequestOptions<"json", false|undefined>)
+                : Observable<IRequestResponse<object, "json">>;
+function request(options : IRequestOptions<"json", true>)
+                : Observable<IRequestResponse<object, "json"> |
+                             IRequestProgress>;
 
-function request(options : IRequestOptions<"blob", false|undefined>) :
-  Observable<IRequestResponse<Blob, "blob">>;
-function request(options : IRequestOptions<"blob", true>) :
-  Observable<IRequestResponse<Blob, "blob">|IRequestProgress>;
+function request(options : IRequestOptions<"blob", false|undefined>)
+                : Observable<IRequestResponse<Blob, "blob">>;
+function request(options : IRequestOptions<"blob", true>)
+                : Observable<IRequestResponse<Blob, "blob"> |
+                             IRequestProgress>;
 
 function request<T>(
-  options : IRequestOptions<XMLHttpRequestResponseType|null|undefined, false|undefined>
+  options : IRequestOptions<XMLHttpRequestResponseType | null | undefined,
+                            false | undefined>
 ) : Observable<IRequestResponse<T, XMLHttpRequestResponseType>>;
 function request<T>(
-  options : IRequestOptions<XMLHttpRequestResponseType|null|undefined, true>
-) : Observable<
-  IRequestResponse<T, XMLHttpRequestResponseType>|IRequestProgress
+  options : IRequestOptions<XMLHttpRequestResponseType | null | undefined,
+                            true>
+) : Observable<IRequestResponse<T, XMLHttpRequestResponseType> |
+               IRequestProgress
 >;
-
 function request<T>(
-  options : IRequestOptions<
-    XMLHttpRequestResponseType|null|undefined, boolean|undefined
-  >
-) : Observable<
-  IRequestResponse<T, XMLHttpRequestResponseType>|IRequestProgress
+  options : IRequestOptions<XMLHttpRequestResponseType |
+                            null |
+                            undefined,
+                            boolean |
+                            undefined>
+) : Observable<IRequestResponse<T, XMLHttpRequestResponseType> |
+               IRequestProgress
 > {
   const requestOptions = {
     url: options.url,
     headers: options.headers,
-    responseType: options.responseType == null ?
-      DEFAULT_RESPONSE_TYPE : options.responseType,
-    timeout: options.timeout == null ?
-      DEFAULT_REQUEST_TIMEOUT : options.timeout,
+    responseType: options.responseType == null ? DEFAULT_RESPONSE_TYPE :
+                                                 options.responseType,
+    timeout: options.timeout == null ? DEFAULT_REQUEST_TIMEOUT :
+                                       options.timeout,
   };
 
   return new Observable((obs) => {
-    const {
-      url,
-      headers,
-      responseType,
-      timeout,
-    } = requestOptions;
+    const { url,
+            headers,
+            responseType,
+            timeout } = requestOptions;
     const xhr = new XMLHttpRequest();
     xhr.open("GET", url, true);
 
@@ -249,17 +246,13 @@ function request<T>(
     if (options.sendProgressEvents === true) {
       xhr.onprogress = function onXHRProgress(event) {
         const currentTime = performance.now();
-        obs.next({
-          type: "progress",
-          value: {
-            url,
-            duration: currentTime - sendingTime,
-            sendingTime,
-            currentTime,
-            size: event.loaded,
-            totalSize: event.total,
-          },
-        });
+        obs.next({ type: "progress",
+                   value: { url,
+                            duration: currentTime - sendingTime,
+                            sendingTime,
+                            currentTime,
+                            size: event.loaded,
+                            totalSize: event.total } });
       };
     }
 
@@ -267,8 +260,9 @@ function request<T>(
       if (xhr.readyState === 4) {
         if (xhr.status >= 200 && xhr.status < 300) {
           const receivedTime = performance.now();
-          const totalSize = xhr.response instanceof ArrayBuffer ?
-           xhr.response.byteLength : event.total;
+          const totalSize = xhr.response instanceof
+                              ArrayBuffer ? xhr.response.byteLength :
+                                            event.total;
           const status = xhr.status;
           const loadedResponseType = xhr.responseType;
           const _url = xhr.responseURL || url;
@@ -276,8 +270,8 @@ function request<T>(
           let responseData : T;
           if (loadedResponseType === "json") {
             // IE bug where response is string with responseType json
-            responseData = xhr.response !== "string" ?
-              xhr.response : toJSONForIE(xhr.responseText);
+            responseData = xhr.response !== "string" ? xhr.response :
+                                                       toJSONForIE(xhr.responseText);
           } else {
             responseData = xhr.response;
           }
@@ -288,19 +282,15 @@ function request<T>(
             return;
           }
 
-          obs.next({
-            type: "response",
-            value: {
-              status,
-              url: _url,
-              responseType: loadedResponseType,
-              sendingTime,
-              receivedTime,
-              duration: receivedTime - sendingTime,
-              size: totalSize,
-              responseData,
-            },
-          });
+          obs.next({ type: "response",
+                     value: { status,
+                              url: _url,
+                              responseType: loadedResponseType,
+                              sendingTime,
+                              receivedTime,
+                              duration: receivedTime - sendingTime,
+                              size: totalSize,
+                              responseData, }, });
           obs.complete();
 
         } else {

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -104,6 +104,4 @@ function normalizeBaseURL(url : string) : string {
   }
 }
 
-export {
-  normalizeBaseURL,
-};
+export { normalizeBaseURL };

--- a/src/utils/rx-throttle.ts
+++ b/src/utils/rx-throttle.ts
@@ -56,19 +56,17 @@ export default function throttle<T, U>(
 
       isPending = true;
       func(...args)
-        .subscribe(
-          (i) => { obs.next(i); },
-          (e) => {
-            hasErroredOrCompleted = true;
-            isPending = false;
-            obs.error(e);
-          },
-          () => {
-            hasErroredOrCompleted = true;
-            isPending = false;
-            obs.complete();
-          }
-        );
+        .subscribe((i) => { obs.next(i); },
+                   (e) => {
+                     hasErroredOrCompleted = true;
+                     isPending = false;
+                     obs.error(e);
+                   },
+                   () => {
+                     hasErroredOrCompleted = true;
+                     isPending = false;
+                     obs.complete();
+                   });
 
       return () => {
         // handle unsubscription

--- a/src/utils/starts_with.ts
+++ b/src/utils/starts_with.ts
@@ -36,7 +36,9 @@ export default function startsWith(
     return completeString.startsWith(searchString, position);
     /* tslint:enable ban */
   }
-  const initialPosition = typeof position === "number" ? Math.max(position, 0) : 0;
-  return completeString
-    .substring(initialPosition, initialPosition + searchString.length) === searchString;
+  const initialPosition = typeof position === "number" ? Math.max(position, 0) :
+                                                         0;
+  return completeString.substring(initialPosition,
+                                  initialPosition + searchString.length
+                                 ) === searchString;
 }

--- a/src/utils/uniq.ts
+++ b/src/utils/uniq.ts
@@ -19,7 +19,7 @@
  * @param {Array.<*>} arr
  * @returns {Array.<*>}
  */
-function uniqFromFilter<T>(arr: T[]) {
+function uniqFromFilter<T>(arr: T[]) : T[] {
   return arr.filter((val, i, self) => self.indexOf(val) === i);
 }
 
@@ -28,7 +28,7 @@ function uniqFromFilter<T>(arr: T[]) {
  * @param {Array.<*>} arr
  * @returns {Array.<*>}
  */
-function uniqFromSet<T>(arr: T[]) {
+function uniqFromSet<T>(arr: T[]) : T[] {
   return Array.from(new Set(arr));
 }
 
@@ -38,9 +38,8 @@ function uniqFromSet<T>(arr: T[]) {
  * @param {Array.<*>} arr
  * @returns {Array.<*>}
  */
-export default typeof (window as any).Set === "function" ?
-  uniqFromSet : uniqFromFilter;
-
+export default typeof (window as any).Set === "function" ? uniqFromSet :
+                                                           uniqFromFilter;
 export {
   uniqFromFilter,
   uniqFromSet,


### PR DESCRIPTION
## Overview

After going back from holidays, playing with rust and reading some literature on the subject, I tried to play a little with the code syntax in the RxPlayer (I know, it's a shallow thing to do with my time :p).

I now think that we can profit from more code readability.

Some very "important" (read hot and central) code, like in the ``src/core/buffers`` directory or the main `init` functions, are becoming hard to follow: some functions takes a lot of arguments, many observables are merged and created...

There is thus maybe some work to do on code simplification to avoid those problems in the first place but as a first step for now, I did this PR to mitigate them.

These modifications are especially related to how TypeScript and RxJS lead us often to have long lines (more than our 90-columns limit). TypeScript by adding types to the mix and RxJS by often leading us to create Observables-returning functions which takes a lot of arguments.

Consequently, we often have to split up a same expression into multiple lines.

The code contained in this PR mainly set a new indentation style in those cases where we just break lines to avoid the 90-columns limit.

## Observation

The "idiomatic" JavaScript syntax looks like that for function calls (also dictated by tools like VSCode, Vim or "prettier"):
```ts
doSomeThingBefore(foo, bar, baz);
callAfunctionWithTooMuchArguments(
  argument1,
  argument2WithAVeryLongName
  argument3WithAVeryLongName
  argument4
);
doSomeThingAfter(foo, bar, baz);
```
Here, we make a new indentation block just for function arguments, the same way we would for any other block (a function declaration, a `for` or `while` loop etc.).

This is fine, but when quickly glancing over a file, these lines usually don't have the same importance than the ones coming after it or before it. Those are often just a declaration of needed arguments without any expression being calculated or the control flow being impacted.

To better illustrate what I want to say, a `for` block would indent our lines the same way:
```ts
doSomeThingBefore(foo, bar, baz);
for (let i = 0; i < 10; i++)
  const a = doThingToDoInTheLoop(i);
  console.log("a:", a);
  const b = doThingsWithA(a);
  console.log("b:", a);
);
doSomeThingAfter(foo, bar, baz);
```
And here that's what we want. The `for` loop creates a branch where one path will be the indented block and the other will just skip it.

Here, the indented block is very important to understand the control flow and what the code does, where it's much less important when you just give to a function the arguments it needs.

You can compare it with the new syntax for the function calls:
```ts
doSomeThingBefore(foo, bar, baz);
callAfunctionWithTooMuchArguments(argument1,
                                  argument2WithAVeryLongName
                                  argument3WithAVeryLongName
                                  argument4);
doSomeThingAfter(foo, bar, baz);
```
Here we immediately know what constitute our function arguments. It becomes much easier to skip over it which is exactly what we want to do most of the time.

## Current solution

As usual, the style in the RxPlayer's code is not enforced. Developpers should just try to maximize readability when writing code.

I've come up with a set of rules which I think improve readability but are absolutely not definitive.

### function calls

When calling functions with too much arguments. Here is the way it was done before:
```ts
doSomeThingBefore(foo, bar, baz);
callAfunctionWithTooMuchArguments(
  argument1,
  argument2WithAVeryLongName
  argument3WithAVeryLongName
  argument4
);
doSomeThingAfter(foo, bar, baz);
```

Here is the way I found to be more readable with some other code around it to better show the difference (inspired from some Rust projects):
```ts
doSomeThingBefore(foo, bar, baz);
callAfunctionWithTooMuchArguments(argument1,
                                  argument2WithAVeryLongName
                                  argument3WithAVeryLongName
                                  argument4);
doSomeThingAfter(foo, bar, baz);
```
Of course, in the rare case where one of those lines still go over the 90 columns limit, we can roll back to the old syntax.

---

In most cases in the RxPlayer we intercept the return value of such function in a variable.
That way:

```ts
const response = callAfunctionWithTooMuchArguments(
  argument1,
  argument2WithAVeryLongName
  argument3WithAVeryLongName
  argument4
);
```

If it doesn't go over the 90 columns limit, we can still do:

```ts
const response = callAfunctionWithTooMuchArguments(argument1,
                                                   argument2WithAVeryLongName
                                                   argument3WithAVeryLongName
                                                   argument4);
```

Here, we have much more chance to go over the 90 columns limit.
This is the fallback syntax I found:

```ts
const response =
  callAfunctionWithTooMuchArguments(argument1,
                                    argument2WithAVeryLongName
                                    argument3WithAVeryLongName
                                    argument4);
```
Here it still can be clear that the first and second line are part of the same expression.

Or another syntax (not decided yet):
```ts
const response = callAfunctionWithTooMuchArguments(
                   argument1,
                   argument2WithAVeryLongName
                   argument3WithAVeryLongName
                   argument4);
```

To note that this new syntax is particularly elegant for errors:
```ts
throw new MediaError("MEDIA_ERR_DECODE",
                                     "Long blabla to better describe what happened",
                                     true);
```

### `if` or `for` blocks

We sometimes have trouble containing the content of a if block on the same line.
This is usually what we do:

```ts
if (
  REALLY_LONG_CONSTANT_IN_THE_CONFIG === true &&
  variableFooBar > otherVariable ||
  something === someOtherThing
) {
  doSomething();
}
```

Like function arguments, this can become hard to read very fast.
I did not sadly find a good enough solution but this minor modification:

```ts
if (REALLY_LONG_CONSTANT_IN_THE_CONFIG === true &&
    variableFooBar > otherVariable ||
    something === someOtherThing
) {
  doSomething();
}
```

Where it's a little more clear where is the code inside the if and code inside the if condition.

same thing for long `for` blocks.

```ts
for (let i = 0;
     i < VERY_LONG_CONSTANT_THAT_GO_OVER_THE_LIMIT_WHEN_ON_THE_SAME_LINE;
     i++
 ) {
  doSomething(i);
}
```

### `type` declaration

We most often use type declaration to set sum types:

This was the old syntax.
```ts
type IMySumType =
  IFirstType |
  ISecondType |
  IThirdType |
  number;
```

The problem here is that those are declared high up in the file and in 90% of case we do not really care about them.

We generally have to scroll past them, that's why I found it important to st a clearer boundary for those. This is the solution I came with:
```ts
type IMySumType = IFirstType |
                  ISecondType |
                  IThirdType |
                  number;
```

Many Haskell devs also use this syntax:
```ts
type IMySumType = IFirstType
                | ISecondType
                | IThirdType
                | number;
```
Which I guess looks cooler and where the "or" operator is more clearly anounced. The problem woulde be that it is less consistent with the rest of the RxPlayer's code.

Still, this is another case where I'm not fixed. But for the moment, the first syntax is used.

In the case where it still goes over the 90 columns limit (or when there is comments for each line), the old syntax is still used.

## `interface`, arrays and objects

This chapter regroups multiple situations:
  - Interface declaration:
    ```ts
    export interface IStoreSessionData {
      session : MediaKeySession|ICustomMediaKeySession;
      sessionType : MediaKeySessionType;
    }
    ```
  - Object creation:
    ```ts
    const obj = {
      a: 4,
      b: 12,
      foo: {},
    };
    ```
    ```ts
    callFunction(arg1, {
      a: 4,
      b: 12,
      foo: {},
    });
    ```
    ```ts
    return {
      a: 4,
      b: 12,
      foo: {},
    };
    ```

  - Object destructuring
    ```ts
    const {
      bidule: 58,
      v: "aa",
      r: 45,
    } = config;
    ```

  - array creation:
  ```ts
  const EME_DEFAULT_WIDEVINE_ROBUSTNESSES = [
    "HW_SECURE_ALL",
    "HW_SECURE_DECODE",
    "HW_SECURE_CRYPTO",
    "SW_SECURE_DECODE",
    "SW_SECURE_CRYPTO",
  ],
  ```

  - array destructuring:
  ```ts
  const [
    "foo",
    "bar",
  ] func();
  ```

For those, I currently found the following syntax more readable (the idea is to easily visually group those objects):

  - Interface declaration:
    ```ts
    export interface IStoreSessionData { session : MediaKeySession |
                                                   ICustomMediaKeySession;
                                         sessionType : MediaKeySessionType; }
    ```
  - Object creation:
    ```ts
    const obj = { a: 4,
                  b: 12,
                  foo: {} };
    ```
    ```ts
    callFunction(arg1,
                 { a: 4,
                   b: 12,
                   foo: {} });
    ```
    ```ts
    return { a: 4,
             b: 12,
             foo: {} };
    ```
  - Object destructuring
    ```ts
    const { bidule: 58,
            v: "aa",
            r: 45 } = config;
    ```
  - array creation:
  ```ts
  const EME_DEFAULT_WIDEVINE_ROBUSTNESSES = [ "HW_SECURE_ALL",
                                              "HW_SECURE_DECODE",
                                              "HW_SECURE_CRYPTO",
                                              "SW_SECURE_DECODE",
                                              "SW_SECURE_CRYPTO" ],
  ```

  - array destructuring:
  ```ts
  const [ "foo",
          "bar" ] func();
  ```


### Ternary operators

Likewise, with the ternary operator I found it much more readable to regroup the different possibilities with a line break:
```ts
const foo = CONFIG_SWITCH_IS_SET ? someValue :
                                   someOtherValue;
```

Here, I found another syntax to be very popular:
```ts
const foo = CONFIG_SWITCH_IS_SET ? someValue
                                 : someOtherValue;
```
Like for the `type` chapter, this second solution is more clear but is less consistent.
I choose the first for now but I could easily change my mind.

When the 90 columns limit is raised I still found it nicer to regroup the possibilities that way:
```ts
return veryVeryLongTernaryCondition ?
         SOLUTION_1 :
         SOLUTION_2;
```

### Function declaration

Now that all that is done, function declaration still looks a little weird:
```ts
function myFunction(
  a: IFooBar,
  b: IFooBarClockTick,
  c: boolean
) : Observable<IFooBaz> {
  // ...
}
```

However here, I did not find a good enough solution.

In consequence, nothing has been done for now for function declaration.

### import and export declaration

Just like function declaration, I did not change anything for import and export declaration.

This is because they are usually very clearly separated from the rest of the code.

This can still change though.

## What I modified for now

As of now, I did not update unit tests. Only regular codes.

I may have forgotten many places, but this is where I fully updated code for now:
  - [x] ``src/compat``
  - [x] ``src/core/abr``
  - [x] ``src/core/api``
  - [x] ``src/core/buffers``
  - [x] ``src/core/eme``
  - [x] ``src/core/init``
  - [x] ``src/core/pipelines``
  - [x] ``src/core/source_buffers``
  - [x] ``src/errors``
  - [ ] ``src/experimental``
  - [x] ``src/features``
  - [x] ``src/manifest``
  - [ ] ``src/parsers``
  - [ ] ``src/transports``
  - [x] ``src/utils``
  - [x] ``src/config.ts``

We can progressively update the style, this does not bother me.
We still have to pay attention to conflicts with our current branch.

For the moment, my advice would be to:
  1. rebase to the commit before that one
  2. Once it's done rebase on that commit but reject all the modifications which created a conflict
  3. Rewrite your code in this style if needed

## Notes

Vim and other tools often do not cooperate (e.g. when auto-indenting which re-set the idiomatic way) so this might not go as smooth as we could want to.
But still, I still think it is an important matter.

one of the rationale for doing so should be: my code will be read (by myself or others) much more time than it will be written/updated.
