### PR TITLE
[Proposal] Add "conformance tests"

### DIFF
--- a/doc/architecture/files.md
+++ b/doc/architecture/files.md
@@ -31,7 +31,7 @@ a single directory or subdirectory, in alphabetical order.
   - [src/core/source_buffers/: SourceBuffers definitions](#core-sb)
   - [src/core/init/: Media streaming logic](#core-init)
 - [src/**/__tests__: the unit tests directories](#src-tests)
-- [tests/: Test strategies, integration and memory tests](#tests)
+- [tests/: the player's tests](#tests)
 
 
 <a name="demo"></a>
@@ -321,17 +321,31 @@ but should still be suffixed by `.test.ts`.
 
 
 <a name="tests"></a>
-## The tests/ directory: Test strategies, integration and memory tests #########
+## The tests/ directory: the player's tests ####################################
 
-The rx-player contains integration tests (test the whole player), unit tests
-(test specific parts of the code) and memory tests (tests the memory usage of
-the player).
+This directory contains most testing code for the RxPlayer.
 
-Integration tests are entirely written in the ``tests/integration``
-subdirectory.
+The rx-player contains multiple type of tests:
 
-Memory tests are entirely written in the ``tests/memory`` subdirectory.
+  - integration tests: test the whole player API and its behavior when playing
+    different contents. The main goal of those tests is to quickly detect
+    regressions.
 
-As for unit tests, they are written alongside the code, in ``__tests__``
-directories. All its configuration can be found at the root of the project,
-in `jest.config.js` (we use the jest library for unit tests).
+    Those are entirely written in the ``tests/integration`` sub-directory.
+
+  - conformance tests: Provide standalone page which allows to quickly test the
+    support of various media-related API on a given device and/or browser.
+
+    The html documents you will find here are basic templates that can be easily
+    modified and deployed for quick testing.
+
+  - unit tests: test specific parts of the code. The main goal here is to check
+    the implementation of smaller units of code.
+
+    They are written alongside the code, in ``__tests__``
+    directories. All its configuration can be found at the root of the project,
+    in `jest.config.js` (we use the jest library for unit tests).
+
+  - memory tests: test the memory usage of the player.
+
+    They are entirely written in the ``tests/memory`` subdirectory.

--- a/tests/conformance/hdcp_policy_check.html
+++ b/tests/conformance/hdcp_policy_check.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<!--
+
+This file allows to quickly test if:
+  - the `getStatusForPolicy` API is defined.
+  - if it is, which HDCP levels are deemed as "usable".
+
+To do that:
+
+  1. update the `keySystem`, `configuration` and `hdcpLevels` properties in the
+     script part of the document.
+
+  2. Run this page from the environment (device and/or browser) you want to test
+
+  3. Check the logs, that's it!
+
+-->
+<html lang="en">
+  <head>
+    <head>
+      <meta charset="UTF-8">
+      <title>RxPlayer Conformance Test - MediaKeySystemAccess support</title>
+    </head>
+    <body>
+      <script charset="utf-8">
+/* eslint-disable no-console */
+/*
+ * Edit those variables to test on a specific MediaKeySystemAccess
+ * configuration.
+ */
+const keySystem = "com.widevine.alpha";
+const configuration = [{
+  initDataTypes: ["cenc"],
+  audioCapabilities:[{
+    robustness: "",
+    contentType: "audio/mp4; codecs=\"mp4a.40.2\"",
+  }],
+  videoCapabilities:[{
+    robustness: "",
+    contentType: "video/mp4;codecs=\"avc1.640028\"",
+  }],
+  sessionTypes: ["temporary"],
+}];
+
+const hdcpLevels = [
+  "1.0", "1.1", "1.2", "1.3", "1.4",
+  "2.0", "2.1", "2.2", "2.3",
+];
+
+console.log("Calling requestMediaKeySystemAccess...");
+navigator.requestMediaKeySystemAccess(keySystem, configuration)
+  .then(mediaKeySystemAccess => {
+    console.log("MediaKeySystemAccess created!",
+                mediaKeySystemAccess.getConfiguration());
+    console.log("Creating MediaKeys...");
+    return mediaKeySystemAccess.createMediaKeys();
+  })
+  .then(mediaKeys => {
+    console.log("MediaKeys created!");
+    console.log("Getting HDCP status...");
+    if (!("getStatusForPolicy" in mediaKeys)) {
+      console.error("getStatusForPolicy API not available.");
+      return ;
+    }
+    recursivelyTestMinHDCPVersion(mediaKeys, 0);
+  });
+
+/**
+ * Test all "minHdcpVersion" in `hdcpLevels`, starting from the index `idx`.
+ * @param {MediaKeys} mediaKeys
+ * @param {number} idx
+ */
+function recursivelyTestMinHDCPVersion(mediaKeys, idx) {
+  if (idx >= hdcpLevels.length) {
+    console.log("Done!");
+    return;
+  }
+  const minHdcpVersion = hdcpLevels[idx];
+  mediaKeys.getStatusForPolicy({ minHdcpVersion })
+    .then(status => {
+      if (status !== "usable") {
+        console.error(`HDCP level ${minHdcpVersion} not usable.`);
+        return;
+      }
+      console.log(`HDCP level ${minHdcpVersion} usable!`);
+    }).catch((err) => {
+      console.error("`getStatusForPolicy` API failed", err);
+    }).finally(() => {
+      recursivelyTestMinHDCPVersion(mediaKeys, idx + 1);
+    });
+}
+      </script>
+    </body>
+</html>

--- a/tests/conformance/media_key_system_access.html
+++ b/tests/conformance/media_key_system_access.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<!--
+
+This file allows to quickly test which MediaKeySystemAccess is supported on the
+current device.
+
+To do that:
+
+  1. update the `configs` property in the script part of the document.
+
+  2. Run this page from the environment (device and/or browser) you want to test
+
+  3. Check the logs, that's it!
+
+-->
+<html lang="en">
+  <head>
+    <head>
+      <meta charset="UTF-8">
+      <title>RxPlayer Conformance Test - MediaKeySystemAccess support</title>
+    </head>
+    <body>
+      <script charset="utf-8">
+/* eslint-disable no-console */
+
+/* Edit this variable to test available MediaKeySystemAccess configurations. */
+const configs = [
+  {
+    keySystem: "com.widevine.alpha",
+    configuration: [{
+      initDataTypes: ["cenc"],
+      audioCapabilities:[{
+        robustness: "",
+        contentType: "audio/mp4; codecs=\"mp4a.40.2\"",
+      }],
+      videoCapabilities:[{
+        robustness: "",
+        contentType: "video/mp4;codecs=\"avc1.640028\"",
+      }],
+      sessionTypes: ["temporary"],
+    }],
+  },
+  {
+    keySystem: "com.microsoft.playready",
+    configuration: [{
+      initDataTypes: ["cenc"],
+      audioCapabilities:[{
+        robustness: "",
+        contentType: "audio/mp4; codecs=\"mp4a.40.2\"",
+      }],
+      videoCapabilities:[{
+        robustness: "",
+        contentType: "video/mp4;codecs=\"avc1.640028\"",
+      }],
+      sessionTypes: ["temporary"],
+    }],
+  },
+];
+
+start();
+
+function start() {
+  recursivelyTestConfig(0);
+}
+
+/**
+ * Recursively tests all MediaKeySystemConfiguration configured in the `configs`
+ * object from the given `idx` index.
+ * @param {number} idx
+ */
+function recursivelyTestConfig(idx) {
+  if (idx >= configs.length) {
+    console.log("Done!");
+    return;
+  }
+
+  const videoElement = createVideoElement();
+  const { keySystem, configuration } = configs[idx];
+  console.log("Testing new config:", keySystem, configuration);
+  createMediaKeySystemAccess(keySystem, configuration)
+    .then((mediaKeySystemAccess) => {
+      return createMediaKeys(mediaKeySystemAccess);
+    })
+    .then((mediaKeys) => {
+      return attachMediaKeysToVideoElement(mediaKeys, videoElement);
+    }).then(() => {
+      console.log(`Configuration ${idx} succeeded!`,
+                  keySystem,
+                  configuration);
+    }).finally(() => {
+      removeElement(videoElement);
+      recursivelyTestConfig(idx + 1);
+    });
+}
+
+/**
+ * @returns {HTMLVideoElement}
+ */
+function createVideoElement() {
+  console.log("Creating video element...");
+  const elt = document.createElement("video");
+  document.body.appendChild(elt);
+  console.log("Video element created.");
+  return elt;
+}
+
+/**
+ * @param {HTMLMediaElement} element
+ */
+function removeElement(element) {
+  element.parentElement.removeChild(element);
+}
+
+/**
+ * @param {string} keySystem
+ * @param {MediaKeySystemConfiguration} mediaKeySystemAccessConfig
+ * @returns {Promise.<MediaKeySystemAccess>}
+ */
+function createMediaKeySystemAccess(keySystem, mediaKeySystemAccessConfig) {
+  console.log("Creating MediaKeySystemAccess");
+  return navigator.requestMediaKeySystemAccess(
+    keySystem,
+    mediaKeySystemAccessConfig,
+  ).then(
+    (mediaKeySystemAccess) => {
+      console.log("MediaKeySystemAccess created.",
+                  mediaKeySystemAccess.getConfiguration());
+      return mediaKeySystemAccess;
+    },
+    (err) => {
+      console.error("Failed to create MediaKeySystemAccess",
+                    keySystem,
+                    mediaKeySystemAccessConfig,
+                    err);
+      throw err;
+    },
+  );
+}
+
+/**
+ * Create A MediaKeys from the given MediaKeySystemAccess.
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess
+ * @returns {Promise}
+ */
+function createMediaKeys(mediaKeySystemAccess) {
+  console.log("Creating MediaKeys.");
+  return mediaKeySystemAccess.createMediaKeys().then(
+    (mediaKeys) => {
+      console.log("MediaKeys created.");
+      return mediaKeys;
+    },
+    (err) => {
+      console.error("Failed to create MediaKeys", err);
+      throw err;
+    },
+  );
+}
+
+/**
+ * Attach the given MediaKeys instance to the given HTMLVideoElement.
+ * @param {MediaKeys} mediaKeys
+ * @param {HTMLVideoElement} videoElement
+ * @returns {Promise}
+ */
+function attachMediaKeysToVideoElement(mediaKeys, videoElement) {
+  console.log("Attaching MediaKeys...");
+  return videoElement.setMediaKeys(mediaKeys).then(
+    () => {
+      console.log("MediaKeys attached.");
+    },
+    (err) => {
+      console.error("Failed to create MediaKeys", err);
+      throw err;
+    },
+  );
+}
+      </script>
+    </body>
+</html>


### PR DESCRIPTION
This is a first try at the implementation of "conformance tests" which allows to quickly test browser API support in various environments (devices and browser).

I added the `conformance` sub-directory in `tests`, which for now contains two HTML files:

  - `media_key_system_access.html`: to quickly check which CDM is available on the platform and which configuration is accepted.

  - `hdcp_policy_check.html`: to quickly check if the `MediaKeys.getStatusForPolicy` is defined and to check if it can be used to detect in advance which minimum HDCP version is supported under the current conditions.

The goal for now with those files is that they can be used as templates we can quickly update to check the support of various features without the need to run and deploy a whole RxPlayer build.

I chose to only define two plain HTML files for now just so it stays very simple to update and deploy but I could imagine factorizing some code in the future and adding a building step when/if we add a lot of different tests there.

How each test can be configured and used is defined as a comment at the top of the corresponding HTML file.

---

Note that we could also use RxPlayer tools to help us with that such as the `MediaCapabilitiesProber`.
Here, I just wanted to do quick and dirty tests so I rewrote everything from scratch and didn't take time to read those tools' API (and to think about how I could integrate it to those tests),  but it could also be used here.