### PR TITLE
Fix text track garbage collection / re-insertion (when manual GC is enabled)

### DIFF
--- a/src/custom_source_buffers/text/html/__tests__/utils.test.ts
+++ b/src/custom_source_buffers/text/html/__tests__/utils.test.ts
@@ -46,6 +46,7 @@ describe("HTML Buffer Manager utils - getCuesBefore", () => {
 
     expect(getCuesBefore(cues, 1.5)).toEqual([
       { start: 0, end: 1, element },
+      { start: 1, end: 2, element },
     ]);
   });
 
@@ -145,6 +146,7 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
     ];
 
     expect(getCuesAfter(cues, 2.5)).toEqual([
+      { start: 2, end: 3, element },
       { start: 3, end: 4, element },
     ]);
   });
@@ -158,6 +160,7 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
     ];
 
     expect(getCuesAfter(cues, 2)).toEqual([
+      { start: 2, end: 3, element },
       { start: 3, end: 4, element },
     ]);
   });
@@ -170,7 +173,9 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
       { start: 3, end: 4, element },
     ];
 
-    expect(getCuesAfter(cues, 3)).toEqual([]);
+    expect(getCuesAfter(cues, 3)).toEqual([
+      { start: 3, end: 4, element },
+    ]);
   });
 
   it("should get the right cues when time is before the start of all cues", () => {
@@ -197,12 +202,13 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
     ];
 
     expect(getCuesAfter(cues, 1)).toEqual([
+      { start: 1, end: 2, element },
       { start: 2, end: 3, element },
       { start: 3, end: 4, element },
     ]);
   });
 
