### PR TITLE
Still retry all other segment's URLs when a non-retryable error happen on the request for one of them

### DIFF
--- a/src/core/fetchers/utils/try_urls_with_backoff.ts
+++ b/src/core/fetchers/utils/try_urls_with_backoff.ts
@@ -175,7 +175,7 @@ export default function tryURLsWithBackoff<T>(
           }
 
           // else, remove that element from the array and go the next URL
-          urlsToTry.splice(index);
+          urlsToTry.splice(index, 1);
           const newIndex = index >= urlsToTry.length - 1 ? 0 :
                                                            index;
           return tryURLsRecursively(urlsToTry[newIndex], newIndex)


### PR DESCRIPTION
This fix concerns segment requests for segment with multiple associated URLs.

Due to a misunderstanding of how the `Array.prototype.slice` API worked, multiple URLs were ignored as soon as one of them failed on an error indicating that we should not retry.

Basically, we wrote:
```ts
urlsToTry.splice(index);
```
Which means that we should remove every URLs in `urlsoTry` from the `index` index.

Where I think we meant:
```ts
urlsToTry.splice(index. 1);
```
Which just does remove the element at `index`.