### PR TITLE
Avoid to keep heavy JS data in RxPlayer logs

### DIFF
--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -345,7 +345,7 @@ export default function RepresentationEstimator({
           })();
           if (forceBandwidthMode) {
             log.debug("ABR: Choosing representation with bandwith estimation.",
-                      chosenRepFromBandwidth);
+                      chosenRepFromBandwidth.id, chosenRepFromBandwidth.bitrate);
             return { bitrate: bandwidthEstimate,
                      representation: chosenRepFromBandwidth,
                      urgent: networkAnalyzer.isUrgent(chosenRepFromBandwidth.bitrate,
@@ -359,7 +359,7 @@ export default function RepresentationEstimator({
               chosenRepFromBandwidth.bitrate >= bufferBasedBitrate)
           {
             log.debug("ABR: Choosing representation with bandwith estimation.",
-                      chosenRepFromBandwidth);
+                      chosenRepFromBandwidth.id, chosenRepFromBandwidth.bitrate);
             return { bitrate: bandwidthEstimate,
                      representation: chosenRepFromBandwidth,
                      urgent: networkAnalyzer.isUrgent(chosenRepFromBandwidth.bitrate,
@@ -382,7 +382,7 @@ export default function RepresentationEstimator({
           })();
           if (bufferBasedBitrate <= maxAutoBitrate) {
             log.debug("ABR: Choosing representation with buffer based bitrate ceiling.",
-                      chosenRepresentation);
+                      chosenRepresentation.id, chosenRepresentation.bitrate);
           }
           return { bitrate: bandwidthEstimate,
                    representation: chosenRepresentation,

--- a/src/core/abr/representation_score_calculator.ts
+++ b/src/core/abr/representation_score_calculator.ts
@@ -87,7 +87,9 @@ export default class RepresentationScoreCalculator {
     if (currentEWMA.getEstimate() > 1 &&
         this._lastRepresentationWithGoodScore !== representation
     ) {
-      log.debug("ABR: New last stable representation", representation);
+      log.debug("ABR: New last stable representation",
+                representation.id,
+                representation.bitrate);
       this._lastRepresentationWithGoodScore = representation;
     }
   }

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -192,7 +192,7 @@ export default class TrackChoiceManager {
     }
     if (periodItem != null) {
       if (periodItem[bufferType] != null) {
-        log.warn(`TrackChoiceManager: ${bufferType} already added for period`, period);
+        log.warn(`TrackChoiceManager: ${bufferType} already added for period`, period.id);
         return;
       } else {
         periodItem[bufferType] = { adaptations, adaptation$ };
@@ -215,13 +215,13 @@ export default class TrackChoiceManager {
   ) : void {
     const periodIndex = findPeriodIndex(this._periods, period);
     if (periodIndex == null) {
-      log.warn(`TrackChoiceManager: ${bufferType} not found for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} not found for period`, period.id);
       return;
     }
 
     const periodItem = this._periods.get(periodIndex);
     if (periodItem[bufferType] == null) {
-      log.warn(`TrackChoiceManager: ${bufferType} already removed for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} already removed for period`, period.id);
       return;
     }
     delete periodItem[bufferType];

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -260,7 +260,7 @@ export default function AdaptationBuffer<T>({
         map((wba) => wba * bufferGoalRatio)
       );
 
-      log.info("Buffer: changing representation", adaptation.type, representation);
+      log.info("Buffer: changing representation", adaptation.type, representation.id);
       return RepresentationBuffer({ clock$,
                                     content: { representation,
                                                adaptation,

--- a/src/core/buffers/buffer_orchestrator.ts
+++ b/src/core/buffers/buffer_orchestrator.ts
@@ -172,7 +172,7 @@ export default function BufferOrchestrator(
   const activePeriodChanged$ = ActivePeriodEmitter(buffersArray).pipe(
     filter((period) : period is Period => period != null),
     map(period => {
-      log.info("Buffer: New active period", period);
+      log.info("Buffer: New active period", period.id);
       return EVENTS.activePeriodChanged(period);
     }));
 
@@ -344,7 +344,7 @@ export default function BufferOrchestrator(
     basePeriod : Period,
     destroy$ : Observable<void>
   ) : Observable<IMultiplePeriodBuffersEvent> {
-    log.info("BO: Creating new Buffer for", bufferType, basePeriod);
+    log.info("BO: Creating new Buffer for", bufferType, basePeriod.id);
 
     // Emits the Period of the next Period Buffer when it can be created.
     const createNextPeriodBuffer$ = new Subject<Period>();
@@ -420,7 +420,7 @@ export default function BufferOrchestrator(
         periodBuffer$.pipe(takeUntil(killCurrentBuffer$)),
         observableOf(EVENTS.periodBufferCleared(bufferType, basePeriod))
           .pipe(tap(() => {
-            log.info("BO: Destroying buffer for", bufferType, basePeriod);
+            log.info("BO: Destroying buffer for", bufferType, basePeriod.id);
           }))
         );
 

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -115,7 +115,7 @@ export default function PeriodBuffer({
   return adaptation$.pipe(
     switchMap((adaptation) => {
       if (adaptation == null) {
-        log.info(`Buffer: Set no ${bufferType} Adaptation`, period);
+        log.info(`Buffer: Set no ${bufferType} Adaptation`, period.id);
         const previousQSourceBuffer = sourceBuffersStore.get(bufferType);
         let cleanBuffer$ : Observable<unknown>;
 
@@ -135,7 +135,7 @@ export default function PeriodBuffer({
         );
       }
 
-      log.info(`Buffer: Updating ${bufferType} adaptation`, adaptation, period);
+      log.info(`Buffer: Updating ${bufferType} adaptation`, adaptation.id);
 
       const newBuffer$ = clock$.pipe(
         take(1),

--- a/src/core/source_buffers/segment_inventory.ts
+++ b/src/core/source_buffers/segment_inventory.ts
@@ -581,7 +581,12 @@ export default class SegmentInventory {
     for (let i = 0; i < inventory.length; i++) {
       if (areSameContent(inventory[i].infos, content)) {
         if (foundIt) {
-          log.warn("SI: Completed Segment is splitted.", content);
+          log.warn("SI: Completed Segment is splitted.", {
+            segmentId: content.segment.id,
+            representationId: content.representation.id,
+            adaptationId: content.segment.id,
+            periodId: content.period.id,
+          });
         }
         foundIt = true;
 
@@ -608,7 +613,12 @@ export default class SegmentInventory {
     }
 
     if (!foundIt) {
-      log.warn("SI: Completed Segment not found", content);
+      log.warn("SI: Completed Segment not found", {
+        segmentId: content.segment.id,
+        representationId: content.representation.id,
+        adaptationId: content.segment.id,
+        periodId: content.period.id,
+      });
     }
   }
 

--- a/src/custom_source_buffers/text/html/parsers.ts
+++ b/src/custom_source_buffers/text/html/parsers.ts
@@ -44,6 +44,6 @@ export default function parseTextTrackToElements(
   }
   log.debug("HTSB: Parser found, parsing...");
   const parsed = parser(data, timestampOffset, language);
-  log.debug("HTTB: Parsed successfully!", parsed);
+  log.debug("HTSB: Parsed successfully!", parsed);
   return parsed;
 }

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -122,7 +122,7 @@ export default class Adaptation {
                                      parsedAdaptation.representations);
 
     if (hadRepresentations && argsRepresentations.length === 0) {
-      log.warn("Incompatible codecs for adaptation", parsedAdaptation);
+      log.warn("Incompatible codecs for adaptation", parsedAdaptation.id);
       const error = new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                                    "An Adaptation contains only incompatible codecs.");
       this.parsingErrors.push(error);

--- a/src/parsers/manifest/dash/flatten_overlapping_periods.ts
+++ b/src/parsers/manifest/dash/flatten_overlapping_periods.ts
@@ -57,7 +57,9 @@ export default function flattenOverlappingPeriods(
       lastFlattenedPeriod.duration == null ||
       (lastFlattenedPeriod.start + lastFlattenedPeriod.duration) > parsedPeriod.start
     ) {
-      log.warn("DASH: Updating overlapping Periods.", lastFlattenedPeriod, parsedPeriod);
+      log.warn("DASH: Updating overlapping Periods.",
+               lastFlattenedPeriod.id,
+               parsedPeriod.id);
       lastFlattenedPeriod.duration = parsedPeriod.start - lastFlattenedPeriod.start;
       lastFlattenedPeriod.end = parsedPeriod.start;
       if (lastFlattenedPeriod.duration <= 0) {

--- a/src/parsers/manifest/dash/get_clock_offset.ts
+++ b/src/parsers/manifest/dash/get_clock_offset.ts
@@ -34,7 +34,7 @@ export default function getClockOffset(
 ) : number|undefined {
   const httpOffset = Date.parse(serverClock) - performance.now();
   if (isNaN(httpOffset)) {
-    log.warn("DASH Parser: Invalid clock received: ",  serverClock);
+    log.warn("DASH Parser: Invalid clock received: ", serverClock);
     return undefined;
   }
   return httpOffset;


### PR DESCRIPTION
As every JS data you log is not garbage collected, memory consumption can increase a lot when logging.

Avoid to log period / rep / adaptation but just ids.