### PR TITLE
transports: allow a segment loader to perform multiple requests

### DIFF
--- a/src/core/fetchers/manifest/create_manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/create_manifest_fetcher.ts
@@ -30,7 +30,7 @@ import {
 } from "../../../errors";
 import Manifest from "../../../manifest";
 import {
-  ILoaderDataLoadedValue,
+  ILoadedManifestResponse,
   ITransportPipelines,
 } from "../../../transports";
 import createRequestScheduler from "../utils/create_request_scheduler";
@@ -159,7 +159,7 @@ export default function createManifestFetcher(
 
           // Prepare RequestScheduler
           // TODO Remove the need of a subject
-          type IRequestSchedulerData = ILoaderDataLoadedValue<string | Document>;
+          type IRequestSchedulerData = ILoadedManifestResponse;
           const schedulerWarnings$ = new Subject<ICustomError>();
           const scheduleRequest =
             createRequestScheduler<IRequestSchedulerData>(backoffOptions,

--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -36,6 +36,7 @@ import {
   ILoaderDataLoadedValue,
   ILoaderProgressEvent,
   ISegmentLoaderArguments,
+  ISegmentLoaderDirectRetryEvent,
   ISegmentLoaderEvent as ITransportSegmentLoaderEvent,
 } from "../../../transports";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -89,7 +90,8 @@ export type ISegmentLoaderEvent<T> = ISegmentLoaderData<T> |
                                      ISegmentLoaderWarning |
                                      ISegmentLoaderChunk |
                                      ISegmentLoaderChunkComplete |
-                                     IABRMetricsEvent;
+                                     IABRMetricsEvent |
+                                     ISegmentLoaderDirectRetryEvent;
 
 /** Cache implementation to avoid re-requesting segment */
 export interface ISegmentLoaderCache<T> {
@@ -228,6 +230,7 @@ export default function createSegmentLoader<T>(
           case "warning":
           case "request":
           case "progress":
+          case "direct-retry":
             return observableOf(arg);
           case "cache":
           case "data-created":

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -27,6 +27,7 @@ import {
   ISegmentLoaderEvent,
   ISegmentParserArguments,
 } from "../types";
+import performSegmentRequest from "../utils/segment_request";
 
 /**
  * @param {Object} args
@@ -37,12 +38,11 @@ export function imageLoader(
     url } : ISegmentLoaderArguments
 ) : Observable< ISegmentLoaderEvent< ArrayBuffer | null > > {
   if (segment.isInit || url === null) {
-    return observableOf({ type: "data-created" as const,
-                          value: { responseData: null } });
+    return observableOf({ type: "data" as const, value: { responseData: null } });
   }
-  return request({ url,
-                   responseType: "arraybuffer",
-                   sendProgressEvents: true });
+  return performSegmentRequest(request({ url,
+                                         responseType: "arraybuffer",
+                                         sendProgressEvents: true }));
 }
 
 /**

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -32,7 +32,7 @@ import dashManifestParser, {
 import objectAssign from "../../utils/object_assign";
 import request from "../../utils/request";
 import {
-  ILoaderDataLoadedValue,
+  ILoadedManifestResponse,
   IManifestParserArguments,
   IManifestParserObservable,
   ITransportOptions,
@@ -46,7 +46,7 @@ import returnParsedManifest from "../utils/return_parsed_manifest";
  */
 function requestStringResource(
   url : string
-) : Observable< ILoaderDataLoadedValue< string > > {
+) : Observable< ILoadedManifestResponse > {
   return request({ url,
                    responseType: "text" })
   .pipe(
@@ -110,7 +110,7 @@ export default function generateManifestParser(
 
       return observableCombineLatest(externalResources$)
         .pipe(mergeMap(loadedResources => {
-          const resources : Array<ILoaderDataLoadedValue<string>> = [];
+          const resources : Array<{ responseData : string }> = [];
           for (let i = 0; i < loadedResources.length; i++) {
             const resource = loadedResources[i];
             if (typeof resource.responseData !== "string") {

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -28,6 +28,7 @@ import {
 } from "../types";
 import byteRange from "../utils/byte_range";
 import isMP4EmbeddedTextTrack from "../utils/is_mp4_embedded_text_track";
+import performSegmentRequest from "../utils/segment_request";
 import addSegmentIntegrityChecks from "./add_segment_integrity_checks_to_loader";
 import initSegmentLoader from "./init_segment_loader";
 import lowLatencySegmentLoader from "./low_latency_segment_loader";
@@ -58,8 +59,7 @@ export default function generateTextTrackLoader(
     const { url } = args;
 
     if (url === null) {
-      return observableOf({ type: "data-created",
-                            value: { responseData: null } });
+      return observableOf({ type: "data", value: { responseData: null } });
     }
 
     if (args.segment.isInit) {
@@ -79,11 +79,11 @@ export default function generateTextTrackLoader(
     // ArrayBuffer when in mp4 to parse isobmff manually, text otherwise
     const responseType = isMP4Embedded ?  "arraybuffer" :
                                           "text";
-    return request<ArrayBuffer|string>({ url,
-                                         responseType,
-                                         headers: Array.isArray(range) ?
-                                           { Range: byteRange(range) } :
-                                           null,
-                                         sendProgressEvents: true });
+    return performSegmentRequest(request({ url,
+                                          responseType,
+                                          headers: Array.isArray(range) ?
+                                            { Range: byteRange(range) } :
+                                            null,
+                                          sendProgressEvents: true }));
   }
 }

--- a/src/transports/local/segment_loader.ts
+++ b/src/transports/local/segment_loader.ts
@@ -25,7 +25,6 @@ import {
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import {
   ISegmentLoaderArguments,
-  ISegmentLoaderDataLoadedEvent,
   ISegmentLoaderEvent,
 } from "../types";
 
@@ -35,10 +34,8 @@ import {
  */
 function loadInitSegment(
   customSegmentLoader : ILocalManifestInitSegmentLoader
-) : Observable< ISegmentLoaderDataLoadedEvent<ArrayBuffer | null>> {
-  return new Observable((obs : Observer<
-    ISegmentLoaderDataLoadedEvent< ArrayBuffer | null >
-  >) => {
+) : Observable<ISegmentLoaderEvent<ArrayBuffer | null>> {
+  return new Observable((obs : Observer< ISegmentLoaderEvent< ArrayBuffer | null > >) => {
     let hasFinished = false;
 
     /**
@@ -51,10 +48,12 @@ function loadInitSegment(
       duration? : number;
     }) => {
       hasFinished = true;
-      obs.next({ type: "data-loaded",
-                 value: { responseData: _args.data,
-                          size: _args.size,
-                          duration: _args.duration } });
+      obs.next({ type: "data", value: { responseData: _args.data } });
+      obs.next({ type: "request-end",
+                 value: { size: _args.size,
+                          duration: _args.duration,
+                          receivedTime: undefined,
+                          sendingTime: undefined } });
       obs.complete();
     };
 
@@ -67,6 +66,7 @@ function loadInitSegment(
       obs.error(err);
     };
 
+    obs.next({ type: "request-begin", value: {} });
     const abort = customSegmentLoader({ resolve, reject });
 
     return () => {
@@ -85,10 +85,8 @@ function loadInitSegment(
 function loadSegment(
   segment : { time : number; duration : number; timestampOffset? : number },
   customSegmentLoader : ILocalManifestSegmentLoader
-) : Observable< ISegmentLoaderDataLoadedEvent<ArrayBuffer | null>> {
-  return new Observable((obs : Observer<
-    ISegmentLoaderDataLoadedEvent< ArrayBuffer | null >
-  >) => {
+) : Observable< ISegmentLoaderEvent<ArrayBuffer | null>> {
+  return new Observable((obs : Observer< ISegmentLoaderEvent< ArrayBuffer | null > >) => {
     let hasFinished = false;
 
     /**
@@ -101,10 +99,12 @@ function loadSegment(
       duration? : number;
     }) => {
       hasFinished = true;
-      obs.next({ type: "data-loaded",
-                 value: { responseData: _args.data,
-                          size: _args.size,
-                          duration: _args.duration } });
+      obs.next({ type: "data", value: { responseData: _args.data } });
+      obs.next({ type: "request-end",
+                 value: { size: _args.size,
+                          duration: _args.duration,
+                          receivedTime: undefined,
+                          sendingTime: undefined } });
       obs.complete();
     };
 
@@ -117,6 +117,7 @@ function loadSegment(
       obs.error(err);
     };
 
+    obs.next({ type: "request-begin", value: { } });
     const abort = customSegmentLoader(segment, { resolve, reject });
 
     return () => {

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -45,7 +45,8 @@ import {
   IAudioVideoParserObservable,
   IChunkTimeInfo,
   IImageParserObservable,
-  ILoaderDataLoadedValue,
+  ILoadedManifestResponse,
+  IManifestLoaderDataLoadedEvent,
   IManifestParserArguments,
   IManifestParserObservable,
   IManifestParserResponseEvent,
@@ -209,12 +210,10 @@ export default function(options : ITransportOptions): ITransportPipelines {
                                                     otherTransportOptions);
             const request$ = scheduleRequest(() =>
                 transport.manifest.loader({ url : ressource.url }).pipe(
-                  filter(
-                    (e): e is { type : "data-loaded";
-                                value : ILoaderDataLoadedValue<Document | string>; } =>
+                  filter((e): e is IManifestLoaderDataLoadedEvent =>
                     e.type === "data-loaded"
                   ),
-                  map((e) : ILoaderDataLoadedValue< Document | string > => e.value)
+                  map((e) : ILoadedManifestResponse => e.value)
                 ));
 
             return request$.pipe(mergeMap((responseValue) => {

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -95,6 +95,24 @@ export interface ILoaderDataLoadedValue<T> {
   size : number | undefined;
 }
 
+/**
+ * Event emitted by a segment loader when it immediately retries a request from
+ * scratch.
+ *
+ * This should only happen in rare occasions as the RxPlayer already has an
+ * advanced logic when it comes to retrying requests.
+ *
+ * An example of such occasion would be when a segment loader deduced that a
+ * request it just did might not have had the right headers.
+ * Here, the segment loader could send this event and then immediately re-do the
+ * request with the right headers set.
+ *
+ * In most other cases, a segment loader should just throw when encountering an
+ * error. The RxPlayer will handle retries by itself.
+ */
+export interface ISegmentLoaderDirectRetryEvent { type : "direct-retry";
+                                                  value : null; }
+
 /** Form that can take a loaded Manifest once loaded. */
 export type ILoadedManifest = Document |
                               string |
@@ -199,6 +217,7 @@ export type IManifestLoaderEvent = IManifestLoaderDataLoadedEvent;
 
 /** Event emitted by a segment loader. */
 export type ISegmentLoaderEvent<T> = ILoaderProgressEvent |
+                                     ISegmentLoaderDirectRetryEvent |
                                      ISegmentLoaderChunkEvent |
                                      ISegmentLoaderDataLoadedEvent<T> |
                                      ISegmentLoaderDataCreatedEvent<T>;

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -60,10 +60,9 @@ export default function callCustomManifestLoader(
 
           obs.next({ type: "data-loaded",
                      value: { responseData: _args.data,
-                              size: _args.size,
-                              duration: _args.duration,
                               url: _args.url,
-                              receivedTime, sendingTime } });
+                              receivedTime,
+                              sendingTime } });
           obs.complete();
         }
       };

--- a/src/transports/utils/check_isobmff_integrity.ts
+++ b/src/transports/utils/check_isobmff_integrity.ts
@@ -15,6 +15,11 @@
  */
 
 import { OtherError } from "../../errors";
+import log from "../../log";
+import {
+  be4toi,
+  be8toi
+} from "../../utils/byte_parsing";
 import findCompleteBox from "./find_complete_box";
 
 /**
@@ -47,4 +52,125 @@ export default function checkISOBMFFIntegrity(
       throw new OtherError("INTEGRITY_ERROR", "Incomplete `mdat` box");
     }
   }
+}
+
+/**
+ * Check if the given ISOBMFF segment contains a truncated box at the end.
+ * The returned value is a number which is equal to:
+ *
+ *   - `0` if nothing appear to be missing at the end of the segment
+ *
+ *   - a positive value if the last box in the given segment is missing some
+ *     bytes. This value indicates the number of bytes missing.
+ *
+ *   - a negative value if the last box in the given segment is missing some
+ *     bytes, but the box in question can be omitted from the chunk.
+ *     That negative value is the amount of bytes you can remove from the end of
+ *     the given segment.
+ *
+ * Returns `undefined` if we know data is missing but we cannot say how much.
+ *
+ * In the rare case we don't know whether data is missing or not (like when
+ * getting a box with a length of `0` indicating that the box goes until the
+ * end), we will assume that the given `buffer` is complete and just return `0`.
+ *
+ * Note: This code has been added - reluctantly - to work-around mistakes on the
+ * byte-range of the last segment on some Canal+ streams. This is a lot of code
+ * for a very rare problem which is on the content packaging size.
+ *
+ * @param {Uint8Array} buffer - The whole ISOBMFF segment
+ * @param {boolean} isInitSegment - `true` if this is an initialization segment,
+ * `false` otherwise.
+ * @returns {number|undefined}
+ */
+export function getMissingBytes(
+  buffer : Uint8Array,
+  isInitSegment : boolean
+) : number | undefined {
+  const bufferLength = buffer.length;
+
+  /** Every boxes name that should be encountered and complete. */
+  const wantedCompleteBoxes = isInitSegment ? [0x66747970 /* ftyp */,
+                                               0x6D6F6F76 /* moov */] :
+                                              [0x6D6F6F66 /* moof */,
+                                               0x6D646174 /* mdat */];
+  /** Offset of the current considered box in `buffer`. */
+  let boxBaseOffset = 0;
+  /**
+   * Name of the last box encountered.
+   * Read as a 32bit (big endian) integer from `buffer`.
+   * `undefined` if no box has been encountered yet.
+   */
+  let name : number | undefined;
+  /**
+   * Size of the last box encountered.
+   * `undefined` if no box has been encountered yet.
+   */
+  let lastBoxSize : number | undefined;
+
+  while (boxBaseOffset + 8 <= bufferLength) {
+    lastBoxSize = be4toi(buffer, boxBaseOffset);
+    name = be4toi(buffer, boxBaseOffset + 4);
+
+    if (lastBoxSize === 0) { // == until the end of the segment
+      // we can never now for sure...
+      // Let's assume the segment is complete
+      return 0;
+    } else if (lastBoxSize === 1) { // == the size is on 8 bytes
+      if (boxBaseOffset + 8 + 8 > bufferLength) {
+        if (wantedCompleteBoxes.length === 0) {
+          // We may have been loading too much data.
+          // Return negative offset to remove that box from the range.
+          return boxBaseOffset - bufferLength;
+        }
+        log.error("ISOBMFF: not enough bytes downloaded for knowing the size of box",
+                  name);
+        return undefined;
+      }
+      lastBoxSize = be8toi(buffer, boxBaseOffset + 8);
+    }
+
+    if (isNaN(lastBoxSize) && lastBoxSize < 0) { // shouldn't happen
+      throw new Error("ISOBMFF: Size out of range");
+    }
+
+    // remove from `wantedCompleteBoxes` if found in it
+    const indexOfName = wantedCompleteBoxes.indexOf(name);
+    if (indexOfName >= 0) {
+      wantedCompleteBoxes.splice(indexOfName, 1);
+    }
+
+    boxBaseOffset += lastBoxSize;
+  }
+
+  if (boxBaseOffset === bufferLength) {
+    return wantedCompleteBoxes.length === 0 ? 0 :
+                                              undefined;
+  }
+
+  // Check if we didn't just read too much
+  if (wantedCompleteBoxes.length === 0) {
+    const missingBytes = bufferLength - boxBaseOffset;
+
+    // We may have been loading too much data.
+    // Return negative offset.
+    log.warn(`ISOBMFF: ISOBMFF box ${name ?? "unknown"}` +
+             `is missing ${missingBytes} bytes.`);
+    return boxBaseOffset - bufferLength;
+  }
+
+  if (boxBaseOffset + 4 <= bufferLength) { // there is enough to read the size
+    lastBoxSize = be4toi(buffer, boxBaseOffset);
+    if (lastBoxSize === 0) { // == until the end of the segment
+      // we can never now for sure...
+      // Let's assume the segment is complete
+      return 0;
+    } else if (lastBoxSize === 1) { // == the size is on 8 bytes
+      log.error("ISOBMFF: not enough bytes downloaded for the last box.");
+      return undefined;
+    }
+  }
+
+  log.error("ISOBMFF: not enough bytes downloaded.");
+  return undefined;
 }

--- a/src/transports/utils/segment_request.ts
+++ b/src/transports/utils/segment_request.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  concat as observableConcat,
+  defer as observableDefer,
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import {
+  mergeMap,
+  startWith,
+} from "rxjs/operators";
+import idGenerator from "../../utils/id_generator";
+import {
+  IRequestProgress,
+  IRequestResponse,
+} from "../../utils/request";
+import {
+  ILoaderRequestEvent,
+  ISegmentLoaderDataLoaded,
+} from "../types";
+
+const generateRequestID = idGenerator();
+
+/**
+ * Link the request observable given to events defined as `ISegmentLoaderEvent`
+ * so it can be directly returned from the transport code.
+ * @param {Observable} requestObs$
+ * @param {string} requestId
+ */
+export default function performSegmentRequest<T>(
+  requestObs$ : Observable<IRequestResponse< T, XMLHttpRequestResponseType > |
+                           IRequestProgress>
+) : Observable<ISegmentLoaderDataLoaded<T> | ILoaderRequestEvent> {
+  return observableDefer(() => {
+    const requestId = generateRequestID();
+    return requestObs$.pipe(
+      mergeMap((evt) => {
+        if (evt.type === "progress") {
+          return observableOf({ type: "progress" as const,
+                                value: { requestId,
+                                         duration: evt.value.duration,
+                                         size: evt.value.size,
+                                         totalSize: evt.value.totalSize } });
+        }
+
+        const response = evt.value;
+        const response$ = observableOf({ type: "data" as const,
+                                         value: { responseData: response.responseData,
+                                                  url: response.url } });
+        const requestEnd$ = observableOf({ type: "request-end" as const,
+                                  value: { requestId,
+                                           duration: response.duration,
+                                           sendingTime: response.sendingTime,
+                                           receivedTime: response.receivedTime,
+                                           size: response.size,
+                                           status: response.status } });
+        return observableConcat(response$, requestEnd$);
+      }),
+      startWith({ type: "request-begin" as const,
+                  value: { requestId } })
+    );
+  });
+}


### PR DESCRIPTION
## Overview

This is a refacto of the "transports" code (the code abstracting the transport protocol like DASH, Smooth etc. in `src/transports`) to improve the bad situation we just created in #785.

The idea here is to decorrelate two kinds of events in the segment loaders:
  - events about the data being available
  - events about requests being started and finished

## The current situation

Previously, the relation between segment loaders and segment requests was implicit: when calling a segment loader, the RxPlayer would consider that a corresponding single segment request had started.

All `"progress"` events then sent by the segment loader would be considered as linked to that request.

At last, a `"data-loaded"` event or a `"chunk-data-complete"` event (respectively depending if the data was sent as a whole or through chunks) would indicate that the request had just finished.
Those last two events contain in their payload attributes allowing to know the amount of bytes that have been loaded and how fast they have been loaded. Those are then used by our adaptive logic to choose the best quality adapted to the user's current network conditions.

## Problem with that situation

But this way of thinking is not always adapted:

   - a segment loader might not always perform a request (for example, Smooth initialization segments are automatically generated from the Manifest's data). Here, the rest of the player would still think that a request has started. In that case, a special "`data-created"` event is sent by the segment loader to indicate that no network metric should be considered.

      This works but this is ugly. A request object still has been created and communicated to the ABR logic by the segment fetchers (even if it was destroyed as soon as the `"data-created"` event is received).

  - with #785, this logic completely breaks down.
     Now, a segment loader is able to perform multiple requests, one after the other.
     To handle that well, a new event had to be created. With #785, we went with a very ugly `"direct-retry"` which looks very out-of-place. Moreover, it seems only useful for that single issue.

   - for DASH contents based on a SegmentBase, it is possible to do two requests in parallel: one for the init segment, the other for the index segment. The old logic kind of "cheated" by pretending of doing only a single request.

## Solution in that PR

The solution brought here is very simple.

Now, the segment loaders have to communicate when they are starting a new segment request, or ending one, through two new events: respectively `"request-begin"` and `"request-end"`, the latter also communicating network metrics (amount of data loaded, how fast etc.).

The events indicating that all data have been loaded like `"data-loaded"` or `"chunk-data-complete"` are still there and don't contain any information about requests anymore. This way we could perform 0-to-N requests to obtain that data and still be able to send those events.

## What's left to do here

I'm not done yet, there is still some issues I'm encountering:
  - How the ABRManager should calculate the bandwidth for pending requests, when multiple requests happened in parallel looks close to impossible.
  - it adds a lot of boilerplate to each of the transports code. I'm still looking at ways of reducing that
  - it brings a possible race condition when network metrics are sent just before the corresponding chunk's data.
    We have to be sure in a way that we are not switching the current quality just before pushing that chunk.