### PR TITLE
Only reload the MediaSource when the most immediately needed PeriodBuffer is asking for it.

### DIFF
--- a/src/core/buffers/adaptation/adaptation_buffer.ts
+++ b/src/core/buffers/adaptation/adaptation_buffer.ts
@@ -44,7 +44,6 @@ import {
   multicast,
   share,
   startWith,
-  take,
   takeUntil,
   tap,
 } from "rxjs/operators";
@@ -235,8 +234,7 @@ export default function AdaptationBuffer<T>({
         // A manual bitrate switch might need an immediate feedback.
         // To do that properly, we need to reload the MediaSource
         if (directManualBitrateSwitching && estimate.manual && i !== 0) {
-          return clock$.pipe(take(1),
-                             map(t => EVENTS.needsMediaSourceReload(t)));
+          return clock$.pipe(map(t => EVENTS.needsMediaSourceReload(period, t)));
         }
 
         const representationChange$ =

--- a/src/core/buffers/events_generators.ts
+++ b/src/core/buffers/events_generators.ts
@@ -124,12 +124,13 @@ const EVENTS = {
   },
 
   needsMediaSourceReload(
+    period : Period,
     { currentTime,
       isPaused } : { currentTime : number;
                      isPaused : boolean; }
   ) : INeedsMediaSourceReload {
     return { type: "needs-media-source-reload",
-             value: { currentTime, isPaused } };
+             value: { currentTime, isPaused, period } };
   },
 
   needsDecipherabilityFlush(

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -122,7 +122,9 @@ export default function PeriodBuffer({
         if (sourceBufferStatus.type === "initialized") {
           log.info(`Buffer: Clearing previous ${bufferType} SourceBuffer`);
           if (SourceBuffersStore.isNative(bufferType)) {
-            return clock$.pipe(map(tick => EVENTS.needsMediaSourceReload(tick)));
+            return clock$.pipe(map((tick) => {
+              return EVENTS.needsMediaSourceReload(period, tick);
+            }));
           }
           cleanBuffer$ = sourceBufferStatus.value
             .removeBuffer(period.start,
@@ -144,7 +146,9 @@ export default function PeriodBuffer({
       if (SourceBuffersStore.isNative(bufferType) &&
           sourceBuffersStore.getStatus(bufferType).type === "disabled")
       {
-        return clock$.pipe(map(tick => EVENTS.needsMediaSourceReload(tick)));
+        return clock$.pipe(map((tick) => {
+          return EVENTS.needsMediaSourceReload(period, tick);
+        }));
       }
 
       log.info(`Buffer: Updating ${bufferType} adaptation`, adaptation, period);
@@ -161,7 +165,7 @@ export default function PeriodBuffer({
                                                        adaptation,
                                                        tick);
           if (strategy.type === "needs-reload") {
-            return observableOf(EVENTS.needsMediaSourceReload(tick));
+            return observableOf(EVENTS.needsMediaSourceReload(period, tick));
           }
 
           const cleanBuffer$ = strategy.type === "clean-buffer" ?

--- a/src/core/buffers/types.ts
+++ b/src/core/buffers/types.ts
@@ -157,7 +157,8 @@ export interface ICompletedBufferEvent { type: "complete-buffer";
 // The MediaSource needs to be reloaded to continue
 export interface INeedsMediaSourceReload { type: "needs-media-source-reload";
                                            value: { currentTime : number;
-                                                    isPaused : boolean; }; }
+                                                    isPaused : boolean;
+                                                    period : Period; }; }
 
 // Emitted after the buffers have been cleaned due to an update of the
 // decipherability status of some segment.


### PR DESCRIPTION
The previous behavior could lead in an infinite loop with multiple Periods.

 For example, let's take two consecutive Periods: the currently playing Period `A` and `B` the next Period we are preloading. Because the current user wants to disable the current video track (without changing his/her video track preferences, so no impact on other Periods) we will be in a case where A needs to have no video SourceBuffer and B needs one.
 
So A will ask for a reload, obtain it, and then we will have no video SourceBuffer. Here, B won't be happy so it will also ask for a reload, also obtain it and we will have a video sourcebuffer, and so on. We will be in an infinite buffering loop.

 The current solution I found is that everything can continue how it was but the 'parent' of both - the `BufferOrchestrator` - will just decide which one has the right to ask for a reload. In this case, reload demands coming from B will be simply ignored. The only one able to ask for a reload will in this case be the first active Period, which here means the most immediately needed one.

 I'm still unsure of whether I should just ignore reload demands from preloaded Periods (which means here that `B` should emit the demand at each clock tick, until its the more immediately needed one) or if the BufferOrchestrator should store that demand and grant it when it become the more immediately needed one. But I chose the first solution for now as it is much easier to implement."