### PR TITLE
replace CONTRIBUTORS file by MAINTAINERS.md

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,6 +1,0 @@
-Alexandre Duros <alexandre.duros@canal-plus.com>
-Antoine Maillard <antoine.maillard@canal-plus.com>
-Guillaume Bentaieb <guillaume.bentaieb@canal-plus.com>
-Guillaume Renault <guillaume.renault@canal-plus.com>
-Paul Berberian <paul.berberian@canal-plus.com>
-Pierre Guilleminot <pierre.guilleminot@canal-plus.com>

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,31 @@
+# Maintainers ##################################################################
+
+This file contains information about current and previous maintainers, which are
+the people allowed to update directly the code of the RxPlayer library and its
+associated tools.
+
+Note that there are other external contributors which are not listed here. Their
+contributions had to be validated and merged by a maintainer.
+
+Please do not contact the people in this file to report an issue, ask an
+RxPlayer-related question or to propose new features.
+
+
+## Current maintainers #########################################################
+
+Here is the list of current maintainers:
+
+- Paul Berberian <paul.berberian@canal-plus.com>
+- Guillaume Renault <guillaume.renault@canal-plus.com>
+- Paul Rosset <paul.rosset@canal-plus.com>
+
+
+## Previous maintainers ########################################################
+
+Here is the list of previous maintainers, which are not working on the project
+anymore:
+
+- Alexandre Duros <alexandre.duros@canal-plus.com>
+- Antoine Maillard <antoine.maillard@canal-plus.com>
+- Guillaume Bentaieb <guillaume.bentaieb@canal-plus.com>
+- Pierre Guilleminot <pierre.guilleminot@canal-plus.com>


### PR DESCRIPTION
The old `CONTRIBUTORS` file, which was kept mostly to not erase the names of the people at the source of the project, was becoming an incomprehensible file.

It mixed old with new contributors, contained only the name of contributors working at Canal+ Group, contained old - now invalid - email addresses.

This is why I've chosen to replace it by a file named `MAINTAINERS.md` instead.

## Why `MAINTAINERS.md`?

The name is directly taken from [GCC](https://github.com/gcc-mirror/gcc/blob/master/MAINTAINERS) (even if many other projects have one, such as [linux](https://github.com/torvalds/linux/blob/master/MAINTAINERS)).

I found the name better than the previous `CONTRIBUTORS` as this file:
  1. does not contain the name of external contributors.
      I understand that we might not want to update that file each time a new person added or removed a line, but in that case, still calling it `CONTRIBUTORS` is false and disrespectful to a behavior we want to encourage
  2. It better communicates our roles than just a vague "contributor"

## Why this order for the current maintainers?

I did it by chronological order, my name is only first as a coincidence - I swear :p

## Why this order for the old maintainers?

There I did by alphabetical order.

First I don't know about the chronological order there, second I don't want to put first who I think was the most important for the project (nor do I know it).

## Why keeping the old non-functionning e-mail addresses from the previous maintainers?

Yeah, I didn't know what to do here. 

I could have removed them but I felt that that would remove a little their identities (in the case they have a common name).
Here we know that it's persons who had a given e-mail address at some point, which looked like they worked at canal+ at some point.
