### PR TITLE
Refresh the Manifest even if we dont have a Manifest URL

### DIFF
--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -32,7 +32,6 @@ import {
 import config from "../../config";
 import log from "../../log";
 import Manifest from "../../manifest";
-import isNonEmptyString from "../../utils/is_non_empty_string";
 import {
   IManifestFetcherParsedResult,
   IManifestFetcherParserOptions,
@@ -203,10 +202,6 @@ export default function manifestUpdateScheduler({
      const fullRefresh = completeRefresh || manifestUpdateUrl === undefined;
      const refreshURL = fullRefresh ? manifest.getUrl() :
                                       manifestUpdateUrl;
-     if (!isNonEmptyString(refreshURL)) {
-       log.warn("Init: Cannot refresh the manifest: no url");
-       return EMPTY;
-     }
      const externalClockOffset = manifest.clockOffset;
 
      if (unsafeMode) {


### PR DESCRIPTION
Under the previous code, we aborted any Manifest refresh operation if we did not find an URL associated to the Manifest. This might seem logical at first, but we may also have a custom `manifestLoader` defined through the corresponding loadVideo option, which make the presence of the URL completely optional.

The real use cases are for when the Manifest is available locally, most of all under the `local` transport to be able to play content offline. In such contents, we never have an URL, only a custo `manifestLoader` which will retrieve the stored contents directly from memory or whatever browser storage API is available (IndexedDB, custom APIs...).