### PR TITLE
Global EME unit tests 

### DIFF
--- a/doc/architecture/files.md
+++ b/doc/architecture/files.md
@@ -30,6 +30,7 @@ a single directory or subdirectory, in alphabetical order.
   - [src/core/fetchers/: The fetchers](#core-fetchers)
   - [src/core/source_buffers/: SourceBuffers definitions](#core-sb)
   - [src/core/init/: Media streaming logic](#core-init)
+- [src/**/__tests__: the unit tests directories](#src-tests)
 - [tests/: Test strategies, integration and memory tests](#tests)
 
 
@@ -293,6 +294,29 @@ defined in `src/custom_source_buffers`.
 
 This is the central part which download manifests, initialize MSE and EME APIs,
 instanciate the Buffer and link together many subparts of the player.
+
+
+<a name="src-tests"></a>
+## src/**/__tests__: the unit tests directories ################################
+
+You will find multiple directories named `__tests__` in the RxPlayer.
+Those contain unit tests and are put in the same directory than the code it
+tests.
+
+Most unit tests files contain only tests for a single source file. Those will
+be put directly at the root of `__tests__` under the name
+`<ORIGINAL_SRC_FILE>.test.ts` (where `<ORIGINAL_SRC_FILE>` is the filename of
+the tested file).
+
+`__tests__` directories can also contain files defining tests for multiple files
+contained in the tested directory.
+Those can be quicker to write and easier to maintain at the expense of being
+less thorough.
+
+Those type of "global" unit tests are put in a special `__global__` directory,
+itself directly at the root of the corresponding `__tests__` directory.
+Their filename don't follow the same convention than single-source unit tests
+but should still be suffixed by `.test.ts`.
 
 
 <a name="tests"></a>

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
   roots: ["<rootDir>/src"],
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  testRegex: ["src\\/.*\\.test.[jt]s"],
   collectCoverage: coverageIsWanted,
   collectCoverageFrom: [
     "src/**/*.ts",

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   roots: ["<rootDir>/src"],
   preset: "ts-jest",
   testEnvironment: "jsdom",
-  testRegex: ["src\\/.*\\.test.[jt]s"],
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   collectCoverage: coverageIsWanted,
   collectCoverageFrom: [
     "src/**/*.ts",

--- a/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
@@ -19,7 +19,6 @@ import {
   Subject,
 } from "rxjs";
 import { takeUntil } from "rxjs/operators";
-import { TypedArray } from "../../../core/eme";
 import {
   bytesToStr,
   strToBytes,
@@ -38,8 +37,8 @@ export interface IOldWebkitHTMLMediaElement extends HTMLVideoElement {
   webkitGenerateKeyRequest : (keyType: string, initData : ArrayBuffer) => void;
   webkitAddKey : (
     keyType: string,
-    key : ArrayBuffer|TypedArray|DataView,
-    kid : ArrayBuffer|TypedArray|DataView|null,
+    key : BufferSource,
+    kid : BufferSource|null,
     sessionId : string
   ) => void;
 }

--- a/src/compat/eme/custom_media_keys/types.ts
+++ b/src/compat/eme/custom_media_keys/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { TypedArray } from "../../../core/eme";
 import { IEventEmitter } from "../../../utils/event_emitter";
 
 export interface ICustomMediaKeySession extends IEventEmitter<IMediaKeySessionEvents> {
@@ -31,11 +30,11 @@ export interface ICustomMediaKeySession extends IEventEmitter<IMediaKeySessionEv
   // Functions
 
   generateRequest(initDataType: string,
-                  initData: ArrayBuffer | TypedArray | DataView | null)
+                  initData: BufferSource | null)
                  : Promise<void>;
 
   load(sessionId: string) : Promise<boolean>;
-  update(response: ArrayBuffer | TypedArray | DataView | null): Promise<void>;
+  update(response: BufferSource | null): Promise<void>;
   close() : Promise<void>;
   remove() : Promise<void>;
 }
@@ -43,7 +42,7 @@ export interface ICustomMediaKeySession extends IEventEmitter<IMediaKeySessionEv
 export interface ICustomMediaKeys {
   _setVideo : (vid : HTMLMediaElement) => void;
   createSession(sessionType? : MediaKeySessionType) : ICustomMediaKeySession;
-  setServerCertificate(setServerCertificate : ArrayBuffer|TypedArray) : Promise<void>;
+  setServerCertificate(setServerCertificate : BufferSource) : Promise<void>;
 }
 
 export interface ICustomMediaKeyStatusMap {

--- a/src/compat/eme/custom_media_keys/webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys.ts
@@ -19,7 +19,6 @@ import {
   Subject,
 } from "rxjs";
 import { takeUntil } from "rxjs/operators";
-import { TypedArray } from "../../../core/eme";
 import EventEmitter from "../../../utils/event_emitter";
 import PPromise from "../../../utils/promise";
 import * as events from "../../event_listeners";
@@ -38,7 +37,7 @@ import {
 export interface ICustomWebKitMediaKeys {
   _setVideo: (videoElement: HTMLMediaElement) => void;
   createSession(mimeType: string, initData: Uint8Array): ICustomMediaKeySession;
-  setServerCertificate(setServerCertificate: ArrayBuffer | TypedArray): Promise<void>;
+  setServerCertificate(setServerCertificate: BufferSource): Promise<void>;
 }
 
 /**

--- a/src/compat/eme/index.ts
+++ b/src/compat/eme/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import closeSession from "./close_session";
 import CustomMediaKeySystemAccess, {
   ICustomMediaKeySystemAccess,
 } from "./custom_key_system_access";
@@ -27,6 +28,7 @@ import generateKeyRequest from "./generate_key_request";
 import getInitData from "./get_init_data";
 
 export {
+  closeSession,
   CustomMediaKeySystemAccess,
   generateKeyRequest,
   getInitData,

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -239,7 +239,7 @@ export interface IPictureInPictureEvent {
  * @param {HTMLMediaElement} mediaElement
  * @returns {Observable}
  */
-export function onPictureInPictureEvent$(
+function onPictureInPictureEvent$(
   mediaElement: HTMLMediaElement
 ): Observable<IPictureInPictureEvent> {
   return observableDefer(() => {
@@ -458,4 +458,5 @@ export {
   onKeyAdded$,
   onKeyError$,
   onKeyStatusesChange$,
+  onPictureInPictureEvent$,
 };

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -28,6 +28,7 @@ import tryToChangeSourceBufferType, {
 } from "./change_source_buffer_type";
 import clearElementSrc from "./clear_element_src";
 import {
+  closeSession,
   CustomMediaKeySystemAccess,
   generateKeyRequest,
   getInitData,
@@ -71,6 +72,7 @@ export {
   addTextTrack,
   canPatchISOBMFFSegment,
   clearElementSrc,
+  closeSession,
   CustomMediaKeySystemAccess,
   events,
   exitFullscreen,

--- a/src/core/eme/__tests__/__global__/get_license.test.ts
+++ b/src/core/eme/__tests__/__global__/get_license.test.ts
@@ -1,0 +1,404 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable no-unsafe-any */
+
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import { concat } from "../../../../utils/byte_parsing";
+import { IContentProtection } from "../../types";
+import {
+  formatFakeChallengeFromInitData,
+  MediaKeySessionImpl,
+  MediaKeysImpl,
+  mockCompat,
+} from "./utils";
+
+/** Default video element used in our tests. */
+const videoElt = document.createElement("video");
+
+/* tslint:disable no-unsafe-any */
+/* tslint:disable max-line-length */
+describe("core - eme - global tests - getLicense", () => {
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  it("should update the session after getLicense resolves with a license", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should update the session after getLicense returns a license directly", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should not update the session after getLicense resolves with null", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should not update the session after getLicense returns null directly", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to retry maximum two times and fail after 3 tries with a rejected promise", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 3,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should be able to retry maximum two times and fail after 3 tries with a thrown error", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 3,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a resolved license", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 2,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a returned license", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 2,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a resolved null", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 2,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a returned null", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 2,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to retry one time and succeed after a time with a resolved license", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 1,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should be able to retry one time and succeed after a time with a returned license", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 1,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a resolved null", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 1,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to retry two times and succeed after a time with a returned null", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: false,
+                      configuredRetries: undefined,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 1,
+                      ignoreLicenseRequests: true }, done);
+  });
+
+  it("should be able to fetch a license directly even when getLicenseConfig.retry is set to `0`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 0,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should fail after first failure when getLicenseConfig.retry is set to `0`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 1,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 0,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should fail after two failures when getLicenseConfig.retry is set to `1`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 2,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 2,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should not fail after one failure when getLicenseConfig.retry is set to `1`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 2,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 1,
+                      ignoreLicenseRequests: false }, done);
+  });
+
+  it("should not fail after 5 failures when getLicenseConfig.retry is set to `6`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 6,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 5,
+                      ignoreLicenseRequests: false }, done);
+  }, 15000);
+
+  it("should fail after 6 failures when getLicenseConfig.retry is set to `6`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: 6,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 6,
+                      ignoreLicenseRequests: false }, done);
+  }, 15000);
+
+  it("should not fail after 5 failures when getLicenseConfig.retry is set to `Infinity`", (done) => {
+    checkGetLicense({ isGetLicensePromiseBased: true,
+                      configuredRetries: Infinity,
+                      configuredTimeout: undefined,
+                      getTimeout: () => undefined,
+                      nbRetries: 5,
+                      ignoreLicenseRequests: false }, done);
+  }, 15000);
+
+});
+
+/**
+ * HUGE function to check most getLicense scenarios.
+ * @param {Object} opts
+ */
+function checkGetLicense(
+  { isGetLicensePromiseBased,
+    configuredRetries,
+    configuredTimeout,
+    getTimeout,
+    nbRetries,
+    ignoreLicenseRequests } : {
+      /**
+       * Set it to false if you want to return directly a value from
+       * `getLicense` (i.e. not wrapped in a Promise).
+       * This is valable both for success, and errors (which will be either
+       * thrown directly or wrapped in a rejecting Promise).
+       *
+       * This value will be forced to `true` if the `getTimeout` call for the
+       * corresponding `getLicense` returns something other than `undefined`.
+       */
+      isGetLicensePromiseBased : boolean;
+      /** Maximum amount of retries: value of getLicenseConfig.retry. */
+      configuredRetries : number | undefined;
+      /**
+       * Return getLicense timeout after which the response will be emitted, in
+       * milliseconds.
+       * Put to `undefined` for no timeout at all (synchronous).
+       * Note that if a timeout is given, getLicense will return a Promise.
+       * As such, `isGetLicensePromiseBased` will be ignored.
+       */
+      getTimeout : (callIdx : number) => number | undefined;
+      /** Maximum configured timeout: value of getLicenseConfig.timeout. */
+      configuredTimeout : number | undefined;
+      /**
+       * Nb of times getLicense should fail in a row.
+       * If put at a higher value or equal to `configuredRetries`, no license
+       * will be obtained.
+       */
+      nbRetries : number;
+      /**
+       * If `true`, getLicense will return `null` - to ignore a request - when
+       * it succeed.
+       */
+      ignoreLicenseRequests : boolean; },
+  done : () => void
+) {
+  // == mocks ==
+  mockCompat();
+  const mediaKeySession = new MediaKeySessionImpl();
+  jest.spyOn(MediaKeysImpl.prototype, "createSession").mockReturnValue(mediaKeySession);
+  const updateSpy = jest.spyOn(mediaKeySession, "update");
+  let remainingRetries = nbRetries;
+  const getLicenseSpy = jest.fn(() => {
+    const callIdx = nbRetries - remainingRetries;
+    const timeout = getTimeout(callIdx);
+    if (remainingRetries === 0) {
+      const challengeU8 = new Uint8Array(challenge);
+      const result = ignoreLicenseRequests ? null :
+                                             concat(challengeU8, challengeU8);
+      if (timeout !== undefined) {
+        return new Promise(resolve => {
+          setTimeout(() => resolve(result), timeout);
+        });
+      }
+      /* tslint:disable ban */
+      return isGetLicensePromiseBased ? Promise.resolve(result) :
+      /* tslint:enable ban */
+                                        result;
+    }
+    remainingRetries--;
+    if (timeout !== undefined) {
+      return new Promise((_, reject) => {
+        setTimeout(() => {
+          reject("AAAA");
+        }, timeout);
+      });
+    }
+    if (!isGetLicensePromiseBased) {
+      throw new Error("AAAA");
+    }
+    /* tslint:disable ban */
+    return Promise.reject(new Error("AAAA"));
+    /* tslint:enable ban */
+  });
+
+  // == vars ==
+  /** Default keySystems configuration used in our tests. */
+  const maxRetries = configuredRetries === undefined ? 3 :
+                                                       configuredRetries;
+  const shouldFail = nbRetries >= maxRetries;
+  let warningsLeft = nbRetries;
+  const ksConfig = [{ type: "com.widevine.alpha",
+                      getLicense: getLicenseSpy,
+                      getLicenseConfig: configuredRetries !== undefined ||
+                                        configuredTimeout !== undefined ?
+                                          { retry: configuredRetries,
+                                            timeout: configuredTimeout } :
+                                          undefined }];
+  let eventsReceived = 0;
+  let licenseReceived = false;
+  const initDataSubject = new Subject<IContentProtection>();
+  const initData = new Uint8Array([54, 55, 75]);
+  const kill$ = new Subject();
+  const challenge = formatFakeChallengeFromInitData(initData, "cenc");
+  function checkKeyLoadError(error : any) {
+    expect(error.name).toEqual("EncryptedMediaError");
+    expect(error.type).toEqual("ENCRYPTED_MEDIA_ERROR");
+    expect(error.code).toEqual("KEY_LOAD_ERROR");
+    expect(error.message).toEqual("AAAA");
+  }
+
+  // == test ==
+  const EMEManager = require("../../eme_manager").default;
+  EMEManager(videoElt, ksConfig, initDataSubject)
+    .pipe(takeUntil(kill$))
+    .subscribe((evt : any) => {
+      eventsReceived++;
+      // Those first three have been tested enough
+      if (eventsReceived <= 3) {
+        return;
+      }
+      if (warningsLeft-- === 0) {
+        if (!licenseReceived) {
+          if (ignoreLicenseRequests) {
+            expect(evt.type).toEqual("no-update");
+            expect(evt.value.initData).toEqual(initData);
+            expect(evt.value.initDataType).toEqual("cenc");
+            expect(updateSpy).toHaveBeenCalledTimes(0);
+          } else {
+            const license = concat(challenge, challenge);
+            expect(evt.type).toEqual("session-updated");
+            expect(evt.value.session).toEqual(mediaKeySession);
+            expect(evt.value.license).toEqual(license);
+            expect(evt.value.initData).toEqual(initData);
+            expect(evt.value.initDataType).toEqual("cenc");
+            expect(updateSpy).toHaveBeenCalledTimes(1);
+            expect(updateSpy).toHaveBeenCalledWith(license);
+          }
+          expect(getLicenseSpy).toHaveBeenCalledTimes(nbRetries + 1);
+          for (let i = 1; i <= nbRetries + 1; i++) {
+            expect(getLicenseSpy).toHaveBeenNthCalledWith(i, challenge, "license-request");
+          }
+          licenseReceived = true;
+          setTimeout(() => {
+            kill$.next();
+            done();
+          }, 5);
+          return;
+        }
+      } else {
+        expect(evt.type).toEqual("warning");
+        checkKeyLoadError(evt.value);
+        const requestIdx = nbRetries - remainingRetries;
+        expect(getLicenseSpy).toHaveBeenCalledTimes(requestIdx);
+        expect(getLicenseSpy).toHaveBeenNthCalledWith(requestIdx, challenge, "license-request");
+        return;
+      }
+      throw new Error(`Unexpected event: ${evt.type}`);
+    }, (error : any) => {
+      if (shouldFail) {
+        checkKeyLoadError(error);
+        expect(eventsReceived).toEqual(5);
+        expect(getLicenseSpy).toHaveBeenCalledTimes(maxRetries);
+        expect(getLicenseSpy).toHaveBeenNthCalledWith(maxRetries, challenge, "license-request");
+        expect(updateSpy).toHaveBeenCalledTimes(0);
+        done();
+      } else {
+        throw new Error(`Unexpected error: ${error}`);
+      }
+    });
+  initDataSubject.next({ type: "cenc", data: initData });
+}

--- a/src/core/eme/__tests__/__global__/init_data.test.ts
+++ b/src/core/eme/__tests__/__global__/init_data.test.ts
@@ -1,0 +1,759 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable no-unsafe-any */
+
+import {
+  EMPTY,
+  // of as observableOf,
+  Subject,
+  // throwError as observableThrow,
+} from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import { IContentProtection } from "../../types";
+import {
+  expectEncryptedEventReceived,
+  expectInitDataIgnored,
+  expectLicenseRequestMessage,
+  MediaKeySessionImpl,
+  MediaKeysImpl,
+  // MediaKeySystemAccessImpl,
+  mockCompat,
+  // testEMEManagerImmediateError,
+} from "./utils";
+
+/**
+ * Create fake encrypted event which should (hopefully) be processed by the EME
+ * logic.
+ * @param {string} initDataType
+ * @param {Uint8Array} initData
+ * @returns {Object}
+ */
+function generateEncryptedEvent(
+  initDataType : string,
+  initData : Uint8Array
+) : Event & { initDataType : string; initData : ArrayBuffer } {
+  /* tslint:disable ban */
+  return Object.assign(new Event("encrypted"),
+                       { initDataType, initData: initData.buffer });
+  /* tslint:enable ban */
+}
+
+/* tslint:disable no-unsafe-any */
+describe("core - eme - global tests - init data", () => {
+  /** Default video element used in our tests. */
+  const videoElt = document.createElement("video");
+
+  const getLicenseSpy = jest.fn(() => {
+    /* tslint:disable ban */
+    return new Promise(() => { /* noop */ });
+    /* tslint:enable ban */
+  });
+
+  /** Default keySystems configuration used in our tests. */
+  const ksConfig = [{ type: "com.widevine.alpha", getLicense: getLicenseSpy }];
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create a session and generate a request when init data is sent through the arguments", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy } = mockCompat();
+    const mediaKeySession = new MediaKeySessionImpl();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockReturnValue(mediaKeySession);
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initDataSubject = new Subject<IContentProtection>();
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              expect(createSessionSpy).toHaveBeenCalledWith("temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    initDataSubject.next({ type: "cenc", data: initData });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should ignore init data already sent through the argument", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy } = mockCompat();
+    const mediaKeySession = new MediaKeySessionImpl();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockReturnValue(mediaKeySession);
+
+    // == vars ==
+    const initDataSubject = new Subject<IContentProtection>();
+    let eventsReceived = 0;
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            break;
+          case 4:
+          case 5:
+          case 6:
+            expectInitDataIgnored(evt, initData, "cenc");
+            if (eventsReceived === 6) {
+              setTimeout(() => {
+                kill$.next();
+                expect(createSessionSpy).toHaveBeenCalledTimes(1);
+                expect(createSessionSpy).toHaveBeenCalledWith("temporary");
+                expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+                expect(generateKeyRequestSpy)
+                  .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                done();
+              }, 10);
+            }
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    initDataSubject.next({ type: "cenc", data: initData });
+    initDataSubject.next({ type: "cenc", data: initData });
+    initDataSubject.next({ type: "cenc", data: initData });
+    initDataSubject.next({ type: "cenc", data: initData });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create multiple sessions for multiple sent init data when unknown", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy } = mockCompat();
+    const mediaKeySession1 = new MediaKeySessionImpl();
+    const mediaKeySession2 = new MediaKeySessionImpl();
+    let createSessionCallIdx = 0;
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockImplementation(() => {
+        return createSessionCallIdx++ === 0 ? mediaKeySession1 :
+                                              mediaKeySession2;
+      });
+
+    // == vars ==
+    const initDataSubject = new Subject<IContentProtection>();
+    let eventsReceived = 0;
+    const initData1 = new Uint8Array([54, 55, 75]);
+    const initData2 = new Uint8Array([87, 32]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData1, "cenc");
+            break;
+          case 4:
+            expectInitDataIgnored(evt, initData1, "cenc");
+            break;
+          case 5:
+            expectLicenseRequestMessage(evt, initData2, "cenc");
+            break;
+          case 6:
+            expectInitDataIgnored(evt, initData1, "cenc");
+            break;
+          case 7:
+            expectInitDataIgnored(evt, initData2, "cenc");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(1, mediaKeySession1, initData1, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(2, mediaKeySession2, initData2, "cenc");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    initDataSubject.next({ type: "cenc", data: initData1 });
+    initDataSubject.next({ type: "cenc", data: initData1 });
+    initDataSubject.next({ type: "cenc", data: initData2 });
+    initDataSubject.next({ type: "cenc", data: initData1 });
+    initDataSubject.next({ type: "cenc", data: initData2 });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create multiple sessions for multiple sent init data types", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy } = mockCompat();
+    const mediaKeySessions = [ new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl() ];
+    let createSessionCallIdx = 0;
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockImplementation(() => {
+        return mediaKeySessions[createSessionCallIdx++];
+      });
+
+    // == vars ==
+    const initDataSubject = new Subject<IContentProtection>();
+    let eventsReceived = 0;
+    const initData1 = new Uint8Array([54, 55, 75]);
+    const initData2 = new Uint8Array([87, 32]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData1, "cenc");
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData1, "cenc2");
+            break;
+          case 5:
+            expectLicenseRequestMessage(evt, initData2, "cenc");
+            break;
+          case 6:
+            expectLicenseRequestMessage(evt, initData2, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(4);
+              expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(3, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    initDataSubject.next({ type: "cenc", data: initData1 });
+    initDataSubject.next({ type: "cenc2", data: initData1 });
+    initDataSubject.next({ type: "cenc", data: initData2 });
+    initDataSubject.next({ type: "cenc2", data: initData2 });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create a session and generate a request when init data is received from the browser", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy, eventTriggers, getInitDataSpy } = mockCompat();
+    const { triggerEncrypted } = eventTriggers;
+    const mediaKeySession = new MediaKeySessionImpl();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockReturnValue(mediaKeySession);
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initData = new Uint8Array([54, 55, 75]);
+    const initDataEvent = generateEncryptedEvent("cenc", initData);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expectEncryptedEventReceived(evt, initData, "cenc");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(1);
+            expect(getInitDataSpy).toHaveBeenCalledWith(initDataEvent);
+            break;
+          case 2:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 3:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              expect(createSessionSpy).toHaveBeenCalledWith("temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    triggerEncrypted.next(initDataEvent);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should ignore init data already received through the browser", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy, eventTriggers, getInitDataSpy } = mockCompat();
+    const { triggerEncrypted } = eventTriggers;
+    const mediaKeySession = new MediaKeySessionImpl();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockReturnValue(mediaKeySession);
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initData = new Uint8Array([54, 55, 75]);
+    const initDataEvent = generateEncryptedEvent("cenc", initData);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+          case 2:
+          case 3:
+          case 4:
+            expectEncryptedEventReceived(evt, initData, "cenc");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(eventsReceived);
+            expect(getInitDataSpy).toHaveBeenNthCalledWith(eventsReceived, initDataEvent);
+            break;
+          case 5:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 6:
+            expect(evt.type).toEqual("attached-media-keys");
+            break;
+          case 7:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            break;
+          case 8:
+          case 9:
+          case 10:
+            expectInitDataIgnored(evt, initData, "cenc");
+            if (eventsReceived === 10) {
+              setTimeout(() => {
+                kill$.next();
+                expect(createSessionSpy).toHaveBeenCalledTimes(1);
+                expect(createSessionSpy).toHaveBeenCalledWith("temporary");
+                expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+                expect(generateKeyRequestSpy)
+                  .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                done();
+              }, 10);
+            }
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    triggerEncrypted.next(initDataEvent);
+    triggerEncrypted.next(initDataEvent);
+    triggerEncrypted.next(initDataEvent);
+    triggerEncrypted.next(initDataEvent);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create multiple sessions for multiple received init data when unknown", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy, eventTriggers, getInitDataSpy } = mockCompat();
+    const { triggerEncrypted } = eventTriggers;
+    const mediaKeySession1 = new MediaKeySessionImpl();
+    const mediaKeySession2 = new MediaKeySessionImpl();
+    let createSessionCallIdx = 0;
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockImplementation(() => {
+        return createSessionCallIdx++ === 0 ? mediaKeySession1 :
+                                              mediaKeySession2;
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initData1 = new Uint8Array([54, 55, 75]);
+    const initData2 = new Uint8Array([87, 32]);
+    const initDataEvent1 = generateEncryptedEvent("cenc", initData1);
+    const initDataEvent2 = generateEncryptedEvent("cenc", initData2);
+    const kill$ = new Subject();
+
+    function checkEncryptedEventReceived(
+      evt : any,
+      initDataEvent : unknown,
+      initData : Uint8Array,
+      nb : number
+    ) {
+      expect(evt.type).toEqual("encrypted-event-received");
+      expect(evt.value.type).toEqual("cenc");
+      expect(evt.value.data).toEqual(initData);
+      expect(getInitDataSpy).toHaveBeenCalledTimes(nb);
+      expect(getInitDataSpy)
+        .toHaveBeenNthCalledWith(nb, initDataEvent);
+    }
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+          case 2:
+            checkEncryptedEventReceived(evt, initDataEvent1, initData1, eventsReceived);
+            break;
+          case 3: checkEncryptedEventReceived(evt, initDataEvent2, initData2, 3); break;
+          case 4: checkEncryptedEventReceived(evt, initDataEvent1, initData1, 4); break;
+          case 5: checkEncryptedEventReceived(evt, initDataEvent2, initData2, 5); break;
+          case 6: expect(evt.type).toEqual("created-media-keys"); break;
+          case 7: expect(evt.type).toEqual("attached-media-keys"); break;
+          case 8: expectLicenseRequestMessage(evt, initData1, "cenc"); break;
+          case 9: expectInitDataIgnored(evt, initData1, "cenc"); break;
+          case 10: expectLicenseRequestMessage(evt, initData2, "cenc"); break;
+          case 11: expectInitDataIgnored(evt, initData1, "cenc"); break;
+          case 12:
+            expectInitDataIgnored(evt, initData2, "cenc");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(1, mediaKeySession1, initData1, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(2, mediaKeySession2, initData2, "cenc");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error(`Unexpected event: ${evt.type}`);
+        }
+      });
+    triggerEncrypted.next(initDataEvent1);
+    triggerEncrypted.next(initDataEvent1);
+    triggerEncrypted.next(initDataEvent2);
+    triggerEncrypted.next(initDataEvent1);
+    triggerEncrypted.next(initDataEvent2);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should create multiple sessions for multiple received init data types", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const { generateKeyRequestSpy, eventTriggers, getInitDataSpy } = mockCompat();
+    const { triggerEncrypted } = eventTriggers;
+    const mediaKeySessions = [ new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl() ];
+    let createSessionCallIdx = 0;
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockImplementation(() => {
+        return mediaKeySessions[createSessionCallIdx++];
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initData1 = new Uint8Array([54, 55, 75]);
+    const initData2 = new Uint8Array([87, 32]);
+    const initDataEvent1 = generateEncryptedEvent("cenc", initData1);
+    const initDataEvent2 = generateEncryptedEvent("cenc2", initData1);
+    const initDataEvent3 = generateEncryptedEvent("cenc", initData2);
+    const initDataEvent4 = generateEncryptedEvent("cenc2", initData2);
+    const kill$ = new Subject();
+
+    function checkEncryptedEventReceived(
+      evt : any,
+      initDataEvent : { initDataType : string },
+      initData : Uint8Array,
+      nb : number
+    ) {
+      expect(evt.type).toEqual("encrypted-event-received");
+      expect(evt.value.type).toEqual(initDataEvent.initDataType);
+      expect(evt.value.data).toEqual(initData);
+      expect(getInitDataSpy).toHaveBeenCalledTimes(nb);
+      expect(getInitDataSpy)
+        .toHaveBeenNthCalledWith(nb, initDataEvent);
+    }
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1: checkEncryptedEventReceived(evt, initDataEvent1, initData1, 1); break;
+          case 2: checkEncryptedEventReceived(evt, initDataEvent2, initData1, 2); break;
+          case 3: checkEncryptedEventReceived(evt, initDataEvent3, initData2, 3); break;
+          case 4: checkEncryptedEventReceived(evt, initDataEvent4, initData2, 4); break;
+          case 5: expect(evt.type).toEqual("created-media-keys"); break;
+          case 6: expect(evt.type).toEqual("attached-media-keys"); break;
+          case 7: expectLicenseRequestMessage(evt, initData1, "cenc"); break;
+          case 8: expectLicenseRequestMessage(evt, initData1, "cenc2"); break;
+          case 9: expectLicenseRequestMessage(evt, initData2, "cenc"); break;
+          case 10:
+            expectLicenseRequestMessage(evt, initData2, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).toHaveBeenCalledTimes(4);
+              expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(3, "temporary");
+              expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    triggerEncrypted.next(initDataEvent1);
+    triggerEncrypted.next(initDataEvent2);
+    triggerEncrypted.next(initDataEvent3);
+    triggerEncrypted.next(initDataEvent4);
+  });
+
+  it("should consider sent event through arguments and received events through the browser the same way", (done) => {
+    // == mocks ==
+    const { generateKeyRequestSpy, eventTriggers, getInitDataSpy } = mockCompat();
+    const { triggerEncrypted } = eventTriggers;
+    const mediaKeySessions = [ new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl(),
+                               new MediaKeySessionImpl() ];
+    let createSessionCallIdx = 0;
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession")
+      .mockImplementation(() => {
+        return mediaKeySessions[createSessionCallIdx++];
+      });
+
+    // == vars ==
+    const initDataSubject = new Subject<IContentProtection>();
+    let eventsReceived = 0;
+    const initData1 = new Uint8Array([54, 55, 75]);
+    const initData2 = new Uint8Array([87, 32]);
+    const initDataEvent1 = generateEncryptedEvent("cenc", initData1);
+    const initDataEvent2 = generateEncryptedEvent("cenc2", initData1);
+    const initDataEvent3 = generateEncryptedEvent("cenc", initData2);
+    const initDataEvent4 = generateEncryptedEvent("cenc2", initData2);
+    const kill$ = new Subject();
+
+    function checkEncryptedEventReceived(
+      evt : any,
+      initDataEvent : { initDataType : string },
+      initData : Uint8Array,
+      nb : number
+    ) {
+      expect(evt.type).toEqual("encrypted-event-received");
+      expect(evt.value.type).toEqual(initDataEvent.initDataType);
+      expect(evt.value.data).toEqual(initData);
+      expect(getInitDataSpy).toHaveBeenCalledTimes(nb);
+      expect(getInitDataSpy)
+        .toHaveBeenNthCalledWith(nb, initDataEvent);
+    }
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1: checkEncryptedEventReceived(evt, initDataEvent1, initData1, 1); break;
+          case 2: expect(evt.type).toEqual("created-media-keys"); break;
+          case 3:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).toHaveBeenCalledTimes(0);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(0);
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData1, "cenc");
+            expect(createSessionSpy).toHaveBeenCalledTimes(1);
+            expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+            expect(generateKeyRequestSpy)
+              .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+            break;
+          case 5:
+            expectInitDataIgnored(evt, initData1, "cenc");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(1);
+            expect(createSessionSpy).toHaveBeenCalledTimes(1);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
+            break;
+          case 6:
+            expectLicenseRequestMessage(evt, initData1, "cenc2");
+            expect(createSessionSpy).toHaveBeenCalledTimes(2);
+            expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+            expect(generateKeyRequestSpy)
+              .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+            break;
+          case 7:
+            checkEncryptedEventReceived(evt, initDataEvent2, initData1, 2);
+            expect(getInitDataSpy).toHaveBeenCalledTimes(2);
+            expect(createSessionSpy).toHaveBeenCalledTimes(2);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+            break;
+          case 8:
+            expectInitDataIgnored(evt, initData1, "cenc2");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(2);
+            expect(createSessionSpy).toHaveBeenCalledTimes(2);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+            break;
+          case 9:
+            expectInitDataIgnored(evt, initData1, "cenc");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(2);
+            expect(createSessionSpy).toHaveBeenCalledTimes(2);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+            break;
+          case 10:
+            checkEncryptedEventReceived(evt, initDataEvent3, initData2, 3);
+            expect(getInitDataSpy).toHaveBeenCalledTimes(3);
+            expect(createSessionSpy).toHaveBeenCalledTimes(2);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
+            break;
+          case 11:
+            expectLicenseRequestMessage(evt, initData2, "cenc");
+            expect(createSessionSpy).toHaveBeenCalledTimes(3);
+            expect(createSessionSpy).toHaveBeenNthCalledWith(3, "temporary");
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(3);
+            expect(generateKeyRequestSpy)
+              .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+            break;
+          case 12:
+            expectInitDataIgnored(evt, initData2, "cenc");
+            expect(getInitDataSpy).toHaveBeenCalledTimes(3);
+            expect(createSessionSpy).toHaveBeenCalledTimes(3);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(3);
+            break;
+          case 13:
+            checkEncryptedEventReceived(evt, initDataEvent4, initData2, 4);
+            expect(getInitDataSpy).toHaveBeenCalledTimes(4);
+            expect(createSessionSpy).toHaveBeenCalledTimes(3);
+            expect(generateKeyRequestSpy).toHaveBeenCalledTimes(3);
+            break;
+          case 14:
+            expectLicenseRequestMessage(evt, initData2, "cenc2");
+            setTimeout(() => {
+              expect(createSessionSpy).toHaveBeenCalledTimes(4);
+              expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
+              expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
+              expect(generateKeyRequestSpy)
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+              kill$.next();
+              done();
+            }, 5);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+    triggerEncrypted.next(initDataEvent1);
+    initDataSubject.next({ type: "cenc", data: initData1 });
+    setTimeout(() => {
+      initDataSubject.next({ type: "cenc2", data: initData1 });
+      triggerEncrypted.next(initDataEvent2);
+      initDataSubject.next({ type: "cenc", data: initData1 });
+      triggerEncrypted.next(initDataEvent3);
+      initDataSubject.next({ type: "cenc", data: initData2 });
+      triggerEncrypted.next(initDataEvent4);
+    }, 5);
+  });
+});

--- a/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
@@ -1,0 +1,476 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable no-unsafe-any */
+
+import {
+  EMPTY,
+  Observable,
+  Subject,
+  throwError as observableThrow,
+} from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import flatMap from "../../../../utils/flat_map";
+import { mockCompat } from "./utils";
+
+const incompatibleMKSAErrorMessage =
+  "EncryptedMediaError (INCOMPATIBLE_KEYSYSTEMS) No key system compatible with your wanted configuration has been found in the current browser.";
+
+const defaultKSConfig = [{
+  audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
+                         robustness: undefined },
+                       { contentType: "audio/webm;codecs=opus",
+                         robustness: undefined } ],
+  distinctiveIdentifier: "optional",
+  initDataTypes: ["cenc"],
+  persistentState: "optional",
+  sessionTypes: ["temporary"],
+  videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"",
+                         robustness: undefined },
+                       { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
+                         robustness: undefined },
+                       { contentType: "video/webm;codecs=\"vp8\"",
+                         robustness: undefined} ],
+}];
+
+const defaultWidevineConfig = (() => {
+  const ROBUSTNESSES = [ "HW_SECURE_ALL",
+                         "HW_SECURE_DECODE",
+                         "HW_SECURE_CRYPTO",
+                         "SW_SECURE_DECODE",
+                         "SW_SECURE_CRYPTO" ];
+  const videoCapabilities = flatMap(ROBUSTNESSES, robustness => {
+    return [{ contentType: "video/mp4;codecs=\"avc1.4d401e\"",
+              robustness },
+            { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
+              robustness },
+            { contentType: "video/webm;codecs=\"vp8\"",
+              robustness } ];
+  });
+  const audioCapabilities = flatMap(ROBUSTNESSES, robustness => {
+    return [{ contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
+              robustness },
+            { contentType: "audio/webm;codecs=opus",
+              robustness } ];
+  });
+  return defaultKSConfig.map(conf => {
+    /* tslint:disable ban */
+    return Object.assign({}, conf, { audioCapabilities, videoCapabilities });
+    /* tslint:enable ban */
+  });
+})();
+const neverCalledFn = jest.fn();
+
+/**
+ * Check that the EMEManager, when called with those arguments, throws
+ * directly without any event emitted.
+ *
+ * If that's the case, resolve with the corresponding error.
+ * Else, reject.
+ * @param {HTMLMediaElement} mediaElement
+ * @param {Array.<Object>} keySystemsConfigs
+ * @param {Observable} contentProtections$
+ * @returns {Promise}
+ */
+function testEMEManagerImmediateError(
+  EMEManager : any,
+  mediaElement : HTMLMediaElement,
+  keySystemsConfigs : unknown[],
+  contentProtections$ : Observable<unknown>
+) : Promise<unknown> {
+  return new Promise((res, rej) => {
+    EMEManager(mediaElement, keySystemsConfigs, contentProtections$)
+      .subscribe(
+        (evt : unknown) => {
+           const eventStr = JSON.stringify(evt as any);
+          rej(new Error("Received an EMEManager event: " + eventStr));
+        },
+        (err : unknown) => { res(err); },
+        () => rej(new Error("EMEManager completed."))
+      );
+  });
+}
+
+/**
+ * Check that the given `keySystemsConfigs` lead directly to an
+ * `INCOMPATIBLE_KEYSYSTEMS` error.
+ * @param {Array.<Object>} keySystemsConfigs
+ * @returns {Promise}
+ */
+async function checkIncompatibleKeySystemsErrorMessage(
+  keySystemsConfigs : unknown[]
+) : Promise<void> {
+  const mediaElement = document.createElement("video");
+  const EMEManager = require("../../eme_manager").default;
+
+  const error : any = await testEMEManagerImmediateError(EMEManager,
+                                                         mediaElement,
+                                                         keySystemsConfigs,
+                                                         EMPTY);
+  expect(error).not.toBe(null);
+  expect(error.message).toEqual(incompatibleMKSAErrorMessage);
+  expect(error.name).toEqual("EncryptedMediaError");
+  expect(error.code).toEqual("INCOMPATIBLE_KEYSYSTEMS");
+}
+
+/* tslint:disable no-unsafe-any */
+describe("core - eme - global tests - media key system access", () => {
+  // Used to implement every functions that should never be called.
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.resetAllMocks();
+    jest.mock("../../set_server_certificate", () => ({ __esModule: true,
+                                                       default: neverCalledFn }));
+  });
+
+  afterEach(() => {
+    expect(neverCalledFn).not.toHaveBeenCalled();
+  });
+
+  it("should throw if an empty keySystemsConfigs is given", async () => {
+    mockCompat();
+    await checkIncompatibleKeySystemsErrorMessage([]);
+  });
+
+  it("should throw if given a single incompatible keySystemsConfigs", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    const getLicenseFn = neverCalledFn;
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: getLicenseFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  it("should throw if given multiple incompatible keySystemsConfigs", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    const config = [ { type: "foo", getLicense: neverCalledFn },
+                     { type: "bar", getLicense: neverCalledFn },
+                     { type: "baz", getLicense: neverCalledFn } ];
+    await checkIncompatibleKeySystemsErrorMessage(config);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(3);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(1, "foo", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(2, "bar", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(3, "baz", defaultKSConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should throw an error if no implementation of requestMediaKeySystemAccess is set", async () => {
+  /* tslint:enable max-line-length */
+    mockCompat({ requestMediaKeySystemAccess: undefined });
+    const mediaElement = document.createElement("video");
+    const EMEManager = require("../../eme_manager").default;
+
+    const config = [{ type: "foo", getLicense: neverCalledFn }];
+    const error : any = await testEMEManagerImmediateError(EMEManager,
+                                                           mediaElement,
+                                                           config,
+                                                           EMPTY);
+    expect(error).not.toBe(null);
+    expect(error.message)
+      .toEqual("requestMediaKeySystemAccess is not implemented in your browser.");
+  });
+
+  it("should throw if given a single incompatible keySystemsConfigs", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should change persistentState value if persistentStateRequired is set to true", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     persistentStateRequired: true }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+
+    const expectedConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { persistentState: "required" });
+      /* tslint:enable ban */
+    });
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", expectedConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should not change persistentState value if persistentStateRequired is set to false", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     persistentStateRequired: false }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should change distinctiveIdentifier value if distinctiveIdentifierRequired is set to true", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{
+      type: "foo",
+      getLicense: neverCalledFn,
+      distinctiveIdentifierRequired: true,
+    }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+
+    const expectedConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { distinctiveIdentifier: "required" });
+      /* tslint:enable ban */
+    });
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", expectedConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should not change distinctiveIdentifier value if distinctiveIdentifierRequired is set to false", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{
+      type: "foo",
+      getLicense: neverCalledFn,
+      distinctiveIdentifierRequired: false,
+    }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  it("should do nothing if just licenseStorage is set", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    const licenseStorage = { save() { throw new Error("Should not save."); },
+                             load() { throw new Error("Should not load."); } };
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     licenseStorage }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should want persistent sessions if both persistentLicense and licenseStorage are set", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    const licenseStorage = { save() { throw new Error("Should not save."); },
+                             load() { throw new Error("Should not load."); } };
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     licenseStorage,
+                                                     persistentLicense: true }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+
+    const expectedConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { persistentState: "required",
+                                       sessionTypes: ["temporary",
+                                                      "persistent-license"] });
+      /* tslint:enable ban */
+    });
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", expectedConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should want persistent sessions if just persistentLicense is set to true", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     persistentLicense: true }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+
+    const expectedConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { persistentState: "required",
+                                       sessionTypes: ["temporary",
+                                                      "persistent-license"] });
+      /* tslint:enable ban */
+    });
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", expectedConfig);
+  });
+
+  it("should do nothing if persistentLicense is set to false", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
+                                                     getLicense: neverCalledFn,
+                                                     persistentLicense: false }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledWith("foo", defaultKSConfig);
+  });
+
+  it("should translate a `clearkey` keySystem", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "clearkey",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(2);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(1, "webkit-org.w3.clearkey", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(2, "org.w3.clearkey", defaultKSConfig);
+  });
+
+  it("should translate a `widevine` keySystem", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "widevine",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenCalledWith("com.widevine.alpha", defaultWidevineConfig);
+  });
+
+  it("should translate a `playready` keySystem", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(3);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(3, "com.youtube.playready", defaultKSConfig);
+  });
+
+  it("should translate a `fairplay` keySystem", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "fairplay",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenCalledWith("com.apple.fps.1_0", defaultKSConfig);
+  });
+
+  it("should translate a multiple keySystems at the same time", async () => {
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
+                                                     getLicense: neverCalledFn },
+                                                   { type: "clearkey",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(5);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(3, "com.youtube.playready", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(4, "webkit-org.w3.clearkey", defaultKSConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(5, "org.w3.clearkey", defaultKSConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should translate a multiple keySystems at the same time with different configs", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
+                                                     persistentLicense: true,
+                                                     getLicense: neverCalledFn },
+                                                   { type: "clearkey",
+                                                     distinctiveIdentifierRequired: true,
+                                                     getLicense: neverCalledFn }]);
+    const expectedPersistentConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { persistentState: "required",
+                                       sessionTypes: ["temporary",
+                                                      "persistent-license"] });
+      /* tslint:enable ban */
+    });
+    const expectedIdentifierConfig = defaultKSConfig.map(conf => {
+      /* tslint:disable ban */
+      return Object.assign({}, conf, { distinctiveIdentifier: "required" });
+      /* tslint:enable ban */
+    });
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(5);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", expectedPersistentConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", expectedPersistentConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(3, "com.youtube.playready", expectedPersistentConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(4, "webkit-org.w3.clearkey", expectedIdentifierConfig);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenNthCalledWith(5, "org.w3.clearkey", expectedIdentifierConfig);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should set widevine robustnesses for a `com.widevine.alpha` keySystem", async () => {
+  /* tslint:enable max-line-length */
+    const requestMediaKeySystemAccessSpy = jest.fn(() => observableThrow("nope"));
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+    await checkIncompatibleKeySystemsErrorMessage([{ type: "com.widevine.alpha",
+                                                     getLicense: neverCalledFn }]);
+    expect(requestMediaKeySystemAccessSpy).toHaveBeenCalledTimes(1);
+    expect(requestMediaKeySystemAccessSpy)
+      .toHaveBeenCalledWith("com.widevine.alpha", defaultWidevineConfig);
+  });
+
+  xit("should not continue to check if the observable is unsubscribed from", () => {
+    return new Promise((res, rej) => {
+      const killSubject$ = new Subject();
+      let rmksHasBeenCalled = false;
+      const requestMediaKeySystemAccessSpy = jest.fn(() => {
+        if (rmksHasBeenCalled) {
+          rej("requestMediaKeySystemAccess has already been called.");
+        }
+        rmksHasBeenCalled = true;
+        killSubject$.next();
+        killSubject$.complete();
+        return observableThrow("nope");
+      });
+      mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessSpy });
+      const mediaElement = document.createElement("video");
+      const EMEManager = require("../../eme_manager").default;
+
+      const config = [ { type: "foo", getLicense: neverCalledFn },
+                       { type: "bar", getLicense: neverCalledFn },
+                       { type: "baz", getLicense: neverCalledFn } ];
+      EMEManager(mediaElement, config, EMPTY)
+        .pipe(takeUntil(killSubject$))
+        .subscribe(
+          () => { rej("We should not have received an event"); },
+          () => { rej("We should not have received an error."); },
+          () =>  {
+            expect(rmksHasBeenCalled).toBe(true);
+            setTimeout(() => { res(); }, 10);
+          }
+        );
+      });
+  });
+});

