### PR TITLE
doc: generalize the use of JSDoc for type, variable and functions doc

### DIFF
--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -44,6 +44,7 @@ import {
   getRange,
 } from "../../utils/ranges";
 
+/** "State" that triggered the clock tick. */
 export type IMediaInfosState = "init" | // set once on first emit
                                "canplay" | // HTML5 Event
                                "play" | // HTML5 Event
@@ -54,36 +55,51 @@ export type IMediaInfosState = "init" | // set once on first emit
                                "ratechange" | // HTML5 Event
                                "timeupdate"; // Interval
 
-// Information recuperated on the media element on each clock
-// tick
+/** Information recuperated on the media element on each clock tick. */
 interface IMediaInfos {
-  bufferGap : number; // Gap between `currentTime` and the next position with
-                      // bufferred data
-  buffered : TimeRanges; // Buffered ranges for the media element
-  currentRange : { start : number; // Buffered ranges related to `currentTime`
+  /** Gap between `currentTime` and the next position with un-buffered data. */
+  bufferGap : number;
+  /** Value of `buffered` (buffered ranges) for the media element. */
+  buffered : TimeRanges;
+  /** The buffered range we are currently playing. */
+  currentRange : { start : number;
                    end : number; } |
                  null;
-  currentTime : number; // Current position set on the media element
-  duration : number; // Current duration set on the media element
-  ended: boolean; // Current `ended` value set on the media element
-  paused : boolean; // Current `paused` value set on the media element
-  playbackRate : number; // Current `playbackRate` set on the mediaElement
-  readyState : number; // Current `readyState` value on the media element
-  seeking : boolean; // Current `seeking` value on the mediaElement
-  state : IMediaInfosState; } // see type
+  /** Current `currentTime` (position) set on the media element. */
+  currentTime : number;
+  /** Current `duration` set on the media element. */
+  duration : number;
+  /** Current `ended` set on the media element. */
+  ended: boolean;
+  /** Current `paused` set on the media element. */
+  paused : boolean;
+  /** Current `playbackRate` set on the media element. */
+  playbackRate : number;
+  /** Current `readyState` value on the media element. */
+  readyState : number;
+  /** Current `seeking` value on the mediaElement. */
+  seeking : boolean;
+  /** "State" that triggered this clock tick. */
+  state : IMediaInfosState; }
 
-type IStalledStatus = { // set if the player is stalled
-                       reason : "seeking" | // Building buffer after seeking
-                                "not-ready" | // Building buffer after low readyState
-                                "buffering"; // Other cases
-                       timestamp : number; // `performance.now` at the time the
-                                           // stalling happened
-                     } |
-                     null; // the player is not stalled
+/** Describes when the player is "stalled" and what event started that status. */
+type IStalledStatus =
+  /** Set if the player is stalled. */
+  {
+    /** What started the player to stall. */
+    reason : "seeking" | // Building buffer after seeking
+             "not-ready" | // Building buffer after low readyState
+             "buffering"; // Other cases
+    /** `performance.now` at the time the stalling happened. */
+    timestamp : number;
+  } |
+  /** The player is not stalled. */
+  null;
 
