### PR TITLE
export IStreamEvent and IStreamEventData types through the exported types APIs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
   - api/events: add `"streamEvent"` event for when a DASH EventStream's event is reached
   - api/events: add `"streamEventSkip"` event for when a DASH EventStream's event is "skipped"
+  - types/events: add `IStreamEvent` and `IStreamEventData` - which define the payload emitted by both a `"streamEvent"` and `"streamEventSkip"` events to the exported types
   - api/tracks: add second argument to `setPreferredAudioTracks`, `setPreferredTextTracks` and `setPreferredVideoTracks` to be able to also apply them to the currently loaded Periods / content
   - text/webvtt: parse settings attributes of WebVTT subtitles when in HTML mode
   - api/tracks: add codec information to `getAvailableAudioTracks` and `getAudioTrack`

--- a/doc/api/exported_types.md
+++ b/doc/api/exported_types.md
@@ -125,7 +125,7 @@ exported:
     ``loadVideo``.
 
 
-### getAvailableAudioTracks ####################################################
+### getAvailableAudioTracks method / availableAudioTracksChange event ##########
 
 The return type of the `getAvailableAudioTracks` method is an array of objects.
 Each of this objects corresponds to the `IAvailableAudioTrack` interface.
@@ -148,7 +148,7 @@ function getAvailableAudioTracks() : IAvailableAudioTrack[] {
 ```
 
 
-### getAvailableTextTracks #####################################################
+### getAvailableTextTracks method / availabletextTracksChange event ############
 
 The return type of the `getAvailableTextTracks` method is an array of objects.
 Each of this objects corresponds to the `IAvailableTextTrack` interface.
@@ -171,7 +171,7 @@ function getAvailableTextTracks() : IAvailableTextTrack[] {
 ```
 
 
-### getAvailableVideoTracks ####################################################
+### getAvailableVideoTracks method / availableVideoTracksChange event ##########
 
 The return type of the `getAvailableVideoTracks` method is an array of objects.
 Each of this objects corresponds to the `IAvailableVideoTrack` interface.
@@ -194,7 +194,7 @@ function getAvailableVideoTracks() : IAvailableVideoTrack[] {
 ```
 
 
-### getAudioTrack/audioTrackChange #############################################
+### getAudioTrack method /audioTrackChange event ###############################
 
 The `IAudioTrack` corresponds to both the type returned by the `getAudioTrack`
 method and emitted as the payload of the `audioTrackChange` event.
@@ -221,7 +221,7 @@ function getCurrentlyDownloadedAudioTrack() : IAudioTrack {
 ```
 
 
-### getTextTrack/textTrackChange ###############################################
+### getTextTrack method / textTrackChange event ###############################3
 
 The `ITextTrack` corresponds to both the type returned by the `getTextTrack`
 method and emitted as the payload of the `textTrackChange` event.
@@ -248,7 +248,7 @@ function getCurrentlyDownloadedTextTrack() : ITextTrack {
 ```
 
 
-### getVideoTrack/videoTrackChange #############################################
+### getVideoTrack method / videoTrackChange event ##############################
 
 The `IVideoTrack` corresponds to both the type returned by the `getVideoTrack`
 method and emitted as the payload of the `videoTrackChange` event.
@@ -272,4 +272,31 @@ rxPlayer.addEventListener("videoTrackChange", (track : IVideoTrack) => {
 function getCurrentlyDownloadedVideoTrack() : IVideoTrack {
   return rxPlayer.getVideoTrack();
 }
+```
+
+### streamEvent / streamEventSkip events #######################################
+
+The type `IStreamEvent` corresponds to the payload of either a `streamEvent` or
+a `streamEventSkip` event.
+
+The type `IStreamEventData` is the type of its `data` property.
+
+Example:
+
+```js
+// the type(s) wanted
+import { IStreamEvent, IStreamEventData } from "rx-player/types";
+
+// hypothetical file exporting an RxPlayer instance
+import rxPlayer from "./player";
+
+function processEventData(eventData : IStreamEventData) {
+  if (eventData.type === "dash-event-stream") {
+    console.log("DASH EventStream's event received!");
+  }
+}
+
+rxPlayer.addEventListener("streamEvent", (evt : IStreamEvent) {
+  processEventData(evt.data);
+});
 ```

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -16,6 +16,10 @@
 
 import Player from "./public_api";
 export {
+  IStreamEvent,
+  IStreamEventData,
+} from "./public_api";
+export {
   IConstructorOptions,
   ILoadVideoOptions,
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -96,11 +96,7 @@ import initializeMediaSourcePlayback, {
   IReloadingMediaSourceEvent,
   IStalledEvent,
 } from "../init";
-import {
-  IPublicNonFiniteStreamEvent,
-  IPublicStreamEvent,
-  IStreamEvent,
-} from "../init/stream_events_emitter";
+import { IStreamEventData } from "../init/stream_events_emitter";
 import SourceBuffersStore, {
   IBufferedChunk,
   IBufferType,
@@ -171,6 +167,13 @@ interface IBitrateEstimate {
   bitrate : number | undefined;
 }
 
+export type IStreamEvent = { data: IStreamEventData;
+                             start: number;
+                             end: number;
+                             onExit?: () => void; } |
+                           { data: IStreamEventData;
+                             start: number; };
+
 /** Every events sent by the RxPlayer's public API. */
 interface IPublicAPIEvent {
   playerStateChange : string;
@@ -199,8 +202,8 @@ interface IPublicAPIEvent {
                                   representation : Representation; }>;
   seeking : null;
   seeked : null;
-  streamEvent : IPublicStreamEvent|IPublicNonFiniteStreamEvent;
-  streamEventSkip : IPublicStreamEvent|IPublicNonFiniteStreamEvent;
+  streamEvent : IStreamEvent;
+  streamEventSkip : IStreamEvent;
 }
 
 /**
@@ -2023,10 +2026,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_onPlaybackEvent(event : IInitEvent) : void {
     switch (event.type) {
       case "stream-event":
-        this._priv_onStreamEvent(event);
+        this.trigger("streamEvent", event.value);
         break;
       case "stream-event-skip":
-        this._priv_onStreamEventSkip(event);
+        this.trigger("streamEventSkip", event.value);
         break;
       case "activePeriodChanged":
         this._priv_onActivePeriodChanged(event.value);
@@ -2177,14 +2180,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           this._priv_trackChoiceManager.update();
         }
       });
-  }
-
-  private _priv_onStreamEvent(event: IStreamEvent) {
-    this.trigger("streamEvent", event.value);
-  }
-
-  private _priv_onStreamEventSkip(event: IStreamEvent) {
-    this.trigger("streamEventSkip", event.value);
   }
 
   /**
@@ -2622,3 +2617,4 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 Player.version = /*PLAYER_VERSION*/"3.21.0";
 
 export default Player;
+export { IStreamEventData };

--- a/src/core/init/stream_events_emitter/index.ts
+++ b/src/core/init/stream_events_emitter/index.ts
@@ -19,10 +19,12 @@ import {
   IPublicNonFiniteStreamEvent,
   IPublicStreamEvent,
   IStreamEvent,
+  IStreamEventData,
 } from "./types";
 
 export {
   IStreamEvent,
+  IStreamEventData,
   IPublicNonFiniteStreamEvent,
   IPublicStreamEvent
 };

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -44,4 +44,7 @@ export {
   IAudioTrackPreference,
   ITextTrackPreference,
   IVideoTrackPreference,
+
+  IStreamEvent,
+  IStreamEventData,
 } from "./core/api";


### PR DESCRIPTION
This is to allow TypeScript codebases to use it