### PR TITLE
Apply default style to TTML if not encountered

### DIFF
--- a/src/parsers/texttracks/ttml/html/create_element.ts
+++ b/src/parsers/texttracks/ttml/html/create_element.ts
@@ -258,9 +258,9 @@ function applyGeneralStyle(
 
   // applies to region
   const displayAlign = style.displayAlign;
-  element.style.display = "flex";
-  element.style.flexDirection = "column";
   if (isNonEmptyString(displayAlign)) {
+    element.style.display = "flex";
+    element.style.flexDirection = "column";
     switch (displayAlign) {
       case "before":
         element.style.justifyContent = "flex-start";

--- a/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
+++ b/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
@@ -64,8 +64,8 @@ const STYLE_ATTRIBUTES = [ "backgroundColor",
                            ];
 
 /**
- * Apply a default style to TTML cue if no conflict is detected
- * with current cue style.
+ * Apply a default style to TTML cue if no style has been already
+ * declared and no conflict is detected with current cue style.
  *
  * No position, orientation and dimension style should have been
  * set to avoid any conflict.

--- a/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
+++ b/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
@@ -35,33 +35,87 @@ import parseCue, {
   ITTMLHTMLCue,
 } from "./parse_cue";
 
- const STYLE_ATTRIBUTES = [ "backgroundColor",
-                            "color",
-                            "direction",
-                            "display",
-                            "displayAlign",
-                            "extent",
-                            "fontFamily",
-                            "fontSize",
-                            "fontStyle",
-                            "fontWeight",
-                            "lineHeight",
-                            "opacity",
-                            "origin",
-                            "overflow",
-                            "padding",
-                            "textAlign",
-                            "textDecoration",
-                            "textOutline",
-                            "unicodeBidi",
-                            "visibility",
-                            "wrapOption",
-                            "writingMode",
+const STYLE_ATTRIBUTES = [ "backgroundColor",
+                           "color",
+                           "direction",
+                           "display",
+                           "displayAlign",
+                           "extent",
+                           "fontFamily",
+                           "fontSize",
+                           "fontStyle",
+                           "fontWeight",
+                           "lineHeight",
+                           "opacity",
+                           "origin",
+                           "overflow",
+                           "padding",
+                           "textAlign",
+                           "textDecoration",
+                           "textOutline",
+                           "unicodeBidi",
+                           "visibility",
+                           "wrapOption",
+                           "writingMode",
 
-                            // Not managed anywhere for now
-                            // "showBackground",
-                            // "zIndex",
-                            ];
+                           // Not managed anywhere for now
+                           // "showBackground",
+                           // "zIndex",
+                           ];
+
+/**
+ * Apply a default style to TTML cue if no conflict is detected
+ * with current cue style.
+ *
+ * No position, orientation and dimension style should have been
+ * set to avoid any conflict.
+ *
+ * The default style propose to set the cue at the bottom, centered
+ * and lightly spaced apart from the edges :
+ *
+ *        -----------------------------------------------
+ *        |                                             |
+ *        |                                             |
+ *        |                                             |
+ *        |                                             |
+ *        |                                             |
+ *        |                                             |
+ *        |            subtitle is displayed            |
+ *        |                    here                     |
+ *        -----------------------------------------------
+ *
+ * @param {Object} cue
+ */
+function applyDefaultTTMLCSSStyle(cue: ITTMLHTMLCue): void {
+  const { element } = cue;
+  const { style: cueStyle } = element;
+  const { childNodes: paragraphNodes } = element;
+  const mainParagraphNode = paragraphNodes[0] as HTMLElement;
+  if (// cue region dimensions
+      cueStyle.width === "" &&
+      cueStyle.height === "" &&
+      // cue region position
+      cueStyle.position === "" &&
+      cueStyle.left === "" &&
+      cueStyle.top === "" &&
+      // cue text position
+      cueStyle.display === "" &&
+      cueStyle.flexDirection === "" &&
+      cueStyle.justifyContent === "" &&
+      // cue text centering
+      mainParagraphNode !== undefined &&
+      mainParagraphNode.style.textAlign === "") {
+    cueStyle.width = "70%";
+    cueStyle.height = "20%";
+    cueStyle.position = "relative";
+    cueStyle.left = "15%";
+    cueStyle.top = "80%";
+    cueStyle.display = "flex";
+    cueStyle.flexDirection = "column";
+    cueStyle.justifyContent = "flex-start";
+    mainParagraphNode.style.textAlign = "center";
+  }
+}
 
 /**
  * Create array of objects which should represent the given TTML text track.
@@ -186,7 +240,9 @@ export default function parseTTMLStringToDIV(
                              paragraphStyle,
                              ttParams,
                              shouldTrimWhiteSpaceOnParagraph);
+
         if (cue !== null) {
+          applyDefaultTTMLCSSStyle(cue);
           ret.push(cue);
         }
       }

--- a/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
+++ b/src/parsers/texttracks/ttml/html/parse_ttml_to_div.ts
@@ -85,6 +85,9 @@ const STYLE_ATTRIBUTES = [ "backgroundColor",
  *        -----------------------------------------------
  *
  * @param {Object} cue
+ * TODO This code can be seen as risky because we might not predict every
+ * possible styles that can enter in conflict.
+ * A better solution should be found in the future
  */
 function applyDefaultTTMLCSSStyle(cue: ITTMLHTMLCue): void {
   const { element } = cue;


### PR DESCRIPTION
No ttml default style seems to be defined in the ttml spec. We choose then that the cue may display in the clearer and cleaner possible way. We now consider that, if no style is declared into the file, we should apply a default region style :

    centred text
    bottom-fixed text

/!\ If no styles are defined for regions, but other styles are, we decide not to apply the default region style. Indeed, we consider the style to have been defined on purpose, and we may interfere with the overall look of the cue if we apply a different style.
As no default style seems to be defined in the ttml spec, we choose to apply the default one if there are no declared style in the final cue, as it may not interfere with any declared one.

Moreover, we now set a white text color by default.