### PR TITLE
Support for SegmentBase without SegmentBase tag and index range

### DIFF
--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -90,6 +90,12 @@ export interface IPrivateInfos {
   metaplaylistInfos? : IMetaPlaylistPrivateInfos;
   localManifestInitSegment? : ILocalManifestInitSegmentPrivateInfos;
   localManifestSegment? : ILocalManifestSegmentPrivateInfos;
+  // There may be an init range but we don't know it.
+  // It should be guessed when fetching.
+  shouldGuessInitRange? : boolean;
+  // If nothing seems to indicate us that content is
+  // fragmented, it might be a static content.
+  mightBeStaticContent? : boolean;
 }
 
 /** Represent a single Segment from a Representation. */

--- a/src/parsers/manifest/dash/indexes/get_init_segment.ts
+++ b/src/parsers/manifest/dash/indexes/get_init_segment.ts
@@ -19,23 +19,26 @@ import { ISegment } from "../../../../manifest";
 /**
  * Construct init segment for the given index.
  * @param {Object} index
- * @returns {Object}
+ * @returns {Object|null}
  */
 export default function getInitSegment(
   index: { timescale: number;
-           initialization?: { mediaURLs: string[] | null; range?: [number, number] };
+           initialization: { mediaURLs: string[] | null;
+                             range?: [number, number]; } | null;
            indexRange?: [number, number];
            indexTimeOffset : number; }
-) : ISegment {
+) : ISegment | null {
   const { initialization } = index;
+  if (initialization === null) {
+    return null;
+  }
   return { id: "init",
            isInit: true,
            time: 0,
            duration: 0,
-           range: initialization != null ? initialization.range :
-                                           undefined,
+           range: initialization.range,
            indexRange: index.indexRange,
-           mediaURLs: initialization?.mediaURLs ?? null,
+           mediaURLs: initialization.mediaURLs ?? null,
            timescale: index.timescale,
            timestampOffset: -(index.indexTimeOffset / index.timescale) };
 }

