### PR TITLE
Be more explicit with RxPlayer's event types

### DIFF
--- a/src/core/init/create_eme_manager.ts
+++ b/src/core/init/create_eme_manager.ts
@@ -35,6 +35,10 @@ import {
 
 const { onEncrypted$ } = events;
 
+/**
+ * Event emitted after deciding that no EME logic should be launched for the
+ * current content.
+ */
 export interface IEMEDisabledEvent { type: "eme-disabled"; }
 
 /**

--- a/src/core/init/events_generators.ts
+++ b/src/core/init/events_generators.ts
@@ -31,7 +31,6 @@ import {
   IManifestReadyEvent,
   IManifestUpdateEvent,
   IReloadingMediaSourceEvent,
-  ISpeedChangedEvent,
   IStalledEvent,
   IWarningEvent,
 } from "./types";
@@ -87,15 +86,6 @@ function manifestUpdate() : IManifestUpdateEvent {
 }
 
 /**
- * Construct a "speedChanged" event.
- * @param {Number} speed
- * @returns {Object}
- */
-function speedChanged(speed : number) : ISpeedChangedEvent {
-  return { type: "speedChanged", value: speed };
-}
-
-/**
  * Construct a "representationChange" event.
  * @param {string} type
  * @param {Object} period
@@ -134,7 +124,6 @@ const INIT_EVENTS = { loaded,
                       manifestUpdate,
                       nullRepresentation,
                       reloadingMediaSource,
-                      speedChanged,
                       stalled,
                       warning };
 

--- a/src/core/init/index.ts
+++ b/src/core/init/index.ts
@@ -16,14 +16,12 @@
 
 import { IStallingItem } from "./get_stalled_events";
 import InitializeOnMediaSource, {
-  IInitEvent,
   IInitializeArguments,
 } from "./initialize_media_source";
 export * from "./types";
 
 export default InitializeOnMediaSource;
 export {
-  IInitEvent,
   IInitializeArguments,
   IStallingItem,
 };

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -41,24 +41,16 @@ import {
 import { MediaError } from "../../errors";
 import log from "../../log";
 import deferSubscriptions from "../../utils/defer_subscriptions";
-import {
-  IEMEManagerEvent,
-  IKeySystemOption,
-} from "../eme";
-import createEMEManager, {
-  IEMEDisabledEvent,
-} from "./create_eme_manager";
+import { IKeySystemOption } from "../eme";
+import createEMEManager from "./create_eme_manager";
 import EVENTS from "./events_generators";
 import { IInitialTimeOptions } from "./get_initial_time";
 import getStalledEvents from "./get_stalled_events";
 import seekAndLoadOnMediaEvents from "./initial_seek_and_play";
 import throwOnMediaError from "./throw_on_media_error";
 import {
+  IDirectfileEvent,
   IInitClockTick,
-  ILoadedEvent,
-  ISpeedChangedEvent,
-  IStalledEvent,
-  IWarningEvent,
 } from "./types";
 import updatePlaybackRate from "./update_playback_rate";
 
@@ -116,14 +108,6 @@ export interface IDirectFileOptions { autoPlay : boolean;
                                       startAt? : IInitialTimeOptions;
                                       url? : string; }
 
-// Events emitted by `initializeDirectfileContent`
-export type IDirectfileEvent = ISpeedChangedEvent |
-                               IStalledEvent |
-                               ILoadedEvent |
-                               IWarningEvent |
-                               IEMEManagerEvent |
-                               IEMEDisabledEvent;
-
 /**
  * Launch a content in "Directfile mode".
  * @param {Object} directfileOptions
@@ -174,7 +158,7 @@ export default function initializeDirectfileContent({
   // little longer while the buffer is empty.
   const playbackRate$ =
     updatePlaybackRate(mediaElement, speed$, clock$, { pauseWhenStalled: true })
-      .pipe(map(EVENTS.speedChanged));
+      .pipe(ignoreElements());
 
   // Create Stalling Manager, an observable which will try to get out of
   // various infinite stalling issues
@@ -216,3 +200,5 @@ export default function initializeDirectfileContent({
                          playbackRate$,
                          stalled$);
 }
+
+export { IDirectfileEvent };

--- a/src/core/init/stream_events_emitter/index.ts
+++ b/src/core/init/stream_events_emitter/index.ts
@@ -20,12 +20,17 @@ import {
   IPublicStreamEvent,
   IStreamEvent,
   IStreamEventData,
+  IStreamEventEvent,
+  IStreamEventSkipEvent,
 } from "./types";
 
 export {
   IStreamEvent,
   IStreamEventData,
   IPublicNonFiniteStreamEvent,
-  IPublicStreamEvent
+  IPublicStreamEvent,
+
+  IStreamEventEvent,
+  IStreamEventSkipEvent,
 };
 export default streamEventsEmitter;

--- a/src/core/init/stream_events_emitter/types.ts
+++ b/src/core/init/stream_events_emitter/types.ts
@@ -50,8 +50,20 @@ export interface IPublicStreamEvent {
   onExit?: () => void;
 }
 
-/** Events sent by the `streamEventsEmitter`. */
-export interface IStreamEvent {
-  type: "stream-event" | "stream-event-skip";
-  value: IPublicStreamEvent | IPublicNonFiniteStreamEvent;
+/** Event emitted when a stream event is encountered. */
+export interface IStreamEventEvent {
+  type: "stream-event";
+  value: IPublicStreamEvent |
+         IPublicNonFiniteStreamEvent;
 }
+
+/** Event emitted when a stream event has just been skipped. */
+export interface IStreamEventSkipEvent {
+  type: "stream-event-skip";
+  value: IPublicStreamEvent |
+         IPublicNonFiniteStreamEvent;
+}
+
+/** Events sent by the `streamEventsEmitter`. */
+export type IStreamEvent = IStreamEventEvent |
+                           IStreamEventSkipEvent;

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -21,11 +21,42 @@ import Manifest, {
   Representation,
 } from "../../manifest";
 import { IStalledStatus } from "../api";
+import {
+  IAttachedMediaKeysEvent,
+  IBlacklistKeysEvent,
+  IBlacklistProtectionDataEvent,
+  ICreatedMediaKeysEvent,
+  IEncryptedEvent,
+  IInitDataIgnoredEvent,
+  INoUpdateEvent,
+  ISessionMessageEvent,
+  ISessionUpdatedEvent,
+} from "../eme";
 import SegmentBuffersStore from "../segment_buffers";
-import { IRepresentationChangeEvent } from "../stream";
+import {
+  IActivePeriodChangedEvent,
+  IAdaptationChangeEvent,
+  IBitrateEstimationChangeEvent,
+  ICompletedStreamEvent,
+  INeedsDecipherabilityFlush,
+  INeedsMediaSourceReload,
+  IPeriodStreamClearedEvent,
+  IPeriodStreamReadyEvent,
+  IProtectedSegmentEvent,
+  IRepresentationChangeEvent,
+  IStreamEventAddedSegment,
+  IStreamManifestMightBeOutOfSync,
+  IStreamNeedsManifestRefresh,
+  IStreamStateActive,
+} from "../stream";
+import { IEMEDisabledEvent } from "./create_eme_manager";
 import { IStallingItem } from "./get_stalled_events";
+import {
+  IStreamEventEvent,
+  IStreamEventSkipEvent,
+} from "./stream_events_emitter";
 
-// Object emitted when the clock ticks
+/** Object awaited by the `Init` on each clock tick. */
 export interface IInitClockTick { currentTime : number;
                                   buffered : TimeRanges;
                                   duration : number;
@@ -41,18 +72,25 @@ export interface IInitClockTick { currentTime : number;
                                             null;
                                   seeking : boolean; }
 
-// The Manifest has been downloaded and parsed for the first time
-export interface IManifestReadyEvent { type : "manifestReady";
-                                       value : { manifest : Manifest }; }
+/** Event sent after the Manifest has been loaded and parsed for the first time. */
+export interface IManifestReadyEvent {
+  type : "manifestReady";
+  value : {
+    /** The Manifest we just parsed. */
+    manifest : Manifest;
+  };
+}
 
-// The Manifest has been refreshed
+/** Event sent after the Manifest has been updated. */
 export interface IManifestUpdateEvent { type: "manifestUpdate";
                                         value: null; }
 
-// The decipherability status of at least one Manifest's Representation has been
-// updated.
-// This generally means that some Representation were detected to be
-// undecipherable on the current device.
+/**
+ * Event sent after updating the decipherability status of at least one
+ * Manifest's Representation.
+ * This generally means that some Representation(s) were detected to be
+ * undecipherable on the current device.
+ */
 export interface IDecipherabilityUpdateEvent {
   type: "decipherabilityUpdate";
   value: Array<{ manifest : Manifest;
@@ -60,28 +98,109 @@ export interface IDecipherabilityUpdateEvent {
                  adaptation : Adaptation;
                  representation : Representation; }>; }
 
-// A minor error happened
+/** Event sent when a minor happened. */
 export interface IWarningEvent { type : "warning";
                                  value : ICustomError; }
 
-// The MediaSource needs to reload (and is reloading) due to a media event
+/**
+ * Event sent when we're starting attach a new MediaSource to the media element
+ * (after removing the previous one).
+ */
 export interface IReloadingMediaSourceEvent { type: "reloading-media-source";
                                               value: undefined; }
 
-// The current playback rate changed.
-// Note: it can be a change wanted by the user or even a manual `0` speed
-// setting to build a buffer.
-export interface ISpeedChangedEvent { type : "speedChanged";
-                                      value : number; }
-
-// The player stalled, leading to buffering.
+/** Event sent after the player stalled, leading to buffering. */
 export interface IStalledEvent { type : "stalled";
                                  value : IStallingItem|null; }
 
-// The content loaded and can now be played
+/**
+ * Event sent just as the content is considered as "loaded".
+ * From this point on, the user can reliably play/pause/resume the stream.
+ */
 export interface ILoadedEvent { type : "loaded";
                                 value : {
                                   segmentBuffersStore: SegmentBuffersStore | null;
                                 }; }
 
 export { IRepresentationChangeEvent };
+
+/** Events emitted by a `MediaSourceLoader`. */
+export type IMediaSourceLoaderEvent = IStalledEvent |
+                                      ILoadedEvent |
+                                      IWarningEvent |
+                                      IStreamEventEvent |
+                                      IStreamEventSkipEvent |
+
+                                      // Coming from the StreamOrchestrator
+
+                                      IActivePeriodChangedEvent |
+                                      IPeriodStreamClearedEvent |
+                                      ICompletedStreamEvent |
+                                      IPeriodStreamReadyEvent |
+                                      INeedsMediaSourceReload |
+                                      IAdaptationChangeEvent |
+                                      IBitrateEstimationChangeEvent |
+                                      INeedsDecipherabilityFlush |
+                                      IRepresentationChangeEvent |
+                                      IStreamEventAddedSegment<unknown> |
+                                      IProtectedSegmentEvent |
+                                      IStreamStateActive |
+                                      IStreamManifestMightBeOutOfSync |
+                                      IStreamNeedsManifestRefresh;
+
+/** Every events emitted by the `Init` module. */
+export type IInitEvent = IManifestReadyEvent |
+                         IManifestUpdateEvent |
+                         IReloadingMediaSourceEvent |
+                         IDecipherabilityUpdateEvent |
+                         IWarningEvent |
+                         IEMEDisabledEvent |
+
+                         // Coming from the `EMEManager`
+
+                         IEncryptedEvent |
+                         ICreatedMediaKeysEvent |
+                         IAttachedMediaKeysEvent |
+                         IInitDataIgnoredEvent |
+                         ISessionMessageEvent |
+                         INoUpdateEvent |
+                         ISessionUpdatedEvent |
+                         IBlacklistKeysEvent |
+                         IBlacklistProtectionDataEvent |
+
+                         // Coming from the `MediaSourceLoader`
+
+                         IStalledEvent |
+                         ILoadedEvent |
+                         IStreamEventEvent |
+                         IStreamEventSkipEvent |
+
+                         // Coming from the `StreamOrchestrator`
+
+                         IActivePeriodChangedEvent |
+                         IPeriodStreamClearedEvent |
+                         ICompletedStreamEvent |
+                         IPeriodStreamReadyEvent |
+                         IAdaptationChangeEvent |
+                         IBitrateEstimationChangeEvent |
+                         IRepresentationChangeEvent |
+                         IStreamEventAddedSegment<unknown> |
+                         IStreamStateActive;
+
+/** Events emitted by the `Init` module for directfile contents. */
+export type IDirectfileEvent = IStalledEvent |
+                               ILoadedEvent |
+                               IWarningEvent |
+                               IEMEDisabledEvent |
+
+                               // Coming from the `EMEManager`
+
+                               IEncryptedEvent |
+                               ICreatedMediaKeysEvent |
+                               IAttachedMediaKeysEvent |
+                               IInitDataIgnoredEvent |
+                               ISessionMessageEvent |
+                               INoUpdateEvent |
+                               ISessionUpdatedEvent |
+                               IBlacklistKeysEvent |
+                               IBlacklistProtectionDataEvent;

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -169,7 +169,7 @@ export default function StreamOrchestrator(
 
   // Emits the activePeriodChanged events every time the active Period changes.
   const activePeriodChanged$ = ActivePeriodEmitter(streamsArray).pipe(
-    filter((period) : period is Period => period != null),
+    filter((period) : period is Period => period !== null),
     map(period => {
       log.info("Stream: New active period", period);
       return EVENTS.activePeriodChanged(period);
@@ -412,16 +412,16 @@ export default function StreamOrchestrator(
                                          wantedBufferAhead$, }
     ).pipe(
       mergeMap((evt : IPeriodStreamEvent) : Observable<IMultiplePeriodStreamsEvent> => {
-        const { type } = evt;
-        if (type === "full-stream") {
+        if (evt.type === "full-stream") {
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
-          if (nextPeriod == null) {
+          if (nextPeriod === null) {
             return observableOf(EVENTS.streamComplete(bufferType));
-          } else {
-            // current Stream is full, create the next one if not
-            createNextPeriodStream$.next(nextPeriod);
           }
-        } else if (type === "active-stream") {
+
+          // current Stream is full, create the next one if not
+          createNextPeriodStream$.next(nextPeriod);
+          return EMPTY;
+        } else if (evt.type === "active-stream") {
           // current Stream is active, destroy next Stream if created
           destroyNextStreams$.next();
         }

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -50,7 +50,8 @@ export interface IStreamEventAddedSegment<T> {
 
 /**
  * The Manifest needs to be refreshed.
- * Note that the Stream might still be active even after sending this event:
+ * Note that a `RepresentationStream` might still be active even after sending
+ * this event:
  * It might download and push segments, send any other event etc.
  */
 export interface IStreamNeedsManifestRefresh {
@@ -60,6 +61,7 @@ export interface IStreamNeedsManifestRefresh {
 
 /**
  * The Manifest is possibly out-of-sync and needs to be refreshed completely.
+ *
  * The Stream made that guess because a segment that should have been available
  * is not and because it suspects this is due to a synchronization problem.
  */
@@ -79,7 +81,10 @@ export interface IStreamNeedsDiscontinuitySeek {
   };
 }
 
-/** Event emitted when a Stream is scheduling new segments to be loaded. */
+/**
+ * Event emitted when a `RepresentationStream` is scheduling new segments to be
+ * loaded.
+ */
 export interface IStreamStateActive {
   type : "active-stream";
   value : {
@@ -88,7 +93,10 @@ export interface IStreamStateActive {
   };
 }
 
-/** Event emitted when the Stream has loaded segments to the end of its SegmentBuffer. */
+/**
+ * Event emitted when a `RepresentationStream` has pushed segments its SegmentBuffer
+ * filling until the end of the associated Period.
+ */
 export interface IStreamStateFull {
   type : "full-stream";
   value : {
@@ -132,17 +140,6 @@ export interface IStreamTerminatingEvent {
   value : undefined;
 }
 
-/** Event sent by a `RepresentationStream`. */
-export type IRepresentationStreamEvent<T> = IStreamEventAddedSegment<T> |
-                                            IProtectedSegmentEvent |
-                                            IStreamStateFull |
-                                            IStreamStateActive |
-                                            IStreamManifestMightBeOutOfSync |
-                                            IStreamNeedsDiscontinuitySeek |
-                                            IStreamNeedsManifestRefresh |
-                                            IStreamTerminatingEvent |
-                                            IStreamWarningEvent;
-
 /** Emitted as new bitrate estimates are done. */
 export interface IBitrateEstimationChangeEvent {
   type : "bitrateEstimationChange";
@@ -158,7 +155,7 @@ export interface IBitrateEstimationChangeEvent {
 }
 
 /**
- * Emitted when a new `RepresentationStream` is created for a given
+ * Emitted when a new `RepresentationStream` is created to load segments from a
  * `Representation`.
  */
 export interface IRepresentationChangeEvent {
@@ -176,16 +173,9 @@ export interface IRepresentationChangeEvent {
                      null; };
 }
 
-/** Event sent by an `AdaptationStream`. */
-export type IAdaptationStreamEvent<T> = IRepresentationStreamEvent<T> |
-                                        IBitrateEstimationChangeEvent |
-                                        INeedsMediaSourceReload |
-                                        INeedsDecipherabilityFlush |
-                                        IRepresentationChangeEvent;
-
 /**
- * Emitted when a new `AdaptationStream` is created for a given
- * `Representation`.
+ * Emitted when a new `AdaptationStream` is created to load segments from an
+ * `Adaptation`.
  */
 export interface IAdaptationChangeEvent {
   type : "adaptationChange";
@@ -364,19 +354,111 @@ export interface INeedsDecipherabilityFlush {
   };
 }
 
+/** Event sent by a `RepresentationStream`. */
+export type IRepresentationStreamEvent<T> = IStreamEventAddedSegment<T> |
+                                            IProtectedSegmentEvent |
+                                            IStreamStateFull |
+                                            IStreamStateActive |
+                                            IStreamManifestMightBeOutOfSync |
+                                            IStreamNeedsDiscontinuitySeek |
+                                            IStreamNeedsManifestRefresh |
+                                            IStreamTerminatingEvent |
+                                            IStreamWarningEvent;
+
+/** Event sent by an `AdaptationStream`. */
+export type IAdaptationStreamEvent<T> = IBitrateEstimationChangeEvent |
+                                        INeedsMediaSourceReload |
+                                        INeedsDecipherabilityFlush |
+                                        IRepresentationChangeEvent |
+
+                                        // From a RepresentationStream
+
+                                        IStreamEventAddedSegment<T> |
+                                        IProtectedSegmentEvent |
+                                        IStreamStateFull |
+                                        IStreamStateActive |
+                                        IStreamManifestMightBeOutOfSync |
+                                        IStreamNeedsDiscontinuitySeek |
+                                        IStreamNeedsManifestRefresh |
+                                        IStreamWarningEvent;
+
 /** Event sent by a `PeriodStream`. */
 export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
-                                 IAdaptationStreamEvent<unknown> |
                                  INeedsMediaSourceReload |
-                                 IAdaptationChangeEvent;
+                                 IAdaptationChangeEvent |
+
+                                 // From an AdaptationStream
+
+                                 IBitrateEstimationChangeEvent |
+                                 INeedsMediaSourceReload |
+                                 INeedsDecipherabilityFlush |
+                                 IRepresentationChangeEvent |
+
+                                 // From a RepresentationStream
+
+                                 IStreamEventAddedSegment<unknown> |
+                                 IProtectedSegmentEvent |
+                                 IStreamStateFull |
+                                 IStreamStateActive |
+                                 IStreamManifestMightBeOutOfSync |
+                                 IStreamNeedsDiscontinuitySeek |
+                                 IStreamNeedsManifestRefresh |
+                                 IStreamWarningEvent;
 
 /** Event coming from function(s) managing multiple PeriodStreams. */
-export type IMultiplePeriodStreamsEvent = IPeriodStreamEvent |
-                                          IPeriodStreamClearedEvent |
-                                          ICompletedStreamEvent;
+export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
+                                          ICompletedStreamEvent |
+
+                                          // From a PeriodStream
+
+                                          IPeriodStreamReadyEvent |
+                                          INeedsMediaSourceReload |
+                                          IAdaptationChangeEvent |
+
+                                          // From an AdaptationStream
+
+                                          IBitrateEstimationChangeEvent |
+                                          INeedsMediaSourceReload |
+                                          INeedsDecipherabilityFlush |
+                                          IRepresentationChangeEvent |
+
+                                          // From a RepresentationStream
+
+                                          IStreamEventAddedSegment<unknown> |
+                                          IProtectedSegmentEvent |
+                                          IStreamStateActive |
+                                          IStreamManifestMightBeOutOfSync |
+                                          IStreamNeedsDiscontinuitySeek |
+                                          IStreamNeedsManifestRefresh |
+                                          IStreamWarningEvent;
 
 /** Every event sent by the `StreamOrchestrator`. */
 export type IStreamOrchestratorEvent = IActivePeriodChangedEvent |
-                                       IMultiplePeriodStreamsEvent |
                                        IEndOfStreamEvent |
-                                       IResumeStreamEvent;
+                                       IResumeStreamEvent |
+
+                                       IPeriodStreamClearedEvent |
+                                       ICompletedStreamEvent |
+
+                                       // From a PeriodStream
+
+                                       IPeriodStreamReadyEvent |
+                                       INeedsMediaSourceReload |
+                                       IAdaptationChangeEvent |
+
+                                       // From an AdaptationStream
+
+                                       IBitrateEstimationChangeEvent |
+                                       INeedsMediaSourceReload |
+                                       INeedsDecipherabilityFlush |
+                                       IRepresentationChangeEvent |
+
+                                       // From a RepresentationStream
+
+                                       IStreamEventAddedSegment<unknown> |
+                                       IProtectedSegmentEvent |
+                                       IStreamStateActive |
+                                       IStreamManifestMightBeOutOfSync |
+                                       IStreamNeedsDiscontinuitySeek |
+                                       IStreamNeedsManifestRefresh |
+                                       IStreamWarningEvent;


### PR DESCRIPTION
Most modules internal to the RxPlayer emit some kind of events.

Due to its architecture, modules are sometimes contained in bigger modules (the most impressive example would be the `StreamOrchestrator`, which "orchestrates" multiple `PeriodStreams`, which switch between `AdaptationStreams` which switch between `RepresentationStreams`).
Those outer-facing "super-modules" most often simply combine the events of all contained sub-modules so they can be handled at a higher level as if they were all coming from the same place (the `StreamOrchestrator` in our example).

This way of doing things for a player has been shown to be relatively maintainable and easy to update.

But it still in my opinion has some drawbacks:

  - first, the way those events were typed was hard to read. The types of those super-modules's events often redirected to the corresponding sub-modules type definitions.

    Because another module should not care about how that module is implemented, and most-of-all because multiple levels of indirection when browsing the code is a bad experience, I chose to impose flat type definitions when it comes to modules.

    This means that the return types of each module, which defines which events a module send, now directly link to the corresponding events with no level of indirection (other than the return type definition).

  - Second, which module had to react to which event could be very un-clear for a newcomer.

    For example a `"needs-media-source-reload"` was bubbled up until the API (the last possible step), even if it has always been already handled by the `Init` (the module handling such events).

    I tried here to not bubble-up events which have no use being sent to outer modules.

I also removed the "speedChanged" event which was sent in strange cases (it was also sent when the player paused playback to build buffer) and which was never used.