### PR TITLE
Code/rename managers

### DIFF
--- a/doc/architecture/api/index.md
+++ b/doc/architecture/api/index.md
@@ -68,7 +68,7 @@ To facilitate those actions, the API relies on multiple building blocks:
     the Player. Many RxPlayer modules rely on that clock.
 
 
-  - __the TrackManager__
+  - __the TrackChoiceManager__
 
     Ease up text/audio/video track switching to provide a simple-to-use API.
 

--- a/doc/architecture/index.md
+++ b/doc/architecture/index.md
@@ -113,9 +113,9 @@ To better understand the player's architecture, you can find below a
      +-------------------------------------------+     |  ~~~> Send events |   |
      |                    API                    |     +-------------------+   |
      +-------------------------------------------+                             |
- +--------------+    |            | ^                                          |
- | TrackManager | <--+            | ~                                          |
- +--------------+                 | ~                                          |
+ +--------------------+    |      | ^                                          |
+ | TrackChoiceManager | <--+      | ~                                          |
+ +--------------------+           | ~                                          |
  Facilitate track                 | ~                                          |
  switching for                    V ~                                          |
  the API                  +---------------+                                    |

--- a/doc/architecture/pipelines/index.md
+++ b/doc/architecture/pipelines/index.md
@@ -12,7 +12,7 @@ Each of those task is performed by a discrete component of the Pipeline:
 
   - The __Manifest Pipeline__ is used to download and parse the manifest file.
 
-  - The __SegmentPipelinesManager__ is used to create Segment pipelines,
+  - The __SegmentPipelineCreator__ is used to create Segment pipelines,
     allowing to download and parse media segments.
 
 
@@ -27,20 +27,20 @@ request and parsing of the Manifest file.
 
 
 
-## The SegmentPipelinesManager #################################################
+## The SegmentPipelineCreator ##################################################
 
-The SegmentPipelineManager allows to easily perform Segment downloads for the
+The SegmentPipelineCreator allows to easily perform Segment downloads for the
 rest of the code.
 This is the part of the code that interacts with the transport protocols -
 defined in `transports` - to load and parse media segments.
 
-To do so, the SegmentPipelineManager creates Pipelines of different types
+To do so, the SegmentPipelineCreator creates "Pipelines" of different types
 (example: a video or audio Pipeline) when you ask for it.
 Through those Pipelines, you can then schedule various segment requests with a
 given priority.
 
 The priority of this request is then corroborated with the priority of all
