### PR TITLE
Fixed VideoTrack demo index being limited to 1 (first choice)

### DIFF
--- a/demo/full/scripts/controllers/knobs/VideoTrack.jsx
+++ b/demo/full/scripts/controllers/knobs/VideoTrack.jsx
@@ -13,19 +13,19 @@ const VideoTrackKnobBase = ({
   currentVideoTrack,
 }) => {
   let options = [];
-  let selectedIndex;
+  let selectedIndex = 0;
 
   if (!availableVideoTracks.length) {
     options = ["Not available"];
-    selectedIndex = 0;
   } else {
     options = ["no video track"].concat(
       availableVideoTracks.map((track, i) => `track ${i}: ${track.id}`),
     );
 
-    selectedIndex = currentVideoTrack ?
-      Math.max(findVideoTrackIndex(currentVideoTrack, availableVideoTracks), 1)
-      : 0;
+    if (currentVideoTrack) {
+      selectedIndex =
+        1 + findVideoTrackIndex(currentVideoTrack, availableVideoTracks);
+    }
   }
 
   const onTrackChange = (evt) => {


### PR DESCRIPTION
Until now, on video track list on RxPlayer's demo, the selected choice was always the wrong one (one upper) when the selected track index was upper than 1.
For example, if you selected the first choice, it was the first one selected. But when if you selected the third, it will be the second one selected, etc.

The index assignment operation in the demo code was wrong because it didn't take into account the first index to be associated to "no track" for the user. And the minimal value was still 1.

Now, the bug does not exist anymore.