### PR TITLE
features: avoid circular dependency in `src/features`

### DIFF
--- a/src/features/__tests__/add_features.test.ts
+++ b/src/features/__tests__/add_features.test.ts
@@ -22,7 +22,7 @@ describe("Features - addFeatures", () => {
 
   it("should do nothing if an empty array is given", () => {
     const feat = {};
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -33,7 +33,7 @@ describe("Features - addFeatures", () => {
 
   it("should throw if something different than a function is given", () => {
     const feat = {};
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -46,7 +46,7 @@ describe("Features - addFeatures", () => {
 
   it("should call the given functions with the features object in argument", () => {
     const feat = { a: 412 };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));

--- a/src/features/__tests__/initialize_features.test.ts
+++ b/src/features/__tests__/initialize_features.test.ts
@@ -25,7 +25,7 @@ describe("Features - initializeFeaturesObject", () => {
       get() { return false; },
     });
     const feat = {};
-    jest.mock("../index", () => ({ default: feat,
+    jest.mock("../features_object", () => ({ default: feat,
                                    __esModule: true as const }));
     const initializeFeaturesObject = require("../initialize_features").default;
     initializeFeaturesObject();
@@ -69,7 +69,7 @@ describe("Features - initializeFeaturesObject", () => {
       emeManager: null,
       directfile: null,
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -126,7 +126,7 @@ describe("Features - initializeFeaturesObject", () => {
       htmlTextTracksBuffer: null,
       htmlTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -158,7 +158,7 @@ describe("Features - initializeFeaturesObject", () => {
       htmlTextTracksBuffer: null,
       htmlTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -190,7 +190,7 @@ describe("Features - initializeFeaturesObject", () => {
       htmlTextTracksBuffer: null,
       htmlTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -222,7 +222,7 @@ describe("Features - initializeFeaturesObject", () => {
       htmlTextTracksBuffer: null,
       htmlTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -254,7 +254,7 @@ describe("Features - initializeFeaturesObject", () => {
       nativeTextTracksBuffer: null,
       nativeTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -286,7 +286,7 @@ describe("Features - initializeFeaturesObject", () => {
       nativeTextTracksBuffer: null,
       nativeTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -318,7 +318,7 @@ describe("Features - initializeFeaturesObject", () => {
       nativeTextTracksBuffer: null,
       nativeTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));
@@ -350,7 +350,7 @@ describe("Features - initializeFeaturesObject", () => {
       nativeTextTracksBuffer: null,
       nativeTextTracksParsers: {},
     };
-    jest.mock("../index", () => ({
+    jest.mock("../features_object", () => ({
       __esModule: true as const,
       default: feat,
     }));

--- a/src/features/add_features.ts
+++ b/src/features/add_features.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import features from "./index";
+import features from "./features_object";
 import { IFeatureFunction } from "./types";
 
 /**

--- a/src/features/features_object.ts
+++ b/src/features/features_object.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IFeaturesObject } from "./types";
+
+/**
+ * Initial features object, with no feature activated by default.
+ * @type {Object}
+ */
+const features : IFeaturesObject = { directfile: null,
+                                     emeManager: null,
+                                     htmlTextTracksBuffer: null,
+                                     htmlTextTracksParsers: {},
+                                     imageBuffer: null,
+                                     imageParser: null,
+                                     nativeTextTracksBuffer: null,
+                                     nativeTextTracksParsers: {},
+                                     transports: {} };
+
+export default features;

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -30,24 +30,8 @@
  */
 
 import addFeatures from "./add_features";
-import {
-  IFeatureFunction,
-  IFeaturesObject,
-} from "./types";
-
-/**
- * Initial features object, with no feature activated by default.
- * @type {Object}
- */
-const features : IFeaturesObject = { directfile: null,
-                                     emeManager: null,
-                                     htmlTextTracksBuffer: null,
-                                     htmlTextTracksParsers: {},
-                                     imageBuffer: null,
-                                     imageParser: null,
-                                     nativeTextTracksBuffer: null,
-                                     nativeTextTracksParsers: {},
-                                     transports: {} };
+import features from "./features_object";
+import { IFeatureFunction } from "./types";
 
 export default features;
 export {

--- a/src/features/initialize_features.ts
+++ b/src/features/initialize_features.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import features from "./index";
+import features from "./features_object";
 
 /**
  * Selects the features to include based on environment variables.


### PR DESCRIPTION
This is a small fix to avoir a circular dependency in the `src/features` directory.

Basically, the `features` object, which, was declared in `src/features/index.ts`, was imported by `src/features/add_features.ts`.
This is problematic because `src/features/index.ts` also imports `src/features/add_features.ts`.

There was no real reason to declare the `features` object in `index.ts` other than convenience. In this commit, I move it to its own
`features_object.ts` file.

This issue led to no build error that I know of, but it is still an ugly avoidable situation.