### PR TITLE
api/doc: deprecate `hideNativeSubtitles`

### DIFF
--- a/doc/api/deprecated.md
+++ b/doc/api/deprecated.md
@@ -272,6 +272,19 @@ player.setPreferredTextTracks([{ language: "fra", closedCaption: false }]);
 ```
 
 
+### hideNativeSubtitle #########################################################
+
+The `hideNativeSubtitle` option is deprecated and won't be replaced.
+
+This is because it was added at a time when our text track API was much less
+advanced. Some applications wanted to handle subtitles themselves and thus hid
+the true "native" subtitles to display them themselves in a better way.
+
+However, this API seems to not be used anymore. Please open an issue if you need
+it.
+
+
+
 ## RxPlayer options
 
 The following RxPlayer constructor options are deprecated.

--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -863,6 +863,13 @@ const supplementaryImageTracks = [{
 <a name="prop-hideNativeSubtitle"></a>
 ### hideNativeSubtitle #########################################################
 
+---
+
+:warning: This option is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+---
+
 _type_: ``Boolean``
 
 _defaults_: ``false``

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -489,9 +489,12 @@ function parseLoadVideoOptions(
              "`setPreferredTextTracks` method instead");
   }
   const defaultTextTrack = normalizeTextTrack(options.defaultTextTrack);
-  const hideNativeSubtitle = options.hideNativeSubtitle == null ?
-    !DEFAULT_SHOW_NATIVE_SUBTITLE :
-    !!options.hideNativeSubtitle;
+
+  let hideNativeSubtitle = !DEFAULT_SHOW_NATIVE_SUBTITLE;
+  if (options.hideNativeSubtitle != null) {
+    warnOnce("The `hideNativeSubtitle` loadVideo option is deprecated");
+    hideNativeSubtitle = !!options.hideNativeSubtitle;
+  }
   const manualBitrateSwitchingMode = options.manualBitrateSwitchingMode == null ?
       DEFAULT_MANUAL_BITRATE_SWITCHING_MODE :
       options.manualBitrateSwitchingMode;


### PR DESCRIPTION
As far as I know, this API was only used at a time when only native subtitles were available.
It makes little sense know, at least under this form.

The funny thing is that I thought that we deprecated that option a long time ago already (there's even an implicit mention in the changelog about it being already deprecated if we scroll down to the v3.11.0 - version which dates back to march 2019!):
```md
  - api: fix (deprecated) option `hideNativeSubtitles`
```