### PR TITLE
eme: add more EME-related logs and raise-up verbositiy for INFO level

### DIFF
--- a/src/core/eme/attach_media_keys.ts
+++ b/src/core/eme/attach_media_keys.ts
@@ -19,7 +19,7 @@ import {
   Observable,
   of as observableOf,
 } from "rxjs";
-import { mergeMap } from "rxjs/operators";
+import { mergeMap, tap } from "rxjs/operators";
 import { setMediaKeys } from "../../compat";
 import log from "../../log";
 import MediaKeysInfosStore from "./media_keys_infos_store";
@@ -74,8 +74,9 @@ export default function attachMediaKeys(
         if (mediaElement.mediaKeys === mediaKeys) {
           return observableOf(null);
         }
-        log.debug("EME: Setting MediaKeys");
-        return setMediaKeys(mediaElement, mediaKeys);
+        log.info("EME: Attaching MediaKeys to the media element");
+        return setMediaKeys(mediaElement, mediaKeys)
+          .pipe(tap(() => { log.info("EME: MediaKeys attached with success"); }));
       })
     );
   });

--- a/src/core/eme/clear_eme_session.ts
+++ b/src/core/eme/clear_eme_session.ts
@@ -35,9 +35,9 @@ export default function clearEMESession(
   mediaElement : HTMLMediaElement
 ) : Observable<never> {
   return observableDefer(() => {
-    log.debug("EME: Clearing-up EME session.");
+    log.info("EME: Clearing-up EME session.");
     if (shouldUnsetMediaKeys()) {
-      log.debug("EME: disposing current MediaKeys.");
+      log.info("EME: disposing current MediaKeys.");
       return disposeMediaKeys(mediaElement)
         .pipe(ignoreElements());
     }
@@ -46,11 +46,11 @@ export default function clearEMESession(
     if (currentState !== null &&
         currentState.keySystemOptions.closeSessionsOnStop === true)
     {
-      log.debug("EME: closing all current sessions.");
+      log.info("EME: closing all current sessions.");
       return currentState.loadedSessionsStore.closeAllSessions()
         .pipe(ignoreElements());
     }
-    log.debug("EME: Nothing to clear. Returning right away. No state =",
+    log.info("EME: Nothing to clear. Returning right away. No state =",
               currentState === null);
     return EMPTY;
   });

--- a/src/core/eme/create_session.ts
+++ b/src/core/eme/create_session.ts
@@ -61,7 +61,7 @@ function loadPersistentSession(
   session: MediaKeySession|ICustomMediaKeySession
 ) : Observable<boolean> {
   return observableDefer(() => {
-    log.debug("EME: Load persisted session", sessionId);
+    log.info("EME: Load persisted session", sessionId);
     return castToObservable(session.load(sessionId));
   });
 }
@@ -102,7 +102,7 @@ export default function createSession(
       keySystemOptions.persistentLicense === true ? "persistent-license" :
                                                     "temporary";
 
-    log.debug(`EME: Create a new ${sessionType} session`);
+    log.info(`EME: Create a new ${sessionType} session`);
 
     const session = loadedSessionsStore
       .createSession(initData, initDataType, sessionType);

--- a/src/core/eme/dispose_media_keys.ts
+++ b/src/core/eme/dispose_media_keys.ts
@@ -37,7 +37,7 @@ export default function disposeMediaKeys(
       return observableOf(null);
     }
 
-    log.debug("EME: Disposing of the current MediaKeys");
+    log.info("EME: Disposing of the current MediaKeys");
     const { loadedSessionsStore } = currentState;
     MediaKeysInfosStore.clearState(mediaElement);
     return loadedSessionsStore.closeAllSessions()

--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -257,6 +257,7 @@ export default function getMediaKeySystemAccess(
   keySystemsConfigs: IKeySystemOption[]
 ) : Observable<IFoundMediaKeySystemAccessEvent> {
   return observableDefer<Observable<IFoundMediaKeySystemAccessEvent>>(() => {
+    log.info("EME: Searching for compatible MediaKeySystemAccess");
     const currentState = MediaKeysInfosStore.getState(mediaElement);
     if (currentState != null) {
       // Fast way to find a compatible keySystem if the currently loaded
@@ -266,7 +267,7 @@ export default function getMediaKeySystemAccess(
                                         currentState.mediaKeySystemAccess,
                                         currentState.keySystemOptions);
       if (cachedKeySystemAccess !== null) {
-        log.debug("EME: Found cached compatible keySystem", cachedKeySystemAccess);
+        log.info("EME: Found cached compatible keySystem", cachedKeySystemAccess);
         return observableOf({
           type: "reuse-media-key-system-access" as "reuse-media-key-system-access",
           value: { mediaKeySystemAccess: cachedKeySystemAccess.keySystemAccess,

--- a/src/core/eme/get_media_keys.ts
+++ b/src/core/eme/get_media_keys.ts
@@ -54,7 +54,7 @@ function createPersistentSessionsStorage(
                                   "No license storage found for persistent license.");
   }
 
-  log.info("EME: Set the given license storage");
+  log.debug("EME: Set the given license storage");
   return new PersistentSessionsStore(licenseStorage);
 }
 
@@ -83,7 +83,7 @@ export default function getMediaKeysInfos(
                               persistentSessionsStore });
       }
 
-      log.debug("EME: Calling createMediaKeys on the MediaKeySystemAccess");
+      log.info("EME: Calling createMediaKeys on the MediaKeySystemAccess");
       return tryCatch(() => castToObservable(mediaKeySystemAccess.createMediaKeys()),
                       undefined).pipe(
         catchError((error : unknown) : never => {
@@ -92,10 +92,13 @@ export default function getMediaKeysInfos(
             "Unknown error when creating MediaKeys.";
           throw new EncryptedMediaError("CREATE_MEDIA_KEYS_ERROR", message);
         }),
-        map((mediaKeys) => ({ mediaKeys,
-                              loadedSessionsStore: new LoadedSessionsStore(mediaKeys),
-                              mediaKeySystemAccess,
-                              keySystemOptions: options,
-                              persistentSessionsStore })));
+        map((mediaKeys) => {
+          log.info("EME: MediaKeys created with success", mediaKeys);
+          return { mediaKeys,
+                   loadedSessionsStore: new LoadedSessionsStore(mediaKeys),
+                   mediaKeySystemAccess,
+                   keySystemOptions: options,
+                   persistentSessionsStore };
+        }));
     }));
 }

--- a/src/core/eme/get_session.ts
+++ b/src/core/eme/get_session.ts
@@ -107,7 +107,7 @@ export default function getSession(
     if (entry !== null) {
       previousLoadedSession = entry.mediaKeySession;
       if (isSessionUsable(previousLoadedSession)) {
-        log.debug("EME: Reuse loaded session", previousLoadedSession.sessionId);
+        log.info("EME: Reuse loaded session", previousLoadedSession.sessionId);
         return observableOf({ type: "loaded-open-session" as const,
                               value: { mediaKeySession: previousLoadedSession,
                                        sessionType: entry.sessionType,

--- a/src/core/eme/init_media_keys.ts
+++ b/src/core/eme/init_media_keys.ts
@@ -25,6 +25,7 @@ import {
   startWith,
   take,
 } from "rxjs/operators";
+import log from "../../log";
 import attachMediaKeys, {
   disableMediaKeys
 } from "./attach_media_keys";
@@ -57,8 +58,10 @@ export default function initMediaKeys(
         disableMediaKeys(mediaElement) :
         observableOf(null);
 
+      log.debug("EME: Disabling old MediaKeys");
       return disableOldMediaKeys$.pipe(
         mergeMap(() => {
+          log.debug("EME: Disabled old MediaKeys. Waiting to attach new MediaKeys");
           return attachMediaKeys$.pipe(
             mergeMap(() => attachMediaKeys(mediaKeysInfos, mediaElement)),
             take(1),

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -81,7 +81,7 @@ export default function trySettingServerCertificate(
       return EMPTY;
     }
 
-    log.debug("EME: Setting server certificate on the MediaKeys");
+    log.info("EME: Setting server certificate on the MediaKeys");
     return setServerCertificate(mediaKeys, serverCertificate).pipe(
       ignoreElements(),
       catchError(error => observableOf({ type: "warning" as const, value: error })));

--- a/src/core/eme/utils/persistent_sessions_store.ts
+++ b/src/core/eme/utils/persistent_sessions_store.ts
@@ -220,7 +220,7 @@ export default class PersistentSessionsStore {
   }
 
   deleteOldSessions(sessionsToDelete : number) : void {
-    log.debug(`EME-PSS: Deleting last ${sessionsToDelete} sessions.`);
+    log.info(`EME-PSS: Deleting last ${sessionsToDelete} sessions.`);
     if (sessionsToDelete <= 0) {
       return;
     }


### PR DESCRIPTION
During recent debugging sessions related to DRM, we found out that important steps, such as the communication of a licence, were only logged when the `LOGGER_LEVEL` is set to DEBUG. As this is a very important step, it seems that log could be displayed even when the level is set to INFO.

In that commit, I chose to display the important EME steps (creating the MediaKeySystemAccess, creating the MediaKeys, attaching the MediaKeys, creating the session, receiving and sending data from the CDM and the possible clean-up on stop) in the INFO logger level (which might raise up the verbosity on that level, but mostly at initialization).

Because the return of some of those steps is almost as important as the action, I chose to also log when those succeed.

This commit also add logs for the DEBUG level at relatively important steps that were not logged before, such as when the EMEManager asks for the permission to attach a new MediaKeys instance.