### PR TITLE
Fixed babel not handling well async / await.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -855,6 +855,58 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.10.1.tgz",
+      "integrity": "sha512-4w2tcglDVEwXJ5qxsY++DgWQdNJcCCsPxfT34wCUwIf2E7dI7pMpH8JczkMBbgBTNzBX62SZlNJ9H+De6Zebaw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.1",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+          "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.1"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+          "integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA==",
+          "dev": true
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.1",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+          "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+          "integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.1",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
   },
   "devDependencies": {
     "@babel/core": "7.9.0",
+    "@babel/plugin-transform-runtime": "7.10.1",
     "@babel/polyfill": "7.8.7",
-    "@babel/plugin-transform-runtime": "^7.10.0",
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "@types/chai": "4.2.11",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   "devDependencies": {
     "@babel/core": "7.9.0",
     "@babel/polyfill": "7.8.7",
+    "@babel/plugin-transform-runtime": "^7.10.0",
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "@types/chai": "4.2.11",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -142,6 +142,7 @@ module.exports = {
               presets: [
                 [ "@babel/env", { loose: true, modules: false } ],
               ],
+              plugins: [[ "@babel/plugin-transform-runtime" ]],
             },
           },
           { loader: "ts-loader" },


### PR DESCRIPTION
To polyfill async / await, babel uses generator functions. Then, it polyfills generator function using a "regenerator" function. The latter can be used in code with either:
- Babel polyfill
or,
- Babel transform runtime plugin

As we do not use Babel polyfill, because we implement our owns polyfill or import independently unique polyfill for some special cases, we shall use regeneration runtime with the plugin.