### PR TITLE
api: make `loadVideo` return a Promise

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -7,6 +7,7 @@
 - [Instantiation](#instantiation)
 - [Basic methods](#meth-group-basic)
     - [loadVideo](#meth-loadVideo)
+    - [reload](#meth-reload)
     - [getPlayerState](#meth-getPlayerState)
     - [addEventListener](#meth-addEventListener)
     - [removeEventListener](#meth-removeEventListener)
@@ -166,6 +167,48 @@ player.loadVideo({
   url: "http://vm2.dashif.org/livesim-dev/segtimeline_1/testpic_6s/Manifest.mpd",
   transport: "dash",
   autoPlay: true,
+});
+```
+
+<a name="meth-reload"></a>
+### reload #####################################################################
+
+_arguments_:
+  - _options_ (``Object | undefined``)
+
+Re-load the last loaded content as fast as possible.
+
+This API can be called at any time after a content has been loaded (the LOADED
+state has been reached), even if the player has been stopped since and even if
+it was due to a fatal error.
+
+The user may need to call this API in several cases. For example, it may be used
+in case of an error that will not reproduce or inversely when the error is
+consistent at a certain playback time (e.g. due to a specific chunk defect).
+
+The options argument is an object containing :
+- _reloadAt_ (``Object | undefined``): The object contain directives about
+the starting playback position :
+  - _relative_ (``string | undefined``) : start playback relatively from the
+  last playback position (last played position before entering into STOPPED or
+  ENDED state).
+  - _position_ (`string`|`undefined`) : absolute position at which we should
+  start playback
+
+If no reload position is defined, start playback at the last playback position.
+
+#### Example
+
+```js
+player.addEventListener("error", (error) => {
+  if (error.code === "BUFFER_APPEND_ERROR") {
+    // Try to reload after the last playback position, in case of defectuous
+    // media content at current time.
+    player.reload({ reloadAt: { relative: +5 }});
+  } else {
+    // Try to reload at the last playback position
+    player.reload();
+  }
 });
 ```
 

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -29,9 +29,10 @@ import {
 } from "../../../utils/languages";
 import warnOnce from "../../../utils/warn_once";
 import {
+  checkReloadOptions,
   parseConstructorOptions,
   parseLoadVideoOptions,
-} from "../option_parsers";
+} from "../option_utils";
 
 jest.mock("../../../log");
 jest.mock("../../../utils/languages");
@@ -1369,5 +1370,61 @@ If badly set, seamless strategy will be used as default`);
                           supplementaryTextTracks: [] },
     });
   });
+});
 
+describe("API - checkReloadOptions", () => {
+  it("Should valid undefined options", () => {
+    const options = undefined;
+    expect(() => checkReloadOptions(options)).not.toThrow();
+  });
+  it("Should valid empty options", () => {
+    const options = {};
+    expect(() => checkReloadOptions(options)).not.toThrow();
+  });
+  it("Should valid options with defined reloadAt.position", () => {
+    const options = {
+      reloadAt: {
+        position: 4,
+      },
+    };
+    expect(() => checkReloadOptions(options)).not.toThrow();
+  });
+  it("Should valid options with defined reloadAt.relative", () => {
+    const options = {
+      reloadAt: {
+        relative: 3,
+      },
+    };
+    expect(() => checkReloadOptions(options)).not.toThrow();
+  });
+  it("Should throw when invalid options", () => {
+    const options = null;
+    expect(() => checkReloadOptions(options as any))
+      .toThrow("API: reload - Invalid options format.");
+  });
+  it("Should throw when invalid reloatAt", () => {
+    const options = {
+      reloadAt: 3,
+    };
+    expect(() => checkReloadOptions(options as any))
+      .toThrow("API: reload - Invalid 'reloadAt' option format.");
+  });
+  it("Should throw when invalid position", () => {
+    const options = {
+      reloadAt: {
+        position: "3",
+      },
+    };
+    expect(() => checkReloadOptions(options as any))
+      .toThrow("API: reload - Invalid 'reloadAt.position' option format.");
+  });
+  it("Should throw when invalid relative position", () => {
+    const options = {
+      reloadAt: {
+        relative: "3",
+      },
+    };
+    expect(() => checkReloadOptions(options as any))
+      .toThrow("API: reload - Invalid 'reloadAt.relative' option format.");
+  });
 });

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -18,16 +18,27 @@ import config from "../../config";
 
 const { FORCED_ENDED_THRESHOLD } = config;
 
+export type IPlayerState = "STOPPED" |
+                           "LOADED" |
+                           "LOADING" |
+                           "PLAYING" |
+                           "PAUSED" |
+                           "ENDED" |
+                           "BUFFERING" |
+                           "SEEKING" |
+                           "RELOADING";
+
 /** Player state dictionnary. */
