### PR TITLE
buffers: Rely directly on the QueuedSourceBuffer for pending operations

### DIFF
--- a/src/core/source_buffers/index.ts
+++ b/src/core/source_buffers/index.ts
@@ -18,8 +18,15 @@ import BufferGarbageCollector from "./garbage_collector";
 import QueuedSourceBuffer, {
   IBufferedChunk,
   IBufferType,
+  IEndOfSegmentInfos,
+  IEndOfSegmentOperation,
   IPushChunkInfos,
   IPushedChunkData,
+  IPushedChunkInventoryInfos,
+  IPushOperation,
+  IQSBOperation,
+  IRemoveOperation,
+  SourceBufferOperation,
 } from "./queued_source_buffer";
 import SourceBuffersStore, {
   ISourceBufferOptions,
@@ -28,12 +35,24 @@ import SourceBuffersStore, {
 
 export default SourceBuffersStore;
 export {
+  QueuedSourceBuffer,
   BufferGarbageCollector,
-  IBufferType,
-  IBufferedChunk,
-  IPushChunkInfos,
-  IPushedChunkData,
+
   ISourceBufferOptions,
   ITextTrackSourceBufferOptions,
-  QueuedSourceBuffer,
+
+  IBufferType,
+  IBufferedChunk,
+
+  IPushChunkInfos,
+  IPushedChunkData,
+  IPushedChunkInventoryInfos,
+
+  IEndOfSegmentInfos,
+
+  SourceBufferOperation,
+  IQSBOperation,
+  IEndOfSegmentOperation,
+  IPushOperation,
+  IRemoveOperation,
 };


### PR DESCRIPTION
Previously a RepresentationBuffer had a special variable named `loadedSegmentPendingPush` which registered every segments for which the request was ended but which were still being pushed to the SourceBuffer.

It is a necessary information to avoid re-download a segment that is neither being downloaded nor being already in the Buffer. Without it, the `RepresentationBuffer` - with enough luck - might decide to re-load the corresponding segment (as it will think that it has been garbage collected by the browser).

I moved that "registration" role to the QueuedSourceBuffer, which already maintains a queue of pending operations. I then added a `getPendingOperations` method to it so a `RepresentationBuffer` can directly look at it to see which downloaded segments are being pushed.

This has the following advantages:

  - it removes a difficult-to-understand logic from the `RepresentationBuffer` code.

  - A `RepresentationBuffer` can know about segments that have been pushed from another `RepresentationBuffer`. This in fact was the main motivation behind this code change, as we might want to maintain multiple `RepresentationBuffer` alive in the future for optimization reasons (e.g. faster switch between qualities).

  - it removes code duplication, as the `QueuedSourceBuffer` already maintained that queue internally

  - it seems more logical to do it that way (only the `QueuedSourceBuffer` knows about which segments are still being
    pushed).

But has the following disadvantages:

  - the corresponding logic in the `RepresentationBuffer` arguably still looks difficult to understand

  - it exposes a lot of `QueuedSourceBuffer`'s internal types to the outside world, which may need more effort to maintain