--- a/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
@@ -74,7 +74,7 @@ describe("core - eme - global tests - media key system access", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.restoreAllMocks();
-    jest.mock("../../set_server_certificate", () => ({ __esModule: true,
+    jest.mock("../../set_server_certificate", () => ({ __esModule: true as const,
                                                        default: neverCalledFn }));
   });
 

--- a/src/core/eme/__tests__/__global__/media_keys.test.ts
+++ b/src/core/eme/__tests__/__global__/media_keys.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable no-unsafe-any */
+
+import {
+  EMPTY,
+  of as observableOf,
+  Subject,
+  // throwError as observableThrow,
+} from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import {
+  MediaKeysImpl,
+  MediaKeySystemAccessImpl,
+  mockCompat,
+  testEMEManagerImmediateError,
+} from "./utils";
+
+/* tslint:disable no-unsafe-any */
+describe("core - eme - global tests - media key system access", () => {
+  /** Used to implement every functions that should never be called. */
+  const neverCalledFn = jest.fn();
+
+  /** Default video element used in our tests. */
+  const videoElt = document.createElement("video");
+
+  /** Default keySystems configuration used in our tests. */
+  const ksConfig = [{ type: "com.widevine.alpha", getLicense: neverCalledFn }];
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+    jest.mock("../../set_server_certificate", () => ({ __esModule: true,
+                                                       default: neverCalledFn }));
+  });
+
+  afterEach(() => {
+    expect(neverCalledFn).not.toHaveBeenCalled();
+  });
+
+  it("should throw if createMediaKeys throws", async () => {
+    // == mocks ==
+    function requestMediaKeySystemAccessBadMediaKeys(
+      keySystem : string,
+      conf : MediaKeySystemConfiguration[]
+    ) {
+      return observableOf({ keySystem,
+                            getConfiguration() { return conf; },
+                            createMediaKeys() { throw new Error("No non no"); } });
+    }
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessBadMediaKeys });
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    const error : any =
+      await testEMEManagerImmediateError(EMEManager, videoElt, ksConfig, EMPTY);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toEqual("EncryptedMediaError (CREATE_MEDIA_KEYS_ERROR) No non no");
+    expect(error.name).toEqual("EncryptedMediaError");
+    expect(error.code).toEqual("CREATE_MEDIA_KEYS_ERROR");
+  });
+
+  it("should throw if createMediaKeys rejects", async () => {
+    // == mocks ==
+    function requestMediaKeySystemAccessRejMediaKeys(
+      keySystem : string,
+      conf : MediaKeySystemConfiguration[]
+    ) {
+      return observableOf({ keySystem,
+                            getConfiguration() { return conf; },
+                            /* tslint:disable ban */
+                            createMediaKeys() { return Promise.reject(new Error("No non no")); } });
+                            /* tslint:enable ban */
+    }
+    mockCompat({ requestMediaKeySystemAccess: requestMediaKeySystemAccessRejMediaKeys });
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    const error : any =
+      await testEMEManagerImmediateError(EMEManager, videoElt, ksConfig, EMPTY);
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toEqual("EncryptedMediaError (CREATE_MEDIA_KEYS_ERROR) No non no");
+    expect(error.name).toEqual("EncryptedMediaError");
+    expect(error.code).toEqual("CREATE_MEDIA_KEYS_ERROR");
+  });
+
+  /* tslint:disable max-line-length */
+  it("should emit a created-media-keys event if createMediaKeys resolves", (done) => {
+  /* tslint:enable max-line-length */
+    mockCompat({});
+    const EMEManager = require("../../eme_manager").default;
+    const kill$ = new Subject();
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        expect(evt.type).toEqual("created-media-keys");
+        kill$.next();
+        done();
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should not create any session until if no encrypted event was received", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const setMediaKeysSpy = jest.fn(() => EMPTY);
+    mockCompat({ setMediaKeys: setMediaKeysSpy });
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+
+    // == test ==
+    let eventsReceived = 0;
+    const kill$ = new Subject();
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        eventsReceived++;
+        expect(evt.type).toEqual("created-media-keys");
+        setTimeout(() => {
+          expect(eventsReceived).toEqual(1);
+          expect(setMediaKeysSpy).toHaveBeenCalledTimes(1);
+          expect(setMediaKeysSpy).toHaveBeenCalledWith(videoElt, new MediaKeysImpl());
+          expect(createSessionSpy).not.toHaveBeenCalled();
+          done();
+        }, 10);
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should emit \"attached-media-keys\" event when the MediaKeys is attached", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const setMediaKeysSpy = jest.fn(() => observableOf(null));
+    mockCompat({ setMediaKeys: setMediaKeysSpy });
+
+    // == test ==
+    let eventsReceived = 0;
+    const kill$ = new Subject();
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            kill$.next();
+            expect(setMediaKeysSpy).toHaveBeenCalledTimes(1);
+            expect(setMediaKeysSpy).toHaveBeenCalledWith(videoElt, new MediaKeysImpl());
+            done();
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should not create any session until if no encrypted event was received", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const setMediaKeysSpy = jest.fn(() => observableOf(null));
+    mockCompat({ setMediaKeys: setMediaKeysSpy });
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+
+    // == test ==
+    let eventsReceived = 0;
+    const kill$ = new Subject();
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfig, EMPTY)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            setTimeout(() => {
+              kill$.next();
+              expect(createSessionSpy).not.toHaveBeenCalled();
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should not attach the MediaKeys but still emit the \"attached-media-keys\" event if already attached", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    const mediaElement = document.createElement("video");
+    const defaultMediaKeys = new MediaKeysImpl();
+    const setMediaKeysSpy = jest.fn(() => observableOf(null));
+    mockCompat({ setMediaKeys: setMediaKeysSpy });
+    jest.spyOn(MediaKeySystemAccessImpl.prototype, "createMediaKeys")
+      /* tslint:disable ban */
+      .mockReturnValue(Promise.resolve(defaultMediaKeys));
+      /* tslint:enable ban */
+    Object.defineProperty(mediaElement, "mediaKeys", {
+      get: jest.fn(() => defaultMediaKeys),
+      set: jest.fn(() => { throw new Error("Should not set MediaKeys manually."); }),
+    });
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+
+    // == test ==
+    let eventsReceived = 0;
+    const kill$ = new Subject();
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(mediaElement, ksConfig, new Subject())
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            setTimeout(() => {
+              kill$.next();
+              expect(setMediaKeysSpy).not.toHaveBeenCalled();
+              expect(createSessionSpy).not.toHaveBeenCalled();
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error("Unexpected event");
+        }
+      });
+  });
+});

