### PR TITLE
Fix/safari mobile playsinline

### DIFF
--- a/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
+++ b/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
@@ -29,7 +29,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     });
     const shouldWaitForDataBeforeLoaded =
       require("../should_wait_for_data_before_loaded");
-    expect(shouldWaitForDataBeforeLoaded.default(false)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(false, true)).toBe(true);
   });
 
   it("should return true if we are not on Safari browser but in directfile mode", () => {
@@ -41,7 +41,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     });
     const shouldWaitForDataBeforeLoaded =
       require("../should_wait_for_data_before_loaded");
-    expect(shouldWaitForDataBeforeLoaded.default(true)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(true);
   });
 
   /* tslint:disable max-line-length */
@@ -55,7 +55,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     });
     const shouldWaitForDataBeforeLoaded =
       require("../should_wait_for_data_before_loaded");
-    expect(shouldWaitForDataBeforeLoaded.default(false)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(false, false)).toBe(true);
   });
 
   it("should return false if we are on the Safari browser and in directfile mode", () => {
@@ -67,7 +67,55 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     });
     const shouldWaitForDataBeforeLoaded =
       require("../should_wait_for_data_before_loaded");
-    expect(shouldWaitForDataBeforeLoaded.default(true)).toBe(false);
+    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(false);
+  });
+
+  it("should return true if we are on the Safari browser, we should play inline and in directfile mode", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true,
+        isSafariMobile: true,
+      };
+    });
+    const shouldWaitForDataBeforeLoaded =
+      require("../should_wait_for_data_before_loaded");
+    expect(shouldWaitForDataBeforeLoaded.default(true, true)).toBe(true);
+  });
+
+  it("should return true if we are on the Safari browser, we should play inline but not in directfile mode", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true,
+        isSafariMobile: true,
+      };
+    });
+    const shouldWaitForDataBeforeLoaded =
+      require("../should_wait_for_data_before_loaded");
+    expect(shouldWaitForDataBeforeLoaded.default(false, true)).toBe(true);
+  });
+
+  it("should return false if we are on the Safari browser, we should not play inline and in directfile mode", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true,
+        isSafariMobile: true,
+      };
+    });
+    const shouldWaitForDataBeforeLoaded =
+      require("../should_wait_for_data_before_loaded");
+    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(false);
+  });
+
+  it("should return true if we are not on the Safari browser, should not play inline and in directfile mode", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true,
+        isSafariMobile: false,
+      };
+    });
+    const shouldWaitForDataBeforeLoaded =
+      require("../should_wait_for_data_before_loaded");
+    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(true);
   });
   beforeEach(() => {
     jest.resetModules();

--- a/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
+++ b/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
@@ -58,7 +58,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     expect(shouldWaitForDataBeforeLoaded.default(false, false)).toBe(true);
   });
 
