### PR TITLE
 api/eme: add getLicenseConfig property to keySystems 

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -123,9 +123,19 @@ This property is an array of objects with the following properties (only
       In any case, the license provided by this function should be of a
       ``BufferSource`` type (example: an ``Uint8Array`` or an ``ArrayBuffer``).
 
-      Note: We set a 10 seconds timeout on this request. If the returned Promise
-      do not resolve or reject under this limit, the player will stop with an
-      error. If this limit is problematic for you, please open an issue.
+      Note: We set a 10 seconds timeout by default on this request (configurable
+      through the `getLicenseConfig` object).
+      If the returned Promise do not resolve or reject under this limit, the
+      player will stop with an error. If this limit is problematic for you,
+      please open an issue.
+
+  - `getLicenseConfig` (`Object|undefined`): Optional configuration for the
+    `getLicense` callback. Can contain the following properties:
+       - `retry` (`Number`|`undefined`) (default: `2`): number of time
+         `getLicense` is retried on error or on timeout before we fail on a
+         `KEY_LOAD_ERROR`
+       - `timeout` (`Number`|`undefined`) (default: `10000`): timeout, in ms,
+         after which we consider the `getLicense` callback to have failed.  
 
   - ``serverCertificate`` (``BufferSource|undefined``): Eventual certificate
     used to encrypt messages to the license server.

--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -135,7 +135,9 @@ This property is an array of objects with the following properties (only
          `getLicense` is retried on error or on timeout before we fail on a
          `KEY_LOAD_ERROR`
        - `timeout` (`Number`|`undefined`) (default: `10000`): timeout, in ms,
-         after which we consider the `getLicense` callback to have failed.  
+         after which we consider the `getLicense` callback to have failed.
+
+         Set it to `-1` to disable any timeout.
 
   - ``serverCertificate`` (``BufferSource|undefined``): Eventual certificate
     used to encrypt messages to the license server.

--- a/src/core/eme/handle_session_events.ts
+++ b/src/core/eme/handle_session_events.ts
@@ -18,6 +18,7 @@ import {
   concat as observableConcat,
   defer as observableDefer,
   EMPTY,
+  identity,
   merge as observableMerge,
   Observable,
   of as observableOf,
@@ -200,7 +201,8 @@ export default function handleSessionEvents(
           10 * 1000;
         return (castToObservable(getLicense) as Observable<TypedArray|ArrayBuffer|null>)
           .pipe(
-            timeout(getLicenseTimeout),
+            getLicenseTimeout >= 0 ? timeout(getLicenseTimeout) :
+                                     identity /* noop */,
             catchError((error : unknown) : never => {
               if (error instanceof TimeoutError) {
                 throw new EncryptedMediaError("KEY_LOAD_TIMEOUT",

--- a/src/core/eme/handle_session_events.ts
+++ b/src/core/eme/handle_session_events.ts
@@ -227,30 +227,30 @@ export default function handleSessionEvents(
     .pipe(
       concatMap((
         evt : IMediaKeySessionHandledEvents | IEMEWarningEvent
-      ) : Observable<IMediaKeySessionHandledEvents | IEMEWarningEvent > => {
-          if (evt.type !== "key-message-handled" &&
-              evt.type !== "key-status-change-handled")
-          {
-            return observableOf(evt);
-          }
+      ) : Observable< IMediaKeySessionHandledEvents | IEMEWarningEvent > => {
+        if (evt.type !== "key-message-handled" &&
+            evt.type !== "key-status-change-handled")
+        {
+          return observableOf(evt);
+        }
 
-          const license = evt.value.license;
+        const license = evt.value.license;
 
-          if (license == null) {
-            log.info("EME: No license given, skipping session.update");
-            return observableOf(evt);
-          }
+        if (license == null) {
+          log.info("EME: No license given, skipping session.update");
+          return observableOf(evt);
+        }
 
-          log.debug("EME: Update session", evt);
-          return castToObservable(session.update(license)).pipe(
-            catchError((error: Error) => {
-              throw new EncryptedMediaError("KEY_UPDATE_ERROR", error.toString(), true);
-            }),
-            mapTo({ type: "session-updated" as const,
-                    value: { session, license }, }),
-            startWith(evt)
-          );
-        }));
+        log.debug("EME: Update session", evt);
+        return castToObservable(session.update(license)).pipe(
+          catchError((error: Error) => {
+            throw new EncryptedMediaError("KEY_UPDATE_ERROR", error.toString(), true);
+          }),
+          mapTo({ type: "session-updated" as const,
+                  value: { session, license }, }),
+          startWith(evt)
+        );
+      }));
 
   const sessionEvents : Observable<IMediaKeySessionHandledEvents |
                                    IEMEWarningEvent> =

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -62,7 +62,6 @@ export type IEMEManagerEvent = IEMEWarningEvent |
                                IAttachedMediaKeysEvent |
                                IMediaKeySessionHandledEvents;
 
-
 // Infos indentifying a MediaKeySystemAccess
 export interface IKeySystemAccessInfos {
   keySystemAccess: ICompatMediaKeySystemAccess |
@@ -110,6 +109,8 @@ export interface IKeySystemOption {
                     TypedArray |
                     ArrayBuffer |
                     null;
+  getLicenseConfig? : { retry? : number;
+                        timeout? : number; };
   serverCertificate? : ArrayBuffer | TypedArray;
   persistentLicense? : boolean;
   licenseStorage? : IPersistedSessionStorage;

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -35,20 +35,33 @@ export interface ICreatedMediaKeysEvent { type: "created-media-keys";
 export interface IAttachedMediaKeysEvent { type: "attached-media-keys";
                                            value: IMediaKeysInfos; }
 
+export type ILicense = TypedArray |
+                       ArrayBuffer;
+
+export interface IKeyMessageHandledEvent { type: "key-message-handled";
+                                           value: { session: MediaKeySession |
+                                                             ICustomMediaKeySession;
+                                                    license: ILicense|null; }; }
+
+export interface IKeyStatusChangeHandledEvent { type: "key-status-change-handled";
+                                                value: { session: MediaKeySession |
+                                                                  ICustomMediaKeySession;
+                                                         license: ILicense|null; }; }
+
+export interface ISessionUpdatedEvent { type: "session-updated";
+                                        value: { session: MediaKeySession |
+                                                          ICustomMediaKeySession;
+                                                 license: ILicense|null; }; }
+
+export type IMediaKeySessionHandledEvents = IKeyMessageHandledEvent |
+                                            IKeyStatusChangeHandledEvent |
+                                            ISessionUpdatedEvent;
+
 export type IEMEManagerEvent = IEMEWarningEvent |
                                ICreatedMediaKeysEvent |
                                IAttachedMediaKeysEvent |
                                IMediaKeySessionHandledEvents;
 
-export type ILicense = TypedArray |
-                       ArrayBuffer;
-
-export interface IMediaKeySessionHandledEvents { type: "key-message-handled" |
-                                                       "key-status-change-handled" |
-                                                       "session-updated";
-                                                 value: { session: MediaKeySession |
-                                                                   ICustomMediaKeySession;
-                                                          license: ILicense|null; }; }
 
 // Infos indentifying a MediaKeySystemAccess
 export interface IKeySystemAccessInfos {


### PR DESCRIPTION
`getLicenseConfig` can be an object with two properties:
  - `retry` (`Number`|`undefined`) (default: `2`): number of time `getLicense` is retried on error or on timeout before we fail on a `KEY_LOAD_ERROR`
  - `timeout` (`Number`|`undefined`) (default: `10000`): timeout, in ms, after which we consider the `getLicense` callback to have failed.  