### PR TITLE
Support for SegmentBase without SegmentBase tag and index range (not to merge anymore)

### DIFF
--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -49,6 +49,7 @@ export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
   shouldGuessInitRange? : boolean;
+  mightBeStaticContent? : boolean;
 }
 
 // ISegment Object.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,9 +48,9 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
-  hypotheticalInitRange? : boolean; // `true` if init range was guessed
-                                    // because of the lack of init infos
-                                    // in the manifest
+  shouldGuessInitRange? : boolean; // `true` if init range should be guessed
+                                   // because of the lack of init infos
+                                   // in the manifest
 }
 
 // ISegment Object.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,6 +48,7 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
+  shouldGuessInitRange? : boolean;
 }
 
 // ISegment Object.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,8 +48,8 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
-  // There may be an init range on a probable init
-  // segment, but we don't it. It should be guessed.
+  // There may be an init range but we don't know it.
+  // It should be guessed when fetching.
   shouldGuessInitRange? : boolean;
   // If nothing seems to indicate us that content is
   // fragmented, it might be a static content.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,9 +48,6 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
-  shouldGuessInitRange? : boolean; // `true` if init range should be guessed
-                                   // because of the lack of init infos
-                                   // in the manifest
 }
 
 // ISegment Object.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,6 +48,9 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
+  hypotheticalInitRange? : boolean; // `true` if init range was guessed
+                                    // because of the lack of init infos
+                                    // in the manifest
 }
 
 // ISegment Object.
