### PR TITLE
parsers/manifest: set a stricter adaptation type

### DIFF
--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -230,6 +230,9 @@ export default function parseAdaptationSets(
                                        adaptationChildren.roles != null ?
                                          adaptationChildren.roles :
                                          null);
+      if (type === undefined) {
+        return acc; // let's not parse unrecognized tracks
+      }
       const representations = parseRepresentations(representationsIR,
                                                    adaptation,
                                                    adaptationInfos);

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -40,22 +40,25 @@ export interface IParsedRepresentation {
   frameRate?: string;
   height?: number;
   mimeType?: string;
+  url? : string;
   width?: number;
 }
 
+export type IParsedAdaptationType = "audio" |
+                                    "video" |
+                                    "text" |
+                                    "image";
+
 // Collection of multiple `Adaptation`, regrouped by type
 export type IParsedAdaptations =
-  Partial<Record<string, IParsedAdaptation[]>>;
+  Partial<Record<IParsedAdaptationType, IParsedAdaptation[]>>;
 
 // Representation of a "track" available in any Period
 export interface IParsedAdaptation {
   // required
   id: string; // Unique ID for all Adaptation of that Period
   representations: IParsedRepresentation[]; // Qualities available for that Adaptation
-  type: "audio" |
-        "video" |
-        "text" |
-        "image";
+  type: IParsedAdaptationType;
 
   // optional
   audioDescription? : boolean; // Whether this Adaptation is an audio-track for

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -52,7 +52,10 @@ export interface IParsedAdaptation {
   // required
   id: string; // Unique ID for all Adaptation of that Period
   representations: IParsedRepresentation[]; // Qualities available for that Adaptation
-  type: string; // `Type` of Adaptation (e.g. `audio`, `video`, `text`, `image`...)
+  type: "audio" |
+        "video" |
+        "text" |
+        "image";
 
   // optional
   audioDescription? : boolean; // Whether this Adaptation is an audio-track for

--- a/src/parsers/manifest/utils/check_manifest_ids.ts
+++ b/src/parsers/manifest/utils/check_manifest_ids.ts
@@ -16,7 +16,10 @@
 
 import log from "../../../log";
 import arrayIncludes from "../../../utils/array_includes";
-import { IParsedManifest } from "../types";
+import {
+  IParsedAdaptationType,
+  IParsedManifest,
+} from "../types";
 
 /**
  * Ensure that no two periods, adaptations from the same period and
@@ -43,7 +46,7 @@ export default function checkManifestIDs(
     }
     const { adaptations } = period;
     const adaptationIDs : string[] = [];
-    Object.keys(adaptations).forEach((type) => {
+    (Object.keys(adaptations) as IParsedAdaptationType[]).forEach((type) => {
       const adaptationsForType = adaptations[type];
       if (adaptationsForType === undefined) {
         return;


### PR DESCRIPTION
An `IParsedAdaptation` can now only have one of those four types:
  - audio
  - video
  - text
  - image

This was already the case but the property's type was still set to `string`.