-requests currently pending in the SegmentPipelineManager (and not only with
+requests currently pending in the SegmentPipelineCreator (and not only with
 those on the current pipeline) to know when the request should effectively be
 done.
 
@@ -61,7 +61,7 @@ If the request has no priorization number, the lowest priorization number
 (the highest priority) will be set on it: ``0``
 
 Basically, any new request will have their priorization number compared to the
-one of the current request(s) done by the SegmentPipelineManager:
+one of the current request(s) done by the SegmentPipelineCreator:
 
   - if no request is already pending, we perform the request immediately
 

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -32,5 +32,5 @@ export {
 export {
   IAudioTrackPreference,
   ITextTrackPreference,
-} from "./track_manager";
+} from "./track_choice_manager";
 export default Player;

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -37,7 +37,7 @@ import { IKeySystemOption } from "../eme";
 import {
   IAudioTrackPreference,
   ITextTrackPreference,
-} from "./track_manager";
+} from "./track_choice_manager";
 
 const { DEFAULT_AUTO_PLAY,
         DEFAULT_INITIAL_BITRATES,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1819,7 +1819,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @param {string} eventName
    * @param {*} value - its new value
    */
-  private _priv_triggerContentEvent<TEventName extends keyof IPublicAPIEvent>(
+  private _priv_triggerEventIfChanged<TEventName extends keyof IPublicAPIEvent>(
     eventName : TEventName,
     value : IPublicAPIEvent[TEventName]
   ) : void {
@@ -1876,7 +1876,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         this._priv_contentInfos.sourceBuffersStore = event.value.sourceBuffersStore;
         break;
       case "decipherabilityUpdate":
-        this._priv_triggerContentEvent("decipherabilityUpdate", event.value);
+        this._priv_triggerEventIfChanged("decipherabilityUpdate", event.value);
         break;
       case "added-segment":
         if (this._priv_contentInfos === null) {
@@ -1994,13 +1994,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     this._priv_contentInfos.currentPeriod = period;
 
-    this._priv_triggerContentEvent("periodChange", period);
-    this._priv_triggerContentEvent("availableAudioTracksChange",
-                                   this.getAvailableAudioTracks());
-    this._priv_triggerContentEvent("availableTextTracksChange",
-                                   this.getAvailableTextTracks());
-    this._priv_triggerContentEvent("availableVideoTracksChange",
-                                    this.getAvailableVideoTracks());
+    this._priv_triggerEventIfChanged("periodChange", period);
+    this._priv_triggerEventIfChanged("availableAudioTracksChange",
+                                     this.getAvailableAudioTracks());
+    this._priv_triggerEventIfChanged("availableTextTracksChange",
+                                     this.getAvailableTextTracks());
+    this._priv_triggerEventIfChanged("availableVideoTracksChange",
+                                     this.getAvailableVideoTracks());
 
     // Emit intial events for the Period
     if (this._priv_trackChoiceManager != null) {
@@ -2008,29 +2008,29 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       const textTrack = this._priv_trackChoiceManager.getChosenTextTrack(period);
       const videoTrack = this._priv_trackChoiceManager.getChosenVideoTrack(period);
 
-      this._priv_triggerContentEvent("audioTrackChange", audioTrack);
-      this._priv_triggerContentEvent("textTrackChange", textTrack);
-      this._priv_triggerContentEvent("videoTrackChange", videoTrack);
+      this._priv_triggerEventIfChanged("audioTrackChange", audioTrack);
+      this._priv_triggerEventIfChanged("textTrackChange", textTrack);
+      this._priv_triggerEventIfChanged("videoTrackChange", videoTrack);
     } else {
-      this._priv_triggerContentEvent("audioTrackChange", null);
-      this._priv_triggerContentEvent("textTrackChange", null);
-      this._priv_triggerContentEvent("videoTrackChange", null);
+      this._priv_triggerEventIfChanged("audioTrackChange", null);
+      this._priv_triggerEventIfChanged("textTrackChange", null);
+      this._priv_triggerEventIfChanged("videoTrackChange", null);
     }
 
-    this._priv_triggerContentEvent("availableAudioBitratesChange",
-                                   this.getAvailableAudioBitrates());
-    this._priv_triggerContentEvent("availableVideoBitratesChange",
-                                   this.getAvailableVideoBitrates());
+    this._priv_triggerEventIfChanged("availableAudioBitratesChange",
+                                     this.getAvailableAudioBitrates());
+    this._priv_triggerEventIfChanged("availableVideoBitratesChange",
+                                     this.getAvailableVideoBitrates());
 
     const activeAudioRepresentations = this.getCurrentRepresentations();
     if (activeAudioRepresentations != null &&
         activeAudioRepresentations.audio != null)
     {
       const bitrate = activeAudioRepresentations.audio.bitrate;
-      this._priv_triggerContentEvent("audioBitrateChange",
-                                     bitrate != null ? bitrate : -1);
+      this._priv_triggerEventIfChanged("audioBitrateChange",
+                                       bitrate != null ? bitrate : -1);
     } else {
-      this._priv_triggerContentEvent("audioBitrateChange", -1);
+      this._priv_triggerEventIfChanged("audioBitrateChange", -1);
     }
 
     const activeVideoRepresentations = this.getCurrentRepresentations();
@@ -2038,10 +2038,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         activeVideoRepresentations.video != null)
     {
       const bitrate = activeVideoRepresentations.video.bitrate;
-      this._priv_triggerContentEvent("videoBitrateChange",
-                                     bitrate != null ? bitrate : -1);
+      this._priv_triggerEventIfChanged("videoBitrateChange",
+                                       bitrate != null ? bitrate : -1);
     } else {
-      this._priv_triggerContentEvent("videoBitrateChange", -1);
+      this._priv_triggerEventIfChanged("videoBitrateChange", -1);
     }
   }
 
@@ -2196,21 +2196,21 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         case "audio":
           const audioTrack = this._priv_trackChoiceManager
             .getChosenAudioTrack(currentPeriod);
-          this._priv_triggerContentEvent("audioTrackChange", audioTrack);
-          this._priv_triggerContentEvent("availableAudioBitratesChange",
-                                         this.getAvailableVideoBitrates());
+          this._priv_triggerEventIfChanged("audioTrackChange", audioTrack);
+          this._priv_triggerEventIfChanged("availableAudioBitratesChange",
+                                           this.getAvailableVideoBitrates());
           break;
         case "text":
           const textTrack = this._priv_trackChoiceManager
             .getChosenTextTrack(currentPeriod);
-          this._priv_triggerContentEvent("textTrackChange", textTrack);
+          this._priv_triggerEventIfChanged("textTrackChange", textTrack);
           break;
         case "video":
           const videoTrack = this._priv_trackChoiceManager
             .getChosenVideoTrack(currentPeriod);
-          this._priv_triggerContentEvent("videoTrackChange", videoTrack);
-          this._priv_triggerContentEvent("availableVideoBitratesChange",
-                                         this.getAvailableVideoBitrates());
+          this._priv_triggerEventIfChanged("videoTrackChange", videoTrack);
+          this._priv_triggerEventIfChanged("availableVideoBitratesChange",
+                                           this.getAvailableVideoBitrates());
           break;
       }
     }
@@ -2255,11 +2255,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                                              representation.bitrate;
     if (period != null && currentPeriod != null && currentPeriod.id === period.id) {
       if (type === "video") {
-        this._priv_triggerContentEvent("videoBitrateChange",
-                                       bitrate != null ? bitrate : -1);
+        this._priv_triggerEventIfChanged("videoBitrateChange",
+                                         bitrate != null ? bitrate : -1);
       } else if (type === "audio") {
-        this._priv_triggerContentEvent("audioBitrateChange",
-                                       bitrate != null ? bitrate : -1);
+        this._priv_triggerEventIfChanged("audioBitrateChange",
+                                         bitrate != null ? bitrate : -1);
       }
     }
   }
@@ -2280,7 +2280,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (bitrate != null) {
       this._priv_bitrateInfos.lastBitrates[type] = bitrate;
     }
