### PR TITLE
Check if bytes are missing from segment when the `checkMediaSegmentIntegrity` option is set

### DIFF
--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -36,6 +36,7 @@ import {
   ILoaderDataLoadedValue,
   ILoaderProgressEvent,
   ISegmentLoaderArguments,
+  ISegmentLoaderDirectRetryEvent,
   ISegmentLoaderEvent as ITransportSegmentLoaderEvent,
 } from "../../../transports";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -89,7 +90,8 @@ export type ISegmentLoaderEvent<T> = ISegmentLoaderData<T> |
                                      ISegmentLoaderWarning |
                                      ISegmentLoaderChunk |
                                      ISegmentLoaderChunkComplete |
-                                     IABRMetricsEvent;
+                                     IABRMetricsEvent |
+                                     ISegmentLoaderDirectRetryEvent;
 
 /** Cache implementation to avoid re-requesting segment */
 export interface ISegmentLoaderCache<T> {
@@ -228,6 +230,7 @@ export default function createSegmentLoader<T>(
           case "warning":
           case "request":
           case "progress":
+          case "direct-retry":
             return observableOf(arg);
           case "cache":
           case "data-created":

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -95,6 +95,24 @@ export interface ILoaderDataLoadedValue<T> {
   size : number | undefined;
 }
 
+/**
+ * Event emitted by a segment loader when it immediately retries a request from
+ * scratch.
+ *
+ * This should only happen in rare occasions as the RxPlayer already has an
+ * advanced logic when it comes to retrying requests.
+ *
+ * An example of such occasion would be when a segment loader deduced that a
+ * request it just did might not have had the right headers.
+ * Here, the segment loader could send this event and then immediately re-do the
+ * request with the right headers set.
+ *
+ * In most other cases, a segment loader should just throw when encountering an
+ * error. The RxPlayer will handle retries by itself.
+ */
+export interface ISegmentLoaderDirectRetryEvent { type : "direct-retry";
+                                                  value : null; }
+
 /** Form that can take a loaded Manifest once loaded. */
 export type ILoadedManifest = Document |
                               string |
@@ -199,6 +217,7 @@ export type IManifestLoaderEvent = IManifestLoaderDataLoadedEvent;
 
 /** Event emitted by a segment loader. */
 export type ISegmentLoaderEvent<T> = ILoaderProgressEvent |
+                                     ISegmentLoaderDirectRetryEvent |
                                      ISegmentLoaderChunkEvent |
                                      ISegmentLoaderDataLoadedEvent<T> |
                                      ISegmentLoaderDataCreatedEvent<T>;

--- a/src/transports/utils/check_isobmff_integrity.ts
+++ b/src/transports/utils/check_isobmff_integrity.ts
@@ -15,6 +15,11 @@
  */
 
 import { OtherError } from "../../errors";
+import log from "../../log";
+import {
+  be4toi,
+  be8toi
+} from "../../utils/byte_parsing";
 import findCompleteBox from "./find_complete_box";
 
 /**
@@ -47,4 +52,125 @@ export default function checkISOBMFFIntegrity(
       throw new OtherError("INTEGRITY_ERROR", "Incomplete `mdat` box");
     }
   }
+}
+
+/**
+ * Check if the given ISOBMFF segment contains a truncated box at the end.
+ * The returned value is a number which is equal to:
+ *
+ *   - `0` if nothing appear to be missing at the end of the segment
+ *
+ *   - a positive value if the last box in the given segment is missing some
+ *     bytes. This value indicates the number of bytes missing.
+ *
+ *   - a negative value if the last box in the given segment is missing some
+ *     bytes, but the box in question can be omitted from the chunk.
+ *     That negative value is the amount of bytes you can remove from the end of
+ *     the given segment.
+ *
+ * Returns `undefined` if we know data is missing but we cannot say how much.
+ *
+ * In the rare case we don't know whether data is missing or not (like when
+ * getting a box with a length of `0` indicating that the box goes until the
+ * end), we will assume that the given `buffer` is complete and just return `0`.
+ *
+ * Note: This code has been added - reluctantly - to work-around mistakes on the
+ * byte-range of the last segment on some Canal+ streams. This is a lot of code
+ * for a very rare problem which is on the content packaging size.
+ *
+ * @param {Uint8Array} buffer - The whole ISOBMFF segment
+ * @param {boolean} isInitSegment - `true` if this is an initialization segment,
+ * `false` otherwise.
+ * @returns {number|undefined}
+ */
+export function getMissingBytes(
+  buffer : Uint8Array,
+  isInitSegment : boolean
+) : number | undefined {
+  const bufferLength = buffer.length;
+
+  /** Every boxes name that should be encountered and complete. */
+  const wantedCompleteBoxes = isInitSegment ? [0x66747970 /* ftyp */,
+                                               0x6D6F6F76 /* moov */] :
+                                              [0x6D6F6F66 /* moof */,
+                                               0x6D646174 /* mdat */];
+  /** Offset of the current considered box in `buffer`. */
+  let boxBaseOffset = 0;
+  /**
+   * Name of the last box encountered.
+   * Read as a 32bit (big endian) integer from `buffer`.
+   * `undefined` if no box has been encountered yet.
+   */
+  let name : number | undefined;
+  /**
+   * Size of the last box encountered.
+   * `undefined` if no box has been encountered yet.
+   */
+  let lastBoxSize : number | undefined;
+
+  while (boxBaseOffset + 8 <= bufferLength) {
+    lastBoxSize = be4toi(buffer, boxBaseOffset);
+    name = be4toi(buffer, boxBaseOffset + 4);
+
+    if (lastBoxSize === 0) { // == until the end of the segment
+      // we can never now for sure...
+      // Let's assume the segment is complete
+      return 0;
+    } else if (lastBoxSize === 1) { // == the size is on 8 bytes
+      if (boxBaseOffset + 8 + 8 > bufferLength) {
+        if (wantedCompleteBoxes.length === 0) {
+          // We may have been loading too much data.
+          // Return negative offset to remove that box from the range.
+          return boxBaseOffset - bufferLength;
+        }
+        log.error("ISOBMFF: not enough bytes downloaded for knowing the size of box",
+                  name);
+        return undefined;
+      }
+      lastBoxSize = be8toi(buffer, boxBaseOffset + 8);
+    }
+
+    if (isNaN(lastBoxSize) && lastBoxSize < 0) { // shouldn't happen
+      throw new Error("ISOBMFF: Size out of range");
+    }
+
+    // remove from `wantedCompleteBoxes` if found in it
+    const indexOfName = wantedCompleteBoxes.indexOf(name);
+    if (indexOfName >= 0) {
+      wantedCompleteBoxes.splice(indexOfName, 1);
+    }
+
+    boxBaseOffset += lastBoxSize;
+  }
+
+  if (boxBaseOffset === bufferLength) {
+    return wantedCompleteBoxes.length === 0 ? 0 :
+                                              undefined;
+  }
+
+  // Check if we didn't just read too much
+  if (wantedCompleteBoxes.length === 0) {
+    const missingBytes = bufferLength - boxBaseOffset;
+
+    // We may have been loading too much data.
+    // Return negative offset.
+    log.warn(`ISOBMFF: ISOBMFF box ${name ?? "unknown"}` +
+             `is missing ${missingBytes} bytes.`);
+    return boxBaseOffset - bufferLength;
+  }
+
+  if (boxBaseOffset + 4 <= bufferLength) { // there is enough to read the size
+    lastBoxSize = be4toi(buffer, boxBaseOffset);
+    if (lastBoxSize === 0) { // == until the end of the segment
+      // we can never now for sure...
+      // Let's assume the segment is complete
+      return 0;
+    } else if (lastBoxSize === 1) { // == the size is on 8 bytes
+      log.error("ISOBMFF: not enough bytes downloaded for the last box.");
+      return undefined;
+    }
+  }
+
+  log.error("ISOBMFF: not enough bytes downloaded.");
+  return undefined;
 }


### PR DESCRIPTION
## Overview

This is a PR done reluctantly to work-around some problems we have with VoD contents at Canal+ Group (not that the feature added is only useful for Canal+ streams, but the problem it fixes should be very rare and due to some encoding/packaging problem anyway).

This PR adds a new behavior for the `checkMediaSegmentIntegrity` option (given as a `transportOptions` to a `loadVideo` call) for DASH contents: it now also checks that the segment requested through byte-range requests did not miss out some bytes due to a wrong `Range` headers in the request.

This would mean that the "sidx" box parsed from the related initialization segment contained wrong values.
This should thus be considered as an error on the content encoding/packaging side, but there is two reasons why we're bringing work-arounds on the client:
  - too many contents have been encoded before that error has been found. Despite multiple requests, the people responsible for encoding/packaging will not fix that problem for already-packaged contents.
  - the problem can be detected and fixed on the client (even if that means the complex logic that this PR brings).

For many months now, we were actually making a git branch after each release which added a commit to it, correcting directly any parsed "sidx" box (example: https://github.com/canalplus/rx-player/commit/1f0ae65dbdb01f024edcf2edec7e1389c7350678)
This appeared to us as the sensible thing to do, as that code was both very simple (even if ugly in many ways) and we didn't have to update the "real" RxPlayer code.

However there is now the problem that more and more codebases want to be able to play those problematic contents and asking everyone to switch to the right git branch is not easily doable.

This PR is thus the occasion of fixing that problem in our regular release without impacting - beside the code size increase - applications without this problem.

## Implementation

There are multiple problems I encountered when doing that code update.

### Defining the wanted behavior

First there were problems which didn't have anything to do with the code per se, but more about the behavior that should be expected:
  1. When should the requests with the right byte-range be performed: just after the initial request or after a backoff delay? If it's after a backoff delay, should it be done after testing possible other URLs from the same segment? Should these other URLs also have their byte-range updated?

  2. What to do if the original request finished on success but the one with the corrected range does not? Return the original segment anyway and pray? Retry? Directly fail?

  3. Does the corrected request count as a retry?

  4. What to do if we know we're missing information, but we are missing too much to know how much information we are missing? Request enough to be able to read how much we're missing? Push the segment anyway?

To those questions, I provided the following answers:

  1. We do the "corrected" request directly after the initial one. Both the initial and the corrected one are now actually considered as only "one loader call" by the segment fetchers logic.
      We chose this with @grenault73 because it seemed to be the most logical choice

  2. I chose to return the original segment to the rest of the player's, even if we considered it to be truncated.
      Here it is because we could expect the server to return an error when we are doing segment request with a byte-range that is too high.

      This also means that technically, we only have one try when requesting problematic segments at Canal+. If the "corrected" request returns an error for whatever reason, we will fail like before.

   3. It does not. As said in (1), both the initial and the corrected requests are considered like only one 'try" now.

   4. Here what we do is a little complicated:
         - if we already have the complete boxes that matters (e.g. moof and mdat), we remove the last incomplete box
         - else, we do as if no byte-range check were performed. We usually finally be encountering the original integrity checking code which will just ask the request to be retried with the usual retry channel.

### How to perform that new request

After defining the wanted behavior, I encountered other problems:
  1. If a custom segment loader has been used for a request, how do we know if it performed a byte-range request or not?
  2. How to communicate the byte range for the new request to the future segment loader - or even worse the future custom segment loader?

For those, I decided to do it (both detection and communication) implicitly by performing all the code (even the retry with the correct request) directly in the segment loader: Byte range are communicated by cloning the initial `segment` object and mutating the new one's `range` property, so that it reflects the calculated "true" range.

Also I added an event sent by the transport pipelines `"direct-retry"` so the segment fetchers can communicate to the `ABRManager` that the request has "restarted" in a way and thus that progress events received until then do not concern the same request.