### PR TITLE
Use padding when fast switching on Safari

### DIFF
--- a/src/compat/__tests__/should_append_buffer_after_padding.test.ts
+++ b/src/compat/__tests__/should_append_buffer_after_padding.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("shouldAppendBufferAfterPadding", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+it("should be true if on Safari", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true,
+               isSafari: true };
+    });
+    /* tslint:disable no-unsafe-any */
+    const shouldAppendBufferAfterPadding =
+      require("../should_append_buffer_after_padding").default;
+    /* tslint:enable no-unsafe-any */
+    expect(shouldAppendBufferAfterPadding).toBe(true);
+  });
+
+it("should be false if not on Safari", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true,
+               isSafari: false };
+    });
+    /* tslint:disable no-unsafe-any */
+    const shouldAppendBufferAfterPadding =
+      require("../should_append_buffer_after_padding").default;
+    /* tslint:enable no-unsafe-any */
+    expect(shouldAppendBufferAfterPadding).toBe(false);
+  });
+});

--- a/src/compat/should_append_buffer_after_padding.ts
+++ b/src/compat/should_append_buffer_after_padding.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isSafari } from "./browser_detection";
+
+/**
+ * When the player decides to load another quality and replace
+ * currently buffered one, it may append buffer on current playback time.
+ *
+ * On Safari, with HSS contents, this provoques green macro-block screens
+ * during the transition. To avoid this situation, we decide not to load a
+ * segment if it may be pushed during playback time. We should not buffer
+ * under a certain padding from the current time.
+ */
+const shouldAppendBufferAfterPadding = isSafari;
+export default shouldAppendBufferAfterPadding;

--- a/src/config.ts
+++ b/src/config.ts
@@ -819,4 +819,12 @@ export default {
    * @type {Number}
    */
   SOURCE_BUFFER_FLUSHING_INTERVAL: 2000,
+
+  /**
+   * Padding under which we should not buffer from the current time, on
+   * Safari. To avoid some buffer appending issues on it, we decide not
+   * to load a segment if it may be pushed during playback time.
+   * @type {Number} - in seconds
+   */
+  CONTENT_REPLACEMENT_PADDING: 2,
 };

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2308,7 +2308,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             .getChosenVideoTrack(currentPeriod);
           this.trigger("videoTrackChange", videoTrack);
 
-
           const availableVideoBitrates = this.getAvailableVideoBitrates();
           this._priv_triggerAvailableBitratesChangeEvent("availableVideoBitratesChange",
                                                          availableVideoBitrates);

--- a/src/core/buffers/representation/get_needed_segments.ts
+++ b/src/core/buffers/representation/get_needed_segments.ts
@@ -185,7 +185,6 @@ function shouldContentBeReplaced(
     return true; // replace segments from another Adaptation
   }
 
-
   const oldContentBitrate = oldContent.representation.bitrate;
   if (knownStableBitrate === undefined) {
     // only re-load comparatively-poor bitrates for the same Adaptation.

--- a/src/core/buffers/representation/get_needed_segments.ts
+++ b/src/core/buffers/representation/get_needed_segments.ts
@@ -37,7 +37,8 @@ import Manifest, {
 import SimpleSet from "../../../utils/simple_set";
 import { IBufferedChunk } from "../../source_buffers";
 
-const { BITRATE_REBUFFERING_RATIO,
+const { CONTENT_REPLACEMENT_PADDING,
+        BITRATE_REBUFFERING_RATIO,
         MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT,
         MINIMUM_SEGMENT_SIZE } = config;
 
@@ -177,7 +178,7 @@ function shouldContentBeReplaced(
   const { segment } = oldContent;
   if (shouldAppendBufferAfterPadding &&
       (segment.time / segment.timescale) <
-      (currentPlaybackTime + segment.duration / segment.timescale)) {
+      (currentPlaybackTime + CONTENT_REPLACEMENT_PADDING)) {
       return false;
   }
 

--- a/src/core/buffers/representation/representation_buffer.ts
+++ b/src/core/buffers/representation/representation_buffer.ts
@@ -228,6 +228,7 @@ export default function RepresentationBuffer<T>({
 
       const segmentInventory = queuedSourceBuffer.getInventory();
       let neededSegments = getNeededSegments({ content,
+                                               currentPlaybackTime: timing.currentTime,
                                                knownStableBitrate,
                                                loadedSegmentPendingPush,
                                                neededRange,

--- a/tslint.json
+++ b/tslint.json
@@ -58,6 +58,7 @@
     "no-bitwise": false,
     "no-boolean-literal-compare": true,
     "no-conditional-assignment": false,
+    "no-consecutive-blank-lines": true,
     "no-console": true,
     "no-construct": true,
     "no-debugger": true,


### PR DESCRIPTION
When the player decides to load another quality and replace currently buffered one, it may append buffer on current playback time.

On Safari, with HSS contents, this provoques green macro-block screens during the transition. To avoid this situation, we decide not to load a segment if it may be pushed during playback time. We should not buffer under a certain padding from the current time.