--- a/src/core/eme/__tests__/__global__/media_keys.test.ts
+++ b/src/core/eme/__tests__/__global__/media_keys.test.ts
@@ -44,7 +44,7 @@ describe("core - eme - global tests - media key system access", () => {
   beforeEach(() => {
     jest.resetModules();
     jest.restoreAllMocks();
-    jest.mock("../../set_server_certificate", () => ({ __esModule: true,
+    jest.mock("../../set_server_certificate", () => ({ __esModule: true as const,
                                                        default: neverCalledFn }));
   });
 

--- a/src/core/eme/__tests__/__global__/server_certificate.test.ts
+++ b/src/core/eme/__tests__/__global__/server_certificate.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* tslint:disable no-unsafe-any */
+
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import { IContentProtection } from "../../types";
+import {
+  expectLicenseRequestMessage,
+  MediaKeysImpl,
+  MediaKeySystemAccessImpl,
+  mockCompat,
+} from "./utils";
+
+/* tslint:disable no-unsafe-any */
+describe("core - eme - global tests - server certificate", () => {
+
+  const getLicenseSpy = jest.fn(() => {
+    /* tslint:disable ban */
+    return new Promise(() => { /* noop */ });
+    /* tslint:enable ban */
+  });
+
+  /** Default video element used in our tests. */
+  const videoElt = document.createElement("video");
+
+  const serverCertificate = [1, 2, 3];
+
+  /** Default keySystems configuration used in our tests. */
+  const ksConfigCert = [{ type: "com.widevine.alpha",
+                          getLicense: getLicenseSpy,
+                          serverCertificate }];
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.restoreAllMocks();
+  });
+
+  /* tslint:disable max-line-length */
+  it("should set the serverCertificate after receiving the first encrypted event", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    mockCompat();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+    const serverCertificateSpy =
+      jest.spyOn(MediaKeysImpl.prototype, "setServerCertificate")
+      .mockImplementation((_serverCertificate : BufferSource) => {
+        expect(createSessionSpy).not.toHaveBeenCalled();
+        /* tslint:disable ban */
+        return Promise.resolve(true);
+        /* tslint:enable ban */
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initDataSubject = new Subject<IContentProtection>();
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfigCert, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              initDataSubject.next({ type: "cenc2", data: initData });
+            }, 10);
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error(`Unexpected event: ${evt.type}`);
+        }
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should emit warning if serverCertificate call rejects but still continue", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    mockCompat();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+    const serverCertificateSpy =
+      jest.spyOn(MediaKeysImpl.prototype, "setServerCertificate")
+      .mockImplementation((_serverCertificate : BufferSource) => {
+        expect(createSessionSpy).not.toHaveBeenCalled();
+        /* tslint:disable ban */
+        return Promise.reject("some error");
+        /* tslint:enable ban */
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initDataSubject = new Subject<IContentProtection>();
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfigCert, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
+          case 3:
+            expect(evt.type).toEqual("warning");
+            expect(evt.value.name).toEqual("EncryptedMediaError");
+            expect(evt.value.type).toEqual("ENCRYPTED_MEDIA_ERROR");
+            expect(evt.value.code).toEqual("LICENSE_SERVER_CERTIFICATE_ERROR");
+            expect(evt.value.message)
+              .toEqual("EncryptedMediaError (LICENSE_SERVER_CERTIFICATE_ERROR) `setServerCertificate` error");
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              initDataSubject.next({ type: "cenc2", data: initData });
+            }, 10);
+            break;
+          case 5:
+            expectLicenseRequestMessage(evt, initData, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error(`Unexpected event: ${evt.type}`);
+        }
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should emit warning if serverCertificate call throws but still continue", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    mockCompat();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+    const serverCertificateSpy =
+      jest.spyOn(MediaKeysImpl.prototype, "setServerCertificate")
+      .mockImplementation((_serverCertificate : BufferSource) => {
+        expect(createSessionSpy).not.toHaveBeenCalled();
+        throw new Error("some error");
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initDataSubject = new Subject<IContentProtection>();
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfigCert, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
+          case 3:
+            expect(evt.type).toEqual("warning");
+            expect(evt.value.name).toEqual("EncryptedMediaError");
+            expect(evt.value.type).toEqual("ENCRYPTED_MEDIA_ERROR");
+            expect(evt.value.code).toEqual("LICENSE_SERVER_CERTIFICATE_ERROR");
+            expect(evt.value.message)
+              .toEqual("EncryptedMediaError (LICENSE_SERVER_CERTIFICATE_ERROR) Error: some error");
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              initDataSubject.next({ type: "cenc2", data: initData });
+            }, 10);
+            break;
+          case 5:
+            expectLicenseRequestMessage(evt, initData, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error(`Unexpected event: ${evt.type}`);
+        }
+      });
+  });
+
+  /* tslint:disable max-line-length */
+  it("should just continue if serverCertificate is undefined", (done) => {
+  /* tslint:enable max-line-length */
+
+    // == mocks ==
+    mockCompat();
+    const createSessionSpy = jest.spyOn(MediaKeysImpl.prototype, "createSession");
+    jest.spyOn(MediaKeySystemAccessImpl.prototype, "createMediaKeys")
+      .mockImplementation(() => {
+        const mediaKeys = new MediaKeysImpl();
+        (mediaKeys as any).setServerCertificate = undefined;
+        /* tslint:disable ban */
+        return Promise.resolve(mediaKeys);
+        /* tslint:enable ban */
+      });
+    const serverCertificateSpy =
+      jest.spyOn(MediaKeysImpl.prototype, "setServerCertificate")
+      .mockImplementation((_serverCertificate : BufferSource) => {
+        expect(createSessionSpy).not.toHaveBeenCalled();
+        /* tslint:disable ban */
+        return Promise.resolve(true);
+        /* tslint:enable ban */
+      });
+
+    // == vars ==
+    let eventsReceived = 0;
+    const initDataSubject = new Subject<IContentProtection>();
+    const initData = new Uint8Array([54, 55, 75]);
+    const kill$ = new Subject();
+
+    // == test ==
+    const EMEManager = require("../../eme_manager").default;
+    EMEManager(videoElt, ksConfigCert, initDataSubject)
+      .pipe(takeUntil(kill$))
+      .subscribe((evt : any) => {
+        switch (++eventsReceived) {
+          case 1:
+            expect(evt.type).toEqual("created-media-keys");
+            break;
+          case 2:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
+          case 3:
+            expectLicenseRequestMessage(evt, initData, "cenc");
+            setTimeout(() => {
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+              expect(createSessionSpy).toHaveBeenCalledTimes(1);
+              initDataSubject.next({ type: "cenc2", data: initData });
+            }, 10);
+            break;
+          case 4:
+            expectLicenseRequestMessage(evt, initData, "cenc2");
+            setTimeout(() => {
+              kill$.next();
+              expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+              expect(createSessionSpy).toHaveBeenCalledTimes(2);
+              done();
+            }, 10);
+            break;
+          default:
+            throw new Error(`Unexpected event: ${evt.type}`);
+        }
+      });
+  });
+});

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EMPTY } from "rxjs";
+
+function generateEmptyEvent() : jest.Mock {
+  return jest.fn(() => EMPTY);
+}
+
+export function mockCompat(exportedFunctions = {}) {
+  const eventSpies : Record<string, jest.Mock> = {
+    onEncrypted$: generateEmptyEvent(),
+    onKeyMessage$: generateEmptyEvent(),
+    onKeyAdded$: generateEmptyEvent(),
+    onKeyError$: generateEmptyEvent(),
+    onKeyStatusesChange$: generateEmptyEvent(),
+  };
+
+  jest.mock("../../../../compat", () => (
+    /* tslint:disable ban */
+    Object.assign({ events: eventSpies }, exportedFunctions))
+    /* tslint:enable ban */
+  );
+
+  return { events: eventSpies };
+}

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -13,27 +13,404 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/* tslint:disable no-unsafe-any */
 
