### PR TITLE
dash/smooth: fix base url resolution logic when query parameters contain "/" characters

### DIFF
--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -75,4 +75,22 @@ describe("utils - normalizeBaseURL", () => {
     expect(normalizeBaseURL(";ojdsfgje/eprowig/tohjroj/9ohyjwoij/s"))
       .toBe(";ojdsfgje/eprowig/tohjroj/9ohyjwoij/");
   });
+  it("should do nothing if the only slash are part of the protocol", () => {
+    expect(normalizeBaseURL("http://www.example.com"))
+      .toBe("http://www.example.com");
+    expect(normalizeBaseURL("https://a.t"))
+      .toBe("https://a.t");
+    expect(normalizeBaseURL("ftp://s"))
+      .toBe("ftp://s");
+  });
+  it("should not include slash coming in query parameters", () => {
+    expect(normalizeBaseURL("http://www.example.com?test/toto"))
+      .toBe("http://www.example.com");
+    expect(normalizeBaseURL("https://ww/ddd?test/toto/efewf/ffe/"))
+      .toBe("https://ww/");
+    expect(normalizeBaseURL("https://ww/rr/d?test/toto/efewf/ffe/"))
+      .toBe("https://ww/rr/");
+    expect(normalizeBaseURL("https://ww/rr/d/?test/toto/efewf/ffe/"))
+      .toBe("https://ww/rr/d/");
+  });
 });

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -96,12 +96,28 @@ export default function resolveURL(...args : Array<string|undefined>) : string {
  * @returns {string}
  */
 function normalizeBaseURL(url : string) : string {
-  const slash = url.lastIndexOf("/");
-  if (slash >= 0) {
-    return url.substring(0, slash + 1);
-  } else {
+  const indexOfLastSlash = url.lastIndexOf("/");
+  if (indexOfLastSlash < 0) {
     return url;
   }
+
+  if (schemeRe.test(url)) {
+    const firstSlashIndex = url.indexOf("/");
+    if (firstSlashIndex >= 0 && indexOfLastSlash === firstSlashIndex + 1) {
+      // The "/" detected is actually the one from the protocol part of the URL
+      // ("https://")
+      return url;
+    }
+  }
+
+  const indexOfQuestionMark = url.indexOf("?");
+  if (indexOfQuestionMark >= 0 && indexOfQuestionMark < indexOfLastSlash) {
+    // There are query parameters. Let's ignore them and re-run the logic
+    // without
+    return normalizeBaseURL(url.substring(0, indexOfQuestionMark));
+  }
+
+  return url.substring(0, indexOfLastSlash + 1);
 }
 
 export { normalizeBaseURL };


### PR DESCRIPTION
We had an issue open (#616) on that subject.

When either the URL of the Manifest or some of the BaseURL in it contain query parameters, which themselves contain slash(es) characters, we included a sub-part of the query parameters in the segments URL.

This is not what we want. We want to only truncate until the last slash coming BEFORE the first question mark.

This PR fix that issue. 

I don't know yet what we should do when a "#" is encountered.