### PR TITLE
misc/emit warning events after parsing an invalid MPD

### DIFF
--- a/src/parsers/manifest/dash/get_http_utc-timing_url.ts
+++ b/src/parsers/manifest/dash/get_http_utc-timing_url.ts
@@ -29,9 +29,9 @@ export default function getHTTPUTCTimingURL(
       value : string;
     } =>
       utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-iso:2014" &&
-      utcTiming.value != null
+      utcTiming.value !== undefined
     );
 
-  return UTCTimingHTTP.length > 0 ?
-    UTCTimingHTTP[0].value : undefined;
+  return UTCTimingHTTP.length > 0 ? UTCTimingHTTP[0].value :
+                                    undefined;
 }

--- a/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
@@ -244,7 +244,9 @@ function parseAdaptationSetAttributes(
         break;
 
       case "group":
-        parseValue("group", attribute.value, parseMPDInteger, "group");
+        parseValue(attribute.value, { asKey: "group",
+                                      parser: parseMPDInteger,
+                                      dashName: "group" });
         break;
 
       case "lang":
@@ -260,27 +262,39 @@ function parseAdaptationSetAttributes(
         break;
 
       case "minBandwidth":
-        parseValue("minBitrate", attribute.value, parseMPDInteger, "minBandwidth");
+        parseValue(attribute.value, { asKey: "minBitrate",
+                                      parser: parseMPDInteger,
+                                      dashName: "minBandwidth" });
         break;
 
       case "maxBandwidth":
-        parseValue("maxBitrate", attribute.value, parseMPDInteger, "maxBandwidth");
+        parseValue(attribute.value, { asKey: "maxBitrate",
+                                      parser: parseMPDInteger,
+                                      dashName: "maxBandwidth" });
         break;
 
       case "minWidth":
-        parseValue("minWidth", attribute.value, parseMPDInteger, "minWidth");
+        parseValue(attribute.value, { asKey: "minWidth",
+                                      parser: parseMPDInteger,
+                                      dashName: "minWidth" });
         break;
 
       case "maxWidth":
-        parseValue("maxWidth", attribute.value, parseMPDInteger, "maxWidth");
+        parseValue(attribute.value, { asKey: "maxWidth",
+                                      parser: parseMPDInteger,
+                                      dashName: "maxWidth" });
         break;
 
       case "minHeight":
-        parseValue("minHeight", attribute.value, parseMPDInteger, "minHeight");
+        parseValue(attribute.value, { asKey: "minHeight",
+                                      parser: parseMPDInteger,
+                                      dashName: "minHeight" });
         break;
 
       case "maxHeight":
-        parseValue("maxHeight", attribute.value, parseMPDInteger, "maxHeight");
+        parseValue(attribute.value, { asKey: "maxHeight",
+                                      parser: parseMPDInteger,
+                                      dashName: "maxHeight" });
         break;
 
       case "minFrameRate": {
@@ -293,24 +307,21 @@ function parseAdaptationSetAttributes(
         break;
 
       case "segmentAlignment":
-        parseValue("segmentAlignment",
-                   attribute.value,
-                   parseIntOrBoolean,
-                   "segmentAlignment");
+        parseValue(attribute.value, { asKey: "segmentAlignment",
+                                      parser: parseIntOrBoolean,
+                                      dashName: "segmentAlignment" });
         break;
 
       case "subsegmentAlignment":
-        parseValue("subsegmentAlignment",
-                   attribute.value,
-                   parseIntOrBoolean,
-                   "subsegmentAlignment");
+        parseValue(attribute.value, { asKey: "subsegmentAlignment",
+                                      parser: parseIntOrBoolean,
+                                      dashName: "subsegmentAlignment" });
         break;
 
       case "bitstreamSwitching":
-        parseValue("bitstreamSwitching",
-                   attribute.value,
-                   parseBoolean,
-                   "bitstreamSwitching");
+        parseValue(attribute.value, { asKey: "bitstreamSwitching",
+                                      parser: parseBoolean,
+                                      dashName: "bitstreamSwitching" });
         break;
 
       case "audioSamplingRate":
@@ -322,7 +333,9 @@ function parseAdaptationSetAttributes(
         break;
 
       case "codingDependency":
-        parseValue("codingDependency", attribute.value, parseBoolean, "codingDependency");
+        parseValue(attribute.value, { asKey: "codingDependency",
+          parser: parseBoolean,
+          dashName: "codingDependency" });
         break;
 
       case "frameRate":
@@ -330,21 +343,21 @@ function parseAdaptationSetAttributes(
         break;
 
       case "height":
-        parseValue("height", attribute.value, parseMPDInteger, "height");
+        parseValue(attribute.value, { asKey: "height",
+                                      parser: parseMPDInteger,
+                                      dashName: "height" });
         break;
 
       case "maxPlayoutRate":
-        parseValue("maxPlayoutRate",
-                   attribute.value,
-                   parseMPDFloat,
-                   "maxPlayoutRate");
+        parseValue(attribute.value, { asKey: "maxPlayoutRate",
+                                      parser: parseMPDFloat,
+                                      dashName: "maxPlayoutRate" });
         break;
 
       case "maximumSAPPeriod":
-        parseValue("maximumSAPPeriod",
-                   attribute.value,
-                   parseMPDFloat,
-                   "maximumSAPPeriod");
+        parseValue(attribute.value, { asKey: "maximumSAPPeriod",
+                                      parser: parseMPDFloat,
+                                      dashName: "maximumSAPPeriod" });
         break;
 
       case "mimeType":
@@ -360,7 +373,9 @@ function parseAdaptationSetAttributes(
         break;
 
       case "width":
-        parseValue("width", attribute.value, parseMPDInteger, "width");
+        parseValue(attribute.value, { asKey: "width",
+                                      parser: parseMPDInteger,
+                                      dashName: "width" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/BaseURL.ts
+++ b/src/parsers/manifest/dash/node_parsers/BaseURL.ts
@@ -56,10 +56,9 @@ export default function parseBaseURL(
         if (attribute.value === "INF") {
           attributes.availabilityTimeOffset = Infinity;
         } else {
-          parseValue("availabilityTimeOffset",
-                     attribute.value,
-                     parseMPDInteger,
-                     "availabilityTimeOffset");
+          parseValue(attribute.value, { asKey: "availabilityTimeOffset",
+                                        parser: parseMPDInteger,
+                                        dashName: "availabilityTimeOffset" });
         }
         break;
     }

--- a/src/parsers/manifest/dash/node_parsers/ContentComponent.ts
+++ b/src/parsers/manifest/dash/node_parsers/ContentComponent.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/** The ContentComponent once parsed. */
 export interface IParsedContentComponent {
   id?: string;
   language?: string;

--- a/src/parsers/manifest/dash/node_parsers/ContentProtection.ts
+++ b/src/parsers/manifest/dash/node_parsers/ContentProtection.ts
@@ -56,7 +56,6 @@ function parseContentProtectionChildren(
 }
 
 /**
- * Parse the "ContentProtection" node of a MPD.
  * @param {Element} root
  * @returns {Object}
  */

--- a/src/parsers/manifest/dash/node_parsers/Initialization.ts
+++ b/src/parsers/manifest/dash/node_parsers/Initialization.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import log from "../../../../log";
-import { parseByteRange } from "./utils";
+import {
+  parseByteRange,
+  ValueParser,
+} from "./utils";
 
 export interface IParsedInitialization {
   range?: [number, number];
@@ -25,21 +27,19 @@ export interface IParsedInitialization {
 
 /**
  * @param {Element} root
- * @returns {Object}
+ * @returns {Array.<Object>}
  */
-export default function parseInitialization(root: Element) : IParsedInitialization {
+export default function parseInitialization(
+  root: Element
+) : [IParsedInitialization, Error[]] {
   const parsedInitialization : IParsedInitialization = {};
+  const warnings : Error[] = [];
+  const parseValue = ValueParser(parsedInitialization, warnings);
   for (let i = 0; i < root.attributes.length; i++) {
     const attribute = root.attributes[i];
     switch (attribute.name) {
-      case "range": {
-        const range = parseByteRange(attribute.value);
-        if (range == null) {
-          log.warn(`DASH: invalid range ("${attribute.value}")`);
-        } else {
-          parsedInitialization.range = range;
-        }
-      }
+      case "range":
+        parseValue("range", attribute.value, parseByteRange, "range");
         break;
 
       case "sourceURL":
@@ -47,5 +47,5 @@ export default function parseInitialization(root: Element) : IParsedInitializati
         break;
     }
   }
-  return parsedInitialization;
+  return [parsedInitialization, warnings];
 }

--- a/src/parsers/manifest/dash/node_parsers/Initialization.ts
+++ b/src/parsers/manifest/dash/node_parsers/Initialization.ts
@@ -39,7 +39,9 @@ export default function parseInitialization(
     const attribute = root.attributes[i];
     switch (attribute.name) {
       case "range":
-        parseValue("range", attribute.value, parseByteRange, "range");
+        parseValue(attribute.value, { asKey: "range",
+                                      parser: parseByteRange,
+                                      dashName: "range" });
         break;
 
       case "sourceURL":

--- a/src/parsers/manifest/dash/node_parsers/MPD.ts
+++ b/src/parsers/manifest/dash/node_parsers/MPD.ts
@@ -26,6 +26,7 @@ import {
   parseDateTime,
   parseDuration,
   parseScheme,
+  ValueParser,
 } from "./utils";
 
 export interface IMPDIntermediateRepresentation { children : IMPDChildren;
@@ -61,24 +62,29 @@ export interface IMPDAttributes {
 /**
  * Parse children of the MPD's root into a simple object.
  * @param {NodeList} mpdChildren
- * @returns {Object}
+ * @returns {Array.<Object>}
  */
-function parseMPDChildren(mpdChildren : NodeList) : IMPDChildren {
+function parseMPDChildren(
+  mpdChildren : NodeList
+) : [IMPDChildren, Error[]] {
   const baseURLs : IBaseURL[] = [];
   const locations : string[] = [];
   const periods : IPeriodIntermediateRepresentation[] = [];
   const utcTimings : IScheme[] = [];
 
+  let warnings : Error[] = [];
   for (let i = 0; i < mpdChildren.length; i++) {
     if (mpdChildren[i].nodeType === Node.ELEMENT_NODE) {
       const currentNode = mpdChildren[i] as Element;
       switch (currentNode.nodeName) {
 
         case "BaseURL":
-          const baseURLObj = parseBaseURL(currentNode);
+          const [ baseURLObj,
+                  baseURLWarnings ] = parseBaseURL(currentNode);
           if (baseURLObj !== undefined) {
             baseURLs.push(baseURLObj);
           }
+          warnings = warnings.concat(baseURLWarnings);
           break;
 
         case "Location":
@@ -88,9 +94,10 @@ function parseMPDChildren(mpdChildren : NodeList) : IMPDChildren {
           break;
 
         case "Period":
-          const period =
+          const [period, periodWarnings] =
             createPeriodIntermediateRepresentation(currentNode);
           periods.push(period);
+          warnings = warnings.concat(periodWarnings);
           break;
 
         case "UTCTiming":
@@ -101,15 +108,19 @@ function parseMPDChildren(mpdChildren : NodeList) : IMPDChildren {
     }
   }
 
-  return { baseURLs, locations, periods, utcTimings };
+  return [ { baseURLs, locations, periods, utcTimings },
+           warnings ];
 }
 
 /**
  * @param {Element} root
- * @returns {Object}
+ * @returns {Array.<Object>}
  */
-function parseMPDAttributes(root : Element) : IMPDAttributes {
+function parseMPDAttributes(root : Element) : [IMPDAttributes, Error[]] {
   const res : IMPDAttributes = {};
+  const warnings : Error[] = [];
+  const parseValue = ValueParser(res, warnings);
+
   for (let i = 0; i < root.attributes.length; i++) {
     const attribute = root.attributes[i];
 
@@ -123,44 +134,81 @@ function parseMPDAttributes(root : Element) : IMPDAttributes {
       case "type":
         res.type = attribute.value;
         break;
+
       case "availabilityStartTime":
-        res.availabilityStartTime = parseDateTime(attribute.value);
+        parseValue("availabilityStartTime",
+                   attribute.value,
+                   parseDateTime,
+                   "availabilityStartTime");
         break;
       case "availabilityEndTime":
-        res.availabilityEndTime = parseDateTime(attribute.value);
+        parseValue("availabilityEndTime",
+                   attribute.value,
+                   parseDateTime,
+                   "availabilityEndTime");
         break;
       case "publishTime":
-        res.publishTime = parseDateTime(attribute.value);
+        parseValue("publishTime",
+                   attribute.value,
+                   parseDateTime,
+                   "publishTime");
         break;
       case "mediaPresentationDuration":
-        res.duration = parseDuration(attribute.value);
+        parseValue("duration",
+                   attribute.value,
+                   parseDuration,
+                   "mediaPresentationDuration");
         break;
       case "minimumUpdatePeriod":
-        res.minimumUpdatePeriod = parseDuration(attribute.value);
+        parseValue("minimumUpdatePeriod",
+                   attribute.value,
+                   parseDuration,
+                   "minimumUpdatePeriod");
         break;
       case "minBufferTime":
-        res.minBufferTime = parseDuration(attribute.value);
+        parseValue("minBufferTime",
+                   attribute.value,
+                   parseDuration,
+                   "minBufferTime");
         break;
       case "timeShiftBufferDepth":
-        res.timeShiftBufferDepth = parseDuration(attribute.value);
+        parseValue("timeShiftBufferDepth",
+                   attribute.value,
+                   parseDuration,
+                   "timeShiftBufferDepth");
         break;
       case "suggestedPresentationDelay":
-        res.suggestedPresentationDelay = parseDuration(attribute.value);
+        parseValue("suggestedPresentationDelay",
+                   attribute.value,
+                   parseDuration,
+                   "suggestedPresentationDelay");
         break;
       case "maxSegmentDuration":
-        res.maxSegmentDuration = parseDuration(attribute.value);
+        parseValue("maxSegmentDuration",
+                   attribute.value,
+                   parseDuration,
+                   "maxSegmentDuration");
         break;
       case "maxSubsegmentDuration":
-        res.maxSubsegmentDuration = parseDuration(attribute.value);
+        parseValue("maxSubsegmentDuration",
+                   attribute.value,
+                   parseDuration,
+                   "maxSubsegmentDuration");
         break;
     }
   }
-  return res;
+  return [res, warnings];
 }
 
+/**
+ * @param {Element} root
+ * @returns {Array.<Object>}
+ */
 export function createMPDIntermediateRepresentation(
   root : Element
-) : IMPDIntermediateRepresentation {
-  return { children: parseMPDChildren(root.childNodes),
-           attributes: parseMPDAttributes(root) };
+) : [IMPDIntermediateRepresentation, Error[]] {
+  const [ children, childrenWarnings ] = parseMPDChildren(root.childNodes);
+  const [ attributes, attrsWarnings ] = parseMPDAttributes(root);
+  const warnings = childrenWarnings.concat(attrsWarnings);
+  return [{ children, attributes }, warnings];
 }

--- a/src/parsers/manifest/dash/node_parsers/MPD.ts
+++ b/src/parsers/manifest/dash/node_parsers/MPD.ts
@@ -136,64 +136,54 @@ function parseMPDAttributes(root : Element) : [IMPDAttributes, Error[]] {
         break;
 
       case "availabilityStartTime":
-        parseValue("availabilityStartTime",
-                   attribute.value,
-                   parseDateTime,
-                   "availabilityStartTime");
+        parseValue(attribute.value, { asKey: "availabilityStartTime",
+                                      parser: parseDateTime,
+                                      dashName: "availabilityStartTime" });
         break;
       case "availabilityEndTime":
-        parseValue("availabilityEndTime",
-                   attribute.value,
-                   parseDateTime,
-                   "availabilityEndTime");
+        parseValue(attribute.value, { asKey: "availabilityEndTime",
+                                      parser: parseDateTime,
+                                      dashName: "availabilityEndTime" });
         break;
       case "publishTime":
-        parseValue("publishTime",
-                   attribute.value,
-                   parseDateTime,
-                   "publishTime");
+        parseValue(attribute.value, { asKey: "publishTime",
+                                      parser: parseDateTime,
+                                      dashName: "publishTime" });
         break;
       case "mediaPresentationDuration":
-        parseValue("duration",
-                   attribute.value,
-                   parseDuration,
-                   "mediaPresentationDuration");
+        parseValue(attribute.value, { asKey: "duration",
+                                      parser: parseDuration,
+                                      dashName: "mediaPresentationDuration" });
         break;
       case "minimumUpdatePeriod":
-        parseValue("minimumUpdatePeriod",
-                   attribute.value,
-                   parseDuration,
-                   "minimumUpdatePeriod");
+        parseValue(attribute.value, { asKey: "minimumUpdatePeriod",
+                                      parser: parseDuration,
+                                      dashName: "minimumUpdatePeriod" });
         break;
       case "minBufferTime":
-        parseValue("minBufferTime",
-                   attribute.value,
-                   parseDuration,
-                   "minBufferTime");
+        parseValue(attribute.value, { asKey: "minBufferTime",
+                                      parser: parseDuration,
+                                      dashName: "minBufferTime" });
         break;
       case "timeShiftBufferDepth":
-        parseValue("timeShiftBufferDepth",
-                   attribute.value,
-                   parseDuration,
-                   "timeShiftBufferDepth");
+        parseValue(attribute.value, { asKey: "timeShiftBufferDepth",
+                                      parser: parseDuration,
+                                      dashName: "timeShiftBufferDepth" });
         break;
       case "suggestedPresentationDelay":
-        parseValue("suggestedPresentationDelay",
-                   attribute.value,
-                   parseDuration,
-                   "suggestedPresentationDelay");
+        parseValue(attribute.value, { asKey: "suggestedPresentationDelay",
+                                      parser: parseDuration,
+                                      dashName: "suggestedPresentationDelay" });
         break;
       case "maxSegmentDuration":
-        parseValue("maxSegmentDuration",
-                   attribute.value,
-                   parseDuration,
-                   "maxSegmentDuration");
+        parseValue(attribute.value, { asKey: "maxSegmentDuration",
+                                      parser: parseDuration,
+                                      dashName: "maxSegmentDuration" });
         break;
       case "maxSubsegmentDuration":
-        parseValue("maxSubsegmentDuration",
-                   attribute.value,
-                   parseDuration,
-                   "maxSubsegmentDuration");
+        parseValue(attribute.value, { asKey: "maxSubsegmentDuration",
+                                      parser: parseDuration,
+                                      dashName: "maxSubsegmentDuration" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/Period.ts
+++ b/src/parsers/manifest/dash/node_parsers/Period.ts
@@ -104,15 +104,21 @@ function parsePeriodAttributes(periodElement : Element) : [IPeriodAttributes, Er
         break;
 
       case "start":
-        parseValue("start", attr.value, parseDuration, "start");
+        parseValue(attr.value, { asKey: "start",
+                                      parser: parseDuration,
+                                      dashName: "start" });
         break;
 
       case "duration":
-        parseValue("duration", attr.value, parseDuration, "duration");
+        parseValue(attr.value, { asKey: "duration",
+                                      parser: parseDuration,
+                                      dashName: "duration" });
         break;
 
       case "bitstreamSwitching":
-        parseValue("bitstreamSwitching", attr.value, parseBoolean, "bitstreamSwitching");
+        parseValue(attr.value, { asKey: "bitstreamSwitching",
+                                      parser: parseBoolean,
+                                      dashName: "bitstreamSwitching" });
         break;
 
       case "xlink:href":

--- a/src/parsers/manifest/dash/node_parsers/Representation.ts
+++ b/src/parsers/manifest/dash/node_parsers/Representation.ts
@@ -136,7 +136,9 @@ function parseRepresentationAttributes(
         break;
 
       case "bandwidth":
-        parseValue("bitrate", attr.value, parseMPDInteger, "bandwidth");
+        parseValue(attr.value, { asKey: "bitrate",
+                                      parser: parseMPDInteger,
+                                      dashName: "bandwidth" });
         break;
 
       case "codecs":
@@ -144,10 +146,9 @@ function parseRepresentationAttributes(
         break;
 
       case "codingDependency":
-        parseValue("codingDependency",
-                   attr.value,
-                   parseBoolean,
-                   "codingDependency");
+        parseValue(attr.value, { asKey: "codingDependency",
+                                      parser: parseBoolean,
+                                      dashName: "codingDependency" });
         break;
 
       case "frameRate":
@@ -155,7 +156,9 @@ function parseRepresentationAttributes(
         break;
 
       case "height":
-        parseValue("height", attr.value, parseMPDInteger, "height");
+        parseValue(attr.value, { asKey: "height",
+                                      parser: parseMPDInteger,
+                                      dashName: "height" });
         break;
 
       case "id":
@@ -163,17 +166,15 @@ function parseRepresentationAttributes(
         break;
 
       case "maxPlayoutRate":
-        parseValue("maxPlayoutRate",
-                   attr.value,
-                   parseMPDFloat,
-                   "maxPlayoutRate");
+        parseValue(attr.value, { asKey: "maxPlayoutRate",
+                                      parser: parseMPDFloat,
+                                      dashName: "maxPlayoutRate" });
         break;
 
       case "maximumSAPPeriod":
-        parseValue("maximumSAPPeriod",
-                   attr.value,
-                   parseMPDFloat,
-                   "maximumSAPPeriod");
+        parseValue(attr.value, { asKey: "maximumSAPPeriod",
+                                      parser: parseMPDFloat,
+                                      dashName: "maximumSAPPeriod" });
         break;
 
       case "mimeType":
@@ -185,10 +186,9 @@ function parseRepresentationAttributes(
         break;
 
       case "qualityRanking":
-        parseValue("qualityRanking",
-                   attr.value,
-                   parseMPDInteger,
-                   "qualityRanking");
+        parseValue(attr.value, { asKey: "qualityRanking",
+                                      parser: parseMPDInteger,
+                                      dashName: "qualityRanking" });
         break;
 
       case "segmentProfiles":
@@ -196,7 +196,9 @@ function parseRepresentationAttributes(
         break;
 
       case "width":
-        parseValue("width", attr.value, parseMPDInteger, "width");
+        parseValue(attr.value, { asKey: "width",
+                                      parser: parseMPDInteger,
+                                      dashName: "width" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/SegmentBase.ts
+++ b/src/parsers/manifest/dash/node_parsers/SegmentBase.ts
@@ -78,47 +78,51 @@ export default function parseSegmentBase(
     const attr = root.attributes[i];
     switch (attr.name) {
       case "timescale":
-        parseValue("timescale", attr.value, parseMPDInteger, "timescale");
+        parseValue(attr.value, { asKey: "timescale",
+                                      parser: parseMPDInteger,
+                                      dashName: "timescale" });
         break;
 
       case "presentationTimeOffset":
-        parseValue("presentationTimeOffset",
-                   attr.value,
-                   parseMPDFloat,
-                   "presentationTimeOffset");
+        parseValue(attr.value, { asKey: "presentationTimeOffset",
+                                      parser: parseMPDFloat,
+                                      dashName: "presentationTimeOffset" });
         break;
 
       case "indexRange":
-        parseValue("indexRange", attr.value, parseByteRange, "indexRange");
+        parseValue(attr.value, { asKey: "indexRange",
+                                      parser: parseByteRange,
+                                      dashName: "indexRange" });
         break;
 
       case "indexRangeExact":
-        parseValue("indexRangeExact",
-                   attr.value,
-                   parseBoolean,
-                   "indexRangeExact");
+        parseValue(attr.value, { asKey: "indexRangeExact",
+                                      parser: parseBoolean,
+                                      dashName: "indexRangeExact" });
         break;
 
       case "availabilityTimeOffset":
-        parseValue("availabilityTimeOffset",
-                   attr.value,
-                   parseMPDFloat,
-                   "availabilityTimeOffset");
+        parseValue(attr.value, { asKey: "availabilityTimeOffset",
+                                      parser: parseMPDFloat,
+                                      dashName: "availabilityTimeOffset" });
         break;
 
       case "availabilityTimeComplete":
-        parseValue("availabilityTimeComplete",
-                   attr.value,
-                   parseBoolean,
-                   "availabilityTimeComplete");
+        parseValue(attr.value, { asKey: "availabilityTimeComplete",
+                                      parser: parseBoolean,
+                                      dashName: "availabilityTimeComplete" });
         break;
 
       case "duration":
-        parseValue("duration", attr.value, parseMPDInteger, "duration");
+        parseValue(attr.value, { asKey: "duration",
+                                      parser: parseMPDInteger,
+                                      dashName: "duration" });
         break;
 
       case "startNumber":
-        parseValue("startNumber", attr.value, parseMPDInteger, "startNumber");
+        parseValue(attr.value, { asKey: "startNumber",
+                                      parser: parseMPDInteger,
+                                      dashName: "startNumber" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/SegmentList.ts
+++ b/src/parsers/manifest/dash/node_parsers/SegmentList.ts
@@ -29,10 +29,14 @@ export interface IParsedSegmentList extends IParsedSegmentBase {
 
 /**
  * @param {Element} root
- * @returns {Object}
+ * @returns {Array}
  */
-export default function parseSegmentList(root: Element) : IParsedSegmentList {
-  const base = parseSegmentBase(root);
+export default function parseSegmentList(
+  root: Element
+) : [IParsedSegmentList, Error[]] {
+  const [base, baseWarnings] = parseSegmentBase(root);
+  let warnings : Error[] = baseWarnings;
+
   const list : IParsedSegmentURL[] = [];
 
   const segmentListChildren = root.childNodes;
@@ -40,8 +44,9 @@ export default function parseSegmentList(root: Element) : IParsedSegmentList {
     if (segmentListChildren[i].nodeType === Node.ELEMENT_NODE) {
       const currentNode = segmentListChildren[i] as Element;
       if (currentNode.nodeName === "SegmentURL") {
-        const segmentURL = parseSegmentURL(currentNode);
+        const [segmentURL, segmentURLWarnings] = parseSegmentURL(currentNode);
         list.push(segmentURL);
+        warnings = warnings.concat(segmentURLWarnings);
       }
     }
   }
@@ -52,8 +57,8 @@ export default function parseSegmentList(root: Element) : IParsedSegmentList {
     throw new Error("Invalid SegmentList: no duration");
   }
 
-  return objectAssign(base, {
-    list,
-    duration: baseDuration, // Ugly but TS is too dumb there
-  });
+  const ret = objectAssign(base, { list,
+                                   // Ugly but TS is too dumb there
+                                   duration: baseDuration });
+  return [ret, warnings];
 }

--- a/src/parsers/manifest/dash/node_parsers/SegmentTemplate.ts
+++ b/src/parsers/manifest/dash/node_parsers/SegmentTemplate.ts
@@ -132,10 +132,9 @@ export default function parseSegmentTemplate(
         if (attribute.value === "INF") {
           ret.availabilityTimeOffset = Infinity;
         }
-        parseValue("availabilityTimeOffset",
-                   attribute.value,
-                   parseMPDInteger,
-                   "availabilityTimeOffset");
+        parseValue(attribute.value, { asKey: "availabilityTimeOffset",
+                                      parser: parseMPDInteger,
+                                      dashName: "availabilityTimeOffset" });
         break;
 
       case "media":
@@ -143,10 +142,9 @@ export default function parseSegmentTemplate(
         break;
 
       case "bitstreamSwitching":
-        parseValue("bitstreamSwitching",
-                   attribute.value,
-                   parseBoolean,
-                   "bitstreamSwitching");
+        parseValue(attribute.value, { asKey: "bitstreamSwitching",
+                                      parser: parseBoolean,
+                                      dashName: "bitstreamSwitching" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/SegmentURL.ts
+++ b/src/parsers/manifest/dash/node_parsers/SegmentURL.ts
@@ -45,7 +45,9 @@ export default function parseSegmentURL(
         break;
 
       case "indexRange":
-        parseValue("indexRange", attribute.value, parseByteRange, "indexRange");
+        parseValue(attribute.value, { asKey: "indexRange",
+                                      parser: parseByteRange,
+                                      dashName: "indexRange" });
         break;
 
       case "index":
@@ -53,7 +55,9 @@ export default function parseSegmentURL(
         break;
 
       case "mediaRange":
-        parseValue("mediaRange", attribute.value, parseByteRange, "mediaRange");
+        parseValue(attribute.value, { asKey: "mediaRange",
+                                      parser: parseByteRange,
+                                      dashName: "mediaRange" });
         break;
     }
   }

--- a/src/parsers/manifest/dash/node_parsers/__tests__/AdaptationSet.test.ts
+++ b/src/parsers/manifest/dash/node_parsers/__tests__/AdaptationSet.test.ts
@@ -18,6 +18,7 @@ import log from "../../../../../log";
 import {
   createAdaptationSetIntermediateRepresentation,
 } from "../AdaptationSet";
+import { MPDError } from "../utils";
 
 function testBooleanAttribute(attributeName : string, variableName? : string) : void {
   const _variableName = variableName == null ? attributeName : variableName;
@@ -30,19 +31,17 @@ function testBooleanAttribute(attributeName : string, variableName? : string) : 
       .parseFromString(`<AdaptationSet ${attributeName}="true" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: true },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: true },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}=\"false\" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: false },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     expect(spyLog).not.toHaveBeenCalled();
     spyLog.mockRestore();
@@ -55,22 +54,26 @@ function testBooleanAttribute(attributeName : string, variableName? : string) : 
     const element1 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="foobar" />`, "text/xml")
       .childNodes[0] as Element;
+    const error1 = new MPDError(
+      `\`${attributeName}\` property is not a boolean value but "foobar"`);
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: false },
+                   children: { baseURLs: [], representations: [] } },
+                 [error1] ]);
+    expect(spyLog).toHaveBeenCalledTimes(1);
+    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="" />`, "text/xml")
       .childNodes[0] as Element;
+    const error2 = new MPDError(
+      `\`${attributeName}\` property is not a boolean value but ""`);
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
-      });
-
-    expect(spyLog).not.toHaveBeenCalled();
+      .toEqual([ { attributes: { [_variableName]: false },
+                   children: { baseURLs: [], representations: [] } },
+                 [error2] ]);
+    expect(spyLog).toHaveBeenCalledTimes(2);
+    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
     spyLog.mockRestore();
   });
 }
@@ -86,19 +89,17 @@ function testStringAttribute(attributeName : string, variableName? : string) : v
       .parseFromString(`<AdaptationSet ${attributeName}="foobar" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: "foobar" },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: "foobar" },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}=\"\" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: "" },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: "" },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
     expect(spyLog).not.toHaveBeenCalled();
     spyLog.mockRestore();
   });
@@ -115,27 +116,26 @@ function testNumberAttribute(attributeName : string, variableName? : string) : v
       .parseFromString(`<AdaptationSet ${attributeName}="012" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: 12 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: 12 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="0" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: 0 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
+
     const element3 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="-50" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element3))
-      .toEqual({
-        attributes: { [_variableName]: -50 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: -50 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
+
     expect(spyLog).not.toHaveBeenCalled();
     spyLog.mockRestore();
   });
@@ -147,36 +147,42 @@ function testNumberAttribute(attributeName : string, variableName? : string) : v
     const element1 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="toto" />`, "text/xml")
       .childNodes[0] as Element;
+    const error1 = new MPDError(
+      `\`${attributeName}\` property is not an integer value but "toto"`);
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error1] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("toto")`);
+    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="PT5M" />`, "text/xml")
       .childNodes[0] as Element;
+    const error2 = new MPDError(
+      `\`${attributeName}\` property is not an integer value but "PT5M"`);
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error2] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("PT5M")`);
+    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
 
     const element3 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="" />`, "text/xml")
       .childNodes[0] as Element;
+    const error3 = new MPDError(
+      `\`${attributeName}\` property is not an integer value but ""`);
 
     expect(createAdaptationSetIntermediateRepresentation(element3))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error3] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("")`);
+    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
     spyLog.mockRestore();
   });
 }
@@ -195,27 +201,26 @@ function testNumberOrBooleanAttribute(
       .parseFromString(`<AdaptationSet ${attributeName}="012" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: 12 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: 12 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="0" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: 0 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
+
     const element3 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="-50" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element3))
-      .toEqual({
-        attributes: { [_variableName]: -50 },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: -50 },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
+
     expect(spyLog).not.toHaveBeenCalled();
     spyLog.mockRestore();
   });
@@ -227,36 +232,42 @@ function testNumberOrBooleanAttribute(
     const element1 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="toto" />`, "text/xml")
       .childNodes[0] as Element;
+    const error1 = new MPDError(
+      `\`${attributeName}\` property is not a boolean nor an integer but "toto"`);
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error1] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("toto")`);
+    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="PT5M" />`, "text/xml")
       .childNodes[0] as Element;
+    const error2 = new MPDError(
+      `\`${attributeName}\` property is not a boolean nor an integer but "PT5M"`);
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error2] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("PT5M")`);
+    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
 
     const element3 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}="" />`, "text/xml")
       .childNodes[0] as Element;
+    const error3 = new MPDError(
+      `\`${attributeName}\` property is not a boolean nor an integer but ""`);
 
     expect(createAdaptationSetIntermediateRepresentation(element3))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [error3] ]);
+
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("")`);
+    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
     spyLog.mockRestore();
   });
 
@@ -268,19 +279,17 @@ function testNumberOrBooleanAttribute(
       .parseFromString(`<AdaptationSet ${attributeName}="true" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: { [_variableName]: true },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: true },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString(`<AdaptationSet ${attributeName}=\"false\" />`, "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: { [_variableName]: false },
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     expect(spyLog).not.toHaveBeenCalled();
     spyLog.mockRestore();
@@ -288,6 +297,7 @@ function testNumberOrBooleanAttribute(
 }
 
 describe("DASH Node Parsers - AdaptationSet", () => {
+
   /* tslint:disable max-line-length */
   it("should correctly parse an AdaptationSet element without attributes nor children", () => {
   /* tslint:enable max-line-length */
@@ -295,11 +305,11 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       .parseFromString("<AdaptationSet />", "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
   });
+
   testStringAttribute("audioSamplingRate");
   testBooleanAttribute("bitstreamSwitching");
   testStringAttribute("codecs");
@@ -333,19 +343,17 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       .parseFromString("<AdaptationSet><BaseURL /></AdaptationSet>", "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
 
     const element2 = new DOMParser()
       .parseFromString("<AdaptationSet><BaseURL></BaseURLs</AdaptationSet>", "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [], representations: [] },
-      });
+      .toEqual([ { attributes: {},
+                   children: { baseURLs: [], representations: [] } },
+                 [] ]);
   });
 
   it("should correctly parse a non-empty baseURLs", () => {
@@ -353,12 +361,15 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       .parseFromString("<AdaptationSet><BaseURL availabilityTimeOffset=\"INF\">a</BaseURL></AdaptationSet>", "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [{ attributes: { availabilityTimeOffset: Infinity },
-                                 value: "a" }],
-                    representations: [] },
-      });
+      .toEqual([
+        {
+          attributes: {},
+          children: { baseURLs: [{ attributes: { availabilityTimeOffset: Infinity },
+                                   value: "a" }],
+                      representations: [] },
+        },
+        [],
+      ]);
 
     const element2 = new DOMParser()
       .parseFromString(
@@ -366,12 +377,15 @@ describe("DASH Node Parsers - AdaptationSet", () => {
         "text/xml"
       ).childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element2))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [{ attributes: { availabilityTimeOffset: 4 },
-                                 value: "foo bar" }],
-                    representations: [] },
-      });
+      .toEqual([
+        {
+          attributes: {},
+          children: { baseURLs: [{ attributes: { availabilityTimeOffset: 4 },
+                                   value: "foo bar" }],
+                      representations: [] },
+        },
+        [],
+      ]);
   });
 
   it("should correctly parse multiple non-empty baseURLs", () => {
@@ -379,15 +393,18 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       .parseFromString("<AdaptationSet><BaseURL availabilityTimeOffset=\"INF\">a</BaseURL><BaseURL availabilityTimeOffset=\"12\">b</BaseURL></AdaptationSet>", "text/xml")
       .childNodes[0] as Element;
     expect(createAdaptationSetIntermediateRepresentation(element1))
-      .toEqual({
-        attributes: {},
-        children: { baseURLs: [
-                                { attributes: { availabilityTimeOffset: Infinity },
-                                  value: "a" },
-                                { attributes: { availabilityTimeOffset: 12 },
-                                  value: "b" },
-                              ],
-                    representations: [] },
-      });
+      .toEqual([
+        {
+          attributes: {},
+          children: { baseURLs: [
+                                  { attributes: { availabilityTimeOffset: Infinity },
+                                    value: "a" },
+                                  { attributes: { availabilityTimeOffset: 12 },
+                                    value: "b" },
+                                ],
+                      representations: [] },
+        },
+        [],
+      ]);
   });
 });

--- a/src/parsers/manifest/dash/node_parsers/__tests__/Initialization.test.ts
+++ b/src/parsers/manifest/dash/node_parsers/__tests__/Initialization.test.ts
@@ -21,172 +21,113 @@ describe("DASH Node Parsers - Initialization", () => {
   });
 
   it("should correctly parse an element with no known attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseInitialization = require("../Initialization").default;
     const element1 = new DOMParser()
       .parseFromString("<Foo />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element1)).toEqual({});
+    expect(parseInitialization(element1)).toEqual([{}, []]);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo test=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element2)).toEqual({});
+    expect(parseInitialization(element2)).toEqual([{}, []]);
 
-    expect(utilsSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with a well-formed `range` attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseInitialization = require("../Initialization").default;
     const element1 = new DOMParser()
-      .parseFromString("<Foo range=\"a\" />", "text/xml")
+      .parseFromString("<Foo range=\"0-1\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element1)).toEqual({ range: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
+    expect(parseInitialization(element1)).toEqual([{ range: [0, 1] }, []]);
 
     const element2 = new DOMParser()
-      .parseFromString("<Foo range=\"\" />", "text/xml")
+      .parseFromString("<Foo range=\"100-1000\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element2)).toEqual({ range: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
+    expect(parseInitialization(element2)).toEqual([{ range: [100, 1000] }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with an incorrect `range` attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => null,
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn").mockImplementation(jest.fn());
 
     const parseInitialization = require("../Initialization").default;
+    const MPDError = require("../utils").MPDError;
     const element1 = new DOMParser()
       .parseFromString("<Foo range=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element1)).toEqual({});
+    const error1 = new MPDError("`range` property has an unrecognized format \"a\"");
+    expect(parseInitialization(element1)).toEqual([{}, [error1]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid range (\"a\")");
+    expect(logSpy).toHaveBeenCalledWith(error1.message);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo range=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element2)).toEqual({});
+    const error2 = new MPDError("`range` property has an unrecognized format \"\"");
+    expect(parseInitialization(element2)).toEqual([{}, [error2]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
     expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid range (\"\")");
+    expect(logSpy).toHaveBeenCalledWith(error2.message);
 
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with a sourceURL attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseInitialization = require("../Initialization").default;
     const element1 = new DOMParser()
       .parseFromString("<Foo sourceURL=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element1)).toEqual({ media: "a" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseInitialization(element1)).toEqual([{ media: "a" }, []]);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo sourceURL=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element2)).toEqual({ media: "" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseInitialization(element2)).toEqual([{ media: "" }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   /* tslint:disable max-line-length */
   it("should correctly parse an element with both a sourceURL and range attributes", () => {
   /* tslint:enable max-line-length */
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseInitialization = require("../Initialization").default;
     const element1 = new DOMParser()
-      .parseFromString("<Foo sourceURL=\"a\" range=\"4\" />", "text/xml")
+      .parseFromString("<Foo sourceURL=\"a\" range=\"4-10\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseInitialization(element1)).toEqual({ media: "a", range: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("4");
+    expect(parseInitialization(element1)).toEqual([ { media: "a", range: [4, 10] },
+                                                    [] ]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 });

--- a/src/parsers/manifest/dash/node_parsers/__tests__/SegmentURL.test.ts
+++ b/src/parsers/manifest/dash/node_parsers/__tests__/SegmentURL.test.ts
@@ -21,255 +21,179 @@ describe("DASH Node Parsers - SegmentURL", () => {
   });
 
   it("should correctly parse an element with no known attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseSegmentURL = require("../SegmentURL").default;
     const element1 = new DOMParser()
       .parseFromString("<Foo />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({});
+    expect(parseSegmentURL(element1)).toEqual([{}, []]);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo test=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({});
+    expect(parseSegmentURL(element2)).toEqual([{}, []]);
 
-    expect(utilsSpy).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   /* tslint:disable max-line-length */
   it("should correctly parse an element with a well-formed `mediaRange` attribute", () => {
   /* tslint:enable max-line-length */
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseSegmentURL = require("../SegmentURL").default;
     const element1 = new DOMParser()
-      .parseFromString("<Foo mediaRange=\"a\" />", "text/xml")
+      .parseFromString("<Foo mediaRange=\"10-100\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({ mediaRange: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
+    expect(parseSegmentURL(element1)).toEqual([{ mediaRange: [10, 100] }, []]);
 
     const element2 = new DOMParser()
-      .parseFromString("<Foo mediaRange=\"\" />", "text/xml")
+      .parseFromString("<Foo mediaRange=\"0-1\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({ mediaRange: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
+    expect(parseSegmentURL(element2)).toEqual([{ mediaRange: [0, 1] }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with an incorrect `mediaRange` attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => null,
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn").mockImplementation(jest.fn());
 
     const parseSegmentURL = require("../SegmentURL").default;
+    const MPDError = require("../utils").MPDError;
     const element1 = new DOMParser()
       .parseFromString("<Foo mediaRange=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({});
+    const error1 = new MPDError(
+      "`mediaRange` property has an unrecognized format \"a\""
+    );
+    expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid mediaRange (\"a\")");
+    expect(logSpy).toHaveBeenCalledWith(error1.message);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo mediaRange=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({});
+    const error2 = new MPDError(
+      "`mediaRange` property has an unrecognized format \"\""
+    );
+    expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
     expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid mediaRange (\"\")");
+    expect(logSpy).toHaveBeenCalledWith(error2.message);
 
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   /* tslint:disable max-line-length */
   it("should correctly parse an element with a well-formed `indexRange` attribute", () => {
   /* tslint:enable max-line-length */
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
     const log = {
       __esModule: true,
       default: { warn: () => null },
     };
-    jest.mock("../utils", () => utils);
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseSegmentURL = require("../SegmentURL").default;
     const element1 = new DOMParser()
-      .parseFromString("<Foo indexRange=\"a\" />", "text/xml")
+      .parseFromString("<Foo indexRange=\"0-100\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({ indexRange: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
+    expect(parseSegmentURL(element1)).toEqual([{ indexRange: [0, 100] }, []]);
 
     const element2 = new DOMParser()
-      .parseFromString("<Foo indexRange=\"\" />", "text/xml")
+      .parseFromString("<Foo indexRange=\"72-47\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({ indexRange: [0, 1] });
-
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
+    expect(parseSegmentURL(element2)).toEqual([{ indexRange: [72, 47] }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with an incorrect `indexRange` attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => null,
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn").mockImplementation(jest.fn());
 
     const parseSegmentURL = require("../SegmentURL").default;
+    const MPDError = require("../utils").MPDError;
     const element1 = new DOMParser()
       .parseFromString("<Foo indexRange=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({});
+    const error1 = new MPDError(
+      "`indexRange` property has an unrecognized format \"a\""
+    );
+    expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(1);
-    expect(utilsSpy).toHaveBeenCalledWith("a");
     expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid indexRange (\"a\")");
+    expect(logSpy).toHaveBeenCalledWith(error1.message);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo indexRange=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({});
+    const error2 = new MPDError(
+      "`indexRange` property has an unrecognized format \"\""
+    );
+    expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
 
-    expect(utilsSpy).toHaveBeenCalledTimes(2);
-    expect(utilsSpy).toHaveBeenCalledWith("");
     expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenCalledWith("DASH: invalid indexRange (\"\")");
+    expect(logSpy).toHaveBeenCalledWith(error2.message);
 
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with a media attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseSegmentURL = require("../SegmentURL").default;
     const element1 = new DOMParser()
       .parseFromString("<Foo media=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({ media: "a" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseSegmentURL(element1)).toEqual([{ media: "a" }, []]);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo media=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({ media: "" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseSegmentURL(element2)).toEqual([{ media: "" }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 
   it("should correctly parse an element with a index attribute", () => {
-    const utils = {
-      __esModule: true,
-      parseByteRange: () => [0, 1],
-    };
-    const log = {
-      __esModule: true,
-      default: { warn: () => null },
-    };
-    jest.mock("../utils", () => utils);
+    const log = { __esModule: true,
+                  default: { warn: () => null } };
     jest.mock("../../../../../log", () => log);
-    const utilsSpy = jest.spyOn(utils, "parseByteRange");
     const logSpy = jest.spyOn(log.default, "warn");
 
     const parseSegmentURL = require("../SegmentURL").default;
     const element1 = new DOMParser()
       .parseFromString("<Foo index=\"a\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element1)).toEqual({ index: "a" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseSegmentURL(element1)).toEqual([{ index: "a" }, []]);
 
     const element2 = new DOMParser()
       .parseFromString("<Foo index=\"\" />", "text/xml")
       .childNodes[0] as Element;
-    expect(parseSegmentURL(element2)).toEqual({ index: "" });
-
-    expect(utilsSpy).not.toHaveBeenCalled();
+    expect(parseSegmentURL(element2)).toEqual([{ index: "" }, []]);
 
     expect(logSpy).not.toHaveBeenCalled();
-    utilsSpy.mockRestore();
     logSpy.mockRestore();
   });
 });

--- a/src/parsers/manifest/dash/node_parsers/__tests__/utils.test.ts
+++ b/src/parsers/manifest/dash/node_parsers/__tests__/utils.test.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  MPDError,
   parseBoolean,
   parseByteRange,
   parseDateTime,
@@ -27,102 +28,139 @@ describe("dash parser helpers", function() {
 
   describe("parseBoolean", () => {
     it("should return true if value is \"true\"", () => {
-      expect(parseBoolean("true")).toEqual(true);
+      expect(parseBoolean("true", "toto")).toEqual([true, null]);
     });
 
     it("should return false if value is \"false\"", () => {
-      expect(parseBoolean("false")).toEqual(false);
+      expect(parseBoolean("false", "titi")).toEqual([false, null]);
     });
 
-    it("should return false for any other value", () => {
-      expect(parseBoolean("")).toEqual(false);
-      expect(parseBoolean("foo")).toEqual(false);
+    it("should return false for and an error any other value", () => {
+      const parsed1 = parseBoolean("", "ab");
+      const parsed2 = parseBoolean("foo", "ba");
+      expect(parsed1[0]).toEqual(false);
+      expect(parsed2[0]).toEqual(false);
+      expect(parsed1[1]).toBeInstanceOf(MPDError);
+      expect(parsed2[1]).toBeInstanceOf(MPDError);
+      expect(parsed1[1]?.message).toEqual(
+        "`ab` property is not a boolean value but \"\"");
+      expect(parsed2[1]?.message).toEqual(
+        "`ba` property is not a boolean value but \"foo\"");
     });
   });
 
   describe("parseIntOrBoolean", () => {
     it("should return true if value is \"true\"", () => {
-      expect(parseIntOrBoolean("true")).toEqual(true);
+      expect(parseIntOrBoolean("true", "toto")).toEqual([true, null]);
     });
 
     it("should return false if value is \"false\"", () => {
-      expect(parseIntOrBoolean("false")).toEqual(false);
+      expect(parseIntOrBoolean("false", "toto")).toEqual([false, null]);
     });
 
     it("should return a number for any number", () => {
-      expect(parseIntOrBoolean("0")).toEqual(0);
-      expect(parseIntOrBoolean("10")).toEqual(10);
-      expect(parseIntOrBoolean("072")).toEqual(72);
-      expect(parseIntOrBoolean("-698")).toEqual(-698);
+      expect(parseIntOrBoolean("0", "foob1")).toEqual([0, null]);
+      expect(parseIntOrBoolean("10", "foob2")).toEqual([10, null]);
+      expect(parseIntOrBoolean("072", "foob3")).toEqual([72, null]);
+      expect(parseIntOrBoolean("-698", "foob4")).toEqual([-698, null]);
     });
 
-    it("should return NaN for any other value", () => {
-      expect(parseIntOrBoolean("")).toEqual(NaN);
-      expect(parseIntOrBoolean("foo")).toEqual(NaN);
+    it("should return null and an error for any other value", () => {
+      const parsed1 = parseIntOrBoolean("", "ab");
+      const parsed2 = parseIntOrBoolean("foo", "ba");
+      expect(parsed1[0]).toEqual(null);
+      expect(parsed2[0]).toEqual(null);
+      expect(parsed1[1]).toBeInstanceOf(MPDError);
+      expect(parsed2[1]).toBeInstanceOf(MPDError);
+      expect(parsed1[1]?.message).toEqual(
+        "`ab` property is not a boolean nor an integer but \"\"");
+      expect(parsed2[1]?.message).toEqual(
+        "`ba` property is not a boolean nor an integer but \"foo\"");
     });
   });
 
   describe("parseDateTime", () => {
     it("should correctly parse a given date into a timestamp", () => {
-      expect(parseDateTime("1970-01-01T00:00:00Z")).toEqual(0);
-      expect(parseDateTime("1998-11-22T10:40:50Z")).toEqual(911731250);
-      expect(parseDateTime("1960-01-01T00:00:00Z")).toEqual(-315619200);
+      expect(parseDateTime("1970-01-01T00:00:00Z", "a")).toEqual([0, null]);
+      expect(parseDateTime("1998-11-22T10:40:50Z", "b")).toEqual([911731250, null]);
+      expect(parseDateTime("1960-01-01T00:00:00Z", "c")).toEqual([-315619200, null]);
     });
 
-    it("should return NaN when the date is not recognized", () => {
-      expect(parseDateTime("foo bar")).toEqual(NaN);
-      expect(parseDateTime("2047-41-52T30:40:50Z")).toEqual(NaN);
+    it("should return null and an error when the date is not recognized", () => {
+      const parsed1 = parseDateTime("foo bar", "ab");
+      const parsed2 = parseDateTime("2047-41-52T30:40:50Z", "ba");
+      expect(parsed1[0]).toEqual(null);
+      expect(parsed2[0]).toEqual(null);
+      expect(parsed1[1]).toBeInstanceOf(MPDError);
+      expect(parsed2[1]).toBeInstanceOf(MPDError);
+      expect(parsed1[1]?.message).toEqual(
+        "`ab` is in an invalid date format: \"foo bar\"");
+      expect(parsed2[1]?.message).toEqual(
+        "`ba` is in an invalid date format: \"2047-41-52T30:40:50Z\"");
     });
   });
 
   describe("parseDuration", () => {
-    it("should translate an empty string to 0", () => {
-      expect(parseDuration("")).toEqual(0);
-    });
-
     it("should correctly parse duration in ISO8061 format", function() {
-      expect(parseDuration("P18Y9M4DT11H9M8S")).toBe(591361748);
+      expect(parseDuration("P18Y9M4DT11H9M8S", "fooba")).toEqual([591361748, null]);
     });
 
     it("should correctly parse duration if missing the year", function() {
-      expect(parseDuration("P9M4DT11H9M8S")).toBe(23713748);
+      expect(parseDuration("P9M4DT11H9M8S", "fooba")).toEqual([23713748, null]);
     });
 
     it("should correctly parse duration if missing the month", function() {
-      expect(parseDuration("P18Y4DT11H9M8S")).toBe(568033748);
+      expect(parseDuration("P18Y4DT11H9M8S", "fooba")).toEqual([568033748, null]);
     });
 
     it("should correctly parse duration if missing the day", function() {
-      expect(parseDuration("P18Y9MT11H9M8S")).toBe(591016148);
+      expect(parseDuration("P18Y9MT11H9M8S", "fooba")).toEqual([591016148, null]);
     });
 
     it("should correctly parse duration if missing the hours", function() {
-      expect(parseDuration("P18Y9M4DT9M8S")).toBe(591322148);
+      expect(parseDuration("P18Y9M4DT9M8S", "fooba")).toEqual([591322148, null]);
     });
 
     it("should correctly parse duration if missing the minutes", function() {
-      expect(parseDuration("P18Y9M4DT11H8S")).toBe(591361208);
+      expect(parseDuration("P18Y9M4DT11H8S", "fooba")).toEqual([591361208, null]);
     });
 
     it("should correctly parse duration if missing the seconds", function() {
-      expect(parseDuration("P18Y9M4DT11H9M")).toBe(591361740);
+      expect(parseDuration("P18Y9M4DT11H9M", "fooba")).toEqual([591361740, null]);
     });
 
-    it("should throw if duration not in ISO8061 format", function() {
-      expect(() => parseDuration("1000")).toThrow();
+    it("should return null and an error if duration not in ISO8061 format", function() {
+      const parsed1 = parseDuration("1000", "fooba");
+      expect(parsed1[0]).toEqual(null);
+      expect(parsed1[1]).toBeInstanceOf(MPDError);
+      expect(parsed1[1]?.message).toEqual(
+        "`fooba` property has an unrecognized format \"1000\"");
     });
+    it("should return 0 and an error if given an empty string", function() {
+      const parsed = parseDuration("", "fooba");
+      expect(parsed[0]).toEqual(0);
+      expect(parsed[1]).toBeInstanceOf(MPDError);
+      expect(parsed[1]?.message).toEqual(
+        "`fooba` property is empty");
+    });
+
   });
 
   describe("parseByteRange", () => {
     it("should correctly parse byte range", function() {
-      const parsedByteRange = parseByteRange("1-1000");
-      expect(parsedByteRange).not.toBe(null);
-      expect((parsedByteRange as [number, number]).length).toBe(2);
-      expect((parsedByteRange as [number, number])[0]).toBe(1);
-      expect((parsedByteRange as [number, number])[1]).toBe(1000);
+      const parsedByteRange = parseByteRange("1-1000", "tots");
+      expect(parsedByteRange[0]).not.toEqual(null);
+      expect(parsedByteRange[1]).toEqual(null);
+      expect((parsedByteRange[0] as [number, number]).length).toEqual(2);
+      expect((parsedByteRange[0] as [number, number])[0]).toEqual(1);
+      expect((parsedByteRange[0] as [number, number])[1]).toEqual(1000);
     });
-    it("should return null if can't parse given byte range", function() {
-      expect(parseByteRange("main")).toBe(null);
+    it("should return null and an error if can't parse given byte range", function() {
+      const parsed1 = parseByteRange("main", "prop");
+      expect(parsed1[0]).toEqual(null);
+      expect(parsed1[1]).toBeInstanceOf(MPDError);
+      expect(parsed1[1]?.message).toEqual(
+        "`prop` property has an unrecognized format \"main\"");
     });
   });
 

--- a/src/parsers/manifest/dash/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/node_parsers/utils.ts
@@ -297,20 +297,22 @@ function ValueParser<T>(
    * This is used only in error formatting,
    */
   return function(
-    objKey : keyof T,
     val : string,
-    parsingFn : (val : string,
-                 displayName : string) => [T[keyof T] | null, MPDError | null],
-    displayName : string
+    { asKey, parser, dashName } : {
+      asKey : keyof T;
+      parser : (val : string,
+                displayName : string) => [T[keyof T] | null, MPDError | null];
+      dashName : string;
+    }
   ) : void {
-    const [parsingResult, parsingError] = parsingFn(val, displayName);
+    const [parsingResult, parsingError] = parser(val, dashName);
     if (parsingError !== null) {
       log.warn(parsingError.message);
       warnings.push(parsingError);
     }
 
     if (parsingResult !== null) {
-      dest[objKey] = parsingResult;
+      dest[asKey] = parsingResult;
     }
   };
 }

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -16,7 +16,9 @@
 
 import {
   combineLatest as observableCombineLatest,
+  concat as observableConcat,
   Observable,
+  of as observableOf,
 } from "rxjs";
 import {
   filter,
@@ -93,8 +95,12 @@ export default function generateManifestParser(
       parserResponse : IMPDParserResponse
     ) : IManifestParserObservable {
       if (parserResponse.type === "done") {
-        const manifest = new Manifest(parserResponse.value, options);
-        return returnParsedManifest(manifest, url);
+        const { warnings, parsed } = parserResponse.value;
+        const warningEvents = warnings.map(warning => ({ type: "warning" as const,
+                                                         value: warning }));
+        const manifest = new Manifest(parsed, options);
+        return observableConcat(observableOf(...warningEvents),
+                                returnParsedManifest(manifest, url));
       }
 
       const { ressources, continue: continueParsing } = parserResponse.value;

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -17,7 +17,6 @@
 import {
   combineLatest as observableCombineLatest,
   Observable,
-  of as observableOf,
 } from "rxjs";
 import {
   filter,
@@ -36,6 +35,7 @@ import {
   IManifestParserObservable,
   ITransportOptions,
 } from "../types";
+import returnParsedManifest from "../utils/return_parsed_manifest";
 
 /**
  * Request external "xlink" ressource from a MPD.
@@ -94,7 +94,7 @@ export default function generateManifestParser(
     ) : IManifestParserObservable {
       if (parserResponse.type === "done") {
         const manifest = new Manifest(parserResponse.value, options);
-        return observableOf({ manifest, url });
+        return returnParsedManifest(manifest, url);
       }
 
       const { ressources, continue: continueParsing } = parserResponse.value;

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -19,7 +19,6 @@
  * It always should be imported through the `features` object.
  */
 
-import { of as observableOf } from "rxjs";
 import Manifest from "../../manifest";
 import parseLocalManifest, {
   ILocalManifest,
@@ -34,6 +33,7 @@ import {
   ITransportPipelines,
 } from "../types";
 import callCustomManifestLoader from "../utils/call_custom_manifest_loader";
+import returnParsedManifest from "../utils/return_parsed_manifest";
 import segmentLoader from "./segment_loader";
 import segmentParser from "./segment_parser";
 import textTrackParser from "./text_parser";
@@ -72,7 +72,7 @@ export default function getLocalManifestPipelines(
       }
       const parsed = parseLocalManifest(response.responseData as ILocalManifest);
       const manifest = new Manifest(parsed, options);
-      return observableOf({ manifest, url: undefined });
+      return returnParsedManifest(manifest);
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -67,6 +67,7 @@ import {
   replaceToken,
   resolveManifest,
 } from "./utils";
+import returnParsedManifest from "../utils/return_parsed_manifest";
 
 const WSX_REG = /\.wsx?(\?token=\S+)?/;
 
@@ -144,7 +145,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
         supplementaryImageTracks: options.supplementaryImageTracks,
         supplementaryTextTracks: options.supplementaryTextTracks,
       });
-      return observableOf({ manifest, url });
+      return returnParsedManifest(manifest, url);
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -57,6 +57,7 @@ import {
   ITransportPipelines,
 } from "../types";
 import checkISOBMFFIntegrity from "../utils/check_isobmff_integrity";
+import returnParsedManifest from "../utils/return_parsed_manifest";
 import generateManifestLoader from "../utils/text_manifest_loader";
 import extractTimingsInfos from "./extract_timings_infos";
 import { patchSegment } from "./isobmff";
@@ -67,7 +68,6 @@ import {
   replaceToken,
   resolveManifest,
 } from "./utils";
-import returnParsedManifest from "../utils/return_parsed_manifest";
 
 const WSX_REG = /\.wsx?(\?token=\S+)?/;
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -196,13 +196,29 @@ export interface ISegmentParserArguments<T> {
 
 // -- response
 
-// Response object returned by the Manifest's parser
-export interface IManifestParserResponse {
-  manifest : Manifest; // the manifest itself
-  url? : string; // final URL of the manifest
+/** Event emitted when a Manifest object has been parsed. */
+export interface IManifestParserResponseEvent {
+  type : "parsed";
+  value: {
+    /** The parsed Manifest Object itself. */
+    manifest : Manifest;
+    /** Final - real - URL (post-redirection) of the Manifest. */
+    url? : string;
+  };
 }
 
-export type IManifestParserObservable = Observable<IManifestParserResponse>;
+/** Event emitted when a minor error was encountered when parsing the Manifest. */
+export interface IManifestParserWarningEvent {
+  type : "warning";
+  value : Error;
+}
+
+/** Events emitted by the Manifest parser. */
+export type IManifestParserEvent = IManifestParserResponseEvent |
+                                   IManifestParserWarningEvent;
+
+/** Observable returned by the Manifest parser. */
+export type IManifestParserObservable = Observable<IManifestParserEvent>;
 
 // Format of a parsed initialization segment
 export interface ISegmentParserParsedInitSegment<T> {

--- a/src/transports/utils/return_parsed_manifest.ts
+++ b/src/transports/utils/return_parsed_manifest.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  concat as observableConcat,
+  EMPTY,
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import Manifest from "../../manifest";
+import {
+  IManifestParserEvent,
+  IManifestParserWarningEvent,
+} from "../../transports";
+
+/**
+ * As a Manifest instance is obtained, emit the right `warning` events
+ * (according to the Manifest's `parsingErrors` property`) followed by the right
+ * `parsed` event, as expected from a Manifest parser.
+ * @param {Manifest} manifest
+ * @param {string|undefined} url
+ * @returns {Observable}
+ */
+export default function returnParsedManifest(
+  manifest : Manifest,
+  url? : string
+) : Observable<IManifestParserEvent> {
+  let warningEvts$ : Observable<IManifestParserWarningEvent> = EMPTY;
+  for (let i = 0; i < manifest.parsingErrors.length; i++) {
+    const warning = manifest.parsingErrors[i];
+    warningEvts$ = observableConcat(warningEvts$,
+                                    observableOf({ type: "warning" as const,
+                                                   value: warning }));
+  }
+  return observableConcat(warningEvts$,
+                          observableOf({ type: "parsed" as const,
+                                         value: { manifest, url } }));
+}

--- a/src/transports/utils/return_parsed_manifest.ts
+++ b/src/transports/utils/return_parsed_manifest.ts
@@ -16,14 +16,12 @@
 
 import {
   concat as observableConcat,
-  EMPTY,
   Observable,
   of as observableOf,
 } from "rxjs";
 import Manifest from "../../manifest";
 import {
   IManifestParserEvent,
-  IManifestParserWarningEvent,
 } from "../../transports";
 
 /**
@@ -38,13 +36,10 @@ export default function returnParsedManifest(
   manifest : Manifest,
   url? : string
 ) : Observable<IManifestParserEvent> {
-  let warningEvts$ : Observable<IManifestParserWarningEvent> = EMPTY;
-  for (let i = 0; i < manifest.parsingErrors.length; i++) {
-    const warning = manifest.parsingErrors[i];
-    warningEvts$ = observableConcat(warningEvts$,
-                                    observableOf({ type: "warning" as const,
-                                                   value: warning }));
-  }
+  const warningEvts$ = observableOf(...manifest.parsingErrors.map(error => ({
+    type: "warning" as const,
+    value: error,
+  })));
   return observableConcat(warningEvts$,
                           observableOf({ type: "parsed" as const,
                                          value: { manifest, url } }));


### PR DESCRIPTION
## Overview

Until now, minor MPD parsing errors (which is mostly when an attribute in the parsed XML is not in the expected format) only resulted in the RxPlayer calling its `log.warn` function (which itself call `console.warn` under certain conditions).

I thought that it may benefit applications to also send `warning` events on those cases, as sending JavaScript objects seems a much more flexible solution than just calling `console.warn` or not depending on the current logger level. For example, this will allow an application to register those through their own logging solution.

To stay in line with our API, such warnings events will have the `PIPELINE_PARSE_ERROR` error code and the `OTHER_ERROR` type.
Users will know which MPD attribute caused a problem by inspecting the human-readable `message` property.

## What I did

The manifest parsers in the transport pipelines (declared in `src/transports/`) now can return two types of events through an Observable (instead of just one):
  - a `warning` event, signaling that a minor error arised
  - a `parsed` event, signaling that the Manifest has now been fully parsed

To stay coherent, minor error while constructing the `Manifest` instance was moved from the fetchers (in `src/core/fetchers`) to the manifest parser.

In the MPD parsers (in `src/parsers/manifest/dash`), I added a `warnings` property which will be returned once the MPD is fully parsed (instead of immediately when the error is found, for simplicity reasons).
Those warnings are for now all constructed in the node_parsers (`src/parsers/manifest/dash/node_parsers`) which are now mainly functions returning a tuple `[value, error[]]`.
I hesitated between this and just adding a `warnings` parameter to each function (which was the first solution I implemented), but I consider the golang-like tuple solution more elegant and less error-prone (what if the `warnings` parameter is used by a closure asynchonously? By using the return value, we will never have this problem)

I only did it for DASH for now. It may also makes sense for Smooth but I didn't take the time to do it.