### PR TITLE
manifest: manifest/code: decorrelate `isLive` from `isDynamic`

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -410,22 +410,24 @@ can be either:
   - ``fromFirstPosition`` (``Number``): relative position from the minimum
     possible one, in seconds.
     That is:
-      - for live contents, from the beginning of the buffer depth (as defined
-        by the Manifest).
-      - for non-live contents, from the position ``0`` (this option should be
-        equivalent to ``position``)
+      - for dynamic (live) contents, from the beginning of the buffer depth (as
+        defined by the Manifest).
+      - for non-dynamic (vod) contents, from the position ``0`` (this option
+        should be equivalent to ``position``)
 
   - ``fromLastPosition`` (``Number``): relative position from the maximum
     possible one, in seconds. Should be a negative number:
-      - for live contents, it is the difference between the starting position
-        and the live edge (as defined by the manifest)
-      - for non-live contents, it is the difference between the starting
-        position and the end position of the content.
+      - for dynamic (e.g. live) contents, it is the difference between the
+        starting position and the currently last possible position, as defined
+        by the manifest.
+      - for VoD contents, it is the difference between the starting position and
+        the end position of the content.
 
   - ``percentage`` (``Number``): percentage of the wanted position. ``0`` being
-    the minimum position possible (0 for static content, buffer depth for live
-    contents) and ``100`` being the maximum position possible (``duration`` for
-    static content, live edge for live contents).
+    the minimum position possible (0 for static content, buffer depth for
+    dynamic contents) and ``100`` being the maximum position possible
+    (``duration`` for VoD content, last currently possible position for dynamic
+    contents).
 
 
 Note: Only one of those properties will be considered, in the same order of
@@ -439,19 +441,20 @@ More information on how the initial position is chosen can be found [in the
 specific documentation page on this subject](../infos/initial_position.md).
 
 
-#### Notes for live contents
-For live contents, ``startAt`` could work not as expected:
+#### Notes for dynamic contents
+
+For dynamic contents, ``startAt`` could work not as expected:
 
   - Depending on the type of Manifest, it will be more or less precize to guess
-    the live edge of the content. This will mostly affect the
+    the current last position of the content. This will mostly affect the
     ``fromLastPosition`` option.
 
   - If the Manifest does not allow to go far enough in the past (not enough
     buffer, server-side) to respect the position wanted, the maximum buffer
     depth will be used as a starting time instead.
 
-  - If the Manifest does not allow to go far enough in the future (live edge
-    sooner) to respect the position wanted, the live edge will be used to define
+  - If the Manifest does not allow to go far enough in the future to respect the
+    position wanted, the current last available position will be used to define
     the starting time instead.
 
 
