### PR TITLE
api: export StringUtils from "rx-player/tools"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 /minimal
 /experimental
 /types
+/tools

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -92,6 +92,7 @@
     - [ErrorCodes](#static-ErrorCodes)
     - [LogLevel](#static-LogLevel)
 - [Tools](#tools)
+    - [StringUtils](#tools-string-parsing)
     - [Experimental - MediaCapabilitiesProber](#tools-mediaCapabilitiesProber)
     - [Experimental - TextTrackRenderer](#tools-textTrackRenderer)
     - [Experimental - parseBifThumbnails](#tools-parseBifThumbnails)
@@ -2517,6 +2518,132 @@ The RxPlayer has several "tools", which are utils which can be imported without
 importing the whole RxPlayer itself.
 
 They are all documented here.
+
+<a name="tools-string-utils"></a>
+### StringUtils ################################################################
+
+Tools to convert strings into bytes and vice-versa.
+
+The RxPlayer internally has a lot of code dealing with strings to bytes
+conversion (and vice-versa). This tool exports that logic so you don't have to
+rewrite it yourself.
+
+You might need one of those functions for example when dealing with challenge
+and licenses, which are often under a binary format.
+
+#### How to import it
+
+The simplest way to import the StringUtils is by importing it as a named export
+from "rx-player/tools", like so:
+```js
+import { StringUtils } from "rx-player/tools";
+
+console.log(StringUtils.strToUtf8("hello😀"));
+```
+
+You can also import only the function(s) you want to use by importing it
+directly from "rx-player/tools/string-utils":
+```js
+import { strToUtf8 } from "rx-player/tools/string-utils";
+console.log(strToUtf8("hello😀"));
+```
+
+#### StringUtils functions
+
+`StringUtils` is an object containing the following functions:
+
+  - `strToUtf8`: Convert a JS string passed as argument to an Uint8Array of its
+    corresponding representation in UTF-8.
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    StringUtils.strToUtf8("hello😀");
+    // => Uint8Array(9) [ 104, 101, 108, 108, 111, 240, 159, 152, 128 ]
+    //                    "h"  "e"  "l"  "l"  "o"  "grinning face" emoji
+    ```
+
+  - `utf8ToStr`: Convert a Uint8Array containing a string encoded with UTF-8
+    into a JS string.
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const uint8Arr = new Uint8Array([104, 101, 108, 108, 111, 240, 159, 152, 128]);
+    StringUtils.utf8ToStr(uint8Arr);
+    // => "hello😀"
+    ```
+
+    Note: if what you have is an `ArrayBuffer`, you have to convert it to an
+    `Uint8Array` first:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const toUint8Array = new Uint8Array(myArrayBuffer);
+    console.log(StringUtils.utf8ToStr(toUint8Array));
+    ```
+
+  - `strToUtf16LE`: Convert a JS string passed as argument to an Uint8Array
+    containing its corresponding representation in UTF-16-LE (little endian
+    UTF-16).
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    StringUtils.strToUtf16LE("hi😀");
+    // => Uint8Array(9) [ 104, 0, 105, 0, 61, 216, 0, 222 ]
+    //                    "h"     "i"     "grinning face" emoji
+    ```
+
+  - `utf16LEToStr`: Convert a Uint8Array containing a string encoded with
+    UTF-16-LE (little endian UTF-16) into a JS string.
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const uint8Arr = new Uint8Array([104, 0, 105, 0, 61, 216, 0, 222]);
+    StringUtils.utf16LEToStr(uint8Arr);
+    // => "hi😀"
+    ```
+
+    Note: if what you have is an `ArrayBuffer`, you have to convert it to an
+    `Uint8Array` first:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const toUint8Array = new Uint8Array(myArrayBuffer);
+    console.log(StringUtils.utf16LEToStr(toUint8Array));
+    ```
+
+  - `strToUtf16BE`: Convert a JS string passed as argument to an Uint8Array
+    containing its corresponding representation in UTF-16-BE (big endian
+    UTF-16).
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    StringUtils.strToUtf16BE("hi😀");
+    // => Uint8Array(9) [ 0, 104, 0, 105, 216, 61, 222, 0 ]
+    //                    "h"     "i"     "grinning face" emoji
+    ```
+
+  - `utf16BEToStr`: Convert a Uint8Array containing a string encoded with
+    UTF-16-BE (big endian UTF-16) into a JS string.
+
+    Example:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const uint8Arr = new Uint8Array([0, 104, 0, 105, 216, 61, 222, 0]);
+    StringUtils.utf16BEToStr(uint8Arr);
+    // => "hi😀"
+    ```
+
+    Note: if what you have is an `ArrayBuffer`, you have to convert it to an
+    `Uint8Array` first:
+    ```js
+    import { StringUtils } from "rx-player/tools";
+    const toUint8Array = new Uint8Array(myArrayBuffer);
+    console.log(StringUtils.utf16BEToStr(toUint8Array));
+    ```
+
 
 <a name="tools-mediaCapabilitiesProber"></a>
 ### MediaCapabilitiesProber ####################################################

--- a/scripts/generate_builds
+++ b/scripts/generate_builds
@@ -230,6 +230,78 @@ echo "/**
  */
 export * from \"../dist/_esm5.processed/features/list/index\";" > features/index.d.ts
 
+echo "creating tools build..."
+rm -rf tools
+mkdir tools
+echo "/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from \"../../dist/_esm5.processed/tools/index.js\";" > tools/index.js
+echo "/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from \"../../dist/_esm5.processed/tools/index\";" > tools/index.d.ts
+echo "/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import StringUtils from \"../../dist/_esm5.processed/tools/string_utils.js\";
+export * from \"../../dist/_esm5.processed/tools/string_utils.js\";
+export default StringUtils;" > tools/string-utils.js
+echo "/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import StringUtils from \"../../dist/_esm5.processed/tools/string_utils\";
+export * from \"../../dist/_esm5.processed/tools/string_utils\";
+export default StringUtils;" > tools/string-utils.d.ts
+
 echo "creating experimental build..."
 rm -rf experimental
 mkdir -p experimental/tools

--- a/src/compat/eme/get_webkit_fairplay_initdata.ts
+++ b/src/compat/eme/get_webkit_fairplay_initdata.ts
@@ -19,8 +19,8 @@ import {
   le4toi,
 } from "../../utils/byte_parsing";
 import {
-  leUtf16ToStr,
-  strToLeUtf16,
+  strToUtf16LE,
+  utf16LEToStr,
 } from "../../utils/string_parsing";
 
 /**
@@ -45,12 +45,12 @@ export default function getWebKitFairPlayInitData(
   if (length + 4 !== initData.length) {
     throw new Error("Unsupported WebKit initData.");
   }
-  const initDataUri = leUtf16ToStr(initData);
+  const initDataUri = utf16LEToStr(initData);
   const skdIndexInInitData = initDataUri.indexOf("skd://");
   const contentIdStr = skdIndexInInitData > -1 ?
     initDataUri.substring(skdIndexInInitData + 6) :
     initDataUri;
-  const id = strToLeUtf16(contentIdStr);
+  const id = strToUtf16LE(contentIdStr);
 
   let offset = 0;
   const res =

--- a/src/parsers/containers/isobmff/drm/playready.ts
+++ b/src/parsers/containers/isobmff/drm/playready.ts
@@ -19,7 +19,7 @@ import { le2toi } from "../../../../utils/byte_parsing";
 import {
   bytesToHex,
   guidToUuid,
-  leUtf16ToStr,
+  utf16LEToStr,
 } from "../../../../utils/string_parsing";
 
 /**
@@ -31,7 +31,7 @@ export function getPlayReadyKIDFromPrivateData(
   data: Uint8Array
 ) : string {
   const xmlLength = le2toi(data, 8);
-  const xml = leUtf16ToStr(data.subarray(10, xmlLength + 10));
+  const xml = utf16LEToStr(data.subarray(10, xmlLength + 10));
   const doc = new DOMParser().parseFromString(xml, "application/xml");
   const kidElement = doc.querySelector("KID");
   if (kidElement === null) {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * as StringUtils from "./string_utils";

--- a/src/tools/string_utils.ts
+++ b/src/tools/string_utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export {
+  beUtf16ToStr,
+  utf16LEToStr,
+  strToBeUtf16,
+  strToUtf16LE,
+  strToUtf8,
+  utf8ToStr,
+} from "../utils/string_parsing";

--- a/src/utils/__tests__/string_parsing.test.ts
+++ b/src/utils/__tests__/string_parsing.test.ts
@@ -49,14 +49,14 @@ describe("utils - string parsing", () => {
     });
   });
 
-  describe("strToLeUtf16", () => {
+  describe("strToUtf16LE", () => {
     it("should return an empty Uint8Array for an empty string", () => {
-      expect(strUtils.strToLeUtf16("")).toEqual(new Uint8Array([]));
+      expect(strUtils.strToUtf16LE("")).toEqual(new Uint8Array([]));
     });
 
     it("should convert a string to little-endian UTF-16 code unit", () => {
       const someLetters = "A❁ლewat";
-      expect(strUtils.strToLeUtf16(someLetters))
+      expect(strUtils.strToUtf16LE(someLetters))
         .toEqual(new Uint8Array([65,
                                  0, // 0x0041 (A)
 
@@ -80,9 +80,40 @@ describe("utils - string parsing", () => {
     });
   });
 
-  describe("leUtf16ToStr", () => {
+  describe("strToBeUtf16", () => {
+    it("should return an empty Uint8Array for an empty string", () => {
+      expect(strUtils.strToBeUtf16("")).toEqual(new Uint8Array([]));
+    });
+
+    it("should convert a string to little-endian UTF-16 code unit", () => {
+      const someLetters = "A❁ლewat";
+      expect(strUtils.strToBeUtf16(someLetters))
+        .toEqual(new Uint8Array([0,
+                                 65, // 0x0041 (A)
+
+                                 39,
+                                 65, // 0x2741 (❁)
+
+                                 16,
+                                 218, // 0x10DA (ლ)
+
+                                 0,
+                                 101,  // 0x065 (e)
+
+                                 0,
+                                 119, // etc.
+
+                                 0,
+                                 97,
+
+                                 0,
+                                 116 ]));
+    });
+  });
+
+  describe("utf16LEToStr", () => {
     it("should return an empty string for an empty Uint8Array", () => {
-      expect(strUtils.leUtf16ToStr(new Uint8Array([]))).toBe("");
+      expect(strUtils.utf16LEToStr(new Uint8Array([]))).toBe("");
     });
 
     it("should convert little-endian UTF-16 to its original string", () => {
@@ -106,7 +137,37 @@ describe("utils - string parsing", () => {
 
                                    116,
                                    0 ]);
-      expect(strUtils.leUtf16ToStr(utf16)).toEqual("A❁ლewat");
+      expect(strUtils.utf16LEToStr(utf16)).toEqual("A❁ლewat");
+    });
+  });
+
+  describe("beUtf16ToStr", () => {
+    it("should return an empty string for an empty Uint8Array", () => {
+      expect(strUtils.beUtf16ToStr(new Uint8Array([]))).toBe("");
+    });
+
+    it("should convert little-endian UTF-16 to its original string", () => {
+     const utf16 = new Uint8Array([0,
+                                   65, // 0x0041 (A)
+
+                                   39,
+                                   65, // 0x2741 (❁)
+
+                                   16,
+                                   218, // 0x10DA (ლ)
+
+                                   0,
+                                   101,  // 0x065 (e)
+
+                                   0,
+                                   119, // etc.
+
+                                   0,
+                                   97,
+
+                                   0,
+                                   116 ]);
+      expect(strUtils.beUtf16ToStr(utf16)).toEqual("A❁ლewat");
     });
   });
 

--- a/src/utils/string_parsing.ts
+++ b/src/utils/string_parsing.ts
@@ -22,7 +22,7 @@ import assert from "./assert";
  * @param {string} str
  * @returns {Uint8Array}
  */
-function strToLeUtf16(str: string): Uint8Array {
+function strToUtf16LE(str: string): Uint8Array {
   const buffer = new ArrayBuffer(str.length * 2);
   const res = new Uint8Array(buffer);
   for (let i = 0; i < res.length; i += 2) {
@@ -34,14 +34,44 @@ function strToLeUtf16(str: string): Uint8Array {
 }
 
 /**
+ * Convert a string to an Uint8Array containing the corresponding UTF-16 code
+ * units in little-endian.
+ * @param {string} str
+ * @returns {Uint8Array}
+ */
+function strToBeUtf16(str: string): Uint8Array {
+  const buffer = new ArrayBuffer(str.length * 2);
+  const res = new Uint8Array(buffer);
+  for (let i = 0; i < res.length; i += 2) {
+    const value = str.charCodeAt(i / 2);
+    res[i + 1] = value & 0xFF;
+    res[i] = value >> 8 & 0xFF;
+  }
+  return res;
+}
+
+/**
  * Construct string from the little-endian UTF-16 code units given.
  * @param {Uint8Array} bytes
  * @returns {string}
  */
-function leUtf16ToStr(bytes : Uint8Array) : string {
+function utf16LEToStr(bytes : Uint8Array) : string {
   let str = "";
   for (let i = 0; i < bytes.length; i += 2) {
     str += String.fromCharCode((bytes[i + 1] << 8) + bytes[i]);
+  }
+  return str;
+}
+
+/**
+ * Construct string from the little-endian UTF-16 code units given.
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+function beUtf16ToStr(bytes : Uint8Array) : string {
+  let str = "";
+  for (let i = 0; i < bytes.length; i += 2) {
+    str += String.fromCharCode((bytes[i] << 8) + bytes[i + 1]);
   }
   return str;
 }
@@ -293,8 +323,11 @@ export {
   strToUtf8,
   utf8ToStr,
 
-  strToLeUtf16,
-  leUtf16ToStr,
+  strToUtf16LE,
+  utf16LEToStr,
+
+  strToBeUtf16,
+  beUtf16ToStr,
 
   guidToUuid,
 };


### PR DESCRIPTION
This commit allows to export util functions related to string to byte parsing and vice-versa.

Considering that an application might have to put its hands into things like challenges or licenses parsing, which depending on the key system might contain text in some form (at least for fairplay and playready) this might be a good idea to let them use our corresponding functions.

I chose to export the following functions for now:
  - `strToUtf8`
  - `utf8ToStr`
  - `strToUtf16LE`: this is `strToLeUtf16` that I renamed by putting the endianness all caps after. This seems to be a more common form for that encoding.
  - `utf16LEToStr`: likewise for `leUtf16ToStr`
  - `strToUtf16BE`: Same thing than strToUtf16LE but for big endian UTF-16.

    We don't need it in the RxPlayer but considering:
      1. We already have a function for little endian UTF-16
      2. It's very easy to implement and test
      3. It should not raise the size of the bundle after tree-shaking occurs

    I chose to add it.

  - `utf16BEToStr`: like `strToUtf16BE` but the other way around

I documented two ways of importing those:
  - Either as a whole `StringUtils` object from `"rx-player/tools"`.

    Example:
    ```js
    import StringUtils from "rx-player/tools";
    console.log(StringUtils.strToUtf16BE("HELLO!"));
    // ...
    ```

  - Either as single function from the `"rx-player/tools/string-utils"` path.

    Example:
    ```js
    import { utf16LEToStr } from "rx-player/tools/string-utils";
    // ...
    ```