### PR TITLE
transports: avoid using double equality, even for null/undefined checks

### DIFF
--- a/src/parsers/containers/isobmff/get_box.ts
+++ b/src/parsers/containers/isobmff/get_box.ts
@@ -27,7 +27,8 @@ import { be4toi } from "../../../utils/byte_parsing";
  */
 function getBoxContent(buf : Uint8Array, boxName : number) : Uint8Array|null {
   const offsets = getBoxOffsets(buf, boxName);
-  return offsets != null ? buf.subarray(offsets[0] + 8, offsets[1]) : null;
+  return offsets !== null ? buf.subarray(offsets[0] + 8, offsets[1]) :
+                            null;
 }
 
 /**
@@ -41,7 +42,8 @@ function getBoxContent(buf : Uint8Array, boxName : number) : Uint8Array|null {
  */
 function getBox(buf : Uint8Array, boxName : number) : Uint8Array|null {
   const offsets = getBoxOffsets(buf, boxName);
-  return offsets != null ? buf.subarray(offsets[0], offsets[1]) : null;
+  return offsets !== null ? buf.subarray(offsets[0], offsets[1]) :
+                            null;
 }
 
 /**

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -32,7 +32,7 @@ import {
 export function imageLoader(
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable< ArrayBuffer | null > {
-  if (segment.isInit || segment.mediaURL == null) {
+  if (segment.isInit || segment.mediaURL === null) {
     return observableOf({ type: "data-created" as const,
                           value: { responseData: null } });
   }
@@ -67,7 +67,7 @@ export function imageParser(
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
 
   // TODO image Parsing should be more on the sourceBuffer side, no?
-  if (data === null || features.imageParser == null) {
+  if (data === null || features.imageParser === null) {
     return observableOf({ type: "parsed-segment",
                           value: { chunkData: null,
                                    chunkInfos: segment.timescale > 0 ?

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -33,11 +33,11 @@ export default function initSegmentLoader(
   url : string,
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
-  if (segment.range == null) {
+  if (segment.range === undefined) {
     return xhr({ url, responseType: "arraybuffer", sendProgressEvents: true });
   }
 
-  if (segment.indexRange == null) {
+  if (segment.indexRange === undefined) {
     return xhr({ url,
                  headers: { Range: byteRange(segment.range) },
                  responseType: "arraybuffer",

--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -45,23 +45,23 @@ export default function lowLatencySegmentLoader(
   }
 
   const { segment } = args;
-  const headers = segment.range != null ? { Range: byteRange(segment.range) } :
-                                          undefined;
+  const headers = segment.range !== undefined ? { Range: byteRange(segment.range) } :
+                                                undefined;
 
   return fetchRequest({ url, headers })
     .pipe(
       scan<IDataChunk | IDataComplete, IScannedChunk>((acc, evt) => {
         if (evt.type === "data-complete") {
-          if (acc.partialChunk != null) {
+          if (acc.partialChunk !== null) {
             log.warn("DASH Pipelines: remaining chunk does not belong to any segment");
           }
           return { event: evt, completeChunks: [], partialChunk: null };
         }
 
         const data = new Uint8Array(evt.value.chunk);
-        const concatenated = acc.partialChunk != null ? concat(acc.partialChunk,
-                                                               data) :
-                                                        data;
+        const concatenated = acc.partialChunk !== null ? concat(acc.partialChunk,
+                                                                data) :
+                                                         data;
         const [ completeChunks,
                 partialChunk ] = extractCompleteChunks(concatenated);
         return { event: evt, completeChunks, partialChunk };
@@ -74,13 +74,13 @@ export default function lowLatencySegmentLoader(
                          value: { responseData: evt.completeChunks[i] } });
         }
         const { event } = evt;
-        if (event != null && event.type === "data-chunk") {
+        if (event !== null && event.type === "data-chunk") {
           const { value } = event;
           emitted.push({ type: "progress",
                          value: { duration: value.duration,
                                   size: value.size,
                                   totalSize: value.totalSize } });
-        } else if (event != null && event.type === "data-complete") {
+        } else if (event !== null && event.type === "data-complete") {
           const { value } = event;
           emitted.push({ type: "data-chunk-complete",
                          value: { duration: value.duration,

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -62,7 +62,7 @@ export default function generateManifestParser(
 ) : (x : IManifestParserArguments) => IManifestParserObservable {
   const { aggressiveMode,
           referenceDateTime } = options;
-  const serverTimeOffset = options.serverSyncInfos != null ?
+  const serverTimeOffset = options.serverSyncInfos !== undefined ?
     options.serverSyncInfos.serverTimestamp - options.serverSyncInfos.clientTime :
     undefined;
   return function manifestParser(
@@ -71,16 +71,14 @@ export default function generateManifestParser(
     const { response, scheduleRequest } = args;
     const argClockOffset = args.externalClockOffset;
     const loaderURL = args.url;
-    const url = response.url == null ? loaderURL :
-                                       response.url;
+    const url = response.url ?? loaderURL;
     const data = typeof response.responseData === "string" ?
                    new DOMParser().parseFromString(response.responseData,
                                                    "text/xml") :
                    // TODO find a way to check if Document?
                    response.responseData as Document;
 
-    const externalClockOffset = serverTimeOffset == null ? argClockOffset :
-                                                           serverTimeOffset;
+    const externalClockOffset = serverTimeOffset ?? argClockOffset;
     const parsedManifest = dashManifestParser(data, { aggressiveMode:
                                                         aggressiveMode === true,
                                                       url,

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -68,8 +68,9 @@ function regularSegmentLoader(
   return xhr({ url,
                responseType: "arraybuffer",
                sendProgressEvents: true,
-               headers: segment.range != null ? { Range: byteRange(segment.range) } :
-                                                undefined });
+               headers: segment.range !== undefined ?
+                 { Range: byteRange(segment.range) } :
+                 undefined });
 }
 
 /**
@@ -110,12 +111,12 @@ export default function generateSegmentLoader(
     content : ISegmentLoaderArguments
   ) : ISegmentLoaderObservable< Uint8Array | ArrayBuffer | null > {
     const { mediaURL } = content.segment;
-    if (mediaURL == null) {
+    if (mediaURL === null) {
       return observableOf({ type: "data-created" as const,
                             value: { responseData: null } });
     }
 
-    if (lowLatencyMode || customSegmentLoader == null) {
+    if (lowLatencyMode || customSegmentLoader === undefined) {
       return regularSegmentLoader(mediaURL, content, lowLatencyMode);
     }
 

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -65,7 +65,7 @@ export default function generateTextTrackLoader(
     const { mediaURL,
             range } = args.segment;
 
-    if (mediaURL == null) {
+    if (mediaURL === null) {
       return observableOf({ type: "data-created",
                             value: { responseData: null } });
     }

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -137,7 +137,7 @@ export default function textTrackParser(
   const { period, representation, segment } = content;
   const { timestampOffset = 0 } = segment;
   const { data, isChunked } = response;
-  if (data == null) { // No data, just return empty infos
+  if (data === null) { // No data, just return empty infos
     if (segment.isInit) {
       return observableOf({ type: "parsed-init-segment",
                             value: { initializationData: null,

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -29,7 +29,7 @@ import callCustomManifestLoader from "../utils/call_custom_manifest_loader";
 function regularManifestLoader(
   { url } : IManifestLoaderArguments
 ) : IManifestLoaderObservable {
-  if (url == null) {
+  if (url === undefined) {
     throw new Error("Cannot perform HTTP(s) request. URL not known");
   }
   return request({ url, responseType: "text" });

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -33,6 +33,7 @@ import parseMetaPlaylist, {
   IParserResponse as IMPLParserResponse,
 } from "../../parsers/manifest/metaplaylist";
 import { IParsedManifest } from "../../parsers/manifest/types";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
 import {
   IAudioVideoParserObservable,
@@ -61,7 +62,7 @@ function getLoaderArguments(
   segment : ISegment,
   offset : number
 ) : ISegmentLoaderArguments {
-  if (segment.privateInfos == null || segment.privateInfos.metaplaylistInfos == null) {
+  if (segment.privateInfos?.metaplaylistInfos === undefined) {
     throw new Error("MetaPlaylist: missing private infos");
   }
   const { manifest,
@@ -107,13 +108,13 @@ function getTransportPipelines(
   options : ITransportOptions
 ) : ITransportPipelines {
   const initialTransport = transports[transportName];
-  if (initialTransport != null) {
+  if (initialTransport !== undefined) {
     return initialTransport;
   }
 
   const feature = features.transports[transportName];
 
-  if (feature == null) {
+  if (feature === undefined) {
     throw new Error(`MetaPlaylist: Unknown transport ${transportName}.`);
   }
   const transport = feature(options);
@@ -127,7 +128,7 @@ function getTransportPipelines(
  */
 function getMetaPlaylistPrivateInfos(segment : ISegment) : IMetaPlaylistPrivateInfos {
   const { privateInfos } = segment;
-  if (privateInfos == null || privateInfos.metaplaylistInfos == null) {
+  if (privateInfos?.metaplaylistInfos === undefined) {
     throw new Error("MetaPlaylist: Undefined transport for content for metaplaylist.");
   }
   return privateInfos.metaplaylistInfos;
@@ -155,8 +156,8 @@ export default function(options : ITransportOptions): ITransportPipelines {
         scheduleRequest,
         externalClockOffset } : IManifestParserArguments
     ) : IManifestParserObservable {
-      const url = response.url == null ? loaderURL :
-                                         response.url;
+      const url = response.url === undefined ? loaderURL :
+                                               response.url;
       const { responseData } = response;
 
       const parserOptions = {
@@ -179,9 +180,6 @@ export default function(options : ITransportOptions): ITransportPipelines {
             const transport = getTransportPipelines(transports,
                                                     ressource.transportType,
                                                     otherTransportOptions);
-            if (transport == null) {
-              throw new Error("MPL: Unrecognized transport.");
-            }
             const request$ = scheduleRequest(() =>
                 transport.manifest.loader({ url : ressource.url }).pipe(
                   filter((e): e is ILoaderDataLoaded< Document | string > =>
@@ -234,7 +232,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
         chunkOffset : number;
         appendWindow : [ number | undefined, number | undefined ]; } {
     const offsetedSegmentOffset = segmentResponse.chunkOffset + contentOffset;
-    if (segmentResponse.chunkData == null) {
+    if (isNullOrUndefined(segmentResponse.chunkData)) {
       return { chunkInfos: segmentResponse.chunkInfos,
                chunkOffset: offsetedSegmentOffset,
                appendWindow: [undefined, undefined] };
@@ -248,16 +246,16 @@ export default function(options : ITransportOptions): ITransportPipelines {
       offsetedChunkInfos.time += scaledContentOffset;
     }
 
-    const offsetedWindowStart = appendWindow[0] != null ?
+    const offsetedWindowStart = appendWindow[0] !== undefined ?
       Math.max(appendWindow[0] + contentOffset, contentOffset) :
       contentOffset;
 
     let offsetedWindowEnd : number|undefined;
-    if (appendWindow[1] != null) {
-      offsetedWindowEnd = contentEnd != null ? Math.min(appendWindow[1] + contentOffset,
-                                                        contentEnd) :
-                                               appendWindow[1] + contentOffset;
-    } else if (contentEnd != null) {
+    if (appendWindow[1] !== undefined) {
+      offsetedWindowEnd = contentEnd !== undefined ?
+        Math.min(appendWindow[1] + contentOffset, contentEnd) :
+        appendWindow[1] + contentOffset;
+    } else if (contentEnd !== undefined) {
       offsetedWindowEnd = contentEnd;
     }
     return { chunkInfos: offsetedChunkInfos,

--- a/src/transports/smooth/extract_timings_infos.ts
+++ b/src/transports/smooth/extract_timings_infos.ts
@@ -20,6 +20,7 @@ import {
   getDurationFromTrun,
   getTRAF,
 } from "../../parsers/containers/isobmff";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import {
   IChunkTimingInfos,
   INextSegmentsInfos,
@@ -87,7 +88,7 @@ export default function extractTimingsInfos(
                                       segment.duration / 4);
 
   const trunDuration = getDurationFromTrun(data);
-  if (trunDuration >= 0 && (segment.duration == null ||
+  if (trunDuration >= 0 && (isNullOrUndefined(segment.duration) ||
       Math.abs(trunDuration - segment.duration) <= maxDecodeTimeDelta)
   ) {
     chunkInfos = { time: segment.time,

--- a/src/transports/smooth/isobmff/create_audio_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_audio_init_segment.ts
@@ -61,7 +61,7 @@ export default function createAudioInitSegment(
 
   const esds = createESDSBox(1, _codecPrivateData);
   const stsd : Uint8Array = (() => {
-    if (pssList.length === 0 || keyId == null) {
+    if (pssList.length === 0 || keyId === undefined) {
       const mp4a = createMP4ABox(1,
                                  channelsCount,
                                  sampleSize,

--- a/src/transports/smooth/isobmff/create_video_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_video_init_segment.ts
@@ -73,7 +73,7 @@ export default function createVideoInitSegment(
   // TODO NAL length is forced to 4
   const avcc = createAVCCBox(sps, pps, nalLength);
   let stsd;
-  if (_pssList.length === 0 || keyId == null) {
+  if (_pssList.length === 0 || keyId === undefined) {
     const avc1 = createAVC1Box(width, height, hRes, vRes, "AVC Coding", 24, avcc);
     stsd = createSTSDBox([avc1]);
   } else {

--- a/src/transports/smooth/isobmff/parse_tfxd.ts
+++ b/src/transports/smooth/isobmff/parse_tfxd.ts
@@ -28,7 +28,7 @@ export interface IISOBMFFBasicSegment {
  */
 export default function parseTfxd(traf : Uint8Array) : IISOBMFFBasicSegment|undefined {
   const tfxd = getUuidContent(traf, 0x6D1D9B05, 0x42D544E6, 0x80E2141D, 0xAFF757B2);
-  if (tfxd == null) {
+  if (tfxd === undefined) {
     return undefined;
   }
   return {

--- a/src/transports/smooth/isobmff/patch_segment.ts
+++ b/src/transports/smooth/isobmff/patch_segment.ts
@@ -37,20 +37,20 @@ export default function patchSegment(
   decodeTime : number
 ) : Uint8Array {
   const moofOffsets = getBoxOffsets(segment, 0x6D6F6F66 /* moof */);
-  if (moofOffsets == null) {
+  if (moofOffsets === null) {
     throw new Error("Smooth: Invalid ISOBMFF given");
   }
   const moofContent = segment.subarray(moofOffsets[0] + 8, moofOffsets[1]);
 
   const mfhdBox = getBox(moofContent, 0x6D666864 /* mfhd */);
   const trafContent = getBoxContent(moofContent, 0x74726166 /* traf */);
-  if (trafContent == null || mfhdBox == null) {
+  if (trafContent === null || mfhdBox === null) {
     throw new Error("Smooth: Invalid ISOBMFF given");
   }
 
   const tfhdBox = getBox(trafContent, 0x74666864 /* tfhd */);
   const trunBox = getBox(trafContent, 0x7472756E /* trun */);
-  if (tfhdBox == null || trunBox == null) {
+  if (tfhdBox === null || trunBox === null) {
     throw new Error("Smooth: Invalid ISOBMFF given");
   }
 

--- a/src/transports/smooth/isobmff/replace_moof.ts
+++ b/src/transports/smooth/isobmff/replace_moof.ts
@@ -37,7 +37,7 @@ export default function replaceMoofInSegment(
   const moofDelta = newMoof.length - oldMoofLength;
 
   const mdatOffsets = getBoxOffsets(segment, 0x6D646174 /* "mdat" */);
-  if (mdatOffsets == null) {
+  if (mdatOffsets === null) {
     throw new Error("Smooth: Invalid ISOBMFF given");
   }
   if (canPatchISOBMFFSegment() && (moofDelta === 0 || moofDelta <= -8)) {

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -37,6 +37,7 @@ import {
   bytesToStr,
   strToBytes,
 } from "../../utils/byte_parsing";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import request from "../../utils/request";
 import stringFromUTF8 from "../../utils/string_from_utf8";
 import warnOnce from "../../utils/warn_once";
@@ -98,7 +99,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     resolver(
       { url } : IManifestLoaderArguments
     ) : Observable<IManifestLoaderArguments> {
-      if (url == null) {
+      if (url === undefined) {
         return observableOf({ url : undefined });
       }
 
@@ -131,8 +132,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     parser(
       { response, url: reqURL } : IManifestParserArguments
     ) : IManifestParserObservable {
-      const url = response.url == null ? reqURL :
-                                         response.url;
+      const url = response.url === undefined ? reqURL :
+                                               response.url;
       const data = typeof response.responseData === "string" ?
         new DOMParser().parseFromString(response.responseData, "text/xml") :
         response.responseData as Document; // TODO find a way to check if Document?
@@ -171,7 +172,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     ) : IAudioVideoParserObservable {
       const { segment, representation, adaptation, manifest } = content;
       const { data, isChunked } = response;
-      if (data == null) {
+      if (data === null) {
         if (segment.isInit) {
           const segmentProtections = representation.getProtectionsInitializationData();
           return observableOf({ type: "parsed-init-segment",
@@ -211,7 +212,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                                isChunked,
                                                                segment,
                                                                manifest.isLive);
-      if (chunkInfos == null) {
+      if (chunkInfos === null) {
         throw new Error("Smooth Segment without time information");
       }
       const chunkData = patchSegment(responseBuffer, chunkInfos.time);
@@ -232,7 +233,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       representation,
     } : ISegmentLoaderArguments
     ) : ISegmentLoaderObservable<string|ArrayBuffer|null> {
-      if (segment.isInit || segment.mediaURL == null) {
+      if (segment.isInit || segment.mediaURL === null) {
         return observableOf({ type: "data-created" as const,
                               value: { responseData: null } });
       }
@@ -301,7 +302,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
         nextSegments = timings.nextSegments;
         chunkInfos = timings.chunkInfos;
-        if (chunkInfos == null) {
+        if (chunkInfos === null) {
           if (isChunked) {
             log.warn("Smooth: Unavailable time data for current text track.");
           } else {
@@ -311,8 +312,9 @@ export default function(options : ITransportOptions) : ITransportPipelines {
           }
         } else {
           _sdStart = chunkInfos.time;
-          _sdEnd = chunkInfos.duration != null ? chunkInfos.time + chunkInfos.duration :
-                                                 undefined;
+          _sdEnd = !isNullOrUndefined(chunkInfos.duration) ?
+            chunkInfos.time + chunkInfos.duration :
+            undefined;
           _sdTimescale = chunkInfos.timescale;
         }
 
@@ -372,14 +374,14 @@ export default function(options : ITransportOptions) : ITransportPipelines {
         _sdData = chunkString;
       }
 
-      if (chunkInfos != null &&
+      if (chunkInfos !== null &&
           Array.isArray(nextSegments) && nextSegments.length > 0)
       {
         addNextSegments(adaptation, nextSegments, chunkInfos);
       }
 
-      const chunkOffset = _sdStart == null ? 0 :
-                                             _sdStart / _sdTimescale;
+      const chunkOffset = _sdStart === undefined ? 0 :
+                                                   _sdStart / _sdTimescale;
       return observableOf({ type: "parsed-segment",
                             value: { chunkData: { type: _sdType,
                                                   data: _sdData,
@@ -397,7 +399,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     loader(
       { segment } : ISegmentLoaderArguments
     ) : ISegmentLoaderObservable<ArrayBuffer|null> {
-      if (segment.isInit || segment.mediaURL == null) {
+      if (segment.isInit || segment.mediaURL === null) {
         // image do not need an init segment. Passthrough directly to the parser
         return observableOf({ type: "data-created" as const,
                               value: { responseData: null } });
@@ -425,7 +427,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
 
       // TODO image Parsing should be more on the sourceBuffer side, no?
-      if (data === null || features.imageParser == null) {
+      if (data === null || features.imageParser === null) {
         return observableOf({ type: "parsed-segment",
                               value: { chunkData: null,
                                        chunkInfos: null,

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -75,7 +75,7 @@ const generateSegmentLoader = (
 } : ISegmentLoaderArguments) : ISegmentLoaderObservable<Uint8Array|ArrayBuffer|null> => {
   if (segment.isInit) {
     if (segment.privateInfos === undefined ||
-        segment.privateInfos.smoothInit == null)
+        segment.privateInfos.smoothInit === undefined)
     {
       throw new Error("Smooth: Invalid segment format");
     }
@@ -125,7 +125,7 @@ const generateSegmentLoader = (
     return observableOf({ type: "data-created" as const,
                           value: { responseData } });
   }
-  else if (segment.mediaURL == null) {
+  else if (segment.mediaURL === null) {
     return observableOf({ type: "data-created" as const,
                           value: { responseData: null } });
   }

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -51,11 +51,11 @@ export default function callCustomManifestLoader(
         if (!hasFallbacked) {
           hasFinished = true;
           const receivedTime =
-            _args.receivingTime != null ? _args.receivingTime - timeAPIsDelta :
-            undefined;
+            _args.receivingTime !== undefined ? _args.receivingTime - timeAPIsDelta :
+                                                undefined;
           const sendingTime =
-            _args.sendingTime != null ? _args.sendingTime - timeAPIsDelta :
-            undefined;
+            _args.sendingTime !== undefined ? _args.sendingTime - timeAPIsDelta :
+                                              undefined;
 
           obs.next({ type: "data-loaded",
                      value: { responseData: _args.data,

--- a/src/transports/utils/document_manifest_loader.ts
+++ b/src/transports/utils/document_manifest_loader.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import request from "../../utils/request";
 import {
   CustomManifestLoader,
@@ -30,7 +31,7 @@ import callCustomManifestLoader from "./call_custom_manifest_loader";
 function regularManifestLoader(
   { url } : IManifestLoaderArguments
 ) : IManifestLoaderObservable {
-  if (url == null) {
+  if (url === undefined) {
     throw new Error("Cannot perform HTTP(s) request. URL not known");
   }
   return request({ url, responseType: "document" });
@@ -44,7 +45,7 @@ function regularManifestLoader(
 export default function generateManifestLoader(
    { customManifestLoader } : { customManifestLoader?: CustomManifestLoader }
 ) : (x : IManifestLoaderArguments) => IManifestLoaderObservable {
-  if (customManifestLoader == null) {
+  if (isNullOrUndefined(customManifestLoader)) {
     return regularManifestLoader;
   }
   return callCustomManifestLoader(customManifestLoader,

--- a/src/transports/utils/get_isobmff_timing_infos.ts
+++ b/src/transports/utils/get_isobmff_timing_infos.ts
@@ -19,6 +19,7 @@ import {
   getDurationFromTrun,
   getTrackFragmentDecodeTime,
 } from "../../parsers/containers/isobmff";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import { IChunkTimingInfos } from "../types";
 
 /**
@@ -70,23 +71,24 @@ export default function getISOBMFFTimingInfos(
 
   if (timescale === segment.timescale) {
     maxDecodeTimeDelta = Math.min(timescale * 0.9,
-                                  segment.duration != null ? segment.duration / 4 :
-                                                             0.25);
+                                  !isNullOrUndefined(segment.duration) ?
+                                    segment.duration / 4 :
+                                    0.25);
     segmentDuration = segment.duration;
   } else {
     maxDecodeTimeDelta =
       Math.min(timescale * 0.9,
-               segment.duration != null ?
+               !isNullOrUndefined(segment.duration) ?
                  ((segment.duration / segment.timescale) * timescale) / 4 :
                    0.25
     );
-    segmentDuration = segment.duration != null ?
+    segmentDuration = !isNullOrUndefined(segment.duration) ?
                         (segment.duration / segment.timescale) * timescale :
                         undefined;
   }
 
   if (baseDecodeTime >= 0) {
-    startTime = segment.timestampOffset != null ?
+    startTime = segment.timestampOffset !== undefined ?
                   baseDecodeTime + (segment.timestampOffset * timescale) :
                   baseDecodeTime;
   } else {
@@ -95,7 +97,7 @@ export default function getISOBMFFTimingInfos(
 
   if (trunDuration >= 0 &&
       (
-        segmentDuration == null ||
+        segmentDuration === undefined ||
         Math.abs(trunDuration - segmentDuration) <= maxDecodeTimeDelta
       ))
   {

--- a/src/transports/utils/parse_text_track.ts
+++ b/src/transports/utils/parse_text_track.ts
@@ -45,8 +45,10 @@ export function extractTextTrackFromISOBMFF(chunkBytes : Uint8Array) : string {
 export function getISOBMFFTextTrackFormat(
   representation : Representation
 ) : "ttml" | "vtt" {
-  const codec = representation.codec == null ? "" :
-                                               representation.codec;
+  const codec = representation.codec;
+  if (codec === undefined) {
+    throw new Error("Cannot parse subtitles: unknown format");
+  }
   switch (codec.toLowerCase()) {
     case "stpp": // stpp === TTML in MP4
     case "stpp.ttml.im1t":
@@ -54,7 +56,6 @@ export function getISOBMFFTextTrackFormat(
     case "wvtt": // wvtt === WebVTT in MP4
       return "vtt";
   }
-
   throw new Error("The codec used for the subtitles " +
                   `"${codec}" is not managed yet.`);
 }
@@ -109,7 +110,7 @@ export function getISOBMFFEmbeddedTextTrackData(
   let startTime : number | undefined;
   let endTime : number | undefined;
   let timescale : number = 1;
-  if (chunkInfos == null) {
+  if (chunkInfos === null) {
     if (!isChunked) {
       log.warn("Transport: Unavailable time data for current text track.");
     } else {
@@ -119,7 +120,7 @@ export function getISOBMFFEmbeddedTextTrackData(
     }
   } else {
     startTime = chunkInfos.time;
-    if (chunkInfos.duration != null) {
+    if (chunkInfos.duration !== undefined) {
       endTime = startTime + chunkInfos.duration;
     } else if (!isChunked) {
       endTime = startTime + segment.duration;


### PR DESCRIPTION
I think that being more explicit in our conditions helps code readability and reduce the chance that a bug is introduced (whether it is because we forgot a case or because the code will evolve in some way which will make a new case possible).

As the task is pretty big, I just did it in `src/transports` for now.