-    this._priv_triggerContentEvent("bitrateEstimationChange", { type, bitrate });
+    this._priv_triggerEventIfChanged("bitrateEstimationChange", { type, bitrate });
   }
 
   /**

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -112,7 +112,7 @@ import {
   parseConstructorOptions,
   parseLoadVideoOptions,
 } from "./option_parsers";
-import TrackManager, {
+import TrackChoiceManager, {
   IAudioTrackPreference,
   ITextTrackPreference,
   ITMAudioTrack,
@@ -121,7 +121,7 @@ import TrackManager, {
   ITMTextTrackListItem,
   ITMVideoTrack,
   ITMVideoTrackListItem
-} from "./track_manager";
+} from "./track_choice_manager";
 
 const { DEFAULT_UNMUTED_VOLUME } = config;
 
@@ -370,11 +370,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
 
   /**
-   * TrackManager instance linked to the current content.
+   * TrackChoiceManager instance linked to the current content.
    * Null if no content has been loaded or if the current content loaded
-   * has no TrackManager.
+   * has no TrackChoiceManager.
    */
-  private _priv_trackManager : TrackManager|null;
+  private _priv_trackChoiceManager : TrackChoiceManager|null;
 
   /**
    * Emit last picture in picture event.
@@ -551,7 +551,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_limitVideoWidth = limitVideoWidth;
     this._priv_mutedMemory = DEFAULT_UNMUTED_VOLUME;
 
-    this._priv_trackManager = null;
+    this._priv_trackChoiceManager = null;
     this._priv_currentError = null;
     this._priv_contentInfos = null;
 
@@ -1511,10 +1511,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return [];
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return [];
     }
-    return this._priv_trackManager.getAvailableAudioTracks(currentPeriod);
+    return this._priv_trackChoiceManager.getAvailableAudioTracks(currentPeriod);
   }
 
   /**
@@ -1526,10 +1526,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return [];
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return [];
     }
-    return this._priv_trackManager.getAvailableTextTracks(currentPeriod);
+    return this._priv_trackChoiceManager.getAvailableTextTracks(currentPeriod);
   }
 
   /**
@@ -1541,10 +1541,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return [];
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return [];
     }
-    return this._priv_trackManager.getAvailableVideoTracks(currentPeriod);
+    return this._priv_trackChoiceManager.getAvailableVideoTracks(currentPeriod);
   }
 
   /**
@@ -1556,10 +1556,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return undefined;
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return undefined;
     }
-    return this._priv_trackManager.getChosenAudioTrack(currentPeriod);
+    return this._priv_trackChoiceManager.getChosenAudioTrack(currentPeriod);
   }
 
   /**
@@ -1571,10 +1571,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return undefined;
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return undefined;
     }
-    return this._priv_trackManager.getChosenTextTrack(currentPeriod);
+    return this._priv_trackChoiceManager.getChosenTextTrack(currentPeriod);
   }
 
   /**
@@ -1586,16 +1586,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return undefined;
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return undefined;
     }
-    return this._priv_trackManager.getChosenVideoTrack(currentPeriod);
+    return this._priv_trackChoiceManager.getChosenVideoTrack(currentPeriod);
   }
 
   /**
    * Update the audio language for the current Period.
    * @param {string} audioId
-   * @throws Error - the current content has no TrackManager.
+   * @throws Error - the current content has no TrackChoiceManager.
    * @throws Error - the given id is linked to no audio track.
    */
   setAudioTrack(audioId : string) : void {
@@ -1603,11 +1603,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       throw new Error("No content loaded");
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       throw new Error("No compatible content launched.");
     }
     try {
-      this._priv_trackManager.setAudioTrackByID(currentPeriod, audioId);
+      this._priv_trackChoiceManager.setAudioTrackByID(currentPeriod, audioId);
     }
     catch (e) {
       throw new Error("player: unknown audio track");
@@ -1617,7 +1617,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /**
    * Update the text language for the current Period.
    * @param {string} sub
-   * @throws Error - the current content has no TrackManager.
+   * @throws Error - the current content has no TrackChoiceManager.
    * @throws Error - the given id is linked to no text track.
    */
   setTextTrack(textId : string) : void {
@@ -1625,11 +1625,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       throw new Error("No content loaded");
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       throw new Error("No compatible content launched.");
     }
     try {
-      this._priv_trackManager.setTextTrackByID(currentPeriod, textId);
+      this._priv_trackChoiceManager.setTextTrackByID(currentPeriod, textId);
     }
     catch (e) {
       throw new Error("player: unknown text track");
@@ -1644,16 +1644,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return;
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       return;
     }
-    return this._priv_trackManager.disableTextTrack(currentPeriod);
+    return this._priv_trackChoiceManager.disableTextTrack(currentPeriod);
   }
 
   /**
    * Update the video track for the current Period.
    * @param {string} videoId
-   * @throws Error - the current content has no TrackManager.
+   * @throws Error - the current content has no TrackChoiceManager.
    * @throws Error - the given id is linked to no video track.
    */
   setVideoTrack(videoId : string) : void {
@@ -1661,11 +1661,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       throw new Error("No content loaded");
     }
     const { currentPeriod } = this._priv_contentInfos;