-import { EMPTY } from "rxjs";
+import {
+  defer as observableDefer,
+  Observable,
+  of as observableOf,
+  Subject,
+} from "rxjs";
+import {
+  base64ToBytes,
+  bytesToBase64,
+} from "../../../../utils/base64";
+import {
+  bytesToStr,
+  strToBytes,
+} from "../../../../utils/byte_parsing";
+import castToObservable from "../../../../utils/cast_to_observable";
+import EventEmitter, { fromEvent } from "../../../../utils/event_emitter";
+import flatMap from "../../../../utils/flat_map";
 
-function generateEmptyEvent() : jest.Mock {
-  return jest.fn(() => EMPTY);
+/** Default MediaKeySystemAccess configuration used by the RxPlayer. */
+export const defaultKSConfig = [{
+  audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
+                         robustness: undefined },
+                       { contentType: "audio/webm;codecs=opus",
+                         robustness: undefined } ],
+  distinctiveIdentifier: "optional" as const,
+  initDataTypes: ["cenc"] as const,
+  persistentState: "optional" as const,
+  sessionTypes: ["temporary"] as const,
+  videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"",
+                         robustness: undefined },
+                       { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
+                         robustness: undefined },
+                       { contentType: "video/webm;codecs=\"vp8\"",
+                         robustness: undefined} ],
+}];
+
+/** Default Widevine MediaKeySystemAccess configuration used by the RxPlayer. */
+export const defaultWidevineConfig = (() => {
+  const ROBUSTNESSES = [ "HW_SECURE_ALL",
+                         "HW_SECURE_DECODE",
+                         "HW_SECURE_CRYPTO",
+                         "SW_SECURE_DECODE",
+                         "SW_SECURE_CRYPTO" ];
+  const videoCapabilities = flatMap(ROBUSTNESSES, robustness => {
+    return [{ contentType: "video/mp4;codecs=\"avc1.4d401e\"",
+              robustness },
+            { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
+              robustness },
+            { contentType: "video/webm;codecs=\"vp8\"",
+              robustness } ];
+  });
+  const audioCapabilities = flatMap(ROBUSTNESSES, robustness => {
+    return [{ contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
+              robustness },
+            { contentType: "audio/webm;codecs=opus",
+              robustness } ];
+  });
+  return defaultKSConfig.map(conf => {
+    /* tslint:disable ban */
+    return Object.assign({}, conf, { audioCapabilities, videoCapabilities });
+    /* tslint:enable ban */
+  });
+})();
+
+/**
+ * Custom implementation of an EME-compliant MediaKeyStatusMap.
+ * @class MediaKeyStatusMapImpl
+ */
+export class MediaKeyStatusMapImpl {
+  public get size() : number {
+    return this._map.size;
+  }
+
+  private _map : Map<ArrayBuffer, MediaKeyStatus>;
+  constructor() {
+    this._map = new Map();
+  }
+
+  public get(keyId: BufferSource): MediaKeyStatus | undefined {
+    const keyIdAB = keyId instanceof ArrayBuffer ? keyId :
+                                                   keyId.buffer;
+    return this._map.get(keyIdAB);
+  }
+
+  public has(keyId: BufferSource): boolean {
+    const keyIdAB = keyId instanceof ArrayBuffer ? keyId :
+                                                   keyId.buffer;
+    return this._map.has(keyIdAB);
+  }
+
+  public forEach(callbackfn: (value: MediaKeyStatus,
+                              key: BufferSource,
+                              parent: MediaKeyStatusMapImpl) => void, thisArg?: any
+  ): void {
+    this._map.forEach((value, key) => callbackfn.bind(thisArg, value, key, this));
+  }
+
+  public __setKeyStatus(keyId : BufferSource, value : MediaKeyStatus | undefined) {
+    const keyIdAB = keyId instanceof ArrayBuffer ? keyId :
+                                                   keyId.buffer;
+    if (value === undefined) {
+      this._map.delete(keyIdAB);
+    } else {
+      this._map.set(keyIdAB, value);
+    }
+  }
 }
 
