### PR TITLE
Faster safer quality switch

### DIFF
--- a/src/core/stream/adaptation/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/create_representation_estimator.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  merge as observableMerge,
+  Observable,
+  Subject,
+} from "rxjs";
+import { MediaError } from "../../../errors";
+import { Adaptation } from "../../../manifest";
+import ABRManager, {
+  IABREstimate,
+  IABRManagerClockTick,
+  IABRMetricsEvent,
+  IABRRequestBeginEvent,
+  IABRRequestEndEvent,
+  IABRRequestProgressEvent,
+} from "../../abr";
+import {
+  IRepresentationChangeEvent,
+  IStreamEventAddedSegment,
+} from "../types";
+
+/**
+ * Create an "estimator$" Observable which will emit which Representation (from
+ * the given `Adaptation`) is the best fit (see `IABREstimate` type definition)
+ * corresponding to the current network and playback conditions.
+ *
+ * This function also returns two subjects that should be used to add feedback
+ * helping the estimator to make its choices:
+ *
+ *   - `requestFeedback$`: Subject through which information about new requests
+ *     and network metrics should be emitted.
+ *
+ *   - `streamFeedback$`: Subject through which stream-related events should be
+ *      emitted.
+ *
+ * You can look at the types defined for both of those Subjects to have more
+ * information on what data is expected. The idea is to provide as much data as
+ * possible so the estimation is as adapted as possible.
+ *
+ * @param {Object} adaptation
+ * @param {Object} abrManager
+ * @param {Observable} clock$
+ * @returns {Object}
+ */
+export default function createRepresentationEstimator(
+  adaptation : Adaptation,
+  abrManager : ABRManager,
+  clock$ : Observable<IABRManagerClockTick>
+) : { estimator$ : Observable<IABREstimate>;
+      streamFeedback$ : Subject<IStreamEventAddedSegment<unknown> |
+                                IRepresentationChangeEvent>;
+      requestFeedback$ : Subject<IABRMetricsEvent |
+                                 IABRRequestBeginEvent |
+                                 IABRRequestProgressEvent |
+                                 IABRRequestEndEvent>; }
+{
+  const streamFeedback$ = new Subject<IStreamEventAddedSegment<unknown> |
+                                      IRepresentationChangeEvent>();
+  const requestFeedback$ = new Subject<IABRMetricsEvent |
+                                       IABRRequestBeginEvent |
+                                       IABRRequestProgressEvent |
+                                       IABRRequestEndEvent>();
+  const abrEvents$ = observableMerge(streamFeedback$, requestFeedback$);
+
+  /** Representations for which a `RepresentationStream` can be created. */
+  const playableRepresentations = adaptation.getPlayableRepresentations();
+  if (playableRepresentations.length <= 0) {
+    const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
+                                    "No Representation in the chosen " +
+                                    "Adaptation can be played");
+    throw noRepErr;
+  }
+
+  const estimator$ = abrManager.get$(adaptation.type,
+                                     playableRepresentations,
+                                     clock$,
+                                     abrEvents$);
+  return { estimator$,
+           streamFeedback$,
+           requestFeedback$ };
+}

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -42,6 +42,7 @@ import {
   IStreamNeedsManifestRefresh,
   IStreamStateActive,
   IStreamStateFull,
+  IStreamTerminatingEvent,
   IStreamWarningEvent,
 } from "./types";
 
@@ -175,6 +176,11 @@ const EVENTS = {
   ) : IRepresentationChangeEvent {
     return { type: "representationChange",
              value: { type, period, representation } };
+  },
+
+  streamTerminating() : IStreamTerminatingEvent {
+    return { type: "stream-terminating",
+             value: undefined };
   },
 
   resumeStream() : IResumeStreamEvent {

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -114,6 +114,24 @@ export interface IProtectedSegmentEvent {
   value : ISegmentProtection;
 }
 
+/**
+ * Event sent when a `RepresentationStream` is terminating:
+ *
+ *   - it has finished all its segment requests and won't do new ones.
+ *
+ *   - it has stopped regularly checking for its current status.
+ *
+ *   - it only waits until all the segments it has loaded have been pushed to the
+ *     SourceBuffer before actually completing.
+ *
+ * You can use this event as a hint that a new `RepresentationStream` can be
+ * created.
+ */
+export interface IStreamTerminatingEvent {
+  type : "stream-terminating";
+  value : undefined;
+}
+
 /** Event sent by a `RepresentationStream`. */
 export type IRepresentationStreamEvent<T> = IStreamEventAddedSegment<T> |
                                             IProtectedSegmentEvent |
@@ -122,6 +140,7 @@ export type IRepresentationStreamEvent<T> = IStreamEventAddedSegment<T> |
                                             IStreamManifestMightBeOutOfSync |
                                             IStreamNeedsDiscontinuitySeek |
                                             IStreamNeedsManifestRefresh |
+                                            IStreamTerminatingEvent |
                                             IStreamWarningEvent;
 
 /** Emitted as new bitrate estimates are done. */


### PR DESCRIPTION
## Overview 

This is an improvement over #781 and builds on top of it.

It tries to fix the last problem with that PR, which is that we might have a short time (maximum 20 milliseconds on my PC) where no segment is loaded when we perform a transition between qualities.

That issue arised lately because #781 added a behavior where we are now waiting until a `RepresentationBuffer` pushed all the segments it has loaded before going to the next `RepresentationBuffer`. We have reasons for doing that, I invite you to read that previous PR to get some context if you want to know more.

## The solution

This solution is basically the one brought in #781 in "The problem with that solution" chapter.

Here a `RepresentationBuffer` emits a new event - for now called `"buffer-terminating"` - to indicate that it has finished loading segments and is now just waiting on all loaded segments to be pushed before completing itself.

When an urgent quality switch necessitates the current `RepresentationBuffer` to immediately stops its requests and let its place to a new `RepresentationBuffer`, here what happens now:
  1. the current `RepresentationBuffer` stops all its current requests
  2. it sends immediately after the `"buffer-terminating"` event
  3. On this event, the parent `AdaptationBuffer` still keep this `RepresentationBuffer` alive, as it might still be pushing some of the segments it has loaded, but also create a new `RepresentationBuffer` right away, which will directly start making requests.
  4. the new `RepresentationBuffer` now also looks at which SourceBuffer operations are pending (thanks to the new `QueuedSourceBuffer` method added in #782) to make its list of segments to request.
       This is to avoid re-downloading a segment that might still be being pushed by the previous `RepresentationBuffer`
  5. Once the old `RepresentationBuffer` has pushed all segments, it can complete itself to free-up resources.

This new solution has an upside in that it also improves the time when transitioning `RepresentationBuffer` following a non-urgent quality switch. Here the logic is the same but the current `RepresentationBuffer` waits for the current HTTP requests to finish before sending the `"buffer-terminating"` event.

## Downsides

I consider that there is still some downsides with that new behavior:

  - it is a little more difficult to follow:
      1. Now, `RepresentationBuffer`s are created recursively as the previous one sent its `"buffer-terminating"` event.
      2. It adds a lot of logic in the `RepresentationBuffer` so that it avoids re-requesting a segment that a previous `RepresentationBuffer` is still pushing.
  - two (or even more) `RepresentationBuffer` for the same `Period` can now be sending events at the same time.
    This should be fine but it might be something we did not expect in the past.
    I quickly checked if this introduced bugs (as something we previously not expected now happens) and it looks like we're fine, but still.