### PR TITLE
DASH: MPD SegmentTemplate inheritance

### DIFF
--- a/src/parsers/manifest/dash/indexes/base.ts
+++ b/src/parsers/manifest/dash/indexes/base.ts
@@ -79,8 +79,8 @@ export interface IBaseIndex {
  * Most of the properties here are already defined in IBaseIndex.
  */
 export interface IBaseIndexIndexArgument {
-  timeline : IIndexSegment[];
-  timescale : number;
+  timeline? : IIndexSegment[];
+  timescale? : number;
   media? : string;
   indexRange?: [number, number];
   initialization?: { media?: string; range?: [number, number] };
@@ -177,7 +177,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
             representationBaseURLs,
             representationId,
             representationBitrate } = context;
-    const { timescale } = index;
+    const timescale = index.timescale ?? 1;
 
     const presentationTimeOffset = index.presentationTimeOffset != null ?
       index.presentationTimeOffset : 0;
@@ -210,11 +210,11 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                                                representationId,
                                                representationBitrate),
                     startNumber: index.startNumber,
-                    timeline: index.timeline,
+                    timeline: index.timeline ?? [],
                     timescale };
     this._scaledPeriodEnd = periodEnd == null ? undefined :
                                                 toIndexTime(periodEnd, this._index);
-    this._isInitialized = index.timeline.length > 0;
+    this._isInitialized = this._index.timeline.length > 0;
   }
 
   /**

--- a/src/parsers/manifest/dash/indexes/list.ts
+++ b/src/parsers/manifest/dash/indexes/list.ts
@@ -97,7 +97,7 @@ export interface IListIndexIndexArgument {
    * timescale (see timescale)
    */
   presentationTimeOffset? : number;
-  timescale : number;
+  timescale? : number;
 }
 
 /** Aditional context needed by a SegmentList RepresentationIndex. */
@@ -132,7 +132,8 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
     const presentationTimeOffset =
       index.presentationTimeOffset != null ? index.presentationTimeOffset :
                                              0;
