### PR TITLE
Correctly update indexes when loading a new manifest

### DIFF
--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -366,6 +366,11 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
    */
   _update(newIndex : TemplateRepresentationIndex) : void {
     this._index = newIndex._index;
+    this._aggressiveMode = newIndex._aggressiveMode;
+    this._isDynamic = newIndex._isDynamic;
+    this._periodStart = newIndex._periodStart;
+    this._relativePeriodEnd = newIndex._relativePeriodEnd;
+    this._manifestBoundsCalculator = newIndex._manifestBoundsCalculator;
   }
 
   /**

--- a/src/parsers/manifest/dash/indexes/timeline.ts
+++ b/src/parsers/manifest/dash/indexes/timeline.ts
@@ -450,6 +450,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     this._scaledPeriodStart = newIndex._scaledPeriodStart;
     this._scaledPeriodEnd = newIndex._scaledPeriodEnd;
     this._lastManifestUpdate = newIndex._lastManifestUpdate;
+    this._manifestBoundsCalculator = newIndex._manifestBoundsCalculator;
   }
 
   /**


### PR DESCRIPTION
We didn't update manifest bounds calculator, which is tricky is some of his properties change.