### PR TITLE
dash: do not update the ManifestBoundsCalculator when updating with a shorter Manifest

### DIFF
--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -498,7 +498,6 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     this._scaledPeriodStart = newIndex._scaledPeriodStart;
     this._scaledPeriodEnd = newIndex._scaledPeriodEnd;
     this._lastUpdate = newIndex._lastUpdate;
-    this._manifestBoundsCalculator = newIndex._manifestBoundsCalculator;
   }
 
   _addSegments() : void {


### PR DESCRIPTION
When loading a content with a `manifestUpdateUrl` (what we call the "short Manifest", where a shorter Manifest is used for Manifest updates to improve update performances), we noticed a bug where we wouldn't be able to seek behind the boundary of the sorter Manifest (thus making the point of that technique moot!).

During debugging, I noticed that updates perform the right modification.
Timelines, which contain information about every segments, were properly updated with segments older than what is in the short Manifest still available.

It was actually the ManifestBoundsCalculator's fault. The ManifestBoundsCalculator is a class allowing "to easily calculate the first and last available positions" of the whole Manifest at any time.
It works today by calculating the minimum position of the Manifest (which is the maximum between all the minimum positions available) and maximum position and by using the monotonic clock (performance.now) to re-calculate that just when we need it, through its `getMinimumBound` and `getMaximumBound` function.

A ManifestBoundsCalculator is associated to a parsed Manifest. Here we would have two, one associated with the regular Manifest - which has the "right" minimum position and one associated with the shorter one - which has a much more advanced (in the future) minimum position.

When doing a regular Manifest update, we usually also update the ManifestBoundsCalculator even if it's most of the time not needed, as the Manifest could evolve in different ways.
But (strangely enough), we also did it when the Manifest used is a shorter one, despite the fact that the area of the code performing that other kind of update is an explicitely different one.

From my point of view, it makes no sense to update the ManifestBoundsCalculator when a shorter Manifest is used. First, it's going to calculate false minimum positions, and second, the old one for
the original Manifest should still be valid (if we suspect that it became invalid, we even have re-synchronisation mechanisms to perform a full Manifest update).

It's funny to consider that updating the ManifestBoundsCalculator did not have an impact right away. It's minimum position calculation were not used right away but at the next timeline-related method call (we clean-up old segments from the timeline before doing actions depending
on them based on the new minimum position lazily).
The fact that it was not really visible why segments were unavailable just after an update made the debugging experience more difficult than it should have been.

So, I just deleted that line! Now seeking works as expected.