### PR TITLE
eme: fetch a new MediaKeySystemAccess if persistentState changes to "required"

### DIFF
--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -96,7 +96,7 @@ function checkCachedMediaKeySystemAccess(
       return false;
     }
 
-    if (ks.persistentLicense === true &&
+    if ((ks.persistentLicense === true || ks.persistentStateRequired === true) &&
         mksConfiguration.persistentState !== "required")
     {
       return false;


### PR DESCRIPTION
We have a logic which avoids to create a new MediaKeySystemAccess each time a new content is loaded by looking at the new `keySystems` configuration and seeing if it is still "compatible" with the one created previously.

This then allow to re-use a given MediaKeys, then to even allow to re-use a previously created MediaKeySession.

However our logic was too "tolerant". Setting the `persistentStateRequired` `keySystems` option to `true` would not ensure that the previously used MediaKeySystemAccess had a `persistentState`
set to `required`.  A `persistentState` set to `optional` or even worse, `not-allowed` would have been accepted.

We now check that if `persistentStateRequired` is set to `true`, the previous MediaKeySystemAccess used has a `persistentState` equal to`required`. If that is not the case, we will create a new MediaKeySystemAccess from scratch.

_PS: Technically, we should also do that with `audioRobustnesses` and `videoRobustnesses`. I did not do that for now as it is a little riskier and needs some tests before being done.
Also, those two APIs are not documented APIs, so hopefully, this should never be used in production code - at least for complex usages like this PR tries to fix._

_PS2: This PR is unrelated to the fact that re-creating a MediaKeys instance and binding to an HTMLMediaElement which already had one before causes problem in certain platforms. The resolution of that issue should come in another PR._

_PS3: There is no way for setting `persistentState` to `not-allowed` as, in our API, we indicate that setting `persistentStateRequired` to `false` means that we don't care, thus means we will set it to
`optional`.
To see if this becomes a problem in the future._