### PR TITLE
fetchers: add the concept of "high priority" segment requests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -713,7 +713,40 @@ export default {
    *
    * @type {Array.<Number>}
    */
-  SEGMENT_PRIORITIES_STEPS : [6, 14],
+  SEGMENT_PRIORITIES_STEPS : [ 2,   // Step 0: 0-2
+                               4,   // Step 1: 2-4 => last high priority
+                               8,   // Step 2: 4-8
+                               12,  // Step 3: 8-12 => first cancellable priority
+                               18,  // Step 4: 12-18
+                               25], // Step 5 18-25
+                                    // Step 6: 25+
+
+  /**
+   * Some segment requests are said to be "high priority".
+   *
+   * Requests in that category once done will cancel any segment request that
+   * has a low priority step (see `SEGMENT_PRIORITIES_STEPS`) - meaning a
+   * priority step equal to `MIN_CANCELABLE_PRIORITY` or more.
+   *
+   * Enter here the last priority step that is considered high priority
+   * (beginning by the step `0`).
+   * @type {number}
+   */
+  MAX_HIGH_PRIORITY_LEVEL: 1, // priority step 1 is the last "high priority"
+
+  /**
+   * Enter here the first priority step (see `SEGMENT_PRIORITIES_STEPS`) that
+   * will be considered as low priority.
+   *
+   * Segment requests with a low priority will be cancelled if a high priority
+   * segment request (see MAX_HIGH_PRIORITY_LEVEL) is scheduled while they are
+   * pending.
+   *
+   * This number should be strictly superior to the value indicated in
+   * `MAX_HIGH_PRIORITY_LEVEL`.
+   * @type {number}
+   */
+  MIN_CANCELABLE_PRIORITY: 3, // priority step 3 onward can be cancelled
 
   /**
    * Robustnesses used in the {audio,video}Capabilities of the

--- a/src/config.ts
+++ b/src/config.ts
@@ -688,6 +688,11 @@ export default {
    * Distances which will be used as limit points, from which a new step is
    * reached (see example).
    *
+   * In the RxPlayer's code, each step is then translated in to a priority
+   * number.
+   * The lower is that number, the lower is the step and the lower is the step,
+   * the higher is the priority.
+   *
    * Note: You can set an empty array to deactivate the steps feature (every
    * Segments have the same priority).
    *
@@ -696,43 +701,43 @@ export default {
    * let's imagine the following SEGMENT_PRIORITIES_STEPS array:
    * [5, 11, 17, 25]
    *
-   * To link each Segments to a corresponding priority (and thus to a specific
-   * step), we have to consider the distance d between the current position and
-   * the start time of the Segment.
+   * To link each Segments to a corresponding priority number (and thus to a
+   * specific step), we have to consider the distance between the current
+   * position and the start time of the Segment.
    *
    * We have in our example 5 groups, which correspond to the following possible
-   * d values:
-   *   1. inferior to 5
-   *   2. between 5 and 11
-   *   3. between 11 and 17
-   *   4. between 17 and 25
-   *   5. superior to 25
+   * distances:
+   *   1. inferior to 5 => first step (priority number = 0)
+   *   2. between 5 and 11 => second step (priority number = 1)
+   *   3. between 11 and 17 => third step (priority number = 2)
+   *   4. between 17 and 25 => fourth step (priority number = 3)
+   *   5. superior to 25 => fifth step (priority number = 4)
    *
    * Segments corresponding to a lower-step will need to all be downloaded
    * before Segments of a newer step begin.
    *
    * @type {Array.<Number>}
    */
-  SEGMENT_PRIORITIES_STEPS : [ 2,   // Step 0: 0-2
-                               4,   // Step 1: 2-4 => last high priority
-                               8,   // Step 2: 4-8
-                               12,  // Step 3: 8-12 => first cancellable priority
-                               18,  // Step 4: 12-18
-                               25], // Step 5 18-25
-                                    // Step 6: 25+
+   SEGMENT_PRIORITIES_STEPS : [ 2,  // 1st Step (priority number = 0):  < 2
+                               4,   // 2nd Step (priority number = 1):  2-4
+                               8,   // 3rd Step (priority number = 2):  4-8
+                               12,  // 4th Step (priority number = 3):  8-12
+                               18,  // 5th Step (priority number = 4):  12-18
+                               25], // 6th Step (priority number = 5):  18-25
+                                    // 7th Step (priority number = 6):  >= 25
 
   /**
    * Some segment requests are said to be "high priority".
    *
    * Requests in that category once done will cancel any segment request that
-   * has a low priority step (see `SEGMENT_PRIORITIES_STEPS`) - meaning a
-   * priority step equal to `MIN_CANCELABLE_PRIORITY` or more.
+   * has a low priority number (see `SEGMENT_PRIORITIES_STEPS`) - meaning a
+   * priority number equal to `MIN_CANCELABLE_PRIORITY` or more.
    *
-   * Enter here the last priority step that is considered high priority
-   * (beginning by the step `0`).
+   * Enter here the last priority number that is considered high priority
+   * (beginning by the first step, which has the priority number `0`).
    * @type {number}
    */
-  MAX_HIGH_PRIORITY_LEVEL: 1, // priority step 1 is the last "high priority"
+  MAX_HIGH_PRIORITY_LEVEL: 1, // priority number 1 and lower is high priority
 
   /**
    * Enter here the first priority step (see `SEGMENT_PRIORITIES_STEPS`) that
@@ -746,7 +751,7 @@ export default {
    * `MAX_HIGH_PRIORITY_LEVEL`.
    * @type {number}
    */
-  MIN_CANCELABLE_PRIORITY: 3, // priority step 3 onward can be cancelled
+  MIN_CANCELABLE_PRIORITY: 3, // priority number 3 onward can be cancelled
 
   /**
    * Robustnesses used in the {audio,video}Capabilities of the

--- a/src/core/fetchers/index.ts
+++ b/src/core/fetchers/index.ts
@@ -21,6 +21,7 @@ import createManifestFetcher, {
 } from "./manifest";
 import SegmentFetcherCreator, {
   IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherCreatorBackoffOptions,
@@ -37,6 +38,8 @@ export {
   IManifestFetcherWarningEvent,
 
   IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
+
   ISegmentFetcherEvent,
 
   ISegmentFetcherCreatorBackoffOptions,

--- a/src/core/fetchers/segment/__tests__/prioritizer.test.ts
+++ b/src/core/fetchers/segment/__tests__/prioritizer.test.ts
@@ -1,0 +1,966 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defer,
+  merge,
+  NEVER,
+  of,
+  timer,
+} from "rxjs";
+import {
+  mapTo,
+  startWith,
+} from "rxjs/operators";
+import Prioritizer, {
+  ITaskEvent,
+} from "../prioritizer";
+
+/* tslint:disable no-floating-promises */
+
+function assert(condition: any, msg?: string): asserts condition {
+  if (!condition) {
+    throw new Error(msg ?? "The asserted condition turned out to be false.");
+  }
+}
+
+describe("SegmentFetchers Prioritizer", () => {
+  // beforeEach(() => {
+  //   jest.resetModules();
+  // });
+  it("should not throw if updating the priority of a non-existent observable", () => {
+    const never$ = NEVER;
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    expect(() => { prioritizer.updatePriority(never$, 1); }).not.toThrow();
+  });
+
+  it("should run Observable right away", () => {
+    const a1$ = of(1);
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+    let completed = 0;
+    prioritizer.create(a1$, 99).subscribe(
+      // next
+      (evt) => {
+        if (emitted === 0) {
+          assert(evt.type === "data",
+                 `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+          expect(evt.value).toEqual(1);
+        } else if (emitted === 1) {
+          expect(evt.type).toEqual("ended");
+        } else {
+          throw new Error("Should not have emitted an other event");
+        }
+        emitted++;
+      },
+
+      // error
+      () => { throw new Error("Should not have thrown"); },
+
+      // complete
+      () => { completed++; });
+    expect(emitted).toEqual(2);
+    expect(completed).toEqual(1);
+  });
+
+  /* tslint:disable max-line-length */
+  it("should throw if the given high priority is a higher (or equal) number than the given low priority", () => {
+    expect(() => new Prioritizer({ prioritySteps: { high: 7, low: 6 } })).toThrow();
+    expect(() => new Prioritizer({ prioritySteps: { high: 7, low: 7 } })).toThrow();
+    expect(() => new Prioritizer({ prioritySteps: { high: 7, low: 8 } })).not.toThrow();
+  });
+
+  it("should run multiple synchronous Observables right away", () => {
+    const a1$ = of(1);
+    const a2$ = of(2);
+    const a3$ = of(3);
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+    let completed = 0;
+
+    function onNext(expectedData : number) {
+      let item = 0;
+      return (evt : ITaskEvent<unknown>) => {
+        if (item === 0) {
+          expect(evt.type).toEqual("data");
+          assert(evt.type === "data"); // for TypeScript
+          expect(evt.value).toEqual(expectedData);
+        } else if (item === 1) {
+          expect(evt.type).toEqual("ended");
+        } else {
+          throw new Error("Should not have emitted an other event: " + evt.type);
+        }
+        item++;
+        emitted++;
+      };
+    }
+
+    prioritizer.create(a1$, 99).subscribe(
+      onNext(1),
+      () => { throw new Error("Should not have thrown"); },
+      () => { completed++; });
+    expect(emitted).toEqual(2);
+    expect(completed).toEqual(1);
+
+    prioritizer.create(a2$, 0).subscribe(
+      onNext(2),
+      () => { throw new Error("Should not have thrown"); },
+      () => { completed++; });
+    expect(emitted).toEqual(4);
+    expect(completed).toEqual(2);
+
+    prioritizer.create(a3$, 3).subscribe(
+      onNext(3),
+      () => { throw new Error("Should not have thrown"); },
+      () => { completed++; });
+    expect(emitted).toEqual(6);
+    expect(completed).toEqual(3);
+  });
+
+  it("should not wait when all Observables have the same priority", (done) => {
+    let obs1Started = false;
+    let obs2Started = false;
+    let obs3Started = false;
+    let obs4Started = false;
+    const obs1$ = defer(() => { obs1Started = true; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started = true; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started = true; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started = true; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 1);
+    const pObs2 = prioritizer.create(obs2$, 1);
+    const pObs3 = prioritizer.create(obs3$, 1);
+    const pObs4 = prioritizer.create(obs4$, 1);
+
+    function expectData(
+      evt : ITaskEvent<unknown>,
+      expectedData : number,
+      shouldHaveStartedObs : boolean
+    ) : void {
+      expect(obs1Started).toEqual(shouldHaveStartedObs);
+      expect(obs2Started).toEqual(shouldHaveStartedObs);
+      expect(obs3Started).toEqual(shouldHaveStartedObs);
+      expect(obs4Started).toEqual(shouldHaveStartedObs);
+      assert(evt.type === "data",
+            `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+      expect(evt.value).toEqual(expectedData);
+    }
+
+    const checkEvents = [ (e : ITaskEvent<unknown>) => expectData(e, 0, false),
+                          (e : ITaskEvent<unknown>) => expectData(e, 1, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 2, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 3, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 4, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended") ];
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .pipe(startWith({ type: "data" as const, value: 0 }))
+      .subscribe(
+        (evt) => {
+          const checker = checkEvents[emitted];
+          if (checker === undefined) {
+            throw new Error("Unexpected event");
+          }
+          checker(evt);
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(9);
+          done();
+        }
+      );
+  });
+
+  it("should not wait when Observables are run from lowest priority to highest", (done) => {
+    let obs1Started = false;
+    let obs2Started = false;
+    let obs3Started = false;
+    let obs4Started = false;
+    const obs1$ = defer(() => { obs1Started = true; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started = true; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started = true; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started = true; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 5 + 4);
+    const pObs2 = prioritizer.create(obs2$, 5 + 3);
+    const pObs3 = prioritizer.create(obs3$, 5 + 2);
+    const pObs4 = prioritizer.create(obs4$, 5 + 1);
+
+    function expectData(
+      evt : ITaskEvent<unknown>,
+      expectedData : number,
+      shouldHaveStartedObs : boolean
+    ) : void {
+      expect(obs1Started).toEqual(shouldHaveStartedObs);
+      expect(obs2Started).toEqual(shouldHaveStartedObs);
+      expect(obs3Started).toEqual(shouldHaveStartedObs);
+      expect(obs4Started).toEqual(shouldHaveStartedObs);
+      assert(evt.type === "data",
+            `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+      expect(evt.value).toEqual(expectedData);
+    }
+
+    const checkEvents = [ (e : ITaskEvent<unknown>) => expectData(e, 0, false),
+                          (e : ITaskEvent<unknown>) => expectData(e, 1, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 2, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 3, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 4, true),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended") ];
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .pipe(startWith({ type: "data" as const, value: 0 }))
+      .subscribe(
+        (evt) => {
+          const checker = checkEvents[emitted];
+          if (checker === undefined) {
+            throw new Error("Unexpected event");
+          }
+          checker(evt);
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(9);
+          done();
+        }
+      );
+  });
+
+  it("should wait for higher-priority Observables", (done) => {
+    let obs1Started = false;
+    let obs2Started = false;
+    let obs3Started = false;
+    let obs4Started = false;
+    const obs1$ = defer(() => { obs1Started = true; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started = true; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started = true; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started = true; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 1);
+    const pObs2 = prioritizer.create(obs2$, 2);
+    const pObs3 = prioritizer.create(obs3$, 3);
+    const pObs4 = prioritizer.create(obs4$, 4);
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .pipe(startWith({ type: "data", value: 0 }))
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(0);
+              break;
+            case 1:
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(false);
+              expect(obs3Started).toEqual(false);
+              expect(obs4Started).toEqual(false);
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              break;
+            case 2:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 3:
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(true);
+              expect(obs3Started).toEqual(false);
+              expect(obs4Started).toEqual(false);
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              break;
+            case 4:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 5:
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(true);
+              expect(obs3Started).toEqual(true);
+              expect(obs4Started).toEqual(false);
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              break;
+            case 6:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 7:
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(true);
+              expect(obs3Started).toEqual(true);
+              expect(obs4Started).toEqual(true);
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              break;
+            case 8:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(9);
+          done();
+        }
+      );
+  });
+
+  it("should interrupt low-priority Observables when a high priority one is created", (done) => {
+    let obs1Started = 0;
+    let obs2Started = 0;
+    let obs3Started = 0;
+    let obs4Started = 0;
+    const obs1$ = defer(() => { obs1Started++; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started++; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started++; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started++; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 20);
+    const pObs2 = prioritizer.create(obs2$, 20 - 1);
+    const pObs3 = prioritizer.create(obs3$, 5);
+    const pObs4 = prioritizer.create(obs4$, 0);
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              expect(evt.type).toEqual("interrupted");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(0);
+              break;
+            case 1:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 2:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 3:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 4:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 5:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 6:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 7:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 8:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(obs1Started).toEqual(2);
+          expect(obs2Started).toEqual(1);
+          expect(obs3Started).toEqual(1);
+          expect(obs4Started).toEqual(1);
+          expect(emitted).toEqual(9);
+          done();
+        }
+      );
+  });
+
+  it("should be able to update a priority", (done) => {
+    let obs1Started = false;
+    let obs2Started = false;
+    let obs3Started = false;
+    let obs4Started = false;
+    const obs1$ = defer(() => { obs1Started = true; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started = true; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started = true; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started = true; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 5 + 1);
+    const pObs2 = prioritizer.create(obs2$, 5 + 2);
+    const pObs3 = prioritizer.create(obs3$, 5 + 3);
+    const pObs4 = prioritizer.create(obs4$, 5 + 4);
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              prioritizer.updatePriority(pObs4, 5 + 1);
+
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(false);
+              expect(obs3Started).toEqual(false);
+              expect(obs4Started).toEqual(true);
+              break;
+            case 1:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 2:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(false);
+              expect(obs3Started).toEqual(false);
+              expect(obs4Started).toEqual(true);
+              break;
+            case 3:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 4:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(true);
+              expect(obs3Started).toEqual(false);
+              expect(obs4Started).toEqual(true);
+              break;
+            case 5:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 6:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              expect(obs1Started).toEqual(true);
+              expect(obs2Started).toEqual(true);
+              expect(obs3Started).toEqual(true);
+              expect(obs4Started).toEqual(true);
+              break;
+            case 7:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(8);
+          done();
+        }
+      );
+  });
+
+  it("should restart interrupted observables if given the right priority", (done) => {
+    let obs1Started = 0;
+    let obs2Started = 0;
+    let obs3Started = 0;
+    let obs4Started = 0;
+    const obs1$ = defer(() => { obs1Started++; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started++; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started++; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started++; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 20);
+    const pObs2 = prioritizer.create(obs2$, 20 - 1);
+    const pObs3 = prioritizer.create(obs3$, 5);
+    const pObs4 = prioritizer.create(obs4$, 0);
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              expect(evt.type).toEqual("interrupted");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(0);
+
+              // pObs1 has just been cancelled by pObs3.
+              // Immediately set it the highest priority.
+              prioritizer.updatePriority(pObs1, 0);
+              break;
+            case 1:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 2:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 3:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 4:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 5:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 6:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 7:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 8:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(obs1Started).toEqual(2);
+          expect(obs2Started).toEqual(1);
+          expect(obs3Started).toEqual(1);
+          expect(obs4Started).toEqual(1);
+          expect(emitted).toEqual(9);
+          done();
+        }
+      );
+  });
+
+  it("should be able to update the priority of pending tasks", (done) => {
+    let obs1Started = 0;
+    let obs2Started = 0;
+    let obs3Started = 0;
+    let obs4Started = 0;
+    const obs1$ = defer(() => { obs1Started++; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started++; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started++; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started++; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 20);
+    const pObs2 = prioritizer.create(obs2$, 20 - 1);
+    const pObs3 = prioritizer.create(obs3$, 5);
+    const pObs4 = prioritizer.create(obs4$, 20 + 10);
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              expect(evt.type).toEqual("interrupted");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(0);
+
+              prioritizer.updatePriority(pObs2, 20 + 12);
+              break;
+            case 1:
+              expect(evt.type).toEqual("interrupted");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(0);
+              expect(obs4Started).toEqual(0);
+              break;
+            case 2:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(0);
+              break;
+            case 3:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 4:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(0);
+              break;
+            case 5:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 6:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 7:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 8:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(2);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 9:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(obs1Started).toEqual(2);
+          expect(obs2Started).toEqual(2);
+          expect(obs3Started).toEqual(1);
+          expect(obs4Started).toEqual(1);
+          expect(emitted).toEqual(10);
+          done();
+        }
+      );
+  });
+
+  it("should be able to interrupt observables after a priority update on a pending task", (done) => {
+    let obs1Started = 0;
+    let obs2Started = 0;
+    let obs3Started = 0;
+    let obs4Started = 0;
+    const obs1$ = defer(() => { obs1Started++; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started++; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started++; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started++; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 20);
+    const pObs2 = prioritizer.create(obs2$, 20);
+    const pObs3 = prioritizer.create(obs3$, 20);
+    const pObs4 = prioritizer.create(obs4$, 20);
+
+    // Put in microtask
+    /* tslint:disable ban */
+    Promise.resolve().then(() => {
+    /* tslint:enable ban*/
+      prioritizer.updatePriority(pObs4, 5);
+    });
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          switch (emitted) {
+            case 0:
+              expect(evt.type).toEqual("interrupted");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 1:
+              expect(evt.type).toEqual("interrupted");
+              break;
+            case 2:
+              expect(evt.type).toEqual("interrupted");
+              break;
+            case 3:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(4);
+              break;
+            case 4:
+              expect(evt.type).toEqual("ended");
+              expect(obs1Started).toEqual(1);
+              expect(obs2Started).toEqual(1);
+              expect(obs3Started).toEqual(1);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 5:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(1);
+              expect(obs1Started).toEqual(2);
+              expect(obs2Started).toEqual(2);
+              expect(obs3Started).toEqual(2);
+              expect(obs4Started).toEqual(1);
+              break;
+            case 6:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 7:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(2);
+              break;
+            case 8:
+              expect(evt.type).toEqual("ended");
+              break;
+            case 9:
+              assert(evt.type === "data",
+                    `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+              expect(evt.value).toEqual(3);
+              break;
+            case 10:
+              expect(evt.type).toEqual("ended");
+              break;
+            default:
+              throw new Error("Unexpected event");
+          }
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(obs1Started).toEqual(2);
+          expect(obs2Started).toEqual(2);
+          expect(obs3Started).toEqual(2);
+          expect(obs4Started).toEqual(1);
+          expect(emitted).toEqual(11);
+          done();
+        }
+      );
+  });
+
+  it("should not start right away an updated observable which has still not the priority", (done) => {
+    let obs1Started = false;
+    let obs2Started = false;
+    let obs3Started = false;
+    let obs4Started = false;
+    const obs1$ = defer(() => { obs1Started = true; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started = true; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started = true; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started = true; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 5);
+    const pObs2 = prioritizer.create(obs2$, 5 + 1);
+    const pObs3 = prioritizer.create(obs3$, 5 + 2);
+    const pObs4 = prioritizer.create(obs4$, 5 + 3);
+
+    function expectData(
+      evt : ITaskEvent<unknown>,
+      expectedData : number,
+      shouldArray : [boolean, boolean, boolean, boolean]
+    ) : void {
+      expect(obs1Started).toEqual(shouldArray[0]);
+      expect(obs2Started).toEqual(shouldArray[1]);
+      expect(obs3Started).toEqual(shouldArray[2]);
+      expect(obs4Started).toEqual(shouldArray[3]);
+      assert(evt.type === "data",
+            `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+      expect(evt.value).toEqual(expectedData);
+    }
+
+    const checkEvents = [ (e : ITaskEvent<unknown>) => expectData(e, 1, [true, false, false, false]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 2, [true, true, false, false]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 3, [true, true, true, true]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 4, [true, true, true, true]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended") ];
+
+    // Put in microtask
+    /* tslint:disable ban*/
+    Promise.resolve().then(() => {
+    /* tslint:enable ban*/
+      prioritizer.updatePriority(pObs4, 5 + 2);
+    });
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          const checker = checkEvents[emitted];
+          if (checker === undefined) {
+            throw new Error("Unexpected event");
+          }
+          checker(evt);
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(checkEvents.length);
+          done();
+        }
+      );
+  });
+
+  it("should not do anything special when updating a pending task with the same priority", (done) => {
+    let obs1Started = 0;
+    let obs2Started = 0;
+    let obs3Started = 0;
+    let obs4Started = 0;
+    const obs1$ = defer(() => { obs1Started++; return timer(1).pipe(mapTo(1)); });
+    const obs2$ = defer(() => { obs2Started++; return timer(1).pipe(mapTo(2)); });
+    const obs3$ = defer(() => { obs3Started++; return timer(1).pipe(mapTo(3)); });
+    const obs4$ = defer(() => { obs4Started++; return timer(1).pipe(mapTo(4)); });
+
+    const prioritizer = new Prioritizer({ prioritySteps: { high: 5, low: 20 } });
+    let emitted = 0;
+
+    const pObs1 = prioritizer.create(obs1$, 20 + 1);
+    const pObs2 = prioritizer.create(obs2$, 5);
+    const pObs3 = prioritizer.create(obs3$, 20 + 2);
+    const pObs4 = prioritizer.create(obs4$, 20 + 3);
+
+    function expectInterrupted(
+      evt : ITaskEvent<unknown>,
+      shouldArray : [number, number, number, number]
+    ) : void {
+      expect(evt.type).toEqual("interrupted");
+      expect(obs1Started).toEqual(shouldArray[0]);
+      expect(obs2Started).toEqual(shouldArray[1]);
+      expect(obs3Started).toEqual(shouldArray[2]);
+      expect(obs4Started).toEqual(shouldArray[3]);
+    }
+
+    function expectData(
+      evt : ITaskEvent<unknown>,
+      expectedData : number,
+      shouldArray : [number, number, number, number]
+    ) : void {
+      expect(obs1Started).toEqual(shouldArray[0]);
+      expect(obs2Started).toEqual(shouldArray[1]);
+      expect(obs3Started).toEqual(shouldArray[2]);
+      expect(obs4Started).toEqual(shouldArray[3]);
+      assert(evt.type === "data",
+            `evt.type should be equal to "data" but was equal to "${evt.type}"`);
+      expect(evt.value).toEqual(expectedData);
+    }
+
+    const checkEvents = [ (e : ITaskEvent<unknown>) => expectInterrupted(e, [1, 1, 0, 0]),
+                          (e : ITaskEvent<unknown>) => expectData(e, 2, [1, 1, 0, 0]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 1, [2, 1, 0, 0]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 3, [2, 1, 1, 0]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended"),
+                          (e : ITaskEvent<unknown>) => expectData(e, 4, [2, 1, 1, 1]),
+                          (e : ITaskEvent<unknown>) => expect(e.type).toEqual("ended") ];
+
+    // Put in microtask
+    /* tslint:disable ban*/
+    Promise.resolve().then(() => {
+    /* tslint:enable ban*/
+      prioritizer.updatePriority(pObs2, 5);
+    });
+
+    merge(pObs1, pObs2, pObs3, pObs4)
+      .subscribe(
+        (evt) => {
+          const checker = checkEvents[emitted];
+          if (checker === undefined) {
+            throw new Error("Unexpected event");
+          }
+          checker(evt);
+          emitted++;
+        },
+        () => { throw new Error("Should not have thrown"); },
+        () => {
+          expect(emitted).toEqual(checkEvents.length);
+          done();
+        }
+      );
+  });
+});

--- a/src/core/fetchers/segment/index.ts
+++ b/src/core/fetchers/segment/index.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { IPrioritizedSegmentFetcher } from "./prioritized_segment_fetcher";
+import {
+  IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
+} from "./prioritized_segment_fetcher";
 import {
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
@@ -28,6 +31,7 @@ import SegmentFetcherCreator, {
 export default SegmentFetcherCreator;
 export {
   IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherEvent,

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -15,21 +15,43 @@
  */
 
 import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import log from "../../../log";
 import { ISegmentLoaderContent } from "./create_segment_loader";
-import ObservablePrioritizer from "./prioritizer";
+import ObservablePrioritizer, { ITaskEvent } from "./prioritizer";
 import {
   ISegmentFetcher,
   ISegmentFetcherEvent,
 } from "./segment_fetcher";
 
+/**
+ * Event sent when a segment request has been temporarly interrupted due to
+ * another request with a high priority.
+ * The request for that segment will restart (from scratch) when requests with
+ * more priority are finished.
+ */
+export interface ISegmentFetcherInterruptedEvent { type : "interrupted"; }
+
+/**
+ * Event sent when a segment request just ended.
+ * You can use this event to schedule another task you wanted to perform at best
+ * immediately after that one (its priority will be checked).
+ */
+export interface IEndedTaskEvent { type : "ended"; }
+
+/** Event sent by a `IPrioritizedSegmentFetcher`. */
+export type IPrioritizedSegmentFetcherEvent<T> = ISegmentFetcherEvent<T> |
+                                                 ISegmentFetcherInterruptedEvent |
+                                                 IEndedTaskEvent;
+
 /** Oject returned by `applyPrioritizerToSegmentFetcher`. */
 export interface IPrioritizedSegmentFetcher<T> {
   /** Create a new request for a segment with a given priority. */
   createRequest : (content : ISegmentLoaderContent,
-                   priority? : number) => Observable<ISegmentFetcherEvent<T>>;
+                   priority? : number) => Observable<IPrioritizedSegmentFetcherEvent<T>>;
 
   /** Update priority of a request created through `createRequest`. */
-  updatePriority : (observable : Observable<ISegmentFetcherEvent<T>>,
+  updatePriority : (observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
                     priority : number) => void;
 }
 
@@ -44,36 +66,56 @@ export interface IPrioritizedSegmentFetcher<T> {
  * @returns {Object}
  */
 export default function applyPrioritizerToSegmentFetcher<T>(
-  prioritizer : ObservablePrioritizer<ISegmentFetcherEvent<T>>,
+  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<T>>,
   fetcher : ISegmentFetcher<T>
 ) : IPrioritizedSegmentFetcher<T> {
+  /**
+   * The observables returned by `createRequest` are not exactly the same than
+   * the one created by the `ObservablePrioritizer`. Because we still have to
+   * keep a handle on that value.
+   */
+  const taskHandlers =
+    new WeakMap<Observable<IPrioritizedSegmentFetcherEvent<T>>,
+                           Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<T>>>>();
   return {
     /**
      * Create a Segment request with a given priority.
      * @param {Object} content - content to request
-     * @param {Number} priority - priority at which the content should be
-     * requested.
+     * @param {Number} priority - priority at which the content should be requested.
+     * Lower number == higher priority.
      * @returns {Observable}
      */
     createRequest(
       content : ISegmentLoaderContent,
       priority : number = 0
-    ) : Observable<ISegmentFetcherEvent<T>> {
-      return prioritizer.create(fetcher(content), priority);
+    ) : Observable<IPrioritizedSegmentFetcherEvent<T>> {
+      const task = prioritizer.create(fetcher(content), priority);
+      const flattenTask = task.pipe(
+        map((evt) => {
+          return evt.type === "data" ? evt.value :
+                                       evt;
+        })
+      );
+      taskHandlers.set(flattenTask, task);
+      return flattenTask;
     },
 
     /**
      * Update the priority of a pending request, created through
      * `createRequest`.
-     * @param {Observable} observable - the corresponding request
-     * @param {Number} priority
+     * @param {Observable} observable - The observables returned by `createRequest`.
+     * @param {Number} priority - The new priority value.
      */
     updatePriority(
-      observable : Observable<ISegmentFetcherEvent<T>>,
+      observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
       priority : number
     ) : void {
-      prioritizer.updatePriority(observable, priority);
+      const correspondingTask = taskHandlers.get(observable);
+      if (correspondingTask === undefined) {
+        log.warn("Fetchers: Cannot update the priority of a request: task not found.");
+        return;
+      }
+      prioritizer.updatePriority(correspondingTask, priority);
     },
-
   };
 }

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -70,7 +70,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
   fetcher : ISegmentFetcher<T>
 ) : IPrioritizedSegmentFetcher<T> {
   /**
-   * The observables returned by `createRequest` are not exactly the same than
+   * The Observables returned by `createRequest` are not exactly the same than
    * the one created by the `ObservablePrioritizer`. Because we still have to
    * keep a handle on that value.
    */
@@ -103,7 +103,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
     /**
      * Update the priority of a pending request, created through
      * `createRequest`.
-     * @param {Observable} observable - The observables returned by `createRequest`.
+     * @param {Observable} observable - The Observable returned by `createRequest`.
      * @param {Number} priority - The new priority value.
      */
     updatePriority(

--- a/src/core/fetchers/segment/prioritizer.ts
+++ b/src/core/fetchers/segment/prioritizer.ts
@@ -227,6 +227,8 @@ export default class ObservablePrioritizer<T> {
     const pObs$ = observableDefer(() => {
       const trigger = new Subject<boolean>();
 
+      const newTask : IPrioritizerTask<T> = { observable: pObs$, priority, trigger };
+
       /**
        * Function executed each time the `trigger` Subject emits.
        * @param {Boolean} shouldRun - If `true`, the observable can run. If
@@ -246,8 +248,6 @@ export default class ObservablePrioritizer<T> {
           this._onTaskEnd(newTask);
         }));
       };
-
-      const newTask : IPrioritizerTask<T> = { observable: pObs$, priority, trigger };
 
       if (!this._hasPriority(newTask)) {
         // This task doesn't have priority yet. Start it on trigger

--- a/src/core/fetchers/segment/prioritizer.ts
+++ b/src/core/fetchers/segment/prioritizer.ts
@@ -249,7 +249,7 @@ export default class ObservablePrioritizer<T> {
         }));
       };
 
-      if (!this._hasPriority(newTask)) {
+      if (!this._canBeStartedNow(newTask)) {
         // This task doesn't have priority yet. Start it on trigger
         this._waitingQueue.push(newTask);
         return trigger.pipe(switchMap(onTrigger));
@@ -293,7 +293,7 @@ export default class ObservablePrioritizer<T> {
 
       waitingQueueElt.priority = priority;
 
-      if (!this._hasPriority(waitingQueueElt)) {
+      if (!this._canBeStartedNow(waitingQueueElt)) {
         return;
       }
 
@@ -443,11 +443,12 @@ export default class ObservablePrioritizer<T> {
   }
 
   /**
-   * Return `true` if the given task should be started immediately.
+   * Return `true` if the given task can be started immediately based on its
+   * priority.
    * @param {Object} task
    * @returns {boolean}
    */
-  private _hasPriority(task : IPrioritizerTask<T>) : boolean {
+  private _canBeStartedNow(task : IPrioritizerTask<T>) : boolean {
     return this._minPendingPriority === null ||
            task.priority <= this._minPendingPriority;
   }

--- a/src/core/fetchers/segment/prioritizer.ts
+++ b/src/core/fetchers/segment/prioritizer.ts
@@ -15,51 +15,133 @@
  */
 
 import {
+  concat as observableConcat,
   defer as observableDefer,
+  EMPTY,
+  merge as observableMerge,
   Observable,
+  of as observableOf,
   Subject,
 } from "rxjs";
 import {
   finalize,
-  mergeMap,
+  map,
+  startWith,
+  switchMap,
 } from "rxjs/operators";
+import log from "../../../log";
 import arrayFindIndex from "../../../utils/array_find_index";
+
+/**
+ * Event sent when the corresponding task is a low-priority task that has just
+ * been temporarly interrupted due to another task with a high priority.
+ * The task will restart (from scratch) when tasks with more priority are
+ * finished.
+ */
+export interface IInterruptedTaskEvent { type : "interrupted"; }
+
+/** Event sent when the corresponding task emit an event. */
+export interface ITaskDataEvent<T> { type : "data";
+                                     value : T; }
+
+/**
+ * Event sent when the corresponding task has ended (it will then complete).
+ * You can use this event to schedule another task you wanted to perform after
+ * that one.
+ */
+export interface IEndedTaskEvent { type : "ended"; }
+
+/** Events sent when a task has been created through the `create` method. */
+export type ITaskEvent<T> = IInterruptedTaskEvent |
+                            ITaskDataEvent<T> |
+                            IEndedTaskEvent;
+
+/** Stored object representing a single task. */
+interface IPrioritizerTask<T> {
+  /** Task to run. */
+  observable : Observable<ITaskEvent<T>>;
+  /**
+   * Subject used to start and interrupt a task:
+   *   - when `true` is emitted the task should be started
+   *   - when `false` is emitted, the task should be interrupted
+   */
+  trigger : Subject<boolean>;
+  /** Priority of the task. Lower that number is, higher is the priority. */
+  priority : number;
+}
+
+/** Options to give to the ObservablePrioritizer. */
+export interface IPrioritizerOptions {
+  /** @see IPrioritizerPrioritySteps */
+  prioritySteps : IPrioritizerPrioritySteps;
+}
+
+/**
+ * Define both the `low` and `high` priority steps:
+ *
+ *   - Any Observable with a priority number that is lower or equal to the
+ *     `high` value will be an Observable with high priority.
+ *
+ *     When Observables with high priorities are scheduled, they immediately
+ *     abort pending Observables with low priorities (which will have then to
+ *     wait until all higher-priority Observable have ended before re-starting).
+ *
+ *   - Any Observable with a priority number that is higher or equal to the
+ *     `low` value will be an Observable with low priority.
+ *
+ *     Pending Observables with low priorities have the added particularity*
+ *     of being aborted as soon as a high priority Observable is scheduled.
+ *
+ *     * Other pending Observables are not aborted when a higher-priority
+ *     Observable is scheduled, as their priorities only affect them before
+ *     they are started (to know when to start them).
+ */
+export interface IPrioritizerPrioritySteps {
+  low : number;
+  high : number;
+}
 
 /**
  * Create Observables which can be priorized between one another.
  *
- * With this class, you can create Observables with linked priority numbers.
+ * With this class, you can link an Observables to a priority number.
  * The lower this number is, the more priority the resulting Observable will
  * have.
  *
- * Such Observable will then basically wait for pending Observables with more
- * priority to finish before "starting".
+ * Such returned Observables - called "tasks" - will then basically wait for
+ * pending task with more priority (i.e. a lower priority number) to finish
+ * before "starting".
  *
- * You can also update the priority of an already-created Observable.
- * This will only have an effect if the Observable is currently "waiting" for
- * its turn (started observable won't be canceled if their priority were
- * lowered).
+ * This only applies for non-pending tasks. For pending tasks, those are usually
+ * not interrupted except in the following case:
+ *
+ * When a task with a "high priority" (which is a configurable priority
+ * value) is created, pending tasks with a "low priority" (also configurable)
+ * will be interrupted. Those tasks will be restarted when all tasks with a
+ * higher priority are finished.
+ *
+ * You can also update the priority of an already-created task.
  *
  * ```js
- * const prioritizer = new ObservablePrioritizer();
+ * const observable1 = Observable.timer(100).pipe(mapTo(1));
+ * const observable2 = Observable.timer(100).pipe(mapTo(2));
+ * const observable3 = Observable.timer(100).pipe(mapTo(3));
+ * const observable4 = Observable.timer(100).pipe(mapTo(4));
+ * const observable5 = Observable.timer(100).pipe(mapTo(5));
  *
- * const observable1 = Observable.of(1);
- * const observable2 = Observable.of(2);
- * const observable3 = Observable.of(3);
- * const observable4 = Observable.of(4);
- * const observable5 = Observable.of(5);
+ * // Instanciate ObservablePrioritizer.
+ * // Also provide a `high` priority step - the maximum priority number a "high
+ * // priority task" has and a `low` priority step - the minimum priority number
+ * // a "low priority task" has.
+ * const prioritizer = new ObservablePrioritizer({
+ *   prioritySteps: { high: 0, low: 20 }
+ * });
  *
  * const pObservable1 = prioritizer.create(observable1, 4);
  * const pObservable2 = prioritizer.create(observable2, 2);
  * const pObservable3 = prioritizer.create(observable3, 1);
  * const pObservable4 = prioritizer.create(observable4, 3);
  * const pObservable5 = prioritizer.create(observable5, 2);
- *
- * // To spice things up, update pObservable1 priority to go before
- * // pObservable4
- * if (i === 5) { // if pObservable5 is currently emitting
- *   prioritizer.updatePriority(pObservable1, 1);
- * }
  *
  * // start every Observables at the same time
  * observableMerge(
@@ -68,8 +150,16 @@ import arrayFindIndex from "../../../utils/array_find_index";
  *   pObservable3,
  *   pObservable4,
  *   pObservable5
- * ).subscribe((i) => {
- *   console.log(i);
+ * ).subscribe((evt) => {
+ *   if (evt.type === "data") {
+ *     console.log(i);
+ *
+ *     // To spice things up, update pObservable1 priority to go before
+ *     // pObservable4
+ *     if (i === 5) { // if pObservable5 is currently emitting
+ *       prioritizer.updatePriority(pObservable1, 1);
+ *     }
+ *   }
  * });
  *
  * // Result:
@@ -88,34 +178,30 @@ import arrayFindIndex from "../../../utils/array_find_index";
  */
 export default class ObservablePrioritizer<T> {
   /**
-   * Priority of the Observables currently running.
-   * Null if no Observable is currently running.
-   * @type {Number|null}
-   * @private
+   * Priority of the most prioritary task currently running.
+   * `null` if no task is currently running.
    */
-  private _pendingPriority : number | null;
+  private _minPendingPriority : number | null;
+  /** Queue of tasks currently waiting for more prioritary ones to finish. */
+  private _waitingQueue : Array<IPrioritizerTask<T>>;
+  /** Tasks currently pending.  */
+  private _pendingTasks : Array<IPrioritizerTask<T>>;
+  /** @see IPrioritizerPrioritySteps */
+  private _prioritySteps : IPrioritizerPrioritySteps;
 
   /**
-   * Number of Observables currently running.
-   * @type {Number|null}
-   * @private
+   * @param {Options} prioritizerOptions
    */
-  private _numberOfPendingObservables : number;
+  constructor({ prioritySteps } : IPrioritizerOptions) {
+    this._minPendingPriority = null;
+    this._waitingQueue = [];
+    this._pendingTasks =  [];
+    this._prioritySteps = prioritySteps;
 
-  /**
-   * Queue of Observables currently waiting for more prioritary Observables
-   * to finish.
-   * @type {Array.<Object>}
-   * @private
-   */
-  private _queue : Array<{ observable : Observable<T>;
-                           trigger : Subject<void>;
-                           priority : number; }>;
-
-  constructor() {
-    this._pendingPriority = null;
-    this._numberOfPendingObservables = 0;
-    this._queue = [];
+    if (this._prioritySteps.high >= this._prioritySteps.low) {
+      throw new Error("FP Error: the max high level priority should be given a lower" +
+                      "priority number than the min low priority.");
+    }
   }
 
   /**
@@ -123,6 +209,7 @@ export default class ObservablePrioritizer<T> {
    *
    * When subscribed to, this Observable will have its priority compared to
    * all the already-running Observables created from this class.
+   *
    * Only if this number is inferior or equal to the priority of the
    * currently-running Observables will it be immediately started.
    * In the opposite case, we will wait for higher-priority Observables to
@@ -136,87 +223,236 @@ export default class ObservablePrioritizer<T> {
    * @param {number} priority
    * @returns {Observable}
    */
-  public create(obs : Observable<T>, priority : number) : Observable<T> {
+  public create(obs : Observable<T>, priority : number) : Observable<ITaskEvent<T>> {
     const pObs$ = observableDefer(() => {
-      if (this._pendingPriority == null || this._pendingPriority >= priority) {
-        // Update the priority and start immediately the Observable
-        this._pendingPriority = priority;
-        return this._startObservable(obs);
-      } else {
-        const trigger = new Subject<void>();
-        this._queue.push({ observable: pObs$, priority, trigger });
-        return trigger
-          .pipe(mergeMap(() => this._startObservable(obs)));
+      const trigger = new Subject<boolean>();
+
+      /**
+       * Function executed each time the `trigger` Subject emits.
+       * @param {Boolean} shouldRun - If `true`, the observable can run. If
+       * `false` it means that it has just been interrupted.
+       * @returns {Observable} - Returns events corresponding to the lifecycle
+       * of the observable.
+       */
+      const onTrigger = (shouldRun : boolean) : Observable<ITaskEvent<T>> => {
+        if (!shouldRun) {
+          return observableOf({ type: "interrupted" as const });
+        }
+        this._onTaskBegin(newTask);
+        return observableConcat(
+          obs.pipe(map((data) => ({ type: "data" as const, value: data }))),
+          observableOf({ type: "ended" as const })
+        ).pipe(finalize(() => {
+          this._onTaskEnd(newTask);
+        }));
+      };
+
+      const newTask : IPrioritizerTask<T> = { observable: pObs$, priority, trigger };
+
+      if (!this._hasPriority(newTask)) {
+        // This task doesn't have priority yet. Start it on trigger
+        this._waitingQueue.push(newTask);
+        return trigger.pipe(switchMap(onTrigger));
       }
+
+      // Start it right away
+      const startTask$ = trigger.pipe(startWith(true), switchMap(onTrigger));
+      return !this._isHighPriority(newTask) ?
+        startTask$ :
+        observableMerge(startTask$,
+
+                        // Note: we want to begin interrupting low-priority tasks just
+                        // after starting the current one because the interrupting
+                        // logic can call external code.
+                        // This would mean re-entrancy, itself meaning that some weird
+                        // half-state could be reached unless we're very careful.
+                        // To be sure no harm is done, we put that code at the last
+                        // possible position (the previous Observable sould be
+                        // performing all its initialization synchronously).
+                        observableDefer(() => { this._interruptCancellableTasks();
+                                                return EMPTY; }));
     });
+
     return pObs$;
   }
 
   /**
-   * Update the priority of an Observable created through the create method.
-   *
-   * Note that this will only have an effect on Observable which are not yet
-   * started.
-   * This means it will only have an effect on:
-   *   - unsubscribed Observables
-   *   - Observables waiting for Observables with an higher priority to
-   *     finish
-   *
+   * Update the priority of an Observable created through the `create` method.
    * @param {Observable} obs
    * @param {number} priority
    */
-  public updatePriority(obs : Observable<T>, priority : number) : void {
-    const index = arrayFindIndex(this._queue,
-                                 (elt) => elt.observable === obs);
+  public updatePriority(obs : Observable<ITaskEvent<T>>, priority : number) : void {
+    const waitingQueueIndex = arrayFindIndex(this._waitingQueue,
+                                             (elt) => elt.observable === obs);
 
-    if (index < 0) {
+    if (waitingQueueIndex >= 0) { // If it was still waiting for its turn
+      const waitingQueueElt = this._waitingQueue[waitingQueueIndex];
+      if (waitingQueueElt.priority === priority) {
+        return;
+      }
+
+      waitingQueueElt.priority = priority;
+
+      if (!this._hasPriority(waitingQueueElt)) {
+        return;
+      }
+
+      this._startTask(waitingQueueIndex);
+
+      if (this._isHighPriority(waitingQueueElt)) {
+        // This task has high priority.
+        // We should cancel every "cancellable" pending task
+        this._interruptCancellableTasks();
+      }
       return;
     }
 
-    const queueElement = this._queue[index];
-    queueElement.priority = priority;
+    const pendingTasksIndex = arrayFindIndex(this._pendingTasks,
+                                             (elt) => elt.observable === obs);
+    if (pendingTasksIndex < 0) {
+      log.warn("FP: request to update the priority of a non-existent task");
+      return;
+    }
 
-    if (this._pendingPriority == null || this._pendingPriority >= priority) {
-      this._queue.splice(index, 1);
-      queueElement.trigger.next();
-      queueElement.trigger.complete();
+    const task = this._pendingTasks[pendingTasksIndex];
+    if (task.priority === priority) {
+      return;
+    }
+
+    const oldPriority = task.priority;
+    task.priority = priority;
+
+    if (priority < oldPriority) {
+      if (this._isHighPriority(task)) {
+        this._interruptCancellableTasks();
+      }
+      return;
+    }
+
+    if (this._minPendingPriority !== null &&
+        this._minPendingPriority <= this._prioritySteps.high)
+    {
+      // We could need to interrupt this task
+      this._interruptPendingTask(pendingTasksIndex);
     }
   }
 
-  private _startObservable(obs : Observable<T>) : Observable<T> {
-    const onObservableFinish = () : void => {
-      this._numberOfPendingObservables--;
+  /**
+   * Interrupt and move back to the waiting queue all pending tasks that are
+   * low priority (having a higher priority number than
+   * `this._prioritySteps.low`).
+   */
+  private _interruptCancellableTasks() : void {
+    for (let i = 0; i < this._pendingTasks.length; i++) {
+      const pendingObj = this._pendingTasks[i];
+      if (pendingObj.priority >= this._prioritySteps.low) {
+        this._interruptPendingTask(i);
 
-      if (this._numberOfPendingObservables > 0) {
-        // still waiting for Observables to finish
-        return;
+        // The previous call could have a lot of potential side-effects.
+        // It is safer to re-start the function to not miss any pending
+        // task that needs to be cancelled.
+        return this._interruptCancellableTasks();
       }
+    }
+  }
 
-      this._pendingPriority = null;
+  /**
+   * Start task which is at the given index in the waiting queue.
+   * The task will be removed from the waiting queue in the process.
+   * @param {number} index
+   */
+  private _startTask(index : number) : void {
+    const task = this._waitingQueue.splice(index, 1)[0];
+    task.trigger.next(true);
+  }
 
-      if (this._queue.length === 0) {
-        return;
+  /**
+   * Move back pending task - which is at the given index in the _pendingTasks
+   * array - back to the waiting queue and interrupt it.
+   * @param {number} index
+   */
+  private _interruptPendingTask(index : number) : void {
+    // Stop task and put it back in the waiting queue
+    const task = this._pendingTasks.splice(index, 1)[0];
+    this._waitingQueue.push(task);
+    if (this._pendingTasks.length === 0) {
+      this._minPendingPriority = null;
+    } else if (this._minPendingPriority === task.priority) {
+      this._minPendingPriority = Math.min(...this._pendingTasks.map(t => t.priority));
+    }
+    task.trigger.next(false);
+  }
+
+  /**
+   * Logic ran when a task begin.
+   * @param {Object} task
+   */
+  private _onTaskBegin(task : IPrioritizerTask<T>) : void {
+    this._minPendingPriority = this._minPendingPriority === null ?
+      task.priority :
+      Math.min(this._minPendingPriority, task.priority);
+    this._pendingTasks.push(task);
+  }
+
+  /**
+   * Logic ran when a task has ended.
+   * @param {Object} task
+   */
+  private _onTaskEnd(task : IPrioritizerTask<T>) : void {
+    const pendingTasksIndex = arrayFindIndex(this._pendingTasks,
+                                             (elt) => elt.observable === task.observable);
+    if (pendingTasksIndex < 0) {
+      return; // Happen for example when the task has been interrupted
+    }
+
+    task.trigger.complete();
+
+    this._pendingTasks.splice(pendingTasksIndex, 1);
+
+    if (this._pendingTasks.length > 0) {
+      return; // still waiting for Observables to finish
+    }
+
+    this._minPendingPriority = null;
+
+    if (this._waitingQueue.length === 0) {
+      return; // no more task to do
+    }
+
+    // Calculate minimum waiting priority
+    this._minPendingPriority = this._waitingQueue.reduce((acc : number | null, elt) => {
+      return acc === null || acc > elt.priority ? elt.priority :
+                                                  acc;
+    }, null);
+
+    // Start all tasks with that minimum priority
+    for (let i = 0; i < this._waitingQueue.length; i++) {
+      const elt = this._waitingQueue[i];
+      if (elt.priority === this._minPendingPriority) {
+        this._startTask(i);
+        i--; // previous operation should have removed that element from the
+             // the waiting queue
       }
+    }
+  }
 
-      this._pendingPriority = this._queue
-        .reduce((acc : number | null, elt) => {
-          return acc == null || acc > elt.priority ? elt.priority :
-                                                     acc;
-        }, null);
+  /**
+   * Return `true` if the given task should be started immediately.
+   * @param {Object} task
+   * @returns {boolean}
+   */
+  private _hasPriority(task : IPrioritizerTask<T>) : boolean {
+    return this._minPendingPriority === null ||
+           task.priority <= this._minPendingPriority;
+  }
 
-      for (let i = 0; i < this._queue.length; i++) {
-        const elt = this._queue[i];
-        if (elt.priority === this._pendingPriority) {
-          this._queue.splice(i, 1);
-          i--;
-          elt.trigger.next();
-          elt.trigger.complete();
-        }
-      }
-    };
-
-    this._numberOfPendingObservables++;
-    return obs
-             .pipe(finalize(onObservableFinish));
+  /**
+   * Returns `true` if the given task can be considered "high priority".
+   * returns false otherwise.
+   * @param {Object} task
+   * @returns {boolean}
+   */
+  private _isHighPriority(task : IPrioritizerTask<T>) : boolean {
+    return task.priority <= this._prioritySteps.high;
   }
 }

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -54,15 +54,29 @@ import createSegmentLoader, {
   ISegmentLoaderWarning,
 } from "./create_segment_loader";
 
+/**
+ * Event sent when the segment request needs to be renewed (e.g. due to an HTTP
+ * error).
+ */
 export type ISegmentFetcherWarning = ISegmentLoaderWarning;
 
+/**
+ * Event sent when a new "chunk" of the segment is available.
+ * A segment can contain n chunk(s) for n >= 0.
+ */
 export interface ISegmentFetcherChunkEvent<T> {
   type : "chunk";
+  /** Parse the downloaded chunk. */
   parse : (initTimescale? : number) => Observable<ISegmentParserResponse<T>>;
 }
 
+/**
+ * Event sent when all "chunk" of the segments have been communicated through
+ * `ISegmentFetcherChunkEvent` events.
+ */
 export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete"; }
 
+/** Event sent by the SegmentFetcher when fetching a segment. */
 export type ISegmentFetcherEvent<T> = ISegmentFetcherChunkCompleteEvent |
                                       ISegmentFetcherChunkEvent<T> |
                                       ISegmentFetcherWarning;

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -15,6 +15,7 @@
  */
 
 import { Subject } from "rxjs";
+import config from "../../../config";
 import { ITransportPipelines } from "../../../transports";
 import {
   IABRMetricsEvent,
@@ -31,6 +32,9 @@ import ObservablePrioritizer from "./prioritizer";
 import createSegmentFetcher, {
   ISegmentFetcherEvent,
 } from "./segment_fetcher";
+
+const { MIN_CANCELABLE_PRIORITY,
+        MAX_HIGH_PRIORITY_LEVEL } = config;
 
 /** Options used by the `SegmentFetcherCreator`. */
 export interface ISegmentFetcherCreatorBackoffOptions {
@@ -85,7 +89,10 @@ export default class SegmentFetcherCreator<T> {
     options : ISegmentFetcherCreatorBackoffOptions
   ) {
     this._transport = transport;
-    this._prioritizer = new ObservablePrioritizer();
+    this._prioritizer = new ObservablePrioritizer({
+      prioritySteps: { high: MAX_HIGH_PRIORITY_LEVEL,
+                       low: MIN_CANCELABLE_PRIORITY },
+    });
     this._backoffOptions = options;
   }
 


### PR DESCRIPTION
Fixes #752 .

## The current situation

In our segment request scheduling logic, we have a notion of priority.

Each new segment request has an associated priority number. The lowest is that number (starting at 0), the highest is that request's priority over other segment requests.

When multiple segment requests are needed (generally we are talking about segment of different types here - like audio, video... - which are downloaded concurrently), the "segment fetchers" (the part of the RxPlayer scheduling and asking for segment requests) will first start the request with the highest priority. Once done, it will start the request with the next highest priority and so on.

Because the player is playing at the same time that the requests are performed, it is possible that the priority of different segment
requests evolve (for example, because a segment that was before far away is now very close).
In that case the segment request's priority is updated accordingly. 

However, until now, a segment request priority only affected when that request will be "started". Once started, a priority update on that request had no effect.

This has been the behavior of the RxPlayer for some time until this PR.

## The problem

I changed a little that logic because in some rare cases (like the one the #752 issue is about), segment requests of very high priority - like segments for the current position, which are necessary before playing - could be needed at the same time that segment requests of very low priority are pending (already started).

In that last situation, it would be sad to limit the speed at which we fetch those high priority segments, because low priority ones are using too much network bandwidth.

## Solution implemented: high and low priorities

For that last situation, I choose to add the concept of both a "high priority" step and a "low priority" step.

When segment requests with "high priority" are scheduled, all "low priority" requests are interrupted. They are put back in the waiting queue, to wait for their turn to be started.

### Problem 1: strange behavior for the buffers

But this brings a strange behavior in the point of view of the `Buffers`: to restart from scratch a request that was already started
and might had already communicated chunks.
For that issue, I make it explicit when an interrupt happens by adding another event, `"interrupted"`, which will be sent any time one of this situation happens.

### Problem 2: new requests added too late

There was a last problem - and not a small one - which is that the current logic has a flaw which is akin to a race condition (though it is not really one).

The problem is that in our current logic, when a `RepresentationBuffer` ask for multiple segment requests, it usually goes the following way:
  1. Ask the segment fetchers for the most needed segment (with its associated priority).
  2. Once it has been fully downloaded, ask the next most needed segment (also with is associated priority).
  3. Go back to 2.

The problem is that the request has finished in the segment fetchers point of view just before (2) is reached. As such, it has already scheduled the next request. This new request might have a lower priority than the one scheduled in (2) but the segment fetchers doesn't know about it yet.

In a perfect situation, the segment fetchers should always compare the priority of all needed segments. As such the `RepresentationBuffer` should be able to tell about the next segment before the request for the current one has ended.

For this issue, I have two ideas, one short term (that I implemented there) and one longer term (that I'm working on in another branch).

#### Short term solution: "ended" event

For the short term solution: we can add another event, today called "ended", which will be sent just before a segment request completes. By adding the next request synchronously on that event, we can ensure that the next request is scheduled before the segment fetchers makes its choice.

This is what I implemented here. This solution has still small issues where we would still have a similar problems when the Buffers interrupt the current segment request before it ends, such as when seeking to a completely different position.

#### Long term solution: smarter, more aware, segment fetchers

For the long term solution: I would like to make the segment fetchers aware of all the "wanted segment list", so they can take the task of scheduling EVERY segments that are needed at a given time, and not just the next segment of a given type.

This basically means moving logic from the `RepresentationBuffer` to the segment fetchers. I feel that we can do a much more "smart" logic in the latter without fearing to complexify the code too much as we are in a smaller, well-contained, unit of code.