### PR TITLE
manifest: when doing partial updates avoid removing too much Periods when one is too old

### DIFF
--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -618,22 +618,10 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     if (updateType === MANIFEST_UPDATE_TYPE.Full) {
       this.minimumTime = newManifest.minimumTime;
       this.uris = newManifest.uris;
-    }
-
-    if (updateType === MANIFEST_UPDATE_TYPE.Full) {
       replacePeriods(this.periods, newManifest.periods);
     } else {
       updatePeriods(this.periods, newManifest.periods);
-    }
 
-    // Re-set this.adaptations for retro-compatibility in v3.x.x
-    /* tslint:disable:deprecation */
-    this.adaptations = this.periods[0] === undefined ?
-                         {} :
-                         this.periods[0].adaptations;
-    /* tslint:enable:deprecation */
-
-    if (updateType === MANIFEST_UPDATE_TYPE.Partial) {
       // Partial updates do not remove old Periods.
       // This can become a memory problem when playing a content long enough.
       // Let's clean manually Periods behind the minimum possible position.
@@ -643,9 +631,16 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
         if (period.end === undefined || period.end > min) {
           break;
         }
-        this.periods.splice(0);
+        this.periods.shift();
       }
     }
+
+    // Re-set this.adaptations for retro-compatibility in v3.x.x
+    /* tslint:disable:deprecation */
+    this.adaptations = this.periods[0] === undefined ?
+                         {} :
+                         this.periods[0].adaptations;
+    /* tslint:enable:deprecation */
 
     // Let's trigger events at the end, as those can trigger side-effects.
     // We do not want the current Manifest object to be incomplete when those

--- a/src/manifest/update_periods.ts
+++ b/src/manifest/update_periods.ts
@@ -77,7 +77,7 @@ export function updatePeriods(
   newPeriods: Period[]
 ) : void {
   if (oldPeriods.length === 0) {
-    oldPeriods.splice(0, oldPeriods.length, ...newPeriods);
+    oldPeriods.splice(0, 0, ...newPeriods);
     return;
   }
   if (newPeriods.length === 0) {


### PR DESCRIPTION
This fix concerns a bug that arised when playing multi-periods live contents when a `manifestUpdateUrl` is set.
When playing those, the player could appear to be rebuffering indefinitely after some time.

The `manifestUpdateUrl` option allows to speed-up the process of parsing giant Manifest files.
As only information about new segments is most of the time needed when doing updates, it permits to use another version of that Manifest with a lower depth for updates.

Because we only know about new segments, we have to perform clean-up of older segments and Periods manually. And that's where the error was: in the clean-up of Periods.

The logic is relatively simple: after updating the Manifest through a so-called "partial" update (done with a shorter version of the
Manifest), we manually remove every Period whose end is older than what the current minimal position in the large Manifest (the "real" one) should be.

The problem was not with this logic but with how we used the `Array.prototype.slice` API.
To remove only the first element of the
periods array, we did:
```ts
this.periods.splice(0);
```

Presumably thinking that it would only remove the element at index `0`.
However, this call will remove instead EVERY periods FROM the index `0` (so all the array's elements).

What we should have done instead would be something like:
```ts
this.periods.splice(0, 1);
```
Which does remove the first element.

However, I chose to use here the `Array.prototype.shift` API instead, which is specialized to remove exactly the first element, to do things more explicitely.

--

Also in this PR:
  - the code handling partial updates was strangely divided into three parts in the `_performUpdate` function. I decided to group them all in a unique `if` for clarity.
  - the code setting the deprecated `manifest.adaptations` property was done before periods being possibly cleaned-up. I reversed that order to be sure `adaptations` always concern the first period element - as it is documented.
  - I did a minor modification in `updatePeriods` to make that function more readable: I replaced a variable with the constant it is known to be set at at that point, `0`.