### PR TITLE
smooth: skip discontinuity even when we're in the middle of it

### DIFF
--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -409,21 +409,21 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    *     is inferior to the timescale)
    *   - The next range starts after the end of the current range.
    *
-   * @param {Number} _time
+   * @param {Number} timeSec
    * @returns {Number} - If a discontinuity is present, this is the Starting
    * time for the next (discontinuited) range. If not this is equal to -1.
    */
-  checkDiscontinuity(_time : number) : number {
+  checkDiscontinuity(timeSec : number) : number {
     this._refreshTimeline();
     const index = this._index;
     const { timeline, timescale = 1 } = index;
-    const time = _time * timescale;
+    const timeTScaled = timeSec * timescale;
 
-    if (time <= 0) {
+    if (timeTScaled <= 0) {
       return -1;
     }
 
-    const segmentIndex = getSegmentIndex(index, time);
+    const segmentIndex = getSegmentIndex(index, timeTScaled);
     if (segmentIndex < 0 || segmentIndex >= timeline.length - 1) {
       return -1;
     }
@@ -439,10 +439,9 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
 
     // when we are actually inside the found range and this range has
     // an explicit discontinuity with the next one
-    if (rangeTo !== nextRange.start &&
-        time >= rangeUp &&
-        time <= rangeTo &&
-        (rangeTo - time) < timescale) {
+    if (rangeTo < nextRange.start &&
+        timeTScaled >= rangeUp &&
+        (rangeTo - timeTScaled) < timescale) {
       return nextRange.start / timescale;
     }
 


### PR DESCRIPTION
There was a strange condition in smooth content handling that made it impossible to skip stream discontinuities when the user seeked at the middle of one.

Basically, the player needed to still be in the segment preceding the discontinuity to be able to skip it. This condition made no much sense, and it isn't something that does exist in the related DASH SegmentTimeline's code.

I'm consequently unsure if this was done on purpose, in which case we would bring a regression here. In anyway, I find this not very probable and if that was the case, that code should have been commented.

---

Note: I also changed some variable's names. The real meat is just one line being deleted.