@@ -73,9 +76,6 @@ export interface ISegment {
   timestampOffset? : number; // Estimated time, in seconds, at which the
                              // concerned segment will be offseted when
                              // decoded.
-  hypotheticalInitRange? : boolean; // `true` if init range was guessed
-                                    // because of the lack of init infos
-                                    // in the manifest
 }
 
 export interface IRepresentationIndexSegmentInfos { duration : number;

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,13 +48,9 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
-  // In case of a segment base content :
-  // If no initialization segment or range is defined, and
-  // if we may have doubts about thet fact that content is
-  // static or fragmented, then we should guess init range
-  // for requesting init segment.
+  // There may be an init range on a probable init
+  // segment, but we don't it. It should be guessed.
   shouldGuessInitRange? : boolean;
-  // In case of a segment base content :
   // If nothing seems to indicate us that content is
   // fragmented, it might be a static content.
   mightBeStaticContent? : boolean;

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -73,6 +73,9 @@ export interface ISegment {
   timestampOffset? : number; // Estimated time, in seconds, at which the
                              // concerned segment will be offseted when
                              // decoded.
+  hypotheticalInitRange? : boolean; // `true` if init range was guessed
+                                    // because of the lack of init infos
+                                    // in the manifest
 }
 
 export interface IRepresentationIndexSegmentInfos { duration : number;

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -49,7 +49,6 @@ export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
   shouldGuessInitRange? : boolean;
-  mightBeStaticContent? : boolean;
 }
 
 // ISegment Object.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -48,7 +48,15 @@ export interface IMetaPlaylistPrivateInfos { transportType : string;
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
+  // In case of a segment base content :
+  // If no initialization segment or range is defined, and
+  // if we may have doubts about thet fact that content is
+  // static or fragmented, then we should guess init range
+  // for requesting init segment.
   shouldGuessInitRange? : boolean;
+  // In case of a segment base content :
+  // If nothing seems to indicate us that content is
+  // fragmented, it might be a static content.
   mightBeStaticContent? : boolean;
 }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -104,30 +104,30 @@ export interface IBaseIndexContextArgument {
  * @returns {Boolean} - true if the segment has been added
  */
 function _addSegmentInfos(
-  index : IBaseIndex,
+  timeline: IIndexSegment[],
+  timescale: number,
   segmentInfos : { time : number;
                    duration : number;
                    timescale : number;
                    count?: number;
                    range?: [number, number]; }
 ) : boolean {
-  if (segmentInfos.timescale !== index.timescale) {
-    const { timescale } = index;
-    index.timeline.push({ start: (segmentInfos.time / segmentInfos.timescale)
-                                 * timescale,
-                          duration: (segmentInfos.duration / segmentInfos.timescale)
-                                    * timescale,
-                          repeatCount: segmentInfos.count === undefined ?
-                            0 :
-                            segmentInfos.count,
-                          range: segmentInfos.range });
+  if (segmentInfos.timescale !== timescale) {
+    timeline.push({ start: (segmentInfos.time / segmentInfos.timescale)
+                           * timescale,
+                    duration: (segmentInfos.duration / segmentInfos.timescale)
+                              * timescale,
+                    repeatCount: segmentInfos.count === undefined ?
+                      0 :
+                      segmentInfos.count,
+                    range: segmentInfos.range });
   } else {
-    index.timeline.push({ start: segmentInfos.time,
-                          duration: segmentInfos.duration,
-                          repeatCount: segmentInfos.count === undefined ?
-                            0 :
-                            segmentInfos.count,
-                          range: segmentInfos.range });
+    timeline.push({ start: segmentInfos.time,
+                    duration: segmentInfos.duration,
+                    repeatCount: segmentInfos.count === undefined ?
+                      0 :
+                      segmentInfos.count,
+                    range: segmentInfos.range });
   }
   return true;
 }
@@ -175,9 +175,11 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       )) {
         if (index.timeline.length === 0 &&
             index.indexRange === undefined) {
-          this._addSegments([{ time: 0,
-                               duration: Number.MAX_VALUE,
-                               timescale: 1 }]);
+          _addSegmentInfos(index.timeline,
+                           index.timescale,
+                           { time: 0,
+                             duration: Number.MAX_VALUE,
+                             timescale: 1 });
         }
         initialization = null;
     } else {
@@ -293,7 +295,8 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                                       range? : [number, number]; }>
   ) : void {
     for (let i = 0; i < nextSegments.length; i++) {
-      _addSegmentInfos(this._index, nextSegments[i]);
+      const { timeline, timescale } = this._index;
+      _addSegmentInfos(timeline, timescale, nextSegments[i]);
     }
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -212,6 +212,13 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    */
   getInitSegment() : ISegment | null {
     const initSegment = getInitSegment(this._index);
+    // /!\ This logic is considered good if and only if the init segment
+    // has the same media URL than the rest of the content.
+    // However, in a segment base configuration, we consider that there may
+    // be a unique URL for both because :
+    // - The segment base concept is to rely on a unique segment, with a unique URL,
+    //   for init and index (there may not exist), and content.
+    // - We have never encountered any kind of this special configuration
     if (initSegment !== null) {
       const shouldGuessInitRange = initSegment.range === undefined;
       const mightBeStaticContent = initSegment.indexRange === undefined;

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -43,10 +43,10 @@ export interface IBaseIndex {
                             // actually will look for a segment in the index
                             // beginning at:
                             // ``` T * timescale + indexTimeOffset ```
-  initialization? : { // information on the initialization segment
+  initialization : { // information on the initialization segment
     mediaURL: string; // URL to access the initialization segment
     range?: [number, number]; // possible byte range to request it
-  };
+  } | null;
   mediaURL : string; // base URL to access any segment. Can contain token to
                      // replace to convert it to a real URL
   startNumber? : number; // number from which the first segments in this index
@@ -141,7 +141,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
 
   // absolute end of the period, timescaled and converted to index time
   private _scaledPeriodEnd : number | undefined;
-  private _mimeType? : string;
 
   /**
    * @param {Object} index
@@ -156,7 +155,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
             representationBitrate,
             mimeType } = context;
     const { timescale } = index;
-    this._mimeType = mimeType;
     const presentationTimeOffset = index.presentationTimeOffset != null ?
       index.presentationTimeOffset : 0;
 
@@ -171,13 +169,24 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
 
     // TODO If indexRange is behind the initialization segment
     // the following logic will not work.
-    const range = index.initialization?.range ??
-                  (index.indexRange !== undefined ? [0, index.indexRange[0] - 1] :
-                                                    undefined);
+
+    const isMP4 = mimeType !== undefined &&
+                  /\/mp4$/.exec(mimeType) !== null;
+
+    const initialization = (() => {
+      if (index.initialization === undefined && !isMP4) {
+        return null; // no init segment in content
+      }
+
+      const range = index.initialization?.range ??
+        (index.indexRange !== undefined ? [0, index.indexRange[0] - 1] :
+                                          undefined);
+      return { mediaURL, range }; // there may be an init segment
+    })();
 
     this._index = { indexRange: index.indexRange,
                     indexTimeOffset,
-                    initialization: { mediaURL, range },
+                    initialization,
                     mediaURL: createIndexURL(representationBaseURL,
                                              index.media,
                                              representationId,
@@ -185,6 +194,14 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                     startNumber: index.startNumber,
                     timeline: index.timeline,
                     timescale };
+
+    if (initialization === null &&
+        index.timeline.length === 0 &&
+        index.indexRange === undefined) {
+      this._addSegments([{ time: 0,
+                           duration: Number.MAX_VALUE,
+                           timescale: 1 }]);
+    }
     this._scaledPeriodEnd = periodEnd == null ? undefined :
                                                 toIndexTime(periodEnd, this._index);
   }
@@ -195,11 +212,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    */
   getInitSegment() : ISegment | null {
     const initSegment = getInitSegment(this._index);
-    if (initSegment.range === undefined) {
-      if (this._mimeType !== undefined &&
-          /\/mp4$/.exec(this._mimeType) === null) {
-        return null;
-      }
+    if (initSegment !== null && initSegment.range === undefined) {
       if (initSegment.privateInfos === undefined) {
         initSegment.privateInfos = {
           shouldGuessInitRange: true,
@@ -217,16 +230,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @returns {Array.<Object>}
    */
   getSegments(_up : number, _to : number) : ISegment[] {
-    if (this._index.initialization?.range === undefined &&
-        this._mimeType !== undefined &&
-        /\/mp4$/.exec(this._mimeType) === null) {
-      return [{ isInit: false,
-                id: "",
-                mediaURL: this._index.mediaURL,
-                time: 0,
-                duration: Number.MAX_VALUE,
-                timescale: 1 }];
-    }
     return getSegmentsFromTimeline(this._index, _up, _to, this._scaledPeriodEnd);
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -167,11 +167,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
 
     // TODO If indexRange is behind the initialization segment
     // the following logic will not work.
-    // If no range and index range are given by manifest, we take
-    // as init segment the nth first bytes (where n = 1500).
-    // Therefore, we need to filter on init boxes after the segment
-    // is loaded, to ensure that we push a complete and dry segment
-    // to buffers.
     let range: [number, number] | undefined;
     if (index.initialization != null) {
       range = index.initialization.range;
@@ -198,8 +193,16 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @returns {Object}
    */
   getInitSegment() : ISegment | null {
-    // As content is not fragmented, no init segment by default
     const initSegment = getInitSegment(this._index);
+    if (initSegment.range === undefined) {
+      if (initSegment.privateInfos === undefined) {
+        initSegment.privateInfos = {
+          shouldGuessInitRange: true,
+        };
+      } else {
+        initSegment.privateInfos.shouldGuessInitRange = true;
+      }
+    }
     return initSegment;
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -191,7 +191,8 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                                              representationId,
                                              representationBitrate),
                     startNumber: index.startNumber,
-                    timeline: index.timeline || [],
+                    timeline: index.timeline !== undefined ? index.timeline :
+                                                             [],
                     timescale: realTimescale };
     this._scaledPeriodEnd = periodEnd == null ? undefined :
                                                 toIndexTime(periodEnd, this._index);

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -170,11 +170,13 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     // TODO If indexRange is behind the initialization segment
     // the following logic will not work.
 
-    const isMP4 = mimeType !== undefined &&
-                  /\/mp4$/.exec(mimeType) !== null;
-
     const initialization = (() => {
-      if (index.initialization === undefined && !isMP4) {
+      if (index.initialization === undefined &&
+          (
+            mimeType === undefined ||
+            /\/mp4$/.exec(mimeType) === null
+          )
+        ) {
         return null; // no init segment in content
       }
 
@@ -215,14 +217,10 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     if (initSegment !== null && initSegment.range === undefined) {
       const mightBeStaticContent = initSegment.indexRange === undefined;
       if (initSegment.privateInfos === undefined) {
-        initSegment.privateInfos = {
-          shouldGuessInitRange: true,
-          mightBeStaticContent,
-        };
-      } else {
-        initSegment.privateInfos.shouldGuessInitRange = true;
-        initSegment.privateInfos.mightBeStaticContent = mightBeStaticContent;
+        initSegment.privateInfos = {};
       }
+      initSegment.privateInfos.shouldGuessInitRange = true;
+      initSegment.privateInfos.mightBeStaticContent = mightBeStaticContent;
     }
     return initSegment;
   }

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -182,7 +182,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     if (index.initialization === undefined &&
         index.indexRange === undefined &&
         this._isContentFragmented) {
-      range = [0, 1500];
       this._hypotheticalInitRange = true;
     } else {
       if (index.initialization != null) {

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -60,8 +60,8 @@ export interface IBaseIndex {
 // `index` Argument for a SegmentBase RepresentationIndex
 // Most of the properties here are already defined in IBaseIndex.
 export interface IBaseIndexIndexArgument {
-  timeline? : IIndexSegment[];
-  timescale? : number;
+  timeline : IIndexSegment[];
+  timescale : number;
   media? : string;
   indexRange?: [number, number];
   initialization?: { media?: string; range?: [number, number] };
@@ -156,8 +156,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     const presentationTimeOffset = index.presentationTimeOffset != null ?
       index.presentationTimeOffset : 0;
 
-    const realTimescale = (timescale != null ? timescale : 1);
-    const indexTimeOffset = presentationTimeOffset - periodStart * realTimescale;
+    const indexTimeOffset = presentationTimeOffset - periodStart * timescale;
 
     const mediaURL = createIndexURL(representationBaseURL,
                                     index.initialization !== undefined ?
@@ -188,9 +187,8 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                                              representationId,
                                              representationBitrate),
                     startNumber: index.startNumber,
-                    timeline: index.timeline !== undefined ? index.timeline :
-                                                             [],
-                    timescale: realTimescale };
+                    timeline: index.timeline,
+                    timescale };
     this._scaledPeriodEnd = periodEnd == null ? undefined :
                                                 toIndexTime(periodEnd, this._index);
   }

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -203,9 +203,12 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       if (initSegment.privateInfos === undefined) {
         initSegment.privateInfos = {
           shouldGuessInitRange: true,
+          mightBeStaticContent: this._index.indexRange === undefined,
         };
       } else {
         initSegment.privateInfos.shouldGuessInitRange = true;
+        initSegment.privateInfos.mightBeStaticContent =
+          this._index.indexRange === undefined;
       }
     }
     return initSegment;

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -176,7 +176,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     // to buffers.
     let range: [number, number] | undefined;
     this._hypotheticalInitRange = true;
-    if (index.initialization == null && index.indexRange === null) {
+    if (index.initialization === undefined && index.indexRange === undefined) {
       range = [0, 1500];
     } else {
       if (index.initialization != null) {

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -137,7 +137,6 @@ function _addSegmentInfos(
  */
 export default class BaseRepresentationIndex implements IRepresentationIndex {
   private _index : IBaseIndex;
-  private _shouldGuessInitRange: boolean;
   private _isContentFragmented: boolean;
 
   // absolute end of the period, timescaled and converted to index time
@@ -178,17 +177,10 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     // is loaded, to ensure that we push a complete and dry segment
     // to buffers.
     let range: [number, number] | undefined;
-    this._shouldGuessInitRange = false;
-    if (index.initialization === undefined &&
-        index.indexRange === undefined &&
-        this._isContentFragmented) {
-      this._shouldGuessInitRange = true;
-    } else {
-      if (index.initialization != null) {
-        range = index.initialization.range;
-      } else if (index.indexRange != null) {
-        range = [0, index.indexRange[0] - 1];
-      }
+    if (index.initialization != null) {
+      range = index.initialization.range;
+    } else if (index.indexRange != null) {
+      range = [0, index.indexRange[0] - 1];
     }
 
     this._index = { indexRange: index.indexRange,
@@ -215,9 +207,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       return null;
     }
     const initSegment = getInitSegment(this._index);
-    initSegment.privateInfos = {
-      shouldGuessInitRange : this._shouldGuessInitRange,
-    };
     return initSegment;
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -137,7 +137,6 @@ function _addSegmentInfos(
  */
 export default class BaseRepresentationIndex implements IRepresentationIndex {
   private _index : IBaseIndex;
-  private _isContentFragmented: boolean;
 
   // absolute end of the period, timescaled and converted to index time
   private _scaledPeriodEnd : number | undefined;
@@ -147,15 +146,13 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @param {Object} context
    */
   constructor(index : IBaseIndexIndexArgument,
-              context : IBaseIndexContextArgument,
-              isContentFragmented: boolean) {
+              context : IBaseIndexContextArgument) {
     const { periodStart,
             periodEnd,
             representationBaseURL,
             representationId,
             representationBitrate } = context;
     const { timescale } = index;
-    this._isContentFragmented = isContentFragmented;
     const presentationTimeOffset = index.presentationTimeOffset != null ?
       index.presentationTimeOffset : 0;
 
@@ -204,9 +201,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    */
   getInitSegment() : ISegment | null {
     // As content is not fragmented, no init segment by default
-    if (!this._isContentFragmented) {
-      return null;
-    }
     const initSegment = getInitSegment(this._index);
     return initSegment;
   }
@@ -217,16 +211,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @returns {Array.<Object>}
    */
   getSegments(_up : number, _to : number) : ISegment[] {
-    if (!this._isContentFragmented) {
-      // Return whole segment
-      return [{ id: "0",
-                isInit: false,
-                number: 0,
-                time: 0,
-                duration: Number.MAX_VALUE,
-                timescale: 1,
-                mediaURL: this._index.mediaURL }];
-    }
     return getSegmentsFromTimeline(this._index, _up, _to, this._scaledPeriodEnd);
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -203,12 +203,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       if (initSegment.privateInfos === undefined) {
         initSegment.privateInfos = {
           shouldGuessInitRange: true,
-          mightBeStaticContent: this._index.indexRange === undefined,
         };
       } else {
         initSegment.privateInfos.shouldGuessInitRange = true;
-        initSegment.privateInfos.mightBeStaticContent =
-          this._index.indexRange === undefined;
       }
     }
     return initSegment;

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -220,7 +220,8 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @returns {Array.<Object>}
    */
   getSegments(_up : number, _to : number) : ISegment[] {
-    if (this._mimeType !== undefined &&
+    if (this._index.initialization?.range === undefined &&
+        this._mimeType !== undefined &&
         /\/mp4$/.exec(this._mimeType) === null) {
       return [{ isInit: false,
                 id: "",

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -167,12 +167,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
 
     // TODO If indexRange is behind the initialization segment
     // the following logic will not work.
-    let range: [number, number] | undefined;
-    if (index.initialization !== undefined) {
-      range = index.initialization.range;
-    } else if (index.indexRange !== undefined) {
-      range = [0, index.indexRange[0] - 1];
-    }
+    const range = index.initialization?.range ??
+                  (index.indexRange !== undefined ? [0, index.indexRange[0] - 1] :
+                                                    undefined);
 
     this._index = { indexRange: index.indexRange,
                     indexTimeOffset,

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -215,7 +215,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       return null;
     }
     const initSegment = getInitSegment(this._index);
-    initSegment.hypotheticalInitRange = this._hypotheticalInitRange;
+    initSegment.privateInfos = {
+      hypotheticalInitRange : this._hypotheticalInitRange,
+    };
     return initSegment;
   }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -168,9 +168,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     // TODO If indexRange is behind the initialization segment
     // the following logic will not work.
     let range: [number, number] | undefined;
-    if (index.initialization != null) {
+    if (index.initialization !== undefined) {
       range = index.initialization.range;
-    } else if (index.indexRange != null) {
+    } else if (index.indexRange !== undefined) {
       range = [0, index.indexRange[0] - 1];
     }
 

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -137,7 +137,7 @@ function _addSegmentInfos(
  */
 export default class BaseRepresentationIndex implements IRepresentationIndex {
   private _index : IBaseIndex;
-  private _hypotheticalInitRange: boolean;
+  private _shouldGuessInitRange: boolean;
   private _isContentFragmented: boolean;
 
   // absolute end of the period, timescaled and converted to index time
@@ -178,11 +178,11 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     // is loaded, to ensure that we push a complete and dry segment
     // to buffers.
     let range: [number, number] | undefined;
-    this._hypotheticalInitRange = false;
+    this._shouldGuessInitRange = false;
     if (index.initialization === undefined &&
         index.indexRange === undefined &&
         this._isContentFragmented) {
-      this._hypotheticalInitRange = true;
+      this._shouldGuessInitRange = true;
     } else {
       if (index.initialization != null) {
         range = index.initialization.range;
@@ -216,7 +216,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     }
     const initSegment = getInitSegment(this._index);
     initSegment.privateInfos = {
-      hypotheticalInitRange : this._hypotheticalInitRange,
+      shouldGuessInitRange : this._shouldGuessInitRange,
     };
     return initSegment;
   }

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -213,12 +213,15 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   getInitSegment() : ISegment | null {
     const initSegment = getInitSegment(this._index);
     if (initSegment !== null && initSegment.range === undefined) {
+      const mightBeStaticContent = initSegment.indexRange === undefined;
       if (initSegment.privateInfos === undefined) {
         initSegment.privateInfos = {
           shouldGuessInitRange: true,
+          mightBeStaticContent,
         };
       } else {
         initSegment.privateInfos.shouldGuessInitRange = true;
+        initSegment.privateInfos.mightBeStaticContent = mightBeStaticContent;
       }
     }
     return initSegment;

--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -212,12 +212,13 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    */
   getInitSegment() : ISegment | null {
     const initSegment = getInitSegment(this._index);
-    if (initSegment !== null && initSegment.range === undefined) {
+    if (initSegment !== null) {
+      const shouldGuessInitRange = initSegment.range === undefined;
       const mightBeStaticContent = initSegment.indexRange === undefined;
       if (initSegment.privateInfos === undefined) {
         initSegment.privateInfos = {};
       }
-      initSegment.privateInfos.shouldGuessInitRange = true;
+      initSegment.privateInfos.shouldGuessInitRange = shouldGuessInitRange;
       initSegment.privateInfos.mightBeStaticContent = mightBeStaticContent;
     }
     return initSegment;

--- a/src/parsers/manifest/dash/indexes/get_init_segment.ts
+++ b/src/parsers/manifest/dash/indexes/get_init_segment.ts
@@ -19,15 +19,18 @@ import { ISegment } from "../../../../manifest";
 /**
  * Construct init segment for the given index.
  * @param {Object} index
- * @returns {Object}
+ * @returns {Object|null}
  */
 export default function getInitSegment(
   index: { timescale: number;
-           initialization?: { mediaURL: string; range?: [number, number] };
+           initialization: { mediaURL: string; range?: [number, number] } | null;
            indexRange?: [number, number];
            indexTimeOffset : number; }
-) : ISegment {
+) : ISegment | null {
   const { initialization } = index;
+  if (initialization === null) {
+    return null;
+  }
   return { id: "init",
            isInit: true,
            time: 0,

--- a/src/parsers/manifest/dash/indexes/get_init_segment.ts
+++ b/src/parsers/manifest/dash/indexes/get_init_segment.ts
@@ -35,11 +35,9 @@ export default function getInitSegment(
            isInit: true,
            time: 0,
            duration: 0,
-           range: initialization != null ? initialization.range :
-                                           undefined,
+           range: initialization.range,
            indexRange: index.indexRange,
-           mediaURL: initialization  != null ? initialization.mediaURL :
-                                               null,
+           mediaURL: initialization.mediaURL,
            timescale: index.timescale,
            timestampOffset: -(index.indexTimeOffset / index.timescale) };
 }

--- a/src/parsers/manifest/dash/indexes/list.ts
+++ b/src/parsers/manifest/dash/indexes/list.ts
@@ -46,10 +46,10 @@ export interface IListIndex {
                             // beginning at:
                             // ``` T * timescale + indexTimeOffset ```
 
-  initialization? : { // information on the initialization segment
+  initialization : { // information on the initialization segment
     mediaURL: string; // URL to access the initialization segment
     range?: [number, number]; // possible byte range to request it
-  };
+  } | null;
   indexRange?: [number, number]; // byte range for a possible index of segments
                                  // in the server
 }
@@ -134,8 +134,8 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
                     duration: index.duration,
                     indexTimeOffset,
                     indexRange: index.indexRange,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       { mediaURL: createIndexURL(representationBaseURL,
                                                index.initialization.media,
                                                representationId,
@@ -147,7 +147,7 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
    * Construct init Segment.
    * @returns {Object}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -39,10 +39,10 @@ export interface ITemplateIndex {
 
   indexRange?: [number, number]; // byte range for a possible index of segments
                                  // in the server
-  initialization?: { // information on the initialization segment
+  initialization: { // information on the initialization segment
     mediaURL: string; // URL to access the initialization segment
     range?: [number, number]; // possible byte range to request it
-  };
+  } | null;
   mediaURL : string; // base URL to access any segment. Can contain token to
                      // replace to convert it to a real URL
   indexTimeOffset : number; // Temporal offset, in the current timescale (see
@@ -149,8 +149,8 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                     timescale,
                     indexRange: index.indexRange,
                     indexTimeOffset,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       { mediaURL: createIndexURL(representationBaseURL,
                                                  index.initialization.media,
                                                  representationId,
@@ -172,7 +172,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
    * Construct init Segment.
    * @returns {Object}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/indexes/timeline.ts
+++ b/src/parsers/manifest/dash/indexes/timeline.ts
@@ -53,10 +53,10 @@ export interface ITimelineIndex {
                             // actually will look for a segment in the index
                             // beginning at:
                             // ``` T * timescale + indexTimeOffset ```
-  initialization? : { // information on the initialization segment
+  initialization : { // information on the initialization segment
     mediaURL: string; // URL to access the initialization segment
     range?: [number, number]; // possible byte range to request it
-  };
+  } | null;
   mediaURL : string; // base URL to access any segment. Can contain token to
                      // replace to convert it to a real URL
   startNumber? : number; // number from which the first segments in this index
@@ -264,8 +264,8 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     this._isDynamic = isDynamic;
     this._index = { indexRange: index.indexRange,
                     indexTimeOffset,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       {
                         mediaURL: createIndexURL(representationBaseURL,
                                                  index.initialization.media,
@@ -289,7 +289,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
    * Construct init Segment.
    * @returns {Object}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -87,7 +87,7 @@ function findAdaptationIndex(
   let adaptationIndex : IRepresentationIndex;
   if (adaptationChildren.segmentBase != null) {
     const { segmentBase } = adaptationChildren;
-    adaptationIndex = new BaseRepresentationIndex(segmentBase, context);
+    adaptationIndex = new BaseRepresentationIndex(segmentBase, context, true);
   } else if (adaptationChildren.segmentList != null) {
     const { segmentList } = adaptationChildren;
     adaptationIndex = new ListRepresentationIndex(segmentList, context);
@@ -97,7 +97,10 @@ function findAdaptationIndex(
       new TimelineRepresentationIndex(segmentTemplate, context) :
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
-    adaptationIndex = new BaseRepresentationIndex({}, context);
+    const { mimeType } = adaptation.attributes;
+    const isContentFragmented = mimeType != null ? /.*?\/mp4$/g.test(mimeType) :
+                                                   false;
+    adaptationIndex = new BaseRepresentationIndex({}, context, isContentFragmented);
   }
   return adaptationIndex;
 }
@@ -137,7 +140,7 @@ export default function parseRepresentations(
         getRepAvailabilityTimeOffset(adaptationInfos.availabilityTimeOffset,
                                      representation.children.baseURL,
                                      segmentBase.availabilityTimeOffset);
-      representationIndex = new BaseRepresentationIndex(segmentBase, context);
+      representationIndex = new BaseRepresentationIndex(segmentBase, context, true);
     } else if (representation.children.segmentList != null) {
       const { segmentList } = representation.children;
       representationIndex = new ListRepresentationIndex(segmentList, context);

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -99,7 +99,7 @@ function findAdaptationIndex(
   } else {
     adaptationIndex = new BaseRepresentationIndex({
       timeline: [],
-      timescale: 1, // set to 1 if no one was provided in the manifest
+      timescale: 1, // set to 1 if no timescale was provided in the manifest
     }, context);
   }
   return adaptationIndex;

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -98,8 +98,9 @@ function findAdaptationIndex(
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
     const { mimeType } = adaptation.attributes;
-    const isContentFragmented = mimeType != null ? /.*?\/mp4$/g.test(mimeType) :
-                                                   false;
+    const isContentFragmented =
+      (mimeType !== undefined && mimeType.length > 0) ? /.*?\/mp4$/g.test(mimeType) :
+                                                        false;
     adaptationIndex = new BaseRepresentationIndex({}, context, isContentFragmented);
   }
   return adaptationIndex;

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -97,13 +97,7 @@ function findAdaptationIndex(
       new TimelineRepresentationIndex(segmentTemplate, context) :
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
-    adaptationIndex = new TemplateRepresentationIndex({
-      duration: Number.MAX_VALUE,
-      timescale: 1,
-      startNumber: 0,
-      initialization: { media: "" },
-      media: "",
-    }, context);
+    adaptationIndex = new BaseRepresentationIndex({}, context);
   }
   return adaptationIndex;
 }

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -124,6 +124,8 @@ export default function parseRepresentations(
     const context = { aggressiveMode: adaptationInfos.aggressiveMode,
                       availabilityTimeOffset: adaptationInfos.availabilityTimeOffset,
                       manifestBoundsCalculator: adaptationInfos.manifestBoundsCalculator,
+                      mimeType: representation.attributes.mimeType ??
+                                adaptation.attributes.mimeType,
                       isDynamic: adaptationInfos.isDynamic,
                       periodEnd: adaptationInfos.end,
                       periodStart: adaptationInfos.start,
@@ -131,9 +133,7 @@ export default function parseRepresentations(
                       representationBaseURL,
                       representationBitrate: representation.attributes.bitrate,
                       representationId: representation.attributes.id,
-                      timeShiftBufferDepth: adaptationInfos.timeShiftBufferDepth,
-                      mimeType: representation.attributes.mimeType ??
-                                adaptation.attributes.mimeType };
+                      timeShiftBufferDepth: adaptationInfos.timeShiftBufferDepth };
     let representationIndex : IRepresentationIndex;
     if (representation.children.segmentBase != null) {
       const { segmentBase } = representation.children;

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -97,7 +97,10 @@ function findAdaptationIndex(
       new TimelineRepresentationIndex(segmentTemplate, context) :
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
-    adaptationIndex = new BaseRepresentationIndex({}, context);
+    adaptationIndex = new BaseRepresentationIndex({
+      timeline: [],
+      timescale: 1, // set to 1 if no one was provided in the manifest
+    }, context);
   }
   return adaptationIndex;
 }

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -120,7 +120,6 @@ export default function parseRepresentations(
     const baseURL = representation.children.baseURL !== undefined ?
       representation.children.baseURL.value : "";
     const representationBaseURL = resolveURL(adaptationInfos.baseURL, baseURL);
-
     // 4-2-1. Find Index
     const context = { aggressiveMode: adaptationInfos.aggressiveMode,
                       availabilityTimeOffset: adaptationInfos.availabilityTimeOffset,
@@ -132,7 +131,9 @@ export default function parseRepresentations(
                       representationBaseURL,
                       representationBitrate: representation.attributes.bitrate,
                       representationId: representation.attributes.id,
-                      timeShiftBufferDepth: adaptationInfos.timeShiftBufferDepth };
+                      timeShiftBufferDepth: adaptationInfos.timeShiftBufferDepth,
+                      mimeType: representation.attributes.mimeType ??
+                                adaptation.attributes.mimeType };
     let representationIndex : IRepresentationIndex;
     if (representation.children.segmentBase != null) {
       const { segmentBase } = representation.children;

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -87,7 +87,7 @@ function findAdaptationIndex(
   let adaptationIndex : IRepresentationIndex;
   if (adaptationChildren.segmentBase != null) {
     const { segmentBase } = adaptationChildren;
-    adaptationIndex = new BaseRepresentationIndex(segmentBase, context, true);
+    adaptationIndex = new BaseRepresentationIndex(segmentBase, context);
   } else if (adaptationChildren.segmentList != null) {
     const { segmentList } = adaptationChildren;
     adaptationIndex = new ListRepresentationIndex(segmentList, context);
@@ -97,11 +97,7 @@ function findAdaptationIndex(
       new TimelineRepresentationIndex(segmentTemplate, context) :
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
-    const { mimeType } = adaptation.attributes;
-    const isContentFragmented =
-      (mimeType !== undefined && mimeType.length > 0) ? /.*?\/mp4$/g.test(mimeType) :
-                                                        false;
-    adaptationIndex = new BaseRepresentationIndex({}, context, isContentFragmented);
+    adaptationIndex = new BaseRepresentationIndex({}, context);
   }
   return adaptationIndex;
 }
@@ -141,7 +137,7 @@ export default function parseRepresentations(
         getRepAvailabilityTimeOffset(adaptationInfos.availabilityTimeOffset,
                                      representation.children.baseURL,
                                      segmentBase.availabilityTimeOffset);
-      representationIndex = new BaseRepresentationIndex(segmentBase, context, true);
+      representationIndex = new BaseRepresentationIndex(segmentBase, context);
     } else if (representation.children.segmentList != null) {
       const { segmentList } = representation.children;
       representationIndex = new ListRepresentationIndex(segmentList, context);

--- a/src/transports/dash/extract_complete_init_chunk.ts
+++ b/src/transports/dash/extract_complete_init_chunk.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../../log";
+import { be4toi } from "../../utils/byte_parsing";
+import findCompleteBox from "../utils/find_complete_box";
+
+/**
+ * Extract the constituent boxes (ftyp / moov) of an init segment.
+ * @param {Uint8Array} buf
+ * @returns {Uint8Array|number}
+ */
+export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|-1 {
+  const ftypBoxIndex = findCompleteBox(buf, 0x66747970 /* ftyp */);
+  if (ftypBoxIndex < 0) {
+    log.error("Incomplete `ftyp` box");
+    return -1;
+  }
+  const ftypBoxSize = be4toi(buf, ftypBoxIndex); // size of the "ftyp" box
+  const ftypBox = buf.subarray(ftypBoxIndex, ftypBoxIndex + ftypBoxSize);
+
+  const moovBoxIndex = findCompleteBox(buf, 0x6d6f6f76 /* moov */);
+  if (ftypBoxIndex < 0) {
+    log.error("Incomplete `moov` box");
+    return -1;
+  }
+  const moovBoxSize = be4toi(buf, moovBoxIndex); // size of the "moov" box
+  const moovBox = buf.subarray(moovBoxIndex, moovBoxIndex + moovBoxSize);
+  const initChunk = new Uint8Array(ftypBoxSize + moovBoxSize);
+  initChunk.set(ftypBox, 0);
+  initChunk.set(moovBox, ftypBoxSize);
+
+  return initChunk;
+}

--- a/src/transports/dash/extract_complete_init_chunk.ts
+++ b/src/transports/dash/extract_complete_init_chunk.ts
@@ -21,13 +21,13 @@ import findCompleteBox from "../utils/find_complete_box";
 /**
  * Extract the constituent boxes (ftyp / moov) of an init segment.
  * @param {Uint8Array} buf
- * @returns {Uint8Array|number}
+ * @returns {Uint8Array|null}
  */
-export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|-1 {
+export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|null {
   const ftypBoxIndex = findCompleteBox(buf, 0x66747970 /* ftyp */);
   if (ftypBoxIndex < 0) {
     log.error("Incomplete `ftyp` box");
-    return -1;
+    return null;
   }
   const ftypBoxSize = be4toi(buf, ftypBoxIndex); // size of the "ftyp" box
   const ftypBox = buf.subarray(ftypBoxIndex, ftypBoxIndex + ftypBoxSize);
@@ -35,7 +35,7 @@ export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|-1
   const moovBoxIndex = findCompleteBox(buf, 0x6D6F6F76 /* moov */);
   if (ftypBoxIndex < 0) {
     log.error("Incomplete `moov` box");
-    return -1;
+    return null;
   }
   const moovBoxSize = be4toi(buf, moovBoxIndex); // size of the "moov" box
   const moovBox = buf.subarray(moovBoxIndex, moovBoxIndex + moovBoxSize);

--- a/src/transports/dash/extract_complete_init_chunk.ts
+++ b/src/transports/dash/extract_complete_init_chunk.ts
@@ -26,7 +26,7 @@ import findCompleteBox from "../utils/find_complete_box";
 export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|null {
   const ftypBoxIndex = findCompleteBox(buf, 0x66747970 /* ftyp */);
   if (ftypBoxIndex < 0) {
-    log.error("Incomplete `ftyp` box");
+    log.error("DASH: Incomplete `ftyp` box");
     return null;
   }
   const ftypBoxSize = be4toi(buf, ftypBoxIndex); // size of the "ftyp" box
@@ -34,7 +34,7 @@ export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|nu
 
   const moovBoxIndex = findCompleteBox(buf, 0x6D6F6F76 /* moov */);
   if (ftypBoxIndex < 0) {
-    log.error("Incomplete `moov` box");
+    log.error("DASH: Incomplete `moov` box");
     return null;
   }
   const moovBoxSize = be4toi(buf, moovBoxIndex); // size of the "moov" box

--- a/src/transports/dash/extract_complete_init_chunk.ts
+++ b/src/transports/dash/extract_complete_init_chunk.ts
@@ -32,7 +32,7 @@ export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|-1
   const ftypBoxSize = be4toi(buf, ftypBoxIndex); // size of the "ftyp" box
   const ftypBox = buf.subarray(ftypBoxIndex, ftypBoxIndex + ftypBoxSize);
 
-  const moovBoxIndex = findCompleteBox(buf, 0x6d6f6f76 /* moov */);
+  const moovBoxIndex = findCompleteBox(buf, 0x6D6F6F76 /* moov */);
   if (ftypBoxIndex < 0) {
     log.error("Incomplete `moov` box");
     return -1;

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -33,9 +33,21 @@ export default function initSegmentLoader(
   url : string,
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
-  if (segment.range === undefined) {
+  if (segment.privateInfos !== undefined &&
+      segment.privateInfos.shouldGuessInitRange === true) {
+    // If no range and index range are given by manifest, we take
+    // as init segment the nth first bytes (where n = 1500).
+    // Therefore, we need to filter on init boxes after the segment
+    // is loaded, to ensure that we push a complete and dry segment
+    // to buffers.
     return xhr({ url,
                  headers: { Range: byteRange([0, 1500]) },
+                 responseType: "arraybuffer",
+                 sendProgressEvents: true });
+  }
+
+  if (segment.range === undefined) {
+    return xhr({ url,
                  responseType: "arraybuffer",
                  sendProgressEvents: true });
   }

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -34,7 +34,8 @@ export default function initSegmentLoader(
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
   if (segment.range == null) {
-    if (segment.hypotheticalInitRange) {
+    if (segment.privateInfos &&
+        segment.privateInfos.hypotheticalInitRange) {
       return xhr({ url,
                    headers: { Range: byteRange([0, 1500]) },
                    responseType: "arraybuffer",

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -35,7 +35,7 @@ export default function initSegmentLoader(
 ) : ISegmentLoaderObservable<ArrayBuffer> {
   if (segment.range == null) {
     if (segment.privateInfos &&
-        segment.privateInfos.hypotheticalInitRange) {
+        segment.privateInfos.shouldGuessInitRange) {
       return xhr({ url,
                    headers: { Range: byteRange([0, 1500]) },
                    responseType: "arraybuffer",

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -39,7 +39,7 @@ export default function initSegmentLoader(
   const mimeType = representation.getMimeTypeString();
   if (segment.privateInfos !== undefined &&
       segment.privateInfos.shouldGuessInitRange === true) {
-    if (/\/(mp4|webm)(\ ?);codecs=/.exec(mimeType) === null) {
+    if (/\/mp4(\ ?);codecs=/.exec(mimeType) === null) {
       return observableOf({
         type: "data-created" as const,
         value: {

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { combineLatest as observableCombineLatest } from "rxjs";
+import {
+  combineLatest as observableCombineLatest,
+  of as observableOf,
+} from "rxjs";
 import { map } from "rxjs/operators";
 import { concat } from "../../utils/byte_parsing";
 import xhr from "../../utils/request";
@@ -31,10 +34,19 @@ import byteRange from "../utils/byte_range";
  */
 export default function initSegmentLoader(
   url : string,
-  { segment } : ISegmentLoaderArguments
-) : ISegmentLoaderObservable<ArrayBuffer> {
+  { segment, representation } : ISegmentLoaderArguments
+) : ISegmentLoaderObservable<ArrayBuffer|null> {
+  const mimeType = representation.getMimeTypeString();
   if (segment.privateInfos !== undefined &&
       segment.privateInfos.shouldGuessInitRange === true) {
+    if (/\/(mp4|webm)(\ ?);codecs=/.exec(mimeType) === null) {
+      return observableOf({
+        type: "data-created" as const,
+        value: {
+          responseData: null,
+        },
+      });
+    }
     // If no range and index range are given by manifest, we take
     // as init segment the nth first bytes (where n = 1500).
     // Therefore, we need to filter on init boxes after the segment

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -16,7 +16,6 @@
 
 import {
   combineLatest as observableCombineLatest,
-  of as observableOf,
 } from "rxjs";
 import { map } from "rxjs/operators";
 import { concat } from "../../utils/byte_parsing";
@@ -34,19 +33,10 @@ import byteRange from "../utils/byte_range";
  */
 export default function initSegmentLoader(
   url : string,
-  { segment, representation } : ISegmentLoaderArguments
-) : ISegmentLoaderObservable<ArrayBuffer|null> {
-  const mimeType = representation.getMimeTypeString();
+  { segment } : ISegmentLoaderArguments
+) : ISegmentLoaderObservable<ArrayBuffer> {
   if (segment.privateInfos !== undefined &&
       segment.privateInfos.shouldGuessInitRange === true) {
-    if (/\/mp4(\ ?);codecs=/.exec(mimeType) === null) {
-      return observableOf({
-        type: "data-created" as const,
-        value: {
-          responseData: null,
-        },
-      });
-    }
     // If no range and index range are given by manifest, we take
     // as init segment the nth first bytes (where n = 1500).
     // Therefore, we need to filter on init boxes after the segment

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -33,15 +33,11 @@ export default function initSegmentLoader(
   url : string,
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
-  if (segment.range == null) {
-    if (segment.privateInfos &&
-        segment.privateInfos.shouldGuessInitRange) {
-      return xhr({ url,
-                   headers: { Range: byteRange([0, 1500]) },
-                   responseType: "arraybuffer",
-                   sendProgressEvents: true });
-    }
-    return xhr({ url, responseType: "arraybuffer", sendProgressEvents: true });
+  if (segment.range === undefined) {
+    return xhr({ url,
+                 headers: { Range: byteRange([0, 1500]) },
+                 responseType: "arraybuffer",
+                 sendProgressEvents: true });
   }
 
   if (segment.indexRange == null) {

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -34,6 +34,12 @@ export default function initSegmentLoader(
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
   if (segment.range == null) {
+    if (segment.hypotheticalInitRange) {
+      return xhr({ url,
+                   headers: { Range: byteRange([0, 1500]) },
+                   responseType: "arraybuffer",
+                   sendProgressEvents: true });
+    }
     return xhr({ url, responseType: "arraybuffer", sendProgressEvents: true });
   }
 

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -48,7 +48,7 @@ function regularSegmentLoader(
   url : string,
   args : ISegmentLoaderArguments,
   lowLatencyMode : boolean
-) : ISegmentLoaderObservable<ArrayBuffer|null> {
+) : ISegmentLoaderObservable<ArrayBuffer> {
 
   if (args.segment.isInit) {
     return initSegmentLoader(url, args);

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -48,7 +48,7 @@ function regularSegmentLoader(
   url : string,
   args : ISegmentLoaderArguments,
   lowLatencyMode : boolean
-) : ISegmentLoaderObservable<ArrayBuffer> {
+) : ISegmentLoaderObservable<ArrayBuffer|null> {
 
   if (args.segment.isInit) {
     return initSegmentLoader(url, args);

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -74,7 +74,10 @@ export default function parser({ content,
                           segmentProtections: [],
                           appendWindow: [period.start, period.end] });
   } else { // it is an initialization segment
-    const shouldExtractCompleteInitChunk = segment.range === undefined;
+    const { privateInfos } = segment;
+    const shouldExtractCompleteInitChunk = privateInfos !== undefined &&
+                                           privateInfos.shouldGuessInitRange === true;
+
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkData) : chunkData;
 

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -42,8 +42,13 @@ export default function parser({ content,
   const { period, representation, segment } = content;
   const { data, isChunked } = response;
   if (data === null) {
-    const isStaticContent = segment.isInit && segment.range === undefined;
-    if (isStaticContent) {
+    // here, it means that we probably are loading a static content as :
+    // - (Init + index) had to be guessed
+    // - No init segment was found
+    // - No next segments are present or parsed
+    if (segment.isInit &&
+        segment.range === undefined &&
+        segment.indexRange === undefined) {
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -77,7 +77,7 @@ export default function parser({ content,
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkData) : chunkData;
 
-    if (completeInitChunk === -1) {
+    if (completeInitChunk === null) {
       throw new Error("Can't extract complete init chunk from loaded data.");
     }
 

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -83,13 +83,16 @@ export default function parser({ content,
         nextSegments === null ||
         nextSegments.length === 0
       ) &&
-      privateInfos?.shouldGuessInitRange === true &&
-      segment.indexRange === undefined
+      privateInfos?.mightBeStaticContent === true
     ) {
-      // here, it means that we probably are loading a static content as :
-      // - (Init + index) had to be guessed
-      // - No init segment was found
-      // - No next segments are present or parsed
+      // The manifest tells that it may be a static content, instead of a
+      // fragmented one, and we do not found :
+      // - An init segment, which could have told us that the content is fragmented
+      // - Next segments from a sidx, which explictely would have told that the
+      //   content is fragmented
+      // Thus, there are very high chances that it is a static content.
+      // We just add a huge segment, without indicating an URL (which means it will take
+      // the default one)
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -82,11 +82,11 @@ export default function parser({ content,
           nextSegments === null ||
           nextSegments.length === 0
         ) &&
-        segment.indexRange === undefined
+        segment.privateInfos?.mightBeStaticContent === true
     ) {
       // There are very high chances that it is a static content, because :
       // - We've already loaded the init segment and found no sidx segments in it.
-      // - No index range was provided.
+      // - The segment indicates that content might be static
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -73,7 +73,10 @@ export default function parser({ content,
                           segmentProtections: [],
                           appendWindow: [period.start, period.end] });
   } else { // it is an initialization segment
-    const completeInitChunk = (segment.hypotheticalInitRange === true) ?
+    const { privateInfos } = segment;
+    const shouldExtractCompleteInitChunk = privateInfos !== undefined &&
+                                           privateInfos.hypotheticalInitRange === true;
+    const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkData) : chunkData;
 
     if (completeInitChunk === -1) {

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -78,19 +78,15 @@ export default function parser({ content,
     const completeInitChunk = privateInfos?.shouldGuessInitRange === true ?
       extractCompleteInitChunk(chunkData) : chunkData;
 
-    if (completeInitChunk === null &&
-      (
-        nextSegments === null ||
-        nextSegments.length === 0
-      ) &&
-      privateInfos?.mightBeStaticContent === true
+    if ((
+          nextSegments === null ||
+          nextSegments.length === 0
+        ) &&
+        segment.indexRange === undefined
     ) {
-      // The manifest tells that it may be a static content, instead of a
-      // fragmented one, and we do not found :
-      // - An init segment, which could have told us that the content is fragmented
-      // - Next segments from a sidx, which explictely would have told that the
-      //   content is fragmented
-      // Thus, there are very high chances that it is a static content.
+      // There are very high chances that it is a static content, because :
+      // - We've already loaded the init segment and found no sidx segments in it.
+      // - No index range was provided.
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -41,7 +41,7 @@ export default function parser({ content,
 ) : ISegmentParserObservable< Uint8Array | ArrayBuffer > {
   const { period, representation, segment } = content;
   const { data, isChunked } = response;
-  if (data == null) {
+  if (data === null) {
     const isStaticContent = segment.isInit && segment.range === undefined;
     if (isStaticContent) {
       representation.index._addSegments([{ time: 0,
@@ -111,7 +111,7 @@ export default function parser({ content,
                            getMDHDTimescale(completeInitChunk);
     }
 
-    const chunkInfos = timescale != null && timescale > 0 ? { time: 0,
+    const chunkInfos = timescale !== null && timescale > 0 ? { time: 0,
                                                               duration: 0,
                                                               timescale } :
                                                             null;

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -90,12 +90,14 @@ export default function parser({ content,
         (
           nextSegments === null ||
           nextSegments.length === 0
-        )
+        ) &&
+        shouldExtractCompleteInitChunk &&
+        segment.indexRange === undefined
     ) {
-      if (!shouldExtractCompleteInitChunk) {
-        throw new Error("Can't extract complete init chunk and segment" +
-                        "references from loaded data.");
-      }
+      // here, it means that we probably are loading a static content as :
+      // - (Init + index) had to be guessed
+      // - No init segment was found
+      // - No next segments are present or parsed
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -75,7 +75,7 @@ export default function parser({ content,
   } else { // it is an initialization segment
     const { privateInfos } = segment;
     const shouldExtractCompleteInitChunk = privateInfos !== undefined &&
-                                           privateInfos.hypotheticalInitRange === true;
+                                           privateInfos.shouldGuessInitRange === true;
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkData) : chunkData;
 

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -24,7 +24,6 @@ import {
   getSegmentsFromCues,
   getTimeCodeScale,
 } from "../../parsers/containers/matroska";
-import BaseRepresentationIndex from "../../parsers/manifest/dash/indexes/base";
 import takeFirstSet from "../../utils/take_first_set";
 import {
   ISegmentParserArguments,
@@ -93,7 +92,7 @@ export default function parser({ content,
           nextSegments.length === 0
         )
     ) {
-      if (!(representation.index instanceof BaseRepresentationIndex)) {
+      if (!shouldExtractCompleteInitChunk) {
         throw new Error("Can't extract complete init chunk and segment" +
                         "references from loaded data.");
       }

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -48,7 +48,8 @@ export default function parser({ content,
     // - No next segments are present or parsed
     if (segment.isInit &&
         segment.range === undefined &&
-        segment.indexRange === undefined) {
+        segment.indexRange === undefined &&
+        segment.privateInfos?.shouldGuessInitRange === true) {
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -78,15 +78,12 @@ export default function parser({ content,
     const completeInitChunk = privateInfos?.shouldGuessInitRange === true ?
       extractCompleteInitChunk(chunkData) : chunkData;
 
-    if ((
-          nextSegments === null ||
-          nextSegments.length === 0
-        ) &&
+    if ((nextSegments === null || nextSegments.length === 0) &&
         segment.privateInfos?.mightBeStaticContent === true
     ) {
       // There are very high chances that it is a static content, because :
-      // - We've already loaded the init segment and found no sidx segments in it.
       // - The segment indicates that content might be static
+      // - We've already loaded the init segment and found no sidx segments in it.
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -43,6 +43,12 @@ export default function parser({ content,
   const { period, representation, segment } = content;
   const { data, isChunked } = response;
   if (data == null) {
+    const isStaticContent = segment.isInit && segment.range === undefined;
+    if (isStaticContent) {
+      representation.index._addSegments([{ time: 0,
+                                           duration: Number.MAX_VALUE,
+                                           timescale: 1 }]);
+    }
     return observableOf({ chunkData: null,
                           chunkInfos: null,
                           chunkOffset: 0,

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -73,9 +73,7 @@ export default function parser({ content,
                           segmentProtections: [],
                           appendWindow: [period.start, period.end] });
   } else { // it is an initialization segment
-    const { privateInfos } = segment;
-    const shouldExtractCompleteInitChunk = privateInfos !== undefined &&
-                                           privateInfos.shouldGuessInitRange === true;
+    const shouldExtractCompleteInitChunk = segment.range === undefined;
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkData) : chunkData;
 

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -64,8 +64,7 @@ function parseMP4EmbeddedTrack({ response,
 
   if (isInit) {
     const { privateInfos } = segment;
-    const shouldExtractCompleteInitChunk = privateInfos !== undefined &&
-                                           privateInfos.shouldGuessInitRange === true;
+    const shouldExtractCompleteInitChunk = privateInfos?.shouldGuessInitRange === true;
 
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkBytes) : chunkBytes;
@@ -75,7 +74,7 @@ function parseMP4EmbeddedTrack({ response,
         sidxSegments === null ||
         sidxSegments.length === 0
       ) &&
-      shouldExtractCompleteInitChunk &&
+      privateInfos?.shouldGuessInitRange === true &&
       segment.indexRange === undefined
     ) {
       // here, it means that we probably are loading a static content as :
@@ -253,18 +252,6 @@ export default function textTrackParser({ response,
   const { timestampOffset = 0 } = segment;
   const { data, isChunked } = response;
   if (data == null) { // No data, just return empty infos
-    // here, it means that we probably are loading a static content as :
-    // - (Init + index) had to be guessed
-    // - No init segment was found
-    // - No next segments are present or parsed
-    if (segment.isInit &&
-        segment.range === undefined &&
-        segment.indexRange === undefined &&
-        segment.privateInfos?.shouldGuessInitRange === true) {
-      representation.index._addSegments([{ time: 0,
-                                           duration: Number.MAX_VALUE,
-                                           timescale: 1 }]);
-    }
     return observableOf({ chunkData: null,
                           chunkInfos: null,
                           chunkOffset: timestampOffset,

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -69,19 +69,15 @@ function parseMP4EmbeddedTrack({ response,
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkBytes) : chunkBytes;
 
-    if (completeInitChunk === null &&
-      (
+    if ((
         sidxSegments === null ||
         sidxSegments.length === 0
-      ) &&
-      privateInfos?.mightBeStaticContent === true
+        ) &&
+        segment.indexRange === undefined
     ) {
-      // The manifest tells that it may be a static content, instead of a
-      // fragmented one, and we do not found :
-      // - An init segment, which could have told us that the content is fragmented
-      // - Next segments from a sidx, which explictely would have told that the
-      //   content is fragmented
-      // Thus, there are very high chances that it is a static content.
+      // There are very high chances that it is a static content, because :
+      // - We've already loaded the init segment and found no sidx segments in it.
+      // - No index range was provided.
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -253,8 +253,13 @@ export default function textTrackParser({ response,
   const { timestampOffset = 0 } = segment;
   const { data, isChunked } = response;
   if (data == null) { // No data, just return empty infos
-    const isStaticContent = segment.isInit && segment.range === undefined;
-    if (isStaticContent) {
+    // here, it means that we probably are loading a static content as :
+    // - (Init + index) had to be guessed
+    // - No init segment was found
+    // - No next segments are present or parsed
+    if (segment.isInit &&
+        segment.range === undefined &&
+        segment.indexRange === undefined) {
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -73,11 +73,11 @@ function parseMP4EmbeddedTrack({ response,
         sidxSegments === null ||
         sidxSegments.length === 0
         ) &&
-        segment.indexRange === undefined
+        segment.privateInfos?.mightBeStaticContent === true
     ) {
       // There are very high chances that it is a static content, because :
       // - We've already loaded the init segment and found no sidx segments in it.
-      // - No index range was provided.
+      // - The segment indicates that content might be static
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -21,20 +21,19 @@ import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
+import BaseRepresentationIndex from "../../parsers/manifest/dash/indexes/base";
 import {
   bytesToStr,
   strToBytes,
 } from "../../utils/byte_parsing";
 import stringFromUTF8 from "../../utils/string_from_utf8";
-import isMP4EmbeddedTextTrack from "./is_mp4_embedded_text_track";
-import getISOBMFFTimingInfos from "./isobmff_timing_infos";
-
 import {
   ISegmentParserArguments,
   ITextParserObservable,
 } from "../types";
 import extractCompleteInitChunk from "./extract_complete_init_chunk";
-import BaseRepresentationIndex from "../../parsers/manifest/dash/indexes/base";
+import isMP4EmbeddedTextTrack from "./is_mp4_embedded_text_track";
+import getISOBMFFTimingInfos from "./isobmff_timing_infos";
 
 /**
  * Parse TextTrack data.

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -21,7 +21,6 @@ import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
-import BaseRepresentationIndex from "../../parsers/manifest/dash/indexes/base";
 import {
   bytesToStr,
   strToBytes,
@@ -77,7 +76,7 @@ function parseMP4EmbeddedTrack({ response,
           sidxSegments.length === 0
         )
     ) {
-      if (!(representation.index instanceof BaseRepresentationIndex)) {
+      if (!shouldExtractCompleteInitChunk) {
         throw new Error("Can't extract complete init chunk and segment" +
                         "references from loaded data.");
       }

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -71,15 +71,17 @@ function parseMP4EmbeddedTrack({ response,
       extractCompleteInitChunk(chunkBytes) : chunkBytes;
 
     if (completeInitChunk === null &&
-        (
-          sidxSegments === null ||
-          sidxSegments.length === 0
-        )
+      (
+        sidxSegments === null ||
+        sidxSegments.length === 0
+      ) &&
+      shouldExtractCompleteInitChunk &&
+      segment.indexRange === undefined
     ) {
-      if (!shouldExtractCompleteInitChunk) {
-        throw new Error("Can't extract complete init chunk and segment" +
-                        "references from loaded data.");
-      }
+      // here, it means that we probably are loading a static content as :
+      // - (Init + index) had to be guessed
+      // - No init segment was found
+      // - No next segments are present or parsed
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -259,7 +259,8 @@ export default function textTrackParser({ response,
     // - No next segments are present or parsed
     if (segment.isInit &&
         segment.range === undefined &&
-        segment.indexRange === undefined) {
+        segment.indexRange === undefined &&
+        segment.privateInfos?.shouldGuessInitRange === true) {
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -74,13 +74,16 @@ function parseMP4EmbeddedTrack({ response,
         sidxSegments === null ||
         sidxSegments.length === 0
       ) &&
-      privateInfos?.shouldGuessInitRange === true &&
-      segment.indexRange === undefined
+      privateInfos?.mightBeStaticContent === true
     ) {
-      // here, it means that we probably are loading a static content as :
-      // - (Init + index) had to be guessed
-      // - No init segment was found
-      // - No next segments are present or parsed
+      // The manifest tells that it may be a static content, instead of a
+      // fragmented one, and we do not found :
+      // - An init segment, which could have told us that the content is fragmented
+      // - Next segments from a sidx, which explictely would have told that the
+      //   content is fragmented
+      // Thus, there are very high chances that it is a static content.
+      // We just add a huge segment, without indicating an URL (which means it will take
+      // the default one)
       representation.index._addSegments([{ time: 0,
                                            duration: Number.MAX_VALUE,
                                            timescale: 1 }]);

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -69,15 +69,12 @@ function parseMP4EmbeddedTrack({ response,
     const completeInitChunk = shouldExtractCompleteInitChunk ?
       extractCompleteInitChunk(chunkBytes) : chunkBytes;
 
-    if ((
-        sidxSegments === null ||
-        sidxSegments.length === 0
-        ) &&
+    if ((sidxSegments === null || sidxSegments.length === 0) &&
         segment.privateInfos?.mightBeStaticContent === true
     ) {
       // There are very high chances that it is a static content, because :
-      // - We've already loaded the init segment and found no sidx segments in it.
       // - The segment indicates that content might be static
+      // - We've already loaded the init segment and found no sidx segments in it.
       // We just add a huge segment, without indicating an URL (which means it will take
       // the default one)
       representation.index._addSegments([{ time: 0,

--- a/tests/contents/DASH_static_SegmentBase_multi_codecs/infos.js
+++ b/tests/contents/DASH_static_SegmentBase_multi_codecs/infos.js
@@ -223,9 +223,6 @@ export default {
                 codec: undefined,
                 mimeType: "text/vtt",
                 index: {
-                  init: {
-                    mediaURL: BASE_URL + "s-el.webvtt",
-                  },
                   segments: [
                     {
                       mediaURL: BASE_URL + "s-el.webvtt",
@@ -248,9 +245,6 @@ export default {
                 codec: undefined,
                 mimeType: "text/vtt",
                 index: {
-                  init: {
-                    mediaURL: BASE_URL + "s-en.webvtt",
-                  },
                   segments: [
                     {
                       mediaURL: BASE_URL + "s-en.webvtt",
@@ -273,9 +267,6 @@ export default {
                 codec: undefined,
                 mimeType: "text/vtt",
                 index: {
-                  init: {
-                    mediaURL: BASE_URL + "s-fr.webvtt",
-                  },
                   segments: [
                     {
                       mediaURL: BASE_URL + "s-fr.webvtt",
@@ -298,9 +289,6 @@ export default {
                 codec: undefined,
                 mimeType: "text/vtt",
                 index: {
-                  init: {
-                    mediaURL: BASE_URL + "s-pt-BR.webvtt",
-                  },
                   segments: [
                     {
                       mediaURL: BASE_URL + "s-pt-BR.webvtt",


### PR DESCRIPTION
The PR is made to fix a bug were :
- A fragmented SegmentBase content was given without any index and init range. The RxPlayer considered it to be static, and tried to load the entire mp4 before pushing it.
--------------------------------------------------------------------------------------------
The fix is :

When a representation is a SegmentBase, we consider that it may be static or fragmented.

If the content is an mp4 :
- If init and index ranges are provided, consider it to be explicitely fragmented.
- If no init range provided, we try to load the 1500 first bytes to extract an init data.
- If no index range is provided, try to extract sidx segments from first loaded bytes. If no sidx segment is found, then consider that content is a static one. If new segments found, consider it to be fragmented and add segments to index.

If the content is not explicitely an mp4, then consider it to be static.
