### PR TITLE
stream: avoid error when updating the priority of a synchronous request

### DIFF
--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -384,8 +384,8 @@ export default function RepresentationStream<T>({
           return observableOf(EVENTS.streamTerminating());
         } else if (currentSegmentRequest.priority !== mostNeededSegment.priority) {
           const { request$ } = currentSegmentRequest;
-          segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
           currentSegmentRequest.priority = mostNeededSegment.priority;
+          segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
         }
         log.debug("Stream: terminate after request.", bufferType);
         return EMPTY;
@@ -428,8 +428,8 @@ export default function RepresentationStream<T>({
       } else if (currentSegmentRequest.priority !== mostNeededSegment.priority) {
         log.debug("Stream: update request priority.", bufferType);
         const { request$ } = currentSegmentRequest;
-        segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
         currentSegmentRequest.priority = mostNeededSegment.priority;
+        segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
       } else {
         log.debug("Stream: update downloading queue", bufferType);
 


### PR DESCRIPTION
This is a fix for a rare new bug we seem to encounter starting from our `v3.21.1` release.

Note that I did not succeed to reproduce it, so this is mostly an hypothesis.

The error might appear when updating the priority of a previously non-pending segment request. If it's priority is high enough for it to be launched right away and if this segment request ends synchronously after being started (which is a relatively rare occurence, but it can be the case for smooth initialization segments - as they are locally-generated - or any cached in-JS initialization segments), it is theorically possible that the `currentSegmentRequest` variable we use in the `RepresentationStream` to refer to the... current segment request is set to `null` directly (as it should because the request just ended).

The corresponding logic does not expect the request to be finished just synchronously after updating its priority, and thus did not re-check whether `currentSegmentRequest` was still set.

A simple but still valid and functional fix is to just mutate `currentSegmentRequest` just before actually doing the update.
The order here should not really matter (it might even be better that way if re-entrancy become involved) and it ensures that the possible side-effects are performed last.

Note that this error should not be possible before the `v3.21.1` because the priority of the initialization segment before that point was always `0`, which is the highest possible priority. Now its priority depends on the priority of the corresponding media segments we want to push.