-// Global information emitted on each clock tick
+/** Information emitted on each clock tick. */
 export interface IClockTick extends IMediaInfos {
-  stalled : IStalledStatus; // see type
+  /** Set if the player is stalled. */
+  stalled : IStalledStatus;
 }
 
 const { SAMPLING_INTERVAL_MEDIASOURCE,

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -18,10 +18,7 @@ import config from "../../config";
 
 const { FORCED_ENDED_THRESHOLD } = config;
 
-/**
- * Player state dictionnary
- * @type {Object}
- */
+/** Player state dictionnary. */
 export const PLAYER_STATES = { STOPPED: "STOPPED",
                                LOADED: "LOADED",
                                LOADING: "LOADING",

--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * /!\ This file is feature-switchable.
+ * It always should be imported through the `features` object.
+ */
+
 import { BehaviorSubject } from "rxjs";
 import { ICompatTextTrackList } from "../../compat/browser_compatibility_types";
 import EventEmitter from "../../utils/event_emitter";
@@ -29,6 +34,7 @@ import {
   ITMVideoTrackListItem,
 } from "./track_choice_manager";
 
+/** Events emitted by the MediaElementTrackChoiceManager. */
 interface IMediaElementTrackChoiceManagerEvents {
   availableVideoTracksChange: ITMVideoTrackListItem[];
   availableAudioTracksChange: ITMAudioTrackListItem[];
@@ -162,24 +168,37 @@ function createVideoTracks(
  */
 export default class MediaElementTrackChoiceManager
   extends EventEmitter<IMediaElementTrackChoiceManagerEvents> {
-  // Array of preferred languages for audio tracks.
-  // Sorted by order of preference descending.
+  /**
+   * Array of preferred languages for audio tracks.
+   * Sorted by order of preference descending.
+   */
   private _preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
 
-  // Array of preferred languages for text tracks.
-  // Sorted by order of preference descending.
+  /**
+   * Array of preferred languages for text tracks.
+   * Sorted by order of preference descending.
+   */
   private _preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
 
+  /** List every available audio tracks available on the media element. */
   private _audioTracks : Array<{ track: ITMAudioTrack; nativeTrack: AudioTrack }>;
+  /** List every available text tracks available on the media element. */
   private _textTracks : Array<{ track: ITMTextTrack; nativeTrack: TextTrack }>;
+  /** List every available video tracks available on the media element. */
   private _videoTracks : Array<{ track: ITMVideoTrack; nativeTrack: VideoTrack }>;
 
+  /** Last audio track emitted as active. */
   private _lastEmittedNativeAudioTrack : AudioTrack | null | undefined;
+  /** Last video track emitted as active. */
   private _lastEmittedNativeVideoTrack : VideoTrack | null | undefined;
+  /** Last text track emitted as active. */
   private _lastEmittedNativeTextTrack : TextTrack | null | undefined;
 
+  /** Native `AudioTrackList` implemented on the media element. */
   private _nativeAudioTracks : AudioTrackList|undefined;
+  /** Native `VideoTrackList` implemented on the media element. */
   private _nativeVideoTracks : VideoTrackList|undefined;
+  /** Native `TextTrackList` implemented on the media element. */
   private _nativeTextTracks : ICompatTextTrackList|undefined;
 
   constructor(
@@ -217,6 +236,12 @@ export default class MediaElementTrackChoiceManager
     this._handleNativeTracksCallbacks();
   }
 
+  /**
+   * Update the currently active audio track by setting the wanted audio track's
+   * ID property.
+   * Throws if the wanted audio track is not found.
+   * @param {string|number|undefined} id
+   */
   public setAudioTrackById(id?: string|number): void {
     for (let i = 0; i < this._audioTracks.length; i++) {
       const { track, nativeTrack } = this._audioTracks[i];
@@ -228,6 +253,9 @@ export default class MediaElementTrackChoiceManager
     throw new Error("Audio track not found.");
   }
 
+  /**
+   * Disable the currently-active text track, if one.
+   */
   public disableTextTrack(): void {
     for (let i = 0; i < this._textTracks.length; i++) {
       const { nativeTrack } = this._textTracks[i];
@@ -235,6 +263,12 @@ export default class MediaElementTrackChoiceManager
     }
   }
 
+  /**
+   * Update the currently active text track by setting the wanted text track's
+   * ID property.
+   * Throws if the wanted text track is not found.
+   * @param {string|number|undefined} id
+   */
   public setTextTrackById(id?: string|number): void {
     let hasSetTrack = false;
     for (let i = 0; i < this._textTracks.length; i++) {
@@ -251,6 +285,12 @@ export default class MediaElementTrackChoiceManager
     }
   }
 
+  /**
+   * Update the currently active video track by setting the wanted video track's
+   * ID property.
+   * Throws if the wanted video track is not found.
+   * @param {string|number|undefined} id
+   */
   public setVideoTrackById(id?: string): void {
     for (let i = 0; i < this._videoTracks.length; i++) {
       const { track, nativeTrack } = this._videoTracks[i];
@@ -262,6 +302,12 @@ export default class MediaElementTrackChoiceManager
     throw new Error("Video track not found.");
   }
 
+  /**
+   * Returns the currently active audio track.
+   * Returns `null` if no audio track is active.
+   * Returns `undefined` if we cannot know which audio track is active.
+   * @returns {Object|null|undefined}
+   */
   public getChosenAudioTrack(): ITMAudioTrack|null|undefined {
     const chosenPrivateAudioTrack = this._getPrivateChosenAudioTrack();
     if (chosenPrivateAudioTrack != null) {
@@ -270,6 +316,12 @@ export default class MediaElementTrackChoiceManager
     return chosenPrivateAudioTrack;
   }
 
+  /**
+   * Returns the currently active text track.
+   * Returns `null` if no text track is active.
+   * Returns `undefined` if we cannot know which text track is active.
+   * @returns {Object|null|undefined}
+   */
   public getChosenTextTrack(): ITMTextTrack|null|undefined {
     const chosenPrivateTextTrack = this._getPrivateChosenTextTrack();
     if (chosenPrivateTextTrack != null) {
@@ -278,6 +330,12 @@ export default class MediaElementTrackChoiceManager
     return chosenPrivateTextTrack;
   }
 
+  /**
+   * Returns the currently active video track.
+   * Returns `null` if no video track is active.
+   * Returns `undefined` if we cannot know which video track is active.
+   * @returns {Object|null|undefined}
+   */
   public getChosenVideoTrack(): ITMVideoTrack|null|undefined {
     const chosenPrivateVideoTrack = this._getPrivateChosenVideoTrack();
     if (chosenPrivateVideoTrack != null) {
@@ -286,6 +344,10 @@ export default class MediaElementTrackChoiceManager
     return chosenPrivateVideoTrack;
   }
 
+  /**
+   * Returns a description of every available audio tracks.
+   * @returns {Array.<Object>}
+   */
   public getAvailableAudioTracks(): ITMAudioTrackListItem[] {
     return this._audioTracks.map(({ track, nativeTrack }) => {
       return { id: track.id,
@@ -296,6 +358,10 @@ export default class MediaElementTrackChoiceManager
     });
   }
 
+  /**
+   * Returns a description of every available text tracks.
+   * @returns {Array.<Object>}
+   */
   public getAvailableTextTracks(): ITMTextTrackListItem[] {
     return this._textTracks.map(({ track, nativeTrack }) => {
       return { id: track.id,
@@ -306,6 +372,10 @@ export default class MediaElementTrackChoiceManager
     });
   }
 
+  /**
+   * Returns a description of every available video tracks.
+   * @returns {Array.<Object>}
+   */
   public getAvailableVideoTracks(): ITMVideoTrackListItem[] {
     return this._videoTracks.map(({ track, nativeTrack }) => {
       return { id: track.id,
@@ -314,6 +384,9 @@ export default class MediaElementTrackChoiceManager
     });
   }
 
+  /**
+   * Free the resources used by the MediaElementTrackChoiceManager.
+   */
   public dispose(): void {
     if (this._nativeVideoTracks !== undefined) {
       this._nativeVideoTracks.onchange = null;
@@ -336,6 +409,12 @@ export default class MediaElementTrackChoiceManager
     this.removeEventListener();
   }
 
+  /**
+   * Get information about the currently chosen audio track.
+   * `undefined` if we cannot know it.
+   * `null` if no audio track is chosen.
+   * @returns {Object|undefined|null}
+   */
   private _getPrivateChosenAudioTrack(): { track: ITMAudioTrack;
                                            nativeTrack: AudioTrack; } |
                                          undefined |
@@ -352,6 +431,12 @@ export default class MediaElementTrackChoiceManager
     return null;
   }
 
+  /**
+   * Get information about the currently chosen video track.
+   * `undefined` if we cannot know it.
+   * `null` if no video track is chosen.
+   * @returns {Object|undefined|null}
+   */
   private _getPrivateChosenVideoTrack(): { track: ITMVideoTrack;
                                            nativeTrack: VideoTrack; } |
                                          undefined |
@@ -368,6 +453,12 @@ export default class MediaElementTrackChoiceManager
     return null;
   }
 
+  /**
+   * Get information about the currently chosen text track.
+   * `undefined` if we cannot know it.
+   * `null` if no text track is chosen.
+   * @returns {Object|undefined|null}
+   */
   private _getPrivateChosenTextTrack(): { track: ITMTextTrack;
                                           nativeTrack: TextTrack; } |
                                         undefined |
@@ -384,6 +475,11 @@ export default class MediaElementTrackChoiceManager
     return null;
   }
 
+  /**
+   * Iterate over every available audio tracks on the media element and over
+   * every set audio track preferences to activate the preferred audio track
+   * on the media element.
+   */
   private _setPreferredAudioTrack() : void {
     const preferredAudioTracks = this._preferredAudioTracks.getValue();
     const normalizedTracks = preferredAudioTracks
@@ -414,6 +510,11 @@ export default class MediaElementTrackChoiceManager
     }
   }
 
+  /**
+   * Iterate over every available text tracks on the media element and over
+   * every set text track preferences to activate the preferred text track
+   * on the media element.
+   */
   private _setPreferredTextTrack() : void {
     const preferredTextTracks = this._preferredTextTracks.getValue();
     const normalizedTracks = preferredTextTracks
@@ -442,8 +543,10 @@ export default class MediaElementTrackChoiceManager
     }
   }
 
-  // Monitor native tracks add, remove and change callback and trigger the
-  // change events.
+  /**
+   * Monitor native tracks add, remove and change callback and trigger the
+   * change events.
+   */
   private _handleNativeTracksCallbacks(): void {
     if (this._nativeAudioTracks !== undefined) {
       this._nativeAudioTracks.onaddtrack = () => {

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -55,52 +55,133 @@ const { DEFAULT_AUTO_PLAY,
 
 export { IKeySystemOption };
 
-interface IServerSyncInfos { serverTimestamp : number;
-                             clientTime : number; }
+/** Value of the `serverSyncInfos` transport option. */
+interface IServerSyncInfos {
+  /** The server timestamp at a given time. */
+  serverTimestamp : number;
+  /**
+   * The client monotonic clock (performance.now) at which `serverTimestamp`
+   * was valid.
+   */
+  clientTime : number;
+}
 
-export interface ITransportOptions { aggressiveMode? : boolean;
-                                     checkMediaSegmentIntegrity? : boolean;
-                                     manifestLoader? : CustomManifestLoader;
-                                     manifestUpdateUrl? : string;
-                                     minimumManifestUpdateInterval? : number;
-                                     segmentLoader? : CustomSegmentLoader;
-                                     representationFilter? : IRepresentationFilter;
-                                     referenceDateTime? : number;
-                                     serverSyncInfos? : IServerSyncInfos; }
+/** Value of the `transportOptions` option of the `loadVideo` method. */
+export interface ITransportOptions {
+  /** Whether we can perform request for segments in advance. */
+  aggressiveMode? : boolean;
+  /**
+   * Whether we should check that an obtain segment is truncated and retry the
+   * request if that's the case.
+   */
+  checkMediaSegmentIntegrity? : boolean;
+  /** Custom implementation for performing Manifest requests. */
+  manifestLoader? : CustomManifestLoader;
+  /** Possible custom URL pointing to a shorter form of the Manifest. */
+  manifestUpdateUrl? : string;
+  /** Minimum bound for Manifest updates, in milliseconds. */
+  minimumManifestUpdateInterval? : number;
+  /** Custom implementation for performing segment requests. */
+  segmentLoader? : CustomSegmentLoader;
+  /** Custom logic to filter out unwanted qualities. */
+  representationFilter? : IRepresentationFilter;
+  /** Base time for the segments in case it is not found in the Manifest. */
+  referenceDateTime? : number;
+  /** Allows to synchronize the server's time with the client's. */
+  serverSyncInfos? : IServerSyncInfos;
+}
 
-export interface ISupplementaryTextTrackOption { url : string;
-                                                 language : string;
-                                                 closedCaption : boolean;
-                                                 mimeType : string;
-                                                 codecs? : string; }
+/**
+ * External text track we have to add to the Manifest once downloaded.
+ * @deprecated
+ */
+export interface ISupplementaryTextTrackOption {
+  /** URL the external text track can be found at. */
+  url : string;
+  /** Language the text track is in. */
+  language : string;
+  /** If `true` the text track contains closed captions. */
+  closedCaption : boolean;
+  /** Mime-type used to know the container and/or format of the text track. */
+  mimeType : string;
+  /** Codec used to know the format of the text track. */
+  codecs? : string;
+}
 
-export interface ISupplementaryImageTrackOption { url : string;
-                                                  mimeType : string; }
+/**
+ * External image (".bif") track we have to add to the Manifest once downloaded.
+ * @deprecated
+ */
+export interface ISupplementaryImageTrackOption {
+  /** URL the external image track can be found at. */
+  url : string;
+  /** Mime-type used to know the format of the image track. */
+  mimeType : string;
+}
 
-export interface IDefaultAudioTrackOption { language : string;
-                                            normalized : string;
-                                            audioDescription : boolean; }
+/**
+ * Value for the `defaultAudioTrack` option of the `loadVideo` method.
+ * @deprecated
+ */
+export interface IDefaultAudioTrackOption {
+  /** The language wanted for the audio track. */
+  language : string;
+  /** The language normalized into ISO639-3 */
+  normalized : string;
+  /** If `true`, this is an audio description for the visually impaired. */
+  audioDescription : boolean;
+}
 
-export interface IDefaultTextTrackOption { language : string;
-                                           normalized : string;
-                                           closedCaption : boolean; }
+/**
+ * Value for the `defaultTextTrack` option of the `loadVideo` method.
+ * @deprecated
+ */
+export interface IDefaultTextTrackOption {
+  /** The language wanted for the text track. */
+  language : string;
+  /** The language normalized into ISO639-3 */
+  normalized : string;
+  /** If `true`, this is closed captions for the hard of hearing. */
+  closedCaption : boolean;
+}
 
-export interface INetworkConfigOption { manifestRetry? : number;
-                                        offlineRetry? : number;
-                                        segmentRetry? : number; }
+/** Value for the `networkConfig` option of the `loadVideo` method. */
+export interface INetworkConfigOption {
+  /**
+   * The amount of time maximum we should retry a Manifest or Manifest-related
+   * request before failing on Error.
+   * Set to `Infinity` for an infinite number of requests.
+   */
+  manifestRetry? : number;
+  /**
+   * The amount of time maximum we should retry a request in general when the
+   * user is offline.
+   * Set to `Infinity` for an infinite number of requests.
+   */
+  offlineRetry? : number;
+  /**
+   * The amount of time maximum we should retry a segment or segment-related
+   * request before failing on Error.
+   * Set to `Infinity` for an infinite number of requests.
+   */
+  segmentRetry? : number;
+}
 
+/** Possible values for the `startAt` option of the `loadVideo` method. */
 export type IStartAtOption = { position : number } |
                              { wallClockTime : Date|number } |
                              { percentage : number } |
                              { fromLastPosition : number } |
                              { fromFirstPosition : number };
 
+/** Value once parsed for the `startAt` option of the `loadVideo` method. */
 type IParsedStartAtOption = { position : number } |
                             { wallClockTime : number } |
                             { percentage : number } |
                             { fromLastPosition : number } |
                             { fromFirstPosition : number };
 
+/** Every options that can be given to the RxPlayer's constructor. */
 export interface IConstructorOptions { maxBufferAhead? : number;
                                        maxBufferBehind? : number;
                                        wantedBufferAhead? : number;
@@ -119,6 +200,7 @@ export interface IConstructorOptions { maxBufferAhead? : number;
                                        maxVideoBitrate? : number;
                                        stopAtEnd? : boolean; }
 
+/** Options of the RxPlayer's constructor once parsed. */
 export interface IParsedConstructorOptions {
   maxBufferAhead : number;
   maxBufferBehind : number;
@@ -139,6 +221,7 @@ export interface IParsedConstructorOptions {
   stopAtEnd : boolean;
 }
 
+/** Every options that can be given to the RxPlayer's `loadVideo` method. */
 export interface ILoadVideoOptions {
   transport : string;
 
@@ -146,10 +229,6 @@ export interface ILoadVideoOptions {
   autoPlay? : boolean;
   keySystems? : IKeySystemOption[];
   transportOptions? : ITransportOptions|undefined;
-  supplementaryTextTracks? : ISupplementaryTextTrackOption[];
-  supplementaryImageTracks? : ISupplementaryImageTrackOption[];
-  defaultAudioTrack? : IDefaultAudioTrackOption|null|undefined;
-  defaultTextTrack? : IDefaultTextTrackOption|null|undefined;
   lowLatencyMode? : boolean;
   networkConfig? : INetworkConfigOption;
   startAt? : IStartAtOption;
@@ -157,8 +236,19 @@ export interface ILoadVideoOptions {
   hideNativeSubtitle? : boolean;
   textTrackElement? : HTMLElement;
   manualBitrateSwitchingMode? : "seamless"|"direct";
+
+  /* tslint:disable deprecation */
+  supplementaryTextTracks? : ISupplementaryTextTrackOption[];
+  supplementaryImageTracks? : ISupplementaryImageTrackOption[];
+  defaultAudioTrack? : IDefaultAudioTrackOption|null|undefined;
+  defaultTextTrack? : IDefaultTextTrackOption|null|undefined;
+  /* tslint:enable deprecation */
 }
 
+/**
+ * Base type which the types for the parsed options of the RxPlayer's
+ * `loadVideo` method exend.
+ */
 interface IParsedLoadVideoOptionsBase {
   url? : string;
   transport : string;
@@ -175,14 +265,26 @@ interface IParsedLoadVideoOptionsBase {
   manualBitrateSwitchingMode : "seamless"|"direct";
 }
 
+/**
+ * Options of the RxPlayer's `loadVideo` method once parsed when a "native"
+ * `textTrackMode` is asked.
+ */
 interface IParsedLoadVideoOptionsNative
           extends IParsedLoadVideoOptionsBase { textTrackMode : "native";
                                                 hideNativeSubtitle : boolean; }
 
+/**
+ * Options of the RxPlayer's `loadVideo` method once parsed when an "html"
+ * `textTrackMode` is asked.
+ */
 interface IParsedLoadVideoOptionsHTML
           extends IParsedLoadVideoOptionsBase { textTrackMode : "html";
                                                 textTrackElement : HTMLElement; }
 
+/**
+ * Type enumerating all possible forms for the parsed options of the RxPlayer's
+ * `loadVideo` method.
+ */
 export type IParsedLoadVideoOptions =
   IParsedLoadVideoOptionsNative |
   IParsedLoadVideoOptionsHTML;

--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -107,7 +107,7 @@ export default function getInitialTime(
     }
     log.debug(`Init: ${liveTime} defined as the live time, applying a live gap` +
               ` of ${suggestedPresentationDelay}`);
-    if (suggestedPresentationDelay != null) {
+    if (suggestedPresentationDelay !== undefined) {
       return Math.max(liveTime - suggestedPresentationDelay, minimumPosition);
     }
     const defaultStartingPos = liveTime - (lowLatencyMode ? DEFAULT_LIVE_GAP.LOW_LATENCY :

--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -38,27 +38,44 @@ import { IFetchManifestResult } from "../pipelines";
 
 const { FAILED_PARTIAL_UPDATE_MANIFEST_REFRESH_DELAY } = config;
 
-export type IManifestFetcher =
-    (manifestURL? : string, externalClockOffset?: number) =>
-      Observable<IFetchManifestResult>;
-
+/** Arguments to give to the `manifestUpdateScheduler` */
 export interface IManifestUpdateSchedulerArguments {
+  /** Function used to refresh the manifest */
   fetchManifest : IManifestFetcher;
+  /** Information about the initial load of the manifest */
   initialManifest : { manifest : Manifest;
                       sendingTime? : number;
                       receivedTime? : number;
                       parsingTime : number; };
+  /** URL at which a shorter version of the Manifest can be found. */
   manifestUpdateUrl : string | undefined;
+  /** Minimum interval to keep between Manifest updates */
   minimumManifestUpdateInterval : number;
+  /** Allows the rest of the code to ask for a Manifest refresh */
   scheduleRefresh$ : IManifestRefreshScheduler;
 }
 
+/** Function defined to refresh the Manifest */
+export type IManifestFetcher =
+    (manifestURL? : string, externalClockOffset?: number) =>
+      Observable<IFetchManifestResult>;
+
+/** Events sent by the `IManifestRefreshScheduler` Observable */
 export interface IManifestRefreshSchedulerEvent {
-  completeRefresh : boolean; // if true, the Manifest should be fully updated
-  delay? : number; // optional wanted refresh delay, which is the minimum time
-                   // you want to wait before updating the manifest
+  /**
+   * if `true`, the Manifest should be fully updated.
+   * if `false`, a shorter version with just the added information can be loaded
+   * instead.
+   */
+  completeRefresh : boolean;
+  /**
+   * Optional wanted refresh delay, which is the minimum time you want to wait
+   * before updating the Manifest
+   */
+  delay? : number;
 }
 
+/** Observable to send events related to refresh requests coming from the Player. */
 export type IManifestRefreshScheduler = Observable<IManifestRefreshSchedulerEvent>;
 
 /**

--- a/src/core/pipelines/manifest/create_manifest_pipeline.ts
+++ b/src/core/pipelines/manifest/create_manifest_pipeline.ts
@@ -45,15 +45,26 @@ import createManifestLoader, {
 } from "./create_manifest_loader";
 import parseManifestPipelineOptions from "./parse_manifest_pipeline_options";
 
-// What will be sent once parsed
-export interface IFetchManifestResult { manifest : Manifest;
-                                        sendingTime? : number;
-                                        receivedTime? : number;
-                                        parsingTime : number; }
+/** What will be sent once parsed. */
+export interface IFetchManifestResult {
+  /** The resulting Manifest */
+  manifest : Manifest;
+  /**
+   * The time (`performance.now()`) at which the request was started (at which
+   * the JavaScript call was done).
+   */
+  sendingTime? : number;
+  /* The time (`performance.now()`) at which the request was fully received. */
+  receivedTime? : number;
+  /* The time taken to parse the Manifest through the corresponding parse function. */
+  parsingTime : number;
+}
 
-// The Manifest Pipeline generated here
+/** The Manifest Pipeline generated here. */
 export interface ICoreManifestPipeline {
+  /** Allows to perform the Manifest request. */
   fetch(url? : string) : Observable<IPipelineLoaderResponse<ILoadedManifest>>;
+  /** Allows to parse a fetched Manifest into a `Manifest` structure. */
   parse(response : IPipelineLoaderResponseValue<ILoadedManifest>,
         url? : string,
         externalClockOffset? : number) : Observable<IFetchManifestResult>;
@@ -68,24 +79,21 @@ export interface IManifestPipelineOptions {
 }
 
 /**
- * Create function allowing to easily fetch and parse the manifest from its URL.
- *
+ * Create function allowing to easily fetch and parse a Manifest from its URL.
  * @example
  * ```js
  * const manifestPipeline = createManifestPipeline(pipelines, options, warning$);
- * manifestPipeline.fetch(manifestURL)
- *  .mergeMap((evt) => {
- *    if (evt.type !== "response") { // Might also receive warning events
- *      return EMPTY;
- *    }
- *    return manifestPipeline.parse(evt.value);
- *  }).subscribe(({ manifest }) => console.log("Manifest:", manifest));
+ * manifestPipeline.fetch(manifestURL).pipe(
+ *   filter((evt) => {
+ *     return evt.type === "response"; // Might also receive warning events
+ *   }),
+ *   mergeMap(evt => manifestPipeline.parse(evt.value))
+ * ).subscribe(({ manifest }) => console.log("Manifest:", manifest));
  * ```
- *
  * @param {Object} pipelines
  * @param {Subject} pipelineOptions
  * @param {Subject} warning$
- * @returns {Function}
+ * @returns {Object}
  */
 export default function createManifestPipeline(
   pipelines : ITransportPipelines,

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -76,7 +76,7 @@ describe("Manifest - Manifest", () => {
                                  transportType: "foobar" };
 
     const fakePeriod = jest.fn((period) => {
-      return { id: `foo${period.id}`, parsingErrors: [] };
+      return { id: `foo${period.id}`, adaptations: {}, parsingErrors: [] };
     });
     jest.mock("../period", () =>  ({ __esModule: true,
                                      default: fakePeriod }));
@@ -87,8 +87,12 @@ describe("Manifest - Manifest", () => {
     expect(fakePeriod).toHaveBeenCalledWith(period1, undefined);
     expect(fakePeriod).toHaveBeenCalledWith(period2, undefined);
 
-    expect(manifest.periods).toEqual([ { id: "foo0", parsingErrors: [] },
-                                       { id: "foo1", parsingErrors: [] } ]);
+    expect(manifest.periods).toEqual([ { id: "foo0",
+                                         adaptations: {},
+                                         parsingErrors: [] },
+                                       { id: "foo1",
+                                         adaptations: {},
+                                         parsingErrors: [] } ]);
     expect(manifest.adaptations).toEqual({});
 
     expect(fakeIdGenerator).toHaveBeenCalledTimes(2);

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -27,19 +27,30 @@ import uniq from "../utils/uniq";
 import filterSupportedRepresentations from "./filter_supported_representations";
 import Representation from "./representation";
 
+/** Every possible value for the Adaptation's `type` property. */
 export type IAdaptationType = "video" | "audio" | "text" | "image";
 
+/** List in an array every possible value for the Adaptation's `type` property. */
 export const SUPPORTED_ADAPTATIONS_TYPE: IAdaptationType[] = [ "audio",
                                                                "video",
                                                                "text",
                                                                "image" ];
 
+/**
+ * Returns true if the given Adaptation's `type` is a valid `type` property.
+ * @param {string} adaptationType
+ * @returns {boolean}
+ */
 function isSupportedAdaptationType(
   adaptationType : string
 ) : adaptationType is IAdaptationType {
   return arrayIncludes(SUPPORTED_ADAPTATIONS_TYPE, adaptationType);
 }
 
+/**
+ * Information describing a single Representation from an Adaptation, to be used
+ * in the `representationFilter` API.
+ */
 export interface IRepresentationInfos { bufferType: IAdaptationType;
                                         language?: string;
                                         isAudioDescription? : boolean;
@@ -47,6 +58,7 @@ export interface IRepresentationInfos { bufferType: IAdaptationType;
                                         isDub? : boolean;
                                         normalizedLanguage? : string; }
 
+/** Type for the `representationFilter` API. */
 export type IRepresentationFilter = (representation: Representation,
                                      adaptationInfos: IRepresentationInfos)
                                     => boolean;
@@ -60,39 +72,46 @@ export type IRepresentationFilter = (representation: Representation,
  * @class Adaptation
  */
 export default class Adaptation {
-
-  // ID uniquely identifying the Adaptation in the Period.
+  /** ID uniquely identifying the Adaptation in the Period. */
   public readonly id : string;
 
-  // Different `Representations` (e.g. qualities) this Adaptation is available
-  // in.
+  /**
+   * Different `Representations` (e.g. qualities) this Adaptation is available
+   * in.
+   */
   public readonly representations : Representation[];
 
-  // Type of this Adaptation.
+  /** Type of this Adaptation. */
   public readonly type : IAdaptationType;
 
-  // Whether this track contains an audio description for the visually impaired.
+  /** Whether this track contains an audio description for the visually impaired. */
   public isAudioDescription? : boolean;
 
-  // Whether this Adaptation contains closed captions for the hard-of-hearing.
+  /** Whether this Adaptation contains closed captions for the hard-of-hearing. */
   public isClosedCaption? : boolean;
 
-  // If `true`, this Adaptation is a "dub", meaning it was recorded in another
-  // language than the original
+  /**
+   * If `true`, this Adaptation is a "dub", meaning it was recorded in another
+   * language than the original one.
+   */
   public isDub? : boolean;
 
-  // Language this Adaptation is in, as announced in the original Manifest.
+  /** Language this Adaptation is in, as announced in the original Manifest. */
   public language? : string;
 
-  // Language this Adaptation is in, when translated into an ISO639-3 code.
+  /** Language this Adaptation is in, when translated into an ISO639-3 code. */
   public normalizedLanguage? : string;
 
-  // `true` if this Adaptation was not present in the original Manifest, but was
-  // manually added after through the corresponding APIs.
+  /**
+   * `true` if this Adaptation was not present in the original Manifest, but was
+   * manually added after through the corresponding APIs.
+   */
   public manuallyAdded? : boolean;
 
-  // Array containing every errors that happened when the Adaptation has been
-  // created, in the order they have happened.
+  /**
+   * Array containing every errors that happened when the Adaptation has been
+   * created, in the order they have happened.
+   */
   public readonly parsingErrors : ICustomError[];
 
   /**

--- a/src/manifest/are_same_content.ts
+++ b/src/manifest/are_same_content.ts
@@ -19,6 +19,10 @@ import Period from "./period";
 import Representation from "./representation";
 import { ISegment } from "./representation_index";
 
+/**
+ * All information needed for a given chunk to know if it has the same content
+ * than another chunk.
+ */
 interface IBufferedChunkInfos { adaptation : Adaptation;
                                 period : Period;
                                 representation : Representation;

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -26,35 +26,40 @@ import Adaptation, {
   IRepresentationFilter,
 } from "./adaptation";
 
-// Structure listing every `Adaptation` in a Period.
+/** Structure listing every `Adaptation` in a Period. */
 export type IManifestAdaptations = Partial<Record<IAdaptationType, Adaptation[]>>;
 
 /**
- * Class representing a single `Period` of the Manifest.
- * A Period contains every information about the content available for a
- * specific period in time.
+ * Class representing the tracks and qualities available from a given time
+ * period in the the Manifest.
  * @class Period
  */
 export default class Period {
-  // ID uniquely identifying the Period in the Manifest.
+  /** ID uniquely identifying the Period in the Manifest. */
   public readonly id : string;
 
-  // Every 'Adaptation' in that Period, per type of Adaptation.
+  /** Every 'Adaptation' in that Period, per type of Adaptation. */
   public adaptations : IManifestAdaptations;
 
-  // Duration of this Period, in seconds.
-  // `undefined` for still-running Periods.
-  public duration? : number;
-
-  // Absolute start time of the Period, in seconds.
+  /** Absolute start time of the Period, in seconds. */
   public start : number;
 
-  // Absolute end time of the Period, in seconds.
-  // `undefined` for still-running Periods.
+  /**
+   * Duration of this Period, in seconds.
+   * `undefined` for still-running Periods.
+   */
+  public duration? : number;
+
+  /**
+   * Absolute end time of the Period, in seconds.
+   * `undefined` for still-running Periods.
+   */
   public end? : number;
 
-  // Array containing every errors that happened when the Period has been
-  // created, in the order they have happened.
+  /**
+   * Array containing every errors that happened when the Period has been
+   * created, in the order they have happened.
+   */
   public readonly parsingErrors : ICustomError[];
 
   /**

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -33,48 +33,61 @@ export interface IContentProtectionsInitDataObject {
  * @class Representation
  */
 class Representation {
-  // ID uniquely identifying the Representation in the Adaptation.
-  // TODO unique for the whole manifest?
+  /** ID uniquely identifying the Representation in the Adaptation. */
   public readonly id : string|number;
 
-  // Interface allowing to request segments for specific times.
+  /**
+   * Interface allowing to get information about segments available for this
+   * Representation.
+   */
   public index : IRepresentationIndex;
 
-  // Bitrate this Representation is in, in bits per seconds.
+  /** Bitrate this Representation is in, in bits per seconds. */
   public bitrate : number;
 
-  // Frame-rate, when it can be applied, of this Representation, in any textual
-  // indication possible (often under a ratio form).
+  /**
+   * Frame-rate, when it can be applied, of this Representation, in any textual
+   * indication possible (often under a ratio form).
+   */
   public frameRate? : string;
 
-  // A string describing the codec used for this Representation.
-  // Examples: vp9, hvc, stpp
-  // undefined if we do not know.
+  /**
+   * A string describing the codec used for this Representation.
+   * undefined if we do not know.
+   */
   public codec? : string;
 
-  // A string describing the mime-type for this Representation.
-  // Examples: audio/mp4, video/webm, application/mp4, text/plain
-  // undefined if we do not know.
+  /**
+   * A string describing the mime-type for this Representation.
+   * Examples: audio/mp4, video/webm, application/mp4, text/plain
+   * undefined if we do not know.
+   */
   public mimeType? : string;
 
-  // If this Representation is linked to video content, this value is the width
-  // in pixel of the corresponding video data.
+  /**
+   * If this Representation is linked to video content, this value is the width
+   * in pixel of the corresponding video data.
+   */
   public width? : number;
 
-  // If this Representation is linked to video content, this value is the height
-  // in pixel of the corresponding video data.
+  /**
+   * If this Representation is linked to video content, this value is the height
+   * in pixel of the corresponding video data.
+   */
   public height? : number;
 
-  // DRM Information for this Representation.
+  /** Encryption information for this Representation. */
   public contentProtections? : IContentProtections;
 
-  // Whether we are able to decrypt this Representation / unable to decrypt it or
-  // if we don't know yet:
-  //   - if `true`, it means that we know we were able to decrypt this
-  //     Representation in the current content.
-  //   - if `false`, it means that we know we were unable to decrypt this
-  //     Representation
-  //   - if `undefined` there is no certainty on this matter
+  /**
+   * Whether we are able to decrypt this Representation / unable to decrypt it or
+   * if we don't know yet:
+   *   - if `true`, it means that we know we were able to decrypt this
+   *     Representation in the current content.
+   *   - if `false`, it means that we know we were unable to decrypt this
+   *     Representation
+   *   - if `undefined` there is no certainty on this matter
+   */
   public decipherable? : boolean;
 
   /**

--- a/src/manifest/representation_index/static.ts
+++ b/src/manifest/representation_index/static.ts
@@ -26,7 +26,7 @@ export interface IStaticRepresentationIndexInfos { media: string; }
  * @class StaticRepresentationIndex
  */
 export default class StaticRepresentationIndex implements IRepresentationIndex {
-  // URL of the content
+  /** URL at which the content is available. */
   private readonly _mediaURLs: string;
 
   /**

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -26,7 +26,10 @@ import {
   ILocalManifestSegmentLoader,
 } from "../../parsers/manifest/local";
 
-// privateInfos specific to Smooth Initialization Segments
+/**
+ * Supplementary information specific to Smooth Initialization segments.
+ * Contains every information needed to generate an initialization segment.
+ */
 export interface ISmoothInitSegmentPrivateInfos { codecPrivateData? : string;
                                                   bitsPerSample? : number;
                                                   channels? : number;
@@ -40,33 +43,48 @@ export interface ISmoothInitSegmentPrivateInfos { codecPrivateData? : string;
                                                     }>;
                                                   }; }
 
+/** Describes a given "real" Manifest for MetaPlaylist's segments. */
 export interface IBaseContentInfos { manifest: Manifest;
                                      period: Period;
                                      adaptation: Adaptation;
                                      representation: Representation; }
 
+/** Supplementary information needed for segments in the "metaplaylist" transport. */
 export interface IMetaPlaylistPrivateInfos { transportType : string;
                                              baseContent : IBaseContentInfos;
                                              contentStart : number;
                                              contentEnd? : number; }
 
-// privateInfos specific to local Manifest's init segments
+/**
+ * Supplementary information needed for initialization segments of the "local"
+ * transport.
+ */
 export interface ILocalManifestInitSegmentPrivateInfos {
+  /** Callback used to load that segment. */
   load : ILocalManifestInitSegmentLoader;
 }
 
-// privateInfos specific to local Manifests
+/** Supplementary information needed for media segments of the "local" transport. */
 export interface ILocalManifestSegmentPrivateInfos {
-  // Callback used to load local manifest's media segment
+  /** Callback used to load that segment. */
   load : ILocalManifestSegmentLoader;
 
-  // Exact same segment than the one given in a local manifest.
-  // Stored (with at best the same reference than in it) to facilitate the job
-  // of retrieving the wanted segment (this task will generally be done by the
-  // content downloader tool) when the RxPlayer asks for it.
+  /**
+   * Exact same segment than the one given in a local manifest.
+   * Stored (with at best the same reference than in it) to facilitate the job
+   * of retrieving the wanted segment (this task will generally be done by the
+   * content downloader tool) when the RxPlayer asks for it.
+   */
   segment : ILocalIndexSegment;
 }
 
+/**
+ * Supplementary information that can be added to any segment depending on the
+ * tranport logic used.
+ * Called "private" as it won't be read or exploited by any code in the core
+ * logic of the player. That information is only here to be retrieved and
+ * exploited by the corresponding transport logic.
+ */
 export interface IPrivateInfos {
   smoothInit? : ISmoothInitSegmentPrivateInfos;
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
@@ -74,36 +92,46 @@ export interface IPrivateInfos {
   localManifestSegment? : ILocalManifestSegmentPrivateInfos;
 }
 
-// ISegment Object.
-// Represent a single Segment from a Representation.
+/** Represent a single Segment from a Representation. */
 export interface ISegment {
-  duration : number; // Estimated duration of the segment, in timescale
-  id : string; // ID of the Segment. Should be unique for this Representation
-  isInit : boolean; // If true, this Segment contains initialization data
-  mediaURLs : string[]|null; // URLs of the segment
-  time : number; // Estimated time of beginning for the segment, in timescale
-  timescale : number; // Timescale to convert time and duration into seconds
-
-  indexRange? : [number, number]; // If set, the corresponding byte-range in the
-                                  // downloaded Segment will contain an index
-                                  // describing other Segments
-                                  // TODO put in privateInfos?
-  number? : number; // Optional number of the Segment
-                    // TODO put in privateInfos?
-  privateInfos? : IPrivateInfos; // Allows a RepresentationIndex to store
-                                 // supplementary information in a given
-                                 // Segment for later downloading/parsing
-  range? : [number, number]; // Optional byte range to retrieve the Segment
-  timestampOffset? : number; // Estimated time, in seconds, at which the
-                             // concerned segment will be offseted when
-                             // decoded.
+  /** Estimated duration of the segment, in timescale. */
+  duration : number;
+  /** ID of the Segment. Should be unique for this Representation. */
+  id : string;
+  /** If true, this Segment contains initialization data. */
+  isInit : boolean;
+  /** URLs where this segment is available. From the most to least prioritary. */
+  mediaURLs : string[]|null;
+  /** Estimated start time for the segment, in timescale. */
+  time : number;
+  /** Timescale to convert `time` and `duration` into seconds. */
+  timescale : number;
+  /**
+   * If set, the corresponding byte-range in the downloaded segment will
+   * contain an index describing other Segments
+   * TODO put in privateInfos?
+   */
+  indexRange? : [number, number];
+  /**
+   * Optional number of the Segment
+   * TODO put in privateInfos?
+   */
+  number? : number;
+  /**
+   * Allows to store supplementary information on a segment that can be later
+   * exploited by the transport logic.
+   */
+  privateInfos? : IPrivateInfos;
+  /** Optional byte range to retrieve the Segment from its URL(s) */
+  range? : [number, number];
+  /**
+   * Estimated time, in seconds, at which the concerned segment should be
+   * offseted when decoded.
+   */
+  timestampOffset? : number;
 }
 
-export interface IRepresentationIndexSegmentInfos { duration : number;
-                                                    time : number;
-                                                    timescale : number; }
-
-// Interface that should be implemented by any Representation's index
+/** Interface that should be implemented by any Representation's `index` value. */
 export default interface IRepresentationIndex {
   /**
    * Returns Segment object allowing to do the Init Segment request.

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-// Enumerate the different ways a Manifest update can be done
+/** Enumerate the different ways a Manifest update can be done. */
 export enum MANIFEST_UPDATE_TYPE {
-  Full, // The full version of the Manifest has been re-downloaded
-  Partial, // Only a shortened version of the Manifest has been downloaded
+  /** The full version of the Manifest has been re-downloaded. */
+  Full,
+  /** Only a shortened version of the Manifest has been downloaded. */
+  Partial,
 }

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -389,8 +389,10 @@ export interface ITransportOptions {
   representationFilter? : IRepresentationFilter;
   segmentLoader? : CustomSegmentLoader;
   serverSyncInfos? : IServerSyncInfos;
+  /* tslint:disable deprecation */
   supplementaryImageTracks? : ISupplementaryImageTrack[];
   supplementaryTextTracks? : ISupplementaryTextTrack[];
+  /* tslint:enable deprecation */
 }
 
 export type ITransportFunction = (options : ITransportOptions) =>


### PR DESCRIPTION
While doing some refactoring, I noticed that JSDoc-type comments (`/** like this one with two stars characters at the beginning */`) for types, values and functions were automatically picked by my TypeScript language server to do things like auto-completion with added documentation.

I thus updated most `src/api` and `src/manifest` comments to switch to JSDoc-type comments when it made sense. Other directories can follow but this is not high priority.

This was tested on both Vim (with the [coc.nvim extension](https://github.com/neoclide/coc.nvim) that I use now) and VSCode.