### PR TITLE
Filter unsupported quality levels when parsing Smooth manifest

### DIFF
--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -188,11 +188,6 @@ function createSmoothStreamingParser(
 
         const codecs = getAudioCodecs(codecPrivateData, fourCC);
 
-        if (codecs === null) {
-          log.warn("Smooth parser: Unsupported audio codec. Ignoring quality level.");
-          return null;
-        }
-
         return {
           audiotag: audiotag !== undefined ? parseInt(audiotag, 10) : audiotag,
           bitrate,
@@ -230,11 +225,6 @@ function createSmoothStreamingParser(
         }
 
         const codecs = getVideoCodecs(codecPrivateData);
-
-        if (codecs === null) {
-          log.warn("Smooth parser: Unsupported video codec. Ignoring quality level.");
-          return null;
-        }
 
         return {
           bitrate,

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -68,9 +68,6 @@ const DEFAULT_MIME_TYPES : Partial<Record<string, string>> = {
   text: "application/ttml+xml",
 };
 
-const DEFAULT_CODECS : Partial<Record<string, string>> = { audio: "mp4a.40.2",
-                                                          video: "avc1.4D401E" };
-
 const MIME_TYPES : Partial<Record<string, string>> = {
   AACL: "audio/mp4",
   AVC1: "video/mp4",
@@ -357,9 +354,7 @@ function createSmoothStreamingParser(
       const mimeType = isNonEmptyString(qualityLevel.mimeType) ?
         qualityLevel.mimeType :
         DEFAULT_MIME_TYPES[adaptationType];
-      const codecs = isNonEmptyString(qualityLevel.codecs) ?
-        qualityLevel.codecs :
-        DEFAULT_CODECS[adaptationType];
+      const codecs = qualityLevel.codecs;
       const id =  adaptationID + "_" +
                   (adaptationType != null ? adaptationType + "-" :
                                             "") +

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -182,14 +182,14 @@ function createSmoothStreamingParser(
                         isNaN(parseInt(bitrateAttr, 10)) ? 0 :
                                                            parseInt(bitrateAttr, 10);
 
-        if (fourCC == null ||
-            MIME_TYPES[fourCC] === undefined ||
+        if ((fourCC !== undefined &&
+             MIME_TYPES[fourCC] === undefined) ||
             codecPrivateData === undefined) {
           log.warn("Smooth parser: Unsupported audio codec. Ignoring quality level.");
           return null;
         }
 
-        const codecs = getAudioCodecs(fourCC, codecPrivateData);
+        const codecs = getAudioCodecs(codecPrivateData, fourCC);
 
         if (codecs === null) {
           log.warn("Smooth parser: Unsupported audio codec. Ignoring quality level.");
@@ -225,8 +225,8 @@ function createSmoothStreamingParser(
                         isNaN(parseInt(bitrateAttr, 10)) ? 0 :
                                                            parseInt(bitrateAttr, 10);
 
-        if (fourCC === undefined ||
-            MIME_TYPES[fourCC] === undefined ||
+        if ((fourCC !== undefined &&
+             MIME_TYPES[fourCC] === undefined) ||
             codecPrivateData === undefined) {
           log.warn("Smooth parser: Unsupported video codec. Ignoring quality level.");
           return null;

--- a/src/parsers/manifest/smooth/get_codecs.ts
+++ b/src/parsers/manifest/smooth/get_codecs.ts
@@ -19,12 +19,12 @@ import isNonEmptyString from "../../../utils/is_non_empty_string";
 /**
  * @param {string} fourCC
  * @param {string} codecPrivateData
- * @returns {string}
+ * @returns {string|null}
  */
 export function getAudioCodecs(
   fourCC : string,
   codecPrivateData : string
-) : string {
+) : string|null {
   let mpProfile : number;
   if (fourCC === "AACH") {
     mpProfile = 5; // High Efficiency AAC Profile
@@ -33,17 +33,21 @@ export function getAudioCodecs(
       (parseInt(codecPrivateData.substring(0, 2), 16) & 0xF8) >> 3 :
       2;
   }
-  return mpProfile !== 0 ? (`mp4a.40.${mpProfile}`) :
-                           "";
+  if (mpProfile === 0) {
+    return null;
+  }
+  return `mp4a.40.${mpProfile}`;
 }
 
 /**
  * @param {string} codecPrivateData
- * @returns {string}
+ * @returns {string|null}
  */
-export function getVideoCodecs(codecPrivateData : string) : string {
+export function getVideoCodecs(codecPrivateData : string) : string|null {
   // we can extract codes only if fourCC is on of "H264", "X264", "DAVC", "AVC1"
   const arr = /00000001\d7([0-9a-fA-F]{6})/.exec(codecPrivateData);
-  return arr !== null && isNonEmptyString(arr[1]) ? "avc1." + arr[1] :
-                                                    "";
+  if (arr === null || !isNonEmptyString(arr[1])) {
+    return null;
+  }
+  return "avc1." + arr[1];
 }

--- a/src/parsers/manifest/smooth/get_codecs.ts
+++ b/src/parsers/manifest/smooth/get_codecs.ts
@@ -19,12 +19,12 @@ import isNonEmptyString from "../../../utils/is_non_empty_string";
 /**
  * @param {string} codecPrivateData
  * @param {string|undefined} fourCC
- * @returns {string|null}
+ * @returns {string}
  */
 export function getAudioCodecs(
   codecPrivateData : string,
   fourCC?: string
-) : string|null {
+) : string {
   let mpProfile : number;
   if (fourCC === "AACH") {
     mpProfile = 5; // High Efficiency AAC Profile
@@ -42,15 +42,12 @@ export function getAudioCodecs(
 
 /**
  * @param {string} codecPrivateData
- * @returns {string|null}
+ * @returns {string}
  */
-export function getVideoCodecs(codecPrivateData : string) : string|null {
+export function getVideoCodecs(codecPrivateData : string) : string {
   // we can extract codes only if fourCC is on of "H264", "X264", "DAVC", "AVC1"
   const arr = /00000001\d7([0-9a-fA-F]{6})/.exec(codecPrivateData);
-  if (arr === null) {
-    return null;
-  }
-  if (!isNonEmptyString(arr[1])) {
+  if (arr === null || !isNonEmptyString(arr[1])) {
     // Return default video codec
     return "avc1.4D401E";
   }

--- a/src/parsers/manifest/smooth/get_codecs.ts
+++ b/src/parsers/manifest/smooth/get_codecs.ts
@@ -17,13 +17,13 @@
 import isNonEmptyString from "../../../utils/is_non_empty_string";
 
 /**
- * @param {string} fourCC
  * @param {string} codecPrivateData
+ * @param {string|undefined} fourCC
  * @returns {string|null}
  */
 export function getAudioCodecs(
-  fourCC : string,
-  codecPrivateData : string
+  codecPrivateData : string,
+  fourCC?: string
 ) : string|null {
   let mpProfile : number;
   if (fourCC === "AACH") {

--- a/src/parsers/manifest/smooth/get_codecs.ts
+++ b/src/parsers/manifest/smooth/get_codecs.ts
@@ -34,7 +34,8 @@ export function getAudioCodecs(
       2;
   }
   if (mpProfile === 0) {
-    return null;
+    // Return default audio codec
+    return "mp4a.40.2";
   }
   return `mp4a.40.${mpProfile}`;
 }
@@ -46,8 +47,12 @@ export function getAudioCodecs(
 export function getVideoCodecs(codecPrivateData : string) : string|null {
   // we can extract codes only if fourCC is on of "H264", "X264", "DAVC", "AVC1"
   const arr = /00000001\d7([0-9a-fA-F]{6})/.exec(codecPrivateData);
-  if (arr === null || !isNonEmptyString(arr[1])) {
+  if (arr === null) {
     return null;
+  }
+  if (!isNonEmptyString(arr[1])) {
+    // Return default video codec
+    return "avc1.4D401E";
   }
   return "avc1." + arr[1];
 }

--- a/src/transports/smooth/isobmff/create_video_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_video_init_segment.ts
@@ -64,6 +64,9 @@ export default function createVideoInitSegment(
   const _pssList = pssList === undefined ? [] :
                                            pssList;
   const [, spsHex, ppsHex] = codecPrivateData.split("00000001");
+  if (spsHex === undefined || ppsHex === undefined) {
+    throw new Error("Smooth: unsupported codec private data.");
+  }
   const sps = hexToBytes(spsHex);
   const pps = hexToBytes(ppsHex);
 

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -81,10 +81,13 @@ const generateSegmentLoader = (
     }
     const smoothInitPrivateInfos = segment.privateInfos.smoothInit;
     let responseData : Uint8Array;
-    const { codecPrivateData = "",
+    const { codecPrivateData,
             protection = { keyId: undefined,
                            keySystems: undefined } } = smoothInitPrivateInfos;
 
+    if (codecPrivateData === undefined) {
+      throw new Error("Smooth: no codec private data.");
+    }
     switch (adaptation.type) {
       case "video": {
         const { width = 0, height = 0 } = representation;


### PR DESCRIPTION
Most of Smooth contents video tracks are in H264/AVC.
The RxPlayer can detect it through some properties (e.g. FourCC, codecPrivateData).
If the player can't detect it, it considers it to be avc1 (while there are high chances that it is something else). So it will ask for the browser to decode avc1, and try to create an init segment with an unsupported codec private data. So, the player crashed at this step.

Now, it filters out the tracks were the FourCC is not known, or the codec private data is undefined.

The current bug can be reproduced by trying to play http://playready.directtaps.net/smoothstreaming/TTLSS720VC1/To_The_Limit_720.ism/Manifest.
On this content, the video track is in VC1. This codec is not supported by web browser (but was supported in Microsoft Silverlight).