### PR TITLE
source-buffers: Do not create a video SourceBuffer on an audio element

### DIFF
--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -50,7 +50,6 @@ import ABRManager from "../../abr";
 import { SegmentFetcherCreator } from "../../fetchers";
 import SourceBuffersStore, {
   BufferGarbageCollector,
-  getBufferTypes,
   IBufferType,
   ITextTrackSourceBufferOptions,
   QueuedSourceBuffer,
@@ -160,7 +159,7 @@ export default function BufferOrchestrator(
       return null;
     }, null));
 
-  const bufferTypes = getBufferTypes();
+  const bufferTypes = sourceBuffersStore.getBufferTypes();
 
   // Every PeriodBuffers for every possible types
   const buffersArray = bufferTypes.map((bufferType) => {

--- a/src/core/source_buffers/index.ts
+++ b/src/core/source_buffers/index.ts
@@ -22,7 +22,6 @@ import QueuedSourceBuffer, {
   IPushedChunkData,
 } from "./queued_source_buffer";
 import SourceBuffersStore, {
-  getBufferTypes,
   ISourceBufferOptions,
   ITextTrackSourceBufferOptions,
 } from "./source_buffers_store";
@@ -37,5 +36,4 @@ export {
   ISourceBufferOptions,
   ITextTrackSourceBufferOptions,
   QueuedSourceBuffer,
-  getBufferTypes,
 };


### PR DESCRIPTION
The RxPlayer can be bound to any HTMLMediaElement (for now this just means audio and video elements). Previously the RxPlayer downloaded all types of buffers ("video", "audio" and depending on the build "text" and "image") regardless of what element was used.

However it's mainly a waste of network resources to download video on an
audio element, as those cannot render the video we will push to its
SourceBuffer.

This PR does a special treatment when encountering an HTMLAudioElement.
Only on this case, no video will be downloaded.

I did that by updating the place where `getBufferTypes` - which returns the complete list of supported buffer types - is defined.
Previously at top-level, it is now a method of the SourceBufferStore (which makes sense as it already contained similar methods such as `isNative`, and as it has to know the list of SourceBuffer to create).
I also had to update its `waitForUsableSourceBuffers` as we don't want to wait for a video SourceBuffer to be created in this case.

I chose to checking for an "audio" element to not include the "video" buffer type and not the other way around (checking for a "video" element to include it) as it gives a nice behavior in the case where an HTMLMediaElement is neither (for now, I don't think this is possible on any platform but it's a possibility).
On every other possible HTMLMediaElement, the previous behavior (both audio and video) will be active.

This feature was inspired from what other players do (most notably the Shaka-Player).