-export const PLAYER_STATES = { STOPPED: "STOPPED",
-                               LOADED: "LOADED",
-                               LOADING: "LOADING",
-                               PLAYING: "PLAYING",
-                               PAUSED: "PAUSED",
-                               ENDED: "ENDED",
-                               BUFFERING: "BUFFERING",
-                               SEEKING: "SEEKING",
-                               RELOADING: "RELOADING" };
+export const PLAYER_STATES =
+  { STOPPED: "STOPPED",
+    LOADED: "LOADED",
+    LOADING: "LOADING",
+    PLAYING: "PLAYING",
+    PAUSED: "PAUSED",
+    ENDED: "ENDED",
+    BUFFERING: "BUFFERING",
+    SEEKING: "SEEKING",
+    RELOADING: "RELOADING" } as Record<IPlayerState, IPlayerState>;
 
 /**
  * Get state string for a _loaded_ content.
@@ -45,7 +56,7 @@ export default function getLoadedContentState(
                              "not-ready" |
                              "buffering"; } |
                   null
-) : string {
+) : IPlayerState {
   if (mediaElement.ended) {
     return PLAYER_STATES.ENDED;
   }

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -35,7 +35,7 @@ export {
   IDefaultTextTrackOption,
   INetworkConfigOption,
   IStartAtOption,
-} from "./option_parsers";
+} from "./option_utils";
 export {
   ITMAudioTrackListItem,
   ITMTextTrackListItem,

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -492,6 +492,32 @@ function parseConstructorOptions(
 }
 
 /**
+ * Check the format of given reload options.
+ * Throw if format in invalid.
+ * @param {object | undefined} options
+ */
+function checkReloadOptions(options?: {
+  reloadAt?: { position?: number; relative?: number };
+}): void {
+  if (options === null ||
+      (typeof options !== "object" && options !== undefined)) {
+    throw new Error("API: reload - Invalid options format.");
+  }
+  if (options?.reloadAt === null ||
+      (typeof options?.reloadAt !== "object" && options?.reloadAt !== undefined)) {
+    throw new Error("API: reload - Invalid 'reloadAt' option format.");
+  }
+  if (typeof options?.reloadAt?.position !== "number" &&
+      options?.reloadAt?.position !== undefined) {
+    throw new Error("API: reload - Invalid 'reloadAt.position' option format.");
+  }
+  if (typeof options?.reloadAt?.relative !== "number" &&
+      options?.reloadAt?.relative !== undefined) {
+    throw new Error("API: reload - Invalid 'reloadAt.relative' option format.");
+  }
+}
+
+/**
  * Parse options given to loadVideo and set default options as found
  * in the config.
  *
@@ -723,6 +749,7 @@ function parseLoadVideoOptions(
 }
 
 export {
+  checkReloadOptions,
   parseConstructorOptions,
   parseLoadVideoOptions,
 };

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -63,7 +63,7 @@ export interface IManifestFetcherParsedResult {
   /** The time (`performance.now()`) at which the request was fully received. */
   receivedTime? : number;
   /* The time taken to parse the Manifest through the corresponding parse function. */
