### PR TITLE
Remove the initial creation of SourceBuffers from init

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1873,10 +1873,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     {
       return null;
     }
-    const queuedSourceBuffer = this._priv_contentInfos
-                                 .sourceBuffersStore.get(bufferType);
-    return queuedSourceBuffer === null ? null :
-                                         queuedSourceBuffer.getInventory();
+    const sourceBufferStatus = this._priv_contentInfos
+                                 .sourceBuffersStore.getStatus(bufferType);
+    return sourceBufferStatus.type === "set" ?
+      sourceBufferStatus.value.getInventory() :
+      null;
   }
 
   /**

--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -291,7 +291,6 @@ export default function BufferOrchestrator(
         enableOutOfBoundsCheck = false;
         destroyBuffers$.next();
         return observableConcat(
-          sourceBuffersStore.onSourceBuffersReady().pipe(ignoreElements()),
           ...rangesToClean.map(({ start, end }) =>
             queuedSourceBuffer.removeBuffer(start, end).pipe(ignoreElements())),
           clock$.pipe(take(1), mergeMap((lastTick) => {

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -165,11 +165,11 @@ export default function PeriodBuffer({
           const bufferGarbageCollector$ = garbageCollectors.get(qSourceBuffer);
           const adaptationBuffer$ = createAdaptationBuffer(adaptation, qSourceBuffer);
 
-          return observableConcat(sourceBuffersStore.onSourceBuffersReady()
-                                    .pipe(ignoreElements()),
-                                  cleanBuffer$,
-                                  observableMerge(adaptationBuffer$,
-                                                  bufferGarbageCollector$));
+          return sourceBuffersStore.onSourceBuffersReady().pipe(mergeMap(() => {
+            return observableConcat(cleanBuffer$,
+                                    observableMerge(adaptationBuffer$,
+                                                    bufferGarbageCollector$));
+          }));
         }));
 
       return observableConcat<IPeriodBufferEvent>(

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -165,7 +165,7 @@ export default function PeriodBuffer({
           const bufferGarbageCollector$ = garbageCollectors.get(qSourceBuffer);
           const adaptationBuffer$ = createAdaptationBuffer(adaptation, qSourceBuffer);
 
-          return sourceBuffersStore.onSourceBuffersReady().pipe(mergeMap(() => {
+          return sourceBuffersStore.waitForUsableSourceBuffers().pipe(mergeMap(() => {
             return observableConcat(cleanBuffer$,
                                     observableMerge(adaptationBuffer$,
                                                     bufferGarbageCollector$));

--- a/src/core/source_buffers/source_buffers_store.ts
+++ b/src/core/source_buffers/source_buffers_store.ts
@@ -211,7 +211,12 @@ export default class SourceBuffersStore {
    * @param {string}
    */
   public disableSourceBuffer(bufferType : IBufferType) : void {
-    if (this._initializedSourceBuffers[bufferType] !== undefined) {
+    const currentValue = this._initializedSourceBuffers[bufferType];
+    if (currentValue === null) {
+      log.warn(`SBS: The ${bufferType} SourceBuffer was already disabled.`);
+      return;
+    }
+    if (currentValue !== undefined) {
       throw new Error("Cannot disable an active SourceBuffer.");
     }
     this._initializedSourceBuffers[bufferType] = null;
@@ -340,6 +345,10 @@ export default class SourceBuffersStore {
     });
   }
 
+  /**
+   * Returns `true` when we're ready to push and decode contents through our
+   * native SourceBuffers.
+   */
   private _areNativeSourceBuffersReady() {
     return this._initializedSourceBuffers.audio !== undefined &&
            this._initializedSourceBuffers.video !== undefined;


### PR DESCRIPTION
Until now, we create both the audio and video SourceBuffers in advance in the `loadOnMediaSource` function. The information used to create those is based on the containers and codecs information of the first representation from the first adaptation from the first period we will play (!).

This ugly behavior was done because:
  1. we need to make sure both SourceBuffers are created before pushing segments to them. If we didn't - and I quote the W3C MSE specification - `a user agent may throw a QuotaExceededError`.
  2. The audio and video logic (which choose the Adaptation and Representation of the corresponding type) do not communicate between one another. Updating the code so they can do so is not straightforward nor is it something that we want to do

Moreover, this behavior is incompatible with three future features we might want to implement:
  - The lazy-downloading of Periods (needed both for MetaPlaylist contents and some type of xlinks in the DASH's MPD).

    Here, we might not have enough information about the first period when in `loadOnMediaSource` because we may not have downloaded that Period yet

  - an "audio-only mode" (which will most probably be just the possibility to disable the video track). 

    With the current logic, a video SourceBuffer would already be created even if we found later that we didn't want it. The video element would be in an infinite rebuffering status, waiting for video segments we will never push.

  - HLS.

    In HLS, we only can reliably get informations about the container when the corresponding Media Playlists has been downloaded. The problem is that Media Playlist are supposed to be downloaded on demand. Like the first feature exposed here, we wouldn't be able to have the necessary information to create the SourceBuffers in advance.
---
To fix this problem, what I did is try to update the API of the `SourceBuffersStore` - which is used to create SourceBuffers today - to add in it this notion of waiting for both SourceBuffers to be ready.

I don't know if it was due to the environment change (due to this particular week) but this was unexpectedly very difficult to do. I spent all day trying different solutions and none looked simple enough.

I ended doing things really explicitely, where we have to "disable" unused SourceBuffers through the SourceBufferStore and not forget to call `onSourceBuffersReady` before pushing to it.

This however still looks unnatural and error-prone to me.

I'm very open to comments and new ideas.