### PR TITLE
Apply default style to TTML if not encountered [to debate]

### DIFF
--- a/src/parsers/texttracks/ttml/html/create_element.ts
+++ b/src/parsers/texttracks/ttml/html/create_element.ts
@@ -62,9 +62,8 @@ function applyTextStyle(
 ) {
   // applies to span
   const color = style.color;
-  if (isNonEmptyString(color)) {
-    element.style.color = ttmlColorToCSSColor(color);
-  }
+  element.style.color = isNonEmptyString(color) ? ttmlColorToCSSColor(color) :
+                                                  "white";
 
   // applies to body, div, p, region, span
   const backgroundColor = style.backgroundColor;

--- a/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
+++ b/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
@@ -22,6 +22,7 @@ import getParentElementsByTagName from "../get_parent_elements_by_tag_name";
 import {
   getStylingAttributes,
   getStylingFromElement,
+  IStyleList,
   IStyleObject,
 } from "../get_styling";
 import {
@@ -164,13 +165,23 @@ export default function parseTTMLStringToDIV(
       const paragraph = paragraphNodes[i];
       if (paragraph instanceof Element) {
         const divs = getParentElementsByTagName(paragraph , "div");
-        const paragraphStyle = objectAssign({},
-                                            bodyStyle,
-                                            getStylingAttributes(STYLE_ATTRIBUTES,
-                                                                 [paragraph,
-                                                                  ...divs],
-                                                                 idStyles,
-                                                                 regionStyles));
+
+        // A default paragraphStyle is set and applied if no styles
+        // were defined on TTML.
+        // If either an idStyle or a regionStyle exists, then we shall
+        // not apply any default style, as our changes may disturb the overall
+        // cue style as it was intended to be.
+        let stylingAttributes: IStyleList = { displayAlign: "after",
+                                              extent: "100% 100%",
+                                              textAlign: "center" };
+        if (idStyles.length > 0 || regionStyles.length > 0) {
+          stylingAttributes = getStylingAttributes(STYLE_ATTRIBUTES,
+                                                   [paragraph,
+                                                    ...divs],
+                                                   idStyles,
+                                                   regionStyles);
+        }
+        const paragraphStyle = objectAssign({}, bodyStyle, stylingAttributes);
 
         const paragraphSpaceAttribute = paragraph.getAttribute("xml:space");
         const shouldTrimWhiteSpaceOnParagraph =


### PR DESCRIPTION
Some ttml xml nodes are used for declaring styles that apply to the subtitles.
- The region styles concern the subtitle parent-area.
- The other styles refer directly to the paragraph.

On the RxPlayer, if no style was declared on the ttml, we chose to apply a minimum style set were the text is non-centred, above and black in the textTrackElement.

No ttml default style seems to be defined in the ttml spec. We choose then that the cue may display in the clearer and cleaner possible way. We now consider that, if no style is declared into the file, we should apply a default region style : 
- centred text
- bottom-fixed text

/!\ If no styles are defined for regions, but other styles are, we decide not to apply the default region style. Indeed, we consider the style to have been defined on purpose, and we may interfere with the overall look of the cue if we apply a different style.
As no default style seems to be defined in the ttml spec, we choose to apply the default one if there are no declared style in the ttml, as it may not interfere with any declared one.

Moreover, we now set a white text color by default.