### PR TITLE
demo: integrate RxPlayer directly in the demo bundle

### DIFF
--- a/demo/full/index.html
+++ b/demo/full/index.html
@@ -8,7 +8,6 @@
 <link rel="stylesheet" href="styles/style.css" media="screen">
 <link rel="icon" type="image/x-icon" href="plus.ico" />
 <script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
-<script type="text/javascript" src="./lib.js" charset="utf-8"></script>
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 <title>RxPlayer - CANAL+</title>
 </head>

--- a/demo/full/scripts/controllers/Main.jsx
+++ b/demo/full/scripts/controllers/Main.jsx
@@ -1,3 +1,4 @@
+import RxPlayer from "rx-player";
 import React from "react";
 import Player from "./Player.jsx";
 
@@ -11,7 +12,7 @@ function MainComponent() {
               <img className="rxplayer-logo" alt="RxPlayer" src="./assets/logo_white.png"/>
             </a>
             <a href="https://github.com/canalplus/rx-player/releases">
-              <span className="version">{" v" + window.RxPlayer.version}</span>
+              <span className="version">{" v" + RxPlayer.version}</span>
             </a>
           </h1>
         </section>

--- a/demo/full/scripts/modules/player/index.js
+++ b/demo/full/scripts/modules/player/index.js
@@ -6,13 +6,14 @@
  * application.
  */
 
+import RxPlayer from "rx-player";
 import { linkPlayerEventsToState } from "./events.js";
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import $handleCatchUpMode from "./catchUp";
 
 const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
-  const player = new window.RxPlayer({
+  const player = new RxPlayer({
     limitVideoWidth: false,
     stopAtEnd: false,
     throttleVideoBitrateWhenHidden: true,

--- a/scripts/deploy_new_demo
+++ b/scripts/deploy_new_demo
@@ -57,7 +57,6 @@ cp -r demo/full/fonts $tmpFontsDir -v
 cp -r demo/full/assets $tmpAssetsDir -v
 cp -r demo/full/styles $tmpStylesDir -v
 cp demo/full/bundle.js $tmpDemoFile -v
-cp demo/full/lib.js $tmpRxPlayerFile -v
 cp demo/full/index.html $tmpIndexFile -v
 cp demo/full/plus.ico $tmpFaviconFile -v
 
@@ -69,7 +68,6 @@ rm -rf "$deployed_branch"
 mkdir -p "$deployed_branch"
 mv $tmpIndexFile "${deployed_branch}/index.html"
 mv $tmpFaviconFile "${deployed_branch}/plus.ico"
-mv $tmpRxPlayerFile "${deployed_branch}/lib.js"
 mv $tmpDemoFile "${deployed_branch}/bundle.js"
 mv $tmpFontsDir/fonts "${deployed_branch}/fonts"
 mv $tmpAssetsDir/assets "${deployed_branch}/assets"

--- a/scripts/generate_full_demo.js
+++ b/scripts/generate_full_demo.js
@@ -14,21 +14,14 @@
  * right options.
  */
 
-const path = require("path");
 const Webpack = require("webpack");
 const webpackDemoConfig = require("../webpack-demo.config.js");
-const webpackLibConfig = require("../webpack.config.js");
 const displayWebpackErrors = require("./display_webpack_errors");
 const getHumanReadableHours = require("./get_human_readable_hours");
 
-// overwrite entries/output (ugly but just werks and did not find any better)
-webpackLibConfig.entry = path.join(__dirname, "../src/index.ts");
-webpackLibConfig.output.path = __dirname;
-webpackLibConfig.output.filename = "../demo/full/lib.js";
-
 
 if (require.main === module) {
-  // called directly
+  // This script is called directly
   const { argv } = process;
   if (argv.includes("-h") || argv.includes("--help")) {
     displayHelp();
@@ -37,7 +30,7 @@ if (require.main === module) {
   const shouldWatch = argv.includes("-w") || argv.includes("--watch");
   generateFullDemo({ watch: shouldWatch });
 } else {
-  // loaded as a module
+  // This script is loaded as a module
   module.exports = generateFullDemo;
 }
 
@@ -47,100 +40,28 @@ if (require.main === module) {
  */
 function generateFullDemo(options) {
   const demoCompiler = Webpack(webpackDemoConfig);
-  const libCompiler = Webpack(webpackLibConfig);
-
   if (!options.watch) {
     /* eslint-disable no-console */
-    console.log(
-      `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-        "Building demo..."
-    );
+    console.log(`\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
+                "Building demo...");
     /* eslint-enable no-console */
     demoCompiler.run(onDemoResult);
-
-    /* eslint-disable no-console */
-    console.log(
-      `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-        "Building library..."
-    );
-    /* eslint-enable no-console */
-    libCompiler.run(onLibResult);
   } else {
     /* eslint-disable no-console */
-    console.log(
-      `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-        "Building demo..."
-    );
+    console.log(`\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
+                "Building demo...");
     /* eslint-enable no-console */
-    const demoCompilerWatching = demoCompiler.watch({
-      aggregateTimeout: 300,
-    }, onDemoResult);
+    const demoCompilerWatching = demoCompiler.watch({ aggregateTimeout: 300 },
+                                                    onDemoResult);
 
     demoCompilerWatching.compiler.hooks.watchRun.intercept({
       call() {
         /* eslint-disable no-console */
-        console.log(
-          `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-            "Re-building demo"
-        );
+        console.log(`\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
+                    "Re-building demo");
         /* eslint-enable no-console */
       },
     });
-
-    /* eslint-disable no-console */
-    console.log(
-      `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-        "Building library..."
-    );
-    /* eslint-enable no-console */
-    const libCompilerWatching = libCompiler.watch({
-      aggregateTimeout: 300,
-    }, onLibResult);
-
-    libCompilerWatching.compiler.hooks.watchRun.intercept({
-      call() {
-        /* eslint-disable no-console */
-        console.log(
-          `\x1b[35m[${getHumanReadableHours()}]\x1b[0m ` +
-            "Re-building library"
-        );
-        /* eslint-enable no-console */
-      },
-    });
-  }
-}
-
-/**
- * Display results when the library finished to build.
- * @param {Error|null|undefined} err
- * @param {Object} stats
- */
-function onLibResult(err, stats) {
-  if (err) {
-    /* eslint-disable no-console */
-    console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Could not compile library:`, err);
-    /* eslint-enable no-console */
-    return;
-  }
-
-  if (
-    stats.compilation.errors && stats.compilation.errors.length ||
-    stats.compilation.warnings && stats.compilation.warnings.length
-  ) {
-    const errors = stats.compilation.errors || [];
-    const warnings = stats.compilation.warnings || [];
-    displayWebpackErrors(errors, warnings);
-    /* eslint-disable no-console */
-    console.log(
-      `\x1b[33m[${getHumanReadableHours()}]\x1b[0m ` +
-      `Library built with ${errors.length} error(s) and ` +
-      ` ${warnings.length} warning(s) (in ${stats.endTime - stats.startTime} ms).`
-    );
-    /* eslint-enable no-console */
-  } else {
-    /* eslint-disable no-console */
-    console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m Library built (in ${stats.endTime - stats.startTime} ms).`);
-    /* eslint-enable no-console */
   }
 }
 
@@ -152,28 +73,28 @@ function onLibResult(err, stats) {
 function onDemoResult(err, stats) {
   if (err) {
     /* eslint-disable no-console */
-    console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Could not compile demo:`, err);
+    console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Could not compile demo:`,
+                  err);
     /* eslint-enable no-console */
     return;
   }
 
-  if (
-    stats.compilation.errors && stats.compilation.errors.length ||
-    stats.compilation.warnings && stats.compilation.warnings.length
-  ) {
+  if (stats.compilation.errors && stats.compilation.errors.length ||
+      stats.compilation.warnings && stats.compilation.warnings.length)
+  {
     const errors = stats.compilation.errors || [];
     const warnings = stats.compilation.warnings || [];
     displayWebpackErrors(errors, warnings);
     /* eslint-disable no-console */
-    console.log(
-      `\x1b[33m[${getHumanReadableHours()}]\x1b[0m ` +
-      `Demo built with ${errors.length} error(s) and ` +
-      ` ${warnings.length} warning(s) (in ${stats.endTime - stats.startTime} ms).`
-    );
+    console.log(`\x1b[33m[${getHumanReadableHours()}]\x1b[0m ` +
+                `Demo built with ${errors.length} error(s) and ` +
+                ` ${warnings.length} warning(s) ` +
+                `(in ${stats.endTime - stats.startTime} ms).`);
     /* eslint-enable no-console */
   } else {
     /* eslint-disable no-console */
-    console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m Demo built (in ${stats.endTime - stats.startTime} ms).`);
+    console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m Demo built ` +
+                `(in ${stats.endTime - stats.startTime} ms).`);
     /* eslint-enable no-console */
   }
 }
@@ -189,7 +110,7 @@ function displayHelp() {
 `Usage: node generateFullDemo.js [options]
 Options:
   -h, --help    Display this help
-  -w, --watch   Re-build each time either the demo or library files change`
+  -w, --watch   Re-build each time either the demo or library files change`,
   /* eslint-enable indent */
   );
   /* eslint-enable no-console */

--- a/scripts/update_gh-pages_demo
+++ b/scripts/update_gh-pages_demo
@@ -48,7 +48,6 @@ tmpDemoList=$(mktemp)
 cp -r demo/full/fonts $tmpFontsDir -v
 cp -r demo/full/assets $tmpAssetsDir -v
 cp -r demo/full/styles $tmpStylesDir -v
-cp demo/full/lib.js $tmpRxPlayerFile -v
 cp demo/full/bundle.js $tmpDemoFile -v
 cp demo/full/index.html $tmpIndexFile -v
 cp demo/full/plus.ico $tmpFaviconFile -v
@@ -62,14 +61,12 @@ rm -rf "versions/$current_version/demo"
 mkdir -p "versions/$current_version/demo"
 rm index.html
 rm plus.ico
-rm lib.js
 rm bundle.js
 rm -rf fonts
 rm -rf assets
 rm -rf styles
 mv $tmpIndexFile "versions/$current_version/demo/index.html"
 mv $tmpFaviconFile "versions/$current_version/demo/plus.ico"
-mv $tmpRxPlayerFile "versions/$current_version/demo/lib.js"
 mv $tmpDemoFile "versions/$current_version/demo/bundle.js"
 mv $tmpFontsDir/fonts "versions/$current_version/demo/fonts"
 mv $tmpAssetsDir/assets "versions/$current_version/demo/assets"
@@ -77,7 +74,6 @@ mv $tmpStylesDir/styles "versions/$current_version/demo/styles"
 mv $tmpDemoList generate_demo_list.js
 ln -s "./versions/$current_version/demo/index.html" index.html
 ln -s "./versions/$current_version/demo/plus.ico" plus.ico
-ln -s "./versions/$current_version/demo/lib.js" lib.js
 ln -s "./versions/$current_version/demo/bundle.js" bundle.js
 ln -s "./versions/$current_version/demo/fonts" fonts
 ln -s "./versions/$current_version/demo/assets" assets
@@ -86,10 +82,10 @@ ln -s "./versions/$current_version/demo/styles" styles
 node generate_demo_list.js
 rm generate_demo_list.js
 
-if [ -n "$(git status --porcelain lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html)" ]; then
+if [ -n "$(git status --porcelain bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html)" ]; then
   echo "-- Current Status on gh-pages: --"
   echo ""
-  git status lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
+  git status bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
 
   while : ; do
     echo ""
@@ -111,21 +107,21 @@ if [ -n "$(git status --porcelain lib.js bundle.js styles fonts assets index.htm
       echo "| h: see this help                                       |"
       echo "+--------------------------------------------------------+"
     elif [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-      git add lib.js bundle.js styles fonts assets index.html plus.ico "versions/$current_version/demo" demo_page_by_version.html
+      git add bundle.js styles fonts assets index.html plus.ico "versions/$current_version/demo" demo_page_by_version.html
       git commit -m "demo: deploy $current_version to the gh-pages" -S
       git push origin gh-pages
       break
     elif [[ $REPLY =~ ^[Dd](iff)?$ ]]; then
-      git diff lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html || true # ignore when return 1
+      git diff bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html || true # ignore when return 1
     elif [[ $REPLY =~ ^[Ss](tatus)?$ ]]; then
-      git status lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
+      git status bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
     elif [[ $REPLY =~ ^[Aa](bort)?$ ]]; then
       echo "exiting"
       exit 0
     elif [[ $REPLY =~ ^[Cc](heckout)?$ ]]; then
-      git checkout lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
+      git checkout bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
     elif [[ $REPLY =~ ^([Tt]|([Ss]tash))?$ ]]; then
-      git stash -u push lib.js bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
+      git stash -u push bundle.js styles fonts assets index.html "versions/$current_version/demo" demo_page_by_version.html
       break
     fi
   done

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,5 +2,5 @@ sonar.projectKey=rx-player
 sonar.projectName=rx-player
 sonar.projectVersion=3.21.1
 sonar.sources=./src,./demo,./tests
-sonar.exclusions=demo/full/bundle.js,demo/full/lib.js,demo/standalone/lib.js,demo/bundle.js
+sonar.exclusions=demo/full/bundle.js,demo/standalone/lib.js,demo/bundle.js
 sonar.host.url=https://sonarcloud.io

--- a/webpack-demo.config.js
+++ b/webpack-demo.config.js
@@ -15,6 +15,14 @@ const isDevMode = RXP_ENV === "development";
 module.exports = {
   mode: isDevMode ? "development" : "production",
   entry: path.join(__dirname, "./demo/full/scripts/index.jsx"),
+  resolve: {
+    extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
+    alias: {
+      ["rx-player$"]: path.resolve(__dirname, "src/index.ts"),
+      ["rx-player/tools$"]: path.resolve(__dirname, "src/tools/index.ts"),
+      ["rx-player/experimental/tools$"]: path.resolve(__dirname, "src/experimental/tools/index.ts"),
+    },
+  },
   output: {
     path: path.join(__dirname, "./demo/full"),
     filename: "bundle.js",
@@ -31,6 +39,15 @@ module.exports = {
   },
   module: {
     rules: [
+      {
+        test: /\.tsx?$/,
+        use: [{
+          loader: "ts-loader",
+          options: {
+            compilerOptions: { sourceMap: true },
+          },
+        }],
+      },
       {
         test: /\.jsx?$/,
         use: {
@@ -63,6 +80,46 @@ module.exports = {
       "__LOGGER_LEVEL__": "\"INFO\"",
       "process.env": {
         NODE_ENV: JSON.stringify("production"),
+      },
+      "__FEATURES__": {
+        BIF_PARSER: true,
+        DASH: true,
+        DIRECTFILE: true,
+        EME: true,
+        HTML_SAMI: true,
+        HTML_SRT: true,
+        HTML_TTML: true,
+        HTML_VTT: true,
+        LOCAL_MANIFEST: true,
+        METAPLAYLIST: true,
+        NATIVE_SAMI: true,
+        NATIVE_SRT: true,
+        NATIVE_TTML: true,
+        NATIVE_VTT: true,
+        SMOOTH: true,
+      },
+
+      // Path relative to src/features where optional features are implemented
+      __RELATIVE_PATH__: {
+        BIF_PARSER: JSON.stringify("../parsers/images/bif.ts"),
+        DASH: JSON.stringify("../transports/dash/index.ts"),
+        DIRECTFILE: JSON.stringify("../core/init/initialize_directfile.ts"),
+        EME_MANAGER: JSON.stringify("../core/eme/index.ts"),
+        HTML_SAMI: JSON.stringify("../parsers/texttracks/sami/html.ts"),
+        HTML_SRT: JSON.stringify("../parsers/texttracks/srt/html.ts"),
+        HTML_TEXT_BUFFER: JSON.stringify("../custom_source_buffers/text/html/index.ts"),
+        HTML_TTML: JSON.stringify("../parsers/texttracks/ttml/html/index.ts"),
+        HTML_VTT: JSON.stringify("../parsers/texttracks/webvtt/html/index.ts"),
+        IMAGE_BUFFER: JSON.stringify("../custom_source_buffers/image/index.ts"),
+        LOCAL_MANIFEST: JSON.stringify("../transports/local/index.ts"),
+        MEDIA_ELEMENT_TRACK_CHOICE_MANAGER: JSON.stringify("../core/api/media_element_track_choice_manager.ts"),
+        METAPLAYLIST: JSON.stringify("../transports/metaplaylist/index.ts"),
+        NATIVE_SAMI: JSON.stringify("../parsers/texttracks/sami/native.ts"),
+        NATIVE_SRT: JSON.stringify("../parsers/texttracks/srt/native.ts"),
+        NATIVE_TEXT_BUFFER: JSON.stringify("../custom_source_buffers/text/native/index.ts"),
+        NATIVE_TTML: JSON.stringify("../parsers/texttracks/ttml/native/index.ts"),
+        NATIVE_VTT: JSON.stringify("../parsers/texttracks/webvtt/native/index.ts"),
+        SMOOTH: JSON.stringify("../transports/smooth/index.ts"),
       },
     }),
   ],


### PR DESCRIPTION
This commit tries to simplify the building phase of the demo, especially now that we'll be more and more dependant on using external RxPlayer tools in it.

Previously, the demo code was separated into two big files:
  - the RxPlayer "lib" file as `lib.js`
  - the demo file as `bundle.js`

Both of them were then included in the demo's `index.html` and `bundle.js` relied on the RxPlayer being accessible through `window.RxPlayer`.

This worked perfectly but there are multiple drawbacks here:

  - Going through `window.RxPlayer` corresponds to the legacy way of depending on the RxPlayer. We advise people to rely on usual ES6 `import` statements everywhere else.

  - In this mode, we cannot rely on features such as tree-shaking.

  - In this mode, we cannot access to the RxPlayer's tools as they are not exposed through `window` but only when imported through `"rx-player/tools"`.
    This is becoming even more important now that the `VideoThumbnailLoader` and the `StringUtils` tools are coming, as both could become useful to the demo.

What I decided here is to update the `webpack-demo.config.js` file which was previously only used to compile the demo down to a `bundle.js` to now also be able to build the RxPlayer's code (by adding typescript rules and by setting compile-time constants there).

I choose to rely on the full RxPlayer (not the minimal one) and to enable all features through the `__FEATURES__` compile-time flags. I also could just import the minimal player on the demo side and import all wanted features one by one in the demo, but considering all (or almost all?) features are used in the demo, I did not see the point of doing that.

I then relied on a webpack features called "alias" which allows to easily gives alias to modules, so as the RxPlayer defined in
`src/index.ts` can be always imported through "rx-player" and, more importantly, tools can be imported through "rx-player/tools".

The build time seems to not be impacted by this change which is a good news. Another good news is that the whole demo size was slightly reduced.

A downside is that the re-building happening after a file modification seems to take a little more time, but it stays at an acceptable level (3 seconds on my PC for a modification on the RxPlayer's `RepresentationStream`).

--

Note: Another upside is that it is now becoming very simple to transition the demo to typescript.
It should now be possible to translate any demo file to typescript and it should work directly.