### PR TITLE
Fix wrong usage of strToUtf8 when what was really wanted was Base64 decoding

### DIFF
--- a/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
@@ -19,12 +19,10 @@ import {
   Subject,
 } from "rxjs";
 import { takeUntil } from "rxjs/operators";
+import { base64ToBytes } from "../../../utils/base64";
 import EventEmitter from "../../../utils/event_emitter";
 import PPromise from "../../../utils/promise";
-import {
-  strToUtf8,
-  utf8ToStr,
-} from "../../../utils/string_parsing";
+import { utf8ToStr } from "../../../utils/string_parsing";
 import * as events from "../../event_listeners";
 import {
   ICustomMediaKeys,
@@ -98,8 +96,8 @@ class OldWebkitMediaKeySession extends EventEmitter<IMediaKeySessionEvents>
                                                license;
             /* tslint:disable no-unsafe-any */
             const json = JSON.parse(utf8ToStr(licenseTypedArray));
-            const key = strToUtf8(atob(json.keys[0].k));
-            const kid = strToUtf8(atob(json.keys[0].kid));
+            const key = base64ToBytes(json.keys[0].k);
+            const kid = base64ToBytes(json.keys[0].kid);
             /* tslint:enable no-unsafe-any */
             resolve(this._vid.webkitAddKey(this._key, key, kid, /* sessionId */ ""));
           } else {

--- a/src/parsers/containers/isobmff/drm/playready.ts
+++ b/src/parsers/containers/isobmff/drm/playready.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import { base64ToBytes } from "../../../../utils/base64";
 import { le2toi } from "../../../../utils/byte_parsing";
 import {
   bytesToHex,
   guidToUuid,
   leUtf16ToStr,
-  strToUtf8,
 } from "../../../../utils/string_parsing";
 
 /**
@@ -40,6 +40,6 @@ export function getPlayReadyKIDFromPrivateData(
   const b64guidKid = kidElement.textContent === null ? "" :
                                                        kidElement.textContent;
 
-  const uuidKid = guidToUuid(strToUtf8(atob(b64guidKid)));
+  const uuidKid = guidToUuid(base64ToBytes(b64guidKid));
   return bytesToHex(uuidKid).toLowerCase();
 }

--- a/src/parsers/manifest/smooth/parse_protection_node.ts
+++ b/src/parsers/manifest/smooth/parse_protection_node.ts
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
+import { base64ToBytes } from "../../../utils/base64";
 import { concat } from "../../../utils/byte_parsing";
-import {
-  hexToBytes,
-  strToUtf8,
-} from "../../../utils/string_parsing";
+import { hexToBytes } from "../../../utils/string_parsing";
 import { getPlayReadyKIDFromPrivateData } from "../../containers/isobmff";
 
 export interface IKeySystem { systemId : string;
@@ -51,9 +49,8 @@ export default function parseProtectionNode(
     throw new Error("Protection should have ProtectionHeader child");
   }
   const header = protectionNode.firstElementChild;
-  const privateData = strToUtf8(
-    atob(header.textContent === null ? "" :
-                                       header.textContent));
+  const privateData = base64ToBytes(header.textContent === null ? "" :
+                                                                  header.textContent);
   const keyIdHex = getPlayReadyKIDFromPrivateData(privateData);
   const keyIdBytes = hexToBytes(keyIdHex);
 


### PR DESCRIPTION
This is a fix of a bug introduced very recently (not yet released) while refactoring our code handling string encoding (#791, corresponding to the merge commit ca11ab9f8fb4dcf0d48fc55cc112e57db0287195).

In those modifications, I replaced most (all?) usages of the`strToBytes` function by the new `strToUtf8` function.

This is because `strToBytes` took an UTF-16 string 2 bytes at a time and considered only the lower 8 bit half to construct another byte array: this suspiciously looks like a naive way to translate UTF-16 encoded ASCII characters to UTF-8.
And it was used most of the time just for that. But not always, and that's where the bug was.

There are multiple places (I counted 3, all fixed in this commit) where it was used for a different use case: to transform base64 to an array of bytes.

The code flow was the following:

  - use the `atob` function which takes Base64-encoded data and returns ""binary"" data under the form of a string. The way it is done is by creating a regular JS string where each characters (group of two UTF-16 bytes) will have the char code of a single byte.

    Let's say we have the following Base64: `6w==`. This corresponds to a single byte set at 0xEB. After `atob` is called on it, we will obtain a string corresponding to `"\u00EB"`, which in JS is the same thing as `"ë"` (`ë` being `0x00EB` in UTF-16).

  - Then on the resulting string, we used the `strToBytes` function.

    This function tooks the UTF-16 "charCode" (basically each group of 2 bytes of the string in UTF-16 converted to decimal) and applied a mask to only get the lower 8 bit.

    This sounds weird but it was OK because `atob` only generated charCodes in the 0-255 range (basically we could say that each byte was transformed into two UTF-16 bytes starting with 0x00) so no information was lost there.

    So with our `"ë"`, we found that it coresponded to `0xEB` which is `235` in decimal, we did `235 & 255` which is still `235` and we created an Uint8Array with only 235 in it.

  - And... we're done! We have successfully translated a base64 string to the corresponding binary data.

When we used `strToUtf8` instead of `strToBytes`, we completely failed on characters that have a representation in UTF-16 but a different one in UTF-8. For example, `ë` in UTF-8 is `0xC3 0xAB`. We would there create a Uint8Array with two elements instead of one, corresponding to `0xC3` and `0xAB`.

The fix is really simple. Instead of doing that ugly hack we did before, I choose to rely instead on the more explicit and relatively new `base64ToBytes` functions for this type of need.