+/**
+ * Custom implementation of an EME-compliant MediaKeySession.
+ * @class MediaKeySessionImpl
+ */
+export class MediaKeySessionImpl extends EventEmitter<any> {
+  public readonly closed : Promise<void>;
+  public readonly expiration: number;
+  public readonly keyStatuses : MediaKeyStatusMapImpl;
+  public readonly sessionId: string;
+  public onkeystatuseschange: ((this: MediaKeySessionImpl, ev: Event) => any) | null;
+  public onmessage: ((this: MediaKeySessionImpl, ev: MediaKeyMessageEvent) => any) | null;
+
+  private _currentKeyId : number;
+  private _close? : () => void;
+  constructor() {
+    super();
+    this._currentKeyId = 0;
+    this.expiration = Number.MAX_VALUE;
+    this.keyStatuses = new MediaKeyStatusMapImpl();
+
+    /* tslint:disable ban */
+    this.closed = new Promise((res) => {
+      this._close = res;
+    });
+    /* tslint:enable ban */
+
+    this.onkeystatuseschange = null;
+    this.onmessage = null;
+    this.sessionId = "";
+  }
+
+  public close() : Promise<void> {
+    if (this._close !== undefined) {
+      this._close();
+    }
+    /* tslint:disable ban */
+    return Promise.resolve();
+    /* tslint:enable ban */
+  }
+
+  public generateRequest(initDataType: string, initData: BufferSource) : Promise<void> {
+    const msg = formatFakeChallengeFromInitData(initData, initDataType);
+    const event : MediaKeyMessageEvent =
+      /* tslint:disable ban */
+      Object.assign(new CustomEvent("message"),
+                    { message: msg.buffer,
+                      messageType: "license-request" as const });
+
+    this.trigger("message", event);
+    if (this.onmessage !== null && this.onmessage !== undefined) {
+      this.onmessage(event);
+    }
+    /* tslint:disable ban */
+    return Promise.resolve();
+    /* tslint:enable ban */
+  }
+
+  public load(_sessionId: string): Promise<boolean> {
+    throw new Error("Not implemented yet");
+  }
+
+  public remove(): Promise<void> {
+    /* tslint:disable ban */
+    return Promise.resolve();
+    /* tslint:enable ban */
+  }
+
+  public update(_response: BufferSource): Promise<void> {
+    this.keyStatuses.__setKeyStatus(new Uint8Array([0, 1, 2, this._currentKeyId++]),
+                                    "usable");
+    const event = new CustomEvent("keystatuseschange");
+    this.trigger("keyStatusesChange", event);
+    if (this.onkeystatuseschange !== null && this.onkeystatuseschange !== undefined) {
+      this.onkeystatuseschange(event);
+    }
+    /* tslint:disable ban */
+    return Promise.resolve();
+    /* tslint:enable ban */
+  }
+}
+
+/**
+ * Custom implementation of an EME-compliant MediaKeys.
+ * @class MediaKeysImpl
+ */
+export class MediaKeysImpl {
+  createSession(_sessionType? : MediaKeySessionType) {
+    return new MediaKeySessionImpl();
+  }
+
+  setServerCertificate(_serverCertificate : BufferSource) {
+    /* tslint:disable ban */
+    return Promise.resolve(true);
+    /* tslint:enable ban */
+  }
+}
+
+/**
+ * Custom implementation of an EME-compliant MediaKeySystemAccess.
+ * @class MediaKeySystemAccessImpl
+ */
+export class MediaKeySystemAccessImpl {
+  public readonly keySystem : string;
+  private readonly _config : MediaKeySystemConfiguration[];
+  constructor(keySystem : string, config : MediaKeySystemConfiguration[]) {
+    this.keySystem = keySystem;
+    this._config = config;
+  }
+  createMediaKeys() {
+    /* tslint:disable ban */
+    return Promise.resolve(new MediaKeysImpl());
+    /* tslint:enable ban */
+  }
+  getConfiguration() {
+    return this._config;
+  }
+}
+
+export function requestMediaKeySystemAccessImpl(
+  keySystem : string,
+  config : MediaKeySystemConfiguration[]
+) {
+  return observableOf(new MediaKeySystemAccessImpl(keySystem, config));
+}
+
+/**
+ * Mock functions coming from the compat directory.
+ */
 export function mockCompat(exportedFunctions = {}) {
+  const triggerEncrypted = new Subject();
+  const triggerKeyMessage = new Subject();
+  const triggerKeyError = new Subject();
+  const triggerKeyStatusesChange = new Subject();
   const eventSpies : Record<string, jest.Mock> = {
-    onEncrypted$: generateEmptyEvent(),
-    onKeyMessage$: generateEmptyEvent(),
-    onKeyAdded$: generateEmptyEvent(),
-    onKeyError$: generateEmptyEvent(),
-    onKeyStatusesChange$: generateEmptyEvent(),
+    onEncrypted$: jest.fn(() => triggerEncrypted),
+    onKeyMessage$: jest.fn((mediaKeySession : MediaKeySessionImpl) => {
+      return fromEvent(mediaKeySession, "message");
+    }),
+    onKeyError$: jest.fn((mediaKeySession : MediaKeySessionImpl) => {
+      return fromEvent(mediaKeySession, "error");
+    }),
+    onKeyStatusesChange$: jest.fn((mediaKeySession : MediaKeySessionImpl) => {
+      return fromEvent(mediaKeySession, "keyStatusesChange");
+    }),
   };
+
+  const rmksaSpy = jest.fn(requestMediaKeySystemAccessImpl);
+  const setMediaKeysSpy = jest.fn(() => observableOf(null));
+  const generateKeyRequestSpy = jest.fn((
+    mks : MediaKeySessionImpl,
+    initData : BufferSource,
+    initDataType : string
+  ) => {
+    return observableDefer(() => {
+      return castToObservable(mks.generateRequest(initDataType, initData));
+    });
+  });
+
+  const getInitDataSpy = jest.fn((encryptedEvent) => {
+    const { initData, initDataType } = encryptedEvent;
+    return { initData: new Uint8Array(initData), initDataType };
+  });
 
   jest.mock("../../../../compat", () => (
     /* tslint:disable ban */
-    Object.assign({ events: eventSpies }, exportedFunctions))
+    Object.assign({ events: eventSpies,
+                    requestMediaKeySystemAccess: rmksaSpy,
+                    setMediaKeys: setMediaKeysSpy,
+                    getInitData: getInitDataSpy,
+                    generateKeyRequest: generateKeyRequestSpy },
+                  exportedFunctions))
     /* tslint:enable ban */
   );
 
