### PR TITLE
manifest: do not update manifest uris on partial updates

### DIFF
--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -606,19 +606,19 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     updateType : MANIFEST_UPDATE_TYPE
   ) : void {
     this.availabilityStartTime = newManifest.availabilityStartTime;
+    this.expired = newManifest.expired;
     this.isDynamic = newManifest.isDynamic;
     this.isLive = newManifest.isLive;
     this.lifetime = newManifest.lifetime;
-    this.expired = newManifest.expired;
     this.maximumTime = newManifest.maximumTime;
-
-    if (updateType === MANIFEST_UPDATE_TYPE.Full) {
-      this.minimumTime = newManifest.minimumTime;
-    }
     this.parsingErrors = newManifest.parsingErrors;
     this.suggestedPresentationDelay = newManifest.suggestedPresentationDelay;
     this.transport = newManifest.transport;
-    this.uris = newManifest.uris;
+
+    if (updateType === MANIFEST_UPDATE_TYPE.Full) {
+      this.minimumTime = newManifest.minimumTime;
+      this.uris = newManifest.uris;
+    }
 
     if (updateType === MANIFEST_UPDATE_TYPE.Full) {
       replacePeriods(this.periods, newManifest.periods);


### PR DESCRIPTION
Fixes #775.

A "partial update" (that is an update with a shorter version of the Manifest to allow parsing optimizations) of a Manifest wrongly updated the `uris` property of the Manifest.

This is not what we want to do because it means that for the RxPlayer the new "true" URL of the Manifest is the one taken from the shorter version.

This has no effect right away, but after some time we might be in a situation where the RxPlayer want to re-perform a "full update" with what it thinks is the URL of the "normal" Manifest (which is in reality still the URL of the shorter version). This usually happens when the RxPlayer wants to make sure its local version of the Manifest is still synchronized to the true version from the server.

When doing so, it resets the current content as if we were playing the shorter version. The most visible difference is that the minimum position appears now to be too high.

I also re-ordered other properties updates in alphabetical order here!