### PR TITLE
webvtt: Add text style based on cue settings in html mode

### DIFF
--- a/src/parsers/texttracks/webvtt/html/__tests__/create_settings_attributes.test.ts
+++ b/src/parsers/texttracks/webvtt/html/__tests__/create_settings_attributes.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import createSettingsAttributes from "../create_settings_attributes";
+
+describe("parsers - webvtt - createSettingsAttributes", () => {
+  const baseStyle = "position: absolute; margin:0;";
+  const baseLeft = "left:50%;";
+  const baseTransform = "transform:translate(-50%,-50%);";
+  const style = baseStyle + baseLeft + baseTransform;
+
+  it("should set width", () => {
+    const settings = {
+      size: "30%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = style + "width:30%;";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set horizontal position, start", () => {
+    const settings = {
+      position: "0%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = baseStyle + "left:0%;" + "transform:translate(-0%, -50%);";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set horizontal position, end", () => {
+    const settings = {
+      position: "100%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = baseStyle + "left:100%;" + "transform:translate(-100%, -50%);";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set horizontal position, middle value", () => {
+    const settings = {
+      position: "60%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = baseStyle + baseTransform + "left:60%;";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set vertical position, top", () => {
+    const settings = {
+      line: "0%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = baseStyle + baseLeft + "top:0%;" + "transform:translate(-50%, -0%);";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set vertical position, end", () => {
+    const settings = {
+      line: "100%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = baseStyle + baseLeft + "top:100%;" + "transform:translate(-50%, -100%);";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set vertical position, middle value", () => {
+    const settings = {
+     line: "60%",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = style + "top:60%;";
+    isEqualStyle(attributes.value, expected);
+  });
+
+  it("should set text align", () => {
+    const settings = {
+      align: "middle",
+    };
+
+    const attributes = createSettingsAttributes(settings);
+
+    const expected = style + "text-align:center";
+    isEqualStyle(attributes.value, expected);
+  });
+});
+
+function isEqualStyle (style1: string, style2: string) {
+  const uniform = (str: string) => str.split(";")
+    .map(s => s.replace(" ", ""))
+    .filter(s => s !== "")
+    .sort();
+  expect(
+    uniform(style1)
+  ).toEqual(
+    uniform(style2)
+  );
+}

--- a/src/parsers/texttracks/webvtt/html/create_settings_attributes.ts
+++ b/src/parsers/texttracks/webvtt/html/create_settings_attributes.ts
@@ -1,0 +1,130 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * How far from edge to start translating the text's origin,
+ * in order to keep all text inside it's box.
+ */
+import objectValues from "../../../../utils/object_values";
+
+const DEFAULT_HORIZONTAL_OFFSET = 30;
+const DEFAULT_VERTICAL_OFFSET = 5;
+
+export default function createSettingsAttributes (
+  settings : Partial<Record<string, string>>
+) : Attr {
+  const pAttr = document.createAttribute("style");
+  pAttr.value = getAttrValue(settings);
+  return pAttr;
+}
+
+const getAttrValue = (settings: Partial<Record<string, string>>) => {
+  const hasSettings = settings !== undefined && objectValues(settings).length !== 0;
+  if (!hasSettings) {
+    return "text-align:center";
+  }
+
+  return (
+    "position: absolute;" +
+    "margin: 0;" +
+    `${getTransformStyle(settings)}` +
+    `${getWidthStyle(settings.size)}` +
+    `${getPositionStyle(settings.position)}` +
+    `${getLineStyle(settings.line)}` +
+    `${getAlignStyle(settings.align)}`
+  );
+};
+
+const getTransformStyle = (settings: Partial<Record<string, string>>) => {
+  const xTranslateDefault = 50;
+  const yTranslateDefault = 50;
+
+  let xPosition = getPercentageValue(settings.position);
+  xPosition = xPosition !== null ?
+    xPosition :
+    xTranslateDefault;
+
+  let yPosition = getPercentageValue(settings.line);
+  yPosition = yPosition !== null ?
+    yPosition :
+    yTranslateDefault;
+
+  const width = getPercentageValue(settings.size);
+  const xOffset = width !== null ?
+    width :
+    DEFAULT_HORIZONTAL_OFFSET;
+  const yOffset = DEFAULT_VERTICAL_OFFSET;
+
+  const isCloseToXEdge = xPosition < xOffset || xPosition > (100 - xOffset);
+  const isCloseToYEdge = yPosition < yOffset || yPosition > (100 - yOffset);
+
+  const xTranslate = isCloseToXEdge ? xPosition : xTranslateDefault;
+  const yTranslate = isCloseToYEdge ? yPosition : yTranslateDefault;
+
+  return `transform: translate(-${xTranslate}%,-${yTranslate}%);`;
+
+} ;
+
+const getWidthStyle = (size: string | undefined) => {
+  return size !== undefined ?
+    `width:${size};` :
+    "";
+};
+
+const getPositionStyle = (positionSetting: string | undefined) => {
+  const positionDefault = 50;
+  let position = getPercentageValue(positionSetting);
+  position = position !== null ?
+    position :
+    positionDefault;
+
+  return `left:${position}%;`;
+};
+
+const getAlignStyle = (alignSetting: string | undefined) => {
+  if (alignSetting === undefined) {
+    return "";
+  }
+
+  const align = alignSetting === "middle" ?
+    "center" :
+    alignSetting;
+
+  return `text-align:${align};`;
+};
+
+const getLineStyle = (lineSetting: string | undefined) => {
+  if (lineSetting === undefined) {
+    return "";
+  }
+
+  const line = getPercentageValue(lineSetting);
+  return `top:${line}%;`;
+};
+
+const getPercentageValue = (percentageString: string | undefined): number | null => {
+  if (percentageString === undefined) {
+    return null;
+  }
+
+  const positionRegex = /^([\d.]+)%(?:,(line-left|line-right|center))?$/;
+  const positionArr = positionRegex.exec(percentageString);
+  if (!Array.isArray(positionArr) || positionArr.length < 2) {
+    return null;
+  }
+
+  return parseInt(positionArr[1], 10);
+};

--- a/src/parsers/texttracks/webvtt/html/to_html.ts
+++ b/src/parsers/texttracks/webvtt/html/to_html.ts
@@ -16,6 +16,7 @@
 
 import isNonEmptyString from "../../../../utils/is_non_empty_string";
 import convertPayloadToHTML from "./convert_payload_to_html";
+import createSettingsAttributes from "./create_settings_attributes";
 import { IStyleElements } from "./parse_style_block";
 
 export interface IVTTHTMLCue { start : number;
@@ -37,12 +38,13 @@ export interface IVTTHTMLCue { start : number;
 export default function toHTML(
   cueObj : { start : number;
              end : number;
+             settings: Partial<Record<string, string>>;
              header? : string;
              payload : string[]; },
   styling : { classes : IStyleElements;
               global? : string; }
 ) : IVTTHTMLCue {
-  const { start, end, header, payload } = cueObj;
+  const { start, end, settings, header, payload } = cueObj;
 
   const region = document.createElement("div");
   const regionAttr = document.createAttribute("style");
@@ -57,8 +59,7 @@ export default function toHTML(
 
   // Get content, format and apply style.
   const pElement = document.createElement("p");
-  const pAttr = document.createAttribute("style");
-  pAttr.value = "text-align:center";
+  const pAttr = createSettingsAttributes(settings);
   pElement.setAttributeNode(pAttr);
 
   const spanElement = document.createElement("span");


### PR DESCRIPTION
We have some use cases where we would like the webvtt cue settings to be applied to the text element when using `html`-mode.

I gave it a try, let me know what you think and if this is something you could consider!

Some notes:
* I mainly used the api described here: https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API.
* I omitted the `vertical` setting for now.
* I also omitted the plain line number valued version of the `line` setting as I couldn't see a appropriate way of doing that at the moment.

I was not able to get the the integration tests to pass locally, but there was unrelated tests failing, so I figure that was due to my local environment in some way. 

