### PR TITLE
abr: limit oscillation in ABR estimates

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -394,7 +394,7 @@ export default {
    */
   ABR_STARVATION_FACTOR: {
     DEFAULT: 0.72,
-    LOW_LATENCY: 0.64,
+    LOW_LATENCY: 0.72,
   },
 
   /**
@@ -403,8 +403,8 @@ export default {
    * @type {Object}
    */
   ABR_REGULAR_FACTOR: {
-    DEFAULT: 0.9,
-    LOW_LATENCY: 0.9,
+    DEFAULT: 0.8,
+    LOW_LATENCY: 0.8,
   },
 
   /**

--- a/src/core/abr/network_analyzer.ts
+++ b/src/core/abr/network_analyzer.ts
@@ -18,6 +18,7 @@ import config from "../../config";
 import log from "../../log";
 import { Representation } from "../../manifest";
 import arrayFind from "../../utils/array_find";
+import arrayFindIndex from "../../utils/array_find_index";
 import BandwidthEstimator from "./bandwidth_estimator";
 import EWMA from "./ewma";
 import {
@@ -31,32 +32,61 @@ const { ABR_REGULAR_FACTOR,
         ABR_STARVATION_GAP,
         OUT_OF_STARVATION_GAP } = config;
 
-interface INetworkAnalizerClockTick {
-  bufferGap : number; // time to the end of the buffer, in seconds
-  currentTime : number; // current position, in seconds
-  speed : number; // current playback rate
-  duration : number; // whole duration of the content
+/** Object describing the current playback conditions. */
+interface IPlaybackConditionsInfo {
+  /**
+   * For the concerned SourceBuffer, difference in seconds between the next
+   * position where no segment data is available and the current position.
+   */
+  bufferGap : number;
+  /** Current playback position on the concerned media element, in seconds. */
+  currentTime : number;
+  /**
+   * Last "playback rate" set by the user. This is the ideal "playback rate" at
+   * which the media should play.
+   */
+  speed : number;
+  /** `duration` property of the HTMLMediaElement on which the content plays. */
+  duration : number;
 }
 
 /**
- * Get the pending request starting with the asked segment position.
+ * Get pending segment request(s) starting with the asked segment position.
  * @param {Object} requests
  * @param {number} position
- * @returns {IRequestInfo|undefined}
+ * @returns {Array.<Object>}
  */
-function getConcernedRequest(
+function getConcernedRequests(
   requests : IRequestInfo[],
   neededPosition : number
-) : IRequestInfo | undefined {
-  for (let i = 0; i < requests.length; i++) {
-    const request = requests[i];
-    if (request.duration > 0) {
-      const segmentEnd = request.time + request.duration;
-      if (segmentEnd > neededPosition && neededPosition - request.time > -0.3) {
-        return request;
-      }
+) : IRequestInfo[] {
+  /** Index of the request for the next needed segment, in `requests`. */
+  const nextSegmentIndex = arrayFindIndex(requests, (request) => {
+    if (request.duration <= 0) {
+      return false;
+    }
+    const segmentEnd = request.time + request.duration;
+    return segmentEnd > neededPosition &&
+           Math.abs(neededPosition - request.time) < -0.3;
+  });
+
+  if (nextSegmentIndex < 0) { // Not found
+    return [];
+  }
+
+  const nextRequest = requests[nextSegmentIndex];
+  const segmentTime = nextRequest.time;
+  const filteredRequests = [nextRequest];
+
+  // Get the possibly multiple requests for that segment's position
+  for (let i = nextSegmentIndex + 1; i < requests.length; i++) {
+    if (requests[i].time === segmentTime) {
+      filteredRequests.push(requests[i]);
+    } else {
+      break;
     }
   }
+  return filteredRequests;
 }
 
 /**
@@ -67,7 +97,8 @@ function getConcernedRequest(
  * @returns {number|undefined}
  */
 function estimateRequestBandwidth(request : IRequestInfo) : number|undefined {
-  if (request.progress.length < 2) {
+  if (request.progress.length < 5) { // threshold from which we can consider
+                                     // progress events reliably
     return undefined;
   }
 
@@ -103,46 +134,54 @@ function estimateRemainingTime(
  * If that's the case, re-calculate the bandwidth urgently based on
  * this single request.
  * @param {Object} pendingRequests - Current pending requests.
- * @param {Object} clock - Information on the current playback.
+ * @param {Object} playbackInfo - Information on the current playback.
+ * @param {Object|null} currentRepresentation - The Representation being
+ * presently being loaded.
  * @param {Number} lastEstimatedBitrate - Last bitrate estimate emitted.
  * @returns {Number|undefined}
  */
 function estimateStarvationModeBitrate(
   pendingRequests : IRequestInfo[],
-  clock : INetworkAnalizerClockTick,
+  playbackInfo : IPlaybackConditionsInfo,
   currentRepresentation : Representation | null,
   lastEstimatedBitrate : number|undefined
 ) : number|undefined {
-  const nextNeededPosition = clock.currentTime + clock.bufferGap;
-  const concernedRequest = getConcernedRequest(pendingRequests, nextNeededPosition);
-  if (concernedRequest === undefined) {
+  const nextNeededPosition = playbackInfo.currentTime + playbackInfo.bufferGap;
+  const concernedRequests = getConcernedRequests(pendingRequests, nextNeededPosition);
+
+  if (concernedRequests.length !== 1) { // 0  == no request
+                                        // 2+ == too complicated to calculate
     return undefined;
   }
 
+  const concernedRequest = concernedRequests[0];
   const chunkDuration = concernedRequest.duration;
   const now = performance.now();
   const lastProgressEvent = concernedRequest.progress.length > 0 ?
     concernedRequest.progress[concernedRequest.progress.length - 1] :
-    null;
+    undefined;
 
   // first, try to do a quick estimate from progress events
   const bandwidthEstimate = estimateRequestBandwidth(concernedRequest);
-  if (lastProgressEvent != null && bandwidthEstimate != null) {
-    const remainingTime =
-      estimateRemainingTime(lastProgressEvent, bandwidthEstimate) * 1.2;
 
-    // if this remaining time is reliable and is not enough to avoid buffering
-    if (
-      (now - lastProgressEvent.timestamp) / 1000 <= remainingTime &&
-      remainingTime > (clock.bufferGap / clock.speed)
-    ) {
-      return bandwidthEstimate;
+  if (lastProgressEvent !== undefined && bandwidthEstimate !== undefined) {
+    const remainingTime = estimateRemainingTime(lastProgressEvent,
+                                                bandwidthEstimate);
+
+    // if the remaining time does seem reliable
+    if ((now - lastProgressEvent.timestamp) / 1000 <= remainingTime) {
+      // Calculate estimated time spent rebuffering if we continue doing that request.
+      const expectedRebufferingTime = remainingTime -
+        (playbackInfo.bufferGap / playbackInfo.speed);
+      if (expectedRebufferingTime > 2000) {
+        return bandwidthEstimate;
+      }
     }
   }
 
   const requestElapsedTime = (now - concernedRequest.requestTimestamp) / 1000;
   const reasonableElapsedTime = requestElapsedTime <=
-    ((chunkDuration * 1.5 + 1) / clock.speed);
+    ((chunkDuration * 1.5 + 2) / playbackInfo.speed);
   if (currentRepresentation == null || reasonableElapsedTime) {
     return undefined;
   }
@@ -150,7 +189,9 @@ function estimateStarvationModeBitrate(
   // calculate a reduced bitrate from the current one
   const factor = chunkDuration / requestElapsedTime;
   const reducedBitrate = currentRepresentation.bitrate * Math.min(0.7, factor);
-  if (lastEstimatedBitrate == null || reducedBitrate < lastEstimatedBitrate) {
+  if (lastEstimatedBitrate === undefined ||
+      reducedBitrate < lastEstimatedBitrate)
+  {
     return reducedBitrate;
   }
 }
@@ -160,43 +201,43 @@ function estimateStarvationModeBitrate(
  * switch immediately if a lower bitrate is more adapted.
  * Returns false if it estimates that you have time before switching to a lower
  * bitrate.
- * @param {Object} clock
+ * @param {Object} playbackInfo
  * @param {Object} requests - Every requests pending, in a chronological
  * order in terms of segment time.
+ * @param {number} abrStarvationGap - "Buffer gap" from which we enter a
+ * "starvation mode".
  * @returns {boolean}
  */
 function shouldDirectlySwitchToLowBitrate(
-  clock : INetworkAnalizerClockTick,
-  requests : IRequestInfo[],
-  abrStarvationGap : number
+  playbackInfo : IPlaybackConditionsInfo,
+  requests : IRequestInfo[]
 ) : boolean {
-   const nextNeededPosition = clock.currentTime + clock.bufferGap;
+  const nextNeededPosition = playbackInfo.currentTime + playbackInfo.bufferGap;
+  const nextRequest = arrayFind(requests, (r) =>
+    r.duration > 0 && (r.time + r.duration) > nextNeededPosition);
 
-   const nextNeededRequest = arrayFind(requests, (r) =>
-     (r.time + r.duration) > nextNeededPosition
-   );
-   if (nextNeededRequest === undefined) {
-     return true;
-   }
+  if (nextRequest === undefined) {
+    return true;
+  }
 
-   const now = performance.now();
-   const lastProgressEvent = nextNeededRequest.progress.length > 0 ?
-     nextNeededRequest.progress[nextNeededRequest.progress.length - 1] :
-     null;
+  const now = performance.now();
+  const lastProgressEvent = nextRequest.progress.length > 0 ?
+    nextRequest.progress[nextRequest.progress.length - 1] :
+    undefined;
 
-   // first, try to do a quick estimate from progress events
-   const bandwidthEstimate = estimateRequestBandwidth(nextNeededRequest);
-   if (lastProgressEvent == null || bandwidthEstimate == null) {
-     return true;
-   }
+  // first, try to do a quick estimate from progress events
+  const bandwidthEstimate = estimateRequestBandwidth(nextRequest);
+  if (lastProgressEvent === undefined || bandwidthEstimate === undefined) {
+    return true;
+  }
 
-   const remainingTime = estimateRemainingTime(lastProgressEvent, bandwidthEstimate);
-   if ((now - lastProgressEvent.timestamp) / 1000 <= (remainingTime * 1.2) &&
-       remainingTime < ((clock.bufferGap / clock.speed) + abrStarvationGap))
-  {
-     return false;
-   }
-   return true;
+  const remainingTime = estimateRemainingTime(lastProgressEvent, bandwidthEstimate);
+  if ((now - lastProgressEvent.timestamp) / 1000 > (remainingTime * 1.2)) {
+    return true;
+  }
+  const expectedRebufferingTime = remainingTime -
+    (playbackInfo.bufferGap / playbackInfo.speed);
+  return expectedRebufferingTime > -1.5;
 }
 
 /**
@@ -228,8 +269,19 @@ export default class NetworkAnalyzer {
     }
   }
 
+  /**
+   * Gives an estimate of the current bandwidth and of the bitrate that should
+   * be considered for chosing a `representation`.
+   * This estimate is only based on network metrics.
+   * @param {Object} playbackInfo - Gives current information about playback
+   * @param {Object} bandwidthEstimator
+   * @param {Object|null} currentRepresentation
+   * @param {Array.<Object>} currentRequests
+   * @param {number|undefined} lastEstimatedBitrate
+   * @returns {Object}
+   */
   public getBandwidthEstimate(
-    clockTick: INetworkAnalizerClockTick,
+    playbackInfo: IPlaybackConditionsInfo,
     bandwidthEstimator : BandwidthEstimator,
     currentRepresentation : Representation | null,
     currentRequests : IRequestInfo[],
@@ -238,7 +290,7 @@ export default class NetworkAnalyzer {
     let newBitrateCeil; // bitrate ceil for the chosen Representation
     let bandwidthEstimate;
     const localConf = this._config;
-    const { bufferGap, currentTime, duration } = clockTick;
+    const { bufferGap, currentTime, duration } = playbackInfo;
 
     // check if should get in/out of starvation mode
     if (isNaN(duration) ||
@@ -261,7 +313,7 @@ export default class NetworkAnalyzer {
     // If so, cancel previous estimates and replace it by the new one
     if (this._inStarvationMode) {
       bandwidthEstimate = estimateStarvationModeBitrate(currentRequests,
-                                                        clockTick,
+                                                        playbackInfo,
                                                         currentRepresentation,
                                                         lastEstimatedBitrate);
 
@@ -291,8 +343,8 @@ export default class NetworkAnalyzer {
       }
     }
 
-    if (clockTick.speed > 1) {
-      newBitrateCeil /= clockTick.speed;
+    if (playbackInfo.speed > 1) {
+      newBitrateCeil /= playbackInfo.speed;
     }
 
     return { bandwidthEstimate, bitrateChosen: newBitrateCeil };
@@ -301,24 +353,22 @@ export default class NetworkAnalyzer {
   /**
    * For a given wanted bitrate, tells if should switch urgently.
    * @param {number} bitrate
-   * @param {Object} clockTick
+   * @param {Object} playbackInfo
    * @returns {boolean}
    */
   public isUrgent(
     bitrate: number,
     currentRepresentation : Representation | null,
     currentRequests : IRequestInfo[],
-    clockTick: INetworkAnalizerClockTick
+    playbackInfo: IPlaybackConditionsInfo
    ) : boolean {
-    if (currentRepresentation == null) {
+    if (currentRepresentation === null) {
       return true;
     } else if (bitrate === currentRepresentation.bitrate) {
       return false;
     } else if (bitrate > currentRepresentation.bitrate) {
       return !this._inStarvationMode;
     }
-    return shouldDirectlySwitchToLowBitrate(clockTick,
-                                            currentRequests,
-                                            this._config.starvationGap);
+    return shouldDirectlySwitchToLowBitrate(playbackInfo, currentRequests);
   }
 }

--- a/src/core/abr/pending_requests_store.ts
+++ b/src/core/abr/pending_requests_store.ts
@@ -111,6 +111,6 @@ export default class PendingRequestsStore {
   public getRequests() : IRequestInfo[] {
     return objectValues(this._currentRequests)
       .filter((x) : x is IRequestInfo => x != null)
-      .sort();
+      .sort((reqA, reqB) => reqA.time - reqB.time);
   }
 }

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -51,11 +51,10 @@ import RepresentationScoreCalculator from "./representation_score_calculator";
  * Adaptive BitRate estimate object.
  *
  * The `RepresentationEstimator` helps the player to choose a Representation
- * (i.e. a quality) by frequently mesuring the current network and playback
+ * (i.e. a quality) by frequently measuring the current network and playback
  * conditions.
  *
- * At regular intervals, it will send an estimate of what the player should
- * play through those `IABREstimate` objects.
+ * At regular intervals, an `IABREstimate` will be sent to that end.
  */
 export interface IABREstimate {
   /**
@@ -67,9 +66,8 @@ export interface IABREstimate {
    */
   bitrate: undefined | number;
   /**
-   * If `true`, the Representation chosen in the current estimate object is
-   * linked to a choice performed manually by the user, such as a bitrate
-   * choice.
+   * If `true`, the `representation` chosen in the current estimate object is
+   * linked to a choice chosen manually by the user.
    *
    * If `false`, this estimate is just due to the adaptative logic.
    */
@@ -78,7 +76,7 @@ export interface IABREstimate {
    * The Representation considered as the most adapted to the current network
    * and playback conditions.
    */
-  representation: Representation; // The chosen representation
+  representation: Representation;
   /**
    * If `true`, the current `representation` suggested should be switched to as
    * soon as possible. For example, you might want to interrupt all pending
@@ -114,16 +112,19 @@ export interface IABREstimate {
   knownStableBitrate?: number;
 }
 
-/** Properties the `RepresentationEstimator` will need at each clock tick. */
+/** Properties the `RepresentationEstimator` will need at each "clock tick". */
 export interface IRepresentationEstimatorClockTick {
   /**
    * For the concerned SourceBuffer, difference in seconds between the next
    * position where no segment data is available and the current position.
    */
   bufferGap : number;
-  /** Current playback position in the video, in seconds. */
+  /** Current playback position on the concerned media element, in seconds. */
   currentTime : number;
-  /** Last "playback rate" asked by the user. */
+  /**
+   * Last "playback rate" set by the user. This is the ideal "playback rate" at
+   * which the media should play.
+   */
   speed : number;
   /** `duration` property of the HTMLMediaElement on which the content plays. */
   duration : number;


### PR DESCRIPTION
This commit tries to improve our ABR performance through three main code updates:

  1. The "factor" used to pick a "safe" Representation from a calculated bandwidth (when not in starvation mode) has been lowered: from 0.9 to 0.8.
     For example, when the calculated bandwidth is 10Mbps and when we're choosing the Representation based on the network bandwidth, only the Representations having a bitrate lower or equal to 8Mbps will be considered.
     This can appear drastic but it is counter balanced by the fact that:
       - more rebuffering situations can be avoided, which is much more important that playing at the best bitrate possible
       - the RxPlayer also has a buffer-based ABR logic, which is not constrained by that factor

  2. When we're in starvation mode, the previous logic checking for sudden fall in bandwidth was too aggressive. This could lead to an oscillating Representation choice when the buffer level is low.

     Now, the condition for sudden fall in quality needs much more conditions to be filled:
       - that only one parallel request exists for that segment
       - that enough progress events (for now 5+) have been received for that segment (so the immediately calculated bandwidth can be more reliable).
       - that according to these calculations, we will rebuffer for at least two seconds
       - if we couldn't perform those bandwidth calculation, I also put the bar higher by stating that the pending request should run for at least the segment's duration * 1.5 + 2 seconds (instead of just +1 second).

  3. When deciding whether a switch to a lower bitrate is urgent, I now consider that it is in more cases: if finishing the current request means (through our simple - though not exact - calculations) that less than 1.5 seconds will be left in the buffer, we switch urgently.

     If we cannot define that number, we also switch urgently.