### PR TITLE
Misc/eme better caching policy

### DIFF
--- a/src/core/eme/get_session.ts
+++ b/src/core/eme/get_session.ts
@@ -133,7 +133,7 @@ export default function getSession(
                                 null = null;
 
     const { loadedSessionsStore } = mediaKeysInfos;
-    const entry = loadedSessionsStore.get(initData, initDataType);
+    const entry = loadedSessionsStore.getAndReuse(initData, initDataType);
     if (entry !== null) {
       previousLoadedSession = entry.mediaKeySession;
       if (isSessionUsable(previousLoadedSession)) {

--- a/src/core/eme/utils/init_data_store.ts
+++ b/src/core/eme/utils/init_data_store.ts
@@ -181,7 +181,9 @@ export default class InitDataStore<T> {
     initDataType : string|undefined,
     initDataHash : number
   ) : number {
-    for (let i = 0; i < this._storage.length; i++) {
+    // Begin by the last element as we usually re-encounter the last stored
+    // initData sooner than the first one.
+    for (let i = this._storage.length - 1; i >= 0; i++) {
       const stored = this._storage[i];
       if (initDataHash === stored.initDataHash && initDataType === stored.initDataType) {
         if (areArraysOfNumbersEqual(initData, stored.initData)) {

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -105,6 +105,28 @@ export default class LoadedSessionsStore {
   }
 
   /**
+   * Like `get` but also moves the corresponding MediaKeySession to the end of
+   * its internal storage, as returned by the `getAll` method.
+   *
+   * This can be used for example to tell when a previously-stored
+   * MediaKeySession is re-used to then be able to implement a caching
+   * replacement algorithm based on the least-recently-used values by just
+   * evicting the first values returned by `getAll`.
+   * @param {Uint8Array} initData
+   * @param {string|undefined} initDataType
+   * @returns {Object|null}
+   */
+  public getAndReuse(
+    initData : Uint8Array,
+    initDataType: string|undefined
+  ) : IStoredSessionData | null {
+    const entry = this._storage.getAndReuse(initData, initDataType);
+    return entry === undefined ? null :
+                                 { mediaKeySession: entry.mediaKeySession,
+                                   sessionType: entry.sessionType };
+  }
+
+  /**
    * Create a new MediaKeySession and store it in this store.
    * @throws {EncryptedMediaError}
    * @param {Uint8Array} initData


### PR DESCRIPTION
This PR contains two simple improvements.

## LoadedSessionStore goes from a FIFO cache to a Least-Recently-Used one instead

In the  `LoadedSessionStore` (which caches previously-created MediaKeySession to avoid too many calls to the license server when zapping between the same contents), the previous cache replacement policy was to replace the MediaKeySession initially created at the earliest time (in a FIFO manner). It would actually make more sense here to replace the least recently used instead.

For example, if a MediaKeySession created long ago is re-used before reaching the cache limit, we don't want to remove its entry from the LoadedSessionsStore before those linked to contents it played just before it - just because its creation time was before.

More simply put, we could say that our replacement policy is now based on the oldest usage time, whereas it was previously based on the oldest creation time.

As a side-note, the previous cache replacement policy was the main reason why our "multiple keys  per content bug" we fixed in v3.20.1 was more of an issue that we initially thought.
Because until now we could encounter it just by zapping through different contents enough time.
With an LRU cache, the only way we could encounter that bug would be to have 50 MediaKeySession in the same content, which is a much rarer case.

--

I implemented that feature by just adding a `getAndReuse`method to the `LoadedSessionsStore` (and its corresponding `InitDataStore` method) so that it can be called instead of just `get` when the goal  is to reuse the MediaKeySession. This method returns the stored value but also re-organize the store to move it at the end behind the scene.
By being sufficiently clear in the documentation, I hope that this does not add too much cognitive load when using the `LoadedSessionsStore`.

## Perform initData lookup from the last encountered one instead of the first one

When wanting to look for a value stored thanks to the `InitDataStore`, we previously went into every stored values from first to last.
However for most initData-related usecases, it is generally more efficient to begin from the last entry to the first one.

For example, when zapping between two live encrypted channels, you generally will only encounter the last two initData consecutively. Re-browsing through the first stored data would just be wasteful here.
This might however not be better for all use cases, but it is still a saner default.