-    const indexTimeOffset = presentationTimeOffset - periodStart * index.timescale;
+    const timescale = index.timescale ?? 1;
+    const indexTimeOffset = presentationTimeOffset - periodStart * timescale;
 
     const list = index.list.map((lItem) => ({
       mediaURLs: createIndexURLs(representationBaseURLs,
@@ -141,7 +142,7 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
                                  representationBitrate),
       mediaRange: lItem.mediaRange }));
     this._index = { list,
-                    timescale: index.timescale,
+                    timescale,
                     duration: index.duration,
                     indexTimeOffset,
                     indexRange: index.indexRange,

--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -97,15 +97,14 @@ export interface ITemplateIndex {
  * Most of the properties here are already defined in ITemplateIndex.
  */
 export interface ITemplateIndexIndexArgument {
-  duration : number;
-  timescale : number;
-
+  duration? : number;
   indexRange?: [number, number];
   initialization?: { media? : string;
                      range? : [number, number]; };
   media? : string;
   presentationTimeOffset? : number;
   startNumber? : number;
+  timescale? : number;
 }
 
 /** Aditional context needed by a SegmentTemplate RepresentationIndex. */
@@ -161,7 +160,6 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     index : ITemplateIndexIndexArgument,
     context : ITemplateIndexContextArgument
   ) {
-    const { timescale } = index;
     const { aggressiveMode,
             availabilityTimeOffset,
             manifestBoundsCalculator,
@@ -171,6 +169,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
             representationBaseURLs,
             representationId,
             representationBitrate } = context;
+    const timescale = index.timescale ?? 1;
 
     this._availabilityTimeOffset = availabilityTimeOffset;
 
@@ -182,6 +181,10 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
 
     const scaledStart = periodStart * timescale;
     const indexTimeOffset = presentationTimeOffset - scaledStart;
+
+    if (index.duration === undefined) {
+      throw new Error("Invalid SegmentTemplate: no duration");
+    }
 
     this._index = { duration: index.duration,
                     timescale,

--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -113,8 +113,7 @@ export interface ITimelineIndexIndexArgument {
   initialization? : { media? : string; range?: [number, number] };
   media? : string;
   startNumber? : number;
-  parseTimeline : () => HTMLCollection;
-  timescale : number;
+  timescale? : number;
   /**
    * Offset present in the index to convert from the mediaTime (time declared in
    * the media segments and in this index) to the presentationTime (time wanted
@@ -236,6 +235,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
    */
   constructor(
     index : ITimelineIndexIndexArgument,
+    timelineParser : () => HTMLCollection,
     context : ITimelineIndexContextArgument
   ) {
     const { manifestBoundsCalculator,
@@ -245,7 +245,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
             representationBitrate,
             periodStart,
             periodEnd } = context;
-    const { timescale } = index;
+    const timescale = index.timescale ?? 1;
 
     const presentationTimeOffset = index.presentationTimeOffset != null ?
       index.presentationTimeOffset :
@@ -273,7 +273,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     }
 
     this._isDynamic = isDynamic;
-    this._parseTimeline = index.parseTimeline;
+    this._parseTimeline = timelineParser;
     this._index = { indexRange: index.indexRange,
                     indexTimeOffset,
                     initialization: index.initialization == null ?

--- a/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
@@ -35,7 +35,6 @@ import parseSegmentList, {
 } from "./SegmentList";
 import parseSegmentTemplate, {
   IParsedSegmentTemplate,
-  IParsedSegmentTimeline,
 } from "./SegmentTemplate";
 import {
   IScheme,
@@ -68,7 +67,7 @@ export interface IAdaptationSetChildren {
 
   segmentBase? : IParsedSegmentBase;
   segmentList? : IParsedSegmentList;
-  segmentTemplate? : IParsedSegmentTemplate|IParsedSegmentTimeline;
+  segmentTemplate? : IParsedSegmentTemplate;
 }
 
 export interface IAdaptationSetAttributes {

--- a/src/parsers/manifest/dash/node_parsers/Period.ts
+++ b/src/parsers/manifest/dash/node_parsers/Period.ts
@@ -24,6 +24,9 @@ import parseBaseURL, {
 import parseEventStream, {
   IParsedStreamEvent
 } from "./EventStream";
+import parseSegmentTemplate, {
+  IParsedSegmentTemplate,
+} from "./SegmentTemplate";
 import {
   parseBoolean,
   parseDuration,
@@ -40,6 +43,7 @@ export interface IPeriodChildren {
   // required
   adaptations : IAdaptationSetIntermediateRepresentation[];
   baseURLs : IBaseURL[];
+  segmentTemplate? : IParsedSegmentTemplate;
   streamEvents? : IParsedStreamEvent[];
 }
 
@@ -61,6 +65,7 @@ export interface IPeriodAttributes {
 function parsePeriodChildren(periodChildren : NodeList) : [IPeriodChildren, Error[]] {
   const baseURLs : IBaseURL[] = [];
   const adaptations : IAdaptationSetIntermediateRepresentation[] = [];
+  let segmentTemplate : IParsedSegmentTemplate | undefined;
 
   let warnings : Error[] = [];
   const streamEvents = [];
@@ -90,11 +95,20 @@ function parsePeriodChildren(periodChildren : NodeList) : [IPeriodChildren, Erro
           streamEvents.push(...newStreamEvents);
           warnings = warnings.concat(eventStreamWarnings);
           break;
+
+        case "SegmentTemplate":
+          const [parsedSegmentTemplate, segmentTemplateWarnings] =
+            parseSegmentTemplate(currentElement);
+          segmentTemplate = parsedSegmentTemplate;
+          if (segmentTemplateWarnings.length > 0) {
+            warnings = warnings.concat(segmentTemplateWarnings);
+          }
+          break;
       }
     }
   }
 
-  return [{ baseURLs, adaptations, streamEvents }, warnings];
+  return [{ baseURLs, adaptations, streamEvents, segmentTemplate }, warnings];
 }
 
 /**

--- a/src/parsers/manifest/dash/node_parsers/Representation.ts
+++ b/src/parsers/manifest/dash/node_parsers/Representation.ts
@@ -25,7 +25,6 @@ import parseSegmentList, {
 } from "./SegmentList";
 import parseSegmentTemplate, {
   IParsedSegmentTemplate,
-  IParsedSegmentTimeline,
 } from "./SegmentTemplate";
 import {
   MPDError,
@@ -47,7 +46,7 @@ export interface IRepresentationChildren {
   // optional
   segmentBase? : IParsedSegmentBase;
   segmentList? : IParsedSegmentList;
-  segmentTemplate? : IParsedSegmentTemplate|IParsedSegmentTimeline;
+  segmentTemplate? : IParsedSegmentTemplate;
 }
 
 export interface IRepresentationAttributes {

--- a/src/parsers/manifest/dash/node_parsers/SegmentBase.ts
+++ b/src/parsers/manifest/dash/node_parsers/SegmentBase.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import objectAssign from "../../../../utils/object_assign";
 import parseInitialization, {
   IParsedInitialization,
 } from "./Initialization";
@@ -42,10 +41,10 @@ interface ISegmentBaseSegment { start: number; // start timestamp
                                 range?: [number, number]; }
 
 export interface IParsedSegmentBase extends ISegmentBaseAttributes {
-  availabilityTimeComplete : boolean;
-  indexRangeExact : boolean;
-  timeline : ISegmentBaseSegment[];
-  timescale : number;
+  availabilityTimeComplete? : boolean;
+  indexRangeExact? : boolean;
+  timeline?: ISegmentBaseSegment[];
+  timescale? : number;
   media?: string;
 }
 
@@ -127,17 +126,5 @@ export default function parseSegmentBase(
     }
   }
 
-  const timescale = attributes.timescale == null ? 1 :
-                                                   attributes.timescale;
-  const indexRangeExact = attributes.indexRangeExact === true;
-  const availabilityTimeComplete = attributes.availabilityTimeComplete == null ?
-    true :
-    attributes.availabilityTimeComplete;
-
-  const ret = objectAssign(attributes,
-                           { availabilityTimeComplete,
-                             indexRangeExact,
-                             timeline: [],
-                             timescale, });
-  return [ret, warnings];
+  return [attributes, warnings];
 }

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -29,6 +29,7 @@ import ManifestBoundsCalculator from "./manifest_bounds_calculator";
 import {
   IAdaptationSetIntermediateRepresentation,
 } from "./node_parsers/AdaptationSet";
+import { IParsedSegmentTemplate } from "./node_parsers/SegmentTemplate";
 import parseRepresentations, {
   IAdaptationInfos,
 } from "./parse_representations";
@@ -53,6 +54,8 @@ export interface IAdaptationSetsContextInfos {
    * this AdaptationSet was received.
    */
   receivedTime? : number;
+  /** SegmentTemplate parsed in the Period, if found. */
+  segmentTemplate? : IParsedSegmentTemplate;
   /** Start time of the current period, in seconds. */
   start : number;
   /** Depth of the buffer for the whole content, in seconds. */
@@ -209,8 +212,8 @@ function getAdaptationSetSwitchingIDs(
  * form.
  * Note that the AdaptationSets returned are sorted by priority (from the most
  * priority to the least one).
- * @param {Array.<Object>} periodsIR
- * @param {Object} manifestInfos
+ * @param {Array.<Object>} adaptationsIR
+ * @param {Object} periodInfos
  * @returns {Array.<Object>}
  */
 export default function parseAdaptationSets(
@@ -273,6 +276,14 @@ export default function parseAdaptationSets(
     const originalID = adaptation.attributes.id;
     let newID : string;
     const adaptationSetSwitchingIDs = getAdaptationSetSwitchingIDs(adaptation);
+    const parentSegmentTemplates = [];
+    if (periodInfos.segmentTemplate !== undefined) {
+      parentSegmentTemplates.push(periodInfos.segmentTemplate);
+    }
+    if (adaptation.children.segmentTemplate !== undefined) {
+      parentSegmentTemplates.push(adaptation.children.segmentTemplate);
+    }
+
     const adaptationInfos : IAdaptationInfos = {
       aggressiveMode: periodInfos.aggressiveMode,
       availabilityTimeOffset,
@@ -280,6 +291,7 @@ export default function parseAdaptationSets(
       manifestBoundsCalculator: periodInfos.manifestBoundsCalculator,
       end: periodInfos.end,
       isDynamic: periodInfos.isDynamic,
+      parentSegmentTemplates,
       receivedTime: periodInfos.receivedTime,
       start: periodInfos.start,
       timeShiftBufferDepth: periodInfos.timeShiftBufferDepth,

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -78,6 +78,7 @@ export type IParserResponse<T> = { type : "needs-ressources";
                                  { type : "done";
                                    value : { parsed : T;
                                              warnings : Error[]; }; };
+
 /**
  * @param {Element} root - The MPD root.
  * @param {Object} args

--- a/src/parsers/manifest/dash/parse_periods.ts
+++ b/src/parsers/manifest/dash/parse_periods.ts
@@ -140,6 +140,7 @@ export interface IPeriodsContextInfos {
                           end: periodEnd,
                           isDynamic,
                           receivedTime,
+                          segmentTemplate: periodIR.children.segmentTemplate,
                           start: periodStart,
                           timeShiftBufferDepth,
                           unsafelyBaseOnPreviousPeriod };

--- a/src/parsers/manifest/dash/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/parse_representation_index.ts
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  IRepresentationIndex,
+  Representation,
+} from "../../../manifest";
+import objectAssign from "../../../utils/object_assign";
+import extractMinimumAvailabilityTimeOffset from "./extract_minimum_availability_time_offset";
+import {
+  BaseRepresentationIndex,
+  ListRepresentationIndex,
+  TemplateRepresentationIndex,
+  TimelineRepresentationIndex
+} from "./indexes";
+import ManifestBoundsCalculator from "./manifest_bounds_calculator";
+import {
+  IAdaptationSetIntermediateRepresentation
+} from "./node_parsers/AdaptationSet";
+import {
+  IRepresentationIntermediateRepresentation
+} from "./node_parsers/Representation";
+import { IParsedSegmentTemplate } from "./node_parsers/SegmentTemplate";
+import resolveBaseURLs from "./resolve_base_urls";
+
+/** Supplementary context needed to parse a RepresentationIndex. */
+export interface IRepresentationInfos {
+  /** Parsed AdaptationSet which contains the Representation. */
+  adaptation : IAdaptationSetIntermediateRepresentation;
+  /** Whether we should request new segments even if they are not yet finished. */
+  aggressiveMode : boolean;
+  /** availability time offset of the concerned Adaptation. */
+  availabilityTimeOffset: number;
+  /** Eventual URLs from which every relative URL will be based on. */
+  baseURLs : string[];
+  /** Allows to obtain the first/last available position of a dynamic content. */
+  manifestBoundsCalculator : ManifestBoundsCalculator;
+  /** End time of the current period, in seconds. */
+  end? : number;
+  /** Whether the Manifest can evolve with time. */
+  isDynamic : boolean;
+  /**
+   * Parent parsed SegmentTemplate elements.
+   * Sorted by provenance from higher level (e.g. Period) to lower-lever (e.g.
+   * AdaptationSet).
+   */
+  parentSegmentTemplates : IParsedSegmentTemplate[];
+  /**
+   * Time (in terms of `performance.now`) at which the XML file containing this
+   * Representation was received.
+   */
+  receivedTime? : number;
+  /** Start time of the current period, in seconds. */
+  start : number;
+  /** Depth of the buffer for the whole content, in seconds. */
+  timeShiftBufferDepth? : number;
+  /**
+   * The parser should take this Representation - which is the same as this one
+   * parsed at an earlier time - as a base to speed-up the parsing process.
+   * /!\ If unexpected differences exist between both, there is a risk of
+   * de-synchronization with what is actually on the server.
+   */
+  unsafelyBaseOnPreviousRepresentation : Representation | null;
+}
+
+/**
+ * Parse the specific segment indexing information found in a representation
+ * into a IRepresentationIndex implementation.
+ * @param {Array.<Object>} representation
+ * @param {Object} representationInfos
+ * @returns {Array.<Object>}
+ */
+export default function parseRepresentationIndex(
+  representation : IRepresentationIntermediateRepresentation,
+  representationInfos : IRepresentationInfos
+) : IRepresentationIndex {
+  const representationBaseURLs = resolveBaseURLs(representationInfos.baseURLs,
+                                                 representation.children.baseURLs);
+  const { aggressiveMode,
+          availabilityTimeOffset,
+          manifestBoundsCalculator,
+          isDynamic,
+          end: periodEnd,
+          start: periodStart,
+          receivedTime,
+          timeShiftBufferDepth,
+          unsafelyBaseOnPreviousRepresentation } = representationInfos;
+  const context = { aggressiveMode,
+                    availabilityTimeOffset,
+                    unsafelyBaseOnPreviousRepresentation,
+                    manifestBoundsCalculator,
+                    isDynamic,
+                    periodEnd,
+                    periodStart,
+                    receivedTime,
+                    representationBaseURLs,
+                    representationBitrate: representation.attributes.bitrate,
+                    representationId: representation.attributes.id,
+                    timeShiftBufferDepth };
+  let representationIndex : IRepresentationIndex;
+  if (representation.children.segmentBase !== undefined) {
+    const { segmentBase } = representation.children;
+    context.availabilityTimeOffset =
+      representationInfos.availabilityTimeOffset +
+      extractMinimumAvailabilityTimeOffset(representation.children.baseURLs) +
+      (segmentBase.availabilityTimeOffset ?? 0);
+    representationIndex = new BaseRepresentationIndex(segmentBase, context);
+  } else if (representation.children.segmentList !== undefined) {
+    const { segmentList } = representation.children;
+    representationIndex = new ListRepresentationIndex(segmentList, context);
+  } else if (representation.children.segmentTemplate !== undefined ||
+             representationInfos.parentSegmentTemplates.length > 0)
+  {
+    const segmentTemplates = representationInfos.parentSegmentTemplates.slice();
+    const childSegmentTemplate = representation.children.segmentTemplate;
+    if (childSegmentTemplate !== undefined) {
+      segmentTemplates.push(childSegmentTemplate);
+    }
+    const segmentTemplate =
+      objectAssign({},
+                   ...segmentTemplates as [IParsedSegmentTemplate] /* Ugly TS Hack */);
+    context.availabilityTimeOffset =
+      representationInfos.availabilityTimeOffset +
+      extractMinimumAvailabilityTimeOffset(representation.children.baseURLs) +
+      (segmentTemplate.availabilityTimeOffset ?? 0);
+    const { timelineParser } = segmentTemplate;
+    representationIndex = timelineParser !== undefined ?
+      new TimelineRepresentationIndex(segmentTemplate, timelineParser, context) :
+      new TemplateRepresentationIndex(segmentTemplate, context);
+  } else {
+    const adaptationChildren = representationInfos.adaptation.children;
+    if (adaptationChildren.segmentBase !== undefined) {
+      const { segmentBase } = adaptationChildren;
+      representationIndex = new BaseRepresentationIndex(segmentBase, context);
+    } else if (adaptationChildren.segmentList !== undefined) {
+      const { segmentList } = adaptationChildren;
+      representationIndex = new ListRepresentationIndex(segmentList, context);
+    } else {
+      representationIndex = new TemplateRepresentationIndex({
+        duration: Number.MAX_VALUE,
+        timescale: 1,
+        startNumber: 0,
+        initialization: { media: "" },
+        media: "",
+      }, context);
+    }
+  }
+  return representationIndex;
+}

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -15,22 +15,12 @@
  */
 
 import log from "../../../log";
-import {
-  Adaptation,
-  IRepresentationIndex,
-  Representation,
-} from "../../../manifest";
+import { Adaptation } from "../../../manifest";
+import objectAssign from "../../../utils/object_assign";
 import {
   IContentProtections,
   IParsedRepresentation,
 } from "../types";
-import extractMinimumAvailabilityTimeOffset from "./extract_minimum_availability_time_offset";
-import {
-  BaseRepresentationIndex,
-  ListRepresentationIndex,
-  TemplateRepresentationIndex,
-  TimelineRepresentationIndex
-} from "./indexes";
 import ManifestBoundsCalculator from "./manifest_bounds_calculator";
 import {
   IAdaptationSetIntermediateRepresentation
@@ -38,7 +28,8 @@ import {
 import {
   IRepresentationIntermediateRepresentation
 } from "./node_parsers/Representation";
-import resolveBaseURLs from "./resolve_base_urls";
+import { IParsedSegmentTemplate } from "./node_parsers/SegmentTemplate";
+import parseRepresentationIndex from "./parse_representation_index";
 
 /** Supplementary context needed to parse a Representation. */
 export interface IAdaptationInfos {
@@ -48,12 +39,18 @@ export interface IAdaptationInfos {
   availabilityTimeOffset: number;
   /** Eventual URLs from which every relative URL will be based on. */
   baseURLs : string[];
-  /** Allows to obtain the first available position of a dynamic content. */
+  /** Allows to obtain the first/last available position of a dynamic content. */
   manifestBoundsCalculator : ManifestBoundsCalculator;
   /** End time of the current period, in seconds. */
   end? : number;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
+  /**
+   * Parent parsed SegmentTemplate elements.
+   * Sorted by provenance from higher level (e.g. Period) to lower-lever (e.g.
+   * AdaptationSet).
+   */
+  parentSegmentTemplates : IParsedSegmentTemplate[];
   /**
    * Time (in terms of `performance.now`) at which the XML file containing this
    * Representation was received.
@@ -74,75 +71,10 @@ export interface IAdaptationInfos {
   unsafelyBaseOnPreviousAdaptation : Adaptation | null;
 }
 
-/** Base context given to the various indexes. */
-interface IIndexContext {
-  /** Whether we should request new segments even if they are not yet finished. */
-  aggressiveMode : boolean;
-  availabilityTimeOffset: number;
-  /** Allows to obtain the first available position of a dynamic content. */
-  manifestBoundsCalculator : ManifestBoundsCalculator;
-  /** Whether the Manifest can evolve with time. */
-  isDynamic : boolean;
-  /** Start of the period concerned by this RepresentationIndex, in seconds. */
-  periodStart : number;
-  /** End of the period concerned by this RepresentationIndex, in seconds. */
-  periodEnd : number|undefined;
-  /** Base URLs for the Representation concerned. */
-  representationBaseURLs : string[];
-  /** ID of the Representation concerned. */
-  representationId? : string;
-  /** Bitrate of the Representation concerned. */
-  representationBitrate? : number;
-  /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number;
-  /**
-   * The parser should take this Representation - which is the same as this one
-   * parsed at an earlier time - as a base to speed-up the parsing process.
-   * /!\ If unexpected differences exist between both, there is a risk of
-   * de-synchronization with what is actually on the server.
-   */
-  unsafelyBaseOnPreviousRepresentation: Representation | null;
-}
-
 /**
- * Find and parse RepresentationIndex located in an AdaptationSet node.
- * Returns a generic parsed SegmentTemplate with a single element if not found.
- * @param {Object} adaptation
- * @param {Object} context
- */
-function findAdaptationIndex(
-  adaptation : IAdaptationSetIntermediateRepresentation,
-  context: IIndexContext
-): IRepresentationIndex {
-  const adaptationChildren = adaptation.children;
-  let adaptationIndex : IRepresentationIndex;
-  if (adaptationChildren.segmentBase != null) {
-    const { segmentBase } = adaptationChildren;
-    adaptationIndex = new BaseRepresentationIndex(segmentBase, context);
-  } else if (adaptationChildren.segmentList != null) {
-    const { segmentList } = adaptationChildren;
-    adaptationIndex = new ListRepresentationIndex(segmentList, context);
-  } else if (adaptationChildren.segmentTemplate != null) {
-    const { segmentTemplate } = adaptationChildren;
-    adaptationIndex = segmentTemplate.indexType === "timeline" ?
-      new TimelineRepresentationIndex(segmentTemplate, context) :
-      new TemplateRepresentationIndex(segmentTemplate, context);
-  } else {
-    adaptationIndex = new TemplateRepresentationIndex({
-      duration: Number.MAX_VALUE,
-      timescale: 1,
-      startNumber: 0,
-      initialization: { media: "" },
-      media: "",
-    }, context);
-  }
-  return adaptationIndex;
-}
-
-/**
- * Process intermediate periods to create final parsed periods.
- * @param {Array.<Object>} periodsIR
- * @param {Object} manifestInfos
+ * Process intermediate representations to create final parsed representations.
+ * @param {Array.<Object>} representationsIR
+ * @param {Object} adaptationInfos
  * @returns {Array.<Object>}
  */
 export default function parseRepresentations(
@@ -156,76 +88,41 @@ export default function parseRepresentations(
        representationIdx++)
   {
     const representation = representationsIR[representationIdx];
-    const representationBaseURLs = resolveBaseURLs(adaptationInfos.baseURLs,
-                                                   representation.children.baseURLs);
 
-  // 1. Get ID
-  let representationID = representation.attributes.id != null ?
-    representation.attributes.id :
-    (String(representation.attributes.bitrate) +
-       (representation.attributes.height != null ?
-          (`-${representation.attributes.height}`) :
-          "") +
-       (representation.attributes.width != null ?
-          (`-${representation.attributes.width}`) :
-          "") +
-       (representation.attributes.mimeType != null ?
-          (`-${representation.attributes.mimeType}`) :
-          "") +
-       (representation.attributes.codecs != null ?
-          (`-${representation.attributes.codecs}`) :
-          ""));
+    // Compute Representation ID
+    let representationID = representation.attributes.id != null ?
+      representation.attributes.id :
+      (String(representation.attributes.bitrate) +
+         (representation.attributes.height != null ?
+            (`-${representation.attributes.height}`) :
+            "") +
+         (representation.attributes.width != null ?
+            (`-${representation.attributes.width}`) :
+            "") +
+         (representation.attributes.mimeType != null ?
+            (`-${representation.attributes.mimeType}`) :
+            "") +
+         (representation.attributes.codecs != null ?
+            (`-${representation.attributes.codecs}`) :
+            ""));
 
     // Avoid duplicate IDs
     while (parsedRepresentations.some(r => r.id === representationID)) {
       representationID += "-dup";
     }
 
-    // 2. Retrieve previous version of the Representation, if one.
+    // Retrieve previous version of the Representation, if one.
     const unsafelyBaseOnPreviousRepresentation = adaptationInfos
       .unsafelyBaseOnPreviousAdaptation?.getRepresentation(representationID) ??
       null;
 
-    // 3. Find Index
-    const context = { aggressiveMode: adaptationInfos.aggressiveMode,
-                      availabilityTimeOffset: adaptationInfos.availabilityTimeOffset,
-                      unsafelyBaseOnPreviousRepresentation,
-                      manifestBoundsCalculator: adaptationInfos.manifestBoundsCalculator,
-                      isDynamic: adaptationInfos.isDynamic,
-                      periodEnd: adaptationInfos.end,
-                      periodStart: adaptationInfos.start,
-                      receivedTime: adaptationInfos.receivedTime,
-                      representationBaseURLs,
-                      representationBitrate: representation.attributes.bitrate,
-                      representationId: representation.attributes.id,
-                      timeShiftBufferDepth: adaptationInfos.timeShiftBufferDepth };
-    let representationIndex : IRepresentationIndex;
-    if (representation.children.segmentBase != null) {
-      const { segmentBase } = representation.children;
-      context.availabilityTimeOffset =
-        adaptationInfos.availabilityTimeOffset +
-        extractMinimumAvailabilityTimeOffset(representation.children.baseURLs) +
-        (segmentBase.availabilityTimeOffset ?? 0);
-      representationIndex = new BaseRepresentationIndex(segmentBase, context);
-    } else if (representation.children.segmentList != null) {
-      const { segmentList } = representation.children;
-      representationIndex = new ListRepresentationIndex(segmentList, context);
-    } else if (representation.children.segmentTemplate != null) {
-      const { segmentTemplate } = representation.children;
-      if (segmentTemplate.indexType === "timeline") {
-        representationIndex = new TimelineRepresentationIndex(segmentTemplate, context);
-      } else {
-      context.availabilityTimeOffset =
-        adaptationInfos.availabilityTimeOffset +
-        extractMinimumAvailabilityTimeOffset(representation.children.baseURLs) +
-        (segmentTemplate.availabilityTimeOffset ?? 0);
-        representationIndex = new TemplateRepresentationIndex(segmentTemplate, context);
-      }
-    } else {
-      representationIndex = findAdaptationIndex(adaptation, context);
-    }
+    const representationInfos = objectAssign({}, adaptationInfos,
+                                             { unsafelyBaseOnPreviousRepresentation,
+                                               adaptation });
+    const representationIndex = parseRepresentationIndex(representation,
+                                                         representationInfos);
 
-    // 3. Find bitrate
+    // Find bitrate
     let representationBitrate : number;
     if (representation.attributes.bitrate == null) {
       log.warn("DASH: No usable bitrate found in the Representation.");
@@ -234,13 +131,13 @@ export default function parseRepresentations(
       representationBitrate = representation.attributes.bitrate;
     }
 
-    // 4. Construct Representation Base
+    // Construct Representation Base
     const parsedRepresentation : IParsedRepresentation =
       { bitrate: representationBitrate,
         index: representationIndex,
         id: representationID };
 
-    // 5. Add optional attributes
+    // Add optional attributes
     let codecs : string|undefined;
     if (representation.attributes.codecs != null) {
       codecs = representation.attributes.codecs;

--- a/tests/contents/DASH_static_SegmentTimeline/index.js
+++ b/tests/contents/DASH_static_SegmentTimeline/index.js
@@ -2,10 +2,14 @@ import manifestInfos from "./infos.js";
 import multiAdaptationSetsInfos from "./multi-AdaptationSets.js";
 import notStartingAt0ManifestInfos from "./not_starting_at_0.js";
 import streamEventsInfos from "./event-stream";
+import segmentTemplateInheritanceASRep from "./segment_template_inheritance_as_rep";
+import segmentTemplateInheritancePeriodAS from "./segment_template_inheritance_period_as";
 
 export {
   manifestInfos,
   multiAdaptationSetsInfos,
   notStartingAt0ManifestInfos,
+  segmentTemplateInheritanceASRep,
+  segmentTemplateInheritancePeriodAS,
   streamEventsInfos,
 };

--- a/tests/contents/DASH_static_SegmentTimeline/media/segment_template_inheritance_as_rep.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/segment_template_inheritance_as_rep.mpd
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created with Unified Streaming Platform(version=1.7.32) -->
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT1M41.568367S"
+  maxSegmentDuration="PT5S"
+  minBufferTime="PT10S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period
+    id="1"
+    duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <SegmentTemplate timescale="44100" startNumber="1"/>
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <Representation
+        id="audio=128000"
+        bandwidth="128000">
+        <SegmentTemplate
+          initialization="ateam-$RepresentationID$.dash"
+          media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline>
+            <S t="0" d="177341" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" r="1" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" r="1" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="177152" />
+            <S d="176128" r="1" />
+            <S d="177152" />
+            <S d="176128" />
+            <S d="64512" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="1000" startNumber="1"/>
+      <Representation
+        id="video=400000"
+        bandwidth="400000"
+        width="220"
+        height="124"
+        sar="248:187"
+        codecs="avc1.42C014"
+        scanType="progressive">
+        <SegmentTemplate
+          initialization="ateam-$RepresentationID$.dash"
+          media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline>
+            <S t="0" d="4004" r="24" />
+            <S d="1376" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation
+        id="video=795000"
+        bandwidth="795000"
+        width="368"
+        height="208"
+        sar="520:391"
+        codecs="avc1.42C014"
+        scanType="progressive">
+        <SegmentTemplate
+          initialization="ateam-$RepresentationID$.dash"
+          media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline>
+            <S t="0" d="4004" r="24" />
+            <S d="1376" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation
+        id="video=1193000"
+        bandwidth="1193000"
+        width="768"
+        height="432"
+        sar="45:34"
+        codecs="avc1.42C01E"
+        scanType="progressive">
+        <SegmentTemplate
+          initialization="ateam-$RepresentationID$.dash"
+          media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline>
+            <S t="0" d="4004" r="24" />
+            <S d="1376" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+      <Representation
+        id="video=1996000"
+        bandwidth="1996000"
+        width="1680"
+        height="944"
+        sar="472:357"
+        codecs="avc1.640028"
+        scanType="progressive">
+        <SegmentTemplate
+          initialization="ateam-$RepresentationID$.dash"
+          media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline>
+            <S t="0" d="4004" r="24" />
+            <S d="1376" />
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+

--- a/tests/contents/DASH_static_SegmentTimeline/media/segment_template_inheritance_period_as.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/segment_template_inheritance_period_as.mpd
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created with Unified Streaming Platform(version=1.7.32) -->
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT1M41.568367S"
+  maxSegmentDuration="PT5S"
+  minBufferTime="PT10S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period
+    id="1"
+    duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+    <SegmentTemplate
+      initialization="ateam-$RepresentationID$.dash"
+      media="ateam-$RepresentationID$-$Time$.dash"/>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <SegmentTemplate timescale="44100">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <Representation
+        id="audio=128000"
+        bandwidth="128000">
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="1000">
+        <SegmentTimeline>
+          <S t="0" d="4004" r="24" />
+          <S d="1376" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video=400000"
+        bandwidth="400000"
+        width="220"
+        height="124"
+        sar="248:187"
+        codecs="avc1.42C014"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video=795000"
+        bandwidth="795000"
+        width="368"
+        height="208"
+        sar="520:391"
+        codecs="avc1.42C014"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video=1193000"
+        bandwidth="1193000"
+        width="768"
+        height="432"
+        sar="45:34"
+        codecs="avc1.42C01E"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video=1996000"
+        bandwidth="1996000"
+        width="1680"
+        height="944"
+        sar="472:357"
+        codecs="avc1.640028"
+        scanType="progressive">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+

--- a/tests/contents/DASH_static_SegmentTimeline/segment_template_inheritance_as_rep.js
+++ b/tests/contents/DASH_static_SegmentTimeline/segment_template_inheritance_as_rep.js
@@ -1,0 +1,207 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_SegmentTimeline/media/";
+export default {
+  url: BASE_URL + "segment_template_inheritance_period_as.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 101.476,
+  minimumPosition: 0,
+  maximumPosition: 101.476,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 101.568367,
+      adaptations: {
+        audio: [
+          {
+            isAudioDescription: undefined,
+            language: undefined,
+            normalizedLanguage: undefined,
+            representations: [
+              {
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-audio=128000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 44100,
+                      duration: 177341,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-0.dash"],
+                    },
+                    {
+                      time: 177341,
+                      timescale: 44100,
+                      duration: 176128,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-177341.dash"],
+                    },
+                    {
+                      time: 353469,
+                      timescale: 44100,
+                      duration: 177152,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-353469.dash"],
+                    },
+                  ],
+                  // ...
+                },
+              },
+            ],
+          },
+        ],
+        video: [
+          {
+            representations: [
+
+              {
+                bitrate: 400000,
+                height: 124,
+                width: 220,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=400000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 795000,
+                height: 208,
+                width: 368,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=795000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 1193000,
+                height: 432,
+                width: 768,
+                codec: "avc1.42C01E",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=1193000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 1996000,
+                height: 944,
+                width: 1680,
+                codec: "avc1.640028",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=1996000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/DASH_static_SegmentTimeline/segment_template_inheritance_period_as.js
+++ b/tests/contents/DASH_static_SegmentTimeline/segment_template_inheritance_period_as.js
@@ -1,0 +1,207 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_SegmentTimeline/media/";
+export default {
+  url: BASE_URL + "segment_template_inheritance_period_as.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 101.476,
+  minimumPosition: 0,
+  maximumPosition: 101.476,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 101.568367,
+      adaptations: {
+        audio: [
+          {
+            isAudioDescription: undefined,
+            language: undefined,
+            normalizedLanguage: undefined,
+            representations: [
+              {
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-audio=128000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 44100,
+                      duration: 177341,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-0.dash"],
+                    },
+                    {
+                      time: 177341,
+                      timescale: 44100,
+                      duration: 176128,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-177341.dash"],
+                    },
+                    {
+                      time: 353469,
+                      timescale: 44100,
+                      duration: 177152,
+                      mediaURLs: [BASE_URL + "dash/ateam-audio=128000-353469.dash"],
+                    },
+                  ],
+                  // ...
+                },
+              },
+            ],
+          },
+        ],
+        video: [
+          {
+            representations: [
+
+              {
+                bitrate: 400000,
+                height: 124,
+                width: 220,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=400000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=400000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 795000,
+                height: 208,
+                width: 368,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=795000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=795000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 1193000,
+                height: 432,
+                width: 768,
+                codec: "avc1.42C01E",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=1193000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1193000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+              {
+                bitrate: 1996000,
+                height: 944,
+                width: 1680,
+                codec: "avc1.640028",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "dash/ateam-video=1996000.dash"],
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-0.dash"],
+                    },
+                    {
+                      time: 4004,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-360360.dash"],
+                    },
+                    {
+                      time: 8008,
+                      timescale: 1000,
+                      duration: 4004,
+                      mediaURLs: [BASE_URL + "dash/ateam-video=1996000-720720.dash"],
+                    },
+                    // ...
+                  ],
+                },
+              },
+
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/DASH_static_SegmentTimeline/urls.js
+++ b/tests/contents/DASH_static_SegmentTimeline/urls.js
@@ -91,6 +91,16 @@ module.exports = [
     path: path.join(__dirname, "media/event-streams.mpd"),
     contentType: "application/dash+xml",
   },
+  {
+    url: BASE_URL + "segment_template_inheritance_period_as.mpd",
+    path: path.join(__dirname, "media/segment_template_inheritance_period_as.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "segment_template_inheritance_as_rep.mpd",
+    path: path.join(__dirname, "media/segment_template_inheritance_as_rep.mpd"),
+    contentType: "application/dash+xml",
+  },
 
   // Audio initialization segment
   {

--- a/tests/integration/scenarios/dash_static.js
+++ b/tests/integration/scenarios/dash_static.js
@@ -8,6 +8,8 @@ import waitForPlayerState from "../../utils/waitForPlayerState";
 import {
   manifestInfos as segmentTimelineManifestInfos,
   notStartingAt0ManifestInfos,
+  segmentTemplateInheritanceASRep,
+  segmentTemplateInheritancePeriodAS,
 } from "../../contents/DASH_static_SegmentTimeline";
 import brokenCencManifestInfos from "../../contents/DASH_static_broken_cenc_in_MPD";
 import {
@@ -25,6 +27,14 @@ describe("DASH non-linear content multi-codecs (SegmentBase)", function () {
 
 describe("DASH non-linear content not starting at 0 (SegmentTimeline)", function () {
   launchTestsForContent(notStartingAt0ManifestInfos);
+});
+
+describe("DASH non-linear content with SegmentTemplate inheritance (Period-AdaptationSet)", function () {
+  launchTestsForContent(segmentTemplateInheritancePeriodAS);
+});
+
+describe("DASH non-linear content with SegmentTemplate inheritance (AdaptationSet-Representation)", function () {
+  launchTestsForContent(segmentTemplateInheritanceASRep);
 });
 
 describe("DASH content CENC wrong version in MPD", function () {


### PR DESCRIPTION
Fixes #767 

This PR implements a new DASH behavior when parsing a MPD:

SegmentTemplate at different levels (for example at the `Period`, `AdaptationSet` _AND_ `Representation` levels) are all merged into one once converted into our internal `Manifest` structure.

This follows multiple MPDs we have seen recently that present this particularity. This should not break any other use-case.

The way I implemented it is by making the node_parsers part of our DASH parser (which has the task to take the MPD from its original `document` form and transform it to a JS object, very close to the original but with attributes in the right type - called the "intermediate representation") even dumber than before by removing the previous explicit distinction between a "SegmentTemplate" and a "SegmentTimeline".

Now, a timeline-based index will just be a SegmentTemplate one containing a `timelineParser` attribute (we are thus here much closer to the original logic of a MPD where a SegmentTimeline is just a child of a SegmentTemplate).

In the node_parsers, I also removed the default values calculated for some attributes of the SegmentTemplate/SegmentTimeline/SegmentBase code. This is because it entered in conflict with the merging happening much later in the parser code. When that merge happen, we wouldn't be able to make the difference between a default attribute and an explicit one, despite the fact that default one can be overwritten when inheriting parent SegmentTemplates intermediate representation.

As the merging code complexify a little the final parsing of a representation (in parse_representations.ts), I created a new file -
parse_representation_index.ts - whose tasks is just to parse a RepresentationIndex. Its exported function has the same signature than the ones in the other parse_XXX.ts files: the corresponding intermediate representation as first argument and supplementary context as a second argument.

I also added some integration tests to check the feature.
I added two test contents for the two cases encountered in the real world:
  1. A MPD with both a SegmentTemplate in a Period indicating the URL forms and one in the AdaptationSet indicating the SegmentTimeline + timescale.
  2. A MPD with a SegmentTemplate in an AdaptationSet indicating the timescale and another in the Representation indicating the SegmentTimeline and urls.