### PR TITLE
code: Manifest structure improvements

### DIFF
--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -87,8 +87,8 @@ export default function getInitialTime(
 
   const minimumPosition = manifest.getMinimumPosition();
   if (manifest.isLive) {
-    const sgp = manifest.suggestedPresentationDelay;
-    const clockOffset = manifest.getClockOffset();
+    const { suggestedPresentationDelay,
+            clockOffset } = manifest;
     const maximumPosition = manifest.getMaximumPosition();
     let liveTime : number;
     if (clockOffset == null) {
@@ -106,9 +106,9 @@ export default function getInitialTime(
                           clockRelativeLiveTime);
     }
     log.debug(`Init: ${liveTime} defined as the live time, applying a live gap` +
-              ` of ${sgp}`);
-    if (sgp != null) {
-      return Math.max(liveTime - sgp, minimumPosition);
+              ` of ${suggestedPresentationDelay}`);
+    if (suggestedPresentationDelay != null) {
+      return Math.max(liveTime - suggestedPresentationDelay, minimumPosition);
     }
     const defaultStartingPos = liveTime - (lowLatencyMode ? DEFAULT_LIVE_GAP.LOW_LATENCY :
                                                             DEFAULT_LIVE_GAP.DEFAULT);

--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -148,7 +148,7 @@ export default function manifestUpdateScheduler({
        log.warn("Init: Cannot refresh the manifest: no url");
        return EMPTY;
      }
-     const externalClockOffset = manifest.getClockOffset();
+     const externalClockOffset = manifest.clockOffset;
      return fetchManifest(refreshURL, externalClockOffset)
        .pipe(mergeMap((value) => {
          const { manifest: newManifest,

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -16,14 +16,25 @@
 
 /* tslint:disable no-unsafe-any */
 describe("Manifest - Manifest", () => {
+  const fakeLogger = { warn: jest.fn(() => undefined),
+                       info: jest.fn(() => undefined) };
+  const fakeGenerateNewId = jest.fn(() => "fakeId");
+  const fakeIdGenerator = jest.fn(() => fakeGenerateNewId);
+
   beforeEach(() => {
     jest.resetModules();
+    fakeLogger.warn.mockClear();
+    fakeLogger.info.mockClear();
+    jest.mock("../../log", () =>  ({ __esModule: true,
+                                     default: fakeLogger }));
+    fakeGenerateNewId.mockClear();
+    fakeIdGenerator.mockClear();
+    jest.mock("../../utils/id_generator", () => ({ __esModule: true,
+                                                   default: fakeIdGenerator }));
+
   });
 
   it("should create a normalized Manifest structure", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
     const simpleFakeManifest = { id: "man",
                                  isDynamic: false,
                                  isLive: false,
@@ -31,14 +42,12 @@ describe("Manifest - Manifest", () => {
                                  periods: [],
                                  transportType: "foobar" };
 
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
-
     const Manifest = require("../manifest").default;
     const manifest = new Manifest(simpleFakeManifest, {});
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(undefined);
-    expect(manifest.id).toEqual("man");
+    expect(manifest.id).toEqual("fakeId");
     expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(undefined);
@@ -50,15 +59,13 @@ describe("Manifest - Manifest", () => {
     expect(manifest.transport).toEqual("foobar");
     expect(manifest.uris).toEqual([]);
 
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should create a Period for each manifest.periods given", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
-
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -71,7 +78,6 @@ describe("Manifest - Manifest", () => {
     const fakePeriod = jest.fn((period) => {
       return { id: `foo${period.id}`, parsingErrors: [] };
     });
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     jest.mock("../period", () =>  ({ __esModule: true,
                                      default: fakePeriod }));
 
@@ -85,17 +91,13 @@ describe("Manifest - Manifest", () => {
                                        { id: "foo1", parsingErrors: [] } ]);
     expect(manifest.adaptations).toEqual({});
 
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should pass a `representationFilter` to the Period if given", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -110,7 +112,6 @@ describe("Manifest - Manifest", () => {
     const fakePeriod = jest.fn((period) => {
       return { id: `foo${period.id}`, parsingErrors: [] };
     });
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     jest.mock("../period", () =>  ({ __esModule: true,
                                      default: fakePeriod }));
     const Manifest = require("../manifest").default;
@@ -122,17 +123,13 @@ describe("Manifest - Manifest", () => {
     expect(fakePeriod).toHaveBeenCalledTimes(2);
     expect(fakePeriod).toHaveBeenCalledWith(period1, representationFilter);
     expect(fakePeriod).toHaveBeenCalledWith(period2, representationFilter);
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should expose the adaptations of the first period if set", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
     const adapP1 = {};
     const adapP2 = {};
     const period1 = { id: "0", start: 4, adaptations: adapP1 };
@@ -147,7 +144,6 @@ describe("Manifest - Manifest", () => {
     const fakePeriod = jest.fn((period) => {
       return { ...period, id: `foo${period.id}`, parsingErrors: [] };
     });
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     jest.mock("../period", () =>  ({ __esModule: true,
                                      default: fakePeriod }));
     const Manifest = require("../manifest").default;
@@ -163,17 +159,13 @@ describe("Manifest - Manifest", () => {
     ]);
     expect(manifest.adaptations).toBe(adapP1);
 
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should push any parsing errors from the Period parsing", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -188,7 +180,6 @@ describe("Manifest - Manifest", () => {
                parsingErrors: [ new Error(`a${period.id}`),
                                 new Error(period.id) ] };
     });
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     jest.mock("../period", () =>  ({
       __esModule: true,
       default: fakePeriod,
@@ -202,15 +193,13 @@ describe("Manifest - Manifest", () => {
     expect(manifest.parsingErrors).toContainEqual(new Error("0"));
     expect(manifest.parsingErrors).toContainEqual(new Error("1"));
 
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should correctly parse every manifest information given", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
-
     const oldPeriod1 = { id: "0", start: 4, adaptations: {} };
     const oldPeriod2 = { id: "1", start: 12, adaptations: {} };
     const time = performance.now();
@@ -228,7 +217,6 @@ describe("Manifest - Manifest", () => {
                               transportType: "foobar",
                               uris: ["url1", "url2"] };
 
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return { ...period,
                id: `foo${period.id}`,
@@ -241,7 +229,7 @@ describe("Manifest - Manifest", () => {
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(5);
-    expect(manifest.id).toEqual("man");
+    expect(manifest.id).toEqual("fakeId");
     expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(13);
@@ -255,18 +243,13 @@ describe("Manifest - Manifest", () => {
     expect(manifest.suggestedPresentationDelay).toEqual(99);
     expect(manifest.transport).toEqual("foobar");
     expect(manifest.uris).toEqual(["url1", "url2"]);
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
   it("should return the first URL given with `getUrl`", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return {
         ...period,
@@ -316,18 +299,9 @@ describe("Manifest - Manifest", () => {
                                uris: [] };
     const manifest2 = new Manifest(oldManifestArgs2, {});
     expect(manifest2.getUrl()).toEqual(undefined);
-
-    logSpy.mockRestore();
   });
 
   it("should update with a new Manifest when calling `update`", () => {
-    const log = { warn: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
-    const logSpy = jest.spyOn(log, "warn").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return {
         ...period,
@@ -402,7 +376,7 @@ describe("Manifest - Manifest", () => {
     manifest.replace(newManifest);
     expect(manifest.adaptations).toEqual(newAdaptations);
     expect(manifest.availabilityStartTime).toEqual(6);
-    expect(manifest.id).toEqual("man2");
+    expect(manifest.id).toEqual("fakeId");
     expect(manifest.isDynamic).toEqual(true);
     expect(manifest.isLive).toEqual(true);
     expect(manifest.lifetime).toEqual(14);
@@ -420,18 +394,14 @@ describe("Manifest - Manifest", () => {
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledWith(oldPeriod2, newPeriod2, 0);
     expect(eeSpy).toHaveBeenCalledTimes(1);
     expect(eeSpy).toHaveBeenCalledWith("manifestUpdate", null);
-    expect(logSpy).not.toHaveBeenCalled();
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    expect(fakeLogger.info).not.toHaveBeenCalled();
+    expect(fakeLogger.warn).not.toHaveBeenCalled();
     eeSpy.mockRestore();
   });
 
   it("should prepend older Periods when calling `update`", () => {
-    const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({
-      __esModule: true,
-      default: log,
-    }));
-
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -445,7 +415,6 @@ describe("Manifest - Manifest", () => {
                               transportType: "foobar",
                               uris: ["url1", "url2"] };
 
-    const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return {
         ...period,
@@ -510,20 +479,17 @@ describe("Manifest - Manifest", () => {
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledWith(oldPeriod1, newPeriod3, 0);
     expect(eeSpy).toHaveBeenCalledTimes(1);
     expect(eeSpy).toHaveBeenCalledWith("manifestUpdate", null);
-    // expect(logSpy).toHaveBeenCalledTimes(2);
-    // expect(logSpy).toHaveBeenCalledWith(
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    // expect(fakeLogger.info).toHaveBeenCalledTimes(2);
+    // expect(fakeLogger.info).toHaveBeenCalledWith(
     //   "Manifest: Adding new Period pre0 after update.");
-    // expect(logSpy).toHaveBeenCalledWith(
+    // expect(fakeLogger.info).toHaveBeenCalledWith(
     //   "Manifest: Adding new Period pre1 after update.");
-    logSpy.mockRestore();
     eeSpy.mockRestore();
   });
 
   it("should append newer Periods when calling `update`", () => {
-    const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
-
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -537,7 +503,6 @@ describe("Manifest - Manifest", () => {
                               transportType: "foobar",
                               uris: ["url1", "url2"] };
 
-    const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return { ...period,
                id: `foo${period.id}`,
@@ -585,18 +550,15 @@ describe("Manifest - Manifest", () => {
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledWith(oldPeriod1, newPeriod1, 0);
     expect(eeSpy).toHaveBeenCalledTimes(1);
     expect(eeSpy).toHaveBeenCalledWith("manifestUpdate", null);
-    // expect(logSpy).toHaveBeenCalledTimes(1);
-    // expect(logSpy)
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    // expect(fakeLogger.warn).toHaveBeenCalledTimes(1);
+    // expect(fakeLogger.warn)
     // .toHaveBeenCalledWith("Manifest: Adding new Periods after update.");
-    logSpy.mockRestore();
     eeSpy.mockRestore();
   });
 
   it("should replace different Periods when calling `update`", () => {
-    const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
-
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -610,7 +572,6 @@ describe("Manifest - Manifest", () => {
                               transportType: "foobar",
                               uris: ["url1", "url2"] };
 
-    const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return { ...period,
                id: `foo${period.id}`,
@@ -656,16 +617,13 @@ describe("Manifest - Manifest", () => {
     expect(fakeUpdatePeriodInPlace).not.toHaveBeenCalled();
     expect(eeSpy).toHaveBeenCalledTimes(1);
     expect(eeSpy).toHaveBeenCalledWith("manifestUpdate", null);
-    // expect(logSpy).toHaveBeenCalledTimes(4);
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    // expect(fakeLogger.info).toHaveBeenCalledTimes(4);
     eeSpy.mockRestore();
   });
 
   it("should merge overlapping Periods when calling `update`", () => {
-    const log = { warn: () => undefined, info: () => undefined };
-    jest.mock("../../log", () =>  ({ __esModule: true,
-                                     default: log }));
-
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -681,7 +639,6 @@ describe("Manifest - Manifest", () => {
                               transportType: "foobar",
                               uris: ["url1", "url2"] };
 
-    const logSpy = jest.spyOn(log, "info").mockImplementation(jest.fn());
     const fakePeriod = jest.fn((period) => {
       return { ...period,
                id: `foo${period.id}`,
@@ -741,8 +698,9 @@ describe("Manifest - Manifest", () => {
     expect(fakeUpdatePeriodInPlace).toHaveBeenCalledWith(oldPeriod2, newPeriod4, 0);
     expect(eeSpy).toHaveBeenCalledTimes(1);
     expect(eeSpy).toHaveBeenCalledWith("manifestUpdate", null);
-    // expect(logSpy).toHaveBeenCalledTimes(5);
-    logSpy.mockRestore();
+    expect(fakeIdGenerator).toHaveBeenCalledTimes(2);
+    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
+    // expect(fakeLogger.info).toHaveBeenCalledTimes(5);
     eeSpy.mockRestore();
   });
 });

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -568,7 +568,9 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     }
 
     /* tslint:disable:deprecation */
-    this.adaptations = this.periods[0].adaptations;
+    this.adaptations = this.periods[0] === undefined ?
+                         {} :
+                         this.periods[0].adaptations;
     /* tslint:enable:deprecation */
 
     this.trigger("manifestUpdate", null);

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -16,7 +16,6 @@
 
 import config from "../../../config";
 import arrayFind from "../../../utils/array_find";
-import idGenerator from "../../../utils/id_generator";
 import { normalizeBaseURL } from "../../../utils/resolve_url";
 import { IParsedManifest } from "../types";
 import checkManifestIDs from "../utils/check_manifest_ids";
@@ -39,8 +38,6 @@ import parsePeriods, {
 import resolveBaseURLs from "./resolve_base_urls";
 
 const { DASH_FALLBACK_LIFETIME_WHEN_MINIMUM_UPDATE_PERIOD_EQUAL_0 } = config;
-
-const generateManifestID = idGenerator();
 
 export interface IMPDParserArguments {
   aggressiveMode : boolean; // Whether we should request new segments even if
@@ -228,8 +225,6 @@ function parseCompleteIntermediateRepresentation(
   const parsedMPD : IParsedManifest = {
     availabilityStartTime,
     clockOffset: args.externalClockOffset,
-    id: rootAttributes.id != null ? rootAttributes.id :
-                                    "gen-dash-manifest-" + generateManifestID(),
     isDynamic,
     isLive: isDynamic,
     periods: parsedPeriods,

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -32,8 +32,6 @@ import {
   ILocalRepresentation,
 } from "./types";
 
-const generateManifestID = idGenerator();
-
 /**
  * @param {Object} localManifest
  * @returns {Object}
@@ -53,7 +51,6 @@ export default function parseLocalManifest(
   const manifest: IParsedManifest = {
     availabilityStartTime: 0,
     expired: localManifest.expired,
-    id: "local-manifest_" + generateManifestID(),
     transportType: "local",
     isDynamic: !localManifest.isFinished,
     isLive: false,

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -58,8 +58,6 @@ export interface IMetaPlaylist {
   }>;
 }
 
-const generateManifestID = idGenerator();
-
 /**
  * Parse playlist string to JSON.
  * Returns an array of contents.
@@ -296,7 +294,6 @@ function createManifest(
   const manifest = { availabilityStartTime: 0,
                      clockOffset,
                      suggestedPresentationDelay: 10,
-                     id: "gen-metaplaylist-man-" + generateManifestID(),
                      periods,
                      transportType: "metaplaylist",
                      isLive: isDynamic,

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -17,7 +17,6 @@
 import log from "../../../log";
 import arrayIncludes from "../../../utils/array_includes";
 import assert from "../../../utils/assert";
-import idGenerator from "../../../utils/id_generator";
 import isNonEmptyString from "../../../utils/is_non_empty_string";
 import objectAssign from "../../../utils/object_assign";
 import resolveURL, {
@@ -52,8 +51,6 @@ import { replaceRepresentationSmoothTokens } from "./utils/tokens";
  * to be generated.
  */
 const DEFAULT_AGGRESSIVE_MODE = false;
-
-const generateManifestID = idGenerator();
 
 interface IAdaptationParserArguments { root : Element;
                                        rootURL : string;
@@ -626,7 +623,6 @@ function createSmoothStreamingParser(
         0 :
         availabilityStartTime,
       clockOffset: serverTimeOffset,
-      id: "gen-smooth-manifest-" + generateManifestID(),
       isLive,
       isDynamic: isLive,
       maximumTime,

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -92,7 +92,6 @@ export interface IParsedPeriod {
 // Representation of the whole Manifest file
 export interface IParsedManifest {
   // required
-  id: string; // Unique ID for the manifest.
   isDynamic : boolean; // If true, this Manifest can be updated
   isLive : boolean; // If true, this Manifest describes a "live" content
   periods: IParsedPeriod[]; // Periods contained in this manifest.

--- a/src/utils/__tests__/id_generator.test.ts
+++ b/src/utils/__tests__/id_generator.test.ts
@@ -16,7 +16,14 @@
 
 import idGenerator from "../id_generator";
 
+const oldNumberDef = window.Number;
+
 describe("utils - idGenerator", () => {
+  afterEach(() => {
+    // There's an ugly test in here that changes the Number object
+    (window as any).Number = oldNumberDef;
+  });
+
   it("should increment an ID", () => {
     const generateNewID = idGenerator();
     expect(generateNewID()).toBe("0");
@@ -42,5 +49,30 @@ describe("utils - idGenerator", () => {
     expect(generateNewID2()).toBe("3");
     expect(generateNewID2()).toBe("4");
     expect(generateNewID3()).toBe("0");
+  });
+  it ("should preprend a 0 after A LOT of ID generation", () => {
+    // Ugly but I don't care
+    (window as any).Number = { MAX_SAFE_INTEGER: 3,
+                               isSafeInteger: (x : number) => x <= 3 };
+    const generateNewID1 = idGenerator();
+    const generateNewID2 = idGenerator();
+    const generateNewID3 = idGenerator();
+    expect(generateNewID1()).toBe("0");
+    expect(generateNewID1()).toBe("1");
+    expect(generateNewID2()).toBe("0");
+    expect(generateNewID1()).toBe("2");
+    expect(generateNewID1()).toBe("00");
+    expect(generateNewID2()).toBe("1");
+    expect(generateNewID2()).toBe("2");
+    expect(generateNewID1()).toBe("01");
+    expect(generateNewID1()).toBe("02");
+    expect(generateNewID2()).toBe("00");
+    expect(generateNewID2()).toBe("01");
+    expect(generateNewID3()).toBe("0");
+
+    expect(generateNewID1()).toBe("000");
+    expect(generateNewID1()).toBe("001");
+    expect(generateNewID1()).toBe("002");
+    expect(generateNewID1()).toBe("0000");
   });
 });

--- a/src/utils/id_generator.ts
+++ b/src/utils/id_generator.ts
@@ -19,8 +19,14 @@
  * @returns {Function}
  */
 export default function idGenerator() : () => string {
-  let lastID = 0;
+  let prefix = "";
+  let currId = -1;
   return function generateNewId() : string {
-    return String(lastID++);
+    currId++;
+    if (currId >= Number.MAX_SAFE_INTEGER) {
+      prefix += "0";
+      currId = 0;
+    }
+    return prefix + String(currId);
   };
 }


### PR DESCRIPTION
Yet another isolation or related commits that were part of a bigger refacto.

This PR contains multiple improvements related to the Manifest structure:
  - the `getClockOffset` method is removed, in profit of just a `clockOffset` property. Most Manifest information is accessible through properties so that difference for the clock offset was a little weird. Even more when we consider that that method just relied on a private `_clockOffset` property

  - We didn't do an empty array check after a Manifest update before getting the adaptations for the first period. This could lead to incomprehensible errors when updating a Manifest when the new updated manifest has no period (which should never happen anyway).

  - When doing a partial Manifest update (with the optimization of the last release), we would be sending a `manifestUpdate` and then manually removing the period that are behind the minimum possible position. This lead to no bug that I know of but could in the future as it is not really logical

  - The `id` property for the Manifest object serves no much purpose for now. It is only used to generate period ids when parsing MetaPlaylist contents.
     I saw even less reason why a manifest parser should have to define one. So I removed that part.
     The funnier part of it all was that that ID could technically change between manifest updates. This is now impossible.

  - The id-generator utils just incremented a JavaScript number. It is technically an IEEE754 double-precision which has its limits. Technically `9007199254740992` is the maximum value from which incrementation by 1 do not have any effect (for [some reasons](https://stackoverflow.com/questions/26380364/why-is-number-max-safe-integer-9-007-199-254-740-991-and-not-9-007-199-254-740-9) JS set Number.MAX_SAFE_INTEGER to 1 less than that number).

      Of course we're speaking of an absurdly large number which had no chance of being reached. But after doing some testing, I saw that there was no sensible performance issues by avoiding that issue (by prefixing and resetting the counter once Number.MAX_SAFE_INTEGER is reached).

     You could still argue that this is over-engineering and not want to merge it, I would understand.

  - the `src/manifest/__tests__/manifest.test.ts` test file was a bit of a mess, with re-definition of mocks everywhere. I cleaned it up a little bit.

  - the `IManifestAdaptations` type was declared twice. In `src/manifest/period.ts` and `src/manifest/manifest.ts`. I deleted the one in `src/manifest/manifest.ts`