### PR TITLE
 local-manifest: create v0.2 of the local-manifest 

### DIFF
--- a/doc/api/local_manifest_v0.1.md
+++ b/doc/api/local_manifest_v0.1.md
@@ -1,4 +1,13 @@
-# Local contents (offline playback) ############################################
+# Local Manifest format version 0.1  ###########################################
+
+---
+
+:warning: The `0.1` version of the local Manifest format is an old version which
+is not properly understood by the RxPlayer anymore.
+
+The last version of this specification can be found [here](./local_manifest.md).
+
+---
 
 ## Preamble ####################################################################
 
@@ -138,11 +147,8 @@ First, let's go into an example, before describing what each property is for:
 ```js
 {
   type: "local", // always set to "local"
-  version: "0.2", // version number, in a MAJOR.MINOR form
-  minimumPosition: 0, // Minimum possible reachable position in the content,
-                      // in seconds
-  maximumPosition: 120, // Maximum possible reachable position in the content,
-                        // in seconds
+  version: "0.1", // version number, in a MAJOR.MINOR form
+  duration: 60000, // duration of the whole content, in ms
   isFinished: true, // if `false`, the content is still downloading
   periods: [ // different "periods" in the content - see below
     // ...
@@ -163,7 +169,7 @@ object:
     RxPlayer that the current content is a local manifest.
 
   - version (`string`): Version number, in a MAJOR.MINOR form.
-    The present documentation is for the `"0.2"` version.
+    The present documentation is for the `"0.1"` version.
 
     A parser for a version with the a given MAJOR version should be able to
     parse and play contents for any of the corresponding MINOR versions.
@@ -172,14 +178,9 @@ object:
     A parser for a version with that major (let's say `0.1`) might be unable to
     parse local Manifests of another version (e.g. `0.2`).
 
-  - minimumPosition (`number|undefined`): Optional minimum position reachable in
-    this content once it has been fully loaded, in seconds.
-
-    If not set or set to `undefined`, the RxPlayer will assume that the content
-    starts at a `0` position.
-
-  - maximumPosition (`number|undefined`): Maximum position reachable in this
-    content once it has been fully loaded, in seconds.
+  - duration (`number`): duration of the whole content, in milliseconds. This
+    means the difference between the absolute maximum position and the absolute
+    minimum position.
 
   - isFinished (`boolean`): `true` indicates that the content has been
     completely downloaded and can now be played as a whole. `false` indicates
@@ -219,8 +220,8 @@ for your local manifest.
 Here's an example of a period object:
 ```js
 {
-  start: 10, // starting position in the whole content, in seconds
-  end: 20, // ending position, in seconds
+  start: 10000, // starting position in the whole content, in ms
+  end: 20000, // ending position, in ms
   adaptations: [ // available tracks for this period
     // ***
   ]
@@ -232,24 +233,23 @@ look like:
 ```js
 {
   type: "local",
-  version: "0.2",
-  minimumPosition: 0,
-  maximumPosition: 60,
+  version: "0.1",
+  duration: 60000,
   isFinished: true,
   periods: [ // Here we have 3 consecutive periods:
     {
       start: 0,
-      end: 10,
+      end: 10000,
       adaptations: [ /* ... */ ]
     },
     {
-      start: 10,
-      end: 30,
+      start: 10000,
+      end: 30000,
       adaptations: [ /* ... */ ]
     },
     {
-      start: 30,
-      end: 60,
+      start: 30000,
+      end: 60000,
       adaptations: [ /* ... */ ]
     },
   ],
@@ -261,9 +261,9 @@ look like:
 
 The following properties are found in a period object:
 
-  - start (`number`): The position in seconds at which the period starts.
+  - start (`number`): The position in milliseconds at which the period starts.
 
-  - end (`number`): The position in seconds at which the period ends.
+  - end (`number`): The position in milliseconds at which the period ends.
 
   - adaptations (`Array.<Object>`): The different tracks available. See below
     for more information.
@@ -317,7 +317,7 @@ Here how it looks when adaptations are integrated in a given period:
 ```js
 {
   start: 0,
-  end: 10,
+  end: 10000,
   adaptations: [
     {
       type: "video",
@@ -500,11 +500,11 @@ it contains itself three properties:
 Let's start by the first one, `segments`. `segments` is an array of objects,
 each object describing a single segment of media data. Each object has the
 following properties:
-  - time (`number`): starting position of the segment, in seconds
-  - duration (`number`): duration of the segment, in seconds
+  - time (`number`): starting position of the segment, in milliseconds
+  - duration (`number`): duration of the segment, in milliseconds
   - timestampOffset (`number|undefined`): optional time offset to add to the
-    segment's internal time in seconds to convert its media time to its
-    presentation time, in seconds.
+    segment's internal time to convert its media time to its presentation time,
+    in milliseconds.
     If you don't know what it is, you will most likely not need it.
 
 Let's see a simple example with four segments of 2 seconds:
@@ -512,19 +512,19 @@ Let's see a simple example with four segments of 2 seconds:
 [
   {
     time: 0,
-    duration: 2
+    duration: 2000
   },
   {
-    time: 2,
-    duration: 2
+    time: 2000,
+    duration: 2000
   },
   {
-    time: 4,
-    duration: 2
+    time: 4000,
+    duration: 2000
   },
   {
-    time: 6,
-    duration: 2
+    time: 6000,
+    duration: 2000
   }
 ]
 ```
@@ -630,35 +630,3 @@ ISOBMFF containers).
 
 We also look into adding supplementary encryption information into the local
 manifest format, but this is not available for now.
-
-
-## Difference with the `0.1` format ############################################
-
-The previous `0.1` version of the local Manifest is now obsolete and is not
-compatible with the new versions of the RxPlayer.
-Its documentation can be found [here](./local_manifest_v0.1.md).
-
-If you were relying on this version before and would like to switch the the
-`0.2` version, to be able to play it on newer versions of the RxPlayer, here
-is the exhaustive list of what changed:
-
-  - a `minimumPosition` has been added to the "period object"
-
-  - a `maximumPosition` has been added to the "period object"
-
-  - the `duration` property of the "period object" has been removed
-
-  - the `start` property from a "period object" is now expressed in seconds
-    instead of in milliseconds.
-
-  - the `end` property from a "period object" is now expressed in seconds
-    instead of in milliseconds.
-
-  - the `time` property from a segment in the "segments array" is now expressed
-    in seconds instead of in milliseconds.
-
-  - the `duration` property from a segment in the "segments array" is now
-    expressed in seconds instead of in milliseconds.
-
-  - the `timestampOffset` property from a segment in the "segments array" is now
-    expressed in seconds. In the `0.1` version the unit of time was unclear.

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -15,8 +15,6 @@
  */
 
 import idGenerator from "../../../utils/id_generator";
-import getMaximumPosition from "../utils/get_maximum_position";
-import getMinimumPosition from "../utils/get_minimum_position";
 
 import {
   IParsedAdaptation,
@@ -42,12 +40,15 @@ export default function parseLocalManifest(
   if (localManifest.type !== "local") {
     throw new Error("Invalid local manifest given. It misses the `type` property.");
   }
-  if (localManifest.version !== "0.1") {
+  if (localManifest.version !== "0.2") {
     throw new Error(`The current Local Manifest version (${localManifest.version})` +
                     " is not compatible with the current version of the RxPlayer");
   }
   const periodIdGenerator = idGenerator();
-  const { isFinished } = localManifest;
+
+  const { minimumPosition,
+          maximumPosition,
+          isFinished } = localManifest;
   const manifest: IParsedManifest = {
     availabilityStartTime: 0,
     expired: localManifest.expired,
@@ -56,37 +57,41 @@ export default function parseLocalManifest(
     isLive: false,
     uris: [],
     periods: localManifest.periods
-      .map(period => parsePeriod(period, periodIdGenerator, isFinished)),
+      .map(period => parsePeriod(period, { periodIdGenerator,
+                                           isFinished })),
+    minimumTime: { isContinuous : false,
+                   value : minimumPosition !== undefined ? minimumPosition :
+                                                           0,
+                   time : performance.now() },
   };
-  const maximumPosition = getMaximumPosition(manifest);
   if (maximumPosition !== undefined) {
     manifest.maximumTime = { isContinuous: false,
                              value : maximumPosition,
                              time : performance.now() };
   }
-  const minimumPosition = getMinimumPosition(manifest);
-  manifest.minimumTime = { isContinuous : false,
-                           value : minimumPosition !== undefined ? minimumPosition :
-                                                                   0,
-                           time : performance.now() };
   return manifest;
 }
 
 /**
  * @param {Object} period
+ * @param {Object} ctxt
  * @returns {Object}
  */
 function parsePeriod(
   period : ILocalPeriod,
-  periodIdGenerator : () => string,
-  isFinished : boolean
+  ctxt : { /** Generate next Period's id */
+           periodIdGenerator : () => string;
+           /** If true, the local Manifest has been fully downloaded. */
+           isFinished : boolean; }
 ) : IParsedPeriod {
+  const { isFinished } = ctxt;
   const adaptationIdGenerator = idGenerator();
   return {
-    id: "period-" + periodIdGenerator(),
+    id: "period-" + ctxt.periodIdGenerator(),
+
     start: period.start,
-    end: period.duration - period.start,
-    duration: period.duration,
+    end: period.end,
+    duration: period.end - period.start,
     adaptations: period.adaptations
       .reduce<Partial<Record<string, IParsedAdaptation[]>>>((acc, ada) => {
         const type = ada.type;
@@ -95,7 +100,8 @@ function parsePeriod(
           adaps = [];
           acc[type] = adaps;
         }
-        adaps.push(parseAdaptation(ada, adaptationIdGenerator, isFinished));
+        adaps.push(parseAdaptation(ada, { adaptationIdGenerator,
+                                          isFinished }));
         return acc;
       }, {}),
   };
@@ -103,22 +109,27 @@ function parsePeriod(
 
 /**
  * @param {Object} adaptation
+ * @param {Object} ctxt
  * @returns {Object}
  */
 function parseAdaptation(
   adaptation : ILocalAdaptation,
-  adaptationIdGenerator : () => string,
-  isFinished : boolean
+  ctxt : { /** Generate next Adaptation's id */
+           adaptationIdGenerator : () => string;
+           /** If true, the local Manifest has been fully downloaded. */
+           isFinished : boolean; }
 ) : IParsedAdaptation {
+  const { isFinished } = ctxt;
   const representationIdGenerator = idGenerator();
   return {
-    id: "adaptation-" + adaptationIdGenerator(),
+    id: "adaptation-" + ctxt.adaptationIdGenerator(),
     type: adaptation.type,
     audioDescription: adaptation.audioDescription,
     closedCaption: adaptation.closedCaption,
     language: adaptation.language,
     representations: adaptation.representations.map((representation) =>
-        parseRepresentation(representation, representationIdGenerator, isFinished)),
+      parseRepresentation(representation, { representationIdGenerator,
+                                            isFinished })),
   };
 }
 
@@ -128,10 +139,13 @@ function parseAdaptation(
  */
 function parseRepresentation(
   representation : ILocalRepresentation,
-  representationIdGenerator : () => string,
-  isFinished : boolean
+  ctxt : { /** Generate next Adaptation's id */
+           representationIdGenerator : () => string;
+           /** If true, the local Manifest has been fully downloaded. */
+           isFinished : boolean; }
 ) : IParsedRepresentation {
-  const id = "representation-" + representationIdGenerator();
+  const { isFinished } = ctxt;
+  const id = "representation-" + ctxt.representationIdGenerator();
   return { id,
            bitrate: representation.bitrate,
            height: representation.height,

--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -61,11 +61,11 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
     const wantedSegments : ILocalIndexSegment[] = [];
     for (let i = 0; i < this._index.segments.length; i++) {
       const segment = this._index.segments[i];
-      const segmentStart = segment.time / 1000;
+      const segmentStart = segment.time;
       if (endTime <= segmentStart) {
         break;
       }
-      const segmentEnd = (segment.time + segment.duration) / 1000;
+      const segmentEnd = segment.time + segment.duration;
       if (segmentEnd > startTime) {
         wantedSegments.push(segment);
       }
@@ -78,7 +78,7 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
           isInit: false,
           time: wantedSegment.time,
           duration: wantedSegment.duration,
-          timescale: 1000,
+          timescale: 1,
           timestampOffset: wantedSegment.timestampOffset,
           mediaURLs: null,
           privateInfos: {
@@ -97,7 +97,7 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
       return undefined;
     }
     const firstSegment = this._index.segments[0];
-    return firstSegment.time / 1000;
+    return firstSegment.time;
   }
 
   /**
@@ -108,7 +108,7 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
       return undefined;
     }
     const lastSegment = this._index.segments[this._index.segments.length - 1];
-    return lastSegment.time / 1000;
+    return lastSegment.time;
   }
 
   /**

--- a/src/parsers/manifest/local/types.ts
+++ b/src/parsers/manifest/local/types.ts
@@ -166,7 +166,7 @@ export interface ILocalIndex {
 
 /** A quality for a given "local" Manifest track (`ILocalAdaptation`). */
 export interface ILocalRepresentation {
-  /** Average number of bytes per second for the segments contained in this quality. */
+  /** Maximum number of bytes per second for the segments contained in this quality. */
   bitrate : number;
   /** DRM information. */
   contentProtections? : IContentProtections;
@@ -209,8 +209,8 @@ export interface ILocalAdaptation {
 export interface ILocalPeriod {
   /** Start time at which the Period begins, in seconds. */
   start: number;
-  /** Duration of the Period (from the start to the end), in seconds. */
-  duration: number;
+  /** End time at which the Period ends, in seconds. */
+  end: number;
   /** The different "tracks" available for this Period. */
   adaptations: ILocalAdaptation[];
 }
@@ -230,9 +230,29 @@ export interface ILocalManifest {
    *        parse it
    * MINOR: Retro-compatible format change.
    *
-   * The current version defined here is "0.1".
+   * The exception is the `0` MAJOR version (i.e. experimental versions).
+   * A parser for a version in that major (let's say `0.1`) might be unable to
+   * parse local Manifests of another version (e.g. `0.2`).
+   *
+   * There are two versions defined for now and we are compatible to both:
+   *
+   *   - "0.1": initial version
+   *
+   *   - "0.2": `minimumPosition` and `maximumPosition` are now defined.
+   *            `duration` has been removed.
+   *
+   *            `start` and `duration` from a ILocalPeriod and `time` and
+   *            `duration` from a `ILocalIndexSegment` are now in seconds
+   *            instead of milliseconds.
    */
   version : string;
+  /**
+   * Minimum position reachable in this content once fully downloaded, in
+   * seconds.
+   *
+   * Set to `0` by default.
+   */
+  minimumPosition? : number;
   /**
    * Maximum position reachable in this content once fully downloaded, in
    * seconds.

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -43,7 +43,7 @@ export interface IContentProtections {
 
 /** Representation of a "quality" available in an Adaptation. */
 export interface IParsedRepresentation {
-  /** Average bitrate the Representation is available in, in bits per seconds. */
+  /** Maximum bitrate the Representation is available in, in bits per seconds. */
   bitrate : number;
   /**
    * Interface to get information about segments associated with this


### PR DESCRIPTION
Note: this PR is based on the #818 PR

This PR creates a new version of the LocalManifest format (which allows to play downloaded contents with the RxPlayer).

This new version has the following main goals:

  - the maximum position and duration advertised by the RxPlayer is now the maximum reachable position in the fully-loaded content.

    Same thing for the minimum position (the minimum reachable position).

    Previously, the duration and maximum position were the maximum position of the first contiguous range of the currently loaded
    content.

    The reason for the change is that has now been decided that it is the role of the downloading tool, not of the player, to advertise
    which segments have effectively been downloaded.

    To allow for this new behavior:
      1. Two properties have been added to a LocalManifest: `minimumPosition` and `maximumPosition`.

      2. The now unneeded `duration` property (a property name I abhor because nobody ever knows if it is the maximum position or the difference between the maximum and the minimum position!) has been removed.

  - simplify the format and its parsing by re-defining every time in the format as expressed in seconds (instead of mostly in milliseconds in the previous format).

    This allows to avoid conversion in both sides as time are the most often expressed either in seconds or in a unit that is expected to be converted to seconds.

  - having a clear documentation reflecting what is actually implemented.
    The previous documented `0.1` version was actually quite different from what was really implemented (a period.duration property was expected instead of a period.end, some values were in seconds despite being documented as milliseconds etc.).