-  it("should return false if we are on the Safari browser and in directfile mode", () => {
+  it("should return false if we are on the Safari browser with no play inline and in directfile mode", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true,
@@ -82,7 +82,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     expect(shouldWaitForDataBeforeLoaded.default(true, true)).toBe(true);
   });
 
-  it("should return true if we are on the Safari browser, we should play inline but not in directfile mode", () => {
+  it("should return true if we are on the Safari browser, play inline but no directfile mode", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true,
@@ -92,18 +92,6 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     const shouldWaitForDataBeforeLoaded =
       require("../should_wait_for_data_before_loaded");
     expect(shouldWaitForDataBeforeLoaded.default(false, true)).toBe(true);
-  });
-
-  it("should return false if we are on the Safari browser, we should not play inline and in directfile mode", () => {
-    jest.mock("../browser_detection", () => {
-      return {
-        __esModule: true,
-        isSafariMobile: true,
-      };
-    });
-    const shouldWaitForDataBeforeLoaded =
-      require("../should_wait_for_data_before_loaded");
-    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(false);
   });
 
   it("should return true if we are not on the Safari browser, should not play inline and in directfile mode", () => {

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -25,14 +25,11 @@ import { isSafariMobile } from "./browser_detection";
  * @returns {Boolean}
  */
 export default function shouldWaitForDataBeforeLoaded(
-  isDirectfile : boolean,
-  mustPlaysInline: boolean
-) : boolean {
-  if (isDirectfile) {
-    if (isSafariMobile && mustPlaysInline) {
-      return true;
-    }
-    return false;
+  isDirectfile: boolean,
+  mustPlayInline: boolean
+): boolean {
+  if (isDirectfile && isSafariMobile) {
+    return mustPlayInline;
   }
-  return !(isSafariMobile && mustPlaysInline);
+  return true;
 }

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -26,13 +26,13 @@ import { isSafariMobile } from "./browser_detection";
  */
 export default function shouldWaitForDataBeforeLoaded(
   isDirectfile : boolean,
-  mustPlaysInline: boolean,
+  mustPlaysInline: boolean
 ) : boolean {
   if (isDirectfile) {
     if (isSafariMobile && mustPlaysInline) {
-      return true
+      return true;
     }
     return false;
   }
-  return !(isSafariMobile && mustPlaysInline)
+  return !(isSafariMobile && mustPlaysInline);
 }

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -25,7 +25,14 @@ import { isSafariMobile } from "./browser_detection";
  * @returns {Boolean}
  */
 export default function shouldWaitForDataBeforeLoaded(
-  isDirectfile : boolean
+  isDirectfile : boolean,
+  mustPlaysInline: boolean,
 ) : boolean {
-  return !isDirectfile || !isSafariMobile;
+  if (isDirectfile) {
+    if (isSafariMobile && mustPlaysInline) {
+      return true
+    }
+    return false;
+  }
+  return !(isSafariMobile && mustPlaysInline)
 }

--- a/src/core/init/initial_seek_and_play.ts
+++ b/src/core/init/initial_seek_and_play.ts
@@ -65,8 +65,7 @@ function canPlay(
       }
       if (!shouldWaitForDataBeforeLoaded(
         isDirectfile,
-        mediaElement.hasAttribute("playsinline"))
-      ) {
+        mediaElement.hasAttribute("playsinline"))) {
         return readyState >= 1 && mediaElement.duration > 0;
       }
       if (readyState >= 4 || (readyState === 3 && currentRange !== null)) {

--- a/src/core/init/initial_seek_and_play.ts
+++ b/src/core/init/initial_seek_and_play.ts
@@ -65,7 +65,7 @@ function canPlay(
       }
       if (!shouldWaitForDataBeforeLoaded(
         isDirectfile,
-        mediaElement.hasAttribute('playsinline'))
+        mediaElement.hasAttribute("playsinline"))
       ) {
         return readyState >= 1 && mediaElement.duration > 0;
       }

--- a/src/core/init/initial_seek_and_play.ts
+++ b/src/core/init/initial_seek_and_play.ts
@@ -63,7 +63,10 @@ function canPlay(
       if (seeking || stalled !== null) {
         return false;
       }
-      if (!shouldWaitForDataBeforeLoaded(isDirectfile)) {
+      if (!shouldWaitForDataBeforeLoaded(
+        isDirectfile,
+        mediaElement.hasAttribute('playsinline'))
+      ) {
         return readyState >= 1 && mediaElement.duration > 0;
       }
       if (readyState >= 4 || (readyState === 3 && currentRange !== null)) {


### PR DESCRIPTION
This is related to the issue #684 

Safari Mobile was firing a DOM error because we were trying to emit the `LOADED` attribute and so the `play` too early, (readyState=1). However, this only when we want to play the video with the attributes `playsinline`:
> **playsinline**
A Boolean attribute indicating that the video is to be played "inline", that is within the element's playback area. Note that the absence of this attribute does not imply that the video will always be played in fullscreen.

That's why we didn't detect the bug in the first place.

Thus, for a video that posses the `playsinline` attributes, `readyState=1` is too early but for a video without it, it is perfectly fine.