### PR TITLE
doc: add stream events tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ player.loadVideo({
 });
 ```
 
-We've also written short tutorials to help you familiarize with the RxPlayer
-API:
+We've also written [short
+tutorials](https://canalplus.github.io/rx-player/doc/pages/tutorials/index.html)
+to help you familiarize with the RxPlayer API:
   - [Quick start into the API](https://canalplus.github.io/rx-player/doc/pages/tutorials/quick_start.html).
   - [Playing contents with DRMs](https://canalplus.github.io/rx-player/doc/pages/tutorials/contents_with_DRM.html).
+  - [Listening to events contained in the content](https://canalplus.github.io/rx-player/doc/pages/tutorials/stream_events.html)
 
 
 ### Minimal Builds #############################################################

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -815,6 +815,19 @@ return an object with the following properties:
     This property is `undefined` if we do not known whether it is in an original
     language.
 
+  - ``representations`` (``Array.<Object>``):
+    [Representations](../terms.md#representation) of this video track, with
+    attributes:
+
+    - ``id`` (``string``): The id used to identify this Representation.
+      No other Representation from this track will have the same `id`.
+
+    - ``bitrate`` (``Number``): The bitrate of this Representation, in bits per
+      seconds.
+
+    - ``codec`` (``string|undefined``): The audio codec the Representation is
+      in, as announced in the corresponding Manifest.
+
 
 ``undefined`` if no audio content has been loaded yet or if its information is
 unknown.
@@ -912,8 +925,8 @@ return an object with the following properties:
 
     - ``height`` (``Number|undefined``): The height of video, in pixels.
 
-    - ``codec`` (``string|undefined``): The codec given in standard MIME type
-      format.
+    - ``codec`` (``string|undefined``): The video codec the Representation is
+      in, as announced in the corresponding Manifest.
 
     - ``frameRate`` (``string|undefined``): The video frame rate.
 
@@ -973,6 +986,19 @@ Each of the objects in the returned array have the following properties:
     If set to `false`, we know that this audio track is in an original language.
     This property is `undefined` if we do not known whether it is in an original
     language.
+
+  - ``representations`` (``Array.<Object>``):
+    [Representations](../terms.md#representation) of this video track, with
+    attributes:
+
+    - ``id`` (``string``): The id used to identify this Representation.
+
+    - ``bitrate`` (``Number``): The bitrate of this Representation, in bits per
+      seconds.
+
+    - ``codec`` (``string|undefined``): The audio codec the Representation is
+      in, as announced in the corresponding Manifest.
+
 
 --
 
@@ -1061,8 +1087,8 @@ Each of the objects in the returned array have the following properties:
 
     - ``height`` (``Number|undefined``): The height of video, in pixels.
 
-    - ``codec`` (``string|undefined``): The codec given in standard MIME type
-      format.
+    - ``codec`` (``string|undefined``): The video codec the Representation is
+      in, as announced in the corresponding Manifest.
 
     - ``frameRate`` (``string|undefined``): The video framerate.
 

--- a/doc/tutorials/index.md
+++ b/doc/tutorials/index.md
@@ -6,3 +6,4 @@ RxPlayer APIs.
 Here is an exhaustive list of the available tutorials:
   - [quick start](./quick_start.md)
   - [playing contents with DRMs](./contents_with_DRM.md)
+  - [listening to stream events](./stream_events.md)

--- a/doc/tutorials/quick_start.md
+++ b/doc/tutorials/quick_start.md
@@ -1,7 +1,7 @@
 # Tutorial: Quick Start ########################################################
 
 Because the RxPlayer exports a lot of functionnalities, you might want to
-quickly test basic usecases before you dive deep into the [whole API
+quickly test basic use cases before you dive deep into the [whole API
 documentation](../api/index.md).
 
 We will here learn how to simply load a video and to react to basic events.

--- a/doc/tutorials/stream_events.md
+++ b/doc/tutorials/stream_events.md
@@ -1,0 +1,310 @@
+# Tutorial: Listening to stream events #########################################
+
+Some contents contain events a player will need to send at a particular point
+in time. We call those in the RxPlayer "stream events".
+
+For example, stream events are often used jointly with ad-insertion, to allow a
+player to notify when an user begin to see a particular ad.
+
+Stream events are not only restrained to ad-related usages though. Any event
+you want to synchronize with the played content can be inserted.
+
+
+
+## Event Formats understood by the RxPlayer ####################################
+
+### DASH EventStream elements ##################################################
+
+For now, the RxPlayer only make use of DASH' EventStream elements.
+
+Such elements are defined in a DASH MPD in the concerned `Period`.
+Here is an example of such element in an MPD:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  type="dynamic"
+  minimumUpdatePeriod="PT2S"
+  timeShiftBufferDepth="PT30M"
+  availabilityStartTime="2011-12-25T12:30:00"
+  minBufferTime="PT4S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+
+    <Period id="1">
+      <EventStream schemeIdUri="urn:uuid:XYZY" timescale="1000" value="call">
+        <Event presentationTime="0" duration="10000" id="0">
+          1 800 10101010
+        </Event>
+        <Event presentationTime="20000" duration="10000" id="1">
+          1 800 10101011
+        </Event>
+        <Event presentationTime="40000" duration="10000" id="2">
+          1 800 10101012
+        </Event>
+        <Event presentationTime="60000" duration="10000" id="3">
+          1 800 10101013
+        </Event>
+      </EventStream>
+      <!-- ... -->
+    </Period>
+
+</MPD>
+```
+
+Here the `<EventStream />` elements and its `<Event />` children elements will
+be parsed by the RxPlayer.
+
+Each `<Event />` element can then be sent through a single RxPlayer events.
+
+
+
+## How to listen to stream events ##############################################
+
+The RxPlayer notify of such events through the usual RxPlayer events.
+
+_As a reminder (or if you didn't know), the RxPlayer can send a multitude of
+[events](../api/player_events.md) that can be listened to by the usage of the
+[addEventListener method](../api/index.md#meth-addEventListener)._
+
+The events related to stream events are:
+
+  - `"streamEvent"`: an event has just been reached.
+
+  - `"streamEventSkip"`: an event has been skipped over. This usually means
+    that a player seek operation resulted in the corresponds event being
+    "missed".
+
+In any case, the corresponding event will be attached as a payload.
+
+Example:
+```js
+// listen to "streamEvent" events
+rxPlayer.addEventListener("streamEvent", (evt) => {
+  console.log("An event has been reached:", evt);
+});
+
+// listen to "streamEventSkip" events
+rxPlayer.addEventListener("streamEventSkip", (evt) => {
+  console.log("We just 'skipped' an event:", evt);
+});
+```
+
+
+
+## The event format ############################################################
+
+Whether you're listening to the `"streamEvent"` or the `"streamEventSkip"`
+event, you will receive an object containing the corresponding event
+information.
+
+Here is an example of such events:
+```js
+{
+  start: 10, // start time of the event, in seconds.
+             //
+             // It is always defined, as a number.
+             //
+             // A start at `10` here means that the event began when the player
+             // reached the position at 10 seconds.
+
+  end: 25, // Optional end time of the event, in seconds.
+           //
+           // It can be undefined or unset for events without any duration.
+           // A end at `25` here indicates that this event only last from the
+           // position at 10 seconds (the `start`) to the position at 25
+           // seconds, or an event with a duration of 15 seconds.
+           //
+           // If `end` is defined, you can be notified when the end of this
+           // event is reached by adding an `onExit` callback to that event
+           // (continue reading this tutorial for more information).
+
+  data: { // The event's data itself.
+
+    type: EVENT_TYPE, // String describing the source of the event.
+
+    value: EVENT_VALUE, // This property's format and content depends on the
+                        // `type` property. For example, when the type property
+                        // is set to "dash-event-stream", this value will be the
+                        // <Event /> element corresponding to that DASH event.
+  }
+}
+```
+
+As written in this example, the underlying format of the event itself will
+depend on the source of the event. For example, an event generated from a DASH's
+`<EventStream />` won't be in the same format that an event generated from a
+MP4's `emsg` box.
+
+You can know which current format is used by checking the value of the
+`data.type` property.
+
+For now, we only have one format: DASH EventStream elements, which will have a
+`data.type` property equal to `"dash-event-stream"`.
+
+
+### DASH EventStream elements ##################################################
+
+A DASH EventStream's event will be parsed under the following format:
+
+```js
+{
+  start: 10, // As usual, the event start time in seconds
+
+  end: 15, // optional end position of the event, in seconds.
+           // Can be not set or set to `undefined` for events without a duration
+
+  data: {
+
+    type: "dash-event-stream", // Type corresponding to a DASH's EventStream's
+                               // Event element
+
+    value: {
+      schemeIdUri: SCHEME_ID_URI,
+      element: EVENT_ELEMENT,
+      timescale: EVENT_TIMESCALE,
+    }
+  }
+}
+```
+
+Where:
+
+  - `SCHEME_ID_URI` will be the value of the corresponding EventStream's
+    `schemeIdUri` attribute
+
+  - `EVENT_ELEMENT` will be the corresponding `<Event />` element in the MPD.
+
+  - `EVENT_TIMESCALE` will be the value of the corresponding EventStream's
+    `timescale` attribute.
+    This indicates a way to convert some time information on an
+    `EVENT_ELEMENT` into seconds (by dividing the value by `timescale`),
+    though it can usually safely be ignored.
+
+For example for the following EventStream:
+```xml
+<EventStream schemeIdUri="urn:uuid:XYZY" timescale="1000" value="call">
+  <Event presentationTime="0" duration="10000" id="0">1 800 10101010</Event>
+  <Event presentationTime="40000" duration="10000" id="1">1 800 10101012</Event>
+  <Event presentationTime="60000" duration="10000" id="2">1 800 10101013</Event>
+</EventStream>
+```
+
+The RxPlayer will define those three events (note: I used custom syntax here to
+include a readable `document` format):
+```jsx
+// The first event:
+{
+  start: 0,
+  end: 10,
+  data: {
+    type: "dash-event-stream",
+    value: {
+      schemeIdUri: "urn::uuid::XYZY",
+      element: <Event presentationTime="0" duration="10000" id="0">
+                 1 800 10101010
+               </Event>,
+      timescale: 1000,
+    }
+  }
+}
+
+// The second event:
+{
+  start: 40,
+  end: 50,
+  data: {
+    type: "dash-event-stream",
+    value: {
+      schemeIdUri: "urn::uuid::XYZY",
+      element: <Event presentationTime="40000" duration="10000" id="1">
+                 1 800 10101012
+               </Event>,
+      timescale: 1000,
+    }
+  }
+}
+
+// The third event:
+{
+  start: 60,
+  end: 70,
+  data: {
+    type: "dash-event-stream",
+    value: {
+      schemeIdUri: "urn::uuid::XYZY",
+      element: <Event presentationTime="60000" duration="10000" id="2">
+                 1 800 10101013
+               </Event>,
+      timescale: 1000,
+    }
+  }
+}
+```
+
+
+## Listening when an event has ended ###########################################
+
+Some stream events have a `end` property, you could thus need to know when an
+event that the RxPlayer reached is now ended.
+
+Thankfully, we planned this need in the API of the RxPlayer.
+
+Any event with a set `end` can be added an `onExit` callback. This callback will
+be called once the event has ended.
+
+So for example you can write:
+```js
+rxPlayer.addEventListener("streamEvent", (evt) => {
+  console.log("An event has been reached:", evt);
+  if (evt.end !== undefined) {
+    evt.onExit = () => {
+      console.log("An event has been exited:", evt);
+    }  ;
+  }
+});
+```
+
+When defined, that `onExit` callback will be called once the RxPlayer either
+reaches the end position of the event or seek outside of the scope of this
+event.
+
+Please note however that even if an event has an `end` property, it is possible
+that the `onExit` callback will never be called. For example, the user could
+stop the content while an event was "active" (we do not trigger `onExit`
+callbacks in that case) or the corresponding `<Event />` could "disappear" from
+the MPD once it has been refreshed.
+
+
+
+## Example #####################################################################
+
+To end this tutorial, lets define a complete example:
+```js
+rxPlayer.addEventListener("streamEvent", (evt) => {
+  console.log("An event has been reached:", evt);
+
+  console.log("This is an event of type:", evt.data.type)
+  if (evt.data.type === "dash-event-stream") {
+    console.log("This is a DASH EventStream's Event element.");
+
+    console.log("schemeIdUri:", evt.data.schemeIdUri);
+    console.log("<Event /> element:", evt.data.element);
+  }
+
+  if (evt.end !== undefined) {
+    evt.onExit = () => {
+      console.log("An event has been exited:", evt);
+    };
+  }
+});
+
+rxPlayer.addEventListener("streamEventSkip", (evt) => {
+  console.log("We just 'skipped' an event:", evt);
+
+  console.log("This was an event of type:", evt.data.type)
+  // ...
+});
+```

--- a/src/core/api/__tests__/media_element_track_choice_manager.test.ts
+++ b/src/core/api/__tests__/media_element_track_choice_manager.test.ts
@@ -63,6 +63,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
         language: "fr",
         audioDescription: false,
         normalized: "fra",
+        representations: [],
       });
       expect(chosenVideoTrack).toEqual({
         id: "gen_video_nolang_1",
@@ -93,6 +94,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
         language: "en",
         audioDescription: false,
         normalized: "eng",
+        representations: [],
       });
 
       trackManager.setTextTrackById("gen_text_en_1");

