### PR TITLE
utils: Fix removeEmptyRanges() with multiple consecutive empty ranges

### DIFF
--- a/src/utils/__tests__/ranges.test.ts
+++ b/src/utils/__tests__/ranges.test.ts
@@ -639,6 +639,36 @@ describe("utils - ranges", () => {
         { start: 100, end: 101 },
       ]);
     });
+    it("should clear multiple sequential ranges", () => {
+      expect(removeEmptyRanges([
+        { start: 30, end: 70 },
+        { start: 90, end: 90 },
+        { start: 90, end: 90 },
+        { start: 90, end: 90 },
+        { start: 100, end: 101 },
+      ])).toEqual([
+        { start: 30, end: 70 },
+        { start: 100, end: 101 },
+      ]);
+    });
+    it("should clear the first and last ranges if they are empty", () => {
+      expect(removeEmptyRanges([
+        { start: 30, end: 30 },
+        { start: 90, end: 91 },
+        { start: 95, end: 96 },
+        { start: 100, end: 100 },
+      ])).toEqual([
+        { start: 90, end: 91 },
+        { start: 95, end: 96 },
+      ]);
+    });
+    it("should return empty array if all ranges are empty", () => {
+      expect(removeEmptyRanges([
+        { start: 90, end: 90 },
+        { start: 90, end: 90 },
+        { start: 90, end: 90 },
+      ])).toEqual([]);
+    });
   });
 
   describe("mergeContiguousRanges", () => {

--- a/src/utils/ranges.ts
+++ b/src/utils/ranges.ts
@@ -71,7 +71,7 @@ function removeEmptyRanges(ranges : IRange[]) : IRange[] {
   for (let index = 0; index < ranges.length; index++) {
     const range = ranges[index];
     if (range.start === range.end) {
-      ranges.splice(index++, 1);
+      ranges.splice(index--, 1);
     }
   }
   return ranges;


### PR DESCRIPTION
Found by code inspection, not by hitting any user-visible problem.

Keeping the post-decrement for consistency with the rest of this file.

Fixes #750 