### PR TITLE
Fix/local manifest fixes

### DIFF
--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -151,12 +151,14 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
   }
 
   _replace(newIndex : LocalRepresentationIndex) : void {
+    this._isFinished = newIndex._isFinished;
     this._index.segments = newIndex._index.segments;
     this._index.loadSegment = newIndex._index.loadSegment;
     this._index.loadInitSegment = newIndex._index.loadInitSegment;
   }
 
   _update(newIndex : LocalRepresentationIndex) : void {
+    this._isFinished = newIndex._isFinished;
     const newSegments = newIndex._index.segments;
     if (newSegments.length <= 0) {
       return;

--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -96,7 +96,8 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
     if (this._index.segments.length === 0) {
       return undefined;
     }
-    return this._index.segments[0].time;
+    const firstSegment = this._index.segments[0];
+    return firstSegment.time / 1000;
   }
 
   /**
@@ -106,7 +107,8 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
     if (this._index.segments.length === 0) {
       return undefined;
     }
-    return this._index.segments[this._index.segments.length - 1].time;
+    const lastSegment = this._index.segments[this._index.segments.length - 1];
+    return lastSegment.time / 1000;
   }
 
   /**


### PR DESCRIPTION
Those are two fixes related to local Manifest (downloaded contents):

## fix getFirstPosition and getLastPosition scale

Both `getFirstPosition` and `getLastPosition` in the local Manifest parser returned inadvertently a value in milliseconds instead of seconds.

This was because segments stored in the local Manifest RepresentationIndex are expressed in milliseconds.

I now convert it back to seconds in those functions by just dividing by `1000`.

## Update `_isFinished` when updating a local Manifest

The previous behavior kept the original `_isFinished` value. This made it impossible to end a local stream which started as dynamic.

I now properly update it.