### PR TITLE
dash: give the clockoffset to the parser instead of just telling it we have one

### DIFF
--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -219,7 +219,7 @@ export default function InitializeOnMediaSource({
 
   const loadContent$ = observableCombineLatest([
     openMediaSource$,
-    fetchManifest({ url, hasClockSynchronization: false }),
+    fetchManifest({ url }),
     emeManager$.pipe(filter(isEMEReadyEvent), take(1)),
   ]).pipe(mergeMap(([ mediaSource, { manifest, sendingTime } ]) => {
 
@@ -234,8 +234,8 @@ export default function InitializeOnMediaSource({
         return EMPTY;
       }
 
-      const hasClockSynchronization = manifest.hasClockSynchronization();
-      return fetchManifest({ url: refreshURL, hasClockSynchronization }).pipe(
+      const externalClockOffset = manifest.getClockOffset();
+      return fetchManifest({ url: refreshURL, externalClockOffset }).pipe(
         tap(({ manifest: newManifest, sendingTime: newSendingTime }) => {
           manifest.update(newManifest);
           manifestRefreshed$.next({ manifest, sendingTime: newSendingTime });

--- a/src/core/pipelines/manifest/create_manifest_pipeline.ts
+++ b/src/core/pipelines/manifest/create_manifest_pipeline.ts
@@ -53,8 +53,8 @@ export interface IRequestSchedulerOptions { maxRetry : number;
 
 export interface IFetchManifestOptions {
   url : string; // URL from which the manifest was requested
-  hasClockSynchronization: boolean; // if true, the client's clock is
-                                    // synchronized with the server's
+  externalClockOffset? : number; // If set, offset to add to `performance.now()`
+                                 // to obtain the current server's time
 }
 
 type IPipelineManifestOptions =
@@ -135,7 +135,7 @@ export default function createManifestPipeline(
    * @returns {Observable}
    */
   return function fetchManifest(
-    { url, hasClockSynchronization } : IFetchManifestOptions
+    { url, externalClockOffset } : IFetchManifestOptions
   ) : Observable<IFetchManifestResult> {
     return loader({ url }).pipe(
 
@@ -153,7 +153,7 @@ export default function createManifestPipeline(
         const { sendingTime } = value;
         return parser({ response: value,
                         url,
-                        hasClockSynchronization,
+                        externalClockOffset,
                         scheduleRequest }
         ).pipe(
           catchError((error: unknown) => {

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -425,8 +425,8 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * If true, this Manifest is currently synchronized with the server's clock.
    * @returns {Boolean}
    */
-  public hasClockSynchronization() : boolean {
-    return this._clockOffset != null;
+  public getClockOffset() : number | undefined {
+    return this._clockOffset;
   }
 
   /**

--- a/src/parsers/manifest/dash/__tests__/parse_from_document.test.ts
+++ b/src/parsers/manifest/dash/__tests__/parse_from_document.test.ts
@@ -27,13 +27,12 @@ describe("parseFromDocument", () => {
     expect(function() {
       parseFromDocument(doc, {
         url: "",
-        loadExternalClock: false,
+        externalClockOffset: 10,
       });
     }).toThrow("document root should be MPD");
     expect(function() {
       parseFromDocument(doc, {
         url: "",
-        loadExternalClock: true,
       });
     }).toThrow("document root should be MPD");
   });

--- a/src/transports/dash/pipelines.ts
+++ b/src/transports/dash/pipelines.ts
@@ -86,7 +86,7 @@ export default function(
     },
 
     parser(
-      { response, url: loaderURL, scheduleRequest, hasClockSynchronization } :
+      { response, url: loaderURL, scheduleRequest, externalClockOffset } :
       IManifestParserArguments< Document | string, string >
     ) : IManifestParserObservable {
       const url = response.url == null ? loaderURL :
@@ -99,7 +99,7 @@ export default function(
       const parsedManifest = dashManifestParser(data, {
         url,
         referenceDateTime,
-        loadExternalClock: !hasClockSynchronization,
+        externalClockOffset,
       });
       return loadExternalResources(parsedManifest);
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -116,14 +116,8 @@ export type ISegmentLoaderObserver<T> = Observer<ISegmentLoaderEvent<T>>;
 export interface IManifestParserArguments<T, U> {
   response : ILoaderDataLoadedValue<T>; // Response from the loader
   url : string; // URL originally requested
-  hasClockSynchronization : boolean; // If true, the current device is currently
-                                     // synchronized with the server's clock.
-                                     // If false, there may be a delay/advance
-                                     // between it and the client's clock.
-                                     // In the latter case, you might need to
-                                     // perform a synchronization step,
-                                     // depending on the type of
-                                     // Manifest.
+  externalClockOffset? : number; // If set, offset to add to `performance.now()`
+                                 // to obtain the current server's time
 
   // allow the parser to load supplementary ressources (of type U)
   scheduleRequest : (request : () => Observable<U>) => Observable<U>;


### PR DESCRIPTION
The previous behavior led to a bug for dynamic SegmentTemplate-based contents without a single SegmentTimeline. This is linked to the fact that we only fetch the UTCTiming the first time the Manifest is parsed and pass for the other ones (as we already have it). The problem is that in a certain condition - the one aforementioned - we use that timing to calculate the maximum possible position (basically the live time here). Without it, we used `Date.now() - 10 seconds` instead (which is most of the time behind the real UTC Time).

The new Behavior now is to actually communicate the clock offset to the parser if we have one. The MPD parser may then use it directly