### PR TITLE
buffers: urgent quality switch now do not interrupt segment pushing operations

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -906,7 +906,7 @@ export default {
    * SourceBuffer is currently updating.
    * @type {Number}
    */
-  SOURCE_BUFFER_FLUSHING_INTERVAL: 2000,
+  SOURCE_BUFFER_FLUSHING_INTERVAL: 500,
 
   /**
    * Padding under which we should not buffer from the current time, on

--- a/src/core/buffers/representation/index.ts
+++ b/src/core/buffers/representation/index.ts
@@ -17,10 +17,12 @@
 import RepresentationBuffer, {
   IRepresentationBufferArguments,
   IRepresentationBufferClockTick,
+  ITerminationOrder,
 } from "./representation_buffer";
 
 export default RepresentationBuffer;
 export {
   IRepresentationBufferArguments,
   IRepresentationBufferClockTick,
+  ITerminationOrder,
 };


### PR DESCRIPTION
## Overview

There was a sort of race condition in the code which could lead to downloaded segments being immediately replaced once the adaptative logic decided to urgently switch the current quality.

That problem is a little hard to explain as it necessitates a lot of context.
I will try to be as descriptive as possible in the next lines.

## Source of the problem: Low-latency support

Since we added low-latency content support, we updated the behavior of a module called the `SegmentInventory` (which stores information about the currently loaded segments). This module allows to let the rest of the code know which segments has currently been pushed to a SourceBuffer.

Low-latency contents often rely on segment being subdivided intomultiple chunks.
For this reason, most of the RxPlayer's code now consider that one segment may contain multiple chunks - even if we're not playing a low-latency content.

Because a segment which has not been completely loaded (e.g. it's associated HTTP request has been interrupted before it completed) might need to be re-loaded from scratch once we encounter it again, the `SegmentInventory` makes a difference between a "partially-loaded" segment and a "complete" segment (i.e. a segment for which all chunks have been loaded).

When the `RepresentationBuffer` - the module deciding which segments to download - asks which segments have already been loaded, it filters out partially-loaded segments to load them again if they are needed again.

It is also the `RepresentationBuffer` which indicates to the `SegmentInventory` (indirectly) when a segment has been completely
loaded.
It does so by calling a specific method, `endOfSegment` once the segment has been completely loaded. That method does not mark the corresponding segment as complete in the `SegmentInventory` right away: It waits until all the corresponding chunks have been pushed to the SourceBuffer.
This way, if any push order for chunks of that segment is interrupted, the segment will not be marked as a complete segment.

## ABRManager's urgent quality switch

For now, all is well, but there is another element in the mix: the `ABRManager`.

The `ABRManager` decides which quality should be downloaded.
When a segment request ends, network metrics are emitted.
Based on those, the `ABRManager` gives recommendations through events indicating, between other things, the `Representation` we should switch to and an associated "urgency" with which the player should switch to it.

There's two urgency level, the rest of the RxPlayer's logic handles each one of them in a different way:

  1. _non-urgent_: the RxPlayer will wait until the current `RepresentationBuffer` has finished pending request(s) and pushed
     the corresponding chunks before creating a new `RepresentationBuffer` linked to the new `Representation`.

  2. _urgent_: here the RxPlayer will stop directly the `RepresentationBuffer` from what it was doing, and directly replace it by a new one linked to the new `Representation`.

## The problem

The problem become apparent once we resume everything that is going on once a segment's request is finished:

  1. The `RepresentationBuffer` calls the `endOfSegment` method, which will mark the corresponding segment as "complete" once every push operations for chunk(s) of that segment (operations which might still be pending) are finished.

  2. Network metrics are sent to the ABRManager, which may now decides that the RxPlayer should switch to another Representation urgently.

  3. When an "urgent" switch happens the RxPlayer interrupts everything the `RepresentationBuffer` was doing and create a new one.

     Every operations scheduled by the previous RepresentationBuffer (such as pushing chunks or even an `endOfSegment` call is
     interrupted).

  4. The new RepresentationBuffer will look at currently loaded segments and decide that those not marked as "complete" should be re-downloaded.

Here, an urgent `Representation` switch can happen really close to the time at which a segment is marked as "complete".

If we're not lucky (and most of the time, we're not), the previous `RepresentationBuffer` will be killed before the last loaded segment has been marked as "complete", even if all the corresponding chunks have already been loaded, or even if the last chunk is being pushed (which is a shame, considering the short amount of time it takes to push a segment).

Because of that, it might be re-loaded by the new `RepresentationBuffer`, which might lead to a waste of bandwidth and of
time.

## The solution brought here

This is a first solution to that problem, albeit not the most performant one.

Where before an "urgent" `Representation` switch just directly interrupted (or as we wrote, "killed") the current `RepresentationBuffer`, now it ""gently"" indicates to it that it should terminate what it does as soon as possible.

This is basically not too different to a non-urgent switch where the `RepresentationBuffer` also decides when to finish. The only difference is that an urgent switch will lead the `RepresentationBuffer` to interrupt pending HTTP requests (but not other pending operations).

Both type of urgency are communicated to the `RepresentationBuffer` through the same Observable, `terminate$` (exact same that is used previously for non-urgent switched), which now emits a boolean property, `urgent`:

  - if set to `true`, the `RepresentationBuffer` will interrupt the current HTTP requests, but will not interrupt the current push operations, nor the awaiting `endOfSegment` operations.

  - if set to `false`, we're in a non-urgent case. Here, the `RepresentationBuffer` keep the same behavior as before: it waits
    until the current segment request finishes and until it has completely pushed the corresponding segment.

## The problem with that solution

However, this solution has a minor problem.

In the RxPlayer, we try to optimize the time at which segment requests are done.

With this fix, we might have a small time where no segment is being downloaded (despite being needed) because we are waiting on previous push/`endOfSegment` operations from the previous `RepresentationBuffer`.

A more performant operation would begin the new segment requests right away, while still pushing the segments from the previous `RepresentationBuffer`.

However this has not been done yet as:

  1. This would be much harder to implement on the current code. To do that:

       - When killing a `RepresentationBuffer`, we should not interrupt its current SourceBuffer operations.

       - The new `RepresentationBuffer` would need a way to tell that chunks from the old `RepresentationBuffer` are being pushed, so that it avoids loading them again.

   2. A push operation only takes around 15ms maximum on my computer, which is not that long (even if we might have different results on other devices) to wait before switching the `RepresentationBuffer`.