### PR TITLE
Move every BufferOrchestrator files to src/core/buffers/orchestrator

### DIFF
--- a/src/core/buffers/orchestrator/active_period_emitter.ts
+++ b/src/core/buffers/orchestrator/active_period_emitter.ts
@@ -32,9 +32,9 @@ import {
   map,
   scan,
 } from "rxjs/operators";
-import { Period } from "../../manifest";
-import { IBufferType } from "../source_buffers";
-import { IMultiplePeriodBuffersEvent } from "./types";
+import { Period } from "../../../manifest";
+import { IBufferType } from "../../source_buffers";
+import { IMultiplePeriodBuffersEvent } from "../types";
 
 interface IPeriodObject { period : Period;
                           buffers: Set<IBufferType>; }

--- a/src/core/buffers/orchestrator/are_buffers_complete.ts
+++ b/src/core/buffers/orchestrator/are_buffers_complete.ts
@@ -24,7 +24,7 @@ import {
   map,
   startWith,
 } from "rxjs/operators";
-import { IMultiplePeriodBuffersEvent } from "./types";
+import { IMultiplePeriodBuffersEvent } from "../types";
 
 /**
  * Returns an Observable which emits ``true`` when all PeriodBuffers given are

--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -37,36 +37,36 @@ import {
   takeUntil,
   tap,
 } from "rxjs/operators";
-import config from "../../config";
-import { MediaError } from "../../errors";
-import log from "../../log";
+import config from "../../../config";
+import { MediaError } from "../../../errors";
+import log from "../../../log";
 import Manifest, {
   Period,
-} from "../../manifest";
-import { fromEvent } from "../../utils/event_emitter";
-import SortedList from "../../utils/sorted_list";
-import WeakMapMemory from "../../utils/weak_map_memory";
-import ABRManager from "../abr";
-import { SegmentPipelineCreator } from "../pipelines";
+} from "../../../manifest";
+import { fromEvent } from "../../../utils/event_emitter";
+import SortedList from "../../../utils/sorted_list";
+import WeakMapMemory from "../../../utils/weak_map_memory";
+import ABRManager from "../../abr";
+import { SegmentPipelineCreator } from "../../pipelines";
 import SourceBuffersStore, {
   BufferGarbageCollector,
   getBufferTypes,
   IBufferType,
   ITextTrackSourceBufferOptions,
   QueuedSourceBuffer,
-} from "../source_buffers";
-import ActivePeriodEmitter from "./active_period_emitter";
-import areBuffersComplete from "./are_buffers_complete";
-import EVENTS from "./events_generators";
-import getBlacklistedRanges from "./get_blacklisted_ranges";
+} from "../../source_buffers";
+import EVENTS from "../events_generators";
 import PeriodBuffer, {
   IPeriodBufferClockTick,
-} from "./period";
+} from "../period";
 import {
   IBufferOrchestratorEvent,
   IMultiplePeriodBuffersEvent,
   IPeriodBufferEvent,
-} from "./types";
+} from "../types";
+import ActivePeriodEmitter from "./active_period_emitter";
+import areBuffersComplete from "./are_buffers_complete";
+import getBlacklistedRanges from "./get_blacklisted_ranges";
 
 export type IBufferOrchestratorClockTick = IPeriodBufferClockTick;
 

--- a/src/core/buffers/orchestrator/get_blacklisted_ranges.ts
+++ b/src/core/buffers/orchestrator/get_blacklisted_ranges.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import log from "../../log";
+import log from "../../../log";
 import {
   Adaptation,
   Period,
   Representation,
-} from "../../manifest";
-import { IRange } from "../../utils/ranges";
-import { QueuedSourceBuffer } from "../source_buffers";
+} from "../../../manifest";
+import { IRange } from "../../../utils/ranges";
+import { QueuedSourceBuffer } from "../../source_buffers";
 
 /**
  * Returns the buffered ranges which hold the given content.

--- a/src/core/buffers/orchestrator/index.ts
+++ b/src/core/buffers/orchestrator/index.ts
@@ -16,8 +16,7 @@
 
 import BufferOrchestrator, {
   IBufferOrchestratorClockTick,
-} from "./orchestrator";
-export * from "./types";
+} from "./buffer_orchestrator";
 
 export default BufferOrchestrator;
 export { IBufferOrchestratorClockTick };


### PR DESCRIPTION
To help with code readability, I moved every BufferOrchestrator-related files to its own directory and no more just at the root of `src/core/buffers`.

This is because those files have the potential to be much more complex if we decide to implement partial periods (btw, let's call them maybe lazy periods, a better informal name).