### PR TITLE
Make much more use of the assertUnreachable function, to check branch exhaustiveness

### DIFF
--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -142,7 +142,7 @@ function getResumeGap(stalled : IStalledStatus, lowLatencyMode : boolean) : numb
       return RESUME_GAP_AFTER_SEEKING[suffix];
     case "not-ready":
       return RESUME_GAP_AFTER_NOT_ENOUGH_DATA[suffix];
-    default:
+    case "buffering":
       return RESUME_GAP_AFTER_BUFFERING[suffix];
   }
 }

--- a/src/core/buffers/representation/representation_buffer.ts
+++ b/src/core/buffers/representation/representation_buffer.ts
@@ -61,6 +61,7 @@ import {
   ISegmentParserParsedInitSegment,
   ISegmentParserSegment,
 } from "../../../transports";
+import assertUnreachable from "../../../utils/assert_unreachable";
 import objectAssign from "../../../utils/object_assign";
 import SimpleSet from "../../../utils/simple_set";
 import {
@@ -454,7 +455,7 @@ export default function RepresentationBuffer<T>({
             } else if (index.canBeOutOfSyncError(evt.value.error, retriedSegment)) {
               return observableOf(EVENTS.manifestMightBeOufOfSync());
             }
-            return EMPTY;
+            return EMPTY; // else, ignore.
           }));
 
       case "parsed-init-segment":
@@ -489,6 +490,9 @@ export default function RepresentationBuffer<T>({
               loadedSegmentPendingPush.remove(segment.id);
             }));
       }
+
+      default:
+        assertUnreachable(evt);
     }
   }
 }

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -39,6 +39,7 @@ import {
 } from "../../compat/";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
+import assertUnreachable from "../../utils/assert_unreachable";
 import filterMap from "../../utils/filter_map";
 import objectAssign from "../../utils/object_assign";
 import getSession, {
@@ -197,6 +198,19 @@ export default function EMEManager(
         case "blacklist-protection-data":
         case "init-data-ignored":
           return observableOf(sessionInfosEvt);
+
+        case "cleaned-old-session":
+        case "cleaning-old-session":
+          return EMPTY;
+
+        case "created-session":
+        case "loaded-open-session":
+        case "loaded-persistent-session":
+          // Do nothing, just to check every possibility is taken
+          break;
+
+        default: // Use TypeScript to check if all possibilities have been checked
+          assertUnreachable(sessionInfosEvt);
       }
       const { initData,
               initDataType,

--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -271,8 +271,10 @@ export default function createSegmentLoader<T>(
             const _complete$ = observableOf({ type: "chunk-complete" as const,
                                               value: null });
             return observableConcat(_complete$, metrics$);
+
+          default:
+            assertUnreachable(arg);
         }
-        return assertUnreachable(arg);
       }));
   };
 }

--- a/src/core/source_buffers/queued_source_buffer.ts
+++ b/src/core/source_buffers/queued_source_buffer.ts
@@ -38,6 +38,7 @@ import {
   Period,
   Representation,
 } from "../../manifest";
+import assertUnreachable from "../../utils/assert_unreachable";
 import objectAssign from "../../utils/object_assign";
 import SegmentInventory, {
   IBufferedChunk,
@@ -451,6 +452,8 @@ export default class QueuedSourceBuffer<T> {
           case SourceBufferAction.Remove:
             this.synchronizeInventory();
             break;
+          default:
+            assertUnreachable(this._pendingTask);
         }
         const { subject } = this._pendingTask;
         this._pendingTask = null;
@@ -488,6 +491,7 @@ export default class QueuedSourceBuffer<T> {
           log.debug("QSB: Acknowledging complete segment", task.value);
           this._flush();
           return;
+
         case SourceBufferAction.Push:
           const nextStep = task.steps.shift();
           if (nextStep == null ||
@@ -507,6 +511,9 @@ export default class QueuedSourceBuffer<T> {
                     end);
           this._sourceBuffer.remove(start, end);
           break;
+
+        default:
+          assertUnreachable(task);
       }
     } catch (e) {
       this._onError(e);
@@ -645,8 +652,9 @@ function convertQueueItemToTask<T>(
     case SourceBufferAction.Remove:
     case SourceBufferAction.EndOfSegment:
       return item;
+    default:
+      assertUnreachable(item);
   }
-  return null;
 }
 
 export { IBufferedChunk };

--- a/src/utils/assert_unreachable.ts
+++ b/src/utils/assert_unreachable.ts
@@ -16,6 +16,30 @@
 
 import { AssertionError } from "../errors";
 
+/**
+ * TypeScript hack to make sure a code path is never taken.
+ *
+ * This can for example be used to ensure that a switch statement handle all
+ * possible cases by adding a default clause calling assertUnreachable with
+ * an argument (it doesn't matter which one).
+ *
+ * @example
+ * function parseBinary(str : "0" | "1") : number {
+ *   switch (str) {
+ *     case "0:
+ *       return 0;
+ *     case "1":
+ *       return 1;
+ *     default:
+ *       // branch never taken. If it can be, TypeScript will yell at us because
+ *       // its argument (here, `str`) is not of the right type.
+ *       assertUnreachable(str);
+ *   }
+ * }
+ * @param {*} _
+ * @throws AssertionError - Throw an AssertionError when called. If we're
+ * sufficiently strict with how we use TypeScript, this should never happen.
+ */
 export default function assertUnreachable(_: never): never {
   throw new AssertionError("Unreachable path taken");
 }


### PR DESCRIPTION
I added multiple `assertUnreachable` checks to branch-heavy places in our code.

Basically, this is mostly to ensure at compile-time that every possible cases have been handled. Here, I'm most-of-all thinking about our event-type discriminated unions which rely on big switch statement where different events correspond to different actions taken in response.

Not doing this assertion could lead to bugs. For example, we could decide to add an event but forget to update a switch elsewhere, which might receive that event and perform a default action on it we do not want it to do.

I actually found an example of that in our code. There is a minor bug where the new (v3.20.1) `cleaning-old-session"` and `"cleaned-old-session"` events were not properly ignored in `eme_manager.ts`.
Here we could be binding again a `SessionEventsListener` to a MediaKeySession which has just been removed.

It could be avoided by adding a call to `assertUnreachable` in the `default` branch of the corresponding `switch`. When we add new events that are concerned by that `switch`, TypeScript alerts us that this call is not legal, redirecting our attention towards that new problem created due to a modification which was first thought as irrelevant to that part of the code.

Still, this `assertUnreachable` trick is not ideal, as it creates the same function in the generated JS code. This means that we do not get all optimizations we could have had, had the check not been added. This is better explained in the TypeScript issue I have opened here:
https://github.com/microsoft/TypeScript/issues/38881