### PR TITLE
Add parseBifThumbnails tools and deprecate other BIF-related APIs

### DIFF
--- a/doc/api/deprecated.md
+++ b/doc/api/deprecated.md
@@ -34,6 +34,36 @@ The fullscreen logic should now be entirely on the application-side. Replacement
 code is provided for each of those APIs below.
 
 
+
+<a name="bif-apis"></a>
+## Image (BIF) APIs ############################################################
+
+The following properties methods and events have been deprecated:
+  - the `imageTrackUpdate` event
+  - the `getImageTrackData` method
+  - the `supplementaryImageTracks` loadVideo option
+
+This is because most code linked to image management will be moved outside the
+RxPlayer. Doing that will both be more flexible for users and much easier to
+maintain for us (albeit with a small time of transition for the application).
+
+You can replace those API by this new exported function:
+[parseBifThumbnails](./parseBifThumbnails.md).
+
+To give more details about why those APIs have been deprecated, there are
+multiple reasons:
+  1. How it should be specified for live contents of for multi-Period DASH
+     contents is not clear enough.
+  2. Integrating it in the RxPlayer's API means that it had to take multiple
+     choices that we prefer to let to the application: whether to retry the
+     request if the it fails or if it is unavailable, whether to do the request
+     at all for users with a low bitrate...
+  3. The task of displaying those thumbnails is ultimately on the UI-side (the
+     part that know where the user wants to seek)
+  4. The biggest part of the code related to it was a simple BIF parser, that
+     can easily be re-implemented by any application.
+
+
 ## RxPlayer Methods ############################################################
 
 The following RxPlayer methods are deprecated.