-  parsingTime : number;
+  parsingTime? : number;
 }
 
 /** Emitted when a fetching or parsing minor error happened. */

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -41,6 +41,7 @@ import {
 import { shouldReloadMediaSourceOnDecipherabilityUpdate } from "../../compat";
 import config from "../../config";
 import log from "../../log";
+import Manifest from "../../manifest";
 import {
   ILoadedManifest,
   ITransportPipelines,
@@ -61,6 +62,7 @@ import {
 import {
   IManifestFetcherParsedResult,
   IManifestFetcherParserOptions,
+  IManifestFetcherWarningEvent,
   ManifestFetcher,
   SegmentFetcherCreator,
 } from "../fetchers";
@@ -266,11 +268,19 @@ export default function InitializeOnMediaSource(
    */
   const mediaError$ = throwOnMediaError(mediaElement);
 
-  const initialManifestRequest$ = (initialManifest === undefined ?
-    fetchManifest(url, { previousManifest: null, unsafeMode: false }) :
-    manifestFetcher.parse(initialManifest, { previousManifest: null,
-                                             unsafeMode: false })
-  );
+  let initialManifestRequest$: Observable<IManifestFetcherParsedResult |
+                                          IManifestFetcherWarningEvent>;
+  if (initialManifest instanceof Manifest) {
+    initialManifestRequest$ = observableOf({ type: "parsed",
+                                             manifest: initialManifest });
+  } else if (initialManifest !== undefined) {
+    initialManifestRequest$ =
+      manifestFetcher.parse(initialManifest, { previousManifest: null,
+                                               unsafeMode: false });
+  } else {
+    initialManifestRequest$ =
+      fetchManifest(url, { previousManifest: null, unsafeMode: false });
+  }
 
   /**
    * Wait for the MediaKeys to have been created before

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -20,6 +20,7 @@ import {
   Observable,
   of as observableOf,
   Subject,
+  throwError,
 } from "rxjs";
 import {
   filter,
@@ -109,8 +110,9 @@ export default function createMediaSourceLoader(
 
     const initialPeriod = manifest.getPeriodForTime(initialTime);
     if (initialPeriod == null) {
-      throw new MediaError("MEDIA_STARTING_TIME_NOT_FOUND",
-                           "Wanted starting time not found in the Manifest.");
+      const error = new MediaError("MEDIA_STARTING_TIME_NOT_FOUND",
+                                   "Wanted starting time not found in the Manifest.");
+      return throwError(error);
     }
 
     /** Interface to create media buffers for loaded segments. */

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -99,7 +99,8 @@ export interface ILoaderDataLoadedValue<T> {
 export type ILoadedManifest = Document |
                               string |
                               IMetaPlaylist |
-                              ILocalManifest;
+                              ILocalManifest |
+                              Manifest;
 
 /** Event emitted by a Manifest loader when the Manifest is fully available. */
 export interface IManifestLoaderDataLoadedEvent {

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -331,6 +331,92 @@ export default function launchTestsForContent(manifestInfos) {
       });
     });
 
+    describe("reload", () => {
+      it("should reload at given absolute position", async function () {
+        player.setVideoBitrate(0);
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        if (!manifestInfos.isLive) {
+          expect(player.getPosition())
+            .to.be.closeTo(manifestInfos.minimumPosition, 0.1);
+        } else {
+          expect(player.getPosition())
+            .to.be.closeTo(manifestInfos.maximumPosition - 10, 5);
+        }
+        player.reload({
+          reloadAt: { position: manifestInfos.minimumPosition + 5 }
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 5, 0.1);
+      });
+      it("should reload at given relative position", async function () {
+        player.setVideoBitrate(0);
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          startAt: { position: manifestInfos.minimumPosition + 2 }
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 2, 0.1);
+        player.reload({ reloadAt: { relative: 5 }});
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 7, 0.1);
+      });
+      it("should reload after stop, at given relative position", async function () {
+        player.setVideoBitrate(0);
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          startAt: { position: manifestInfos.minimumPosition + 2 }
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 2, 0.1);
+        player.stop();
+        player.reload({ reloadAt: { relative: 5 }});
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 7, 0.1);
+      });
+      it("should reload when seeking at last playback position", async function () {
+        player.setVideoBitrate(0);
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          startAt: { position: manifestInfos.minimumPosition }
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition, 0.1);
+        player.seekTo({ position: manifestInfos.minimumPosition + 5 });
+        player.reload();
+        await waitForLoadedStateAfterLoadVideo(player);
+        expect(player.getPosition())
+          .to.be.closeTo(manifestInfos.minimumPosition + 5, 0.1);
+      });
+      it("should not reload when content is not loaded", async function () {
+        player.setVideoBitrate(0);
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          startAt: { position: manifestInfos.minimumPosition }
+        });
+        expect(() => player.reload())
+          .to.throw("API: Can't reload without having previously loaded a content.");
+      });
+      it("should not reload when no content", async function () {
+        player.setVideoBitrate(0);
+        expect(() => player.reload())
+          .to.throw("API: Can't reload without having previously loaded a content.");
+      });
+    });
+
     describe("getCurrentAdaptations", () => {
       it("should return the currently played adaptations", async function () {
         player.setVideoBitrate(0);


### PR DESCRIPTION
closes #778

This is a proposal to make the `loadVideo` method return a Promise.

One of the main added value of doing that is that an application developper will be able to use async/await APIs on it which might be a improvement over event listeners depending on the coding style of said application.

The Promise returned by `loadVideo` has the following behavior in this proposal:

  - As soon as we reach the `LOADED` state for the current content, the corresponding Promise is resolved with no payload

  - If a fatal error happened before we reach the `LOADED` state for the current content, we reject the Promise with an Object which takes the following form:

    ```ts
    { type: "error", error: TheErrorInQuestion }
    ```

    This is done just after the "error" event is sent (this is necessary to avoid ugly race conditions where the "error" would be sent
    despite another content being loaded since).

  - If the current content was stopped before it had the time to reach the `LOADED` state (if for example it has been stopped of if a new content has been loaded since), we reject the Promise with an object taking the following form:

    ```ts
    { type: "aborted", error: null }
    ```

    I chose to still add an `error` property set to `null` here to not vary too much the format of objects rejected by that Promise. The
    user can thus expect that an `error` property will always be set, either to an Error or to null.

There is still some things I consider ugly with the code proposed here:

  1. I didn't want to trigger Unhandled Promise Rejection Warnings if the Promise was not properly handled, as the user of the API can get the corresponding error through other means (`"error" event or `getError` API).
     As such, I added an ugly empty catch just to tell the browser it's OK.

  2. To know when an error happened before the `LOADED` state, we rely on error throwed by the `playback$` Observable (which is what the `Init` module returns).
     This is not the best thing for two reasons:

       - this is redundant as the `loaded$` Observable rely on that `playback$` Observable. I still wanted to include both to be more explicit.

       - We could add a development in the future which would add a new way to fail, which does not go through `playback$`.
         A more generic way to find out errors might be preferable.

  3. As written earlier in this commentary. We have to be careful here to not introduce a race condition. The Promise should be rejected preferably AFTER the `"error"` event is sent.
     If it is not, we should take care to not send this events in a case where the user load a new content (or else, he/she/it will think
     that the event is for the new loaded content).