-  it("should return an empty arraywhen time is the end of all cues", () => {
+  it("should return an empty array when time is the end of all cues", () => {
     const element = document.createElement("div");
     const cues = [
       { start: 1, end: 2, element },
@@ -213,7 +219,7 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
     expect(getCuesAfter(cues, 4)).toEqual([]);
   });
 
-  it("should return an empty arraywhen time is after the end of all cues", () => {
+  it("should return an empty array when time is after the end of all cues", () => {
     const element = document.createElement("div");
     const cues = [
       { start: 1, end: 2, element },
@@ -260,23 +266,19 @@ describe("HTML Buffer Manager utils - areNearlyEqual", () => {
 describe("HTML Buffer Manager utils - removeCuesInfosBetween", () => {
   it("should remove cues infos between end of a cue and start of another cue", () => {
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-      { start: 2, end: 3, element },
-      { start: 3, end: 4, element },
-      { start: 4, end: 5, element },
-      { start: 5, end: 6, element },
-    ];
+    const cues = [ { start: 1, end: 2, element },
+                   { start: 2, end: 3, element },
+                   { start: 3, end: 4, element },
+                   { start: 4, end: 5, element },
+                   { start: 5, end: 6, element } ];
 
-    const cueInfo = {
-      start: 1,
-      end: 6,
-      cues,
-    };
+    const cueInfo = { start: 1,
+                      end: 6,
+                      cues };
 
     expect(removeCuesInfosBetween(cueInfo, 2, 5)).toEqual([
       { cues: [{ start: 1, end: 2, element }], start: 1, end: 2 },
-      { cues: [], start: 5, end: 6 },
+      { cues: [{ start: 5, end: 6, element }], start: 5, end: 6 },
     ]);
   });
 
@@ -290,15 +292,19 @@ describe("HTML Buffer Manager utils - removeCuesInfosBetween", () => {
       { start: 5, end: 6, element },
     ];
 
-    const cueInfo = {
-      start: 1,
-      end: 6,
-      cues,
-    };
+    const cueInfo = { start: 1,
+                      end: 6,
+                      cues };
 
     expect(removeCuesInfosBetween(cueInfo, 2.5, 4.5)).toEqual([
-      { cues: [{ start: 1, end: 2, element }], start: 1, end: 2.5 },
-      { cues: [{ start: 5, end: 6, element }], start: 4.5, end: 6 },
+      { cues: [ { start: 1, end: 2, element },
+                { start: 2, end: 3, element } ],
+              start: 1,
+              end: 2.5 },
+      { cues: [ { start: 4, end: 5, element },
+                { start: 5, end: 6, element } ],
+              start: 4.5,
+              end: 6 },
     ]);
   });
 
@@ -310,11 +316,9 @@ describe("HTML Buffer Manager utils - removeCuesInfosBetween", () => {
       { start: 5, end: 6, element },
     ];
 
-    const cueInfo = {
-      start: 1,
-      end: 6,
-      cues,
-    };
+    const cueInfo = { start: 1,
+                      end: 6,
+                      cues };
 
     expect(removeCuesInfosBetween(cueInfo, 2.5, 4.5)).toEqual([
       { cues: [{ start: 1, end: 2, element }], start: 1, end: 2.5 },

--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -169,10 +169,8 @@ export default class HTMLTextSourceBuffer
         }
 
         // to spread the time error, we divide the regular chosen interval.
-        // As the clock is also based on real video events, we cannot just
-        // divide by two the regular interval.
         const time = Math.max(this._videoElement.currentTime +
-                              MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 2000,
+                              (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
                               0);
         const cue = this._buffer.get(time);
         if (cue === undefined) {

--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -171,7 +171,7 @@ export default class HTMLTextSourceBuffer
         // to spread the time error, we divide the regular chosen interval.
         // As the clock is also based on real video events, we cannot just
         // divide by two the regular interval.
-        const time = Math.max(this._videoElement.currentTime -
+        const time = Math.max(this._videoElement.currentTime +
                               MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 2000,
                               0);
         const cue = this._buffer.get(time);

--- a/src/custom_source_buffers/text/html/utils.ts
+++ b/src/custom_source_buffers/text/html/utils.ts
@@ -65,23 +65,23 @@ export function areNearlyEqual(a : number, b : number) : boolean {
 }
 
 /**
- * Get all cues strictly before the given time.
+ * Get all cues which have data before the given time.
  * @param {Object} cues
  * @param {Number} time
  * @returns {Array.<Object>}
  */
 export function getCuesBefore(cues : IHTMLCue[], time : number) : IHTMLCue[] {
-  for (let i = 0; i < cues.length; i++) {
+  for (let i = cues.length - 1; i >= 0; i--) {
     const cue = cues[i];
-    if (time < cue.end) {
-      return cues.slice(0, i);
+    if (cue.start < time) {
+      return cues.slice(0, i + 1);
     }
   }
-  return cues.slice();
+  return [];
 }
 
 /**
- * Get all cues strictly after the given time.
+ * Get all cues which have data after the given time.
  * @param {Object} cues
  * @param {Number} time
  * @returns {Array.<Object>}
@@ -89,7 +89,7 @@ export function getCuesBefore(cues : IHTMLCue[], time : number) : IHTMLCue[] {
 export function getCuesAfter(cues : IHTMLCue[], time : number) : IHTMLCue[] {
   for (let i = 0; i < cues.length; i++) {
     const cue = cues[i];
-    if (cue.start > time) {
+    if (cue.end > time) {
       return cues.slice(i, cues.length);
     }
   }
@@ -107,15 +107,15 @@ export function removeCuesInfosBetween(
   start : number,
   end : number
 ) : [ICuesGroup, ICuesGroup] {
-  const end1 = Math.max(cuesInfos.start, start);
+  const endCuesInfos1 = Math.max(cuesInfos.start, start);
   const cues1 = getCuesBefore(cuesInfos.cues, start);
   const cuesInfos1 = { start: cuesInfos.start,
-                       end: end1,
+                       end: endCuesInfos1,
                        cues: cues1 };
 
-  const start2 = Math.min(end, cuesInfos.end);
+  const startCuesInfos2 = Math.min(end, cuesInfos.end);
   const cues2 = getCuesAfter(cuesInfos.cues, end);
-  const cuesInfos2 = { start: start2,
+  const cuesInfos2 = { start: startCuesInfos2,
                        end: cuesInfos.end,
                        cues: cues2 };
   return [cuesInfos1, cuesInfos2];

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -573,7 +573,7 @@ export default function launchTestsForContent(
           autoPlay: false,
         });
         await waitForLoadedStateAfterLoadVideo(player);
-        await sleep(200);
+        await sleep(500);
 
         const initialBufferGap = player.getVideoBufferGap();
         expect(player.getPosition()).to.be.closeTo(minimumPosition, 0.1);
@@ -582,7 +582,7 @@ export default function launchTestsForContent(
 
         xhrMock.lock();
         player.seekTo(minimumPosition + 5);
-        await sleep(200);
+        await sleep(300);
         expect(player.getVideoLoadedTime()).to.be
           .closeTo(initialBufferGap, 0.1);
 


### PR DESCRIPTION
In this branch:

  1. we are much less aggressive with text track garbage collection: When removing in the middle of a cue in a given segment, we update the start of the segment but keep the corresponding cue (it was removed before).
It will just last less time than initially set for (but that's what we want)

  2. Some fixes have been brought in the `remove` function of the HTML text track BufferManager.
     The remove function missed some possible cases.

  3. Be exhaustive in the different possibilities in the `insert` function of the HTML text track BufferManager.
       Using GC means that we will be left with sub-parts of a segment in the buffer instead of the whole thing. When comparing it to a new, complete, segment which should be put somewhere around it, we have to compare both of their placement (e.g. one before/after the other, at the same place, overlapping at the start, overlapping at the end, one completey included in the other, multiple are overlapping in the other etc.).
    The `insert` function has been refactored and should (normally) handle all possible cases now.

  4. Minor text tracks improvements: because displaying the text track at exactly the right time is highly difficult, we had to find ways to reduce the possible delay between the time at which a text track is displayed and the time at which it should be displayed. If previously the logic was that it was better to be late than early, I think the opposite makes much more sense. We're speaking only from a magnitude of several dozens of ms here (if the browser follows) so it's not a huge deal anyway.