@@ -152,6 +182,16 @@ function exitFullscreen() {
 ```
 
 
+### getImageTrackData ##########################################################
+
+`getImageTrackData` has been deprecated like most API related to BIF thumbnail
+parsing.
+You can read [the related chapter](#bif-apis) for more information.
+
+You can replace this API by using the
+[parseBifThumbnails](./parseBifThumbnails.md) tool.
+
+
 
 ## RxPlayer Events #############################################################
 
@@ -168,7 +208,7 @@ It should not be needed anymore as most advanced needs should be better answered
 by an ``html`` text track mode.
 
 
-## fullscreenChange ############################################################
+### fullscreenChange ###########################################################
 
 ``fullscreenChange`` events have been deprecated as it is part of our Fullscreen
 APIs, see [the related chapter](#fullscreen-apis) for more information.
@@ -190,6 +230,17 @@ mediaElement.addEventListener("fullscreenChange", () => {
   }
 });
 ```
+
+
+### imageTrackUpdate ###########################################################
+
+`imageTrackUpdate` events have been deprecated like most API related to BIF
+thumbnail parsing.
+You can read [the related chapter](#bif-apis) for more information.
+
+You can replace this API by using the
+[parseBifThumbnails](./parseBifThumbnails.md) tool.
+
 
 
 ## loadVideo options ###########################################################
@@ -320,6 +371,16 @@ Please bear in mind however that they are two completely different APIs, doing
 the transition might take some time.
 
 The `TextTrackRenderer` tool is documented [here](./TextTrackRenderer.md).
+
+
+### supplementaryImageTracks ###################################################
+
+The `supplementaryImageTracks` events have been deprecated like most API related
+to BIF thumbnail parsing.
+You can read [the related chapter](#bif-apis) for more information.
+
+You can replace this API by using the
+[parseBifThumbnails](./parseBifThumbnails.md) tool.
 
 
 ### hideNativeSubtitle #########################################################

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -72,9 +72,9 @@
     - [getPlaybackRate](#meth-getPlaybackRate)
     - [setPlaybackRate](#meth-setPlaybackRate)
     - [getCurrentKeySystem](#meth-getCurrentKeySystem)
-    - [getImageTrackData](#meth-getImageTrackData)
     - [getMinimumPosition](#meth-getMinimumPosition)
     - [getMaximumPosition](#meth-getMaximumPosition)
+    - [getImageTrackData (deprecated)](#meth-getImageTrackData)
     - [setFullscreen (deprecated)](#meth-setFullscreen)
     - [exitFullscreen (deprecated)](#meth-exitFullscreen)
     - [isFullscreen (deprecated)](#meth-isFullscreen)
@@ -1572,21 +1572,6 @@ _return value_: ``string|undefined``
 Returns the type of keySystem used for DRM-protected contents.
 
 
-<a name="meth-getImageTrackData"></a>
-### getImageTrackData ##########################################################
-
-_return value_: ``Array.<Object>|null``
-
-The current image track's data, null if no content is loaded / no image track
-data is available.
-
-The returned array follows the usual image playlist structure, defined
-[here](./images.md#api-structure).
-
-``null`` in _DirectFile_ mode (see [loadVideo
-options](./loadVideo_options.md#prop-transport)).
-
-
 <a name="meth-getMinimumPosition"></a>
 ### getMinimumPosition #########################################################
 
@@ -1624,6 +1609,28 @@ player.seekTo({
   position: player.getMaximumPosition()
 });
 ```
+
+
+<a name="meth-getImageTrackData"></a>
+### getImageTrackData ##########################################################
+
+---
+
+:warning: This method is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+---
+
+_return value_: ``Array.<Object>|null``
+
+The current image track's data, null if no content is loaded / no image track
+data is available.
+
+The returned array follows the usual image playlist structure, defined
+[here](./images.md#api-structure).
+
+``null`` in _DirectFile_ mode (see [loadVideo
+options](./loadVideo_options.md#prop-transport)).
 
 
 <a name="meth-setFullscreen"></a>

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -81,6 +81,8 @@
     - [getNativeTextTrack (deprecated)](#meth-getNativeTextTrack)
 - [Tools](#tools)
     - [Experimental - MediaCapabilitiesProber](#tools-mediaCapabilitiesProber)
+    - [Experimental - TextTrackRenderer](#tools-textTrackRenderer)
+    - [Experimental - parseBifThumbnails](#tools-parseBifThumbnails)
 
 
 
@@ -1713,6 +1715,15 @@ const textTrack = el.textTracks.length ? el.textTracks[0] : null;
 <a name="tools-mediaCapabilitiesProber"></a>
 ### MediaCapabilitiesProber ####################################################
 
+---
+
+:warning: This tool is experimental. This only means that its API can change at
+any new RxPlayer version (with all the details in the corresponding release
+note).
+
+---
+
+
 An experimental tool to probe browser media capabilities:
   - Decoding capabilities
   - DRM support
@@ -1725,6 +1736,14 @@ You can find its documentation [here](./mediaCapabilitiesProber.md).
 <a name="tools-textTrackRenderer"></a>
 ### TextTrackRenderer ##########################################################
 
+---
+
+:warning: This tool is experimental. This only means that its API can change at
+any new RxPlayer version (with all the details in the corresponding release
+note).
+
+---
+
 The TextTrackRenderer allows to easily render subtitles synchronized to a video
 element.
 
@@ -1732,3 +1751,20 @@ It allows easily to dynamically add subtitles (as long as it is in one of the
 following format: srt, ttml, webVTT or SAMI) to a played video.
 
 This tool is documented [here](./TextTrackRenderer.md).
+
+
+<a name="tools-parseBifThumbnails"></a>
+### parseBifThumbnails #########################################################
+
+---
+
+:warning: This tool is experimental. This only means that its API can change at
+any new RxPlayer version (with all the details in the corresponding release
+note).
+
+---
+
+The `parseBifThumbnails` function parses BIF files, which is a format created by
+Canal+ to declare thumbnails linked to a given content.
+
+This tool is documented [here](./parseBifThumbnails.md).

--- a/doc/api/parseBifThumbnails.md
+++ b/doc/api/parseBifThumbnails.md
@@ -1,0 +1,77 @@
+# parseBifThumbnails ###########################################################
+
+`parseBifThumbnails` is a function allowing to easily parse `BIF` files, which
+is a file format crafted to contain video thumbnails.
+
+Those are usually used to give a visual indication of where in a given media you
+will seek to when hovering a progress bar.
+
+
+## About BIF files #############################################################
+
+The BIF format is straightforward. It contains several metadata and then all the
+images for the whole content, in their original format (e.g. "jpeg"),
+concatenated.
+
+
+
+## How to import it ############################################################
+
+`parseBifThumbnails` is for now considered an "experimental" tool. This means
+that its API could change at any new version of the RxPlayer (don't worry, we
+would still document all changes made to it in the corresponding release note).
+
+As an experimental tool, it is imported as such:
+```ts
+import { parseBifThumbnails } from "rx-player/experimental/tools";
+```
+
+You can then begin to use it right away.
+
+
+
+## How to use it ###############################################################
+
+As a simple parser, `parseBifThumbnails` takes the downloaded BIF file in an
+ArrayBuffer form and returns its content under an object format, like this:
+
+```js
+import { parseBifThumbnails } from "rx-player/experimental/tools";
+
+// optionally, fetch the BIF resource through the usual APIs
+fetch("http://www.example.com/thumbnails.bif").then(function(response) {
+  return response.arrayBuffer(); // obtain an ArrayBuffer response
+}).then(function(buffer) {
+  const parsedBif = parseBifThumbnails(buffer);
+  console.log("parsed BIF:", parsedBif);
+};
+```
+
+Here is an example of the returned data:
+```js
+{
+  version: "0.0.0.0", // BIF version. For the moment, only "0.0.0.0" is
+                      // specified.
+  images: [    // Array of thumbnails for this content
+    {
+      startTime: 0, // Start position at which the thumbnail should be applied
+                    // to, in milliseconds.
+                    // For example, a time of `5000`, indicates that this
+                    // thumbnail should be shown from the 5 second mark in the
+                    // content (until the next image is displayed instead)
+      image: ArrayBuffer() // The thumbnail itself, in an ArrayBuffer form.
+    },
+    {
+      startTime: 10000,
+      endTime: 20000,
+      thumbnail: ArrayBuffer()
+    },
+    {
+      startTime: 20000,
+      endTime: 30000,
+      thumbnail: ArrayBuffer()
+    },
+    // ...
+  ],
+}
+```

--- a/doc/api/player_events.md
+++ b/doc/api/player_events.md
@@ -17,13 +17,13 @@
     - [availableVideoBitratesChange](#events-availableVideoBitratesChange)
     - [audioBitrateChange](#events-audioBitrateChange)
     - [videoBitrateChange](#events-videoBitrateChange)
-    - [imageTrackUpdate](#events-imageTrackUpdate)
-    - [fullscreenChange](#events-fullscreenChange)
     - [bitrateEstimationChange](#events-bitrateEstimationChange)
     - [warning](#events-warning)
     - [error](#events-error)
     - [periodChange](#events-periodChange)
     - [decipherabilityUpdate](#events-decipherabilityUpdate)
+    - [imageTrackUpdate (deprecated)](#events-imageTrackUpdate)
+    - [fullscreenChange (deprecated)](#events-fullscreenChange)
     - [nativeTextTracksChange (deprecated)](#events-nativeTextTracksChange)
 
 
@@ -396,45 +396,6 @@ time it changes (based on the last received segment).
 `-1` when the bitrate is not known.
 
 
-<a name="events-imageTrackUpdate"></a>
-### imageTrackUpdate ###########################################################
-
-_payload type_: ``Object``
-
----
-
-:warning: This event is not sent in _DirectFile_ mode (see [loadVideo
-options](./loadVideo_options.md#prop-transport)).
-
----
-
-Triggered each time the current image playlist changes (has new images).
-
-Has the following property in its payload:
-  _data_ (``Array.<Object>``): Every image data.
-
-  Each image has a structure as defined in the [Images structure
-  page](./images.md#api-structure).
-
-
-<a name="events-fullscreenChange"></a>
-### fullscreenChange ###########################################################
-
----
-
-:warning: This event is deprecated, it will disappear in the next major
-release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
-
----
-
-_payload type_: ``Boolean``
-
-Triggered each time the video player goes/exits fullscreen mode.
-
-The payload is ``true`` if the player entered fullscreen, ``false`` if it exited
-it.
-
-
 <a name="events-bitrateEstimationChange"></a>
 ### bitrateEstimationChange ####################################################
 
@@ -549,6 +510,52 @@ Each of those objects have the following properties:
 
 You can then know if any of those Representations are becoming decipherable or
 not through their `decipherable` property.
+
+
+<a name="events-imageTrackUpdate"></a>
+### imageTrackUpdate ###########################################################
+
+---
+
+:warning: This event is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+---
+
+_payload type_: ``Object``
+
+---
+
+:warning: This event is not sent in _DirectFile_ mode (see [loadVideo
+options](./loadVideo_options.md#prop-transport)).
+
+---
+
+Triggered each time the current image playlist changes (has new images).
+
+Has the following property in its payload:
+  _data_ (``Array.<Object>``): Every image data.
+
+  Each image has a structure as defined in the [Images structure
+  page](./images.md#api-structure).
+
+
+<a name="events-fullscreenChange"></a>
+### fullscreenChange ###########################################################
+
+---
+
+:warning: This event is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+---
+
+_payload type_: ``Boolean``
+
+Triggered each time the video player goes/exits fullscreen mode.
+
+The payload is ``true`` if the player entered fullscreen, ``false`` if it exited
+it.
 
 
 <a name="events-nativeTextTracksChange"></a>

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -455,6 +455,8 @@ function parseLoadVideoOptions(
     transportOptions.supplementaryTextTracks = supplementaryTextTracks;
   }
   if (options.supplementaryImageTracks !== undefined) {
+    warnOnce("The `supplementaryImageTracks` loadVideo option is deprecated.\n" +
+             "Please use the `parseBifThumbnails` tool instead.");
     const supplementaryImageTracks =
       Array.isArray(options.supplementaryImageTracks) ?
         options.supplementaryImageTracks : [options.supplementaryImageTracks];

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -308,7 +308,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      *
      * null if the current content has no image playlist linked to it.
      *
-     * TODO Need complete refactoring for live or multi-periods contents
+     * @deprecated
      */
     thumbnails : IBifThumbnail[]|null;
 
@@ -1714,12 +1714,17 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
   /**
    * @returns {Array.<Object>|null}
+   * @deprecated
    */
   getImageTrackData() : IBifThumbnail[] | null {
+    warnOnce("`getImageTrackData` is deprecated." +
+             "Please use the `parseBifThumbnails` tool instead.");
     if (this._priv_contentInfos === null) {
       return null;
     }
+    /* tslint:disable deprecation */
     return this._priv_contentInfos.thumbnails;
+    /* tslint:enable deprecation */
   }
 
   /**
@@ -1885,14 +1890,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         }
 
         // Manage image tracks
-        // TODO Better way? Perhaps externalize Image track management in a tool
+        // @deprecated
         const { content, segmentData } = event.value;
         if (content.adaptation.type === "image") {
           if (segmentData != null && (segmentData as { type : string }).type === "bif") {
             const imageData = (segmentData as { data : IBifThumbnail[] }).data;
+            /* tslint:disable deprecation */
             this._priv_contentInfos.thumbnails = imageData;
             this.trigger("imageTrackUpdate",
                          { data: this._priv_contentInfos.thumbnails });
+            /* tslint:enable deprecation */
           }
         }
     }

--- a/src/experimental/tools/index.ts
+++ b/src/experimental/tools/index.ts
@@ -15,9 +15,11 @@
  */
 
 import mediaCapabilitiesProber from "./mediaCapabilitiesProber";
+import parseBifThumbnails from "./parseBIFThumbnails";
 import TextTrackRenderer from "./TextTrackRenderer";
 
 export {
   mediaCapabilitiesProber,
+  parseBifThumbnails,
   TextTrackRenderer,
 };

--- a/src/experimental/tools/parseBIFThumbnails.ts
+++ b/src/experimental/tools/parseBIFThumbnails.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import parseBif from "../../parsers/images/bif";
+
+export interface IBifThumbnail { startTime : number;
+                                 image : ArrayBuffer; }
+
+export interface IBifObject { version : string;
+                              images : IBifThumbnail[]; }
+
+/**
+ * Parse thumbnails in the "BIF" format into a more exploitable form.
+ * @param {Uint8Array} buf - The BIF file
+ * @returns {Object}
+ */
+export default function parseBifThumbnails(
+  buf : ArrayBuffer
+) : IBifObject {
+  const parsed = parseBif(new Uint8Array(buf));
+  return { version: parsed.version,
+           images: parsed.thumbs.map(t => {
+             return { startTime: t.ts,
+                      image: t.data.buffer };
+           }) };
+}


### PR DESCRIPTION
Add experimental `parseBifThumbnails` tool, which simply parse a BIF (thumbnails) file into an exploitable object.

I consequently deprecated the following elements from the API:
  - the `imageTrackUpdate` event
  - the `getImageTrackData` method
  - the `supplementaryImageTracks` loadVideo option

There are multiple reasons. The most important ones are about BIF in general:
  1. How it should be specified for live contents of for multi-Period DASH contents is not clear enough. Today, no solution exist.
  2. Integrating it in the RxPlayer's API means that it had to take multiple choices that we prefer to let to the application: whether to retry the request if the it fails or if it is unavailable, whether to do the request at all for users with a low bitrate...
  3. The task of displaying those thumbnails is ultimately on the UI-side (we have to know where the user wants to seek)

We might re-integrate a notion of thumbnails inside the core RxPlayer code but this will most probably be a better defined format for situations such as live-streaming, multi-periods content or just very long contents (e.g. the DASH-IF way of doing things through image sprites check all checkboxes).