### PR TITLE
Enable/Disable fast switching

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -18,6 +18,7 @@
     - [supplementaryImageTracks](#prop-supplementaryImageTracks)
     - [hideNativeSubtitle](#prop-hideNativeSubtitle)
     - [networkConfig](#prop-networkConfig)
+    - [enableFastSwitching](#prop-enableFastSwitching)
     - [supplementaryTextTracks (deprecated)](#prop-supplementaryTextTracks)
     - [defaultAudioTrack (deprecated)](#prop-defaultAudioTrack)
     - [defaultTextTrack (deprecated)](#prop-defaultTextTrack)
@@ -1042,6 +1043,57 @@ This object can take the following properties (all are optional):
 
   - the request failed because of an unknown XHR error (might be a
     parsing/interface error)
+
+
+
+<a name="prop-enableFastSwitching"></a>
+### enableFastSwitching ########################################################
+
+_type_: ``boolean``
+
+_defaults_: ``true``
+
+---
+
+:warning: This option is not available in _DirectFile_ mode (see [transport
+option](#prop-transport)).
+
+---
+
+Enable (when set to `true` and by default) or disable (when set to `false`) the
+"fast-switching" feature.
+
+"Fast-switching" is an optimization which allows the RxPlayer to replace
+low-quality segments (i.e.  with a low bitrate) with higher-quality segments
+(higher bitrate) in the buffer in some situations.
+
+This is used for example to obtain a faster quality transition when the user's
+network bandwidth raise up: instead of pushing the new high-quality segments at
+the end of the current buffer, we push them much sooner - "on top" of already
+pushed low-quality segments - so the user can quickly see the better quality.
+
+In most cases, this is a feature you want. On some rare devices however,
+replacing segments is poorly supported.
+We've for example seen on a few devices that old replaced segments were still
+decoded (and not the new better-quality segments that should have replaced
+them). On other devices, replacing segments resulted in visible small decoding
+issues.
+
+Setting `enableFastSwitching` to `false` thus allows to disable the
+fast-switching behavior. Note that it is - sadly - difficult to know when you
+need to disable it.
+In the great majority of cases, enabling fast-switching (the default behavior)
+won't lead to any problem. So we advise to only disable it when you suspect that
+segment replacement when the quality raises is at the source of some issues
+you're having (in which case it will help to see if that's really the case).
+
+It is also important to add that setting `enableFastSwitching` to `false` only
+disable the fast-switching feature and not all the logic where the RxPlayer is
+replacing segments it already pushed to the buffer.
+Forbiding the RxPlayer to replace segments altogether is today not possible and
+would even break playback in some situations: when multi-Period DASH contents
+have overlapping segments, when the browser garbage-collect partially a
+segment...
 
 
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,20 @@ export default {
                                                        "direct",
 
   /**
+   * Default behavior for the `enableFastSwitching` loadVideo options.
+   *
+   * Fast-switching allows to provide quicker transitions from lower quality
+   * segments to higher quality segments but might be badly supported on some
+   * devices.
+   * When enabled, the RxPlayer might replace segments of a lower-quality
+   * (with a lower bitrate) with segments of a higher quality (with a higher
+   * bitrate). This allows to have a fast transition when network conditions
+   * improve.
+   * When disabled, segments of a lower-quality will not be replaced.
+   */
+  DEFAULT_ENABLE_FAST_SWITCHING: true,
+
+  /**
    * If set to true, video through loadVideo will auto play by default
    * @type {Boolean}
    */

--- a/src/core/api/__tests__/option_parsers.test.ts
+++ b/src/core/api/__tests__/option_parsers.test.ts
@@ -418,6 +418,7 @@ describe("API - parseLoadVideoOptions", () => {
     autoPlay: false,
     defaultAudioTrack: undefined,
     defaultTextTrack: undefined,
+    enableFastSwitching: true,
     hideNativeSubtitle: false,
     keySystems: [],
     lowLatencyMode: false,
@@ -764,6 +765,30 @@ describe("API - parseLoadVideoOptions", () => {
       url: "foo",
       transport: "bar",
       manualBitrateSwitchingMode: "seamless",
+    });
+  });
+
+  it("should authorize setting a valid enableFastSwitching option", () => {
+    expect(parseLoadVideoOptions({
+      enableFastSwitching: false,
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      enableFastSwitching: false,
+    });
+
+    expect(parseLoadVideoOptions({
+      enableFastSwitching: true,
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      enableFastSwitching: true,
     });
   });
 

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -27,6 +27,7 @@ import {
   CustomSegmentLoader,
   ITransportOptions as IParsedTransportOptions,
 } from "../../transports";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import {
   normalizeAudioTrack,
   normalizeTextTrack,
@@ -41,6 +42,7 @@ import {
 } from "./track_choice_manager";
 
 const { DEFAULT_AUTO_PLAY,
+        DEFAULT_ENABLE_FAST_SWITCHING,
         DEFAULT_INITIAL_BITRATES,
         DEFAULT_LIMIT_VIDEO_WIDTH,
         DEFAULT_MANUAL_BITRATE_SWITCHING_MODE,
@@ -239,6 +241,7 @@ export interface ILoadVideoOptions {
   hideNativeSubtitle? : boolean;
   textTrackElement? : HTMLElement;
   manualBitrateSwitchingMode? : "seamless"|"direct";
+  enableFastSwitching? : boolean;
 
   /* tslint:disable deprecation */
   supplementaryTextTracks? : ISupplementaryTextTrackOption[];
@@ -266,6 +269,7 @@ interface IParsedLoadVideoOptionsBase {
   defaultTextTrack : ITextTrackPreference|null|undefined;
   startAt : IParsedStartAtOption|undefined;
   manualBitrateSwitchingMode : "seamless"|"direct";
+  enableFastSwitching : boolean;
 }
 
 /**
@@ -623,6 +627,10 @@ function parseLoadVideoOptions(
       DEFAULT_MANUAL_BITRATE_SWITCHING_MODE :
       options.manualBitrateSwitchingMode;
 
+  const enableFastSwitching = isNullOrUndefined(options.enableFastSwitching) ?
+    DEFAULT_ENABLE_FAST_SWITCHING :
+    options.enableFastSwitching;
+
   if (textTrackMode === "html") {
     // TODO Better way to express that in TypeScript?
     if (options.textTrackElement == null) {
@@ -668,6 +676,7 @@ function parseLoadVideoOptions(
   return { autoPlay,
            defaultAudioTrack,
            defaultTextTrack,
+           enableFastSwitching,
            hideNativeSubtitle,
            keySystems,
            lowLatencyMode,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -614,6 +614,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const { autoPlay,
             defaultAudioTrack,
             defaultTextTrack,
+            enableFastSwitching,
             keySystems,
             lowLatencyMode,
             manualBitrateSwitchingMode,
@@ -713,7 +714,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         { textTrackMode: "html" as const,
           textTrackElement: options.textTrackElement };
 
-      const bufferOptions = objectAssign({ manualBitrateSwitchingMode },
+      const bufferOptions = objectAssign({ enableFastSwitching,
+                                           manualBitrateSwitchingMode },
                                          this._priv_bufferOptions);
 
       // We've every options set up. Start everything now

--- a/src/core/buffers/adaptation/index.ts
+++ b/src/core/buffers/adaptation/index.ts
@@ -15,8 +15,14 @@
  */
 
 import AdaptationBuffer, {
+  IAdaptationBufferArguments,
   IAdaptationBufferClockTick,
+  IAdaptationBufferOptions,
 } from "./adaptation_buffer";
 
 export default AdaptationBuffer;
-export { IAdaptationBufferClockTick };
+export {
+  IAdaptationBufferArguments,
+  IAdaptationBufferClockTick,
+  IAdaptationBufferOptions,
+};

--- a/src/core/buffers/index.ts
+++ b/src/core/buffers/index.ts
@@ -16,8 +16,12 @@
 
 import BufferOrchestrator, {
   IBufferOrchestratorClockTick,
+  IBufferOrchestratorOptions,
 } from "./orchestrator";
 export * from "./types";
 
 export default BufferOrchestrator;
-export { IBufferOrchestratorClockTick };
+export {
+  IBufferOrchestratorClockTick,
+  IBufferOrchestratorOptions,
+};

--- a/src/core/buffers/orchestrator/buffer_orchestrator.ts
+++ b/src/core/buffers/orchestrator/buffer_orchestrator.ts
@@ -51,12 +51,12 @@ import { SegmentFetcherCreator } from "../../fetchers";
 import SourceBuffersStore, {
   BufferGarbageCollector,
   IBufferType,
-  ITextTrackSourceBufferOptions,
   QueuedSourceBuffer,
 } from "../../source_buffers";
 import EVENTS from "../events_generators";
 import PeriodBuffer, {
   IPeriodBufferClockTick,
+  IPeriodBufferOptions,
 } from "../period";
 import {
   IBufferOrchestratorEvent,
@@ -71,6 +71,13 @@ export type IBufferOrchestratorClockTick = IPeriodBufferClockTick;
 
 const { MAXIMUM_MAX_BUFFER_AHEAD,
         MAXIMUM_MAX_BUFFER_BEHIND } = config;
+
+/** Options tweaking the behavior of the BufferOrchestrator. */
+export type IBufferOrchestratorOptions =
+  IPeriodBufferOptions &
+  { wantedBufferAhead$ : BehaviorSubject<number>;
+    maxBufferAhead$ : Observable<number>;
+    maxBufferBehind$ : Observable<number>; };
 
 /**
  * Create and manage the various Buffer Observables needed for the content to
@@ -107,11 +114,7 @@ export default function BufferOrchestrator(
   abrManager : ABRManager,
   sourceBuffersStore : SourceBuffersStore,
   segmentFetcherCreator : SegmentFetcherCreator<any>,
-  options: { wantedBufferAhead$ : BehaviorSubject<number>;
-             maxBufferAhead$ : Observable<number>;
-             maxBufferBehind$ : Observable<number>;
-             textTrackOptions? : ITextTrackSourceBufferOptions;
-             manualBitrateSwitchingMode : "seamless" | "direct"; }
+  options: IBufferOrchestratorOptions
 ) : Observable<IBufferOrchestratorEvent> {
   const { manifest, initialPeriod } = content;
   const { maxBufferAhead$, maxBufferBehind$, wantedBufferAhead$ } = options;

--- a/src/core/buffers/orchestrator/index.ts
+++ b/src/core/buffers/orchestrator/index.ts
@@ -16,7 +16,11 @@
 
 import BufferOrchestrator, {
   IBufferOrchestratorClockTick,
+  IBufferOrchestratorOptions,
 } from "./buffer_orchestrator";
 
 export default BufferOrchestrator;
-export { IBufferOrchestratorClockTick };
+export {
+  IBufferOrchestratorClockTick,
+  IBufferOrchestratorOptions,
+};

--- a/src/core/buffers/period/index.ts
+++ b/src/core/buffers/period/index.ts
@@ -17,6 +17,7 @@
 import PeriodBuffer, {
   IPeriodBufferArguments,
   IPeriodBufferClockTick,
+  IPeriodBufferOptions,
 } from "./period_buffer";
 
 export default PeriodBuffer;
@@ -24,4 +25,5 @@ export default PeriodBuffer;
 export {
   IPeriodBufferArguments,
   IPeriodBufferClockTick,
+  IPeriodBufferOptions,
 };

--- a/src/core/buffers/period/period_buffer.ts
+++ b/src/core/buffers/period/period_buffer.ts
@@ -50,7 +50,9 @@ import SourceBuffersStore, {
   ITextTrackSourceBufferOptions,
   QueuedSourceBuffer,
 } from "../../source_buffers";
-import AdaptationBuffer from "../adaptation";
+import AdaptationBuffer, {
+  IAdaptationBufferOptions,
+} from "../adaptation";
 import EVENTS from "../events_generators";
 import {
   IAdaptationBufferEvent,
@@ -82,10 +84,13 @@ export interface IPeriodBufferArguments {
   garbageCollectors : WeakMapMemory<QueuedSourceBuffer<unknown>, Observable<never>>;
   segmentFetcherCreator : SegmentFetcherCreator<any>;
   sourceBuffersStore : SourceBuffersStore;
-  options: { manualBitrateSwitchingMode : "seamless" | "direct";
-             textTrackOptions? : ITextTrackSourceBufferOptions; };
+  options: IPeriodBufferOptions;
   wantedBufferAhead$ : BehaviorSubject<number>;
 }
+
+/** Options tweaking the behavior of the PeriodBuffer. */
+export type IPeriodBufferOptions = IAdaptationBufferOptions &
+                                   { textTrackOptions? : ITextTrackSourceBufferOptions };
 
 /**
  * Create single PeriodBuffer Observable:

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -105,6 +105,11 @@ export interface IInitializeArguments {
     maxBufferBehind$ : Observable<number>;
     /** Strategy when switching the current bitrate manually (smooth vs reload). */
     manualBitrateSwitchingMode : "seamless" | "direct";
+    /**
+     * Enable/Disable fastSwitching: allow to replace lower-quality segments by
+     * higher-quality ones to have a faster transition.
+     */
+    enableFastSwitching : boolean;
   };
   /** Regularly emit current playback conditions. */
   clock$ : Observable<IInitClockTick>;

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  BehaviorSubject,
   EMPTY,
   merge as observableMerge,
   Observable,
@@ -37,11 +36,10 @@ import Manifest from "../../manifest";
 import ABRManager from "../abr";
 import BufferOrchestrator, {
   IBufferOrchestratorEvent,
+  IBufferOrchestratorOptions,
 } from "../buffers";
 import { SegmentFetcherCreator } from "../fetchers";
-import SourceBuffersStore, {
-  ITextTrackSourceBufferOptions,
-} from "../source_buffers";
+import SourceBuffersStore from "../source_buffers";
 import createBufferClock from "./create_buffer_clock";
 import { setDurationToMediaSource } from "./create_media_source";
 import { maintainEndOfStream } from "./end_of_stream";
@@ -65,15 +63,7 @@ import updatePlaybackRate from "./update_playback_rate";
 // Arguments needed by `createMediaSourceLoader`
 export interface IMediaSourceLoaderArguments {
   abrManager : ABRManager; // Helps to choose the right Representation
-  bufferOptions : { // Buffers-related options
-    wantedBufferAhead$ : BehaviorSubject<number>; // buffer "goal"
-    maxBufferAhead$ : Observable<number>; // To GC after the current position
-    maxBufferBehind$ : Observable<number>; // to GC before the current position
-    textTrackOptions : ITextTrackSourceBufferOptions; // TextTrack configuration
-
-    // strategy when switching the current bitrate manually
-    manualBitrateSwitchingMode : "seamless"|"direct";
-  };
+  bufferOptions : IBufferOrchestratorOptions;
   clock$ : Observable<IInitClockTick>; // Emit position information
   manifest : Manifest; // Manifest of the content we want to play
   mediaElement : HTMLMediaElement; // Media Element on which the content will be


### PR DESCRIPTION
Closes #779 

"Fast-switching" is a behavior allowing to replace low-quality segments (i.e. with a low bitrate) with higher-quality segments
(higher bitrate) in the buffer. This is for example used to provide a faster quality transition to the user when its network bandwidth
quickly raise up.

This is a nice feature in most cases but in a few cases, the application could want to disable it.

For example, some devices have poor support for segment replacement, which is a necessary feature when fast-switching is enabled: Some devices still decode the segments that should have been replaced, other have decoding issues when a segment is replaced.

Because of that, I propose a new loadVideo option, `enableFastSwitching` - which will be set to `true` by default - which will allow to enable /  disable this optimization.