### PR TITLE
demo: don't depend on babel/polyfill for the demo anymore

### DIFF
--- a/demo/full/scripts/index.js
+++ b/demo/full/scripts/index.js
@@ -1,8 +1,13 @@
-import "@babel/polyfill";
+// import polyfills
+import "core-js/stable";
+
+// import runtime for generators and async/await
+import "regenerator-runtime/runtime";
+
 import React from "react";
 import ReactDOM from "react-dom";
 import Main from "./controllers/Main.jsx";
 
 window.onload = function() {
   ReactDOM.render(<Main />, document.getElementById("player-container"));
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -964,16 +964,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.8.7.tgz",
-      "integrity": "sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.6.5",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.5.tgz",
@@ -2738,6 +2728,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -3759,9 +3755,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
   "devDependencies": {
     "@babel/core": "7.9.0",
     "@babel/plugin-transform-runtime": "7.10.1",
-    "@babel/polyfill": "7.8.7",
     "@babel/preset-env": "7.9.5",
     "@babel/preset-react": "7.9.4",
     "@types/chai": "4.2.11",
@@ -139,6 +138,7 @@
     "chai": "4.2.0",
     "chart.js": "2.9.3",
     "cheerio": "1.0.0-rc.3",
+    "core-js": "3.6.5",
     "cross-env": "7.0.2",
     "css-loader": "3.5.2",
     "eslint": "6.8.0",
@@ -165,6 +165,7 @@
     "raw-loader": "4.0.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "regenerator-runtime": "0.13.5",
     "sanitize-html": "1.23.0",
     "semver": "7.3.0",
     "sinon": "9.0.2",


### PR DESCRIPTION
As seen in another PR (#729) the @babel/polyfill was only a shortcut to both core-js and the regenerator-runtime, which are also two different things.

Understandably, @babel/polyfill is now deprecated in profit of importing both directly.

Despite the appearance I add no dependency to the RxPlayer here, as what I added was already a dependency of @babel/polyfill.
Consequently, I even removed one (which is... @babel/polyfill!).

This seems to lead toward a less readable code when importing both in the demo but it actually kind of make much more sense when the time comes where you have to understand what all this does.

I would still have preferred not have to do with a regenerator runtime all together (still don't know why it's not added directly by babel during transpilation).