-  return { events: eventSpies };
+  return { eventSpies,
+           eventTriggers: { triggerEncrypted,
+                            triggerKeyMessage,
+                            triggerKeyError,
+                            triggerKeyStatusesChange },
+           requestMediaKeySystemAccessSpy: rmksaSpy,
+           getInitDataSpy,
+           setMediaKeysSpy,
+           generateKeyRequestSpy };
+}
+
+/**
+ * Check that the EMEManager, when called with those arguments, throws
+ * directly without any event emitted.
+ *
+ * If that's the case, resolve with the corresponding error.
+ * Else, reject.
+ * @param {HTMLMediaElement} mediaElement
+ * @param {Array.<Object>} keySystemsConfigs
+ * @param {Observable} contentProtections$
+ * @returns {Promise}
+ */
+export function testEMEManagerImmediateError(
+  EMEManager : any,
+  mediaElement : HTMLMediaElement,
+  keySystemsConfigs : unknown[],
+  contentProtections$ : Observable<unknown>
+) : Promise<unknown> {
+  return new Promise((res, rej) => {
+    EMEManager(mediaElement, keySystemsConfigs, contentProtections$)
+      .subscribe(
+        (evt : unknown) => {
+           const eventStr = JSON.stringify(evt as any);
+          rej(new Error("Received an EMEManager event: " + eventStr));
+        },
+        (err : unknown) => { res(err); },
+        () => rej(new Error("EMEManager completed."))
+      );
+  });
+}
+
+/**
+ * Check that the event received corresponds to the session-message event for a
+ * license request.
+ * @param {Object} evt
+ * @param {Uint8Array} initData
+ * @param {string|undefined} initDataType
+ */
+export function expectLicenseRequestMessage(
+  evt : { type : string; value : any},
+  initData : Uint8Array,
+  initDataType : string | undefined
+) : void {
+  expect(evt.type).toEqual("session-message");
+  expect(evt.value.messageType).toEqual("license-request");
+  expect(evt.value.initData).toEqual(initData);
+  expect(evt.value.initDataType).toEqual(initDataType);
+}
+
+/**
+ * @param {Object} evt
+ * @param {Uint8Array} initData
+ * @param {string|undefined} initDataType
+ */
+export function expectInitDataIgnored(
+  evt : { type : string; value : any},
+  initData : Uint8Array,
+  initDataType : string | undefined
+) : void {
+  expect(evt.type).toEqual("init-data-ignored");
+  expect(evt.value.data).toEqual(initData);
+  expect(evt.value.type).toEqual(initDataType);
+}
+
+/**
+ * @param {Object} evt
+ * @param {Uint8Array} initData
+ * @param {string|undefined} initDataType
+ */
+export function expectEncryptedEventReceived(
+  evt : { type : string; value : any},
+  initData : Uint8Array,
+  initDataType : string | undefined
+) : void {
+  expect(evt.type).toEqual("encrypted-event-received");
+  expect(evt.value.type).toEqual(initDataType);
+  expect(evt.value.data).toEqual(initData);
+}
+
+/**
+ * Does the reverse operation than what `formatFakeChallengeFromInitData` does:
+ * Retrieve initialization data from a fake challenge done in our tests
+ * @param {Uint8Array} challenge
+ * @returns {Object}
+ */
+export function extrackInfoFromFakeChallenge(
+  challenge : Uint8Array
+) : { initData : Uint8Array; initDataType : string } {
+  const licenseData = JSON.stringify(bytesToStr(challenge));
+  const initData = base64ToBytes(licenseData[1]);
+  return { initData, initDataType: licenseData[0] };
+}
+
+/**
+ * @param {BufferSource} initData
+ * @param {string} initDataType
+ * @returns {Uint8Array}
+ */
+export function formatFakeChallengeFromInitData(
+  initData : BufferSource,
+  initDataType : string
+) : Uint8Array {
+  const initDataAB = initData instanceof ArrayBuffer ? initData :
+                                                       initData.buffer;
+  const objChallenge = [initDataType, bytesToBase64(new Uint8Array(initDataAB))];
+  return strToBytes(JSON.stringify(objChallenge));
 }

