### PR TITLE
api/transports: add `progress` callback to segmentLoader

### DIFF
--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -79,7 +79,6 @@ export default function lowLatencySegmentLoader(
           emitted.push({ type: "progress",
                          value: { duration: value.duration,
                                   size: value.size,
-                                  url: value.url,
                                   totalSize: value.totalSize } });
         } else if (event != null && event.type === "data-complete") {
           const { value } = event;

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -134,11 +134,11 @@ export default function generateSegmentLoader(
        * Callback triggered when the custom segment loader has a response.
        * @param {Object} args
        */
-      const resolve = (_args : {
-        data : ArrayBuffer|Uint8Array;
-        size? : number;
-        duration? : number;
-      }) => {
+      const resolve = (
+        _args : { data : ArrayBuffer|Uint8Array;
+                  size? : number;
+                  duration? : number; }
+      ) => {
         if (!hasFallbacked) {
           hasFinished = true;
           obs.next({ type: "data-loaded" as const,
@@ -160,6 +160,18 @@ export default function generateSegmentLoader(
         }
       };
 
+      const progress = (
+        _args : { duration : number;
+                  size : number;
+                  totalSize? : number; }
+      ) => {
+        if (!hasFallbacked) {
+          obs.next({ type: "progress", value: { duration: _args.duration,
+                                                size: _args.size,
+                                                totalSize: _args.totalSize } });
+        }
+      };
+
       /**
        * Callback triggered when the custom segment loader wants to fallback to
        * the "regular" implementation
@@ -175,7 +187,7 @@ export default function generateSegmentLoader(
         /* tslint:enable deprecation */
       };
 
-      const callbacks = { reject, resolve, fallback };
+      const callbacks = { reject, resolve, progress, fallback };
       const abort = customSegmentLoader(args, callbacks);
 
       return () => {

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -174,6 +174,18 @@ const generateSegmentLoader = (
         }
       };
 
+      const progress = (
+        _args : { duration : number;
+                  size : number;
+                  totalSize? : number; }
+      ) => {
+        if (!hasFallbacked) {
+          obs.next({ type: "progress", value: { duration: _args.duration,
+                                                size: _args.size,
+                                                totalSize: _args.totalSize } });
+        }
+      };
+
       const fallback = () => {
         hasFallbacked = true;
 
@@ -184,7 +196,7 @@ const generateSegmentLoader = (
         /* tslint:enable deprecation */
       };
 
-      const callbacks = { reject, resolve, fallback };
+      const callbacks = { reject, resolve, fallback, progress };
       const abort = customSegmentLoader(args, callbacks);
 
       return () => {

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -98,7 +98,6 @@ export interface ILoaderDataCreated<T> { type : "data-created";
 export interface ILoaderProgress { type : "progress";
                                    value : { duration : number;
                                              size : number;
-                                             url : string;
                                              totalSize? : number; }; }
 
 // Event emitted by loaders when a chunk of the response is available
@@ -379,6 +378,10 @@ export type CustomSegmentLoader = (
                                     duration? : number; })
                           => void;
 
+                progress : (args : { duration : number;
+                                     size : number;
+                                     totalSize? : number; })
+                           => void;
                 reject : (err? : Error) => void;
                 fallback? : () => void; }
 ) =>


### PR DESCRIPTION
Add `progress` callback to the segmentLoader API, to improve our adaptive logic when P2P is involved.

Without that callback, we are much less performant after a sudden fall in bandwidth.