### PR TITLE
eme: fix `closeAllSessions` call to REALLY close all MediaKeySessions

### DIFF
--- a/src/core/eme/utils/persistent_sessions_store.ts
+++ b/src/core/eme/utils/persistent_sessions_store.ts
@@ -168,7 +168,7 @@ export default class PersistentSessionsStore {
     initDataType : string|undefined
   ) : void {
     const index = this.getIndex(initData, initDataType);
-    if (index !== -1) {
+    if (index === -1) {
       log.warn("EME-PSS: initData to delete not found.");
       return;
     }


### PR DESCRIPTION
We had an unfortunate issue when calling the `closeAllSessions` method of a LoadedSessionsStore, where no MediaKeySessions would actually be removed (and we would just be leaving them dangling on the MediaKeys).

Thankfully the impact of that issue was rather limited.

From what I can see, only applications using the `closeSessionsOnStop` `keySystems` option should have been impacted as the other path calling that method also remove the corresponding MediaKeys instance from the HTMLMediaElement (which should - I'm guessing here - correctly garbage collect its associated MediaKeySessions).

The issue in itself was tricky:
  1. We're defining multiple Observables which will remove one by one the current MediaKeySessions.
  2. We re-initialize the `_storage` private property. This is I guess so that we're not re-using (due to a possible race condition) MediaKeySessions that we're still in the process of removing. (So we make it believe that it has absolutely no MediaKeySessions)
  3. We return the Observables created in (1), and they are executed

As Observables are usually executed lazily and as the process of removing a MediaKeySession actually rely on the `_storage` private property this created a bad side-effect where a MediaKeySession we wanted to remove was not found anymore.

I hesitated here between two things:

  - Either just delete the re-initialization of the `_storage` property.
    As each `closeSession` call will remove its entry from it synchronously and as each Observables is merged (and thus everything is done synchronously), this could be a perfect solution.

  - Actually separate the code removing the entry from _storage from the code closing a MediaKeySession and only call the latter in this case (and re-initialize _storage just before, like we did).

I chose the second solution as the first one is more "fragile" (we would always need to do thing synchronously and never have any side-effect which has to rely on _storage in the meantime).

The second solution being implemented as a top-level function, we can even ensure that it cannot access the _storage property in any way.