--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -28,6 +28,7 @@ import {
   ICompatVideoTrack,
   ICompatVideoTrackList,
 } from "../../compat/browser_compatibility_types";
+import { Representation } from "../../manifest";
 import EventEmitter from "../../utils/event_emitter";
 import normalizeLanguage from "../../utils/languages";
 import {
@@ -83,7 +84,8 @@ function createAudioTracks(
 ): Array<{ track: { id: string;
                     normalized: string;
                     language: string;
-                    audioDescription: boolean; };
+                    audioDescription: boolean;
+                    representations: Representation[]; };
            nativeTrack: ICompatAudioTrack; }> {
   const newAudioTracks = [];
   const languagesOccurences: Partial<Record<string, number>> = {};
@@ -100,7 +102,8 @@ function createAudioTracks(
     const track = { language: audioTrack.language,
                     id,
                     normalized: normalizeLanguage(audioTrack.language),
-                    audioDescription: false };
+                    audioDescription: false,
+                    representations: [] as Representation[] };
     newAudioTracks.push({ track,
                           nativeTrack: audioTrack });
   }
@@ -149,7 +152,7 @@ function createTextTracks(
 function createVideoTracks(
   videoTracks: ICompatVideoTrackList
 ): Array<{ track: { id: string;
-                    representations: []; };
+                    representations: Representation[]; };
            nativeTrack: ICompatVideoTrack; }> {
   const newVideoTracks = [];
   const languagesOccurences: Partial<Record<string, number>> = {};
@@ -164,7 +167,7 @@ function createVideoTracks(
                occurences.toString();
     languagesOccurences[language] = occurences + 1;
     newVideoTracks.push({ track: { id,
-                                   representations: [] as [] },
+                                   representations: [] as Representation[] },
                           nativeTrack: videoTrack });
   }
   return newVideoTracks;
