### PR TITLE
text/ttml: handle styles inheritance of other styles

### DIFF
--- a/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
+++ b/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
@@ -44,13 +44,13 @@ describe("resolve_styles_inheritance", () => {
 
   it("should resolve simple inheritance", () => {
     logWarnMock.mockReturnValue(undefined);
-    const initialStyle = [
+    const initialStyle1 = [
       { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: ["2"] },
       { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
       { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
     ];
-    resolveStylesInheritance(initialStyle);
-    expect(initialStyle).toEqual([
+    resolveStylesInheritance(initialStyle1);
+    expect(initialStyle1).toEqual([
       { id: "1",
         style: { titi: "toto",
                  tata: "tutu",
@@ -59,6 +59,25 @@ describe("resolve_styles_inheritance", () => {
         extendsStyles: [] },
       { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
       { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ]);
+    const initialStyle2 = [
+      { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: ["1"] },
+    ];
+    resolveStylesInheritance(initialStyle2);
+    expect(initialStyle2).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tutu" },
+        extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3",
+        style: { titu: "totu",
+                 tatu: "tatu",
+                 titi: "toto",
+                 tata: "tutu" },
+        extendsStyles: [] },
     ]);
     expect(logWarnMock).not.toHaveBeenCalled();
   });

--- a/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
+++ b/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../../../../log";
+import resolveStylesInheritance from "../resolve_styles_inheritance";
+
+/* tslint:disable no-unsafe-any */
+jest.mock("../../../../log");
+const logWarnMock = log.warn as jest.Mock<ReturnType<typeof log.warn>>;
+
+describe("resolve_styles_inheritance", () => {
+  afterEach(() => {
+    logWarnMock.mockReset();
+  });
+
+  it("should not update styles without any inheritance", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should resolve simple inheritance", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: ["2"] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tutu",
+                 toti: "toti",
+                 tati: "totu" },
+        extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should be able to inherit multiple styles at once", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tutu"}, extendsStyles: ["2", "3"] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tutu",
+                 toti: "toti",
+                 tati: "totu",
+                 titu: "totu",
+                 tatu: "tatu" },
+        extendsStyles: [] },
+      { id: "2", style: { toti: "toti", tati: "totu"}, extendsStyles: [] },
+      { id: "3", style: { titu: "totu", tatu: "tatu"}, extendsStyles: [] },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should correctly overwrite inherited properties", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["2", "3"] },
+      { id: "2", style: { titi: "tito", tata: "titu"}, extendsStyles: [] },
+      { id: "3", style: { teti: "teto", tata: "tutu"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tuto",
+                 teti: "teto" },
+        extendsStyles: [] },
+      { id: "2", style: { titi: "tito", tata: "titu"}, extendsStyles: [] },
+      { id: "3", style: { teti: "teto", tata: "tutu"}, extendsStyles: [] },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should correctly handle multiple levels of inheritance", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["2", "3"] },
+      { id: "2", style: { titi: "tito", tata: "titu"}, extendsStyles: ["4"] },
+      { id: "3", style: { teti: "teto", tata: "tutu"}, extendsStyles: [] },
+      { id: "4", style: { four: "4", four2: "four2"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tuto",
+                 teti: "teto",
+                 four: "4",
+                 four2: "four2" },
+        extendsStyles: [] },
+      { id: "2",
+        style: { titi: "tito",
+                 tata: "titu",
+                 four: "4",
+                 four2: "four2" },
+        extendsStyles: [] },
+      { id: "3", style: { teti: "teto", tata: "tutu"}, extendsStyles: [] },
+      { id: "4", style: { four: "4", four2: "four2"}, extendsStyles: [] },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should avoid infinite inheritance loops", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["2", "3"] },
+      { id: "2", style: { titi: "tito", teta: "tutu"}, extendsStyles: ["3"] },
+      { id: "3", style: { tata: "toto", tota: "tutu"}, extendsStyles: ["2"] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tuto",
+                 teta: "tutu",
+                 tota: "tutu" },
+        extendsStyles: [] },
+      { id: "2",
+        style: { titi: "tito",
+                 teta: "tutu",
+                 tata: "toto",
+                 tota: "tutu" },
+        extendsStyles: [] },
+      { id: "3",
+        style: { tata: "toto",
+                 tota: "tutu",
+                 titi: "tito",
+                 teta: "tutu" }, extendsStyles: [] },
+    ]);
+    expect(logWarnMock)
+      .toHaveBeenNthCalledWith(1, "TTML Parser: infinite style inheritance loop avoided");
+    expect(logWarnMock)
+      .toHaveBeenNthCalledWith(2, "TTML Parser: infinite style inheritance loop avoided");
+    expect(logWarnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("should ignore unknown IDs", () => {
+    logWarnMock.mockReturnValue(undefined);
+    const initialStyle = [
+      { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["3", "6", "2"] },
+      { id: "2", style: { titi: "tito", teta: "tutu"}, extendsStyles: [] },
+      { id: "3", style: { tata: "toto", tota: "tutu"}, extendsStyles: [] },
+    ];
+    resolveStylesInheritance(initialStyle);
+    expect(initialStyle).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tuto",
+                 teta: "tutu",
+                 tota: "tutu" },
+        extendsStyles: [] },
+      { id: "2",
+        style: { titi: "tito",
+                 teta: "tutu"},
+        extendsStyles: [] },
+      { id: "3",
+        style: { tata: "toto",
+                 tota: "tutu"},
+        extendsStyles: [] },
+    ]);
+    expect(logWarnMock)
+      .toHaveBeenNthCalledWith(1, "TTML Parser: unknown style inheritance: 6");
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
+++ b/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
@@ -137,13 +137,43 @@ describe("resolve_styles_inheritance", () => {
 
   it("should avoid infinite inheritance loops", () => {
     logWarnMock.mockReturnValue(undefined);
-    const initialStyle = [
+
+    // 1. simple case
+    const initialStyle1 = [
+      { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["3"] },
+      { id: "2", style: { titi: "tito", teta: "tutu"}, extendsStyles: [] },
+      { id: "3", style: { tata: "toto", tota: "tutu"}, extendsStyles: ["1"] },
+    ];
+    resolveStylesInheritance(initialStyle1);
+    expect(initialStyle1).toEqual([
+      { id: "1",
+        style: { titi: "toto",
+                 tata: "tuto",
+                 tota: "tutu" },
+        extendsStyles: [] },
+      { id: "2",
+        style: { titi: "tito",
+                 teta: "tutu" },
+        extendsStyles: [] },
+      { id: "3",
+        style: { tata: "toto",
+                 tota: "tutu",
+                 titi: "toto" }, extendsStyles: [] },
+    ]);
+
+    expect(logWarnMock)
+      .toHaveBeenNthCalledWith(1, "TTML Parser: infinite style inheritance loop avoided");
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+    logWarnMock.mockReset();
+
+    // 2. More complex case
+    const initialStyle2 = [
       { id: "1", style: { titi: "toto", tata: "tuto"}, extendsStyles: ["2", "3"] },
       { id: "2", style: { titi: "tito", teta: "tutu"}, extendsStyles: ["3"] },
       { id: "3", style: { tata: "toto", tota: "tutu"}, extendsStyles: ["2"] },
     ];
-    resolveStylesInheritance(initialStyle);
-    expect(initialStyle).toEqual([
+    resolveStylesInheritance(initialStyle2);
+    expect(initialStyle2).toEqual([
       { id: "1",
         style: { titi: "toto",
                  tata: "tuto",

--- a/src/parsers/texttracks/ttml/get_styling.ts
+++ b/src/parsers/texttracks/ttml/get_styling.ts
@@ -22,8 +22,12 @@ import startsWith from "../../../utils/starts_with";
 export type IStyleList =
   Partial<Record<string, string>>;
 
-export interface IStyleObject { id: string;
-                                style: IStyleList; }
+// Object defining a single element's (region/style...) style parameters
+export interface IStyleObject {
+  id : string; // The ID of the current element
+  style : IStyleList; // All set style preference
+  extendsStyles : string[]; // ID of the "style" elements this element extends
+}
 
 /**
  * Retrieve the attributes given in arguments in the given nodes and their

--- a/src/parsers/texttracks/ttml/html/__tests__/ttml_color_to_css_color.test.ts
+++ b/src/parsers/texttracks/ttml/html/__tests__/ttml_color_to_css_color.test.ts
@@ -43,4 +43,20 @@ describe("ttmlColorToCSSColor", () => {
     expect(ttmlColorToCSSColor("#88A0"))
       .toEqual("rgba(136,136,170,0)");
   });
+
+  it("should translate values based on rgb characters", () => {
+    expect(ttmlColorToCSSColor("rgb(57, 98, 77)"))
+      .toEqual("rgb(57,98,77)");
+    expect(ttmlColorToCSSColor("rgb(67,8,57)"))
+      .toEqual("rgb(67,8,57)");
+  });
+
+  it("should translate values based on rgba characters", () => {
+    expect(ttmlColorToCSSColor("rgba(67,8,77,255)"))
+      .toEqual("rgba(67,8,77,1)");
+    expect(ttmlColorToCSSColor("rgba(57, 98, 77, 0)"))
+      .toEqual("rgba(57,98,77,0)");
+    expect(ttmlColorToCSSColor("rgba(57, 98, 77,128)"))
+      .toEqual("rgba(57,98,77,0.5019607843137255)");
+  });
 });

--- a/src/parsers/texttracks/ttml/html/ttml_color_to_css_color.ts
+++ b/src/parsers/texttracks/ttml/html/ttml_color_to_css_color.ts
@@ -17,6 +17,8 @@
 import {
   REGXP_4_HEX_COLOR,
   REGXP_8_HEX_COLOR,
+  REGXP_RGB_COLOR,
+  REGXP_RGBA_COLOR,
 } from "../regexps";
 
 /**
@@ -27,6 +29,7 @@ import {
 export default function ttmlColorToCSSColor(color : string) : string {
   // TODO check all possible color fomats
   let regRes;
+
   regRes = REGXP_8_HEX_COLOR.exec(color);
   if (regRes != null) {
     return "rgba(" +
@@ -35,14 +38,31 @@ export default function ttmlColorToCSSColor(color : string) : string {
       String(parseInt(regRes[3], 16)) + "," +
       String(parseInt(regRes[4], 16) / 255) + ")";
   }
-  regRes = REGXP_4_HEX_COLOR.exec(color);
 
+  regRes = REGXP_4_HEX_COLOR.exec(color);
   if (regRes != null) {
     return "rgba(" +
       String(parseInt(regRes[1] + regRes[1], 16)) + "," +
       String(parseInt(regRes[2] + regRes[2], 16)) + "," +
       String(parseInt(regRes[3] + regRes[3], 16)) + "," +
       String(parseInt(regRes[4] + regRes[4], 16) / 255) + ")";
+  }
+
+  regRes = REGXP_RGB_COLOR.exec(color);
+  if (regRes != null) {
+    return "rgb(" +
+      String(+regRes[1]) + "," +
+      String(+regRes[2]) + "," +
+      String(+regRes[3]) + ")";
+  }
+
+  regRes = REGXP_RGBA_COLOR.exec(color);
+  if (regRes != null) {
+    return "rgba(" +
+      String(+regRes[1]) + "," +
+      String(+regRes[2]) + "," +
+      String(+regRes[3]) + "," +
+      String(+regRes[4] / 255) + ")";
   }
   return color;
 }

--- a/src/parsers/texttracks/ttml/native/parse_ttml_to_vtt.ts
+++ b/src/parsers/texttracks/ttml/native/parse_ttml_to_vtt.ts
@@ -40,6 +40,7 @@ import {
   getTextNodes,
 } from "../nodes";
 import { REGXP_PERCENT_VALUES, } from "../regexps";
+import resolveStylesInheritance from "../resolve_styles_inheritance";
 
 /**
  * Style attributes currently used.
@@ -101,13 +102,17 @@ function parseTTMLStringToVTT(
       if (styleNode instanceof Element) {
         const styleID = styleNode.getAttribute("xml:id");
         if (styleID != null) {
-          styles.push({
-            id: styleID,
-            style: getStylingFromElement(styleNode),
-          });
+          const subStyles = styleNode.getAttribute("style");
+          const extendsStyles = subStyles === null ? [] :
+                                                     subStyles.split(" ");
+          styles.push({ id: styleID,
+                        style: getStylingFromElement(styleNode),
+                        extendsStyles });
         }
       }
     }
+
+    resolveStylesInheritance(styles);
 
     // construct regions array based on the xml as an optimization
     const regions : IStyleObject[] = [];
@@ -125,10 +130,11 @@ function parseTTMLStringToVTT(
               regionStyle = objectAssign({}, style.style, regionStyle);
             }
           }
-          regions.push({
-            id: regionID,
-            style: regionStyle,
-          });
+          regions.push({ id: regionID,
+                         style: regionStyle,
+
+                         // already handled
+                         extendsStyles: [] });
         }
       }
     }

--- a/src/parsers/texttracks/ttml/regexps.ts
+++ b/src/parsers/texttracks/ttml/regexps.ts
@@ -43,9 +43,17 @@ const REGXP_8_HEX_COLOR =
   /^#([0-9A-f]{2})([0-9A-f]{2})([0-9A-f]{2})([0-9A-f]{2})$/;
 const REGXP_4_HEX_COLOR = /^#([0-9A-f])([0-9A-f])([0-9A-f])([0-9A-f])$/;
 
+const REGXP_RGB_COLOR =
+  /^rgb\( *(\d+) *, *(\d+) *, *(\d+) *\)/;
+
+const REGXP_RGBA_COLOR =
+  /^rgba\( *(\d+) *, *(\d+) *, *(\d+) *, *(\d+) *\)/;
+
 export {
   REGXP_4_HEX_COLOR,
   REGXP_8_HEX_COLOR,
+  REGXP_RGB_COLOR,
+  REGXP_RGBA_COLOR,
   REGXP_LENGTH,
   REGXP_PERCENT_VALUES,
   REGXP_TIME_COLON,

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -56,9 +56,9 @@ export default function resolveStylesInheritance(
   styles : IStyleObject[]
 ) : void {
   // keep track of all the indexes parsed to avoid infinite loops
-  const indexesAlreadyResolving : number[] = [];
+  const recursivelyBrowsedIndexes : number[] = [];
   function resolveStyleInheritance(styleElt : IStyleObject, index : number) {
-    indexesAlreadyResolving.push(index);
+    recursivelyBrowsedIndexes.push(index);
     for (let j = 0; j < styleElt.extendsStyles.length; j++) {
       const extendedStyleID = styleElt.extendsStyles[j];
       const extendedStyleIndex = arrayFindIndex(styles,
@@ -67,7 +67,7 @@ export default function resolveStylesInheritance(
         log.warn("TTML Parser: unknown style inheritance: " + extendedStyleID);
       } else {
         const extendedStyle = styles[extendedStyleIndex];
-        if (arrayIncludes(indexesAlreadyResolving, extendedStyleIndex)) {
+        if (arrayIncludes(recursivelyBrowsedIndexes, extendedStyleIndex)) {
           log.warn("TTML Parser: infinite style inheritance loop avoided");
         } else {
           resolveStyleInheritance(extendedStyle, extendedStyleIndex);
@@ -79,5 +79,6 @@ export default function resolveStylesInheritance(
   }
   for (let i = 0; i < styles.length; i++) {
     resolveStyleInheritance(styles[i], i);
+    recursivelyBrowsedIndexes.length = 0; // reset
   }
 }

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import objectAssign from "object-assign";
+import log from "../../../log";
+import arrayFindIndex from "../../../utils/array_find_index";
+import arrayIncludes from "../../../utils/array_includes";
+import { IStyleObject } from "./get_styling";
+
+/**
+ * Transform all styles inheriting from other styles to the same styles but with
+ * the inheritance removed (by resolving those inheritance here).
+ *
+ * Note that the original style object is directly muted with every inheritance
+ * they had resolved and removed.
+ *
+ * To make a pseudo-code analogy this would be equivalent to transform those
+ * two classes:
+ * ```
+ * class A {
+ *   methodA() {}
+ * }
+ *
+ * class B extends A {
+ *   method B() {}
+ * }
+ * ```
+ * into the same two classes without inheritance:
+ * ```
+ * class A {
+ *   methodA() {}
+ * }
+ * class B {
+ *   methodA() {} // inherited from class A
+ *   methodB() {}
+ * }
+ * ```
+ *
+ * Doing this here allows to simplify further treatment of those styles.
+ * @param {Array.<Object>} styles
+ * @returns {Array.<Object>}
+ */
+export default function resolveStylesInheritance(
+  styles : IStyleObject[]
+) : void {
+  // keep track of all the indexes parsed to avoid infinite loops
+  const recursivelyBrowsedIndexes : number[] = [];
+  function resolveStyleInheritance(styleElt : IStyleObject, index : number) {
+    recursivelyBrowsedIndexes.push(index);
+    for (let j = 0; j < styleElt.extendsStyles.length; j++) {
+      const extendedStyleID = styleElt.extendsStyles[j];
+      const extendedStyleIndex = arrayFindIndex(styles,
+                                                (x) => x.id === extendedStyleID);
+      if (extendedStyleIndex < 0) {
+        log.warn("TTML Parser: unknown style inheritance: " + extendedStyleID);
+      } else {
+        const extendedStyle = styles[extendedStyleIndex];
+        if (arrayIncludes(recursivelyBrowsedIndexes, extendedStyleIndex)) {
+          log.warn("TTML Parser: infinite style inheritance loop avoided");
+        } else {
+          resolveStyleInheritance(extendedStyle, extendedStyleIndex);
+        }
+        styleElt.style = objectAssign({}, extendedStyle.style, styleElt.style);
+      }
+    }
+    styleElt.extendsStyles.length = 0;
+  }
+  for (let i = 0; i < styles.length; i++) {
+    resolveStyleInheritance(styles[i], i);
+  }
+}

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -57,9 +57,9 @@ export default function resolveStylesInheritance(
   styles : IStyleObject[]
 ) : void {
   // keep track of all the indexes parsed to avoid infinite loops
-  const recursivelyBrowsedIndexes : number[] = [];
+  const indexesAlreadyResolving : number[] = [];
   function resolveStyleInheritance(styleElt : IStyleObject, index : number) {
-    recursivelyBrowsedIndexes.push(index);
+    indexesAlreadyResolving.push(index);
     for (let j = 0; j < styleElt.extendsStyles.length; j++) {
       const extendedStyleID = styleElt.extendsStyles[j];
       const extendedStyleIndex = arrayFindIndex(styles,
@@ -68,7 +68,7 @@ export default function resolveStylesInheritance(
         log.warn("TTML Parser: unknown style inheritance: " + extendedStyleID);
       } else {
         const extendedStyle = styles[extendedStyleIndex];
-        if (arrayIncludes(recursivelyBrowsedIndexes, extendedStyleIndex)) {
+        if (arrayIncludes(indexesAlreadyResolving, extendedStyleIndex)) {
           log.warn("TTML Parser: infinite style inheritance loop avoided");
         } else {
           resolveStyleInheritance(extendedStyle, extendedStyleIndex);

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -24,8 +24,8 @@ import { IStyleObject } from "./get_styling";
  * Transform all styles inheriting from other styles to the same styles but with
  * the inheritance removed (by resolving those inheritance here).
  *
- * Note that the original style object is directly muted with every inheritance
- * they had resolved and removed.
+ * Note that the original style object is directly mutated with every
+ * inheritance they had resolved and removed.
  *
  * To make a pseudo-code analogy this would be equivalent to transform those
  * two classes:

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -51,7 +51,6 @@ import { IStyleObject } from "./get_styling";
  *
  * Doing this here allows to simplify further treatment of those styles.
  * @param {Array.<Object>} styles
- * @returns {Array.<Object>}
  */
 export default function resolveStylesInheritance(
   styles : IStyleObject[]


### PR DESCRIPTION
This PR brings a fix and a feature relative to TTML subtitles:
  1. fix alpha information from a "rgba" value in TTML. The bug was due to the fact that we previously thought that it works the same way than for a rgba CSS value. It does not. In CSS it goes from a range starting at 0 (transparent) and ending at 1 (opaque) whereas for TTML it goes from 0 (transparent) to 255 (opaque).

  2. Style elements can inherit from other style elements. This was previously not done because it could go ugly quickly. The solution I found was to "resolve" the inheritance just after parsing every style elements (so before parsing almost everything else).
      The way I did it might not be the best way, the `IStyleObject` interface now contains an `extendsStyles` property that becomes unnecessary in most of the code. But it works.
      I also handled infinite inheritance loop by ignoring already-considered IDs for the currently-resolved element.
      Also, inheriting a not-defined ID just triggers a log.warn,

I added unit tests for both of these cases.