### PR TITLE
Provide `currentTime` and `isPaused` when reloading the MediaSource

### DIFF
--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -43,6 +43,7 @@ import {
   map,
   observeOn,
   share,
+  take,
   takeUntil,
 } from "rxjs/operators";
 import log from "../../../log";
@@ -76,6 +77,7 @@ export interface IAdaptationBufferClockTick extends IRepresentationBufferClockTi
   bufferGap : number; // /!\ bufferGap of the SourceBuffer
   duration : number; // duration of the HTMLMediaElement
   isLive : boolean; // If true, we're playing a live content
+  isPaused: boolean; // If true, the player is on pause
   speed : number; // Current regular speed asked by the user
 }
 
@@ -168,7 +170,8 @@ export default function AdaptationBuffer<T>(
         // A manual bitrate switch might need an immediate feedback.
         // To do that properly, we need to reload the MediaSource
         if (directManualBitrateSwitching && estimate.manual && i !== 0) {
-          return observableOf(EVENTS.needsMediaSourceReload());
+          return clock$.pipe(take(1),
+                             map(EVENTS.needsMediaSourceReload));
         }
         const representationChange$ =
           observableOf(EVENTS.representationChange(adaptation.type,

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -171,7 +171,7 @@ export default function AdaptationBuffer<T>(
         // To do that properly, we need to reload the MediaSource
         if (directManualBitrateSwitching && estimate.manual && i !== 0) {
           return clock$.pipe(take(1),
-                             map(EVENTS.needsMediaSourceReload));
+                             map(t => EVENTS.needsMediaSourceReload(t)));
         }
         const representationChange$ =
           observableOf(EVENTS.representationChange(adaptation.type,

--- a/src/core/buffers/events_generators.ts
+++ b/src/core/buffers/events_generators.ts
@@ -109,8 +109,11 @@ const EVENTS = {
              value : { bufferType } };
   },
 
-  needsMediaSourceReload() : INeedsMediaSourceReload {
-    return { type: "needs-media-source-reload", value: undefined };
+  needsMediaSourceReload(
+    { currentTime, isPaused } : { currentTime : number; isPaused : boolean}
+  ) : INeedsMediaSourceReload {
+    return { type: "needs-media-source-reload",
+             value: { currentTime, isPaused } };
   },
 
   periodBufferReady(

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -72,6 +72,7 @@ export interface IPeriodBufferClockTick {
   currentTime : number; // the current position we are in the video in s
   duration : number; // duration of the HTMLMediaElement
   isLive : boolean; // If true, we're playing a live content
+  isPaused: boolean; // If true, the player is on pause
   liveGap? : number; // gap between the current position and the live edge of
                      // the content. Not set for non-live contents
   readyState : number; // readyState of the HTMLMediaElement
@@ -160,7 +161,7 @@ export default function PeriodBuffer({
                                                        bufferType,
                                                        tick);
           if (strategy.type === "needs-reload") {
-            return observableOf(EVENTS.needsMediaSourceReload());
+            return observableOf(EVENTS.needsMediaSourceReload(tick));
           }
 
           const cleanBuffer$ = strategy.type === "clean-buffer" ?

--- a/src/core/buffers/types.ts
+++ b/src/core/buffers/types.ts
@@ -141,7 +141,8 @@ export interface ICompletedBufferEvent { type: "complete-buffer";
 
 // The MediaSource needs to be reloaded to continue
 export interface INeedsMediaSourceReload { type: "needs-media-source-reload";
-                                           value: undefined; }
+                                           value: { currentTime : number;
+                                                    isPaused : boolean; }; }
 
 // Events coming from single PeriodBuffer
 export type IPeriodBufferEvent = IPeriodBufferReadyEvent |

--- a/src/core/init/create_buffer_clock.ts
+++ b/src/core/init/create_buffer_clock.ts
@@ -20,6 +20,7 @@ import {
   Observable,
 } from "rxjs";
 import {
+  filter,
   ignoreElements,
   map,
   tap,
@@ -52,6 +53,7 @@ export default function createBufferClock(
   let initialSeekPerformed = false;
 
   const updateIsPlaying$ = initialPlay$.pipe(
+    filter((evt) => evt !== "not-loaded-metadata"),
     tap(() => { initialPlayPerformed = true; }),
     ignoreElements());
 

--- a/src/core/init/create_buffer_clock.ts
+++ b/src/core/init/create_buffer_clock.ts
@@ -55,7 +55,7 @@ export default function createBufferClock(
   let initialPlayPerformed = false;
   let initialSeekPerformed = false;
 
-  const updateIsPlaying$ = initialPlay$.pipe(
+  const updateIsPaused$ = initialPlay$.pipe(
     tap(() => { initialPlayPerformed = true; }),
     ignoreElements());
 
@@ -90,5 +90,5 @@ export default function createBufferClock(
         };
       }));
 
-  return observableMerge(updateIsPlaying$, updateTimeOffset$, clock$);
+  return observableMerge(updateIsPaused$, updateTimeOffset$, clock$);
 }

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -137,6 +137,10 @@ export type IInitEvent = IManifestReadyEvent |
                          IReloadingMediaSourceEvent |
                          IWarningEvent;
 
+// Informations needed when reloading the MediaSource
+interface IReloadingInfos { currentTime : number;
+                            isPaused : boolean; }
+
 /**
  * Central part of the player.
  *
@@ -258,15 +262,13 @@ export default function InitializeOnMediaSource({
     const initialTime = getInitialTime(manifest, startAt);
     log.debug("Init: Initial time calculated:", initialTime);
 
-    const reloadMediaSource$ = new Subject<void>();
+    const reloadMediaSource$ = new Subject<IReloadingInfos>();
     const onEvent = createEventListener(reloadMediaSource$,
                                         refreshManifest);
     const handleReloads$ : Observable<IInitEvent> = reloadMediaSource$.pipe(
-      switchMap(() => {
-        const currentPosition = mediaElement.currentTime;
-        const isPaused = mediaElement.paused;
+      switchMap(({ currentTime, isPaused }) => {
         return openMediaSource(mediaElement).pipe(
-          mergeMap(newMS => loadOnMediaSource(newMS, currentPosition, !isPaused)),
+          mergeMap(newMS => loadOnMediaSource(newMS, currentTime, !isPaused)),
           mergeMap(onEvent),
           startWith(EVENTS.reloadingMediaSource())
         );
@@ -313,7 +315,7 @@ export default function InitializeOnMediaSource({
  * @returns {Function}
  */
 function createEventListener(
-  reloadMediaSource$ : Subject<void>,
+  reloadMediaSource$ : Subject<IReloadingInfos>,
   refreshManifest : () => Observable<never>
 ) : (evt : IMediaSourceLoaderEvent) => Observable<IInitEvent> {
   /**
@@ -324,7 +326,7 @@ function createEventListener(
   return function onEvent(evt : IMediaSourceLoaderEvent) {
     switch (evt.type) {
       case "needs-media-source-reload":
-        reloadMediaSource$.next();
+        reloadMediaSource$.next(evt.value);
         break;
 
       case "needs-manifest-refresh":

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -23,6 +23,7 @@ import {
   Subject,
 } from "rxjs";
 import {
+  filter,
   finalize,
   ignoreElements,
   map,
@@ -147,9 +148,13 @@ export default function createMediaSourceLoader({
     const { seek$, load$ } =
       seekAndLoadOnMediaEvents(clock$, mediaElement, initialTime, autoPlay);
 
-    const bufferClock$ = createBufferClock(manifest, clock$, speed$,
-                                           seek$, load$,
-                                           initialTime, autoPlay);
+    const initialPlay$ = load$.pipe(filter((evt) => evt !== "not-loaded-metadata"));
+    const bufferClock$ = createBufferClock(clock$, { autoPlay,
+                                                     initialPlay$,
+                                                     initialSeek$: seek$,
+                                                     manifest,
+                                                     speed$,
+                                                     startTime: initialTime });
 
     // Will be used to cancel any endOfStream tries when the contents resume
     const cancelEndOfStream$ = new Subject<null>();

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -147,7 +147,9 @@ export default function createMediaSourceLoader({
     const { seek$, load$ } =
       seekAndLoadOnMediaEvents(clock$, mediaElement, initialTime, autoPlay);
 
-    const bufferClock$ = createBufferClock(manifest, clock$, seek$, speed$, initialTime);
+    const bufferClock$ = createBufferClock(manifest, clock$, speed$,
+                                           seek$, load$,
+                                           initialTime, autoPlay);
 
     // Will be used to cancel any endOfStream tries when the contents resume
     const cancelEndOfStream$ = new Subject<null>();


### PR DESCRIPTION
Previously the `currentTime` and `paused` status was entirely based on the media element.

This could cause problem if we were reloading when we we were not yet playing.
Now, the entity asking for a reload has to provide the time and pausing status at which it wishes to reload.