@@ -490,8 +493,7 @@ player.loadVideo({
 player.loadVideo({
   // ...
   startAt: {
-    fromLastPosition: -60 // 1 minute before the end (before the live edge
-                          // for live contents)
+    fromLastPosition: -60 // 1 minute before the end
   }
 })
 ```
@@ -548,7 +550,7 @@ considered stable:
     some DASH contents relying on a number-based SegmentTemplate segment
     indexing scheme.
 
-    The upside is that you might have more segments close to the live edge.
+    The upside is that you will have the last segments sooner.
 
     The downside is that requests for segments which did not had time to
     generate might trigger a `NetworkError`. Depending on your other settings

--- a/doc/api/player_events.md
+++ b/doc/api/player_events.md
@@ -91,10 +91,11 @@ The object emitted as the following properties:
   - ``maximumBufferTime`` (``Number|undefined``): The maximum time until which
     the buffer can currently be filled. That is:
 
-    - for non-live contents, the duration.
+    - for static contents (like VoD), the duration.
 
-    - for live contents, the live edge minus a security margin we added to avoid
-      buffering ahead of it.
+    - for dynamic contents (like live contents), the current maximum available
+      position (live edge for live contents) minus a security margin we added to
+      avoid buffering ahead of it.
 
   - ``wallClockTime`` (``Number|undefined``): Only for live contents. The
     current time converted to wall-clock time in seconds.

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -86,7 +86,6 @@ import {
 export interface IAdaptationBufferClockTick extends IRepresentationBufferClockTick {
   bufferGap : number; // /!\ bufferGap of the SourceBuffer
   duration : number; // duration of the HTMLMediaElement
-  isLive : boolean; // If true, we're playing a live content
   isPaused: boolean; // If true, the player is on pause
   speed : number; // Current regular speed asked by the user
 }

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -62,10 +62,9 @@ import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
 export interface IPeriodBufferClockTick {
   currentTime : number; // the current position we are in the video in s
   duration : number; // duration of the HTMLMediaElement
-  isLive : boolean; // If true, we're playing a live content
   isPaused: boolean; // If true, the player is on pause
-  liveGap? : number; // gap between the current position and the live edge of
-                     // the content. Not set for non-live contents
+  liveGap? : number; // gap between the current position and the edge of a
+                     // live content. Not set for non-live contents
   readyState : number; // readyState of the HTMLMediaElement
   speed : number; // playback rate at which the content plays
   stalled : object|null; // if set, the player is currently stalled

--- a/src/core/buffers/representation/representation_buffer.ts
+++ b/src/core/buffers/representation/representation_buffer.ts
@@ -82,8 +82,8 @@ import pushDataToSourceBufferWithRetries from "./push_data";
 // Item emitted by the Buffer's clock$
 export interface IRepresentationBufferClockTick {
   currentTime : number; // the current position we are in the video in s
-  liveGap? : number; // gap between the current position and the live edge of
-                     // the content. Not set for non-live contents
+  liveGap? : number; // gap between the current position and the edge of a
+                     // live content. Not set for non-live contents
   stalled : object|null; // if set, the player is currently stalled
   wantedTimeOffset : number; // offset in s to add to currentTime to obtain the
                              // position we actually want to download from

--- a/src/core/init/create_buffer_clock.ts
+++ b/src/core/init/create_buffer_clock.ts
@@ -72,7 +72,6 @@ export default function createBufferClock(
           duration: tick.duration,
           isPaused: initialPlayPerformed ? tick.paused :
                                            !autoPlay,
-          isLive,
           liveGap: isLive ? manifest.getMaximumPosition() - tick.currentTime :
                             Infinity,
           readyState: tick.readyState,

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -22,17 +22,14 @@ describe("Manifest - Manifest", () => {
 
   it("should create a normalized Manifest structure", () => {
     const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-    const simpleFakeManifest = {
-      id: "man",
-      isLive: false,
-      duration: 5,
-      periods: [],
-      transportType: "foobar",
-    };
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
+    const simpleFakeManifest = { id: "man",
+                                 isDynamic: false,
+                                 isLive: false,
+                                 duration: 5,
+                                 periods: [],
+                                 transportType: "foobar" };
 
     const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
 
@@ -43,6 +40,7 @@ describe("Manifest - Manifest", () => {
     expect(manifest.availabilityStartTime).toEqual(undefined);
     expect(manifest.baseURL).toEqual(undefined);
     expect(manifest.id).toEqual("man");
+    expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(undefined);
     expect(manifest.maximumTime).toEqual(undefined);
@@ -59,14 +57,13 @@ describe("Manifest - Manifest", () => {
 
   it("should create a Period for each manifest.periods given", () => {
     const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
 
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
+                                 isDynamic: false,
                                  isLive: false,
                                  duration: 5,
                                  periods: [period1, period2],
@@ -102,13 +99,12 @@ describe("Manifest - Manifest", () => {
 
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
-    const simpleFakeManifest = {
-      id: "man",
-      isLive: false,
-      duration: 5,
-      periods: [period1, period2],
-      transportType: "foobar",
-    };
+    const simpleFakeManifest = { id: "man",
+                                 isDynamic: false,
+                                 isLive: false,
+                                 duration: 5,
+                                 periods: [period1, period2],
+                                 transportType: "foobar" };
 
     const representationFilter = function() { return false; };
 
@@ -116,10 +112,8 @@ describe("Manifest - Manifest", () => {
       return { id: `foo${period.id}`, parsingErrors: [] };
     });
     const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     const Manifest = require("../manifest").default;
 
     /* tslint:disable no-unused-expression */
@@ -144,22 +138,19 @@ describe("Manifest - Manifest", () => {
     const adapP2 = {};
     const period1 = { id: "0", start: 4, adaptations: adapP1 };
     const period2 = { id: "1", start: 12, adaptations: adapP2 };
-    const simpleFakeManifest = {
-      id: "man",
-      isLive: false,
-      duration: 5,
-      periods: [period1, period2],
-      transportType: "foobar",
-    };
+    const simpleFakeManifest = { id: "man",
+                                 isDynamic: false,
+                                 isLive: false,
+                                 duration: 5,
+                                 periods: [period1, period2],
+                                 transportType: "foobar" };
 
     const fakePeriod = jest.fn((period) => {
       return { ...period, id: `foo${period.id}`, parsingErrors: [] };
     });
     const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     const Manifest = require("../manifest").default;
 
     const manifest = new Manifest(simpleFakeManifest, {});
@@ -186,20 +177,17 @@ describe("Manifest - Manifest", () => {
 
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
-    const simpleFakeManifest = {
-      id: "man",
-      isLive: false,
-      duration: 5,
-      periods: [period1, period2],
-      transportType: "foobar",
-    };
+    const simpleFakeManifest = { id: "man",
+                                 isDynamic: false,
+                                 isLive: false,
+                                 duration: 5,
+                                 periods: [period1, period2],
+                                 transportType: "foobar" };
 
     const fakePeriod = jest.fn((period) => {
-      return {
-        id: `foo${period.id}`,
-        parsingErrors: [ new Error(`a${period.id}`),
-                         new Error(period.id) ],
-      };
+      return { id: `foo${period.id}`,
+               parsingErrors: [ new Error(`a${period.id}`),
+                                new Error(period.id) ] };
     });
     const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     jest.mock("../period", () =>  ({
@@ -221,42 +209,35 @@ describe("Manifest - Manifest", () => {
 
   it("should correctly parse every manifest information given", () => {
     const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
 
     const oldPeriod1 = { id: "0", start: 4, adaptations: {} };
     const oldPeriod2 = { id: "1", start: 12, adaptations: {} };
     const time = performance.now();
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [oldPeriod1, oldPeriod2],
-      maximumTime: { isContinuous: false, value: 10, time },
-      minimumTime: { isContinuous: true, value: 5, time },
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              parsingErrors: [new Error("a"), new Error("b")],
+                              periods: [oldPeriod1, oldPeriod2],
+                              maximumTime: { isContinuous: false, value: 10, time },
+                              minimumTime: { isContinuous: true, value: 5, time },
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
-      return {
-        ...period,
-        id: `foo${period.id}`,
-        parsingErrors: [new Error(period.id)],
-      };
+      return { ...period,
+               id: `foo${period.id}`,
+               parsingErrors: [new Error(period.id)] };
     });
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     const Manifest = require("../manifest").default;
     const manifest = new Manifest(oldManifestArgs, {});
 
@@ -264,6 +245,7 @@ describe("Manifest - Manifest", () => {
     expect(manifest.availabilityStartTime).toEqual(5);
     expect(manifest.baseURL).toEqual("test");
     expect(manifest.id).toEqual("man");
+    expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(13);
     expect(manifest.parsingErrors).toEqual([new Error("0"), new Error("1")]);
@@ -301,13 +283,13 @@ describe("Manifest - Manifest", () => {
     }));
     const Manifest = require("../manifest").default;
 
-    const oldManifestArgs1 = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
+    const oldManifestArgs1 = { availabilityStartTime: 5,
+                               baseURL: "test",
+                               duration: 12,
+                               id: "man",
+                               isDynamic: false,
+                               isLive: false,
+                               lifetime: 13,
       parsingErrors: [new Error("a"), new Error("b")],
       periods: [
         { id: "0", start: 4, adaptations: {} },
@@ -321,23 +303,22 @@ describe("Manifest - Manifest", () => {
     const manifest1 = new Manifest(oldManifestArgs1, {});
     expect(manifest1.getUrl()).toEqual("url1");
 
-    const oldManifestArgs2 = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      minimumTime: 4,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [
-        { id: "0", start: 4, adaptations: {} },
-        { id: "1", start: 12, adaptations: {} },
-      ],
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: [],
-    };
+    const oldManifestArgs2 = { availabilityStartTime: 5,
+                               baseURL: "test",
+                               duration: 12,
+                               id: "man",
+                               isDynamic: false,
+                               isLive: false,
+                               lifetime: 13,
+                               minimumTime: 4,
+                               parsingErrors: [new Error("a"), new Error("b")],
+                               periods: [
+                                 { id: "0", start: 4, adaptations: {} },
+                                 { id: "1", start: 12, adaptations: {} },
+                               ],
+                               suggestedPresentationDelay: 99,
+                               transportType: "foobar",
+                               uris: [] };
     const manifest2 = new Manifest(oldManifestArgs2, {});
     expect(manifest2.getUrl()).toEqual(undefined);
 
@@ -376,24 +357,26 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
 
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [
-        { id: "0", start: 4, adaptations: {} },
-        { id: "1", start: 12, adaptations: {} },
-      ],
-      maximumTime: { isContinuous: false, value: 10, time: 30000 },
-      minimumTime: { isContinuous: true, value: 7, time: 10000 },
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              parsingErrors: [ new Error("a"),
+                                               new Error("b") ],
+                              periods: [ { id: "0", start: 4, adaptations: {} },
+                                         { id: "1", start: 12, adaptations: {} } ],
+                              maximumTime: { isContinuous: false,
+                                             value: 10,
+                                             time: 30000 },
+                              minimumTime: { isContinuous: true,
+                                             value: 7,
+                                             time: 10000 },
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const Manifest = require("../manifest").default;
     const manifest = new Manifest(oldManifestArgs, {});
@@ -407,29 +390,28 @@ describe("Manifest - Manifest", () => {
     const newAdaptations = {};
     const newPeriod1 = { id: "foo0", start: 4, adaptations: {} };
     const newPeriod2 = { id: "foo1", start: 12, adaptations: {} };
-    const newManifest : any = {
-      _duration: 13,
-      adaptations: newAdaptations,
-      availabilityStartTime: 6,
-      baseURL: "test2",
-      id: "man2",
-      isLive: true,
-      lifetime: 14,
-      parsingErrors: [new Error("c"), new Error("d")],
-      suggestedPresentationDelay: 100,
-      timeShiftBufferDepth: 3,
-      maximumTime: newMaximumTime,
-      minimumTime: newMinimumTime,
-      periods: [newPeriod1, newPeriod2],
-      transport: "foob",
-      uris: ["url3", "url4"],
-    };
+    const newManifest : any = { adaptations: newAdaptations,
+                                availabilityStartTime: 6,
+                                baseURL: "test2",
+                                id: "man2",
+                                isDynamic: true,
+                                isLive: true,
+                                lifetime: 14,
+                                parsingErrors: [new Error("c"), new Error("d")],
+                                suggestedPresentationDelay: 100,
+                                timeShiftBufferDepth: 3,
+                                maximumTime: newMaximumTime,
+                                minimumTime: newMinimumTime,
+                                periods: [newPeriod1, newPeriod2],
+                                transport: "foob",
+                                uris: ["url3", "url4"] };
 
     manifest.update(newManifest);
     expect(manifest.adaptations).toEqual(newAdaptations);
     expect(manifest.availabilityStartTime).toEqual(6);
     expect(manifest.baseURL).toEqual("test2");
     expect(manifest.id).toEqual("man2");
+    expect(manifest.isDynamic).toEqual(true);
     expect(manifest.isLive).toEqual(true);
     expect(manifest.lifetime).toEqual(14);
     expect(manifest.parsingErrors).toEqual([new Error("c"), new Error("d")]);
@@ -458,20 +440,19 @@ describe("Manifest - Manifest", () => {
       default: log,
     }));
 
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      minimumTime: 4,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [{ id: "1", start: 4, adaptations: {} }],
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              minimumTime: 4,
+                              parsingErrors: [new Error("a"), new Error("b")],
+                              periods: [{ id: "1", start: 4, adaptations: {} }],
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
@@ -490,10 +471,8 @@ describe("Manifest - Manifest", () => {
       oldPeriod.adaptations = newPeriod.adaptations;
       oldPeriod.parsingErrors = newPeriod.parsingErrors;
     });
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     jest.mock("../update_period_in_place", () =>  ({
       __esModule: true,
       default: fakeUpdatePeriodInPlace,
@@ -504,39 +483,34 @@ describe("Manifest - Manifest", () => {
 
     const eeSpy = jest.spyOn(manifest, "trigger").mockImplementation(jest.fn());
 
-    const newPeriod1 = {
-      id: "pre0",
-      start: 0,
-      adaptations: {},
-      parsingErrors: [],
-    };
-    const newPeriod2 = {
-      id: "pre1",
-      start: 2,
-      adaptations: {},
-      parsingErrors: [],
-    };
-    const newPeriod3 = {
-      id: "foo1",
-      start: 4,
-      adaptations: {},
-      parsingErrors: [],
-    };
-    const newManifest = {
-        _duration: 13,
-      adaptations: {},
-      availabilityStartTime: 6,
-      baseURL: "test2",
-      id: "man2",
-      isLive: true,
-      lifetime: 14,
-      minimumTime: 5,
-      parsingErrors: [new Error("c"), new Error("d")],
-      suggestedPresentationDelay: 100,
-      periods: [newPeriod1, newPeriod2, newPeriod3],
-      transport: "foob",
-      uris: ["url3", "url4"],
-    };
+    const newPeriod1 = { id: "pre0",
+                         start: 0,
+                         adaptations: {},
+                         parsingErrors: [] };
+    const newPeriod2 = { id: "pre1",
+                         start: 2,
+                         adaptations: {},
+                         parsingErrors: [] };
+    const newPeriod3 = { id: "foo1",
+                         start: 4,
+                         adaptations: {},
+                         parsingErrors: [] };
+    const newManifest = { adaptations: {},
+                          availabilityStartTime: 6,
+                          baseURL: "test2",
+                          id: "man2",
+                          isDynamic: false,
+                          isLive: true,
+                          lifetime: 14,
+                          minimumTime: 5,
+                          parsingErrors: [ new Error("c"),
+                                           new Error("d") ],
+                          suggestedPresentationDelay: 100,
+                          periods: [ newPeriod1,
+                                     newPeriod2,
+                                     newPeriod3 ],
+                          transport: "foob",
+                          uris: ["url3", "url4"] };
 
     manifest.update(newManifest as any);
 
@@ -557,33 +531,28 @@ describe("Manifest - Manifest", () => {
 
   it("should append newer Periods when calling `update`", () => {
     const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
 
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      minimumTime: 4,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [{ id: "1" }],
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              minimumTime: 4,
+                              parsingErrors: [new Error("a"), new Error("b")],
+                              periods: [{ id: "1" }],
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
-      return {
-        ...period,
-        id: `foo${period.id}`,
-        parsingErrors: [new Error(period.id)],
-      };
+      return { ...period,
+               id: `foo${period.id}`,
+               parsingErrors: [new Error(period.id)] };
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -591,10 +560,8 @@ describe("Manifest - Manifest", () => {
       });
       oldPeriod.id = newPeriod.id;
     });
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     jest.mock("../update_period_in_place", () =>  ({
       __esModule: true,
       default: fakeUpdatePeriodInPlace,
@@ -608,21 +575,19 @@ describe("Manifest - Manifest", () => {
     const newPeriod1 = { id: "foo1" };
     const newPeriod2 = { id: "post0" };
     const newPeriod3 = { id: "post1" };
-    const newManifest = {
-        _duration: 13,
-      adaptations: {},
-      availabilityStartTime: 6,
-      baseURL: "test2",
-      id: "man2",
-      isLive: true,
-      lifetime: 14,
-      minimumTime: 5,
-      parsingErrors: [new Error("c"), new Error("d")],
-      suggestedPresentationDelay: 100,
-      periods: [newPeriod1, newPeriod2, newPeriod3],
-      transport: "foob",
-      uris: ["url3", "url4"],
-    };
+    const newManifest = { adaptations: {},
+                          availabilityStartTime: 6,
+                          baseURL: "test2",
+                          id: "man2",
+                          isDynamic: false,
+                          isLive: true,
+                          lifetime: 14,
+                          minimumTime: 5,
+                          parsingErrors: [new Error("c"), new Error("d")],
+                          suggestedPresentationDelay: 100,
+                          periods: [newPeriod1, newPeriod2, newPeriod3],
+                          transport: "foob",
+                          uris: ["url3", "url4"] };
 
     manifest.update(newManifest as any);
 
@@ -641,33 +606,28 @@ describe("Manifest - Manifest", () => {
 
   it("should replace different Periods when calling `update`", () => {
     const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
 
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      minimumTime: 4,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [{ id: "1" }],
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              minimumTime: 4,
+                              parsingErrors: [new Error("a"), new Error("b")],
+                              periods: [{ id: "1" }],
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
-      return {
-        ...period,
-        id: `foo${period.id}`,
-        parsingErrors: [new Error(period.id)],
-      };
+      return { ...period,
+               id: `foo${period.id}`,
+               parsingErrors: [new Error(period.id)] };
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -675,10 +635,8 @@ describe("Manifest - Manifest", () => {
       });
       oldPeriod.id = newPeriod.id;
     });
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     jest.mock("../update_period_in_place", () =>  ({
       __esModule: true,
       default: fakeUpdatePeriodInPlace,
@@ -691,21 +649,19 @@ describe("Manifest - Manifest", () => {
     const newPeriod1 = { id: "diff0" };
     const newPeriod2 = { id: "diff1" };
     const newPeriod3 = { id: "diff2" };
-    const newManifest = {
-        _duration: 13,
-      adaptations: {},
-      availabilityStartTime: 6,
-      baseURL: "test2",
-      id: "man2",
-      isLive: true,
-      lifetime: 14,
-      minimumTime: 5,
-      parsingErrors: [new Error("c"), new Error("d")],
-      suggestedPresentationDelay: 100,
-      periods: [newPeriod1, newPeriod2, newPeriod3],
-      transport: "foob",
-      uris: ["url3", "url4"],
-    };
+    const newManifest = { adaptations: {},
+                          availabilityStartTime: 6,
+                          baseURL: "test2",
+                          id: "man2",
+                          isDynamic: false,
+                          isLive: true,
+                          lifetime: 14,
+                          minimumTime: 5,
+                          parsingErrors: [new Error("c"), new Error("d")],
+                          suggestedPresentationDelay: 100,
+                          periods: [newPeriod1, newPeriod2, newPeriod3],
+                          transport: "foob",
+                          uris: ["url3", "url4"] };
 
     manifest.update(newManifest as any);
 
@@ -721,35 +677,30 @@ describe("Manifest - Manifest", () => {
 
   it("should merge overlapping Periods when calling `update`", () => {
     const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: log }));
 
-    const oldManifestArgs = {
-      availabilityStartTime: 5,
-      baseURL: "test",
-      duration: 12,
-      id: "man",
-      isLive: false,
-      lifetime: 13,
-      minimumTime: 4,
-      parsingErrors: [new Error("a"), new Error("b")],
-      periods: [{ id: "1", start: 2 },
-                { id: "2", start: 4 },
-                { id: "3", start: 6 }],
-      suggestedPresentationDelay: 99,
-      transportType: "foobar",
-      uris: ["url1", "url2"],
-    };
+    const oldManifestArgs = { availabilityStartTime: 5,
+                              baseURL: "test",
+                              duration: 12,
+                              id: "man",
+                              isDynamic: false,
+                              isLive: false,
+                              lifetime: 13,
+                              minimumTime: 4,
+                              parsingErrors: [new Error("a"), new Error("b")],
+                              periods: [{ id: "1", start: 2 },
+                                        { id: "2", start: 4 },
+                                        { id: "3", start: 6 }],
+                              suggestedPresentationDelay: 99,
+                              transportType: "foobar",
+                              uris: ["url1", "url2"] };
 
     const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
-      return {
-        ...period,
-        id: `foo${period.id}`,
-        parsingErrors: [new Error(period.id)],
-      };
+      return { ...period,
+               id: `foo${period.id}`,
+               parsingErrors: [new Error(period.id)] };
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -758,10 +709,8 @@ describe("Manifest - Manifest", () => {
       oldPeriod.id = newPeriod.id;
       oldPeriod.start = newPeriod.start;
     });
-    jest.mock("../period", () =>  ({
-      __esModule: true,
-      default: fakePeriod,
-    }));
+    jest.mock("../period", () =>  ({ __esModule: true,
+                                     default: fakePeriod }));
     jest.mock("../update_period_in_place", () =>  ({
       __esModule: true,
       default: fakeUpdatePeriodInPlace,
@@ -777,31 +726,31 @@ describe("Manifest - Manifest", () => {
     const newPeriod3 = { id: "diff0", start: 3 };
     const newPeriod4 = { id: "foo2", start: 4 };
     const newPeriod5 = { id: "post0", start: 5 };
-    const newManifest = {
-        _duration: 13,
-      adaptations: {},
-      availabilityStartTime: 6,
-      baseURL: "test2",
-      id: "man2",
-      isLive: true,
-      lifetime: 14,
-      minimumTime: 5,
-      parsingErrors: [new Error("c"), new Error("d")],
-      suggestedPresentationDelay: 100,
-      periods: [newPeriod1, newPeriod2, newPeriod3, newPeriod4, newPeriod5],
-      transport: "foob",
-      uris: ["url3", "url4"],
-    };
+    const newManifest = { adaptations: {},
+                          availabilityStartTime: 6,
+                          baseURL: "test2",
+                          id: "man2",
+                          isDynamic: false,
+                          isLive: true,
+                          lifetime: 14,
+                          minimumTime: 5,
+                          parsingErrors: [new Error("c"), new Error("d")],
+                          suggestedPresentationDelay: 100,
+                          periods: [ newPeriod1,
+                                     newPeriod2,
+                                     newPeriod3,
+                                     newPeriod4,
+                                     newPeriod5 ],
+                          transport: "foob",
+                          uris: ["url3", "url4"] };
 
     manifest.update(newManifest as any);
 
-    expect(manifest.periods).toEqual([
-      newPeriod1,
-      newPeriod2,
-      newPeriod3,
-      newPeriod4,
-      newPeriod5,
-    ]);
+    expect(manifest.periods).toEqual([ newPeriod1,
+                                       newPeriod2,
+                                       newPeriod3,
+                                       newPeriod4,
+                                       newPeriod5 ]);
 
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledTimes(2);
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledWith(oldPeriod1, newPeriod2);

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -80,7 +80,7 @@ export interface IManifestEvents {
  * while staying agnostic of the transport protocol used (Smooth or DASH).
  *
  * The Manifest and its contained information can evolve over time (like when
- * updating a live manifest of when right management forbid some tracks from
+ * updating a dynamic manifest or when right management forbid some tracks from
  * being played).
  * To perform actions on those changes, any module using this Manifest can
  * listen to its sent events and react accordingly.
@@ -103,10 +103,14 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   // a specific period in time.
   public readonly periods : Period[];
 
-  // If true, this Manifest describes a content still running live.
-  // If false, this Manifest describes a finished content.
-  // At the moment this specificity cannot change with time.
-  // TODO Handle that case?
+  // If true, the Manifest can evolve over time. New content can be downloaded,
+  // properties of the manifest can be changed.
+  public isDynamic : boolean;
+
+  // If true, this Manifest describes a live content.
+  // A live content is a specific kind of dynamic content where you want to play
+  // as close as possible to the maximum position.
+  // E.g., a TV channel is a live content.
   public isLive : boolean;
 
   // Every URI linking to that Manifest, used for refreshing it.
@@ -187,6 +191,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     /* tslint:enable:deprecation */
 
     this.minimumTime = args.minimumTime;
+    this.isDynamic = args.isDynamic;
     this.isLive = args.isLive;
     this.uris = args.uris === undefined ? [] :
                                           args.uris;
@@ -319,6 +324,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     this.availabilityStartTime = newManifest.availabilityStartTime;
     this.baseURL = newManifest.baseURL;
     this.id = newManifest.id;
+    this.isDynamic = newManifest.isDynamic;
     this.isLive = newManifest.isLive;
     this.lifetime = newManifest.lifetime;
     this.maximumTime = newManifest.maximumTime;

--- a/src/parsers/manifest/dash/__tests__/manifest_bounds_calculator.test.ts
+++ b/src/parsers/manifest/dash/__tests__/manifest_bounds_calculator.test.ts
@@ -123,7 +123,7 @@ describe("DASH parsers - ManifestBoundsCalculator", () => {
   });
 
   /* tslint:disable max-line-length */
-  it("should authorize and handle multiple `setLastPositionOffset` calls for live contents", () => {
+  it("should authorize and handle multiple `setLastPositionOffset` calls for dynamic contents", () => {
   /* tslint:enable max-line-length */
     let date = 5000;
     const performanceSpy = jest.spyOn(performance, "now")

--- a/src/parsers/manifest/dash/get_first_time_from_adaptation.ts
+++ b/src/parsers/manifest/dash/get_first_time_from_adaptation.ts
@@ -18,7 +18,7 @@ import { IParsedAdaptation } from "../types";
 
 /**
  * Returns "first time of reference" from the adaptation given, considering a
- * live content.
+ * dynamic content.
  * Undefined if a time could not be found.
  *
  * We consider the latest first time from every representations in the given

--- a/src/parsers/manifest/dash/get_last_time_from_adaptation.ts
+++ b/src/parsers/manifest/dash/get_last_time_from_adaptation.ts
@@ -18,7 +18,7 @@ import { IParsedAdaptation } from "../types";
 
 /**
  * Returns "last time of reference" from the adaptation given, considering a
- * live content.
+ * dynamic content.
  * Undefined if a time could not be found.
  * Null if the Adaptation has no segments (it could be that it didn't started or
  * that it already finished for example).

--- a/src/parsers/manifest/dash/manifest_bounds_calculator.ts
+++ b/src/parsers/manifest/dash/manifest_bounds_calculator.ts
@@ -18,7 +18,7 @@
  * This class allows to easily calculate the first and last available positions
  * in a content at any time.
  *
- * That task can be an hard for live DASH contents: it depends on a
+ * That task can be an hard for dynamic DASH contents: it depends on a
  * `timeShiftBufferDepth` defined in the MPD and on the maximum possible
  * position.
  *
@@ -94,7 +94,7 @@ export default class ManifestBoundsCalculator {
 
   /**
    * Returns `true` if the last position and the position time
-   * (for live content only) have been comunicated.
+   * (for dynamic content only) have been comunicated.
    * `false` otherwise.
    * @returns {boolean}
    */

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -230,6 +230,7 @@ function parseCompleteIntermediateRepresentation(
     clockOffset: args.externalClockOffset,
     id: rootAttributes.id != null ? rootAttributes.id :
                                     "gen-dash-manifest-" + generateManifestID(),
+    isDynamic,
     isLive: isDynamic,
     periods: parsedPeriods,
     suggestedPresentationDelay: rootAttributes.suggestedPresentationDelay,

--- a/src/parsers/manifest/dash/parse_periods.ts
+++ b/src/parsers/manifest/dash/parse_periods.ts
@@ -177,12 +177,12 @@ export default function parsePeriods(
  * it would indicate a last position superior to the `minimumTime` given.
  *
  * This last part allows for example to detect which Period is likely to be the
- * "live" one in multi-periods contents. By giving the Period's start as a
- * `minimumTime`, you ensure that you will get a value only if the live time is
- * in that period.
+ * "current" one in multi-periods contents. By giving the Period's start as a
+ * `minimumTime`, you ensure that you will get a value only if the current time
+ * is in that period.
  *
  * This is useful as guessing the live time from the clock can be seen as a last
- * resort. By detecting that the live time is before the currently considered
+ * resort. By detecting that the current time is before the currently considered
  * Period, we can just parse and look at the previous Period. If we can guess
  * the live time more directly from that previous one, we might be better off
  * than just using the clock.

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -42,8 +42,8 @@ export interface IAdaptationInfos {
   baseURL? : string; // Eventual URL from which every relative URL will be based
                      // on
   manifestBoundsCalculator : ManifestBoundsCalculator; // Allows to obtain the first
-                                                 // available position of a live
-                                                 // content
+                                                       // available position of a
+                                                       // dynamic content
   end? : number; // End time of the current period, in seconds
   isDynamic : boolean; // Whether the Manifest can evolve with time
   receivedTime? : number; // time (in terms of `performance.now`) at which the
@@ -59,8 +59,8 @@ interface IIndexContext {
                             // they are not yet finished
   availabilityTimeOffset: number;
   manifestBoundsCalculator : ManifestBoundsCalculator; // Allows to obtain the first
-                                                       // available position of a live
-                                                       // content
+                                                       // available position of a
+                                                       // dynamic content
   isDynamic : boolean; // Whether the Manifest can evolve with time
   periodStart : number; // Start of the period concerned by this
                         // RepresentationIndex, in seconds

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -610,6 +610,7 @@ function createSmoothStreamingParser(
       clockOffset: serverTimeOffset,
       id: "gen-smooth-manifest-" + generateManifestID(),
       isLive,
+      isDynamic: isLive,
       maximumTime,
       minimumTime,
       periods: [{ adaptations,

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -147,6 +147,7 @@ export interface ISmoothRIOptions {
   segmentPrivateInfos : ISmoothInitSegmentPrivateInfos;
 }
 
+// Information allowing to generate an init segment
 interface ISmoothInitSegmentPrivateInfos {
   bitsPerSample? : number;
   channels? : number;

--- a/src/parsers/manifest/smooth/utils/add_segment_infos.ts
+++ b/src/parsers/manifest/smooth/utils/add_segment_infos.ts
@@ -20,14 +20,8 @@ export interface IIndexSegment { start : number;
                                  duration : number;
                                  repeatCount: number; }
 
-export interface ITimelineIndex { presentationTimeOffset? : number;
-                                  timescale : number;
-                                  media : string;
-                                  timeline : IIndexSegment[];
-                                  startNumber? : number;
-                                  isLive : boolean;
-                                  timeShiftBufferDepth? : number;
-                                  manifestReceivedTime? : number; }
+export interface ITimelineIndex { timescale : number;
+                                  timeline : IIndexSegment[]; }
 
 /**
  * Add a new segment to the index.

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -87,9 +87,10 @@ export interface IParsedPeriod {
 export interface IParsedManifest {
   // required
   id: string; // Unique ID for the manifest.
-  isLive : boolean; // If true, this Manifest describes a content not finished yet.
+  isDynamic : boolean; // If true, this Manifest can be updated
+  isLive : boolean; // If true, this Manifest describes a "live" content
   periods: IParsedPeriod[]; // Periods contained in this manifest.
-  transportType: string; // "smooth", "dash" etc.
+  transportType: string; // "smooth", "dash", "metaplaylist" etc.
 
   // optional
   availabilityStartTime? : number; // Base time from which the segments are generated.

--- a/tests/contents/DASH_dynamic_SegmentTemplate/infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate/infos.js
@@ -10,6 +10,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "Manifest.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   periods: [
     {

--- a/tests/contents/DASH_dynamic_SegmentTimeline/infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTimeline/infos.js
@@ -10,6 +10,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "Manifest.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   periods: [
     {

--- a/tests/contents/DASH_dynamic_UTCTimings/with_direct.js
+++ b/tests/contents/DASH_dynamic_UTCTimings/with_direct.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_with_direct.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   availabilityStartTime: 0,
   periods: [

--- a/tests/contents/DASH_dynamic_UTCTimings/with_direct_and_http.js
+++ b/tests/contents/DASH_dynamic_UTCTimings/with_direct_and_http.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_with_direct_and_http.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   availabilityStartTime: 0,
   periods: [

--- a/tests/contents/DASH_dynamic_UTCTimings/with_http.js
+++ b/tests/contents/DASH_dynamic_UTCTimings/with_http.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_with_http.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   availabilityStartTime: 0,
   periods: [

--- a/tests/contents/DASH_dynamic_UTCTimings/without_timings.js
+++ b/tests/contents/DASH_dynamic_UTCTimings/without_timings.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_without_timings.mpd",
   transport: "dash",
+  isDynamic: true,
   isLive: true,
   availabilityStartTime: 0,
   periods: [

--- a/tests/contents/DASH_static_SegmentBase_multi_codecs/infos.js
+++ b/tests/contents/DASH_static_SegmentBase_multi_codecs/infos.js
@@ -10,6 +10,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "dash.mpd",
   transport: "dash",
+  isDynamic: false,
   isLive: false,
   duration: 60.022,
   minimumPosition: 0,

--- a/tests/contents/DASH_static_SegmentTemplate_Multi_Periods/infos.js
+++ b/tests/contents/DASH_static_SegmentTemplate_Multi_Periods/infos.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "mp4-live-periods-mpd.mpd",
   transport: "dash",
+  isDynamic: false,
   isLive: false,
   duration: 240,
   minimumPosition: 0,

--- a/tests/contents/DASH_static_SegmentTimeline/infos.js
+++ b/tests/contents/DASH_static_SegmentTimeline/infos.js
@@ -7,6 +7,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "ateam.mpd",
   transport: "dash",
+  isDynamic: false,
   isLive: false,
   duration: 101.476,
   minimumPosition: 0,

--- a/tests/contents/DASH_static_SegmentTimeline/not_starting_at_0.js
+++ b/tests/contents/DASH_static_SegmentTimeline/not_starting_at_0.js
@@ -7,6 +7,7 @@ const BASE_URL = "http://" +
 export default {
   url: BASE_URL + "not_starting_at_0.mpd",
   transport: "dash",
+  isDynamic: false,
   isLive: false,
   minimumPosition: 12.032222222222222,
   maximumPosition: 101.476,

--- a/tests/contents/Smooth_static/custom_attributes.js
+++ b/tests/contents/Smooth_static/custom_attributes.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_Custom_Attributes.xml",
   transport: "smooth",
+  isDynamic: false,
   isLive: false,
   duration: 75,
   minimumPosition: 0,

--- a/tests/contents/Smooth_static/empty_text_track.js
+++ b/tests/contents/Smooth_static/empty_text_track.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_Empty_Text_Track.xml",
   transport: "smooth",
+  isDynamic: false,
   isLive: false,
   duration: 75,
   minimumPosition: 0,

--- a/tests/contents/Smooth_static/not_starting_at_0.js
+++ b/tests/contents/Smooth_static/not_starting_at_0.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_Not_Starting_at_0.xml",
   transport: "smooth",
+  isDynamic: false,
   isLive: false,
   duration: 75 - 6.016,
   minimumPosition: 6.016,

--- a/tests/contents/Smooth_static/regular.js
+++ b/tests/contents/Smooth_static/regular.js
@@ -8,6 +8,7 @@ const BASE_URL = "http://" +
 const manifestInfos = {
   url: BASE_URL + "Manifest_Regular.xml",
   transport: "smooth",
+  isDynamic: false,
   isLive: false,
   duration: 75,
   minimumPosition: 0,

--- a/tests/integration/scenarios/dash_live.js
+++ b/tests/integration/scenarios/dash_live.js
@@ -41,6 +41,7 @@ describe("DASH live content (SegmentTimeline)", function () {
     expect(manifest.transport)
       .to.equal(manifestInfos.transport);
     expect(typeof manifest.id).to.equal("string");
+    expect(manifest.isDynamic).to.equal(true);
     expect(manifest.isLive).to.equal(true);
     expect(manifest.getUrl()).to.equal(manifestInfos.url);
 

--- a/tests/integration/scenarios/dash_live_SegmentTemplate.js
+++ b/tests/integration/scenarios/dash_live_SegmentTemplate.js
@@ -40,6 +40,7 @@ describe("DASH live content (SegmentTemplate)", function() {
     expect(manifest.transport)
       .to.equal(manifestInfos.transport);
     expect(typeof manifest.id).to.equal("string");
+    expect(manifest.isDynamic).to.equal(true);
     expect(manifest.isLive).to.equal(true);
     expect(manifest.getUrl()).to.equal(manifestInfos.url);
 

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -14,6 +14,7 @@ import XHRMock from "../../utils/request_mock";
  * url {string}
  * transport {string}
  * duration {number}
+ * isDynamic {boolean}
  * isLive {boolean}
  * maximumPosition? {number}
  * minimumPosition? {number}
@@ -45,20 +46,17 @@ import XHRMock from "../../utils/request_mock";
  *                                                .mediaURL {string}
  * ```
  */
-export default function launchTestsForContent(
-  manifestInfos
-) {
+export default function launchTestsForContent(manifestInfos) {
   let player;
   let xhrMock;
 
-  const {
-    availabilityStartTime,
-    isLive,
-    maximumPosition,
-    minimumPosition,
-    periods: periodsInfos,
-    transport,
-  } = manifestInfos;
+  const { availabilityStartTime,
+          isDynamic,
+          isLive,
+          maximumPosition,
+          minimumPosition,
+          periods: periodsInfos,
+          transport } = manifestInfos;
 
   const firstPeriodIndex = isLive ? periodsInfos.length - 1 : 0;
   const videoRepresentationsForFirstPeriod =
@@ -175,6 +173,7 @@ export default function launchTestsForContent(
         expect(typeof manifest).to.equal("object");
         expect(manifest.transport).to.equal(transport);
         expect(typeof manifest.id).to.equal("string");
+        expect(manifest.isDynamic).to.equal(isDynamic);
         expect(manifest.isLive).to.equal(isLive);
         expect(manifest.getUrl()).to.equal(manifestInfos.url);
 


### PR DESCRIPTION
This will allow future use cases such as dynamic but non-live local contents. Basically, dynamic contents are not finished yet and continue to be recorded and live contents are meant to be played close to the live edge