### PR TITLE
tools: Make the TextTrackRenderer not experimental anymore

### DIFF
--- a/doc/api/TextTrackRenderer.md
+++ b/doc/api/TextTrackRenderer.md
@@ -29,7 +29,7 @@ import TextTrackRenderer, {
   VTT_PARSER,
   SRT_PARSER,
   SAMI_PARSER,
-} from "rx-player/experimental/tools/TextTrackRenderer";
+} from "rx-player/tools/TextTrackRenderer";
 
 // Add the needed parsers to the TextTrackRenderer
 TextTrackRenderer.addParsers([ TTML_PARSER, VTT_PARSER, SRT_PARSER, SAMI_PARSER ]);
@@ -77,13 +77,9 @@ try {
 
 ## How to import it ############################################################
 
-The TextTrackRenderer is still considered an "experimental" tool. This means
-that its API could change at any new version of the RxPlayer (don't worry, we
-would still document all changes made to it in the corresponding release note).
-
-As an experimental tool, the TextTrackRenderer is imported as such:
+The TextTrackRenderer alone can be imported as such:
 ```ts
-import TextTrackRenderer from "rx-player/experimental/tools/TextTrackRenderer";
+import TextTrackRenderer from "rx-player/tools/TextTrackRenderer";
 ```
 
 But just importing the TextTrackRenderer alone is pointless, you also have to
@@ -98,7 +94,7 @@ of:
 import TextTrackRenderer, {
   TTML_PARSER,
   SRT_PARSER,
-} from "rx-player/experimental/tools/TextTrackRenderer";
+} from "rx-player/tools/TextTrackRenderer";
 TextTrackRenderer.addParsers([ TTML_PARSER, SRT_PARSER ]);
 ```
 

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -93,8 +93,8 @@
     - [LogLevel](#static-LogLevel)
 - [Tools](#tools)
     - [StringUtils](#tools-string-parsing)
+    - [TextTrackRenderer](#tools-textTrackRenderer)
     - [Experimental - MediaCapabilitiesProber](#tools-mediaCapabilitiesProber)
-    - [Experimental - TextTrackRenderer](#tools-textTrackRenderer)
     - [Experimental - parseBifThumbnails](#tools-parseBifThumbnails)
     - [Experimental - createMetaplaylist](#tools-createMetaplaylist)
 
@@ -2645,6 +2645,18 @@ console.log(strToUtf8("hello😀"));
     ```
 
 
+<a name="tools-textTrackRenderer"></a>
+### TextTrackRenderer ##########################################################
+
+The TextTrackRenderer allows to easily render subtitles synchronized to a video
+element.
+
+It allows easily to dynamically add subtitles (as long as it is in one of the
+following format: srt, ttml, webVTT or SAMI) to a played video.
+
+This tool is documented [here](./TextTrackRenderer.md).
+
+
 <a name="tools-mediaCapabilitiesProber"></a>
 ### MediaCapabilitiesProber ####################################################
 
@@ -2664,26 +2676,6 @@ An experimental tool to probe browser media capabilities:
   - Display capabilities
 
 You can find its documentation [here](./mediaCapabilitiesProber.md).
-
-
-<a name="tools-textTrackRenderer"></a>
-### TextTrackRenderer ##########################################################
-
---
-
-:warning: This tool is experimental. This only means that its API can change at
-any new RxPlayer version (with all the details in the corresponding release
-note).
-
---
-
-The TextTrackRenderer allows to easily render subtitles synchronized to a video
-element.
-
-It allows easily to dynamically add subtitles (as long as it is in one of the
-following format: srt, ttml, webVTT or SAMI) to a played video.
-
-This tool is documented [here](./TextTrackRenderer.md).
 
 
 <a name="tools-parseBifThumbnails"></a>

--- a/scripts/generate_builds
+++ b/scripts/generate_builds
@@ -165,74 +165,26 @@ export * from \"../dist/_esm5.processed/features/list/index\";" > features/index
 echo "creating tools build..."
 rm -rf tools
 mkdir tools
-echo "/**
- * Copyright 2015 CANAL+ Group
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+echo "${copyright_text}
 export * from \"../../dist/_esm5.processed/tools/index.js\";" > tools/index.js
-echo "/**
- * Copyright 2015 CANAL+ Group
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+echo "${copyright_text}
 export * from \"../../dist/_esm5.processed/tools/index\";" > tools/index.d.ts
-echo "/**
- * Copyright 2015 CANAL+ Group
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+echo "${copyright_text}
 import StringUtils from \"../../dist/_esm5.processed/tools/string_utils.js\";
 export * from \"../../dist/_esm5.processed/tools/string_utils.js\";
 export default StringUtils;" > tools/string-utils.js
-echo "/**
- * Copyright 2015 CANAL+ Group
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+echo "${copyright_text}
 import StringUtils from \"../../dist/_esm5.processed/tools/string_utils\";
 export * from \"../../dist/_esm5.processed/tools/string_utils\";
 export default StringUtils;" > tools/string-utils.d.ts
