### PR TITLE
Feat/preferred video tracks

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -64,6 +64,8 @@
     - [getPreferredAudioTracks](#meth-getPreferredAudioTracks)
     - [setPreferredTextTracks](#meth-setPreferredTextTracks)
     - [getPreferredTextTracks](#meth-getPreferredTextTracks)
+    - [setPreferredVideoTracks](#meth-setPreferredVideoTracks)
+    - [getPreferredVideoTracks](#meth-getPreferredVideoTracks)
     - [getCurrentAdaptations](#meth-getCurrentAdaptations)
     - [getCurrentRepresentations](#meth-getCurrentRepresentations)
     - [dispose](#meth-dispose)
@@ -1316,7 +1318,7 @@ During this period of time:
 
 :warning: This option will have no effect in _DirectFile_ mode
 (see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
-- No video track API was supported on the current browser
+- No video track API is supported on the current browser
 - The media file tracks are not supported on the browser
 
 ---
@@ -1363,7 +1365,7 @@ preferences, codec preferences or both.
 It is defined as an array of objects, each object describing constraints a
 track should respect.
 
-If the first object - defining the first set of constraints - can not be
+If the first object - defining the first set of constraints - cannot be
 respected under the currently available audio tracks, the RxPlayer will skip
 it and check with the second object and so on.
 As such, this array should be sorted by order of preference: from the most
@@ -1476,7 +1478,7 @@ player.setPreferredAudioTracks([
 
 :warning: This option will have no effect in _DirectFile_ mode
 (see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
-- No audio track API was supported on the current browser
+- No audio track API is supported on the current browser
 - The media file tracks are not supported on the browser
 
 ---
@@ -1555,7 +1557,7 @@ player.setPreferredTextTracks([
 
 :warning: This option will have no effect in _DirectFile_ mode
 (see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
-- No text track API was supported on the current browser
+- No text track API is supported on the current browser
 - The media file tracks are not supported on the browser
 
 ---
@@ -1580,6 +1582,101 @@ it was called:
                        // caption for the hard of hearing
 }
 ```
+
+
+<a name="meth-setPreferredVideoTracks"></a>
+### setPreferredVideoTracks ####################################################
+
+_arguments_: ``Array.<Object>``
+
+Allows the RxPlayer to choose an initial video track.
+
+It is defined as an array of objects, each object describing constraints a
+track should respect.
+
+If the first object - defining the first set of constraints - cannot be
+respected under the currently available video tracks, the RxPlayer will skip
+it and check with the second object and so on.
+As such, this array should be sorted by order of preference: from the most
+wanted constraints to the least.
+
+Here is all the possible constraints you can set in any one of those objects
+(note that all properties are optional here, only those set will have an effect
+on which tracks will be filtered):
+```js
+{
+  codec: { // {Object|undefined} Constraints about the codec wanted.
+           // if not set or set to `undefined` we won't filter based on codecs.
+
+    test: /hvc/, // {RegExp} RegExp validating the type of codec you want.
+
+    all: true, // {Boolean} Whether all the profiles (i.e. Representation) in a
+               // track should be checked against the RegExp given in `test`.
+               // If `true`, we will only choose a track if EVERY profiles for
+               // it have a codec information that is validated by that RegExp.
+               // If `false`, we will choose a track if we know that at least
+               // A SINGLE profile from it has codec information validated by
+               // that RegExp.
+  }
+}
+```
+
+This logic is ran each time a new `Period` with video tracks is loaded by the
+RxPlayer. This means at the start of the content, but also when [pre-]loading a
+new DASH `Period` or a new MetaPlaylist `content`.
+
+Please note that those preferences won't be re-applied once the logic was
+already run for a given `Period`.
+Simply put, once set this preference will be applied to all contents but:
+
+  - the current Period being played (or the current loaded content, in the case
+    of single-Period contents such as in Smooth streaming).
+    In that case, the current video track preference will stay in place.
+
+  - the Periods which have already been loaded in the current content.
+    Those will keep their last set video track preferences (e.g. the preferred
+    video tracks at the time they were first loaded).
+
+To update the current video track in those cases, you should use the
+`setVideoTrack` method once they are currently played.
+
+
+#### Examples
+
+Let's imagine that you prefer to have a track which contains only H265
+profiles. You can do:
+```js
+player.setPreferredVideoTracks([ { codec: { all: false, test: /^hvc/ } } ]);
+```
+
+Now let's imagine you want to start without any video track enabled (e.g. to
+start in an audio-only mode). To do that, you can simply do:
+```js
+player.setPreferredVideoTracks([null]);
+```
+
+---
+
+:warning: This option will have no effect in _DirectFile_ mode
+(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
+- No video track API is supported on the current browser
+- The media file tracks are not supported on the browser
+
+---
+
+
+<a name="meth-getPreferredVideoTracks"></a>
+### getPreferredVideoTracks ####################################################
+
+_return value_: ``Array.<Object>``
+
+Returns the current list of preferred video tracks - by order of preference.
+
+This returns the data in the same format that it was given to either the
+`preferredVideoTracks` constructor option or the last `setPreferredVideoTracks`
+if it was called.
+
+It will return an empty Array if none of those two APIs were used until now.
 
 
 <a name="meth-getManifest"></a>

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1587,7 +1587,7 @@ it was called:
 <a name="meth-setPreferredVideoTracks"></a>
 ### setPreferredVideoTracks ####################################################
 
-_arguments_: ``Array.<Object>``
+_arguments_: ``Array.<Object|null>``
 
 Allows the RxPlayer to choose an initial video track.
 
@@ -1599,6 +1599,10 @@ respected under the currently available video tracks, the RxPlayer will skip
 it and check with the second object and so on.
 As such, this array should be sorted by order of preference: from the most
 wanted constraints to the least.
+
+When the next encountered constraint is set to `null`, the player will simply
+disable the video track. If you want to disable the video track by default,
+you can just set `null` as the first element of this array (e.g. `[null]`).
 
 Here is all the possible constraints you can set in any one of those objects
 (note that all properties are optional here, only those set will have an effect

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1622,6 +1622,13 @@ on which tracks will be filtered):
                // A SINGLE profile from it has codec information validated by
                // that RegExp.
   }
+  signInterpreted: true, // {Boolean|undefined} If set to `true`, only tracks
+                         // which are known to contains a sign language
+                         // interpretation will be considered.
+                         // If set to `false`, only tracks which are known
+                         // to not contain it will be considered.
+                         // if not set or set to `undefined` we won't filter
+                         // based on that status.
 }
 ```
 
@@ -1653,8 +1660,33 @@ profiles. You can do:
 player.setPreferredVideoTracks([ { codec: { all: false, test: /^hvc/ } } ]);
 ```
 
-Now let's imagine you want to start without any video track enabled (e.g. to
-start in an audio-only mode). To do that, you can simply do:
+With that same constraint, let's no consider that the current user prefer in any
+case to have a sign language interpretation on screen:
+```js
+player.setPreferredVideoTracks([
+  // first let's consider the best case: H265 + sign language interpretation
+  {
+    codec: { all: false, test: /^hvc/ }
+    signInterpreted: true,
+  },
+
+  // If not available, we still prefer a sign interpreted track without H265
+  { signInterpreted: true },
+
+  // If not available either, we would prefer an H265 content
+  { codec: { all: false, test: /^hvc/ } },
+
+  // Note: If this is also available, we will here still have a video track
+  // but which do not respect any of the constraints set here.
+]);
+would thus prefer the video to contain a sign language interpretation.
+We could set both the previous and that new constraint that way:
+
+---
+
+For a totally different example, let's imagine you want to start without any
+video track enabled (e.g. to start in an audio-only mode). To do that, you can
+simply do:
 ```js
 player.setPreferredVideoTracks([null]);
 ```

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -12,6 +12,7 @@
     - [wantedBufferAhead](#prop-wantedBufferAhead)
     - [preferredAudioTracks](#prop-preferredAudioTracks)
     - [preferredTextTracks](#prop-preferredTextTracks)
+    - [preferredVideoTracks](#prop-preferredVideoTracks)
     - [maxBufferAhead](#prop-maxBufferAhead)
     - [maxBufferBehind](#prop-maxBufferBehind)
     - [limitVideoWidth](#prop-limitVideoWidth)
@@ -234,7 +235,7 @@ either language preferences, codec preferences or both.
 It is defined as an array of objects, each object describing constraints a
 track should respect.
 
-If the first object - defining the first set of constraints - can not be
+If the first object - defining the first set of constraints - cannot be
 respected under the currently available audio tracks, the RxPlayer will skip
 it and check with the second object and so on.
 As such, this array should be sorted by order of preference: from the most
@@ -383,6 +384,77 @@ const player = new RxPlayer({
     { language: "ita", closedCaption: false },
     null
   ]
+});
+```
+
+---
+
+:warning: This option will have no effect for contents loaded in _DirectFile_
+mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+
+---
+
+
+<a name="prop-preferredVideoTracks"></a>
+### preferredVideoTracks #######################################################
+
+_type_: ``Array.<Object|null>``
+
+_defaults_: ``[]``
+
+This option allows to help the RxPlayer choose an initial video track.
+
+It is defined as an array of objects, each object describing constraints a
+track should respect.
+
+If the first object - defining the first set of constraints - cannot be
+respected under the currently available video tracks, the RxPlayer will skip
+it and check with the second object and so on.
+As such, this array should be sorted by order of preference: from the most
+wanted constraints to the least.
+
+Here is all the possible constraints you can set in any one of those objects
+(note that all properties are optional here, only those set will have an effect
+on which tracks will be filtered):
+```js
+{
+  codec: { // {Object|undefined} Constraints about the codec wanted.
+           // if not set or set to `undefined` we won't filter based on codecs.
+
+    test: /hvc/, // {RegExp} RegExp validating the type of codec you want.
+
+    all: true, // {Boolean} Whether all the profiles (i.e. Representation) in a
+               // track should be checked against the RegExp given in `test`.
+               // If `true`, we will only choose a track if EVERY profiles for
+               // it have a codec information that is validated by that RegExp.
+               // If `false`, we will choose a track if we know that at least
+               // A SINGLE profile from it has codec information validated by
+               // that RegExp.
+  }
+}
+```
+
+This array of preferrences can be updated at any time through the
+``setPreferredVideoTracks`` method, documented
+[here](./index.md#meth-getPreferredVideoTracks).
+
+#### Examples
+
+Let's imagine that you prefer to have a track which contains at least one H265
+profile.
+
+You can do:
+```js
+const player = new RxPlayer({
+  preferredVideoTracks: [ { codec: { all: false, test: /^hvc/ } } ]
+});
+```
+
+Now let's imagine you want to start without any video track enabled (e.g. to
+start in an audio-only mode). To do that, you can simply do:
+```js
+const player = new RxPlayer({
+  preferredVideoTracks: [null]
 });
 ```
 

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -334,8 +334,10 @@ const player = new RxPlayer({
 
 ---
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+:warning: This option will have no effect in _DirectFile_ mode
+(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
+- No audio track API is supported on the current browser
+- The media file tracks are not supported on the browser
 
 ---
 
@@ -389,8 +391,10 @@ const player = new RxPlayer({
 
 ---
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+:warning: This option will have no effect in _DirectFile_ mode
+(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
+- No text track API is supported on the current browser
+- The media file tracks are not supported on the browser
 
 ---
 
@@ -496,8 +500,10 @@ const player = new RxPlayer({
 
 ---
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+:warning: This option will have no effect in _DirectFile_ mode
+(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
+- No video track API is supported on the current browser
+- The media file tracks are not supported on the browser
 
 ---
 

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -435,6 +435,13 @@ on which tracks will be filtered):
                // A SINGLE profile from it has codec information validated by
                // that RegExp.
   }
+  signInterpreted: true, // {Boolean|undefined} If set to `true`, only tracks
+                         // which are known to contains a sign language
+                         // interpretation will be considered.
+                         // If set to `false`, only tracks which are known
+                         // to not contain it will be considered.
+                         // if not set or set to `undefined` we won't filter
+                         // based on that status.
 }
 ```
 
@@ -445,17 +452,42 @@ This array of preferrences can be updated at any time through the
 #### Examples
 
 Let's imagine that you prefer to have a track which contains at least one H265
-profile.
-
-You can do:
+profile. You can do:
 ```js
 const player = new RxPlayer({
   preferredVideoTracks: [ { codec: { all: false, test: /^hvc/ } } ]
 });
 ```
 
-Now let's imagine you want to start without any video track enabled (e.g. to
-start in an audio-only mode). To do that, you can simply do:
+With that same constraint, let's no consider that the current user is deaf and
+would thus prefer the video to contain a sign language interpretation.
+We could set both the previous and that new constraint that way:
+```js
+const player = new RxPlayer({
+  preferredVideoTracks: [
+    // first let's consider the best case: H265 + sign language interpretation
+    {
+      codec: { all: false, test: /^hvc/ }
+      signInterpreted: true,
+    },
+
+    // If not available, we still prefer a sign interpreted track without H265
+    { signInterpreted: true },
+
+    // If not available either, we would prefer an H265 content
+    { codec: { all: false, test: /^hvc/ } },
+
+    // Note: If this is also available, we will here still have a video track
+    // but which do not respect any of the constraints set here.
+  ]
+});
+```
+
+---
+
+For a totally different example, let's imagine you want to start without any
+video track enabled (e.g. to start in an audio-only mode). To do that, you can
+simply do:
 ```js
 const player = new RxPlayer({
   preferredVideoTracks: [null]

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -413,6 +413,10 @@ it and check with the second object and so on.
 As such, this array should be sorted by order of preference: from the most
 wanted constraints to the least.
 
+When the next encountered constraint is set to `null`, the player will simply
+disable the video track. If you want to disable the video track by default,
+you can just set `null` as the first element of this array (e.g. `[null]`).
+
 Here is all the possible constraints you can set in any one of those objects
 (note that all properties are optional here, only those set will have an effect
 on which tracks will be filtered):

--- a/src/core/api/__tests__/media_element_track_choice_manager.test.ts
+++ b/src/core/api/__tests__/media_element_track_choice_manager.test.ts
@@ -41,6 +41,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
         {
           preferredAudioTracks: new BehaviorSubject([] as any[]),
           preferredTextTracks: new BehaviorSubject([] as any[]),
+          preferredVideoTracks: new BehaviorSubject([] as any[]),
         },
         fakeMediaElement as any
       );
@@ -79,6 +80,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
         {
           preferredAudioTracks: new BehaviorSubject([] as any[]),
           preferredTextTracks: new BehaviorSubject([] as any[]),
+          preferredVideoTracks: new BehaviorSubject([] as any[]),
         },
         fakeMediaElement as any
       );
@@ -108,6 +110,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
       {
         preferredAudioTracks: new BehaviorSubject([] as any[]),
         preferredTextTracks: new BehaviorSubject([] as any[]),
+        preferredVideoTracks: new BehaviorSubject([] as any[]),
       },
       fakeMediaElement as any
     );
@@ -134,6 +137,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
       {
         preferredAudioTracks: new BehaviorSubject([] as any[]),
         preferredTextTracks: new BehaviorSubject([] as any[]),
+        preferredVideoTracks: new BehaviorSubject([] as any[]),
       },
       fakeMediaElement as any
     );
@@ -157,6 +161,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
       {
         preferredAudioTracks: new BehaviorSubject([] as any[]),
         preferredTextTracks: new BehaviorSubject([] as any[]),
+        preferredVideoTracks: new BehaviorSubject([] as any[]),
       },
       fakeMediaElement as any
     );
@@ -183,6 +188,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
       {
         preferredAudioTracks: new BehaviorSubject([] as any[]),
         preferredTextTracks: new BehaviorSubject([] as any[]),
+        preferredVideoTracks: new BehaviorSubject([] as any[]),
       },
       fakeMediaElement as any
     );

--- a/src/core/api/__tests__/option_parsers.test.ts
+++ b/src/core/api/__tests__/option_parsers.test.ts
@@ -81,6 +81,7 @@ describe("API - parseConstructorOptions", () => {
     stopAtEnd: true,
     preferredAudioTracks: [],
     preferredTextTracks: [],
+    preferredVideoTracks: [],
   };
 
   it("should create default values if no option is given", () => {
@@ -334,6 +335,17 @@ describe("API - parseConstructorOptions", () => {
     expect(parseConstructorOptions({ preferredTextTracks })).toEqual({
       ...defaultConstructorOptions,
       preferredTextTracks,
+    });
+  });
+
+  it("should authorize setting a preferredVideoTracks option", () => {
+    const preferredVideoTracks = [
+      { codec: { all: true, test: /hvc/ } },
+      null,
+    ];
+    expect(parseConstructorOptions({ preferredVideoTracks })).toEqual({
+      ...defaultConstructorOptions,
+      preferredVideoTracks,
     });
   });
 

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -40,5 +40,6 @@ export {
 
   IAudioTrackPreference,
   ITextTrackPreference,
+  IVideoTrackPreference,
 } from "./track_choice_manager";
 export default Player;

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -37,6 +37,7 @@ import { IKeySystemOption } from "../eme";
 import {
   IAudioTrackPreference,
   ITextTrackPreference,
+  IVideoTrackPreference,
 } from "./track_choice_manager";
 
 const { DEFAULT_AUTO_PLAY,
@@ -192,6 +193,7 @@ export interface IConstructorOptions { maxBufferAhead? : number;
 
                                        preferredAudioTracks? : IAudioTrackPreference[];
                                        preferredTextTracks? : ITextTrackPreference[];
+                                       preferredVideoTracks? : IVideoTrackPreference[];
 
                                        videoElement? : HTMLMediaElement;
                                        initialVideoBitrate? : number;
@@ -212,6 +214,7 @@ export interface IParsedConstructorOptions {
 
   preferredAudioTracks : IAudioTrackPreference[];
   preferredTextTracks : ITextTrackPreference[];
+  preferredVideoTracks : IVideoTrackPreference[];
 
   videoElement : HTMLMediaElement;
   initialVideoBitrate : number;
@@ -311,6 +314,7 @@ function parseConstructorOptions(
 
   let preferredAudioTracks : IAudioTrackPreference[];
   let preferredTextTracks : ITextTrackPreference[];
+  let preferredVideoTracks : IVideoTrackPreference[];
 
   let videoElement : HTMLMediaElement;
   let initialVideoBitrate : number;
@@ -392,6 +396,17 @@ function parseConstructorOptions(
     preferredAudioTracks = [];
   }
 
+  if (options.preferredVideoTracks !== undefined) {
+    if (!Array.isArray(options.preferredVideoTracks)) {
+      warnOnce("Invalid `preferredVideoTracks` option, it should be an Array");
+      preferredVideoTracks = [];
+    } else {
+      preferredVideoTracks = options.preferredVideoTracks;
+    }
+  } else {
+    preferredVideoTracks = [];
+  }
+
   if (options.videoElement == null) {
     videoElement = document.createElement("video");
   } else if (options.videoElement instanceof HTMLMediaElement) {
@@ -454,6 +469,7 @@ function parseConstructorOptions(
            throttleVideoBitrateWhenHidden,
            preferredAudioTracks,
            preferredTextTracks,
+           preferredVideoTracks,
            initialAudioBitrate,
            initialVideoBitrate,
            maxAudioBitrate,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2091,9 +2091,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       preferredTextTracks: initialTextTrack === undefined ?
         this._priv_preferredTextTracks :
         new BehaviorSubject([initialTextTrack]),
-      preferredVideoTracks: initialTextTrack === undefined ?
-        this._priv_preferredVideoTracks :
-        new BehaviorSubject([] as IVideoTrackPreference[]),
+      preferredVideoTracks: this._priv_preferredVideoTracks,
     });
 
     fromEvent(manifest, "manifestUpdate")

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -734,7 +734,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
               new BehaviorSubject([defaultAudioTrack]),
             preferredTextTracks: defaultTextTrack === undefined ?
               this._priv_preferredTextTracks :
-              new BehaviorSubject([defaultTextTrack]) },
+              new BehaviorSubject([defaultTextTrack]),
+            preferredVideoTracks: this._priv_preferredVideoTracks },
           this.videoElement
         );
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -122,7 +122,8 @@ import TrackChoiceManager, {
   ITMTextTrack,
   ITMTextTrackListItem,
   ITMVideoTrack,
-  ITMVideoTrackListItem
+  ITMVideoTrackListItem,
+  IVideoTrackPreference,
 } from "./track_choice_manager";
 
 const { DEFAULT_UNMUTED_VOLUME } = config;
@@ -354,6 +355,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /** List of favorite text tracks, in preference order. */
   private _priv_preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
 
+  /** List of favorite video tracks, in preference order. */
+  private _priv_preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>;
+
   /**
    * TrackChoiceManager instance linked to the current content.
    * `null` if no content has been loaded or if the current content loaded
@@ -440,6 +444,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             maxVideoBitrate,
             preferredAudioTracks,
             preferredTextTracks,
+            preferredVideoTracks,
             throttleWhenHidden,
             throttleVideoBitrateWhenHidden,
             videoElement,
@@ -539,6 +544,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     this._priv_preferredAudioTracks = new BehaviorSubject(preferredAudioTracks);
     this._priv_preferredTextTracks = new BehaviorSubject(preferredTextTracks);
+    this._priv_preferredVideoTracks = new BehaviorSubject(preferredVideoTracks);
   }
 
   /**
@@ -1794,6 +1800,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   /**
+   * Returns the current list of preferred text tracks, in preference order.
+   * @returns {Array.<Object>}
+   */
+  getPreferredVideoTracks() : IVideoTrackPreference[] {
+    return this._priv_preferredVideoTracks.getValue();
+  }
+
+  /**
    * Set the list of preferred audio tracks, in preference order.
    * @param {Array.<Object>} tracks
    */
@@ -1815,6 +1829,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                       "Should have been an Array.");
     }
     return this._priv_preferredTextTracks.next(tracks);
+  }
+
+  /**
+   * Set the list of preferred text tracks, in preference order.
+   * @param {Array.<Object>} tracks
+   */
+  setPreferredVideoTracks(tracks : IVideoTrackPreference[]) : void {
+    if (!Array.isArray(tracks)) {
+      throw new Error("Invalid `setPreferredVideoTracks` argument. " +
+                      "Should have been an Array.");
+    }
+    return this._priv_preferredVideoTracks.next(tracks);
   }
 
   /**
@@ -2064,6 +2090,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       preferredTextTracks: initialTextTrack === undefined ?
         this._priv_preferredTextTracks :
         new BehaviorSubject([initialTextTrack]),
+      preferredVideoTracks: initialTextTrack === undefined ?
+        this._priv_preferredVideoTracks :
+        new BehaviorSubject([] as IVideoTrackPreference[]),
     });
 
     fromEvent(manifest, "manifestUpdate")

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -50,7 +50,8 @@ export type ITextTrackPreference = null |
 /** Single preference for a video track Adaptation. */
 export type IVideoTrackPreference = null |
                                     { codec? : { all: boolean;
-                                                 test: RegExp; }; };
+                                                 test: RegExp; };
+                                      signInterpreted? : boolean; };
 
 /** Audio track returned by the TrackChoiceManager. */
 export interface ITMAudioTrack { language : string;
@@ -996,6 +997,11 @@ function findFirstOptimalVideoAdaptation(
     }
 
     const foundAdaptation = arrayFind(videoAdaptations, (videoAdaptation) => {
+      if (preferredVideoTrack.signInterpreted !== undefined &&
+          preferredVideoTrack.signInterpreted !== videoAdaptation.isSignInterpreted)
+      {
+        return false;
+      }
       if (preferredVideoTrack.codec === undefined) {
         return true;
       }

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -43,4 +43,5 @@ export {
 
   IAudioTrackPreference,
   ITextTrackPreference,
+  IVideoTrackPreference,
 } from "./core/api";


### PR DESCRIPTION
Add the `preferredVideoTrack` constructor option and `setPreferredVideoTracks` / `getPreferredVideoTracks` methods to either set a video track preference or to start with no video track.

Video track preferences can be based for now either on the codec or if there's a sign language interpretation in the video track or not.
Like the text track preferences, a value of `null` can also be set to disable the video track when previous constraints cannot be respected.