### PR TITLE
eme/init/compat: reload the MediaSource after a decipherability updat…

### DIFF
--- a/src/compat/__tests__/should_reload_media_source_on_decipherability_update.test.ts
+++ b/src/compat/__tests__/should_reload_media_source_on_decipherability_update.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import shouldReloadMediaSourceOnDecipherabilityUpdate from "../should_reload_media_source_on_decipherability_update";
+
+describe("Compat - shouldReloadMediaSourceOnDecipherabilityUpdate", () => {
+  it("should return true for an unknown key system", () => {
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate(null)).toEqual(true);
+  });
+
+  it("should return false for any string containing the string \"widevine\"", () => {
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("widevine")).toEqual(false);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("com.widevine.alpha"))
+      .toEqual(false);
+  });
+
+  it("should return true for any string not containing the string \"widevine\"", () => {
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("idevine")).toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("widevin")).toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("playready")).toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("com.nagra.prm"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("webkit-org.w3.clearkey"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("org.w3.clearkey"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("com.microsoft.playready"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("com.chromecast.playready"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate("com.youtube.playready"))
+      .toEqual(true);
+    expect(shouldReloadMediaSourceOnDecipherabilityUpdate(""))
+      .toEqual(true);
+  });
+});

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -56,6 +56,7 @@ import onHeightWidthChange from "./on_height_width_change";
 import patchWebkitSourceBuffer from "./patch_webkit_source_buffer";
 import play$ from "./play";
 import setElementSrc$ from "./set_element_src";
+import shouldReloadMediaSourceOnDecipherabilityUpdate from "./should_reload_media_source_on_decipherability_update";
 import shouldRenewMediaKeys from "./should_renew_media_keys";
 import shouldUnsetMediaKeys from "./should_unset_media_keys";
 import shouldValidateMetadata from "./should_validate_metadata";
@@ -98,6 +99,7 @@ export {
   requestMediaKeySystemAccess,
   setElementSrc$,
   setMediaKeys,
+  shouldReloadMediaSourceOnDecipherabilityUpdate,
   shouldRenewMediaKeys,
   shouldUnsetMediaKeys,
   shouldValidateMetadata,

--- a/src/compat/should_reload_media_source_on_decipherability_update.ts
+++ b/src/compat/should_reload_media_source_on_decipherability_update.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns true if we have to reload the MediaSource due to an update in the
+ * decipherability status of some segments based on the current key sytem.
+ *
+ * We found that on all Widevine targets tested, a simple seek is sufficient.
+ * As widevine clients make a good chunk of users, we can make a difference
+ * between them and others as it is for the better.
+ * @param {string|null} currentKeySystem
+ * @returns {Boolean}
+ */
+export default function shouldReloadMediaSourceOnDecipherabilityUpdate(
+  currentKeySystem : string | null
+) : boolean {
+  return currentKeySystem === null ||
+         currentKeySystem.indexOf("widevine") < 0;
+}

--- a/src/core/buffers/events_generators.ts
+++ b/src/core/buffers/events_generators.ts
@@ -31,12 +31,12 @@ import {
   IBufferManifestMightBeOutOfSync,
   IBufferNeedsDiscontinuitySeek,
   IBufferNeedsManifestRefresh,
-  IBufferNeedsNudgingSeek,
   IBufferStateActive,
   IBufferStateFull,
   IBufferWarningEvent,
   ICompletedBufferEvent,
   IEndOfStreamEvent,
+  INeedsDecipherabilityFlush,
   INeedsMediaSourceReload,
   IPeriodBufferClearedEvent,
   IPeriodBufferReadyEvent,
@@ -130,9 +130,15 @@ const EVENTS = {
              value: { currentTime, isPaused } };
   },
 
-  needsNudgingSeek() : IBufferNeedsNudgingSeek {
-    return { type: "needs-nudging-seek",
-             value: null };
+  needsDecipherabilityFlush(
+    { currentTime,
+      isPaused,
+      duration } : { currentTime : number;
+                     isPaused : boolean;
+                     duration : number; }
+  ) : INeedsDecipherabilityFlush {
+    return { type: "needs-decipherability-flush",
+             value: { currentTime, isPaused, duration } };
   },
 
   periodBufferReady(

--- a/src/core/buffers/types.ts
+++ b/src/core/buffers/types.ts
@@ -115,7 +115,7 @@ export interface IRepresentationChangeEvent {
 export type IAdaptationBufferEvent<T> = IRepresentationBufferEvent<T> |
                                         IBitrateEstimationChangeEvent |
                                         INeedsMediaSourceReload |
-                                        IBufferNeedsNudgingSeek |
+                                        INeedsDecipherabilityFlush |
                                         IRepresentationChangeEvent;
 
 // The currently-downloaded Adaptation changed.
@@ -159,10 +159,14 @@ export interface INeedsMediaSourceReload { type: "needs-media-source-reload";
                                            value: { currentTime : number;
                                                     isPaused : boolean; }; }
 
-// Emitted when we might need to perform a very small seek to continue playback.
-// (e.g. to flush the current buffers)
-export interface IBufferNeedsNudgingSeek { type: "needs-nudging-seek";
-                                           value: null; }
+// Emitted after the buffers have been cleaned due to an update of the
+// decipherability status of some segment.
+// It now needs the current buffer to be "flushed" to be sure it can
+// continue.
+export interface INeedsDecipherabilityFlush { type: "needs-decipherability-flush";
+                                              value: { currentTime : number;
+                                                       isPaused : boolean;
+                                                       duration : number; }; }
 
 // Events coming from single PeriodBuffer
 export type IPeriodBufferEvent = IPeriodBufferReadyEvent |

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -186,13 +186,6 @@ export default function createMediaSourceLoader({
               handleDiscontinuity(gap[1], mediaElement);
             }
             return EMPTY;
-          case "needs-nudging-seek":
-            const { currentTime } = mediaElement;
-            if (currentTime + 0.001 < mediaElement.duration) {
-              mediaElement.currentTime += 0.001;
-            } else {
-              mediaElement.currentTime = currentTime;
-            }
           default:
             return observableOf(evt);
         }


### PR DESCRIPTION
…e when widevine is not used