+echo "${copyright_text}
+import TextTrackRenderer from \"../../dist/_esm5.processed/tools/TextTrackRenderer/index.js\";
+export * from \"../../dist/_esm5.processed/tools/TextTrackRenderer/index.js\";
+export default TextTrackRenderer;" > tools/TextTrackRenderer.js
+echo "${copyright_text}
+import TextTrackRenderer from \"../../dist/_esm5.processed/tools/TextTrackRenderer/index\";
+export * from \"../../dist/_esm5.processed/tools/TextTrackRenderer/index\";
+export default TextTrackRenderer;" > tools/TextTrackRenderer.d.ts
 
 echo "creating experimental build..."
 rm -rf experimental
@@ -241,14 +193,6 @@ echo "${copyright_text}
 export * from \"../../dist/_esm5.processed/experimental/tools/index.js\";" > experimental/tools/index.js
 echo "${copyright_text}
 export * from \"../../dist/_esm5.processed/experimental/tools/index\";" > experimental/tools/index.d.ts
-echo "${copyright_text}
-import TextTrackRenderer from \"../../dist/_esm5.processed/experimental/tools/TextTrackRenderer/index.js\";
-export * from \"../../dist/_esm5.processed/experimental/tools/TextTrackRenderer/index.js\";
-export default TextTrackRenderer;" > experimental/tools/TextTrackRenderer.js
-echo "${copyright_text}
-import TextTrackRenderer from \"../../dist/_esm5.processed/experimental/tools/TextTrackRenderer/index\";
-export * from \"../../dist/_esm5.processed/experimental/tools/TextTrackRenderer/index\";
-export default TextTrackRenderer;" > experimental/tools/TextTrackRenderer.d.ts
 
 mkdir -p experimental/features
 echo "${copyright_text}

--- a/src/experimental/tools/index.ts
+++ b/src/experimental/tools/index.ts
@@ -17,11 +17,9 @@
 import createMetaplaylist from "./createMetaplaylist";
 import mediaCapabilitiesProber from "./mediaCapabilitiesProber";
 import parseBifThumbnails from "./parseBIFThumbnails";
-import TextTrackRenderer from "./TextTrackRenderer";
 
 export {
   createMetaplaylist,
   mediaCapabilitiesProber,
   parseBifThumbnails,
-  TextTrackRenderer,
 };

--- a/src/tools/TextTrackRenderer/index.ts
+++ b/src/tools/TextTrackRenderer/index.ts
@@ -19,10 +19,10 @@ import TextTrackRenderer, {
 } from "./text_track_renderer";
 
 // -- exported parsers --
-export { HTML_SAMI_PARSER as SAMI_PARSER } from "../../../features/list/html_sami_parser";
-export { HTML_SRT_PARSER as SRT_PARSER } from "../../../features/list/html_srt_parser";
-export { HTML_TTML_PARSER as TTML_PARSER } from "../../../features/list/html_ttml_parser";
-export { HTML_VTT_PARSER as VTT_PARSER } from "../../../features/list/html_vtt_parser";
+export { HTML_SAMI_PARSER as SAMI_PARSER } from "../../features/list/html_sami_parser";
+export { HTML_SRT_PARSER as SRT_PARSER } from "../../features/list/html_srt_parser";
+export { HTML_TTML_PARSER as TTML_PARSER } from "../../features/list/html_ttml_parser";
+export { HTML_VTT_PARSER as VTT_PARSER } from "../../features/list/html_vtt_parser";
 
 export default TextTrackRenderer;
 export { ISetTextTrackArguments };

--- a/src/tools/TextTrackRenderer/text_track_renderer.ts
+++ b/src/tools/TextTrackRenderer/text_track_renderer.ts
@@ -14,20 +14,29 @@
  * limitations under the License.
  */
 
-import HTMLTextSourceBuffer from "../../../custom_source_buffers/text/html";
+import HTMLTextSourceBuffer from "../../custom_source_buffers/text/html";
 import {
   addFeatures,
   IFeatureFunction,
-} from "../../../features";
+} from "../../features";
 
-// Argument for the `setTextTrack` method
+/** Arguments for the `setTextTrack` method. */
 export interface ISetTextTrackArguments {
-  data : string; // All the text tracks to display
-  type : string; // The text track format (e.g. "ttml", "srt", "vtt" or "sami")
-  timeOffset? : number; // Offset, in seconds, that will be added to each
-                        // subtitle's start and end time.
-  language? : string; // Define the language of the subtitles.
-                      // Only needed by some formats, such as SAMI.
+  /** The text track data. */
+  data : string;
+  /** The format of the text track data in `data` (e.g. "ttml", "srt", "vtt" or "sami") */
+  type : string;
+  /**
+   * Offset, in seconds, that will be added to each subtitle's start and end time.
+   * If not set or if set to `0`, no offset will be added.
+   */
+  timeOffset? : number;
+  /**
+   * Define the language of the subtitles.
+   * Only required by some formats, such as SAMI.
+   * Can be unset for most other cases.
+   */
+  language? : string;
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -15,3 +15,6 @@
  */
 
 export * as StringUtils from "./string_utils";
+import TextTrackRenderer from "./TextTrackRenderer";
+
+export { TextTrackRenderer };


### PR DESCRIPTION
Considering the small API of the TextTrackRenderer, and considering it has already been seen to work reliably with multiple formats, we can begin to remove its `experimental` status.

This means that we ensure API compatibility at least until a future `v4.x.x`.