### PR TITLE
Feat/api seeking events

### DIFF
--- a/doc/api/player_events.md
+++ b/doc/api/player_events.md
@@ -6,7 +6,11 @@
 - [Overview](#overview)
 - [Events](#events)
     - [playerStateChange](#events-playerStateChange)
+    - [error](#events-error)
+    - [warning](#events-warning)
     - [positionUpdate](#events-positionUpdate)
+    - [seeking](#events-seeking)
+    - [seeked](#events-seeked)
     - [availableAudioTracksChange](#events-availableAudioTracksChange)
     - [availableTextTracksChange](#events-availableTextTracksChange)
     - [availableVideoTracksChange](#events-availableVideoTracksChange)
@@ -18,8 +22,6 @@
     - [audioBitrateChange](#events-audioBitrateChange)
     - [videoBitrateChange](#events-videoBitrateChange)
     - [bitrateEstimationChange](#events-bitrateEstimationChange)
-    - [warning](#events-warning)
-    - [error](#events-error)
     - [periodChange](#events-periodChange)
     - [decipherabilityUpdate](#events-decipherabilityUpdate)
     - [imageTrackUpdate (deprecated)](#events-imageTrackUpdate)
@@ -66,6 +68,28 @@ As it is a central part of our API and can be difficult concept to understand,
 we have a special [page of documentation on player states](./states.md).
 
 
+<a name="events-error"></a>
+### error ######################################################################
+
+_payload type_: ``Error``
+
+Triggered each time a fatal (for content playback) error happened.
+
+The payload is the corresponding error. See [the Player Error
+documentation](./errors.md) for more information.
+
+
+<a name="events-warning"></a>
+### warning ####################################################################
+
+_payload type_: ``Error``
+
+Triggered each time a non-fatal (for content playback) error happened.
+
+The payload is the corresponding error. See [the Player Error
+documentation](./errors.md) for more information.
+
+
 <a name="events-positionUpdate"></a>
 ### positionUpdate #############################################################
 
@@ -102,6 +126,20 @@ The object emitted as the following properties:
     That is the real live position (and not the position as announced by the
     video element).
 
+
+
+<a name="events-seeking"></a>
+### seeking #################################################
+
+Emitted when a "seek" operation (to "move"/"skip" to another position) begins
+on the currently loaded content.
+
+
+<a name="events-seeked"></a>
+### seeked #################################################
+
+Emitted when a "seek" operation (to "move"/"skip" to another position) on the
+currently loaded content has finished
 
 
 <a name="events-availableAudioTracksChange"></a>
@@ -424,28 +462,6 @@ The payload is an object with the following properties:
     This bitrate is smoothed by doing a (complex) mean on an extended period of
     time, so it often does not link directly to the current calculated bitrate.
 
-
-
-<a name="events-warning"></a>
-### warning ####################################################################
-
-_payload type_: ``Error``
-
-Triggered each time a non-fatal (for content playback) error happened.
-
-The payload is the corresponding error. See [the Player Error
-documentation](./errors.md) for more information.
-
-
-<a name="events-error"></a>
-### error ######################################################################
-
-_payload type_: ``Error``
-
-Triggered each time a fatal (for content playback) error happened.
-
-The payload is the corresponding error. See [the Player Error
-documentation](./errors.md) for more information.
 
 
 <a name="events-periodChange"></a>

--- a/src/core/api/emit_seek_events.ts
+++ b/src/core/api/emit_seek_events.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defer as observableDefer,
+  EMPTY,
+  fromEvent as observableFromEvent,
+  merge as observableMerge,
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import {
+  mapTo,
+  mergeMap,
+  startWith,
+  switchMapTo,
+  take,
+} from "rxjs/operators";
+import { IClockTick } from "./clock";
+
+/**
+ * Returns Observable which will emit:
+ *   - `"seeking"` when we are seeking in the given mediaElement
+ *   - `"seeked"` when a seek is considered as finished by the given clock$
+ *     Observable.
+ * @param {HTMLMediaElement} mediaElement
+ * @param {Observable} clock$
+ * @returns {Observable}
+ */
+export default function emitSeekEvents(
+ mediaElement : HTMLMediaElement | null,
+ clock$ : Observable<IClockTick>
+) : Observable<"seeking" | "seeked"> {
+  return observableDefer(() => {
+    if (mediaElement === null) {
+      return EMPTY;
+    }
+
+    const isSeeking$ = observableFromEvent(mediaElement, "seeking")
+      .pipe(mapTo("seeking" as const));
+
+    const hasSeeked$ = observableFromEvent(mediaElement, "seeked").pipe(
+      switchMapTo(
+        clock$.pipe(
+          mergeMap((tick : IClockTick) => {
+            return tick.stalled === null || tick.stalled.reason !== "seeking" ?
+              observableOf("seeked" as const) :
+              EMPTY;
+          }),
+          take(1))));
+    const seekingEvents$ = observableMerge(isSeeking$, hasSeeked$);
+    return mediaElement.seeking ? seekingEvents$.pipe(startWith("seeking" as const)) :
+                                  seekingEvents$;
+  });
+}

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -103,6 +103,7 @@ import SourceBuffersStore, {
 import createClock, {
   IClockTick
 } from "./clock";
+import emitSeekEvents from "./emit_seek_events";
 import getPlayerState, {
   PLAYER_STATES,
 } from "./get_player_state";
@@ -171,6 +172,8 @@ interface IPublicAPIEvent {
                                   period : Period;
                                   adaptation : Adaptation;
                                   representation : Representation; }>;
+  seeking : null;
+  seeked : null;
 }
 
 /**
@@ -836,7 +839,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     clock$
       .pipe(takeUntil(this._priv_stopCurrentContent$))
-      .subscribe(x => this._priv_triggerTimeChange(x), noop);
+      .subscribe(x => this._priv_triggerPositionUpdate(x), noop);
+
+    loaded$.pipe(
+      switchMapTo(emitSeekEvents(this.videoElement, clock$)),
+      takeUntil(this._priv_stopCurrentContent$)
+    ).subscribe((evt : "seeking" | "seeked") => {
+      log.info(`API: Triggering "${evt}" event`);
+      this.trigger(evt, null);
+    });
 
     playerState$
       .pipe(takeUntil(this._priv_stopCurrentContent$))
@@ -2335,7 +2346,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    *
    * @param {Object} clockTick
    */
-  private _priv_triggerTimeChange(clockTick : IClockTick) : void {
+  private _priv_triggerPositionUpdate(clockTick : IClockTick) : void {
     if (this._priv_contentInfos === null) {
       log.warn("API: Cannot perform time update: no content loaded.");
       return;

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1453,7 +1453,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(1);
         expect(player.getAvailableAudioTracks()).to.eql([]);
         await xhrMock.flush();
-        await sleep(1);
+        await sleep(50);
 
         const audioTracks = player.getAvailableAudioTracks();
 
@@ -1501,7 +1501,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(1);
         expect(player.getAvailableTextTracks()).to.eql([]);
         await xhrMock.flush();
-        await sleep(1);
+        await sleep(50);
 
         const textTracks = player.getAvailableTextTracks();
 
@@ -1549,7 +1549,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(1);
         expect(player.getAvailableVideoTracks()).to.eql([]);
         await xhrMock.flush();
-        await sleep(1);
+        await sleep(50);
 
         const videoTracks = player.getAvailableVideoTracks();
 


### PR DESCRIPTION
Add two new events:
  - `seeking`: we're beginning to seek in a loaded content
  - `seeked`: we finished seeking in a loaded content

Its rules (when it is sent, how to know a seek has ended etc.) are much simpler than the `playerStateChange`, on which the user had to rely before for that same information.

Now the API seems clearer:
  - you want to know when a seek operation began? Use `seeking`.
  - you want to know when a seek operation finished? Use `seeked`
  - you want to know what the player is doing currently (its state) and when that changes? Use `playerStateChange`.

To give an example of their differences, seeking to an already buffered part might not trigger a `SEEKING` state (as the player could be able to continue playing with no interruption, its current "state" would not change) but will trigger both a `seeking` and `seeked` event.

The user could also rely on the `seeking` and `seeked` events sent by the media element, but the RxPlayer has its own definition of `seeked` which might be different from it (e.g. we might want to wait a little longer to make sure enough data has been loaded).
Likewise `seeking` is sent by the media element at every seek operation whereas the RxPlayer only emit it for loaded contents (e.g. the initial seek to get to the initial position will not trigger a `seeking` event from the RxPlayer but will emit one from the media element). 

  