### PR TITLE
audioTrackSwitchingMode api on loadVideo

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -13,6 +13,7 @@
     - [transportOptions](#prop-transportOptions)
     - [textTrackMode](#prop-textTrackMode)
     - [textTrackElement](#prop-textTrackElement)
+    - [audioTrackSwitchingMode](#prop-audioTrackSwitchingMode)
     - [manualBitrateSwitchingMode](#prop-manualBitrateSwitchingMode)
     - [lowLatencyMode](#prop-lowLatencyMode)
     - [networkConfig](#prop-networkConfig)
@@ -892,6 +893,44 @@ than the media element it applies to (this allows us to properly place the
 subtitles position without polling where the video is in your UI).
 You can however re-size or update the style of it as you wish, to better suit
 your UI needs.
+
+
+<a name="prop-audioTrackSwitchingMode"></a>
+### audioTrackSwitchingMode ####################################################
+
+_type_: ``string``
+
+_defaults_: ``"seamless"``
+
+---
+
+:warning: This option is not available in _DirectFile_ mode (see [transport
+option](#prop-transport)).
+
+---
+
+Behavior taken by the player when switching to a different audio track, through
+the `setAudioTrack` method.
+
+There are two possible values:
+
+  - ``"seamless"``: The transition between the old audio track and the new one
+    happens seamlessly, without interruption.
+    This is the default behavior.
+
+    As an inconvenient, you might have at worst a few seconds in the previous
+    audio track before the new one can be heard.
+
+  - ``"direct"``: The player will try to switch to the new audio track as soon
+    as possible, which might lead to an interruption while it is doing so.
+
+    Note that while switching audio track with a `"direct"`
+    `audioTrackSwitchingMode`, it is possible that the player goes into the
+    `"RELOADING"` state (during which the video will disappear and many APIs
+    will become unavailable) to be able to switch to the new track.
+
+    More information about the ``"RELOADING"`` state can be found in [the
+    player states documentation](./states).
 
 
 <a name="prop-manualBitrateSwitchingMode"></a>

--- a/src/config.ts
+++ b/src/config.ts
@@ -77,6 +77,19 @@ export default {
   DEFAULT_ENABLE_FAST_SWITCHING: true,
 
   /**
+   * Strategy to adopt when manually switching of audio adaptation.
+   * Can be either:
+   *    - "seamless": transitions are smooth but could be not immediate.
+   *    - "direct": that strategy will be "smart", if the mimetype and the codec,
+   *    change, we will perform a hard reload of the media source, however, if it
+   *    doesn't change, we will just perform a small flush by removing buffered range,
+   *    and perform, a small seek on the media element.
+   *    Transitions are faster, but we could see appear a reloading or seeking state.
+   */
+  DEFAULT_AUDIO_TRACK_SWITCHING_MODE: "seamless" as "seamless" |
+                                                    "direct",
+
+  /**
    * If set to true, video through loadVideo will auto play by default
    * @type {Boolean}
    */

--- a/src/core/api/__tests__/option_parsers.test.ts
+++ b/src/core/api/__tests__/option_parsers.test.ts
@@ -415,6 +415,7 @@ describe("API - parseLoadVideoOptions", () => {
   });
 
   const defaultLoadVideoOptions = {
+    audioTrackSwitchingMode: "seamless",
     autoPlay: false,
     defaultAudioTrack: undefined,
     defaultTextTrack: undefined,
@@ -809,6 +810,53 @@ describe("API - parseLoadVideoOptions", () => {
       url: "foo",
       transport: "bar",
       manualBitrateSwitchingMode: "seamless",
+    });
+  });
+
+  it("should authorize setting a valid audioTrackSwitchingMode option", () => {
+    expect(parseLoadVideoOptions({
+      audioTrackSwitchingMode: "direct",
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      audioTrackSwitchingMode: "direct",
+    });
+
+    expect(parseLoadVideoOptions({
+      audioTrackSwitchingMode: "seamless",
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      audioTrackSwitchingMode: "seamless",
+    });
+  });
+
+  it("should set a 'seamess' audioTrackSwitching mode when the parameter is invalid or not specified", () => {
+    expect(parseLoadVideoOptions({
+      audioTrackSwitchingMode: "foo-bar" as any,
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      audioTrackSwitchingMode: "seamless",
+    });
+
+    expect(parseLoadVideoOptions({
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      audioTrackSwitchingMode: "seamless",
     });
   });
 

--- a/src/core/api/option_parsers.ts
+++ b/src/core/api/option_parsers.ts
@@ -28,6 +28,7 @@ import {
   ILoadedManifest,
   ITransportOptions as IParsedTransportOptions,
 } from "../../transports";
+import arrayIncludes from "../../utils/array_includes";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import {
   normalizeAudioTrack,
@@ -47,6 +48,7 @@ const { DEFAULT_AUTO_PLAY,
         DEFAULT_INITIAL_BITRATES,
         DEFAULT_LIMIT_VIDEO_WIDTH,
         DEFAULT_MANUAL_BITRATE_SWITCHING_MODE,
+        DEFAULT_AUDIO_TRACK_SWITCHING_MODE,
         DEFAULT_MAX_BITRATES,
         DEFAULT_MAX_BUFFER_AHEAD,
         DEFAULT_MAX_BUFFER_BEHIND,
@@ -245,6 +247,7 @@ export interface ILoadVideoOptions {
   textTrackElement? : HTMLElement;
   manualBitrateSwitchingMode? : "seamless"|"direct";
   enableFastSwitching? : boolean;
+  audioTrackSwitchingMode? : "seamless"|"direct";
 
   /* tslint:disable deprecation */
   supplementaryTextTracks? : ISupplementaryTextTrackOption[];
@@ -274,6 +277,7 @@ interface IParsedLoadVideoOptionsBase {
   startAt : IParsedStartAtOption|undefined;
   manualBitrateSwitchingMode : "seamless"|"direct";
   enableFastSwitching : boolean;
+  audioTrackSwitchingMode : "seamless"|"direct";
 }
 
 /**
@@ -562,6 +566,16 @@ function parseLoadVideoOptions(
   const manifestUpdateUrl = options.transportOptions?.manifestUpdateUrl;
   const minimumManifestUpdateInterval =
     options.transportOptions?.minimumManifestUpdateInterval ?? 0;
+  let audioTrackSwitchingMode = isNullOrUndefined(options.audioTrackSwitchingMode)
+                                  ? DEFAULT_AUDIO_TRACK_SWITCHING_MODE
+                                  : options.audioTrackSwitchingMode;
+  if (!arrayIncludes(["seamless", "direct"], audioTrackSwitchingMode)) {
+    log.warn("The `audioTrackSwitchingMode` loadVideo option must match one of the following strategy name:\n" +
+             "- `seamless`\n" +
+             "- `direct`\n" +
+             "If badly set, " + DEFAULT_AUDIO_TRACK_SWITCHING_MODE + " strategy will be used as default");
+    audioTrackSwitchingMode = DEFAULT_AUDIO_TRACK_SWITCHING_MODE;
+  }
 
   const transportOptions = objectAssign({}, transportOptsArg, {
     /* tslint:disable deprecation */
@@ -693,6 +707,7 @@ function parseLoadVideoOptions(
            initialManifest,
            lowLatencyMode,
            manualBitrateSwitchingMode,
+           audioTrackSwitchingMode,
            manifestUpdateUrl,
            minimumManifestUpdateInterval,
            networkConfig,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -612,6 +612,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     log.info("API: Calling loadvideo", options);
 
     const { autoPlay,
+            audioTrackSwitchingMode,
             defaultAudioTrack,
             defaultTextTrack,
             enableFastSwitching,
@@ -716,7 +717,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           textTrackElement: options.textTrackElement };
 
       const bufferOptions = objectAssign({ enableFastSwitching,
-                                           manualBitrateSwitchingMode },
+                                           manualBitrateSwitchingMode,
+                                           audioTrackSwitchingMode },
                                          this._priv_bufferOptions);
 
       // We've every options set up. Start everything now

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -105,6 +105,8 @@ export interface IInitializeArguments {
      * higher-quality ones to have a faster transition.
      */
     enableFastSwitching : boolean;
+    /** Strategy when switching of audio track. */
+    audioTrackSwitchingMode : "seamless" | "direct";
   };
   /** Regularly emit current playback conditions. */
   clock$ : Observable<IInitClockTick>;

--- a/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
@@ -152,20 +152,6 @@ export default class AudioVideoSegmentBuffer
                              null;
 
   /**
-   * Current `type` of the underlying SourceBuffer.
-   * Might be changed for codec-switching purposes.
-   */
-  private _currentCodec : string;
-
-  /**
-   * Public access to the SourceBuffer's current codec.
-   * @returns {string}
-   */
-  public get codec() : string {
-    return this._currentCodec;
-  }
-
-  /**
    * @constructor
    * @param {string} bufferType
    * @param {string} codec
@@ -186,7 +172,7 @@ export default class AudioVideoSegmentBuffer
     this._queue = [];
     this._pendingTask = null;
     this._lastInitSegment = null;
-    this._currentCodec = codec;
+    this.codec = codec;
 
     // Some browsers (happened with firefox 66) sometimes "forget" to send us
     // `update` or `updateend` events.

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -70,6 +70,16 @@ export abstract class SegmentBuffer<T> {
   /** Default implementation of an inventory of segment metadata. */
   protected _segmentInventory : SegmentInventory;
 
+  /**
+   * Mimetype+codec combination the SegmentBuffer is currently working with.
+   * Depending on the implementation, segments with a different codecs could be
+   * incompatible.
+   *
+   * `undefined` either if unknown or if the codec does not matter for this
+   * SegmentBuffer implementation.
+   */
+  public codec : string | undefined;
+
   constructor() {
     // Use SegmentInventory by default for inventory purposes
     this._segmentInventory = new SegmentInventory();

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -153,6 +153,17 @@ export interface IAdaptationStreamOptions {
    * those devices.
    */
   enableFastSwitching : boolean;
+  /**
+   * Strategy to adopt when manually switching of audio adaptation.
+   * Can be either:
+   *    - "seamless": transitions are smooth but could be not immediate.
+   *    - "direct": strategy will be "smart", if the mimetype and the codec,
+   *    change, we will perform a hard reload of the media source, however, if it
+   *    doesn't change, we will just perform a small flush by removing buffered range
+   *    and performing, a small seek on the media element.
+   *    Transitions are faster, but, we could see appear a reloading or seeking state.
+   */
+  audioTrackSwitchingMode : "seamless" | "direct";
 }
 
 /**

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -163,6 +163,7 @@ export default function PeriodStream({
       const newStream$ = clock$.pipe(
         take(1),
         mergeMap((tick) => {
+          const { audioTrackSwitchingMode } = options;
           const segmentBuffer = createOrReuseSegmentBuffer(segmentBuffersStore,
                                                            bufferType,
                                                            adaptation,
@@ -172,7 +173,8 @@ export default function PeriodStream({
           const strategy = getAdaptationSwitchStrategy(segmentBuffer,
                                                        period,
                                                        adaptation,
-                                                       playbackInfos);
+                                                       playbackInfos,
+                                                       audioTrackSwitchingMode);
           if (strategy.type === "needs-reload") {
             return observableOf(EVENTS.needsMediaSourceReload(period, tick));
           }
@@ -180,8 +182,7 @@ export default function PeriodStream({
           const cleanBuffer$ = strategy.type === "clean-buffer" ?
             observableConcat(...strategy.value.map(({ start, end }) =>
                                segmentBuffer.removeBuffer(start, end))
-                            ).pipe(ignoreElements()) :
-            EMPTY;
+                            ).pipe(ignoreElements()) : EMPTY;
 
           const bufferGarbageCollector$ = garbageCollectors.get(segmentBuffer);
           const adaptationStream$ = createAdaptationStream(adaptation, segmentBuffer);

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -389,6 +389,7 @@ export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
                                  // From an AdaptationStream
 
                                  IBitrateEstimationChangeEvent |
+                                 INeedsMediaSourceReload |
                                  INeedsDecipherabilityFlush |
                                  IRepresentationChangeEvent |
 
@@ -416,6 +417,7 @@ export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
                                           // From an AdaptationStream
 
                                           IBitrateEstimationChangeEvent |
+                                          INeedsMediaSourceReload |
                                           INeedsDecipherabilityFlush |
                                           IRepresentationChangeEvent |
 
@@ -446,6 +448,7 @@ export type IStreamOrchestratorEvent = IActivePeriodChangedEvent |
                                        // From an AdaptationStream
 
                                        IBitrateEstimationChangeEvent |
+                                       INeedsMediaSourceReload |
                                        INeedsDecipherabilityFlush |
                                        IRepresentationChangeEvent |
 

--- a/src/utils/__tests__/are_codecs_compatible.test.ts
+++ b/src/utils/__tests__/are_codecs_compatible.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import areCodecsCompatible from "../are_codecs_compatible";
+
+describe("are_codecs_compatible", () => {
+  it("should return false as one is different from the other", () => {
+    expect(areCodecsCompatible("", "audio/mp4;codecs=\"mp4a.42.2\"")).toEqual(
+      false
+    );
+  });
+
+  it("should return false as the mimeType is different", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;codecs=\"mp4a.40.2\"",
+        "audio/mp3;codecs=\"mp4a.40.2\""
+      )
+    ).toEqual(false);
+  });
+
+  it("should return false as the codec is different", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;codecs=\"mp4a.40.2\"",
+        "audio/mp4;codecs=\"av1.40.2\""
+      )
+    ).toEqual(false);
+  });
+
+  it("should return true as only the codec version is different", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;codecs=\"mp4a.40.2\"",
+        "audio/mp4;codecs=\"mp4a.42.2\""
+      )
+    ).toEqual(true);
+  });
+
+  it("should return true as they are exactly same", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;toto=5;codecs=\"mp4a.40.2\";test=4",
+        "audio/mp4;toto=5;codecs=\"mp4a.40.2\";test=4"
+      )
+    ).toEqual(true);
+  });
+
+  it("should return true as their codecs are same", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;toto=6;codecs=\"mp4a.40.2\";test=4",
+        "audio/mp4;toto=5;codecs=\"mp4a.40.2\";test=4"
+      )
+    ).toEqual(true);
+  });
+
+  it("should return false as their codecs are different", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;toto=6;codecs=\"av1.40.2\";test=4",
+        "audio/mp4;toto=5;codecs=\"mp4a.40.2\";test=4"
+      )
+    ).toEqual(false);
+  });
+
+  it("should return false as codecs have been found", () => {
+    expect(
+      areCodecsCompatible(
+        "audio/mp4;toto=6;test=4",
+        "audio/mp4;toto=5;test=4"
+      )
+    ).toEqual(false);
+  });
+});

--- a/src/utils/are_codecs_compatible.ts
+++ b/src/utils/are_codecs_compatible.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import arrayFind from "./array_find";
+import startsWith from "./starts_with";
+
+/**
+ * This function is a shortcut that helps differentiate two codecs
+ * of the form "audio/mp4;codecs=\"av1.40.2\"".
+ *
+ * @param codecA
+ * @param codecB
+ * @returns A boolean that tell whether or not those two codecs provided are even.
+ */
+function areCodecsCompatible(a: string, b: string): boolean {
+  const [mimeTypeA, ...propsA] = a.split(";");
+  const [mimeTypeB, ...propsB] = b.split(";");
+
+  if (mimeTypeA !== mimeTypeB) {
+    return false;
+  }
+
+  const codecsA = arrayFind(propsA, (prop) => startsWith(prop, "codecs="));
+  const codecsB = arrayFind(propsB, (prop) => startsWith(prop, "codecs="));
+  if (codecsA === undefined || codecsB === undefined) {
+    return false;
+  }
+
+  const codecA = codecsA.substring(7);
+  const codecB = codecsB.substring(7);
+  if (codecA.split(".")[0] !== codecB.split(".")[0]) {
+    return false;
+  }
+
+  return true;
+}
+
+export default areCodecsCompatible;


### PR DESCRIPTION
This merge request refer to [#801 ](https://github.com/canalplus/rx-player/issues/801)

Basically, it allows you through an entry on the  `loadVideo` method API,  inside `transportOptions` to specify a `string` (for now) on `audioTrackSwitchingMode` property to specify a special strategy concerning the push of audio segment inside the source buffer in order to whether adopt a smooth transition or whether to specify a more direct transition by flushing the current buffer in order to let the new segment take place quicker.

#### Strategies identity:
- `smooth`: This is the default behavior, it allows you to switch "smoothly" to the wanted audio adaptation, in some cases the switch can take up to 2 sec.
- `flush`: By using `flush`, we will take care of flushing the audio source buffer by performing a very small seek in order to switch to the wanted audio adaptation. Permit to switch faster but could look aggressive during the video playback.
- `reload`: The `reload` strategies, however, allows you to reload the whole media source. it is instant but a small reload will appear on the screen since we destroy the source buffer and build it again from scratch.

These strategies allow adapting depending on the environment u are playing on and so give you more flexibility.

PS: This is only a first try to implement the **feature**, I also have to adapt the API depending on the strategies chosen.