-    if (this._priv_trackManager === null || currentPeriod === null) {
+    if (this._priv_trackChoiceManager === null || currentPeriod === null) {
       throw new Error("No compatible content launched.");
     }
     try {
-      this._priv_trackManager.setVideoTrackByID(currentPeriod, videoId);
+      this._priv_trackChoiceManager.setVideoTrackByID(currentPeriod, videoId);
     }
     catch (e) {
       throw new Error("player: unknown video track");
@@ -1794,7 +1794,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_contentLock$.next(true);
 
     this._priv_contentInfos = null;
-    this._priv_trackManager = null;
+    this._priv_trackChoiceManager = null;
 
     this._priv_contentEventsMemory = {};
 
@@ -1962,7 +1962,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_contentInfos.manifest = manifest;
 
     const { initialAudioTrack, initialTextTrack } = this._priv_contentInfos;
-    this._priv_trackManager = new TrackManager({
+    this._priv_trackChoiceManager = new TrackChoiceManager({
       preferredAudioTracks: initialAudioTrack === undefined ?
         this._priv_preferredAudioTracks :
         new BehaviorSubject([initialAudioTrack]),
@@ -1975,8 +1975,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       .pipe(takeUntil(this._priv_stopCurrentContent$))
       .subscribe(() => {
         // Update the tracks chosen if it changed
-        if (this._priv_trackManager != null) {
-          this._priv_trackManager.update();
+        if (this._priv_trackChoiceManager != null) {
+          this._priv_trackChoiceManager.update();
         }
       });
   }
@@ -2003,10 +2003,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                                     this.getAvailableVideoTracks());
 
     // Emit intial events for the Period
-    if (this._priv_trackManager != null) {
-      const audioTrack = this._priv_trackManager.getChosenAudioTrack(period);
-      const textTrack = this._priv_trackManager.getChosenTextTrack(period);
-      const videoTrack = this._priv_trackManager.getChosenVideoTrack(period);
+    if (this._priv_trackChoiceManager != null) {
+      const audioTrack = this._priv_trackChoiceManager.getChosenAudioTrack(period);
+      const textTrack = this._priv_trackChoiceManager.getChosenTextTrack(period);
+      const videoTrack = this._priv_trackChoiceManager.getChosenVideoTrack(period);
 
       this._priv_triggerContentEvent("audioTrackChange", audioTrack);
       this._priv_triggerContentEvent("textTrackChange", textTrack);
@@ -2060,32 +2060,32 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     switch (type) {
 
       case "video":
-        if (this._priv_trackManager === null) {
-          log.error("API: TrackManager not instanciated for a new video period");
+        if (this._priv_trackChoiceManager === null) {
+          log.error("API: TrackChoiceManager not instanciated for a new video period");
           adaptation$.next(null);
         } else {
-          this._priv_trackManager.addPeriod(type, period, adaptation$);
-          this._priv_trackManager.setInitialVideoTrack(period);
+          this._priv_trackChoiceManager.addPeriod(type, period, adaptation$);
+          this._priv_trackChoiceManager.setInitialVideoTrack(period);
         }
         break;
 
       case "audio":
-        if (this._priv_trackManager === null) {
-          log.error(`API: TrackManager not instanciated for a new ${type} period`);
+        if (this._priv_trackChoiceManager === null) {
+          log.error(`API: TrackChoiceManager not instanciated for a new ${type} period`);
           adaptation$.next(null);
         } else {
-          this._priv_trackManager.addPeriod(type, period, adaptation$);
-          this._priv_trackManager.setInitialAudioTrack(period);
+          this._priv_trackChoiceManager.addPeriod(type, period, adaptation$);
+          this._priv_trackChoiceManager.setInitialAudioTrack(period);
         }
         break;
 
       case "text":
-        if (this._priv_trackManager === null) {
-          log.error(`API: TrackManager not instanciated for a new ${type} period`);
+        if (this._priv_trackChoiceManager === null) {
+          log.error(`API: TrackChoiceManager not instanciated for a new ${type} period`);
           adaptation$.next(null);
         } else {
-          this._priv_trackManager.addPeriod(type, period, adaptation$);
-          this._priv_trackManager.setInitialTextTrack(period);
+          this._priv_trackChoiceManager.addPeriod(type, period, adaptation$);
+          this._priv_trackChoiceManager.setInitialTextTrack(period);
         }
         break;
 
@@ -2110,13 +2110,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }) : void {
     const { type, period } = value;
 
-    // Clean-up track choice from TrackManager
+    // Clean-up track choice from TrackChoiceManager
     switch (type) {
       case "audio":
       case "text":
       case "video":
-        if (this._priv_trackManager != null) {
-          this._priv_trackManager.removePeriod(type, period);
+        if (this._priv_trackChoiceManager != null) {
+          this._priv_trackChoiceManager.removePeriod(type, period);
         }
         break;
     }
@@ -2150,8 +2150,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (this._priv_contentInfos !== null) {
       this._priv_contentInfos.sourceBuffersStore = null;
     }
-    if (this._priv_trackManager !== null) {
-      this._priv_trackManager.resetPeriods();
+    if (this._priv_trackChoiceManager !== null) {
+      this._priv_trackChoiceManager.resetPeriods();
     }
   }
 
@@ -2188,23 +2188,26 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       activePeriodAdaptations[type] = adaptation;
     }
 
-    if (this._priv_trackManager != null &&
+    if (this._priv_trackChoiceManager != null &&
         currentPeriod != null && period != null &&
         period.id === currentPeriod.id
     ) {
       switch (type) {
         case "audio":
-          const audioTrack = this._priv_trackManager.getChosenAudioTrack(currentPeriod);
+          const audioTrack = this._priv_trackChoiceManager
+            .getChosenAudioTrack(currentPeriod);
           this._priv_triggerContentEvent("audioTrackChange", audioTrack);
           this._priv_triggerContentEvent("availableAudioBitratesChange",
                                          this.getAvailableVideoBitrates());
           break;
         case "text":
-          const textTrack = this._priv_trackManager.getChosenTextTrack(currentPeriod);
+          const textTrack = this._priv_trackChoiceManager
+            .getChosenTextTrack(currentPeriod);
           this._priv_triggerContentEvent("textTrackChange", textTrack);
           break;
         case "video":
-          const videoTrack = this._priv_trackManager.getChosenVideoTrack(currentPeriod);
+          const videoTrack = this._priv_trackChoiceManager
+            .getChosenVideoTrack(currentPeriod);
           this._priv_triggerContentEvent("videoTrackChange", videoTrack);
           this._priv_triggerContentEvent("availableVideoBitratesChange",
                                          this.getAvailableVideoBitrates());

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -45,14 +45,14 @@ export type ITextTrackPreference = null |
                                    { language : string;
                                      closedCaption : boolean; };
 
-// audio track returned by the TrackManager
+// audio track returned by the TrackChoiceManager
 export interface ITMAudioTrack { language : string;
                                  normalized : string;
                                  audioDescription : boolean;
                                  dub? : boolean;
                                  id : number|string; }
 
-// text track returned by the TrackManager
+// text track returned by the TrackChoiceManager
 export interface ITMTextTrack { language : string;
                                 normalized : string;
                                 closedCaption : boolean;
@@ -65,19 +65,19 @@ interface ITMVideoRepresentation { id : string|number;
                                    codec? : string;
                                    frameRate? : string; }
 
-// video track returned by the TrackManager
+// video track returned by the TrackChoiceManager
 export interface ITMVideoTrack { id : number|string;
                                  representations: ITMVideoRepresentation[]; }
 
-// audio track from a list of audio tracks returned by the TrackManager
+// audio track from a list of audio tracks returned by the TrackChoiceManager
 export interface ITMAudioTrackListItem
   extends ITMAudioTrack { active : boolean; }
 
-// text track from a list of text tracks returned by the TrackManager
+// text track from a list of text tracks returned by the TrackChoiceManager
 export interface ITMTextTrackListItem
   extends ITMTextTrack { active : boolean; }
 
-// video track from a list of video tracks returned by the TrackManager
+// video track from a list of video tracks returned by the TrackChoiceManager
 export interface ITMVideoTrackListItem
   extends ITMVideoTrack { active : boolean; }
 
@@ -128,10 +128,10 @@ function normalizeTextTracks(
 /**
  * Manage audio and text tracks for all active periods.
  * Chose the audio and text tracks for each period and record this choice.
- * @class TrackManager
+ * @class TrackChoiceManager
  */
-export default class TrackManager {
-  // Current Periods considered by the TrackManager.
+export default class TrackChoiceManager {
+  // Current Periods considered by the TrackChoiceManager.
   // Sorted by start time ascending
   private _periods : SortedList<ITMPeriodInfos>;
 
@@ -192,7 +192,7 @@ export default class TrackManager {
     }
     if (periodItem != null) {
       if (periodItem[bufferType] != null) {
-        log.warn(`TrackManager: ${bufferType} already added for period`, period);
+        log.warn(`TrackChoiceManager: ${bufferType} already added for period`, period);
         return;
       } else {
         periodItem[bufferType] = { adaptations, adaptation$ };
@@ -215,13 +215,13 @@ export default class TrackManager {
   ) : void {
     const periodIndex = findPeriodIndex(this._periods, period);
     if (periodIndex == null) {
-      log.warn(`TrackManager: ${bufferType} not found for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} not found for period`, period);
       return;
     }
 
     const periodItem = this._periods.get(periodIndex);
     if (periodItem[bufferType] == null) {
-      log.warn(`TrackManager: ${bufferType} already removed for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} already removed for period`, period);
       return;
     }
     delete periodItem[bufferType];
@@ -261,7 +261,7 @@ export default class TrackManager {
     const audioInfos = periodItem != null ? periodItem.audio :
                                             null;
     if (audioInfos == null || periodItem == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
     const preferredAudioTracks = this._preferredAudioTracks.getValue();
@@ -299,7 +299,7 @@ export default class TrackManager {
     const textInfos = periodItem != null ? periodItem.text :
                                            null;
     if (textInfos == null || periodItem == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
     const preferredTextTracks = this._preferredTextTracks.getValue();
@@ -335,7 +335,7 @@ export default class TrackManager {
     const videoInfos = periodItem != null ? periodItem.video :
                                             null;
     if (videoInfos == null || periodItem == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
     const videoAdaptations = period.adaptations.video === undefined ?
@@ -367,7 +367,7 @@ export default class TrackManager {
     const audioInfos = periodItem != null ? periodItem.audio :
                                             null;
     if (audioInfos == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
     const wantedAdaptation = arrayFind(audioInfos.adaptations,
@@ -395,7 +395,7 @@ export default class TrackManager {
     const textInfos = periodItem != null ? periodItem.text :
                                            null;
     if (textInfos == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
     const wantedAdaptation = arrayFind(textInfos.adaptations,
                                        ({ id }) => id === wantedId);
@@ -456,7 +456,7 @@ export default class TrackManager {
     const textInfos = periodItem != null ? periodItem.text :
                                            null;
     if (textInfos == null) {
-      throw new Error("TrackManager: Given Period not found.");
+      throw new Error("TrackChoiceManager: Given Period not found.");
     }
     const chosenTextAdaptation = this._textChoiceMemory.get(period);
     if (chosenTextAdaptation === null) {

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -66,7 +66,7 @@ import ABRManager, {
   IABRMetric,
   IABRRequest,
 } from "../../abr";
-import { SegmentPipelinesManager } from "../../pipelines";
+import { SegmentPipelineCreator } from "../../pipelines";
 import { QueuedSourceBuffer } from "../../source_buffers";
 import EVENTS from "../events_generators";
 import RepresentationBuffer, {
@@ -99,7 +99,7 @@ export interface IAdaptationBufferArguments<T> {
               adaptation : Adaptation; }; // content to download
   options: { manualBitrateSwitchingMode : "seamless" | "direct" }; // Switch strategy
   queuedSourceBuffer : QueuedSourceBuffer<T>; // Interact with the SourceBuffer
-  segmentPipelinesManager : SegmentPipelinesManager<any>; // Load and parse segments
+  segmentPipelineCreator : SegmentPipelineCreator<any>; // Load and parse segments
   wantedBufferAhead$ : BehaviorSubject<number>; // Buffer goal wanted by the user
 }
 
@@ -121,7 +121,7 @@ export default function AdaptationBuffer<T>({
   content,
   options,
   queuedSourceBuffer,
-  segmentPipelinesManager,
+  segmentPipelineCreator,
   wantedBufferAhead$,
 } : IAdaptationBufferArguments<T>) : Observable<IAdaptationBufferEvent<T>> {
   const directManualBitrateSwitching = options.manualBitrateSwitchingMode === "direct";
@@ -163,7 +163,7 @@ export default function AdaptationBuffer<T>({
                                                           abrEvents$)
       .pipe(subscribeOn(asapScheduler), share());
 
-  const segmentFetcher = segmentPipelinesManager.createPipeline(adaptation.type,
+  const segmentFetcher = segmentPipelineCreator.createPipeline(adaptation.type,
                                                                 requestsEvents$);
 
   // Bitrate higher or equal to this value should not be replaced by segments of

--- a/src/core/buffers/buffer_orchestrator.ts
+++ b/src/core/buffers/buffer_orchestrator.ts
@@ -47,7 +47,7 @@ import { fromEvent } from "../../utils/event_emitter";
 import SortedList from "../../utils/sorted_list";
 import WeakMapMemory from "../../utils/weak_map_memory";
 import ABRManager from "../abr";
-import { SegmentPipelinesManager } from "../pipelines";
+import { SegmentPipelineCreator } from "../pipelines";
 import SourceBuffersStore, {
   BufferGarbageCollector,
   getBufferTypes,
@@ -97,7 +97,7 @@ const { MAXIMUM_MAX_BUFFER_AHEAD,
  * to play.
  * @param {Object} sourceBuffersStore - Will be used to lazily create
  * SourceBuffer instances associated with the current content.
- * @param {Object} segmentPipelinesManager - Download segments
+ * @param {Object} segmentPipelineCreator - Download segments
  * @param {Object} options
  * @returns {Observable}
  *
@@ -110,7 +110,7 @@ export default function BufferOrchestrator(
   clock$ : Observable<IBufferOrchestratorClockTick>,
   abrManager : ABRManager,
   sourceBuffersStore : SourceBuffersStore,
-  segmentPipelinesManager : SegmentPipelinesManager<any>,
+  segmentPipelineCreator : SegmentPipelineCreator<any>,
   options: { wantedBufferAhead$ : BehaviorSubject<number>;
              maxBufferAhead$ : Observable<number>;
              maxBufferBehind$ : Observable<number>;
@@ -390,7 +390,7 @@ export default function BufferOrchestrator(
                                          clock$,
                                          content: { manifest, period: basePeriod },
                                          garbageCollectors,
-                                         segmentPipelinesManager,
+                                         segmentPipelineCreator,
                                          sourceBuffersStore,
                                          options,
                                          wantedBufferAhead$, }

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -43,7 +43,7 @@ import Manifest, {
 import { getLeftSizeOfRange } from "../../../utils/ranges";
 import WeakMapMemory from "../../../utils/weak_map_memory";
 import ABRManager from "../../abr";
-import { SegmentPipelinesManager } from "../../pipelines";
+import { SegmentPipelineCreator } from "../../pipelines";
 import SourceBuffersStore, {
   IBufferType,
   ITextTrackSourceBufferOptions,
@@ -80,7 +80,7 @@ export interface IPeriodBufferArguments {
   content : { manifest : Manifest;
               period : Period; };
   garbageCollectors : WeakMapMemory<QueuedSourceBuffer<unknown>, Observable<never>>;
-  segmentPipelinesManager : SegmentPipelinesManager<any>;
+  segmentPipelineCreator : SegmentPipelineCreator<any>;
   sourceBuffersStore : SourceBuffersStore;
   options: { manualBitrateSwitchingMode : "seamless" | "direct";
              textTrackOptions? : ITextTrackSourceBufferOptions; };
@@ -103,7 +103,7 @@ export default function PeriodBuffer({
   clock$,
   content,
   garbageCollectors,
-  segmentPipelinesManager,
+  segmentPipelineCreator,
   sourceBuffersStore,
   options,
   wantedBufferAhead$,
@@ -197,7 +197,7 @@ export default function PeriodBuffer({
                               content: { manifest, period, adaptation },
                               options,
                               queuedSourceBuffer: qSourceBuffer,
-                              segmentPipelinesManager,
+                              segmentPipelineCreator,
                               wantedBufferAhead$ })
     .pipe(catchError((error : unknown) => {
       // non native buffer should not impact the stability of the

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -56,7 +56,7 @@ import {
 import {
   createManifestPipeline,
   IFetchManifestResult,
-  SegmentPipelinesManager,
+  SegmentPipelineCreator,
 } from "../pipelines";
 import { ITextTrackSourceBufferOptions } from "../source_buffers";
 import createEMEManager, {
@@ -173,10 +173,10 @@ export default function InitializeOnMediaSource(
   );
 
   // Creates pipelines for downloading segments.
-  const segmentPipelinesManager =
-    new SegmentPipelinesManager<any>(pipelines, { lowLatencyMode,
-                                                  offlineRetry,
-                                                  segmentRetry });
+  const segmentPipelineCreator =
+    new SegmentPipelineCreator<any>(pipelines, { lowLatencyMode,
+                                                 offlineRetry,
+                                                 segmentRetry });
 
   // Create ABR Manager, which will choose the right "Representation" for a
   // given "Adaptation".
@@ -217,7 +217,7 @@ export default function InitializeOnMediaSource(
       clock$,
       manifest,
       mediaElement,
-      segmentPipelinesManager,
+      segmentPipelineCreator,
       speed$,
     });
 

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -40,7 +40,7 @@ import ABRManager from "../abr";
 import BufferOrchestrator, {
   IBufferOrchestratorEvent,
 } from "../buffers";
-import { SegmentPipelinesManager } from "../pipelines";
+import { SegmentPipelineCreator } from "../pipelines";
 import SourceBuffersStore, {
   ITextTrackSourceBufferOptions,
 } from "../source_buffers";
@@ -77,8 +77,8 @@ export interface IMediaSourceLoaderArguments {
   manifest : Manifest; // Manifest of the content we want to play
   mediaElement : HTMLMediaElement; // Media Element on which the content will be
                                    // played
-  segmentPipelinesManager : SegmentPipelinesManager<any>; // Interface to download
-                                                          // segments
+  segmentPipelineCreator : SegmentPipelineCreator<any>; // Interface to download
+                                                        // segments
   speed$ : Observable<number>; // Emit the speed.
                                // /!\ Should replay the last value on subscription.
 }
@@ -103,7 +103,7 @@ export default function createMediaSourceLoader({
   speed$,
   bufferOptions,
   abrManager,
-  segmentPipelinesManager,
+  segmentPipelineCreator,
 } : IMediaSourceLoaderArguments) : (
   mediaSource : MediaSource,
   initialTime : number,
@@ -169,7 +169,7 @@ export default function createMediaSourceLoader({
                                         bufferClock$,
                                         abrManager,
                                         sourceBuffersStore,
-                                        segmentPipelinesManager,
+                                        segmentPipelineCreator,
                                         bufferOptions
     ).pipe(
       mergeMap((evt) : Observable<IMediaSourceLoaderEvent> => {

--- a/src/core/pipelines/index.ts
+++ b/src/core/pipelines/index.ts
@@ -17,25 +17,25 @@
 import createManifestPipeline, {
   IFetchManifestResult,
 } from "./manifest";
-import SegmentPipelinesManager, {
+import SegmentPipelineCreator, {
   IPrioritizedSegmentFetcher,
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherEvent,
   ISegmentFetcherWarning,
-  ISegmentPipelineManagerOptions,
+  ISegmentPipelineCreatorOptions,
 } from "./segment";
 
 export {
   createManifestPipeline,
-  SegmentPipelinesManager,
+  SegmentPipelineCreator,
 
   IFetchManifestResult,
 
   IPrioritizedSegmentFetcher,
   ISegmentFetcherEvent,
 
-  ISegmentPipelineManagerOptions,
+  ISegmentPipelineCreatorOptions,
 
   ISegmentFetcherChunkEvent,
   ISegmentFetcherChunkCompleteEvent,

--- a/src/core/pipelines/segment/index.ts
+++ b/src/core/pipelines/segment/index.ts
@@ -21,16 +21,16 @@ import {
   ISegmentFetcherEvent,
   ISegmentFetcherWarning,
 } from "./segment_fetcher";
-import SegmentPipelinesManager, {
-  ISegmentPipelineManagerOptions,
-} from "./segment_pipelines_manager";
+import SegmentPipelineCreator, {
+  ISegmentPipelineCreatorOptions,
+} from "./segment_pipeline_creator";
 
-export default SegmentPipelinesManager;
+export default SegmentPipelineCreator;
 export {
   IPrioritizedSegmentFetcher,
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherEvent,
   ISegmentFetcherWarning,
-  ISegmentPipelineManagerOptions,
+  ISegmentPipelineCreatorOptions,
 };

--- a/src/core/pipelines/segment/segment_pipeline_creator.ts
+++ b/src/core/pipelines/segment/segment_pipeline_creator.ts
@@ -31,7 +31,7 @@ import createSegmentFetcher, {
   ISegmentFetcherEvent,
 } from "./segment_fetcher";
 
-export interface ISegmentPipelineManagerOptions {
+export interface ISegmentPipelineCreatorOptions {
   lowLatencyMode : boolean; // Whether the content is a low-latency content
                             // This has an impact on default backoff delays
   offlineRetry? : number; // Configuration for the maximum number of retries
@@ -45,43 +45,40 @@ export interface ISegmentPipelineManagerOptions {
  * Interact with the networking pipelines to download segments with the right
  * priority.
  *
- * @class SegmentPipelinesManager
+ * @class SegmentPipelineCreator
  *
  * @example
  * ```js
- * // 1 - create the manager
- * const segmentPipelinesManager = new SegmentPipelinesManager(transport);
+ * const creator = new SegmentPipelineCreator(transport);
  *
  * // 2 - create a new pipeline with its own options
- * const pipeline = segmentPipelinesManager.createPipeline("audio", {
+ * const pipeline = creator.createPipeline("audio", {
  *   maxRetry: Infinity,
  *   maxRetryOffline: Infinity,
  * });
  *
  * // 3 - load a segment with a given priority
  * pipeline.createRequest(myContent, 1)
- *
  *   // 4 - parse it
  *   .pipe(
  *     filter(evt => evt.type === "response"),
  *     mergeMap(response => response.parse());
  *   )
- *
  *   // 5 - use it
  *   .subscribe((res) => console.log("audio segment downloaded:", res));
  * ```
  */
-export default class SegmentPipelinesManager<T> {
+export default class SegmentPipelineCreator<T> {
   private readonly _transport : ITransportPipelines;
   private readonly _prioritizer : ObservablePrioritizer<ISegmentFetcherEvent<T>>;
-  private readonly _pipelineOptions : ISegmentPipelineManagerOptions;
+  private readonly _pipelineOptions : ISegmentPipelineCreatorOptions;
 
   /**
    * @param {Object} transport
    */
   constructor(
     transport : ITransportPipelines,
-    options : ISegmentPipelineManagerOptions
+    options : ISegmentPipelineCreatorOptions
   ) {
     this._transport = transport;
     this._prioritizer = new ObservablePrioritizer();

--- a/src/custom_source_buffers/text/html/__tests__/utils.test.ts
+++ b/src/custom_source_buffers/text/html/__tests__/utils.test.ts
@@ -22,7 +22,7 @@ import {
   removeCuesInfosBetween,
 } from "../utils";
 
-describe("HTML Buffer Manager utils - getCuesBefore", () => {
+describe("HTML Text buffer utils - getCuesBefore", () => {
   it("should get the right cues when time is the start of a cue", () => {
     const element = document.createElement("div");
     const cues = [
@@ -136,7 +136,7 @@ describe("HTML Buffer Manager utils - getCuesBefore", () => {
   });
 });
 
-describe("HTML Buffer Manager utils - getCuesAfter", () => {
+describe("HTML Text buffer utils - getCuesAfter", () => {
   it("should get the right cues when time is between start and end of a cue", () => {
     const element = document.createElement("div");
     const cues = [
@@ -249,7 +249,7 @@ describe("HTML Buffer Manager utils - getCuesAfter", () => {
   });
 });
 
-describe("HTML Buffer Manager utils - areNearlyEqual", () => {
+describe("HTML Text buffer utils - areNearlyEqual", () => {
   it("should return false if input number are not nearly equals", () => {
     expect(areNearlyEqual(5, 6)).toBe(false);
   });
@@ -263,7 +263,7 @@ describe("HTML Buffer Manager utils - areNearlyEqual", () => {
   });
 });
 
-describe("HTML Buffer Manager utils - removeCuesInfosBetween", () => {
+describe("HTML Text buffer utils - removeCuesInfosBetween", () => {
   it("should remove cues infos between end of a cue and start of another cue", () => {
     const element = document.createElement("div");
     const cues = [ { start: 1, end: 2, element },

--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -35,8 +35,8 @@ import {
 import config from "../../../config";
 import log from "../../../log";
 import AbstractSourceBuffer from "../../abstract_source_buffer";
-import TextBufferManager from "./buffer_manager";
 import parseTextTrackToElements from "./parsers";
+import TextTrackCuesStore from "./text_track_cues_store";
 import updateProportionalElements from "./update_proportional_elements";
 
 const { onEnded$,
@@ -128,7 +128,7 @@ export default class HTMLTextSourceBuffer
   private readonly _textTrackElement : HTMLElement;
 
   // Buffer containing the data
-  private readonly _buffer : TextBufferManager;
+  private readonly _buffer : TextTrackCuesStore;
 
   // We could need us to automatically update styling depending on
   // `_textTrackElement`'s size. This Subject allows to stop that
@@ -156,7 +156,7 @@ export default class HTMLTextSourceBuffer
     this._textTrackElement = textTrackElement;
     this._clearSizeUpdates$ = new Subject();
     this._destroy$ = new Subject();
-    this._buffer = new TextBufferManager();
+    this._buffer = new TextTrackCuesStore();
     this._currentCue = null;
 
     // update text tracks

--- a/src/custom_source_buffers/text/html/text_track_cues_store.ts
+++ b/src/custom_source_buffers/text/html/text_track_cues_store.ts
@@ -29,9 +29,9 @@ import {
 /**
  * Manage the buffer of the HTML text Sourcebuffer.
  * Allows to add, remove and recuperate cues at given times.
- * @class TextBufferManager
+ * @class TextTrackCuesStore
  */
-export default class TextBufferManager {
+export default class TextTrackCuesStore {
   private _cuesBuffer : ICuesGroup[];
 
   constructor() {


### PR DESCRIPTION
Renamed ThingsManager modules into another name which should give a better idea of what they do (hopefully):
 - `TrackManager` -> `TrackChoiceManager` (yeah we didn't drop it totally for that one!)
 - `SegmentPipelinesManager` -> `SegmentPipelineCreator`
 - `TextBufferManager` -> `TextTrackCuesStore`

The `ABRManager` and `EMEManager` stay that way for now.