@@ -407,7 +410,8 @@ export default class MediaElementTrackChoiceManager
                language: track.language,
                normalized: track.normalized,
                audioDescription: track.audioDescription,
-               active: nativeTrack.enabled };
+               active: nativeTrack.enabled,
+               representations: track.representations };
     });
   }
 

--- a/src/parsers/texttracks/webvtt/html/__tests__/create_style_attribute.test.ts
+++ b/src/parsers/texttracks/webvtt/html/__tests__/create_style_attribute.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import createStyleAttribute from "../create_style_attribute";
+
+describe("parsers - webvtt - createStyleAttribute", () => {
+  const alwaysAppliedStyle = "position: absolute; margin:0;";
+  const defaultWidth = "width:100%;";
+  const defaultLeft = "left:50%;";
+  const defaultTransform = "transform:translate(-50%,0%);";
+  const defaultTop = "top:auto;";
+  const defaultTextAlign = "text-align:center;";
+  const style = alwaysAppliedStyle + defaultWidth + defaultLeft +
+    defaultTop + defaultTextAlign + defaultTransform;
+
+  it("should set width", () => {
+    const settings = {
+      size: "30%",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected =
+      alwaysAppliedStyle + defaultLeft + defaultTop + defaultTextAlign +
+      defaultTransform + "width:30%;";
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set horizontal position", () => {
+    const settings = {
+      position: "10%",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected =
+      alwaysAppliedStyle + defaultWidth + defaultTop + defaultTextAlign +
+      defaultTransform + "left:10%;";
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set horizontal position with alignment", () => {
+    const settings = {
+      position: "10%,line-left",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected = alwaysAppliedStyle + defaultWidth + defaultTop + defaultTextAlign + "transform:translate(0%, 0%);" + "left:10%;";
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set horizontal position and position alignment based on align if no position present", () => {
+    const settings = {
+      align: "right",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected = alwaysAppliedStyle + defaultWidth + defaultTop + "left:100%;" + "transform:translate(-100%, 0%);" + "text-align:right;";
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set vertical position", () => {
+    const settings = {
+      line: "0%",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected = alwaysAppliedStyle + defaultWidth + defaultLeft + defaultTextAlign + "top:0%;" + "transform:translate(-50%, 0%);" ;
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set vertical position with line alignment", () => {
+    const settings = {
+      line: "10%,center",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    const expected = alwaysAppliedStyle + defaultWidth + defaultLeft + defaultTextAlign + "top:10%;" + "transform:translate(-50%, -50%);";
+    isEqualStyle(attribute.value, expected);
+  });
+
+  it("should set text align", () => {
+    const settings = {
+      align: "center",
+    };
+
+    const attribute = createStyleAttribute(settings);
+
+    isEqualStyle(attribute.value, style);
+  });
+});
+
+ const isEqualStyle = (style1: string, style2: string) => {
+  const uniform = (str: string) => str.split(";")
+    .map(s => s.replace(" ", ""))
+    .filter(s => s !== "")
+    .sort();
+  expect(
+    uniform(style1)
+  ).toEqual(
+    uniform(style2)
+  );
+};

--- a/src/parsers/texttracks/webvtt/html/create_style_attribute.ts
+++ b/src/parsers/texttracks/webvtt/html/create_style_attribute.ts
@@ -1,0 +1,222 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import objectValues from "../../../../utils/object_values";
+
+/**
+ * Construct a DOM attribute reflecting given cue settings
+ * @param {Partial<Record<string, string>>} settings
+ * @returns {Attr}
+ */
+export default function createStyleAttribute (
+  settings : Partial<Record<string, string>>
+) : Attr {
+  const pAttr = document.createAttribute("style");
+  pAttr.value = getAttrValue(settings);
+  return pAttr;
+}
+
+const getAttrValue = (settings: Partial<Record<string, string>>) => {
+  const hasSettings = settings !== undefined && objectValues(settings).length !== 0;
+  if (!hasSettings) {
+    return "text-align:center";
+  }
+
+  const xPositioning = getPositioningX(settings);
+  const yPositioning = getPositioningY(settings);
+
+  return (
+    "position: absolute;" +
+    "margin: 0;" +
+    `transform: translate(${xPositioning.offset}%,${yPositioning.offset}%);` +
+    `width: ${getSizePercentage(settings.size)}%;` +
+    `left: ${xPositioning.position}%;` +
+    `top: ${yPositioning.position !== null ? `${yPositioning.position}%` : "auto"};` +
+    `text-align: ${getAlignValue(settings.align)};`
+  );
+};
+
+enum PositionAlignment {
+  LINE_LEFT = "line-left",
+  CENTER = "center",
+  LINE_RIGHT = "line-right",
+}
+
+enum Align {
+  LEFT = "left",
+  CENTER = "center",
+  RIGHT = "right",
+}
+
+enum LineAlignment {
+  START = "start",
+  CENTER = "center",
+  END = "end",
+}
+
+interface IXPosition {
+  position: number;
+  offset: number;
+}
+
+const getPositioningX = (settings: Partial<Record<string, string>>): IXPosition => {
+  return {
+    position: getXPositionPercentage(settings),
+    offset: getXOffsetPercentage(settings),
+  };
+};
+
+const getXPositionPercentage = (settings: Partial<Record<string, string>>): number => {
+  const positionPercentage = getPercentageValue(settings.position);
+  if (positionPercentage !== null) {
+    return positionPercentage;
+  }
+
+  const align = getAlignValue(settings.align);
+  const alignMap = {
+    [Align.LEFT]: 0,
+    [Align.CENTER]: 50,
+    [Align.RIGHT]: 100,
+  };
+
+  return alignMap[align];
+};
+
+const getXOffsetPercentage = (settings: Partial<Record<string, string>>): number => {
+  const getPositionAlignment = (positionSetting: string): PositionAlignment | null => {
+    const positionRegex = /,(line-left|line-right|center)/;
+    const matches = positionRegex.exec(positionSetting);
+
+    if (!Array.isArray(matches) || matches.length < 2) {
+      return null;
+    }
+
+    return matches[1] as PositionAlignment;
+  };
+
+  const positionAlignmentMap = {
+    [PositionAlignment.LINE_LEFT]: 0,
+    [PositionAlignment.CENTER]: -50,
+    [PositionAlignment.LINE_RIGHT]: -100,
+  };
+
+  const positionAlignment = settings.position !== undefined ?
+    getPositionAlignment(settings.position) :
+    null;
+
+  if (positionAlignment !== null) {
+    return positionAlignmentMap[positionAlignment];
+  }
+
+  const alignMap = {
+    [Align.LEFT]: 0,
+    [Align.CENTER]: -50,
+    [Align.RIGHT]: -100,
+  };
+
+  const align = settings.align !== undefined ?
+    getAlignValue(settings.align)
+    : Align.CENTER;
+
+  return alignMap[align];
+};
+
+interface IYPosition {
+  position: number | null;
+  offset: number;
+}
+
+const getPositioningY = (settings: Partial<Record<string, string>>): IYPosition => {
+  return {
+    position: getYPositionPercentage(settings.line),
+    offset: getYOffsetPercentage(settings.line),
+  };
+};
+
+const getYPositionPercentage = (lineSetting: string | undefined): number | null => {
+  return getPercentageValue(lineSetting);
+};
+
+const getYOffsetPercentage = (lineSetting: string | undefined) => {
+  const getLineAlignment = (line: string): LineAlignment | null => {
+    const positionRegex = /,(start|center|end)/;
+    const matches = positionRegex.exec(line);
+
+    if (!Array.isArray(matches) || matches.length < 2) {
+      return null;
+    }
+
+    return matches[1] as LineAlignment;
+  };
+
+  const lineAlignmentMap = {
+    [LineAlignment.START]: 0,
+    [LineAlignment.CENTER]: -50,
+    [LineAlignment.END]: -100,
+  };
+
+  if (lineSetting === undefined) {
+    return lineAlignmentMap[LineAlignment.START];
+  }
+
+  const lineAlignment = getLineAlignment(lineSetting);
+
+  return lineAlignment !== null ?
+    lineAlignmentMap[lineAlignment] :
+    lineAlignmentMap[LineAlignment.START];
+};
+
+const getAlignValue = (alignSetting: string | undefined): Align => {
+  switch (alignSetting) {
+    case "left":
+    case "start":
+      return "left" as Align;
+    case "right":
+    case "end":
+      return "right" as Align;
+    default:
+      return "center" as Align;
+  }
+};
+
+const getSizePercentage = (sizeSetting: string | undefined) => {
+  const defaultSize = 100;
+  return getPercentageValueOrDefault(sizeSetting, defaultSize);
+};
+
+const getPercentageValueOrDefault = (
+  percentageString: string | undefined, defaultValue: number
+): number => {
+  const value = getPercentageValue(percentageString);
+
+  return value !== null ?
+    value :
+    defaultValue;
+};
+
+const getPercentageValue = (percentageString: string | undefined): number | null => {
+  if (percentageString === undefined) {
+    return null;
+  }
+
+  const percentageValueRegex = /^([\d.]+)%/;
+  const matches = percentageValueRegex.exec(percentageString);
+  if (!Array.isArray(matches) || matches.length < 2) {
+    return null;
+  }
+
+  return parseInt(matches[1], 10);
+};

--- a/src/parsers/texttracks/webvtt/html/to_html.ts
+++ b/src/parsers/texttracks/webvtt/html/to_html.ts
@@ -16,6 +16,7 @@
 
 import isNonEmptyString from "../../../../utils/is_non_empty_string";
 import convertPayloadToHTML from "./convert_payload_to_html";
+import createStyleAttribute from "./create_style_attribute";
 import { IStyleElements } from "./parse_style_block";
 
 export interface IVTTHTMLCue { start : number;
@@ -37,12 +38,13 @@ export interface IVTTHTMLCue { start : number;
 export default function toHTML(
   cueObj : { start : number;
              end : number;
+             settings: Partial<Record<string, string>>;
              header? : string;
              payload : string[]; },
   styling : { classes : IStyleElements;
               global? : string; }
 ) : IVTTHTMLCue {
-  const { start, end, header, payload } = cueObj;
+  const { start, end, settings, header, payload } = cueObj;
 
   const region = document.createElement("div");
   const regionAttr = document.createAttribute("style");
@@ -57,8 +59,7 @@ export default function toHTML(
 
   // Get content, format and apply style.
   const pElement = document.createElement("p");
-  const pAttr = document.createAttribute("style");
-  pAttr.value = "text-align:center";
+  const pAttr = createStyleAttribute(settings);
   pElement.setAttributeNode(pAttr);
 
   const spanElement = document.createElement("span");


### PR DESCRIPTION
This new tutorial will explain how to listen to stream events in the RxPlayer.

It also acts as a draft here to help define a stream event API that is:
  - featureful
  - future-proof (for example, `emsg` box will surely go through the same API)
  - understandable and usable by a library user.

Any change @grenault73 ?