### PR TITLE
Add language property to adapation for local manifest

### DIFF
--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -119,6 +119,7 @@ function parseAdaptation(
     type: adaptation.type,
     audioDescription: adaptation.audioDescription,
     closedCaption: adaptation.closedCaption,
+    language: adaptation.language,
     representations: adaptation.representations.map((representation) =>
         parseRepresentation(representation, representationIdGenerator, isFinished)),
   };


### PR DESCRIPTION
The `language` property on adaptation was omitted for a local manifest.

I don't know if it was intentional or just a miss but I think it would be very useful to have it back.