### PR TITLE
Deprecate `getManifest`, `getCurrentAdaptations` and `getCurrentRepresentations`

### DIFF
--- a/doc/api/deprecated.md
+++ b/doc/api/deprecated.md
@@ -69,6 +69,50 @@ multiple reasons:
 The following RxPlayer methods are deprecated.
 
 
+### getManifest ################################################################
+
+`getManifest` returns our internal representation we have of a given "manifest"
+document.
+
+Though it was first exposed to allow users to have access to more precize
+information on the current content, this method also limited us on the possible
+evolutions we could do, as changing what this function returns would mean
+breaking the API.
+
+We also realized that that method was not used for now by the implementation we
+know of.
+
+For now, we decided we will simply remove that API in the next major version. If
+that's a problem for you, please open an issue.
+
+
+### getCurrentAdaptations ######################################################
+
+`getCurrentAdaptations` returns an object describing each tracks available for
+the current Period in the current content.
+
+Like `getManifest`, we found that this API was not much used and limited us on
+the possible evolutions we can do on the RxPlayer.
+
+Again like `getManifest`, we plan to remove that API completely without
+replacing it.
+If that's a problem for you, please open an issue.
+
+
+### getCurrentRepresentations ##################################################
+
+`getCurrentRepresentations` returns an object describing each "qualities"
+available in the current chosen tracks.
+
+Exactly like `getCurrentAdaptations` and `getManifest`, we found that this API:
+  - was not used as far as we know
+  - limited the evolutions we could do on the RxPlayer's code without breaking
+    the API.
+
+We thus plan to remove that API completely without replacing it.
+If that's a problem for you, please open an issue.
+
+
 ### getNativeTextTrack #########################################################
 
 ``getNativeTextTrack`` returned the first ``TextTrack`` element attached to the

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -76,11 +76,11 @@
  - [Content information](#meth-group-content-info)
     - [isLive](#meth-isLive)
     - [getUrl](#meth-getUrl)
-    - [getManifest](#meth-getManifest)
-    - [getCurrentAdaptations](#meth-getCurrentAdaptations)
-    - [getCurrentRepresentations](#meth-getCurrentRepresentations)
     - [getCurrentKeySystem](#meth-getCurrentKeySystem)
  - [Deprecated](#meth-group-deprecated)
+    - [getManifest (deprecated)](#meth-getManifest)
+    - [getCurrentAdaptations (deprecated)](#meth-getCurrentAdaptations)
+    - [getCurrentRepresentations (deprecated)](#meth-getCurrentRepresentations)
     - [getImageTrackData (deprecated)](#meth-getImageTrackData)
     - [setFullscreen (deprecated)](#meth-setFullscreen)
     - [exitFullscreen (deprecated)](#meth-exitFullscreen)
@@ -2145,9 +2145,31 @@ if it was called.
 
 It will return an empty Array if none of those two APIs were used until now.
 
+<a name="meth-getCurrentKeySystem"></a>
+### getCurrentKeySystem ########################################################
+
+_return value_: ``string|undefined``
+
+Returns the type of keySystem used for DRM-protected contents.
+
+
+
+<a name="meth-group-deprecated"></a>
+## Deprecated ##################################################################
+
+The following methods are deprecated. They are still supported but we advise
+users to not use those as they might become not supported in the future.
+
 
 <a name="meth-getManifest"></a>
 ### getManifest ################################################################
+
+--
+
+:warning: This method is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+--
 
 _return value_: ``Manifest|null``
 
@@ -2165,6 +2187,13 @@ The Manifest will be available before the player reaches the ``"LOADED"`` state.
 
 <a name="meth-getCurrentAdaptations"></a>
 ### getCurrentAdaptations ######################################################
+
+--
+
+:warning: This method is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+--
 
 _return value_: ``Object|null``
 
@@ -2185,6 +2214,13 @@ options](./loadVideo_options.md#prop-transport)).
 <a name="meth-getCurrentRepresentations"></a>
 ### getCurrentRepresentations ##################################################
 
+--
+
+:warning: This method is deprecated, it will disappear in the next major
+release ``v4.0.0`` (see [Deprecated APIs](./deprecated.md)).
+
+--
+
 _return value_: ``Object|null``
 
 Returns the [Representations](../terms.md#representation) being loaded per type
@@ -2200,21 +2236,6 @@ An Representation object structure is relatively complex and is described in the
 ``null`` in _DirectFile_ mode (see [loadVideo
 options](./loadVideo_options.md#prop-transport)).
 
-
-<a name="meth-getCurrentKeySystem"></a>
-### getCurrentKeySystem ########################################################
-
-_return value_: ``string|undefined``
-
-Returns the type of keySystem used for DRM-protected contents.
-
-
-
-<a name="meth-group-deprecated"></a>
-## Deprecated ##################################################################
-
-The following methods are deprecated. They are still supported but we advise
-users to not use those as they might become not supported in the future.
 
 
 <a name="meth-getImageTrackData"></a>

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -912,9 +912,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /**
    * Returns manifest/playlist object.
    * null if the player is STOPPED.
+   * @deprecated
    * @returns {Manifest|null} - The current Manifest (`null` when not known).
    */
   getManifest() : Manifest|null {
+    warnOnce("getManifest is deprecated." +
+             " Please open an issue if you used this API.");
     if (this._priv_contentInfos === null) {
       return null;
     }
@@ -924,11 +927,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /**
    * Returns Adaptations (tracks) for every currently playing type
    * (audio/video/text...).
+   * @deprecated
    * @returns {Object|null} - The current Adaptation objects, per type (`null`
    * when none is known for now.
    */
   getCurrentAdaptations(
   ) : Partial<Record<IBufferType, Adaptation|null>> | null {
+    warnOnce("getCurrentAdaptations is deprecated." +
+             " Please open an issue if you used this API.");
     if (this._priv_contentInfos === null) {
       return null;
     }
@@ -945,11 +951,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /**
    * Returns representations (qualities) for every currently playing type
    * (audio/video/text...).
+   * @deprecated
    * @returns {Object|null} - The current Representation objects, per type
    * (`null` when none is known for now.
    */
   getCurrentRepresentations(
   ) : Partial<Record<IBufferType, Representation|null>> | null {
+    warnOnce("getCurrentRepresentations is deprecated." +
+             " Please open an issue if you used this API.");
     if (this._priv_contentInfos === null) {
       return null;
     }
@@ -1223,7 +1232,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Number|undefined}
    */
   getVideoBitrate() : number|undefined {
+    /* tslint:disable deprecation */
     const representations = this.getCurrentRepresentations();
+    /* tslint:enable deprecation */
     if (representations === null || representations.video == null) {
       return undefined;
     }
@@ -1235,7 +1246,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Number|undefined}
    */
   getAudioBitrate() : number|undefined {
+    /* tslint:disable deprecation */
     const representations = this.getCurrentRepresentations();
+    /* tslint:enable deprecation */
     if (representations === null || representations.audio == null) {
       return undefined;
     }
@@ -2146,10 +2159,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_triggerAvailableBitratesChangeEvent("availableVideoBitratesChange",
                                                    this.getAvailableVideoBitrates());
 
+    /* tslint:disable deprecation */
     const audioBitrate = this.getCurrentRepresentations()?.audio?.bitrate ?? -1;
+    /* tslint:enable deprecation */
     this._priv_triggerCurrentBitrateChangeEvent("audioBitrateChange", audioBitrate);
 
+    /* tslint:disable deprecation */
     const videoBitrate = this.getCurrentRepresentations()?.video?.bitrate ?? -1;
+    /* tslint:enable deprecation */
     this._priv_triggerCurrentBitrateChangeEvent("videoBitrateChange", videoBitrate);
   }
 


### PR DESCRIPTION
This PR deprecate the following 3 APIs:
  -  `getManifest`
  - `getCurrentAdaptations`
  - `getCurrentRepresentations`

This is because they expose our internal representation of the manifest, which may be something that we want to change without breaking the API.

We could also add a translation layer to be sure we didn't broke it while still being able to update it, but they seem to not be really used, so there would be no point.

Also, not having the word `Adaptation` in any of our method's names (there's still a property given to a custom `segmentLoader` though) opens the way for renaming that concept into the more universal "Track" in a future version.