### PR TITLE
fix(eme-safari): Add compat for recent eme safari support

### DIFF
--- a/src/compat/eme/generate_key_request.ts
+++ b/src/compat/eme/generate_key_request.ts
@@ -129,6 +129,7 @@ export default function generateKeyRequest(
     } else {
       patchedInit = initData;
     }
+    console.warn('GENERATE REQUEST', session);
     return castToObservable(session.generateRequest(initDataType || "",
                                                     patchedInit));
   });

--- a/src/compat/eme/set_media_keys.ts
+++ b/src/compat/eme/set_media_keys.ts
@@ -33,8 +33,15 @@ function _setMediaKeys(
   elt : HTMLMediaElement,
   mediaKeys : MediaKeys|ICustomMediaKeys|null
 ) : any {
+  console.warn("MEDIA KEYS SET VIDEO", mediaKeys);
+  (mediaKeys as any)._setVideo(elt)
   if (mediaKeys instanceof CustomMediaKeys) {
     return mediaKeys._setVideo(elt);
+  }
+
+  if ((elt as any).webkitSetMediaKeys) {
+    const webKitNativeMediaKey = (mediaKeys as any)._getWebKitMediaKeys();
+    return (mediaKeys as any)._setWebKitMediaKeys(webKitNativeMediaKey);
   }
 
   if (elt.setMediaKeys) {
@@ -43,10 +50,6 @@ function _setMediaKeys(
 
   if (mediaKeys === null) {
     return;
-  }
-
-  if ((elt as any).WebkitSetMediaKeys) {
-    return (elt as any).WebkitSetMediaKeys(mediaKeys);
   }
 
   if ((elt as any).mozSetMediaKeys) {

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -401,13 +401,13 @@ const onRemoveSourceBuffers$ = compatibleListener(["onremovesourcebuffer"]);
  * @param {HTMLMediaElement} mediaElement
  * @returns {Observable}
  */
-const onEncrypted$ = compatibleListener<MediaEncryptedEvent>(["encrypted", "needkey"]);
+const onEncrypted$ = compatibleListener<MediaEncryptedEvent>(["encrypted", "needkey"], ['webkit']);
 
 /**
  * @param {MediaKeySession} mediaKeySession
  * @returns {Observable}
  */
-const onKeyMessage$ = compatibleListener<MediaKeyMessageEvent>(["keymessage", "message"]);
+const onKeyMessage$ = compatibleListener<MediaKeyMessageEvent>(["keymessage", "message"], ['webkit']);
 
 /**
  * @param {MediaKeySession} mediaKeySession
@@ -419,7 +419,7 @@ const onKeyAdded$ = compatibleListener(["keyadded", "ready"]);
  * @param {MediaKeySession} mediaKeySession
  * @returns {Observable}
  */
-const onKeyError$ = compatibleListener(["keyerror", "error"]);
+const onKeyError$ = compatibleListener(["keyerror", "error"], ['webkit']);
 
 /**
  * @param {MediaKeySession} mediaKeySession


### PR DESCRIPTION
EME API on Safari browser has changed in the relative recent release.

Since, it's possible to play encrypted content with the `DirectFile` API, it's worth having a EME compatibility with EME safari in case where someone want to use the native support of HLS media element on Safari with DRM.

This PR aim to provide support for EME API on Safari.