### PR TITLE
utils: add filterMap utils

### DIFF
--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -39,6 +39,7 @@ import {
 } from "../../compat/";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
+import filterMap from "../../utils/filter_map";
 import getSession, {
   IEncryptedEvent,
 } from "./get_session";
@@ -101,13 +102,13 @@ export default function EMEManager(
     tap((evt) => {
       log.debug("EME: Encrypted event received from media element.", evt);
     }),
-    mergeMap((evt) : Observable<IEncryptedEvent> => {
+    filterMap<MediaEncryptedEvent, IEncryptedEvent, null>((evt) => {
       const { initData, initDataType } = getInitData(evt);
       if (initData == null) {
-        return EMPTY;
+        return null;
       }
-      return observableOf({ type: initDataType, data: initData });
-    }),
+      return { type: initDataType, data: initData };
+    }, null),
     shareReplay({ refCount: true })); // multiple Observables listen to that one
                                       // as soon as the EMEManager is subscribed
 

--- a/src/utils/__tests__/filter_map.test.ts
+++ b/src/utils/__tests__/filter_map.test.ts
@@ -20,7 +20,7 @@ import {
 } from "rxjs";
 import filterMap from "../filter_map";
 
-describe("utils - concatMapLatest", () => {
+describe("utils - filterMap", () => {
   it("should filter when the token given is mapped", (done) => {
     const counter$ : Observable<number> = observableOf(0);
     let itemReceived = false;

--- a/src/utils/__tests__/filter_map.test.ts
+++ b/src/utils/__tests__/filter_map.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import filterMap from "../filter_map";
+
+describe("utils - concatMapLatest", () => {
+  it("should filter when the token given is mapped", (done) => {
+    const counter$ : Observable<number> = observableOf(0);
+    let itemReceived = false;
+    counter$.pipe(
+      filterMap((i: number) => i, 0)
+    ).subscribe({
+      next() { itemReceived = true; },
+      complete() {
+        expect(itemReceived).toBe(false);
+        done();
+      },
+    });
+  });
+
+  it("should still map all other tokens", (done) => {
+    const arr = [];
+    for (let i = 0; i < 10; i++) {
+      arr.push(i);
+    }
+    const counter$ : Observable<number> = observableOf(...arr);
+    const receivedArr : number[] = [];
+    counter$.pipe(
+      filterMap((i: number) => i * 2, 6)
+    ).subscribe({
+      next(val) {
+        receivedArr.push(val);
+      },
+      complete() {
+        expect(receivedArr).toHaveLength(10 - 1);
+        expect(receivedArr[0]).toEqual(0);
+        expect(receivedArr[1]).toEqual(2);
+        expect(receivedArr[2]).toEqual(4);
+        expect(receivedArr[3]).toEqual(8);
+        expect(receivedArr[4]).toEqual(10);
+        done();
+      },
+    });
+  });
+
+  it("should map everything when the token is not found", (done) => {
+    const arr = [];
+    for (let i = 0; i < 10; i++) {
+      arr.push(i);
+    }
+    const counter$ : Observable<number> = observableOf(...arr);
+    const receivedArr : number[] = [];
+    counter$.pipe(
+      filterMap((i: number) => i * 2, null)
+    ).subscribe({
+      next(val) {
+        receivedArr.push(val);
+      },
+      complete() {
+        expect(receivedArr).toHaveLength(10);
+        expect(receivedArr[0]).toEqual(0);
+        expect(receivedArr[1]).toEqual(2);
+        expect(receivedArr[2]).toEqual(4);
+        expect(receivedArr[3]).toEqual(6);
+        expect(receivedArr[4]).toEqual(8);
+        done();
+      },
+    });
+  });
+});

--- a/src/utils/filter_map.ts
+++ b/src/utils/filter_map.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defer as observableDefer,
+  Observable,
+} from "rxjs";
+import {
+  filter,
+  map,
+} from "rxjs/operators";
+
+/**
+ * Special kind of map which will ignore the result when the value emitted
+ * corresponds to a given token.
+ *
+ * This can also be performed through a `mergeMap` (by returning the `EMPTY`
+ * Observable when we want to ignore events) but using `filterMap` is both more
+ * straightforward and more performant.
+ * @param {function} callback
+ * @param {*} filteringToken
+ * @returns {function}
+ */
+export default function filterMap<T, U, V>(
+  callback: (arg: T, i: number) => U | V,
+  filteringToken : V
+): (source: Observable<T>) => Observable<U> {
+  return (source: Observable<T>) => observableDefer(() => {
+    return source.pipe(map(callback),
+                       filter((x : U | V) : x is U => x !== filteringToken));
+  });
+}


### PR DESCRIPTION
Add `filterMap` utils when we both want to map and filter out some values.

The previous way for doing that was through the `mergeMap` operator, by returning the EMPTY observable when we wanted to ignore a value. However doing that and needing to always wrap values in an Observable was both less readable and, it turns out, much less performant than we originally thought.

After doing some tests, both by creating a simple [node.js script](https://gist.github.com/peaBerberian/221800d218730fcf86c6bef4705e129d) (notes: it needs rxjs as a dependency, also the first set of tests takes a lot of time and can be ignored, this is probably due to the JIT compiler warming up) and by running benchmarking tools (like [hyperfine](https://github.com/sharkdp/hyperfine)) we found that even for a very small number of items emitted (5), using `filterMap` seems to be two times faster than using a `mergeMap` (we would be talking about 1ms here, but this can grow up as items emitted also grow up).

From:
```js
mergeMap(x => {
  if (shouldDouble(x)) {
    return of(x * 2);
  } else if (shouldTriple(x)) {
    return of(x * 3);
  } else if (shouldReturn(x)) {
    return of(x);
  }
  return EMPTY;
}).subscribe(x => console.log("x:", x);
```

To:
```js
filterMap(x => {
  if (shouldDouble(x)) {
    return x * 2;
  } else if (shouldTriple(x)) {
    return x * 3;
  } else if (shouldReturn(x)) {
    return x;
  }
  return null;
}, null).subscribe(x => console.log("x:", x);
```