### PR TITLE
MPD@minimumUpdatePeriod set to 0: solution 1 - shouldRefresh

### DIFF
--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -43,6 +43,7 @@ export interface IPeriodInfos {
                                                        // available position of a content
   end? : number; // End time of the current period, in seconds
   isDynamic : boolean; // Whether the Manifest can evolve with time
+  minimumUpdatePeriod : number | undefined; // Value of MPD@minimumUpdatePeriod
   receivedTime? : number; // time (in terms of `performance.now`) at which the
                           // XML file containing this AdaptationSet was received
   start : number; // Start time of the current period, in seconds
@@ -213,6 +214,7 @@ export default function parseAdaptationSets(
         manifestBoundsCalculator: periodInfos.manifestBoundsCalculator,
         end: periodInfos.end,
         isDynamic: periodInfos.isDynamic,
+        minimumUpdatePeriod: periodInfos.minimumUpdatePeriod,
         receivedTime: periodInfos.receivedTime,
         start: periodInfos.start,
         timeShiftBufferDepth: periodInfos.timeShiftBufferDepth,

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -217,6 +217,7 @@ function parseCompleteIntermediateRepresentation(
                           clockOffset,
                           duration: rootAttributes.duration,
                           isDynamic,
+                          minimumUpdatePeriod: rootAttributes.minimumUpdatePeriod,
                           receivedTime: args.manifestReceivedTime,
                           timeShiftBufferDepth,
                           xlinkInfos };

--- a/src/parsers/manifest/dash/parse_periods.ts
+++ b/src/parsers/manifest/dash/parse_periods.ts
@@ -51,6 +51,7 @@ export interface IManifestInfos {
   clockOffset? : number;
   duration? : number;
   isDynamic : boolean;
+  minimumUpdatePeriod : number | undefined; // Value of MPD@minimumUpdatePeriod
   receivedTime? : number; // time (in terms of `performance.now`) at which the
                           // XML file containing this Period was received
   timeShiftBufferDepth? : number; // Depth of the buffer for the whole content,
@@ -117,6 +118,7 @@ export default function parsePeriods(
                           manifestBoundsCalculator,
                           end: periodEnd,
                           isDynamic,
+                          minimumUpdatePeriod: manifestInfos.minimumUpdatePeriod,
                           receivedTime,
                           start: periodStart,
                           timeShiftBufferDepth };

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -46,6 +46,7 @@ export interface IAdaptationInfos {
                                                        // dynamic content
   end? : number; // End time of the current period, in seconds
   isDynamic : boolean; // Whether the Manifest can evolve with time
+  minimumUpdatePeriod : number | undefined; // Value of MPD@minimumUpdatePeriod
   receivedTime? : number; // time (in terms of `performance.now`) at which the
                           // XML file containing this Representation was received
   start : number; // Start time of the current period, in seconds
@@ -62,6 +63,7 @@ interface IIndexContext {
                                                        // available position of a
                                                        // dynamic content
   isDynamic : boolean; // Whether the Manifest can evolve with time
+  minimumUpdatePeriod : number | undefined; // Value of MPD@minimumUpdatePeriod
   periodStart : number; // Start of the period concerned by this
                         // RepresentationIndex, in seconds
   periodEnd : number|undefined; // End of the period concerned by this
@@ -128,6 +130,7 @@ export default function parseRepresentations(
                       availabilityTimeOffset: adaptationInfos.availabilityTimeOffset,
                       manifestBoundsCalculator: adaptationInfos.manifestBoundsCalculator,
                       isDynamic: adaptationInfos.isDynamic,
+                      minimumUpdatePeriod: adaptationInfos.minimumUpdatePeriod,
                       periodEnd: adaptationInfos.end,
                       periodStart: adaptationInfos.start,
                       receivedTime: adaptationInfos.receivedTime,


### PR DESCRIPTION
When a minimumUpdatePeriod is set to 0, base updates on the previous segment s last position through the shouldRefresh method.

DASH Manifest based on a SegmentTimeline should normally have a MPD@minimumUpdatePeriod attribute which should be sufficient to know when to refresh it.

    // However, there is a specific case, for when it is equal to 0.
    // As of DASH-IF IOP (valid in v4.3), when a DASH's MPD set a
    // MPD@minimumUpdatePeriod to `0`, a client should not refresh the MPD
    // unless told to do so through inband events, in the stream.
    // In reality however, we found it to not always be the case (even with
    // DASH-IF own streams) and moreover to not always be the best thing to do.
    // We prefer to rely here on our own logic in that case:
    // If a new segment had time to be generated since the last update, we
    // refresh.