### PR TITLE
utils: add `deferSubscriptions` operator

### DIFF
--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -25,7 +25,6 @@
  */
 
 import {
-  asapScheduler,
   BehaviorSubject,
   concat as observableConcat,
   defer as observableDefer,
@@ -45,7 +44,6 @@ import {
   multicast,
   share,
   startWith,
-  subscribeOn,
   take,
   takeUntil,
   tap,
@@ -61,6 +59,7 @@ import Manifest, {
   Representation,
 } from "../../../manifest";
 import concatMapLatest from "../../../utils/concat_map_latest";
+import deferInitialSubscriptions from "../../../utils/defer_initial_subscriptions";
 import ABRManager, {
   IABREstimate,
   IABRMetric,
@@ -160,7 +159,7 @@ export default function AdaptationBuffer<T>({
                                                           decipherableRepresentations,
                                                           clock$,
                                                           abrEvents$)
-      .pipe(subscribeOn(asapScheduler), share());
+      .pipe(deferInitialSubscriptions(), share());
 
   const segmentFetcher = segmentFetcherCreator.createSegmentFetcher(adaptation.type,
                                                                     requestsEvents$);

--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -59,7 +59,7 @@ import Manifest, {
   Representation,
 } from "../../../manifest";
 import concatMapLatest from "../../../utils/concat_map_latest";
-import deferInitialSubscriptions from "../../../utils/defer_initial_subscriptions";
+import deferSubscriptions from "../../../utils/defer_subscriptions";
 import ABRManager, {
   IABREstimate,
   IABRMetric,
@@ -159,7 +159,7 @@ export default function AdaptationBuffer<T>({
                                                           decipherableRepresentations,
                                                           clock$,
                                                           abrEvents$)
-      .pipe(deferInitialSubscriptions(), share());
+      .pipe(deferSubscriptions(), share());
 
   const segmentFetcher = segmentFetcherCreator.createSegmentFetcher(adaptation.type,
                                                                     requestsEvents$);

--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  asapScheduler,
   BehaviorSubject,
   concat as observableConcat,
   defer as observableDefer,
@@ -32,7 +31,6 @@ import {
   map,
   mergeMap,
   share,
-  subscribeOn,
   take,
   takeUntil,
   tap,
@@ -43,6 +41,7 @@ import log from "../../../log";
 import Manifest, {
   Period,
 } from "../../../manifest";
+import deferInitialSubscriptions from "../../../utils/defer_initial_subscriptions";
 import { fromEvent } from "../../../utils/event_emitter";
 import SortedList from "../../../utils/sorted_list";
 import WeakMapMemory from "../../../utils/weak_map_memory";
@@ -165,7 +164,7 @@ export default function BufferOrchestrator(
   // Every PeriodBuffers for every possible types
   const buffersArray = bufferTypes.map((bufferType) => {
     return manageEveryBuffers(bufferType, initialPeriod)
-      .pipe(subscribeOn(asapScheduler), share());
+      .pipe(deferInitialSubscriptions(), share());
   });
 
   // Emits the activePeriodChanged events every time the active Period changes.

--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -41,7 +41,7 @@ import log from "../../../log";
 import Manifest, {
   Period,
 } from "../../../manifest";
-import deferInitialSubscriptions from "../../../utils/defer_initial_subscriptions";
+import deferSubscriptions from "../../../utils/defer_subscriptions";
 import { fromEvent } from "../../../utils/event_emitter";
 import SortedList from "../../../utils/sorted_list";
 import WeakMapMemory from "../../../utils/weak_map_memory";
@@ -164,7 +164,7 @@ export default function BufferOrchestrator(
   // Every PeriodBuffers for every possible types
   const buffersArray = bufferTypes.map((bufferType) => {
     return manageEveryBuffers(bufferType, initialPeriod)
-      .pipe(deferInitialSubscriptions(), share());
+      .pipe(deferSubscriptions(), share());
   });
 
   // Emits the activePeriodChanged events every time the active Period changes.

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -40,7 +40,7 @@ import {
 } from "../../compat";
 import { MediaError } from "../../errors";
 import log from "../../log";
-import deferInitialSubscriptions from "../../utils/defer_initial_subscriptions";
+import deferSubscriptions from "../../utils/defer_subscriptions";
 import {
   IEMEManagerEvent,
   IKeySystemOption,
@@ -163,7 +163,7 @@ export default function initializeDirectfileContent({
   // issue.
   const emeManager$ = linkURL$.pipe(
     mergeMap(() => createEMEManager(mediaElement, keySystems, EMPTY)),
-    deferInitialSubscriptions(),
+    deferSubscriptions(),
     share()
   );
 

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -20,7 +20,6 @@
  */
 
 import {
-  asapScheduler,
   EMPTY,
   merge as observableMerge,
   Observable,
@@ -33,7 +32,6 @@ import {
   mergeMap,
   mergeMapTo,
   share,
-  subscribeOn,
   take,
 } from "rxjs/operators";
 import {
@@ -42,6 +40,7 @@ import {
 } from "../../compat";
 import { MediaError } from "../../errors";
 import log from "../../log";
+import deferInitialSubscriptions from "../../utils/defer_initial_subscriptions";
 import {
   IEMEManagerEvent,
   IKeySystemOption,
@@ -164,7 +163,7 @@ export default function initializeDirectfileContent({
   // issue.
   const emeManager$ = linkURL$.pipe(
     mergeMap(() => createEMEManager(mediaElement, keySystems, EMPTY)),
-    subscribeOn(asapScheduler), // multiple Observables here are based on this one
+    deferInitialSubscriptions(),
     share()
   );
 

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  asapScheduler,
   BehaviorSubject,
   combineLatest as observableCombineLatest,
   merge as observableMerge,
@@ -31,7 +30,6 @@ import {
   mergeMap,
   share,
   startWith,
-  subscribeOn,
   switchMap,
   take,
   takeUntil,
@@ -41,6 +39,7 @@ import { shouldReloadMediaSourceOnDecipherabilityUpdate } from "../../compat";
 import config from "../../config";
 import log from "../../log";
 import { ITransportPipelines } from "../../transports";
+import deferInitialSubscriptions from "../../utils/defer_initial_subscriptions";
 import { fromEvent } from "../../utils/event_emitter";
 import objectAssign from "../../utils/object_assign";
 import throttle from "../../utils/rx-throttle";
@@ -213,8 +212,8 @@ export default function InitializeOnMediaSource(
    * The MediaSource will be closed on unsubscription.
    */
   const openMediaSource$ = openMediaSource(mediaElement).pipe(
-    subscribeOn(asapScheduler), // to launch subscriptions only when all
-    share());                   // Observables here are linked
+    deferInitialSubscriptions(),
+    share());
 
   /** Send content protection data to the `EMEManager`. */
   const protectedSegments$ = new Subject<IContentProtection>();
@@ -222,8 +221,8 @@ export default function InitializeOnMediaSource(
   /** Create `EMEManager`, an observable which will handle content DRM. */
   const emeManager$ = openMediaSource$.pipe(
     mergeMap(() => createEMEManager(mediaElement, keySystems, protectedSegments$)),
-    subscribeOn(asapScheduler), // to launch subscriptions only when all
-    share());                   // Observables here are linked
+    deferInitialSubscriptions(),
+    share());
 
   /**
    * Translate errors coming from the media element into RxPlayer errors
@@ -241,8 +240,8 @@ export default function InitializeOnMediaSource(
 
   /** Do the first Manifest request. */
   const initialManifestRequest$ = fetchManifest(url, undefined).pipe(
-    subscribeOn(asapScheduler), // to launch subscriptions only when all
-    share());                   // Observables here are linked
+    deferInitialSubscriptions(),
+    share());
 
   const initialManifestRequestWarnings$ = initialManifestRequest$
     .pipe(filter((evt) : evt is IWarningEvent => evt.type === "warning"));

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -39,7 +39,7 @@ import { shouldReloadMediaSourceOnDecipherabilityUpdate } from "../../compat";
 import config from "../../config";
 import log from "../../log";
 import { ITransportPipelines } from "../../transports";
-import deferInitialSubscriptions from "../../utils/defer_initial_subscriptions";
+import deferSubscriptions from "../../utils/defer_subscriptions";
 import { fromEvent } from "../../utils/event_emitter";
 import objectAssign from "../../utils/object_assign";
 import throttle from "../../utils/rx-throttle";
@@ -212,7 +212,7 @@ export default function InitializeOnMediaSource(
    * The MediaSource will be closed on unsubscription.
    */
   const openMediaSource$ = openMediaSource(mediaElement).pipe(
-    deferInitialSubscriptions(),
+    deferSubscriptions(),
     share());
 
   /** Send content protection data to the `EMEManager`. */
@@ -221,7 +221,7 @@ export default function InitializeOnMediaSource(
   /** Create `EMEManager`, an observable which will handle content DRM. */
   const emeManager$ = openMediaSource$.pipe(
     mergeMap(() => createEMEManager(mediaElement, keySystems, protectedSegments$)),
-    deferInitialSubscriptions(),
+    deferSubscriptions(),
     share());
 
   /**
@@ -240,7 +240,7 @@ export default function InitializeOnMediaSource(
 
   /** Do the first Manifest request. */
   const initialManifestRequest$ = fetchManifest(url, undefined).pipe(
-    deferInitialSubscriptions(),
+    deferSubscriptions(),
     share());
 
   const initialManifestRequestWarnings$ = initialManifestRequest$

--- a/src/utils/__tests__/defer_subscriptions.test.ts
+++ b/src/utils/__tests__/defer_subscriptions.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { timer } from "rxjs";
+import {
+  mapTo,
+  share,
+  startWith,
+} from "rxjs/operators";
+import deferSubscriptions from "../defer_subscriptions";
+
+describe("utils - deferSubscriptions", () => {
+  /* tslint:disable max-line-length */
+  it("should wait until all subscription in the current script are done before emitting", (done) => {
+  /* tslint:enable max-line-length */
+    let logs = "";
+    const myObservableDeferred = timer(5).pipe(mapTo("A"),
+                                               startWith("S"),
+                                               deferSubscriptions(),
+                                               share());
+
+    myObservableDeferred.subscribe(
+      x => { logs += `1:${x}-`; },
+      () => { /* noop */ },
+      () => {
+        expect(logs).toEqual("1:S-2:S-1:A-2:A-3:A-4:A-");
+        done();
+      });
+    myObservableDeferred.subscribe(x => { logs += `2:${x}-`; });
+
+    setTimeout(() => {
+      myObservableDeferred.subscribe(x => { logs += `3:${x}-`; });
+      myObservableDeferred.subscribe(x => { logs += `4:${x}-`; });
+    }, 1);
+  });
+});

--- a/src/utils/defer_initial_subscriptions.ts
+++ b/src/utils/defer_initial_subscriptions.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import nextTick from "next-tick";
+import {
+  asapScheduler,
+  Observable,
+} from "rxjs";
+import { subscribeOn } from "rxjs/operators";
+
+/**
+ * At the first subscription, instead of "running" the Observable right away,
+ * wait until the current script has finished executing before actually running
+ * this Observable.
+ *
+ * This can be important for example when you want in a given function to
+ * exploit the same shared Observable which may send synchronous events directly
+ * after subscription.
+ * Calling `deferInitialSubscriptions` in those cases will make sure that all
+ * such subscriptions in the same function are registered before the Observable
+ * start emitting events (as long as such Subscriptions are done synchronously).
+ *
+ * @example
+ * ```js
+ * const myObservable = rxjs.timer(100).pipe(mapTo("ASYNC MSG"),
+ *                                           startWith("SYNCHRONOUS MSG"),
+ *                                           share());
+ *
+ * myObservable.subscribe(x => console.log("Sub1:", x));
+ * myObservable.subscribe(x => console.log("Sub2:", x));
+ *
+ * setTimeout(() => {
+ *   myObservable.subscribe(x => console.log("Sub3:", x));
+ * }, 50);
+ *
+ * // You will get:
+ * // Sub1: SYNCHRONOUS MSG
+ * // Sub1: ASYNC MSG
+ * // Sub2: ASYNC MSG
+ * // Sub3: ASYNC MSG
+ *
+ * // ------------------------------
+ *
+ * const myObservableDeferred = rxjs.timer(100).pipe(mapTo("ASYNC MSG"),
+ *                                                   startWith("SYNCHRONOUS MSG"),
+ *                                                   deferInitialSubscriptions(),
+ *                                                   // NOTE: the order is important here
+ *                                                   share());
+ *
+ * myObservableDeferred.subscribe(x => console.log("Sub1:", x));
+ * myObservableDeferred.subscribe(x => console.log("Sub2:", x));
+ *
+ * setTimeout(() => {
+ *   myObservableDeferred.subscribe(x => console.log("Sub3:", x));
+ * }, 50);
+ *
+ * // You will get:
+ * // Sub1: SYNCHRONOUS MSG
+ * // Sub2: SYNCHRONOUS MSG
+ * // Sub1: ASYNC MSG
+ * // Sub2: ASYNC MSG
+ * // Sub3: ASYNC MSG
+ * ```
+ * @returns {function}
+ */
+export default function deferInitialSubscriptions<T>(
+) : (source: Observable<T>) => Observable<T> {
+  let isSubscriptionAsyncWithFirstOne = false;
+  return (source: Observable<T>) => {
+    if (isSubscriptionAsyncWithFirstOne) {
+      return source;
+    }
+    nextTick(() => { isSubscriptionAsyncWithFirstOne = true; });
+
+    // TODO asapScheduler seems to not push the subscription in the microtask
+    // queue as nextTick does but in a regular event loop queue.
+    // This means that the subscription will be run even later that we wish for.
+    // This is not dramatic but it could be better.
+    // Either this is a problem with RxJS or this was wanted, in which case we
+    // may need to add our own scheduler.
+    return source.pipe(subscribeOn(asapScheduler));
+  };
+}

--- a/src/utils/defer_subscriptions.ts
+++ b/src/utils/defer_subscriptions.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import nextTick from "next-tick";
 import {
   asapScheduler,
   Observable,
@@ -22,15 +21,15 @@ import {
 import { subscribeOn } from "rxjs/operators";
 
 /**
- * At the first subscription, instead of "running" the Observable right away,
- * wait until the current script has finished executing before actually running
- * this Observable.
+ * At  subscription, instead of "running" the Observable right away, wait until
+ * the current script has finished executing before actually running this
+ * Observable.
  *
  * This can be important for example when you want in a given function to
  * exploit the same shared Observable which may send synchronous events directly
  * after subscription.
- * Calling `deferInitialSubscriptions` in those cases will make sure that all
- * such subscriptions in the same function are registered before the Observable
+ * Calling `deferSubscriptions` in those cases will make sure that all such
+ * subscriptions in the same function are registered before the Observable
  * start emitting events (as long as such Subscriptions are done synchronously).
  *
  * @example
@@ -56,7 +55,7 @@ import { subscribeOn } from "rxjs/operators";
  *
  * const myObservableDeferred = rxjs.timer(100).pipe(mapTo("ASYNC MSG"),
  *                                                   startWith("SYNCHRONOUS MSG"),
- *                                                   deferInitialSubscriptions(),
+ *                                                   deferSubscriptions(),
  *                                                   // NOTE: the order is important here
  *                                                   share());
  *
@@ -76,15 +75,9 @@ import { subscribeOn } from "rxjs/operators";
  * ```
  * @returns {function}
  */
-export default function deferInitialSubscriptions<T>(
+export default function deferSubscriptions<T>(
 ) : (source: Observable<T>) => Observable<T> {
-  let isSubscriptionAsyncWithFirstOne = false;
   return (source: Observable<T>) => {
-    if (isSubscriptionAsyncWithFirstOne) {
-      return source;
-    }
-    nextTick(() => { isSubscriptionAsyncWithFirstOne = true; });
-
     // TODO asapScheduler seems to not push the subscription in the microtask
     // queue as nextTick does but in a regular event loop queue.
     // This means that the subscription will be run even later that we wish for.


### PR DESCRIPTION
Add `deferSubscriptions` operator:

At subscription, instead of "running" the Observable right away, it will wait until the current script has finished executing before actually running this Observable.

This can be important for example when you want in a given function to exploit the same shared Observable which may send synchronous events directly after subscription.
Calling `deferSubscriptions` in those cases will make sure that all such subscriptions in the same function are registered before the Observable start emitting events (as long as such Subscriptions are done synchronously).

Example:
```js
const myObservable = rxjs.timer(100).pipe(mapTo("ASYNC MSG"),
                                          startWith("SYNCHRONOUS MSG"),
                                          share());

myObservable.subscribe(x => console.log("Sub1:", x));
myObservable.subscribe(x => console.log("Sub2:", x));

setTimeout(() => {
  myObservable.subscribe(x => console.log("Sub3:", x));
}, 50);

// You will get:
// Sub1: SYNCHRONOUS MSG
// Sub1: ASYNC MSG
// Sub2: ASYNC MSG
// Sub3: ASYNC MSG

// ------------------------------

const myObservableDeferred = rxjs.timer(100).pipe(mapTo("ASYNC MSG"),
                                                  startWith("SYNCHRONOUS MSG"),
                                                  deferSubscriptions(),
                                                  // NOTE: the order is important here
                                                  share());

myObservableDeferred.subscribe(x => console.log("Sub1:", x));
myObservableDeferred.subscribe(x => console.log("Sub2:", x));

setTimeout(() => {
  myObservableDeferred.subscribe(x => console.log("Sub3:", x));
}, 50);

// You will get:
// Sub1: SYNCHRONOUS MSG
// Sub2: SYNCHRONOUS MSG
// Sub1: ASYNC MSG
// Sub2: ASYNC MSG
// Sub3: ASYNC MSG
```