--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -18,8 +18,12 @@ import {
   defer as observableDefer,
   Observable,
   of as observableOf,
-  Subscription,
+  throwError as observableThrow,
 } from "rxjs";
+import {
+  catchError,
+  map,
+} from "rxjs/operators";
 import {
   ICustomMediaKeySystemAccess,
   requestMediaKeySystemAccess,
@@ -301,27 +305,34 @@ export default function getMediaKeySystemAccess(
       }
       , []);
 
-    return new Observable((obs) => {
-      let disposed = false;
-      let sub: Subscription|null;
+    return recursivelyTestKeySystems(0);
 
-      /**
-       * Test the key system as defined in keySystemsType[index].
-       * @param {Number} index
-       */
-      function testKeySystem(index: number) : void {
-        // completely quit the loop if unsubscribed
-        if (disposed) {
-          return;
-        }
-
+    /**
+     * Test all key system configuration stored in `keySystemsType` one by one
+     * recursively.
+     * Returns an Observable which emit the MediaKeySystemAccess if one was
+     * found compatible with one of the configurations or just throws if none
+     * were found to be compatible.
+     * @param {Number} index - The index in `keySystemsType` to start from.
+     * Should be set to `0` when calling directly.
+     * @returns {Observable}
+     */
+    function recursivelyTestKeySystems(
+      index : number
+    ) : Observable<IFoundMediaKeySystemAccessEvent> {
         // if we iterated over the whole keySystemsType Array, quit on error
         if (index >= keySystemsType.length) {
-          obs.error(new EncryptedMediaError("INCOMPATIBLE_KEYSYSTEMS",
-                                            "No key system compatible with your " +
-                                            "wanted configuration has been found " +
-                                            "in the current browser."));
-          return;
+          const error = new EncryptedMediaError("INCOMPATIBLE_KEYSYSTEMS",
+                                                "No key system compatible with your " +
+                                                "wanted configuration has been found " +
+                                                "in the current browser.");
+          return observableThrow(error);
+        }
+
+        if (requestMediaKeySystemAccess == null) {
+          const error = Error("requestMediaKeySystemAccess is not " +
+                              "implemented in your browser.");
+          return observableThrow(error);
         }
 
         const { keyName, keyType, keySystemOptions } = keySystemsType[index];
@@ -333,37 +344,19 @@ export default function getMediaKeySystemAccess(
                   `${index + 1} of ${keySystemsType.length}`,
                   keySystemConfigurations);
 
-        if (requestMediaKeySystemAccess == null) {
-          throw new Error("requestMediaKeySystemAccess is not " +
-                          "implemented in your browser.");
-        }
-
-        sub = requestMediaKeySystemAccess(keyType, keySystemConfigurations)
-          .subscribe((keySystemAccess) => {
+        return requestMediaKeySystemAccess(keyType, keySystemConfigurations).pipe(
+          map((keySystemAccess) => {
             log.info("EME: Found compatible keysystem", keyType, keySystemConfigurations);
-            obs.next({ type: "create-media-key-system-access",
-                       value: { options: keySystemOptions,
-                                mediaKeySystemAccess: keySystemAccess },
-                      });
-            obs.complete();
-          },
-          () => {
+            return { type: "create-media-key-system-access" as const,
+                     value: { options: keySystemOptions,
+                              mediaKeySystemAccess: keySystemAccess } };
+          }),
+          catchError(() => {
             log.debug("EME: Rejected access to keysystem",
                       keyType,
                       keySystemConfigurations);
-            sub = null;
-            testKeySystem(index + 1);
-          });
-      }
-
-      testKeySystem(0);
-
-      return () => {
-        disposed = true;
-        if (sub != null) {
-          sub.unsubscribe();
-        }
-      };
-    });
+            return recursivelyTestKeySystems(index + 1);
+          }));
+    }
   });
 }

