### PR TITLE
demo: now use "!" as a key separator in generated links

### DIFF
--- a/demo/full/scripts/lib/url_hash.js
+++ b/demo/full/scripts/lib/url_hash.js
@@ -16,19 +16,19 @@
  * and booleans.
  *
  * The key is designated by a name. This is a string of any length which should
- * not contain any backslash ("\") or underscore ("_") character as those are
- * reserved, but could technically contain any other characters (we are though
- * usually limited here by URL-encoding).
- * Each of those keys are prepended by a backslash ("\") character.
+ * not contain any exclamation mark ("!") or underscore ("_") character as those
+ * are reserved, but could technically contain any other characters (we are
+ * though usually limited here by URL-encoding).
+ * Each of those keys are prepended by an exclamation mark ("!") character.
  *
  * To communicate a boolean value, that key is immediately either followed by
- * the next key (which is again, prepended by a backslash character) or by
- * the end of the whole string, which indicates the end of the data.
+ * the next key (which is again, prepended by an exclamation mark character) or
+ * by the end of the whole string, which indicates the end of the data.
  * A boolean value encountered is always inferred to be `true`. To set is to
  * `false`, just remove the key from the string. There is no difference between
  * `false` and a not-defined key.
  * Example:
- * http://www.example.com/#\lowLatency\noAutoplay
+ * http://www.example.com/#!lowLatency!noAutoplay
  * => will get you the following JS Object:
  * ```js
  * {
@@ -47,10 +47,10 @@
  * more Base-36 numbers, an equal ("=") sign is added to mark the end of this
  * length.
  * The data then starts just after that equal sign and ends at the end of the
- * announced length (followed either by the following field - prepended by a
- * backslash - or the end of the string).
+ * announced length (followed either by the following field - prepended by an
+ * exclamation mark - or the end of the string).
  * Example with both booleans and strings and a `FIELD_LENGTH` of 4:
- * http://www.example.com/#\lowLatency\manifest_1n=http://www.example.com/streaming/dash_contents/Manifest.mpd\foobar
+ * http://www.example.com/#!lowLatency!manifest_1n=http://www.example.com/streaming/dash_contents/Manifest.mpd!foobar
  * => will get you
  * ```js
  * {
@@ -70,19 +70,29 @@ export function parseHashInURL(hashStr) {
   }
 
   const parsed = {};
-  let hashOffset = 2; // initial "#\"
+
+  // Note a previous version made use of the non-percent-encodable "\" separator
+  // instead of the "!" we use today.
+  // To still support links done in previous version, we want to detect which
+  // of those two separators is used.
+  // Fortunately, the first key also starts with a separator. This means that
+  // the separator should always be the second character of the hash (after
+  // "#").
+  const separatorChar = hashStr[1];
+
+  let hashOffset = 2; // initial "#!"
 
   const hashLen = hashStr.length;
   while (hashOffset + 1 <= hashLen) {
     const unparsedStr = hashStr.substring(hashOffset);
-    const nextBackSlash = unparsedStr.indexOf("\\");
+    const nextSeparator = unparsedStr.indexOf(separatorChar);
     const nextUnderscore = unparsedStr.indexOf("_");
     if (nextUnderscore <= 0 ||
-        (nextBackSlash >= 0 && nextUnderscore > nextBackSlash))
+        (nextSeparator >= 0 && nextUnderscore > nextSeparator))
     {
       // this is a boolean
-      const fieldLength = nextBackSlash >= 0 ?
-        nextBackSlash :
+      const fieldLength = nextSeparator >= 0 ?
+        nextSeparator :
         unparsedStr.length;
       const fieldName = unparsedStr.substring(0, fieldLength);
       hashOffset += fieldLength; // skip field name
@@ -109,7 +119,7 @@ export function parseHashInURL(hashStr) {
       const data = hashStr.substring(dataStart, hashOffset);
       parsed[fieldName] = data;
     }
-    hashOffset += 1; // skip next "\"
+    hashOffset += 1; // skip next separator
   }
   return parsed;
 }
@@ -141,32 +151,32 @@ export function generateLinkForCustomContent({
   let drmTypeString = "";
   let customKeySystemString = "";
   if (manifestURL) {
-    urlString = "\\manifest_" +
+    urlString = "!manifest_" +
                 manifestURL.length.toString(36) +
                 "=" + manifestURL;
   }
   if (transport) {
-    transportString = "\\tech_" +
+    transportString = "!tech_" +
                       transport.length.toString(36) +
                       "=" + transport;
   }
   if (chosenDRMType) {
-    drmTypeString = "\\drm_" +
+    drmTypeString = "!drm_" +
                     chosenDRMType.length.toString(36) +
                     "=" + chosenDRMType;
   }
   if (customKeySystem) {
-    customKeySystemString = "\\customKeySystem_" +
+    customKeySystemString = "!customKeySystem_" +
                             customKeySystem.length.toString(36) +
                             "=" + customKeySystem;
   }
   if (licenseServerUrl) {
-    licenseServerUrlString = "\\licenseServ_" +
+    licenseServerUrlString = "!licenseServ_" +
                              licenseServerUrl.length.toString(36) +
                              "=" + licenseServerUrl;
   }
   if (serverCertificateUrl) {
-    serverCertificateUrlString = "\\certServ_" +
+    serverCertificateUrlString = "!certServ_" +
                                  serverCertificateUrl.length.toString(36) +
                                  "=" + serverCertificateUrl;
   }
@@ -181,10 +191,10 @@ export function generateLinkForCustomContent({
          location.pathname +
          (location.search ? location.search : "") +
          "#" +
-         (!autoPlay ? "\\noAutoplay" : "") +
-         (lowLatency ? "\\lowLatency" : "") +
-         (fallbackKeyError ? "\\fallbackKeyError" : "") +
-         (fallbackLicenseRequest ? "\\fallbackLicenseRequest" : "") +
+         (!autoPlay ? "!noAutoplay" : "") +
+         (lowLatency ? "!lowLatency" : "") +
+         (fallbackKeyError ? "!fallbackKeyError" : "") +
+         (fallbackLicenseRequest ? "!fallbackLicenseRequest" : "") +
          transportString +
          urlString +
          drmTypeString +


### PR DESCRIPTION
Fixes #758.

We used a backslash ("\") character as a key separator in generated link but I found out those needed to be percent-encoded to be in a valid URL.

We had no problem when directly linking to that URL but I found out, after sharing that link on outlook, that the link didn't work as expected anymore. This is because outlook percent-encoded it (this seems to be a side effect of their "safelink" protection scheme).

When getting links that where percent-encoded, the demo page didn't know what to do and thus acted as if no content was set through the URL (as a resilience measure).

By using now "!", a perfectly valid character in the fragment of an URL, we can now avoid that issue.

Note that the demo page is still compatible with URL with "\" characters, so links created with older versions still work.