### PR TITLE
demo: add an "Other" drm choice to specify a custom key system

### DIFF
--- a/demo/full/scripts/components/GenerateLinkURL.jsx
+++ b/demo/full/scripts/components/GenerateLinkURL.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+/**
+ * @param {Object} props
+ * @returns {Object}
+ */
+export default function GeneratedLinkURL({
+  url,
+}) {
+
+  if (url === undefined || url === null || url === "") {
+    return (
+      <span>
+        {"URL: "}
+        <a className="generated-url-link none">
+          Not a valid content!
+        </a>
+      </span>);
+  }
+  return (
+    <span>
+      {"URL: "}
+      <a className="generated-url-link" href={url}>
+        {url}
+      </a>
+    </span>);
+}

--- a/demo/full/scripts/lib/parseDRMConfigurations.js
+++ b/demo/full/scripts/lib/parseDRMConfigurations.js
@@ -4,14 +4,13 @@ import {
   bytesToUTF16Str,
 } from "./bytes.js";
 
-export default function parseDRMConfigurations(
-  drmConfigurations,
-  { fallbackKeyError, fallbackLicenseRequest }
-) {
+export default function parseDRMConfigurations(drmConfigurations) {
   return Promise.all(drmConfigurations.map(drmConfig => {
-    const { licenseServerUrl,
-            serverCertificateUrl,
-            drm } = drmConfig;
+    const { drm,
+            fallbackKeyError,
+            fallbackLicenseRequest,
+            licenseServerUrl,
+            serverCertificateUrl } = drmConfig;
 
     if (!licenseServerUrl) {
       return ;

--- a/demo/full/scripts/lib/url_hash.js
+++ b/demo/full/scripts/lib/url_hash.js
@@ -122,20 +122,22 @@ export function parseHashInURL(hashStr) {
  */
 export function generateLinkForCustomContent({
   autoPlay, // true if autoPlay should be on
-  drmType, // enabled DRM
-  fallbackKeyError,
-  fallbackLicenseRequest,
+  chosenDRMType, // DRM Choice
+  customKeySystem, // key system of a custom DRM if one
+  fallbackKeyError, // `true` if the corresponding switch is enabled
+  fallbackLicenseRequest, // `true` if the corresponding switch is enabled
   licenseServerUrl,
-  lowLatency,
+  lowLatency, // True if the low-latency switch is enabled
   manifestURL,
   serverCertificateUrl,
-  transport,
+  transport, // Choice for the transport protocol
 }) {
   let urlString = "";
   let transportString = "";
   let licenseServerUrlString = "";
   let serverCertificateUrlString = "";
   let drmTypeString = "";
+  let customKeySystemString = "";
   if (manifestURL) {
     urlString = "\\manifest_" +
                 manifestURL.length.toString(36) +
@@ -146,10 +148,15 @@ export function generateLinkForCustomContent({
                       transport.length.toString(36) +
                       "=" + transport;
   }
-  if (drmType) {
+  if (chosenDRMType) {
     drmTypeString = "\\drm_" +
-                    drmType.length.toString(36) +
-                    "=" + drmType;
+                    chosenDRMType.length.toString(36) +
+                    "=" + chosenDRMType;
+  }
+  if (customKeySystem) {
+    customKeySystemString = "\\customKeySystem_" +
+                            customKeySystem.length.toString(36) +
+                            "=" + customKeySystem;
   }
   if (licenseServerUrl) {
     licenseServerUrlString = "\\licenseServ_" +
@@ -179,6 +186,7 @@ export function generateLinkForCustomContent({
          transportString +
          urlString +
          drmTypeString +
+         customKeySystemString +
          licenseServerUrlString +
          serverCertificateUrlString;
 }


### PR DESCRIPTION
Add the possibility to set a custom key system in the demo page.

To choose a custom key system, the user just as to select the "Other" drm type. Doing that will make a new field appear to specify which key system a user want.