--- a/src/core/eme/get_media_keys.ts
+++ b/src/core/eme/get_media_keys.ts
@@ -23,9 +23,7 @@ import {
   map,
   mergeMap,
 } from "rxjs/operators";
-import {
-  EncryptedMediaError,
-} from "../../errors";
+import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
 import tryCatch from "../../utils/rx-try_catch";

--- a/src/core/eme/session_events_listener.ts
+++ b/src/core/eme/session_events_listener.ts
@@ -60,7 +60,6 @@ import {
   INoUpdateEvent,
   ISessionMessageEvent,
   ISessionUpdatedEvent,
-  TypedArray,
 } from "./types";
 
 const { onKeyError$,
@@ -132,9 +131,7 @@ export default function SessionEventsListener(
         const getLicenseTimeout = isNullOrUndefined(getLicenseConfig.timeout) ?
           10 * 1000 :
           getLicenseConfig.timeout;
-        return (castToObservable(getLicense) as Observable< TypedArray |
-                                                            ArrayBuffer |
-                                                            null >)
+        return (castToObservable(getLicense) as Observable<BufferSource|null>)
           .pipe(getLicenseTimeout >= 0 ? timeout(getLicenseTimeout) :
                                          identity /* noop */);
       });
@@ -261,7 +258,7 @@ function formatGetLicenseError(error: unknown) : ICustomError {
  */
 function updateSessionWithMessage(
   session : MediaKeySession | ICustomMediaKeySession,
-  message : ArrayBuffer | TypedArray | null,
+  message : BufferSource | null,
   initData : Uint8Array,
   initDataType : string | undefined
 ) : Observable<INoUpdateEvent | ISessionUpdatedEvent> {
@@ -301,7 +298,7 @@ function handleKeyStatusesChangeEvent(
     }
     return castToObservable(
                keySystem.onKeyStatusesChange(keyStatusesEvent, session)
-             ) as Observable< TypedArray | ArrayBuffer | null >;
+             ) as Observable< BufferSource | null >;
   }).pipe(
     map(licenseObject => ({ type: "key-status-change-handled" as const,
                             value : { session, license: licenseObject } })),

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -25,9 +25,7 @@ import {
   ignoreElements,
 } from "rxjs/operators";
 import { ICustomMediaKeys } from "../../compat";
-import {
-  EncryptedMediaError,
-} from "../../errors";
+import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
 import {

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -28,10 +28,8 @@ import { ICustomMediaKeys } from "../../compat";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
-import {
-  IEMEWarningEvent,
-  TypedArray,
-} from "./types";
+import tryCatch from "../../utils/rx-try_catch";
+import { IEMEWarningEvent } from "./types";
 
 /**
  * Call the setServerCertificate API with the given certificate.
@@ -49,12 +47,14 @@ import {
  */
 function setServerCertificate(
   mediaKeys : ICustomMediaKeys|MediaKeys,
-  serverCertificate : ArrayBuffer|TypedArray
-) : Observable<unknown> {
+  serverCertificate : BufferSource
+) : Observable<boolean> {
   return observableDefer(() => {
-    return castToObservable(
-      (mediaKeys as MediaKeys).setServerCertificate(serverCertificate)
-    ).pipe(catchError((error: unknown) => {
+    return tryCatch<void, boolean>(() =>
+      castToObservable(
+        (mediaKeys as MediaKeys).setServerCertificate(serverCertificate)
+      )
+    , undefined).pipe(catchError((error: unknown) => {
       log.warn("EME: mediaKeys.setServerCertificate returned an error", error);
       const reason = error instanceof Error ? error.toString() :
                                               "`setServerCertificate` error";
@@ -72,7 +72,7 @@ function setServerCertificate(
  */
 export default function trySettingServerCertificate(
   mediaKeys : ICustomMediaKeys|MediaKeys,
-  serverCertificate : ArrayBuffer|TypedArray
+  serverCertificate : BufferSource
 ) : Observable<IEMEWarningEvent> {
   return observableDefer(() => {
     if (typeof mediaKeys.setServerCertificate !== "function") {

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -142,7 +142,7 @@ export type IEMEManagerEvent = IEMEWarningEvent | // minor error
                                IBlacklistKeysEvent | // keyIDs undecipherable
                                IBlacklistProtectionDataEvent; // initData undecipherable
 
-export type ILicense = TypedArray |
+export type ILicense = BufferSource |
                        ArrayBuffer;
 
 // Segment protection manually sent to the EMEManager
@@ -278,29 +278,16 @@ export interface IPersistentSessionInfoV0 {
 export interface IPersistentSessionStorage { load() : IPersistentSessionInfo[];
                                              save(x : IPersistentSessionInfo[]) : void; }
 
-export type TypedArray = Int8Array |
-                         Int16Array |
-                         Int32Array |
-                         Uint8Array |
-                         Uint16Array |
-                         Uint32Array |
-                         Uint8ClampedArray |
-                         Float32Array |
-                         Float64Array;
-
 // Options given by the caller
 export interface IKeySystemOption {
   type : string;
   getLicense : (message : Uint8Array, messageType : string)
-                 => Promise<TypedArray |
-                            ArrayBuffer |
-                            null> |
-                    TypedArray |
-                    ArrayBuffer |
+                 => Promise<BufferSource | null> |
+                    BufferSource |
                     null;
   getLicenseConfig? : { retry? : number;
                         timeout? : number; };
-  serverCertificate? : ArrayBuffer | TypedArray;
+  serverCertificate? : BufferSource;
   persistentLicense? : boolean;
   licenseStorage? : IPersistentSessionStorage;
   persistentStateRequired? : boolean;
@@ -308,11 +295,8 @@ export interface IKeySystemOption {
   closeSessionsOnStop? : boolean;
   onKeyStatusesChange? : (evt : Event, session : MediaKeySession |
                                                  ICustomMediaKeySession)
-                           => Promise<TypedArray |
-                                      ArrayBuffer |
-                                      null> |
-                              TypedArray |
-                              ArrayBuffer |
+                           => Promise<BufferSource | null> |
+                              BufferSource |
                               null;
   videoRobustnesses?: Array<string|undefined>;
   audioRobustnesses?: Array<string|undefined>;

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -27,10 +27,10 @@ import {
   ignoreElements,
 } from "rxjs/operators";
 import {
+  closeSession,
   ICustomMediaKeys,
   ICustomMediaKeySession,
 } from "../../../compat";
-import closeSession$ from "../../../compat/eme/close_session";
 import { EncryptedMediaError } from "../../../errors";
 import log from "../../../log";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
@@ -242,7 +242,7 @@ function safelyCloseMediaKeySession(
   mediaKeySession : MediaKeySession | ICustomMediaKeySession
 ) : Observable<unknown> {
   log.debug("EME-LSS: Close MediaKeySession", mediaKeySession);
-  return closeSession$(mediaKeySession)
+  return closeSession(mediaKeySession)
     .pipe(catchError((err : unknown) => {
       log.error("EME-LSS: Could not close MediaKeySession: " +
                 (err instanceof Error ? err.toString() :


### PR DESCRIPTION
## Current situation on EME tests

The EME part of our code has very few tests despite having the highest density of [spotted] issues in  our last releases.

We actually completely skip that part in our integration tests. This is because the time investment to add them is important:
  - first we have to provide encrypted contents to our tests (and not our "real" production ones as we are open-source)
   - we would need to test clearkey + playready + widevine (+ nagra?) contents and run tests on devices that support those. Doing this is planned but it's not yet the case.
  - it would take a lot of time to write tests for every small EME features (such as our session caching logic)
  - some tests would not run in an acceptable time limit (like reaching our maximum 1000 simultaneous persistent MediaKeySessions)

## EME regressions of the last release

In our last release, the v3.21.0, we fixed two EME-related regressions about two rarely used features:
  - the serialization of persistent session's data was not functional anymore
  - the `closeSessionsOnStop` option did not... close any session on stop.

We do a lot of manual testing before each release but those issues slept through the net as they need some rarely-used configuration options to be used (and as we did not set those in our manual tests).

As we consider regressions to be a very serious problem, something has to be done to avoid them happening again.

## The solution provided here

### Between integration and unit tests

Regression-detection is usually the role of our integration tests (when completed with our manual tests).
We also have unit tests, but their role are more about testing the implementation of a new code. Once the corresponding code is updated, we most likely will have to update our unit tests, but our integration tests will stay the same. As such they are a poor choice for being a regression-detection mechanism.

On the other hand - as written in a previous chapter - writing integration tests for every single EME features would take us too much time, and would be complex to put in place.

We thus need something in-between integration tests and unit tests:
  - More focused on DRM than our integration tests, with mocking capabilities (to mock various CDM integration, config properties etc.)
  - More maintainable and faster to write than plain unit tests.

### "Global" unit tests

Enters "global" unit tests.

Those tests are regrouped in a ``__global__`` directory, at the root of `__tests__` directories (so, alongside unit tests), themselves placed at the root of the directory they provide tests for.

For example, our global EME unit tests are found in `src/core/eme/__tests__/__global__`.

Unlike "regular" unit tests, global unit tests won't just test code exported by a single file:
it will test the code exported by the whole directory.

For example, in `src/core/eme/__tests__/__global__`, we are talking about testing the whole `EMEManager` implementation: its arguments, return values and the browser APIs it calls.

Those global tests can also tests other helper functions exported in `src/core/eme`. For example, we could check `clearEMESession`.

A key difference with integration tests is that those global unit tests will mock most external code, such as the EME implementation. This way, we can tests multiple CDM configurations and quirks without testing on the corresponding platforms.

We can also tweak configuration values, such as the maximum number of stored persistent sessions, to run those tests in an acceptable time.

## What I've done now

For now, I just tested that the browser API `requestMediaKeySystemAccess` (as exposed by `src/compat`) was called with the right arguments depending on the options given.

I also tested that multiple configurations will be tested in the right order as previous configurations are refused. I use coverage reports to make sure that every sensible branch of the code there is taken.

## What is left to be done

There is still a lot of global unit tests to be written on `src/core/eme`.

Global unit tests is also is also a good solution for other parts of the code that are pretty-well self-contained (such as parsers in `src/parsers`). For now nothing is planned for those but it would be a good idea to begin implementing some simple tests for those other parts.