--- a/src/parsers/manifest/dash/indexes/list.ts
+++ b/src/parsers/manifest/dash/indexes/list.ts
@@ -50,12 +50,12 @@ export interface IListIndex {
    */
   indexTimeOffset : number;
   /** Information on the initialization segment. */
-  initialization? : {
+  initialization : {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
     range?: [number, number];
-  };
+  } | null;
   /** Information on the list of segments for this index. */
   list: Array<{
     /** URLs of the segment. */
@@ -145,8 +145,8 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
                     duration: index.duration,
                     indexTimeOffset,
                     indexRange: index.indexRange,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       { mediaURLs: createIndexURLs(representationBaseURLs,
                                                   index.initialization.media,
                                                   representationId,
@@ -156,9 +156,9 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
 
   /**
    * Construct init Segment.
-   * @returns {Object}
+   * @returns {Object | null}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -49,12 +49,12 @@ export interface ITemplateIndex {
   /** Byte range for a possible index of segments in the server. */
   indexRange?: [number, number];
   /** Information on the initialization segment. */
-  initialization? : {
+  initialization : {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
     range?: [number, number];
-  };
+  } | null;
   /**
    * URL base to access any segment.
    * Can contain token to replace to convert it to real URLs.
@@ -187,8 +187,8 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                     timescale,
                     indexRange: index.indexRange,
                     indexTimeOffset,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       { mediaURLs: createIndexURLs(representationBaseURLs,
                                                   index.initialization.media,
                                                   representationId,
@@ -210,7 +210,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
    * Construct init Segment.
    * @returns {Object}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -65,12 +65,12 @@ export interface ITimelineIndex {
    */
   indexTimeOffset : number;
   /** Information on the initialization segment. */
-  initialization? : {
+  initialization : {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
     range?: [number, number];
-  };
+  } | null;
   /**
    * Base URL(s) to access any segment. Can contain tokens to replace to convert
    * it to real URLs.
@@ -276,8 +276,8 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     this._parseTimeline = index.parseTimeline;
     this._index = { indexRange: index.indexRange,
                     indexTimeOffset,
-                    initialization: index.initialization == null ?
-                      undefined :
+                    initialization: index.initialization === undefined ?
+                      null :
                       {
                         mediaURLs: createIndexURLs(representationBaseURLs,
                                                   index.initialization.media,
@@ -299,9 +299,9 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
 
   /**
    * Construct init Segment.
-   * @returns {Object}
+   * @returns {Object | null}
    */
-  getInitSegment() : ISegment {
+  getInitSegment() : ISegment | null {
     return getInitSegment(this._index);
   }
 

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -128,12 +128,9 @@ function findAdaptationIndex(
       new TimelineRepresentationIndex(segmentTemplate, context) :
       new TemplateRepresentationIndex(segmentTemplate, context);
   } else {
-    adaptationIndex = new TemplateRepresentationIndex({
-      duration: Number.MAX_VALUE,
-      timescale: 1,
-      startNumber: 0,
-      initialization: { media: "" },
-      media: "",
+    adaptationIndex = new BaseRepresentationIndex({
+      timeline: [],
+      timescale: 1, // set to 1 if no timescale was provided in the manifest
     }, context);
   }
   return adaptationIndex;
@@ -191,6 +188,8 @@ export default function parseRepresentations(
                       availabilityTimeOffset: adaptationInfos.availabilityTimeOffset,
                       unsafelyBaseOnPreviousRepresentation,
                       manifestBoundsCalculator: adaptationInfos.manifestBoundsCalculator,
+                      mimeType: representation.attributes.mimeType ??
+                                adaptation.attributes.mimeType,
                       isDynamic: adaptationInfos.isDynamic,
                       periodEnd: adaptationInfos.end,
                       periodStart: adaptationInfos.start,

--- a/src/transports/dash/extract_complete_init_chunk.ts
+++ b/src/transports/dash/extract_complete_init_chunk.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../../log";
+import { be4toi } from "../../utils/byte_parsing";
+import findCompleteBox from "../utils/find_complete_box";
+
+/**
+ * Extract the constituent boxes (ftyp / moov) of an init segment.
+ * @param {Uint8Array} buf
+ * @returns {Uint8Array|null}
+ */
+export default function extractCompleteInitChunk(buf: Uint8Array): Uint8Array|null {
+  const ftypBoxIndex = findCompleteBox(buf, 0x66747970 /* ftyp */);
+  if (ftypBoxIndex < 0) {
+    log.error("DASH: Incomplete `ftyp` box");
+    return null;
+  }
+  const ftypBoxSize = be4toi(buf, ftypBoxIndex); // size of the "ftyp" box
+  const ftypBox = buf.subarray(ftypBoxIndex, ftypBoxIndex + ftypBoxSize);
+
+  const moovBoxIndex = findCompleteBox(buf, 0x6D6F6F76 /* moov */);
+  if (ftypBoxIndex < 0) {
+    log.error("DASH: Incomplete `moov` box");
+    return null;
+  }
+  const moovBoxSize = be4toi(buf, moovBoxIndex); // size of the "moov" box
+  const moovBox = buf.subarray(moovBoxIndex, moovBoxIndex + moovBoxSize);
+  const initChunk = new Uint8Array(ftypBoxSize + moovBoxSize);
+  initChunk.set(ftypBox, 0);
+  initChunk.set(moovBox, ftypBoxSize);
+
+  return initChunk;
+}

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -33,6 +33,18 @@ export default function initSegmentLoader(
   url : string,
   { segment } : ISegmentLoaderArguments
 ) : ISegmentLoaderObservable<ArrayBuffer> {
+  if (segment.privateInfos?.shouldGuessInitRange === true) {
+    // If no range and index range are given by manifest, we take
+    // as init segment the nth first bytes (where n = 1500).
+    // Therefore, we need to filter on init boxes after the segment
+    // is loaded, to ensure that we push a complete and dry segment
+    // to buffers.
+    return xhr({ url,
+                 headers: { Range: byteRange([0, 1500]) },
+                 responseType: "arraybuffer",
+                 sendProgressEvents: true });
+  }
+
   if (segment.range === undefined) {
     return xhr({ url, responseType: "arraybuffer", sendProgressEvents: true });
   }


### PR DESCRIPTION
The PR is made to fix a bug were :
- A fragmented SegmentBase content was given without any index and init range. The RxPlayer considered it to be static, and tried to load the entire mp4 before pushing it.
--------------------------------------------------------------------------------------------
The fix is :

When a representation is a SegmentBase, we consider that it may be static or fragmented.

If the content is an mp4 :
- If init and index ranges are provided, consider it to be explicitely fragmented.
- If no init range provided, we try to load the 1500 first bytes to extract an init data.
- If no index range is provided, try to extract sidx segments from first loaded bytes. If no sidx segment is found, then consider that content is a static one. If new segments found, consider it to be fragmented and add segments to index.

If the content is not explicitely an mp4, then consider it to be static.
