### PR TITLE
Convert GUID Playready KID when necessary

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -29,7 +29,8 @@ const isIEOrEdge : boolean = isNode ?
   navigator.appName === "Netscape" &&
   /(Trident|Edge)\//.test(navigator.userAgent);
 
-const isChromiumEdge = navigator.userAgent.indexOf("edg") !== -1;
+const isEdgeChromium: boolean = !isNode &&
+                                navigator.userAgent.toLowerCase().indexOf("edg/") !== -1;
 
 const isFirefox : boolean = !isNode &&
                             navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
@@ -53,7 +54,7 @@ const isSafariMobile : boolean = !isNode &&
                                  /iPad|iPhone|iPod/.test(navigator.platform);
 
 export {
-  isChromiumEdge,
+  isEdgeChromium,
   isIE11,
   isIEOrEdge,
   isFirefox,

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -29,6 +29,8 @@ const isIEOrEdge : boolean = isNode ?
   navigator.appName === "Netscape" &&
   /(Trident|Edge)\//.test(navigator.userAgent);
 
+const isChromiumEdge = navigator.userAgent.indexOf("edg") !== -1;
+
 const isFirefox : boolean = !isNode &&
                             navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
 
@@ -51,6 +53,7 @@ const isSafariMobile : boolean = !isNode &&
                                  /iPad|iPhone|iPod/.test(navigator.platform);
 
 export {
+  isChromiumEdge,
   isIE11,
   isIEOrEdge,
   isFirefox,

--- a/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
+++ b/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { guidToUuid } from "../../utils/string_parsing";
+import {
+  isChromiumEdge,
+  isIEOrEdge,
+} from "../browser_detection";
+
+/**
+ * Get KID from MediaKeySession keyStatus, and convert it in usual big-endian kid
+ * if necessary. On EDGE, Microsoft Playready KID are presented into little-endian GUID.
+ * @param {String} keySystem
+ * @param {Uint8Array} baseKeyId
+ * @returns {Uint8Array}
+ */
+export default function getUUIDKidFromKeyStatusKID(keySystem: string,
+                                                   baseKeyId: Uint8Array): Uint8Array {
+  if (keySystem.indexOf("playready") !== -1 &&
+      (isIEOrEdge || isChromiumEdge)) {
+    return guidToUuid(baseKeyId);
+  }
+  return baseKeyId;
+}

--- a/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
+++ b/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
@@ -27,7 +27,7 @@ import {
  * @param {Uint8Array} baseKeyId
  * @returns {Uint8Array}
  */
-export default function getUUIDKidFromKeyStatusKID(keySystem: string,
+export default function getUUIDKIDFromKeyStatusKID(keySystem: string,
                                                    baseKeyId: Uint8Array): Uint8Array {
   if (keySystem.indexOf("playready") !== -1 &&
       (isIEOrEdge || isChromiumEdge)) {

--- a/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
+++ b/src/compat/eme/get_uuid_kid_from_keystatus_kid.ts
@@ -16,7 +16,7 @@
 
 import { guidToUuid } from "../../utils/string_parsing";
 import {
-  isChromiumEdge,
+  isEdgeChromium,
   isIEOrEdge,
 } from "../browser_detection";
 
@@ -30,7 +30,7 @@ import {
 export default function getUUIDKIDFromKeyStatusKID(keySystem: string,
                                                    baseKeyId: Uint8Array): Uint8Array {
   if (keySystem.indexOf("playready") !== -1 &&
-      (isIEOrEdge || isChromiumEdge)) {
+      (isIEOrEdge || isEdgeChromium)) {
     return guidToUuid(baseKeyId);
   }
   return baseKeyId;

--- a/src/core/eme/check_key_statuses.ts
+++ b/src/core/eme/check_key_statuses.ts
@@ -15,6 +15,7 @@
  */
 
 import { ICustomMediaKeySession } from "../../compat";
+import getUUIDKidFromKeyStatusKID from "../../compat/eme/get_uuid_kid_from_keystatus_kid";
 import { EncryptedMediaError } from "../../errors";
 import {
   IEMEWarningEvent,
@@ -49,12 +50,14 @@ export default function checkKeyStatuses(
     /* tslint:enable no-unsafe-any */
     // Hack present because the order of the arguments has changed in spec
     // and is not the same between some versions of Edge and Chrome.
-    const [keyStatus, keyId] = (() => {
+    const [keyStatus, keyStatusKeyId] = (() => {
       return (typeof _arg1  === "string" ? [_arg1, _arg2] :
                                            [_arg2, _arg1]
              ) as [MediaKeyStatus, ArrayBuffer];
     })();
 
+    const keyId = getUUIDKidFromKeyStatusKID(keySystem.type,
+                                             new Uint8Array(keyStatusKeyId));
     switch (keyStatus) {
       case KEY_STATUSES.EXPIRED: {
         const error = new EncryptedMediaError("KEY_STATUS_CHANGE_ERROR",

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -178,6 +178,7 @@ export default function EMEManager(
             value: objectAssign({
               keySystemOptions: mediaKeysInfos.keySystemOptions,
               persistentSessionsStore: mediaKeysInfos.persistentSessionsStore,
+              keySystem: mediaKeysInfos.mediaKeySystemAccess.keySystem,
             }, evt.value),
           };
         }));
@@ -220,7 +221,8 @@ export default function EMEManager(
               mediaKeySession,
               sessionType,
               keySystemOptions,
-              persistentSessionsStore } = sessionInfosEvt.value;
+              persistentSessionsStore,
+              keySystem } = sessionInfosEvt.value;
 
       const generateRequest$ = sessionInfosEvt.type !== "created-session" ?
           EMPTY :
@@ -244,6 +246,7 @@ export default function EMEManager(
 
       return observableMerge(SessionEventsListener(mediaKeySession,
                                                    keySystemOptions,
+                                                   keySystem,
                                                    { initData, initDataType }),
                              generateRequest$)
         .pipe(catchError(err => {

--- a/src/parsers/containers/isobmff/drm/playready.ts
+++ b/src/parsers/containers/isobmff/drm/playready.ts
@@ -16,8 +16,10 @@
 
 import { le2toi } from "../../../../utils/byte_parsing";
 import {
-    guidToUuid,
-    leUtf16ToStr,
+  bytesToHex,
+  guidToUuid,
+  leUtf16ToStr,
+  strToUtf8,
 } from "../../../../utils/string_parsing";
 
 /**
@@ -35,7 +37,9 @@ export function getPlayReadyKIDFromPrivateData(
   if (kidElement === null) {
     throw new Error("Cannot parse PlayReady private data: invalid XML");
   }
-  const kid = kidElement.textContent === null ? "" :
-                                                kidElement.textContent;
-  return guidToUuid(atob(kid)).toLowerCase();
+  const b64guidKid = kidElement.textContent === null ? "" :
+                                                       kidElement.textContent;
+
+  const uuidKid = guidToUuid(strToUtf8(atob(b64guidKid)));
+  return bytesToHex(uuidKid).toLowerCase();
 }

--- a/src/utils/__tests__/string_parsing.test.ts
+++ b/src/utils/__tests__/string_parsing.test.ts
@@ -149,21 +149,25 @@ describe("utils - string parsing", () => {
 
   describe("guidToUuid", () => {
     it("should throw if the length is different than 16 bytes", () => {
-      expect(() => strUtils.guidToUuid("")).toThrow();
-      expect(() => strUtils.guidToUuid("abca")).toThrow();
-      expect(() => strUtils.guidToUuid("a;rokgr;oeo;reugporugpuwrhpwjtw")).toThrow();
+      expect(() => strUtils.guidToUuid(new Uint8Array(0))).toThrow();
+      expect(() => strUtils.guidToUuid(new Uint8Array(4))).toThrow();
+      expect(() => strUtils.guidToUuid(new Uint8Array(20))).toThrow();
     });
     it("should translate PlayReady GUID to universal UUID", () => {
-      const uuid1 = String.fromCharCode(
-        ...[15, 27, 175, 76, 7, 184, 156, 73, 181, 133, 213, 230, 192, 48, 134, 31]
-      );
-      const uuid2 = String.fromCharCode(
-        ...[212, 72, 21, 77, 26, 220, 79, 95, 101, 86, 92, 99, 110, 189, 1, 111]
-      );
+      const uuid1 = new Uint8Array(
+        [15, 27, 175, 76, 7, 184, 156, 73, 181, 133, 213, 230, 192, 48, 134, 31]);
+      const uuid2 = new Uint8Array(
+        [212, 72, 21, 77, 26, 220, 79, 95, 101, 86, 92, 99, 110, 189, 1, 111]);
       expect(strUtils.guidToUuid(uuid1))
-        .toBe("afc21b0f074cb8c2c29c49c2b5c285c3");
+        .toEqual(
+          new Uint8Array(
+            [76, 175, 27, 15, 184, 7, 73, 156, 181, 133, 213, 230, 192, 48, 134, 31])
+        );
       expect(strUtils.guidToUuid(uuid2))
-      .toBe("154894c31a4d9cc34f5f65565c636ec2");
+        .toEqual(
+          new Uint8Array(
+            [77, 21, 72, 212, 220, 26, 95, 79, 101, 86, 92, 99, 110, 189, 1, 111])
+        );
     });
   });
 

--- a/src/utils/string_parsing.ts
+++ b/src/utils/string_parsing.ts
@@ -252,33 +252,33 @@ function bytesToHex(bytes : Uint8Array, sep : string = "") : string {
 }
 
 /**
- * @param {string} uuid
- * @returns {string}
- * @throws AssertionError - The uuid length is not 16
+ * Convert little-endian GUID into big-endian UUID.
+ * @param {Uint8Array} guid
+ * @returns {Uint8Array} - uuid
+ * @throws AssertionError - The guid length is not 16
  */
-function guidToUuid(uuid : string) : string {
-  assert(uuid.length === 16, "UUID length should be 16");
-  const buf = strToUtf8(uuid);
+function guidToUuid(guid : Uint8Array) : Uint8Array {
+  assert(guid.length === 16, "GUID length should be 16");
 
-  const p1A = buf[0];
-  const p1B = buf[1];
-  const p1C = buf[2];
-  const p1D = buf[3];
-  const p2A = buf[4];
-  const p2B = buf[5];
-  const p3A = buf[6];
-  const p3B = buf[7];
-  const p4 = buf.subarray(8, 10);
-  const p5 = buf.subarray(10, 16);
+  const p1A = guid[0];
+  const p1B = guid[1];
+  const p1C = guid[2];
+  const p1D = guid[3];
+  const p2A = guid[4];
+  const p2B = guid[5];
+  const p3A = guid[6];
+  const p3B = guid[7];
+  const p4 = guid.subarray(8, 10);
+  const p5 = guid.subarray(10, 16);
 
-  const ord = new Uint8Array(16);
-  ord[0] = p1D; ord[1] = p1C; ord[2] = p1B; ord[3] = p1A; // swap32 BE -> LE
-  ord[4] = p2B; ord[5] = p2A;                             // swap16 BE -> LE
-  ord[6] = p3B; ord[7] = p3A;                             // swap16 BE -> LE
-  ord.set(p4,  8);
-  ord.set(p5, 10);
+  const uuid = new Uint8Array(16);
+  uuid[0] = p1D; uuid[1] = p1C; uuid[2] = p1B; uuid[3] = p1A;
+  uuid[4] = p2B; uuid[5] = p2A;
+  uuid[6] = p3B; uuid[7] = p3A;
+  uuid.set(p4,  8);
+  uuid.set(p5, 10);
 
-  return bytesToHex(ord);
+  return uuid;
 }
 
 export {

--- a/src/utils/string_parsing.ts
+++ b/src/utils/string_parsing.ts
@@ -260,23 +260,21 @@ function bytesToHex(bytes : Uint8Array, sep : string = "") : string {
 function guidToUuid(guid : Uint8Array) : Uint8Array {
   assert(guid.length === 16, "GUID length should be 16");
 
-  const p1A = guid[0];
-  const p1B = guid[1];
-  const p1C = guid[2];
-  const p1D = guid[3];
-  const p2A = guid[4];
-  const p2B = guid[5];
-  const p3A = guid[6];
-  const p3B = guid[7];
-  const p4 = guid.subarray(8, 10);
-  const p5 = guid.subarray(10, 16);
+  const [p1A, p1B, p1C, p1D,
+         p2A, p2B,
+         p3A, p3B] = guid;
 
   const uuid = new Uint8Array(16);
+  // swapping byte endian on 4 bytes
+  // [1, 2, 3, 4] => [4, 3, 2, 1]
   uuid[0] = p1D; uuid[1] = p1C; uuid[2] = p1B; uuid[3] = p1A;
+  // swapping byte endian on 2 bytes
+  // [5, 6] => [6, 5]
   uuid[4] = p2B; uuid[5] = p2A;
+  // swapping byte endian on 2 bytes
+  // [7, 8] => [8, 7]
   uuid[6] = p3B; uuid[7] = p3A;
-  uuid.set(p4,  8);
-  uuid.set(p5, 10);
+  uuid.set(guid.subarray(8, 16),  8);
 
   return uuid;
 }


### PR DESCRIPTION
Media data can be cyphered in a stream. A media content is cyphered with a key, who is identifiable with a public KeyID. A content may not be playable depending on the playback device / client authorizations.

In the RxPlayer, we use manifest content protection data to associate a a media quality to a CENC formatted KeyID. Then, when the MediaKeySession informs us about key statuses, we can deduct the decipherability status of a quality.

For this reason, we need the KeyIDs in our caches to be the same format. PlayReady KeyID's are little-endian GUID, whether it be on PSSHs or in EDGE and IE11 keyStatuses map from MediaKeySession. Standard CENC KeyID are big-endian UUID (cenc, widevine). Hence, our decipherability record logic can't work because those are two different formats.

This PR fixes that by converting Microsoft keyStatuses keyIDs from litte-endian GUID to big-endian UUID.

