### PR TITLE
api: throw a better error when an invalid `preferredAudioTracks` or `…

### DIFF
--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -277,7 +277,7 @@ mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
 <a name="prop-preferredTextTracks"></a>
 ### preferredTextTracks ########################################################
 
-_type_: ``Array.<Object>``
+_type_: ``Array.<Object|null>``
 
 _defaults_: ``[]``
 
@@ -295,7 +295,8 @@ subtitles:
 ```
 
 All elements in that Array should be set in preference order: from the most
-preferred to the least preferred. You can set `null` for no subtitles.
+preferred to the least preferred. You can set `null` in that array for no
+subtitles.
 
 When loading a content, the RxPlayer will then try to choose its text track by
 comparing what is available with your current preferences (i.e. if the most

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -268,13 +268,27 @@ function parseConstructorOptions(
       !!options.throttleVideoBitrateWhenHidden;
   }
 
-  preferredAudioTracks = options.preferredAudioTracks == null ?
-    [] :
-    options.preferredAudioTracks;
+  if (options.preferredTextTracks !== undefined) {
+    if (!Array.isArray(options.preferredTextTracks)) {
+      warnOnce("Invalid `preferredTextTracks` option, it should be an Array");
+      preferredTextTracks = [];
+    } else {
+      preferredTextTracks = options.preferredTextTracks;
+    }
+  } else {
+    preferredTextTracks = [];
+  }
 
-  preferredTextTracks = options.preferredTextTracks == null ?
-    [] :
-    options.preferredTextTracks;
+  if (options.preferredAudioTracks !== undefined) {
+    if (!Array.isArray(options.preferredAudioTracks)) {
+      warnOnce("Invalid `preferredAudioTracks` option, it should be an Array");
+      preferredAudioTracks = [];
+    } else {
+      preferredAudioTracks = options.preferredAudioTracks;
+    }
+  } else {
+    preferredAudioTracks = [];
+  }
 
   if (options.videoElement == null) {
     videoElement = document.createElement("video");

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1725,6 +1725,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @param {Array.<Object>} tracks
    */
   setPreferredAudioTracks(tracks : IAudioTrackPreference[]) : void {
+    if (!Array.isArray(tracks)) {
+      throw new Error("Invalid `setPreferredAudioTracks` argument. " +
+                      "Should have been an Array.");
+    }
     return this._priv_preferredAudioTracks.next(tracks);
   }
 
@@ -1733,6 +1737,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @param {Array.<Object>} tracks
    */
   setPreferredTextTracks(tracks : ITextTrackPreference[]) : void {
+    if (!Array.isArray(tracks)) {
+      throw new Error("Invalid `setPreferredTextTracks` argument. " +
+                      "Should have been an Array.");
+    }
     return this._priv_preferredTextTracks.next(tracks);
   }
 


### PR DESCRIPTION
…preferredTextTracks` value is given