### PR TITLE
api: allow applying track preferences to already loaded Periods

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1134,10 +1134,8 @@ If you want to update the track for other Periods as well, you might want to
 either:
   - update the current audio track once a `"periodChange"` event has been
     received.
-  - update the preferred audio tracks through the
-    [setPreferredAudioTracks](#meth-setPreferredAudioTracks) method. To ensure
-    that already-loaded Periods also consider that change, you might need to
-    then re-load the content through a new `loadVideo` call.
+  - update first the preferred audio tracks through the
+    [setPreferredAudioTracks](#meth-setPreferredAudioTracks) method.
 
 --
 
@@ -1175,11 +1173,8 @@ If you want to update the track for other Periods as well, you might want to
 either:
   - update the current text track once a `"periodChange"` event has been
     received.
-  - update the preferred text tracks through the
-    [setPreferredTextTracks](#meth-setPreferredTextTracks) method. To ensure
-    that already-loaded Periods also consider that change, you might need to
-    then re-load the content through a new `loadVideo` call.
-
+  - update first the preferred text tracks through the
+    [setPreferredTextTracks](#meth-setPreferredTextTracks) method.
 
 
 --
@@ -1210,13 +1205,14 @@ Note for multi-Period contents:
 
 This method will only have an effect on the [Period](../terms.md#period) that is
 currently playing.
+
 If you want to disable the text track for other Periods as well, you might want
-to either:
-  - call `disableTextTrack` once a `"periodChange"` event has been received.
-  - update the preferred text tracks through the
-    [setPreferredVideoTracks](#meth-setPreferredVideoTracks) method. To ensure
-    that already-loaded Periods also consider that change, you might need to
-    then re-load the content through a new `loadVideo` call.
+to call [setPreferredVideoTracks](#meth-setPreferredVideoTracks) instead. With
+this method, you can globally apply a `null` text track preference - which means
+that you would prefer having no text track - by setting its second argument to
+`true`.
+
+More information can be found on that API's documentation.
 
 
 <a name="meth-setVideoTrack"></a>
@@ -1261,10 +1257,8 @@ If you want to update the track for other Periods as well, you might want to
 either:
   - update the current video track once a `"periodChange"` event has been
     received.
-  - update the preferred video tracks through the
-    [setPreferredVideoTracks](#meth-setPreferredVideoTracks) method. To ensure
-    that already-loaded Periods also consider that change, you might need to
-    then re-load the content through a new `loadVideo` call.
+  - update first the preferred video tracks through the
+    [setPreferredVideoTracks](#meth-setPreferredVideoTracks) method.
 
 --
 
@@ -1289,14 +1283,14 @@ Note for multi-Period contents:
 
 This method will only have an effect on the [Period](../terms.md#period) that is
 currently playing.
+
 If you want to disable the video track for other Periods as well, you might want
-to either:
-  - call `disableVideoTrack` once a `"periodChange"` event has been received.
-  - update the preferred video tracks through the
-    [setPreferredVideoTracks](#meth-setPreferredVideoTracks) method to include
-    `null` (which meaning that you want no video track). To ensure that
-    already-loaded Periods also consider that change, you might need to then
-    re-load the content through a new `loadVideo` call.
+to call [setPreferredVideoTracks](#meth-setPreferredVideoTracks) instead. With
+this method, you can globally apply a `null` video track preference - which means
+that you would prefer having no video track - by setting its second argument to
+`true`.
+
+More information can be found on that API's documentation.
 
 --
 
@@ -1320,19 +1314,16 @@ payload) while the video track is still actually active.
 <a name="meth-setPreferredAudioTracks"></a>
 ### setPreferredAudioTracks ####################################################
 
-_arguments_: ``Array.<Object>``
+_argument 1_: ``Array.<Object>``
+_argument 2_: ``Boolean | undefined``
 
 Allows the RxPlayer to choose an initial audio track, based on language
 preferences, codec preferences or both.
 
-It is defined as an array of objects, each object describing constraints a
-track should respect.
+--
 
-If the first object - defining the first set of constraints - cannot be
-respected under the currently available audio tracks, the RxPlayer will skip
-it and check with the second object and so on.
-As such, this array should be sorted by order of preference: from the most
-wanted constraints to the least.
+The first argument should be set as an array of objects, each object describing
+constraints an audio track should respect.
 
 Here is all the possible constraints you can set in any one of those objects
 (note that all properties are optional here, only those set will have an effect
@@ -1367,24 +1358,41 @@ on which tracks will be filtered):
 }
 ```
 
-This logic is ran each time a new `Period` with audio tracks is loaded by the
-RxPlayer. This means at the start of the content, but also when [pre-]loading a
-new DASH `Period` or a new MetaPlaylist `content`.
+When encountering a new content or a new choice of tracks in a given content,
+the RxPlayer will look at each object in that array.
+If the first object in it defines constaints that cannot be respected under the
+currently available audio tracks, the RxPlayer will consider the second object
+in the array and so on.
 
-Please note that those preferences won't be re-applied once the logic was
-already run for a given `Period`.
-Simply put, once set this preference will be applied to all contents but:
+As such, this array should be sorted by order of preference: from the most
+wanted constraints to the least.
 
-  - the current Period being played (or the current loaded content, in the case
-    of single-Period contents such as in Smooth streaming).
-    In that case, the current audio preference will stay in place.
+--
 
-  - the Periods which have already been loaded in the current content.
-    Those will keep their last set audio preferences (e.g. the preferred audio
-    tracks at the time they were first loaded).
+The second argument to that function is an optional boolean which - when set
+to `true` - will apply that preference to the content and Period that have
+already been playing.
 
-To update the current audio track in those cases, you should use the
-`setAudioTrack` method once they are currently playing.
+By setting it to `true`, you might thus change the currently-active track and
+the active track of Periods (in DASH) or sub-contents (in MetaPlaylist) that
+have already been played in the current content.
+
+By setting it to `false`, `undefined` or not setting it, those preferences will
+only be applied each time a __new__ Period or sub-content is loaded by the
+RxPlayer.
+
+Simply put, if you don't set the second argument to `true` those preferences
+won't be applied to:
+
+  - the content being currently played.
+    Here, the current audio preference will stay in place.
+
+  - the Periods or sub-contents which have already been loaded for the current
+    content.
+    Those will keep the audio track chosen at the last time they were loaded.
+
+If you want the preferences to also be applied to those, you can set the second
+argument to `true`.
 
 
 #### Examples
@@ -1462,11 +1470,18 @@ It will return an empty Array if none of those two APIs were used until now.
 <a name="meth-setPreferredTextTracks"></a>
 ### setPreferredTextTracks #####################################################
 
-_arguments_: ``Array.<Object|null>``
+_argument 1_: ``Array.<Object|null>``
+_argument 2_: ``Boolean | undefined``
 
-Update the text track (or subtitles) preferences at any time.
+Allows the RxPlayer to choose an initial text track, based on language
+and accessibility preferences.
 
-This method takes an array of objects describing the languages wanted:
+--
+
+The first argument should be set as an array of objects, each object describing
+constraints a text track should respect.
+
+Here is all the properties that should be set in a single object of that array.
 ```js
 {
   language: "fra", // {string} The wanted language
@@ -1476,28 +1491,48 @@ This method takes an array of objects describing the languages wanted:
 }
 ```
 
-All elements in that Array should be set in preference order: from the most
-preferred to the least preferred. You can set `null` for no subtitles.
+When encountering a new content or a new choice of tracks in a given content,
+the RxPlayer will look at each object in that array.
+If the first object in it defines constaints that cannot be respected under the
+currently available text tracks, the RxPlayer will consider the second object
+in the array and so on.
 
-When encountering a new Period or a new content, the RxPlayer will then try to
-choose its text track by comparing what is available with your current
-preferences (i.e. if the most preferred is not available, it will look if the
-second one is etc.).
+As such, this array should be sorted by order of preference: from the most
+wanted constraints to the least.
 
-Please note that those preferences will only apply either to the next loaded
-content or to the next newly encountered Period.
-Simply put, once set this preference will be applied to all contents but:
+You can set `null` instead of an object to mean that you want no subtitles.
+When reaching that point of the array, the RxPlayer will just disable the
+current text track.
 
-  - the current Period being played (or the current loaded content, in the case
-    of Smooth streaming). In that case, the current text track preference will
-    stay in place.
+As such, if you never want any subtitles, you can just set this argument to
+`[null]` (an array with only the value `null` at the first position).
 
-  - the Periods which have already been played in the current loaded content.
-    Those will keep the last set text track preference at the time it was
-    played.
+--
 
-To update the current text track in those cases, you should use the
-`setTextTrack` method.
+The second argument to that function is an optional boolean which - when set
+to `true` - will apply that preference to the content and Period that have
+already been playing.
+
+By setting it to `true`, you might thus change the currently-active text track
+and the active text track of Periods (in DASH) or sub-contents (in
+MetaPlaylist) that have already been played in the current content.
+
+By setting it to `false`, `undefined` or not setting it, those preferences will
+only be applied each time a __new__ Period or sub-content is loaded by the
+RxPlayer.
+
+Simply put, if you don't set the second argument to `true` those preferences
+won't be applied to:
+
+  - the content being currently played.
+    Here, the current text track preference will stay in place.
+
+  - the Periods or sub-contents which have already been loaded for the current
+    content.
+    Those will keep the text track chosen at the last time they were loaded.
+
+If you want the preferences to also be applied to those, you can set the second
+argument to `true`.
 
 #### Example
 
@@ -1511,7 +1546,18 @@ player.setPreferredTextTracks([
   { language: "fra", closedCaption: false },
   { language: "ita", closedCaption: false },
   null
-])
+]);
+```
+
+This won't apply on the currently loaded content(s), if you also want that, you
+can add `true` as a second argument:
+
+```js
+player.setPreferredTextTracks([
+  { language: "fra", closedCaption: false },
+  { language: "ita", closedCaption: false },
+  null
+], true);
 ```
 
 --
@@ -1541,6 +1587,150 @@ it was called:
                        // caption for the hard of hearing
 }
 ```
+
+
+<a name="meth-setPreferredVideoTracks"></a>
+### setPreferredVideoTracks ####################################################
+
+_argument 1_: ``Array.<Object>``
+_argument 2_: ``Boolean | undefined``
+
+Allows the RxPlayer to choose an initial video track, based on codec
+preferences, accessibility preferences or both.
+
+--
+
+The first argument should be set as an array of objects, each object describing
+constraints a video track should respect.
+
+Here is all the possible constraints you can set in any one of those objects
+(note that all properties are optional here, only those set will have an effect
+on which tracks will be filtered):
+```js
+{
+  codec: { // {Object|undefined} Constraints about the codec wanted.
+           // if not set or set to `undefined` we won't filter based on codecs.
+
+    test: /hvc/, // {RegExp} RegExp validating the type of codec you want.
+
+    all: true, // {Boolean} Whether all the profiles (i.e. Representation) in a
+               // track should be checked against the RegExp given in `test`.
+               // If `true`, we will only choose a track if EVERY profiles for
+               // it have a codec information that is validated by that RegExp.
+               // If `false`, we will choose a track if we know that at least
+               // A SINGLE profile from it has codec information validated by
+               // that RegExp.
+  }
+  signInterpreted: true, // {Boolean|undefined} If set to `true`, only tracks
+                         // which are known to contains a sign language
+                         // interpretation will be considered.
+                         // If set to `false`, only tracks which are known
+                         // to not contain it will be considered.
+                         // if not set or set to `undefined` we won't filter
+                         // based on that status.
+}
+```
+
+If the first defined object in that array - defining the first set of
+constraints - cannot be respected under the currently available video tracks,
+the RxPlayer will check with the second object instead and so on.
+
+As such, this array should be sorted by order of preference: from the most
+wanted constraints to the least.
+
+When the next encountered constraint is set to `null`, the player will simply
+disable the video track. If you want to disable the video track by default,
+you can just set `null` as the first element of this array (e.g. like `[null]`).
+
+--
+
+The second argument to that function is an optional boolean which - when set
+to `true` - will apply that preference to the content and Period that have
+already been playing.
+
+By setting it to `true`, you might thus change the currently-active track and
+the active track of Periods (in DASH) or sub-contents (in MetaPlaylist) that
+have already been played in the current content.
+
+By setting it to `false`, `undefined` or not setting it, those preferences will
+only be applied each time a __new__ Period (or sub-content) is loaded by the
+RxPlayer.
+
+Simply put, if you don't set the second argument to `true` those preferences
+won't be applied to:
+
+  - the content being currently played.
+    Here, the current video preference will stay in place.
+
+  - the Periods or sub-contents which have already been loaded for the current
+    content.
+    Those will keep the video track chosen at the last time they were loaded.
+
+If you want the preferences to also be applied to those, you can set the second
+argument to `true`.
+
+
+#### Examples
+
+Let's imagine that you prefer to have a track which contains only H265
+profiles. You can do:
+```js
+player.setPreferredVideoTracks([ { codec: { all: false, test: /^hvc/ } } ]);
+```
+
+With that same constraint, let's no consider that the current user prefer in any
+case to have a sign language interpretation on screen:
+```js
+player.setPreferredVideoTracks([
+  // first let's consider the best case: H265 + sign language interpretation
+  {
+    codec: { all: false, test: /^hvc/ }
+    signInterpreted: true,
+  },
+
+  // If not available, we still prefer a sign interpreted track without H265
+  { signInterpreted: true },
+
+  // If not available either, we would prefer an H265 content
+  { codec: { all: false, test: /^hvc/ } },
+
+  // Note: If this is also available, we will here still have a video track
+  // but which do not respect any of the constraints set here.
+]);
+would thus prefer the video to contain a sign language interpretation.
+We could set both the previous and that new constraint that way:
+
+---
+
+For a totally different example, let's imagine you want to play without any
+video track enabled (e.g. to start in an audio-only mode). To do that, you can
+simply do:
+```js
+player.setPreferredVideoTracks([null], true);
+```
+
+---
+
+:warning: This option will have no effect in _DirectFile_ mode
+(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
+- No video track API is supported on the current browser
+- The media file tracks are not supported on the browser
+
+---
+
+
+<a name="meth-getPreferredVideoTracks"></a>
+### getPreferredVideoTracks ####################################################
+
+_return value_: ``Array.<Object>``
+
+Returns the current list of preferred video tracks - by order of preference.
+
+This returns the data in the same format that it was given to either the
+`preferredVideoTracks` constructor option or the last `setPreferredVideoTracks`
+if it was called.
+
+It will return an empty Array if none of those two APIs were used until now.
 
 
 
@@ -2050,136 +2240,6 @@ if (url) {
 }
 ```
 
-
-<a name="meth-setPreferredVideoTracks"></a>
-### setPreferredVideoTracks ####################################################
-
-_arguments_: ``Array.<Object|null>``
-
-Allows the RxPlayer to choose an initial video track.
-
-It is defined as an array of objects, each object describing constraints a
-track should respect.
-
-If the first object - defining the first set of constraints - cannot be
-respected under the currently available video tracks, the RxPlayer will skip
-it and check with the second object and so on.
-As such, this array should be sorted by order of preference: from the most
-wanted constraints to the least.
-
-When the next encountered constraint is set to `null`, the player will simply
-disable the video track. If you want to disable the video track by default,
-you can just set `null` as the first element of this array (e.g. `[null]`).
-
-Here is all the possible constraints you can set in any one of those objects
-(note that all properties are optional here, only those set will have an effect
-on which tracks will be filtered):
-```js
-{
-  codec: { // {Object|undefined} Constraints about the codec wanted.
-           // if not set or set to `undefined` we won't filter based on codecs.
-
-    test: /hvc/, // {RegExp} RegExp validating the type of codec you want.
-
-    all: true, // {Boolean} Whether all the profiles (i.e. Representation) in a
-               // track should be checked against the RegExp given in `test`.
-               // If `true`, we will only choose a track if EVERY profiles for
-               // it have a codec information that is validated by that RegExp.
-               // If `false`, we will choose a track if we know that at least
-               // A SINGLE profile from it has codec information validated by
-               // that RegExp.
-  }
-  signInterpreted: true, // {Boolean|undefined} If set to `true`, only tracks
-                         // which are known to contains a sign language
-                         // interpretation will be considered.
-                         // If set to `false`, only tracks which are known
-                         // to not contain it will be considered.
-                         // if not set or set to `undefined` we won't filter
-                         // based on that status.
-}
-```
-
-This logic is ran each time a new `Period` with video tracks is loaded by the
-RxPlayer. This means at the start of the content, but also when [pre-]loading a
-new DASH `Period` or a new MetaPlaylist `content`.
-
-Please note that those preferences won't be re-applied once the logic was
-already run for a given `Period`.
-Simply put, once set this preference will be applied to all contents but:
-
-  - the current Period being played (or the current loaded content, in the case
-    of single-Period contents such as in Smooth streaming).
-    In that case, the current video track preference will stay in place.
-
-  - the Periods which have already been loaded in the current content.
-    Those will keep their last set video track preferences (e.g. the preferred
-    video tracks at the time they were first loaded).
-
-To update the current video track in those cases, you should use the
-`setVideoTrack` method once they are currently played.
-
-
-#### Examples
-
-Let's imagine that you prefer to have a track which contains only H265
-profiles. You can do:
-```js
-player.setPreferredVideoTracks([ { codec: { all: false, test: /^hvc/ } } ]);
-```
-
-With that same constraint, let's no consider that the current user prefer in any
-case to have a sign language interpretation on screen:
-```js
-player.setPreferredVideoTracks([
-  // first let's consider the best case: H265 + sign language interpretation
-  {
-    codec: { all: false, test: /^hvc/ }
-    signInterpreted: true,
-  },
-
-  // If not available, we still prefer a sign interpreted track without H265
-  { signInterpreted: true },
-
-  // If not available either, we would prefer an H265 content
-  { codec: { all: false, test: /^hvc/ } },
-
-  // Note: If this is also available, we will here still have a video track
-  // but which do not respect any of the constraints set here.
-]);
-would thus prefer the video to contain a sign language interpretation.
-We could set both the previous and that new constraint that way:
-
----
-
-For a totally different example, let's imagine you want to start without any
-video track enabled (e.g. to start in an audio-only mode). To do that, you can
-simply do:
-```js
-player.setPreferredVideoTracks([null]);
-```
-
----
-
-:warning: This option will have no effect in _DirectFile_ mode
-(see [loadVideo options](./loadVideo_options.md#prop-transport)) when either :
-- No video track API is supported on the current browser
-- The media file tracks are not supported on the browser
-
----
-
-
-<a name="meth-getPreferredVideoTracks"></a>
-### getPreferredVideoTracks ####################################################
-
-_return value_: ``Array.<Object>``
-
-Returns the current list of preferred video tracks - by order of preference.
-
-This returns the data in the same format that it was given to either the
-`preferredVideoTracks` constructor option or the last `setPreferredVideoTracks`
-if it was called.
-
-It will return an empty Array if none of those two APIs were used until now.
 
 <a name="meth-getCurrentKeySystem"></a>
 ### getCurrentKeySystem ########################################################

--- a/src/core/api/__tests__/media_element_track_choice_manager.test.ts
+++ b/src/core/api/__tests__/media_element_track_choice_manager.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { BehaviorSubject } from "rxjs";
 import MediaElementTrackChoiceManager from "../media_element_track_choice_manager";
 
 const fakeMediaElement = {
@@ -38,11 +37,6 @@ const fakeMediaElement = {
 describe("API - MediaElementTrackChoiceManager", () => {
   it("should returns correct results for getter", () => {
       const trackManager = new MediaElementTrackChoiceManager(
-        {
-          preferredAudioTracks: new BehaviorSubject([] as any[]),
-          preferredTextTracks: new BehaviorSubject([] as any[]),
-          preferredVideoTracks: new BehaviorSubject([] as any[]),
-        },
         fakeMediaElement as any
       );
       const audioTracks = trackManager.getAvailableAudioTracks();
@@ -78,11 +72,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
   });
   it("should returns correct results for setters", () => {
       const trackManager = new MediaElementTrackChoiceManager(
-        {
-          preferredAudioTracks: new BehaviorSubject([] as any[]),
-          preferredTextTracks: new BehaviorSubject([] as any[]),
-          preferredVideoTracks: new BehaviorSubject([] as any[]),
-        },
         fakeMediaElement as any
       );
 
@@ -109,11 +98,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
   });
   it("should emit available tracks change when changing text contents", (done) => {
     const trackManager = new MediaElementTrackChoiceManager(
-      {
-        preferredAudioTracks: new BehaviorSubject([] as any[]),
-        preferredTextTracks: new BehaviorSubject([] as any[]),
-        preferredVideoTracks: new BehaviorSubject([] as any[]),
-      },
       fakeMediaElement as any
     );
 
@@ -136,11 +120,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
 
   it("should emit available tracks change when changing video contents", (done) => {
     const trackManager = new MediaElementTrackChoiceManager(
-      {
-        preferredAudioTracks: new BehaviorSubject([] as any[]),
-        preferredTextTracks: new BehaviorSubject([] as any[]),
-        preferredVideoTracks: new BehaviorSubject([] as any[]),
-      },
       fakeMediaElement as any
     );
 
@@ -160,11 +139,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
 
   it("should emit available tracks change when changing audio contents", (done) => {
     const trackManager = new MediaElementTrackChoiceManager(
-      {
-        preferredAudioTracks: new BehaviorSubject([] as any[]),
-        preferredTextTracks: new BehaviorSubject([] as any[]),
-        preferredVideoTracks: new BehaviorSubject([] as any[]),
-      },
       fakeMediaElement as any
     );
 
@@ -187,11 +161,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
 
   it("should emit chosen track when changing text content", (done) => {
     const trackManager = new MediaElementTrackChoiceManager(
-      {
-        preferredAudioTracks: new BehaviorSubject([] as any[]),
-        preferredTextTracks: new BehaviorSubject([] as any[]),
-        preferredVideoTracks: new BehaviorSubject([] as any[]),
-      },
       fakeMediaElement as any
     );
 

--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -19,7 +19,6 @@
  * It always should be imported through the `features` object.
  */
 
-import { BehaviorSubject } from "rxjs";
 import {
   ICompatAudioTrack,
   ICompatAudioTrackList,
@@ -183,19 +182,19 @@ export default class MediaElementTrackChoiceManager
    * Array of preferred settings for audio tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
+  private _preferredAudioTracks : IAudioTrackPreference[];
 
   /**
    * Array of preferred languages for text tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
+  private _preferredTextTracks : ITextTrackPreference[];
 
   /**
    * Array of preferred settings for video tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>;
+  private _preferredVideoTracks : IVideoTrackPreference[];
 
   /** List every available audio tracks available on the media element. */
   private _audioTracks : Array<{ track: ITMAudioTrack; nativeTrack: ICompatAudioTrack }>;
@@ -247,17 +246,12 @@ export default class MediaElementTrackChoiceManager
    */
   private _videoTrackLockedOn : ICompatVideoTrack | undefined | null;
 
-  constructor(
-    defaults : { preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
-                 preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
-                 preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>; },
-    mediaElement: HTMLMediaElement
-  ) {
+  constructor(mediaElement: HTMLMediaElement) {
     super();
 
-    this._preferredAudioTracks = defaults.preferredAudioTracks;
-    this._preferredTextTracks = defaults.preferredTextTracks;
-    this._preferredVideoTracks = defaults.preferredVideoTracks;
+    this._preferredAudioTracks = [];
+    this._preferredTextTracks = [];
+    this._preferredVideoTracks = [];
 
     // TODO In practice, the audio/video/text tracks API are not always implemented on
     // the media element, although Typescript HTMLMediaElement types tend to mean
@@ -281,6 +275,57 @@ export default class MediaElementTrackChoiceManager
     this._lastEmittedNativeTextTrack = this._getPrivateChosenTextTrack()?.nativeTrack;
 
     this._handleNativeTracksCallbacks();
+  }
+
+  /**
+   * Set the list of preferred audio tracks, in preference order.
+   * @param {Array.<Object>} preferredAudioTracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredAudioTracks(
+    preferredAudioTracks : IAudioTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredAudioTracks = preferredAudioTracks;
+    if (shouldApply) {
+      this._applyAudioPreferences();
+    }
+  }
+
+  /**
+   * Set the list of preferred text tracks, in preference order.
+   * @param {Array.<Object>} preferredTextTracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredTextTracks(
+    preferredTextTracks : ITextTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredTextTracks = preferredTextTracks;
+    if (shouldApply) {
+      this._applyTextPreferences();
+    }
+  }
+
+  /**
+   * Set the list of preferred video tracks, in preference order.
+   * @param {Array.<Object>} preferredVideoTracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredVideoTracks(
+    preferredVideoTracks : IVideoTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredVideoTracks = preferredVideoTracks;
+    if (shouldApply) {
+      this._applyVideoPreferences();
+    }
   }
 
   /**
@@ -539,7 +584,7 @@ export default class MediaElementTrackChoiceManager
    *   - if we still do not find an optimal track, let the one chosen by default
    */
   private _setOptimalAudioTrack() : void {
-    // 1. first check if the last set track is available, set it if that's the case
+    // First check if the last set track is available, set it if that's the case
     if (this._audioTrackLockedOn !== undefined) {
       for (let i = 0; i < this._audioTracks.length; i++) {
         const { nativeTrack } = this._audioTracks[i];
@@ -549,12 +594,19 @@ export default class MediaElementTrackChoiceManager
         }
       }
     }
+    this._applyAudioPreferences();
+  }
 
-    // Else set the preferred one
-    // Also reset the set audio track, for a behavior easier to understand
+  /**
+   * Try to find a track corresponding to the audio track preferences:
+   *   - if found, set it as the active track
+   *   - if not found, let the chosen audio track by default
+   */
+  private _applyAudioPreferences() : void {
+    // Re-set the last manually set audio track
     this._audioTrackLockedOn = undefined;
 
-    const preferredAudioTracks = this._preferredAudioTracks.getValue();
+    const preferredAudioTracks = this._preferredAudioTracks;
     for (let i = 0; i < preferredAudioTracks.length; i++) {
       const track = preferredAudioTracks[i];
       if (track !== null && track.language !== undefined) {
@@ -562,7 +614,7 @@ export default class MediaElementTrackChoiceManager
         for (let j = 0; j < this._audioTracks.length; j++) {
           const audioTrack = this._audioTracks[j];
           if (audioTrack.track.normalized === normalized &&
-              audioTrack.track.audioDescription === track.audioDescription
+            audioTrack.track.audioDescription === track.audioDescription
           ) {
             audioTrack.nativeTrack.enabled = true;
             return;
@@ -581,7 +633,7 @@ export default class MediaElementTrackChoiceManager
    *   - if we still do not find an optimal track, just disable it.
    */
   private _setOptimalTextTrack() : void {
-    // 1. first check if the last set track is available, set it if that's the case
+    // First check if the last set track is available, set it if that's the case
     if (this._textTrackLockedOn === null) {
       disableTextTracks(this._textTracks);
       return;
@@ -601,10 +653,19 @@ export default class MediaElementTrackChoiceManager
     }
 
     // Else set the preferred one
-    // Also reset the set text track, for a behavior easier to understand
+    this._applyTextPreferences();
+  }
+
+  /**
+   * Try to find a track corresponding to the text track preferences:
+   *   - if found, set it as the active track
+   *   - if not found, let the chosen text track by default
+   */
+  private _applyTextPreferences() : void {
+    // Re-set the last manually set audio track
     this._textTrackLockedOn = undefined;
 
-    const preferredTextTracks = this._preferredTextTracks.getValue();
+    const preferredTextTracks = this._preferredTextTracks;
     for (let i = 0; i < preferredTextTracks.length; i++) {
       const track = preferredTextTracks[i];
       if (track === null) {
@@ -654,7 +715,16 @@ export default class MediaElementTrackChoiceManager
     }
 
     // Else set the preferred one
-    // Also reset the set text track, for a behavior easier to understand
+    this._applyVideoPreferences();
+  }
+
+  /**
+   * Try to find a track corresponding to the text track preferences:
+   *   - if found, set it as the active track
+   *   - if not found, let the chosen text track by default
+   */
+  private _applyVideoPreferences() : void {
+    // Re-set the last manually set video track
     this._videoTrackLockedOn = undefined;
 
     // NOTE: As we cannot access either codec information or sign interpretation
@@ -664,7 +734,7 @@ export default class MediaElementTrackChoiceManager
     // set preferrence is "no video track" (i.e. `null`) as this is the only
     // constraint that we know we can respect.
     // Else, just chose the first track.
-    const preferredVideoTracks = this._preferredVideoTracks.getValue();
+    const preferredVideoTracks = this._preferredVideoTracks;
     const hasNullPreference = preferredVideoTracks.some(p => p === null);
     if (hasNullPreference) {
       disableVideoTracks(this._videoTracks);
@@ -698,7 +768,6 @@ export default class MediaElementTrackChoiceManager
           const newAudioTracks = createAudioTracks(this._nativeAudioTracks);
           if (areTrackArraysDifferent(this._audioTracks, newAudioTracks)) {
             this._audioTracks = newAudioTracks;
-            this._setOptimalAudioTrack();
             this.trigger("availableAudioTracksChange", this.getAvailableAudioTracks());
             const chosenAudioTrack = this._getPrivateChosenAudioTrack();
             if (chosenAudioTrack?.nativeTrack !== this._lastEmittedNativeAudioTrack) {

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -349,14 +349,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     sourceBuffersStore : SourceBuffersStore | null;
   };
 
-  /** List of favorite audio tracks, in preference order. */
-  private _priv_preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
+  /** List of favorite audio tracks, in preference order.  */
+  private _priv_preferredAudioTracks : IAudioTrackPreference[];
 
-  /** List of favorite text tracks, in preference order. */
-  private _priv_preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
+  /** List of favorite text tracks, in preference order.  */
+  private _priv_preferredTextTracks : ITextTrackPreference[];
 
   /** List of favorite video tracks, in preference order. */
-  private _priv_preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>;
+  private _priv_preferredVideoTracks : IVideoTrackPreference[];
 
   /**
    * TrackChoiceManager instance linked to the current content.
@@ -542,9 +542,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     this._priv_setPlayerState(PLAYER_STATES.STOPPED);
 
-    this._priv_preferredAudioTracks = new BehaviorSubject(preferredAudioTracks);
-    this._priv_preferredTextTracks = new BehaviorSubject(preferredTextTracks);
-    this._priv_preferredVideoTracks = new BehaviorSubject(preferredVideoTracks);
+    this._priv_preferredAudioTracks = preferredAudioTracks;
+    this._priv_preferredTextTracks = preferredTextTracks;
+    this._priv_preferredVideoTracks = preferredVideoTracks;
   }
 
   /**
@@ -728,16 +728,22 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       }
 
       this._priv_mediaElementTrackChoiceManager =
-        new features.directfile.mediaElementTrackChoiceManager(
-          { preferredAudioTracks: defaultAudioTrack === undefined ?
-              this._priv_preferredAudioTracks :
-              new BehaviorSubject([defaultAudioTrack]),
-            preferredTextTracks: defaultTextTrack === undefined ?
-              this._priv_preferredTextTracks :
-              new BehaviorSubject([defaultTextTrack]),
-            preferredVideoTracks: this._priv_preferredVideoTracks },
-          this.videoElement
-        );
+        new features.directfile.mediaElementTrackChoiceManager(this.videoElement);
+
+      const preferredAudioTracks = defaultAudioTrack === undefined ?
+        this._priv_preferredAudioTracks :
+        [defaultAudioTrack];
+      this._priv_mediaElementTrackChoiceManager
+        .setPreferredAudioTracks(preferredAudioTracks, true);
+
+      const preferredTextTracks = defaultTextTrack === undefined ?
+        this._priv_preferredTextTracks :
+        [defaultTextTrack];
+      this._priv_mediaElementTrackChoiceManager
+        .setPreferredTextTracks(preferredTextTracks, true);
+
+      this._priv_mediaElementTrackChoiceManager
+        .setPreferredVideoTracks(this._priv_preferredVideoTracks, true);
 
       this.trigger("availableAudioTracksChange",
         this._priv_mediaElementTrackChoiceManager.getAvailableAudioTracks());
@@ -1788,7 +1794,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Array.<Object>}
    */
   getPreferredAudioTracks() : IAudioTrackPreference[] {
-    return this._priv_preferredAudioTracks.getValue();
+    return this._priv_preferredAudioTracks;
   }
 
   /**
@@ -1796,7 +1802,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Array.<Object>}
    */
   getPreferredTextTracks() : ITextTrackPreference[] {
-    return this._priv_preferredTextTracks.getValue();
+    return this._priv_preferredTextTracks;
   }
 
   /**
@@ -1804,43 +1810,79 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Array.<Object>}
    */
   getPreferredVideoTracks() : IVideoTrackPreference[] {
-    return this._priv_preferredVideoTracks.getValue();
+    return this._priv_preferredVideoTracks;
   }
 
   /**
    * Set the list of preferred audio tracks, in preference order.
    * @param {Array.<Object>} tracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
    */
-  setPreferredAudioTracks(tracks : IAudioTrackPreference[]) : void {
+  setPreferredAudioTracks(
+    tracks : IAudioTrackPreference[],
+    shouldApply : boolean = false
+  ) : void {
     if (!Array.isArray(tracks)) {
       throw new Error("Invalid `setPreferredAudioTracks` argument. " +
                       "Should have been an Array.");
     }
-    return this._priv_preferredAudioTracks.next(tracks);
+    this._priv_preferredAudioTracks = tracks;
+    if (this._priv_trackChoiceManager !== null) {
+      this._priv_trackChoiceManager.setPreferredAudioTracks(tracks, shouldApply);
+    } else if (this._priv_mediaElementTrackChoiceManager !== null) {
+      this._priv_mediaElementTrackChoiceManager.setPreferredAudioTracks(tracks,
+                                                                        shouldApply);
+    }
   }
 
   /**
    * Set the list of preferred text tracks, in preference order.
    * @param {Array.<Object>} tracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Periods. `false` if it should only
+   * be applied to new content.
    */
-  setPreferredTextTracks(tracks : ITextTrackPreference[]) : void {
+  setPreferredTextTracks(
+    tracks : ITextTrackPreference[],
+    shouldApply : boolean = false
+  ) : void {
     if (!Array.isArray(tracks)) {
       throw new Error("Invalid `setPreferredTextTracks` argument. " +
                       "Should have been an Array.");
     }
-    return this._priv_preferredTextTracks.next(tracks);
+    this._priv_preferredTextTracks = tracks;
+    if (this._priv_trackChoiceManager !== null) {
+      this._priv_trackChoiceManager.setPreferredTextTracks(tracks, shouldApply);
+    } else if (this._priv_mediaElementTrackChoiceManager !== null) {
+      this._priv_mediaElementTrackChoiceManager.setPreferredTextTracks(tracks,
+                                                                       shouldApply);
+    }
   }
 
   /**
    * Set the list of preferred text tracks, in preference order.
    * @param {Array.<Object>} tracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
    */
-  setPreferredVideoTracks(tracks : IVideoTrackPreference[]) : void {
+  setPreferredVideoTracks(
+    tracks : IVideoTrackPreference[],
+    shouldApply : boolean =  false
+  ) : void {
     if (!Array.isArray(tracks)) {
       throw new Error("Invalid `setPreferredVideoTracks` argument. " +
                       "Should have been an Array.");
     }
-    return this._priv_preferredVideoTracks.next(tracks);
+    this._priv_preferredVideoTracks = tracks;
+    if (this._priv_trackChoiceManager !== null) {
+      this._priv_trackChoiceManager.setPreferredVideoTracks(tracks, shouldApply);
+    } else if (this._priv_mediaElementTrackChoiceManager !== null) {
+      this._priv_mediaElementTrackChoiceManager.setPreferredVideoTracks(tracks,
+                                                                        shouldApply);
+    }
   }
 
   /**
@@ -2099,15 +2141,20 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_contentInfos.manifest = manifest;
 
     const { initialAudioTrack, initialTextTrack } = this._priv_contentInfos;
-    this._priv_trackChoiceManager = new TrackChoiceManager({
-      preferredAudioTracks: initialAudioTrack === undefined ?
-        this._priv_preferredAudioTracks :
-        new BehaviorSubject([initialAudioTrack]),
-      preferredTextTracks: initialTextTrack === undefined ?
-        this._priv_preferredTextTracks :
-        new BehaviorSubject([initialTextTrack]),
-      preferredVideoTracks: this._priv_preferredVideoTracks,
-    });
+    this._priv_trackChoiceManager = new TrackChoiceManager();
+
+    const preferredAudioTracks = initialAudioTrack === undefined ?
+      this._priv_preferredAudioTracks :
+      [initialAudioTrack];
+    this._priv_trackChoiceManager.setPreferredAudioTracks(preferredAudioTracks, true);
+
+    const preferredTextTracks = initialTextTrack === undefined ?
+      this._priv_preferredTextTracks :
+      [initialTextTrack];
+    this._priv_trackChoiceManager.setPreferredTextTracks(preferredTextTracks, true);
+
+    this._priv_trackChoiceManager.setPreferredVideoTracks(this._priv_preferredVideoTracks,
+                                                          true);
 
     fromEvent(manifest, "manifestUpdate")
       .pipe(takeUntil(this._priv_stopCurrentContent$))

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -19,10 +19,7 @@
  * switching for an easier API management.
  */
 
-import {
-  BehaviorSubject,
-  Subject,
-} from "rxjs";
+import { Subject } from "rxjs";
 import log from "../../log";
 import {
   Adaptation,
@@ -167,7 +164,7 @@ function normalizeTextTracks(
 
 /**
  * Manage audio and text tracks for all active periods.
- * Chose the audio and text tracks for each period and record this choice.
+ * Choose the audio and text tracks for each period and record this choice.
  * @class TrackChoiceManager
  */
 export default class TrackChoiceManager {
@@ -181,19 +178,19 @@ export default class TrackChoiceManager {
    * Array of preferred settings for audio tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
+  private _preferredAudioTracks : IAudioTrackPreference[];
 
   /**
    * Array of preferred languages for text tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
+  private _preferredTextTracks : ITextTrackPreference[];
 
   /**
    * Array of preferred settings for video tracks.
    * Sorted by order of preference descending.
    */
-  private _preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>;
+  private _preferredVideoTracks : IVideoTrackPreference[];
 
   /** Memoization of the previously-chosen audio Adaptation for each Period. */
   private _audioChoiceMemory : WeakMap<Period, Adaptation|null>;
@@ -204,26 +201,67 @@ export default class TrackChoiceManager {
   /** Memoization of the previously-chosen video Adaptation for each Period. */
   private _videoChoiceMemory : WeakMap<Period, Adaptation|null>;
 
-  /**
-   * @param {BehaviorSubject<Array.<Object|null>>} preferredAudioTracks - Array
-   * of audio track preferences
-   * @param {BehaviorSubject<Array.<Object|null>>} preferredAudioTracks - Array
-   * of text track preferences
-   */
-  constructor(defaults : {
-    preferredAudioTracks : BehaviorSubject<IAudioTrackPreference[]>;
-    preferredTextTracks : BehaviorSubject<ITextTrackPreference[]>;
-    preferredVideoTracks : BehaviorSubject<IVideoTrackPreference[]>;
-  }) {
+  constructor() {
     this._periods = new SortedList((a, b) => a.period.start - b.period.start);
 
     this._audioChoiceMemory = new WeakMap();
     this._textChoiceMemory = new WeakMap();
     this._videoChoiceMemory = new WeakMap();
 
-    this._preferredAudioTracks = defaults.preferredAudioTracks;
-    this._preferredTextTracks = defaults.preferredTextTracks;
-    this._preferredVideoTracks = defaults.preferredVideoTracks;
+    this._preferredAudioTracks = [];
+    this._preferredTextTracks = [];
+    this._preferredVideoTracks = [];
+  }
+
+  /**
+   * Set the list of preferred audio tracks, in preference order.
+   * @param {Array.<Object>} preferredAudioTracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredAudioTracks(
+    preferredAudioTracks : IAudioTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredAudioTracks = preferredAudioTracks;
+    if (shouldApply) {
+      this._applyAudioPreferences();
+    }
+  }
+
+  /**
+   * Set the list of preferred text tracks, in preference order.
+   * @param {Array.<Object>} preferredTextTracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Periods. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredTextTracks(
+    preferredTextTracks : ITextTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredTextTracks = preferredTextTracks;
+    if (shouldApply) {
+      this._applyTextPreferences();
+    }
+  }
+
+  /**
+   * Set the list of preferred text tracks, in preference order.
+   * @param {Array.<Object>} tracks
+   * @param {boolean} shouldApply - `true` if those preferences should be
+   * applied on the currently loaded Period. `false` if it should only
+   * be applied to new content.
+   */
+  public setPreferredVideoTracks(
+    preferredVideoTracks : IVideoTrackPreference[],
+    shouldApply : boolean
+  ) : void {
+    this._preferredVideoTracks = preferredVideoTracks;
+    if (shouldApply) {
+      this._applyVideoPreferences();
+    }
   }
 
   /**
@@ -295,9 +333,9 @@ export default class TrackChoiceManager {
    *   2. If not found, the preferences
    */
   public update() : void {
-    this._updateAudioTrackChoices();
-    this._updateTextTrackChoices();
-    this._updateVideoTrackChoices();
+    this._resetChosenAudioTracks();
+    this._resetChosenTextTracks();
+    this._resetChosenVideoTracks();
   }
 
   /**
@@ -314,7 +352,6 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const preferredAudioTracks = this._preferredAudioTracks.getValue();
     const audioAdaptations = period.getPlayableAdaptations("audio");
     const chosenAudioAdaptation = this._audioChoiceMemory.get(period);
 
@@ -325,6 +362,7 @@ export default class TrackChoiceManager {
                !arrayIncludes(audioAdaptations, chosenAudioAdaptation)
     ) {
       // Find the optimal audio Adaptation
+      const preferredAudioTracks = this._preferredAudioTracks;
       const normalizedPref = normalizeAudioTracks(preferredAudioTracks);
       const optimalAdaptation = findFirstOptimalAudioAdaptation(audioAdaptations,
                                                                 normalizedPref);
@@ -350,7 +388,6 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const preferredTextTracks = this._preferredTextTracks.getValue();
     const textAdaptations = period.getPlayableAdaptations("text");
     const chosenTextAdaptation = this._textChoiceMemory.get(period);
     if (chosenTextAdaptation === null) {
@@ -360,6 +397,7 @@ export default class TrackChoiceManager {
                !arrayIncludes(textAdaptations, chosenTextAdaptation)
     ) {
       // Find the optimal text Adaptation
+      const preferredTextTracks = this._preferredTextTracks;
       const normalizedPref = normalizeTextTracks(preferredTextTracks);
       const optimalAdaptation = findFirstOptimalTextAdaptation(textAdaptations,
                                                                normalizedPref);
@@ -384,7 +422,6 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const preferredVideoTracks = this._preferredVideoTracks.getValue();
     const videoAdaptations = period.getPlayableAdaptations("video");
     const chosenVideoAdaptation = this._videoChoiceMemory.get(period);
 
@@ -394,6 +431,7 @@ export default class TrackChoiceManager {
     } else if (chosenVideoAdaptation === undefined ||
                !arrayIncludes(videoAdaptations, chosenVideoAdaptation)
     ) {
+      const preferredVideoTracks = this._preferredVideoTracks;
       const optimalAdaptation = findFirstOptimalVideoAdaptation(videoAdaptations,
                                                                 preferredVideoTracks);
       this._videoChoiceMemory.set(period, optimalAdaptation);
@@ -730,8 +768,43 @@ export default class TrackChoiceManager {
     });
   }
 
-  private _updateAudioTrackChoices() {
-    const preferredAudioTracks = this._preferredAudioTracks.getValue();
+  /**
+   * Reset all audio tracks choices to corresponds to the current preferences.
+   */
+  private _applyAudioPreferences() : void {
+    // Remove all memoized choices and start over
+    this._audioChoiceMemory = new WeakMap();
+    this._resetChosenAudioTracks();
+  }
+
+  /**
+   * Reset all text tracks choices to corresponds to the current preferences.
+   */
+  private _applyTextPreferences() : void {
+    // Remove all memoized choices and start over
+    this._textChoiceMemory = new WeakMap();
+    this._resetChosenTextTracks();
+  }
+
+  /**
+   * Reset all video tracks choices to corresponds to the current preferences.
+   */
+  private _applyVideoPreferences() : void {
+    // Remove all memoized choices and start over
+    this._videoChoiceMemory = new WeakMap();
+    this._resetChosenVideoTracks();
+  }
+
+  /**
+   * Choose again the best audio tracks for all current Periods.
+   * This is based on two things:
+   *   1. what was the track previously chosen for that Period (by checking
+   *      `this._audioChoiceMemory`).
+   *   2. If no track were previously chosen or if it is not available anymore
+   *      we check the audio preferences.
+   */
+  private _resetChosenAudioTracks() {
+    const preferredAudioTracks = this._preferredAudioTracks;
     const normalizedPref = normalizeAudioTracks(preferredAudioTracks);
 
     const recursiveUpdateAudioTrack = (index : number) : void => {
@@ -776,8 +849,16 @@ export default class TrackChoiceManager {
     recursiveUpdateAudioTrack(0);
   }
 
-  private _updateTextTrackChoices() {
-    const preferredTextTracks = this._preferredTextTracks.getValue();
+  /**
+   * Choose again the best text tracks for all current Periods.
+   * This is based on two things:
+   *   1. what was the track previously chosen for that Period (by checking
+   *      `this._textChoiceMemory`).
+   *   2. If no track were previously chosen or if it is not available anymore
+   *      we check the text preferences.
+   */
+  private _resetChosenTextTracks() {
+    const preferredTextTracks = this._preferredTextTracks;
     const normalizedPref = normalizeTextTracks(preferredTextTracks);
 
     const recursiveUpdateTextTrack = (index : number) : void => {
@@ -822,8 +903,16 @@ export default class TrackChoiceManager {
     recursiveUpdateTextTrack(0);
   }
 
-  private _updateVideoTrackChoices() {
-    const preferredVideoTracks = this._preferredVideoTracks.getValue();
+  /**
+   * Choose again the best video tracks for all current Periods.
+   * This is based on two things:
+   *   1. what was the track previously chosen for that Period (by checking
+   *      `this._videoChoiceMemory`).
+   *   2. If no track were previously chosen or if it is not available anymore
+   *      we check the video preferences.
+   */
+  private _resetChosenVideoTracks() {
+    const preferredVideoTracks = this._preferredVideoTracks;
     const recursiveUpdateVideoTrack = (index : number) : void => {
       if (index >= this._periods.length()) {
         // we did all video Buffers, exit

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -192,13 +192,13 @@ export default class TrackChoiceManager {
    */
   private _preferredVideoTracks : IVideoTrackPreference[];
 
-  /** Memoization of the previously-chosen audio Adaptation for each Period. */
+  /** Memorization of the previously-chosen audio Adaptation for each Period. */
   private _audioChoiceMemory : WeakMap<Period, Adaptation|null>;
 
-  /** Memoization of the previously-chosen text Adaptation for each Period. */
+  /** Memorization of the previously-chosen text Adaptation for each Period. */
   private _textChoiceMemory : WeakMap<Period, Adaptation|null>;
 
-  /** Memoization of the previously-chosen video Adaptation for each Period. */
+  /** Memorization of the previously-chosen video Adaptation for each Period. */
   private _videoChoiceMemory : WeakMap<Period, Adaptation|null>;
 
   constructor() {
@@ -772,7 +772,7 @@ export default class TrackChoiceManager {
    * Reset all audio tracks choices to corresponds to the current preferences.
    */
   private _applyAudioPreferences() : void {
-    // Remove all memoized choices and start over
+    // Remove all memorized choices and start over
     this._audioChoiceMemory = new WeakMap();
     this._resetChosenAudioTracks();
   }
@@ -781,7 +781,7 @@ export default class TrackChoiceManager {
    * Reset all text tracks choices to corresponds to the current preferences.
    */
   private _applyTextPreferences() : void {
-    // Remove all memoized choices and start over
+    // Remove all memorized choices and start over
     this._textChoiceMemory = new WeakMap();
     this._resetChosenTextTracks();
   }
@@ -790,7 +790,7 @@ export default class TrackChoiceManager {
    * Reset all video tracks choices to corresponds to the current preferences.
    */
   private _applyVideoPreferences() : void {
-    // Remove all memoized choices and start over
+    // Remove all memorized choices and start over
     this._videoChoiceMemory = new WeakMap();
     this._resetChosenVideoTracks();
   }

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -364,15 +364,80 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
                                        audioDescription: true } ]);
     player.setPreferredVideoTracks([ { codec: { all: false,
                                                 test: /avc1\.640028/},
-                                       signInterpreted: true }]);
+                                       signInterpreted: true }], false);
     player.setPreferredTextTracks([ { language: "de",
-                                      closedCaption: false } ]);
+                                      closedCaption: false } ], undefined);
     await sleep(100);
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
 
     await goToSecondPeriod();
+    checkAudioTrack("fr", "fra", true);
+    checkTextTrack("de", "deu", false);
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+  });
+
+  it("should not update the previous tracks for non-applied preferences", async () => {
+    await loadContent();
+    await sleep(100);
+    checkAudioTrack("de", "deu", false);
+    checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+
+    await goToSecondPeriod();
+    player.setPreferredAudioTracks([ { language: "fr",
+                                       audioDescription: true } ]);
+    player.setPreferredVideoTracks([ { codec: { all: false,
+                                                test: /avc1\.640028/},
+                                       signInterpreted: true }], false);
+    player.setPreferredTextTracks([ { language: "de",
+                                      closedCaption: false } ], undefined);
+    await sleep(100);
+    await goToFirstPeriod();
+    checkAudioTrack("de", "deu", false);
+    checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+  });
+
+  it("should update the current tracks for applied preferences", async () => {
+    await loadContent();
+    player.setPreferredAudioTracks([ { language: "fr",
+                                       audioDescription: true } ], true);
+    player.setPreferredVideoTracks([ { codec: { all: false,
+                                                test: /avc1\.640028/},
+                                       signInterpreted: true }], true);
+    player.setPreferredTextTracks([ { language: "de",
+                                      closedCaption: false } ], true);
+    await sleep(100);
+    checkAudioTrack("fr", "fra", true);
+    checkTextTrack("de", "deu", false);
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+
+    await goToSecondPeriod();
+    checkAudioTrack("fr", "fra", true);
+    checkTextTrack("de", "deu", false);
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+  });
+
+  it("should update the previous tracks for applied preferences", async () => {
+    await loadContent();
+    await sleep(100);
+    checkAudioTrack("de", "deu", false);
+    checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+
+    await goToSecondPeriod();
+    player.setPreferredAudioTracks([ { language: "fr",
+                                       audioDescription: true } ], true);
+    player.setPreferredVideoTracks([ { codec: { all: false,
+                                                test: /avc1\.640028/},
+                                       signInterpreted: true }], true);
+    player.setPreferredTextTracks([ { language: "de",
+                                      closedCaption: false } ], true);
+    await sleep(100);
+    await goToFirstPeriod();
+    await sleep(100);
     checkAudioTrack("fr", "fra", true);
     checkTextTrack("de", "deu", false);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);


### PR DESCRIPTION
# Allow to "apply" track preferences to loaded Periods

## The current track APIs

This PR allows the RxPlayer to fill what I would call a hole in our APIs related to track management.

We have `set{Audio,Video,Text}Track` which allow to select a specific track but those only set the track for the current Period and have no influence on the potential other ones. This was done because you might not find the exact same tracks in other Periods.

`disable{Video,Text}Track` work the same way. Here we could just choose to disable that track for every Periods but we chose to stay coherent with the setters APIs.

When you want to influence the tracks from other Periods, you have to use the track preference APIs (like `setPreferred{Audio,Video,Text}Tracks`). However here we have the reverse problem.

Those APIs won't update the choices for Periods that have either been already played or the one currently playing (technically it won't impact "already loaded" periods so we're even talking about future Periods that are pre-loading here).

The reason behind that behavior if that when you already played a content, you might want to retrieve the exact same track when you seek back to it, even if your preferences changed in the meantime.

## The problem

But now comes a problem. What if you want to, let's say, switch to audio-only for a whole multi-Period content?

You could both call `disableVideoTrack` and then `setPreferredVideoTracks([null])` and you would be pretty close, but we will still have an active video track for already loaded Periods which are not the currently playing one.

The recommended solution (written in the API documentation) for now for those kind of use cases is to either:
  - call the setter/disable API on `periodChange` events (so here, call `disableVideoTrack` each time a `periodChange` is received)
  - setting it as a preference and reload the content

The second option is pretty bad as we would be reloading the content from scratch and this will lead to a visible interruption for the user.

But even the first option is not ideal:

  - the application has to add an event listener (and its corresponding disposing logic), which is never fun and harder to reason about than just calling a simple method directly

  - we could potentially have pre-loaded unwanted segments (when pre-loading that Period) before switching to that Period

  - when speaking about `disableVideoTrack` specifically, under the current code, we might need to reload two times in a row the MediaSource:
       1. Once when switching the Period and emitting the periodChange event, when we think that we need a video track
       2. A second time when the application actually calls `disableVideoTrack`.
   
    For that case specifically, we could ensure that no reload are performed before the `periodChange` event is sent, but I don't really know if that behavior would make more sense.

## The Solution

We thought about making the setters APIs (`set{Audio,Video,Text}Track` and `disable{Video,Text}Track`) more powerful by adding the possibility to set track for other Periods.

But doing that would mean that the application has to know about every Periods in the current content. This is not straightforward because the list of Periods can change over time (in a live content for example).

This may also be to complicated for a regular user, setting and applying a preferred track should be an accessible API as it corresponds to an often constated use case.

So we finally decided to add another - optional - argument to the `setPreferred{Audio,Video,Text}Tracks` APIs.
This new argument is a boolean which should be set to `true` if you want to apply the preferences to the already-loaded Periods.

The API documentation is not updated yet but I think we could describe setting this option to `true` as "applying the preference to the current content" which is really easy to understand.

That way, true audio-only mode could be implemented by doing:
```js
rxPlayer.setPreferredVideoTracks([null], true);
```
Which might not be really straightforward, but - if well explained in the `disableVideoTrack` API documentation - should still be simple enough.

## A downside to that solution

This solution has still what I consider a big downside.  

Let's say you want to choose a specific audio track for the current period and you want that choice influence languages of any other Periods.

What we would immediately think of is to first call `setAudioTrack` with the wanted track's id and then `setPreferredAudioTrack([/* ... */], true]);` with the wanted languages.

But doing that would overwrite our choice for the currently playing Period. We have to call `setAudioTrack` after calling `setPreferredAudioTrack` to avoid that, which can seem less logical.

Anyway, this is a low enough concern for me, so I decided to still implement that solution.