### PR TITLE
Fix/stop relying on clock

### DIFF
--- a/src/parsers/manifest/dash/__tests__/get_clock_offset.test.ts
+++ b/src/parsers/manifest/dash/__tests__/get_clock_offset.test.ts
@@ -19,7 +19,7 @@ describe("DASH Parser - getClockOffset", () => {
     jest.resetModules();
   });
 
-  it("should calculate a millisecond offset relatively to Date.now", () => {
+  it("should calculate a millisecond offset relatively to performance.now", () => {
     const warnSpy = jest.fn();
     jest.mock("../../../../log", () => ({
       __esModule: true,
@@ -27,8 +27,8 @@ describe("DASH Parser - getClockOffset", () => {
     }));
 
     const getClockOffset = require("../get_clock_offset").default;
-    const dateSpy = jest.spyOn(Date, "now")
-      .mockReturnValue(Date.parse("2019-03-26T11:00:00Z")); // 30s
+    const dateSpy = jest.spyOn(performance, "now")
+      .mockReturnValue(Date.parse("2019-03-24T13:00:00Z"));
 
     expect(getClockOffset("2019-03-25T12:00:00Z")).toEqual(82800000);
     expect(warnSpy).not.toHaveBeenCalled();

--- a/src/parsers/manifest/dash/__tests__/get_maximum_time.test.ts
+++ b/src/parsers/manifest/dash/__tests__/get_maximum_time.test.ts
@@ -21,20 +21,18 @@ describe("DASH Parser - getMaximumTime", () => {
 
   it("should return the last time reference if set", () => {
     const warnSpy = jest.fn();
-    jest.mock("../../../../log", () => ({
-      __esModule: true,
-      default: { warn: warnSpy },
-    }));
+    jest.mock("../../../../log", () => ({ __esModule: true,
+                                          default: { warn: warnSpy } }));
     const getMaximumTime = require("../get_maximum_time").default;
 
-    expect(getMaximumTime({
-      availabilityStartTime: undefined,
-      clockOffset: undefined,
-    }, 5)).toEqual(5);
-    expect(getMaximumTime({
-      availabilityStartTime: 4,
-      clockOffset: 12,
-    }, 5)).toEqual(5);
+    expect(getMaximumTime({ availabilityStartTime: undefined,
+                            clockOffset: undefined },
+                          5))
+          .toEqual(5);
+    expect(getMaximumTime({ availabilityStartTime: 4,
+                            clockOffset: 12 },
+                          5))
+          .toEqual(5);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
@@ -43,53 +41,46 @@ describe("DASH Parser - getMaximumTime", () => {
   it("should return `now - clockOffset` if clockOffset is set without a lastTimeReference nor an availabilityStartTime", () => {
   /* tslint:enable max-line-length */
     const warnSpy = jest.fn();
-    jest.mock("../../../../log", () => ({
-      __esModule: true,
-      default: { warn: warnSpy },
-    }));
-    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(30000); // 30s
+    jest.mock("../../../../log", () => ({ __esModule: true,
+                                          default: { warn: warnSpy } }));
+    const performanceSpy = jest.spyOn(performance, "now").mockReturnValue(30000); // 30s
 
     const getMaximumTime = require("../get_maximum_time").default;
 
-    expect(getMaximumTime({ clockOffset: 5000 })).toEqual(30 - 5);
+    expect(getMaximumTime({ clockOffset: 5000 })).toEqual(30 + 5);
 
-    expect(dateSpy).toHaveBeenCalledTimes(1);
+    expect(performanceSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
-    dateSpy.mockRestore();
+    performanceSpy.mockRestore();
   });
 
   /* tslint:disable max-line-length */
   it("should deduct availabilityStartTime if clockOffset is set without a lastTimeReference but with an availabilityStartTime", () => {
   /* tslint:enable max-line-length */
     const warnSpy = jest.fn();
-    jest.mock("../../../../log", () => ({
-      __esModule: true,
-      default: { warn: warnSpy },
-    }));
-    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(30000); // 30s
+    jest.mock("../../../../log", () => ({ __esModule: true,
+                                          default: { warn: warnSpy } }));
+    const performanceSpy = jest.spyOn(performance, "now").mockReturnValue(30000); // 30s
 
     const getMaximumTime = require("../get_maximum_time").default;
 
-    expect(getMaximumTime({
-      clockOffset: 5000,
-      availabilityStartTime: 10,
-    })).toEqual(30 - 5 - 10);
+    expect(getMaximumTime({ clockOffset: 5000,
+                            availabilityStartTime: 10 }))
+          .toEqual(30 + 5 - 10);
 
-    expect(dateSpy).toHaveBeenCalledTimes(1);
+    expect(performanceSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
-    dateSpy.mockRestore();
+    performanceSpy.mockRestore();
   });
 
   /* tslint:disable max-line-length */
   it("should return `now - 10s` and warn without a clockOffset, a lastTimeReference nor an availabilityStartTime", () => {
   /* tslint:enable max-line-length */
     const warnSpy = jest.fn();
-    jest.mock("../../../../log", () => ({
-      __esModule: true,
-      default: { warn: warnSpy },
-    }));
+    jest.mock("../../../../log", () => ({ __esModule: true,
+                                          default: { warn: warnSpy } }));
     const dateSpy = jest.spyOn(Date, "now").mockReturnValue(30000); // 30s
 
     const getMaximumTime = require("../get_maximum_time").default;
@@ -98,10 +89,9 @@ describe("DASH Parser - getMaximumTime", () => {
 
     expect(dateSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "DASH Parser: no clock synchronization mechanism found." +
-      "Setting a live gap of 10 seconds as a security."
-    );
+    expect(warnSpy).toHaveBeenCalledWith("DASH Parser: no clock synchronization " +
+                                         "mechanism found. Setting a live gap of " +
+                                         "10 seconds as a security.");
     warnSpy.mockRestore();
     dateSpy.mockRestore();
   });
@@ -110,24 +100,19 @@ describe("DASH Parser - getMaximumTime", () => {
   it("should deduct availabilityStartTime and warn without a clockOffset, a lastTimeReference but with an availabilityStartTime", () => {
   /* tslint:enable max-line-length */
     const warnSpy = jest.fn();
-    jest.mock("../../../../log", () => ({
-      __esModule: true,
-      default: { warn: warnSpy },
-    }));
+    jest.mock("../../../../log", () => ({ __esModule: true,
+                                          default: { warn: warnSpy } }));
     const dateSpy = jest.spyOn(Date, "now").mockReturnValue(30000); // 30s
 
     const getMaximumTime = require("../get_maximum_time").default;
 
-    expect(getMaximumTime({
-      availabilityStartTime: 10,
-    })).toEqual(30 - 10 - 10);
+    expect(getMaximumTime({ availabilityStartTime: 10 })).toEqual(30 - 10 - 10);
 
     expect(dateSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "DASH Parser: no clock synchronization mechanism found." +
-      "Setting a live gap of 10 seconds as a security."
-    );
+    expect(warnSpy).toHaveBeenCalledWith("DASH Parser: no clock synchronization " +
+                                         "mechanism found. Setting a live gap of " +
+                                         "10 seconds as a security.");
     warnSpy.mockRestore();
     dateSpy.mockRestore();
   });

--- a/src/parsers/manifest/dash/get_clock_offset.ts
+++ b/src/parsers/manifest/dash/get_clock_offset.ts
@@ -17,16 +17,22 @@
 import log from "../../../log";
 
 /**
- * Get offset the client's has with the given time, in milliseconds.
- * For example, a response of 1000 would mean that the client is currently 1
- * second in advance when compared with the given time.
+ * Get difference between the server's clock, in milliseconds and the return of
+ * the JS function `performance.now`.
+ * This property allows to calculate the server time at any moment.
+ *
+ * `undefined` if we could not define such offset (in which case, you could have
+ * to rely on the user's clock instead).
+ *
+ * For example, a response of 1000 would mean that performance.now() is 1 second
+ * behind the server's time.
  * @param {string} serverClock
  * @returns {number|undefined}
  */
 export default function getClockOffset(
   serverClock : string
 ) : number|undefined {
-  const httpOffset = Date.now() - Date.parse(serverClock);
+  const httpOffset = Date.parse(serverClock) - performance.now();
   if (isNaN(httpOffset)) {
     log.warn("DASH Parser: Invalid clock received: ",  serverClock);
     return undefined;

--- a/src/parsers/manifest/dash/get_maximum_time.ts
+++ b/src/parsers/manifest/dash/get_maximum_time.ts
@@ -36,11 +36,11 @@ export default function getMaximumTime(
   const ast = parsedMPD.availabilityStartTime || 0;
   if (parsedMPD.clockOffset == null) {
     log.warn("DASH Parser: no clock synchronization mechanism found." +
-      "Setting a live gap of 10 seconds as a security.");
+             " Setting a live gap of 10 seconds as a security.");
     const now = Date.now() - 10000;
     return now / 1000 - ast;
   } else {
-    const now = Date.now() - parsedMPD.clockOffset;
+    const now = performance.now() + parsedMPD.clockOffset;
     return now / 1000 - ast;
   }
 }

--- a/src/parsers/manifest/dash/get_time_limits.ts
+++ b/src/parsers/manifest/dash/get_time_limits.ts
@@ -22,15 +22,12 @@ export default function getTimeLimits(
   parsedMPD : IParsedManifest,
   lastTimeReference? : number,
   timeShiftBufferDepth? : number
-) : [
-  { isContinuous : boolean; value : number; time : number }, // minimum
-  { isContinuous : boolean; value : number; time : number } // maximum
-] {
+) : [ { isContinuous : boolean; value : number; time : number }, // minimum
+      { isContinuous : boolean; value : number; time : number } /* maximum */ ]
+{
   const time = performance.now();
   const maximumTime = getMaximumTime(parsedMPD, lastTimeReference);
   const minimumTime = getMinimumTime(maximumTime, timeShiftBufferDepth);
-  return [
-    { isContinuous: true, value: minimumTime, time },
-    { isContinuous: true, value: maximumTime, time },
-  ];
+  return [ { isContinuous: true, value: minimumTime, time },
+           { isContinuous: true, value: maximumTime, time } ];
 }

--- a/src/transports/utils/manifest_loader.ts
+++ b/src/transports/utils/manifest_loader.ts
@@ -50,36 +50,29 @@ const manifestPreLoader = (
 
       /**
        * Callback triggered when the custom manifest loader has a response.
-       * @param {Object} args - Which contains:
-       *   - data {*} - The manifest data
-       *   - size {Number} - The manifest size
-       *   - duration {Number} - The duration of the request, in ms
+       * @param {Object}
        */
-      const resolve = (_args : {
-        data : Document|string;
-        size : number;
-        duration : number;
-        url? : string;
-        receivingTime? : number;
-        sendingTime? : number;
-      }) => {
+      const resolve = (_args : { data : Document | string;
+                                 size : number;
+                                 duration : number;
+                                 url? : string;
+                                 receivingTime? : number;
+                                 sendingTime? : number; }) =>
+      {
         if (!hasFallbacked) {
           hasFinished = true;
-          const receivedTime = _args.receivingTime != null ?
-            _args.receivingTime - timeAPIsDelta : undefined;
-          const sendingTime = _args.sendingTime != null ?
-            _args.sendingTime - timeAPIsDelta : undefined;
-          obs.next({
-            type: "response",
-            value: {
-              responseData: _args.data,
-              size: _args.size,
-              duration: _args.duration,
-              url: _args.url,
-              receivedTime,
-              sendingTime,
-            },
-          });
+          const receivedTime =
+            _args.receivingTime != null ? _args.receivingTime - timeAPIsDelta :
+                                          undefined;
+          const sendingTime =
+            _args.sendingTime != null ? _args.sendingTime - timeAPIsDelta :
+                                        undefined;
+          obs.next({ type: "response",
+                     value: { responseData: _args.data,
+                              size: _args.size,
+                              duration: _args.duration,
+                              url: _args.url,
+                              receivedTime, sendingTime } });
           obs.complete();
         }
       };


### PR DESCRIPTION
# Only rely on the user's clock as a last solution

## Overview

We generally do not depend on the user's clock to know about which segment requests to perform. This is even more true since we support DASH's `UTCTiming` elements, which allows us to synchronize with UTC.

However, we still stored internally several offsets relative to the user's clock.

One of this was `presentationLiveGap`. It is the difference between `Date.now` (which represents [unix time](https://en.wikipedia.org/wiki/Unix_time)) and the current last segment announced in the manifest.

Thanks to that variable, we could guess if new segments had time to be generated in the Manifest before refreshing it, `Date.now` acting here as a time counter since the time the Manifest was last downloaded.

That trick worked pretty well but there was still an issue we initially didn't consider: the user clock is not always linear.

For example, two events can mess with our "time counter":
  - the user updates its local clock
  - [`Date.now` assumes that there's always 86,400,000 milliseconds per day, as such leap seconds are ignored](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-time-values-and-time-range)

The second problem was already known but ignored. Leap seconds are [rare enough](https://www.timeanddate.com/time/leap-seconds-future.html) and the disagreement small enough that it basically doesn't matter.

The first one however was less expected.

Someone messing with its clock while playing a content could lead to bad situations, like buffering for a very long time.

## Solution

The current solution found was to stop relying on `Date.now` which is too much linked to the user's clock, but to rely on `performance.now` as much as possible instead. [`performance.now` is guaranteed to increase monotonically over time](https://www.w3.org/TR/hr-time-1/#sec-monotonic-clock) so it's a perfect match here.

The user's clock still had to be used on very specific cases, when it seems to be a last resort: such as when we obtain a dynamic MPD without a `SegmentTimeline` nor an `UTCTiming` element. Here, we felt obligated to "guess" the end time of the last segment by using `Date.now` minus a security margin (which is of 10 seconds for now).