### PR TITLE
eme: better log why a session is not considered as "usable"

### DIFF
--- a/src/core/eme/utils/is_session_usable.ts
+++ b/src/core/eme/utils/is_session_usable.ts
@@ -39,14 +39,25 @@ export default function isSessionUsable(
     keyStatuses.push(keyStatus);
   });
 
-  if (keyStatuses.length > 0 &&
-      (
-        !arrayIncludes(keyStatuses, "expired") &&
-        !arrayIncludes(keyStatuses, "internal-error")
-      )
-  ) {
-    log.debug("EME: Reuse loaded session", loadedSession.sessionId);
-    return true;
+  if (keyStatuses.length <= 0) {
+    log.debug("EME: isSessionUsable: MediaKeySession given has an empty keyStatuses",
+              loadedSession);
+    return false;
   }
-  return false;
+
+  if (arrayIncludes(keyStatuses, "expired")) {
+    log.debug("EME: isSessionUsable: MediaKeySession given has an expired key",
+              loadedSession.sessionId);
+    return false;
+  }
+
+  if (arrayIncludes(keyStatuses, "internal-error")) {
+    log.debug("EME: isSessionUsable: MediaKeySession given has a key with an " +
+              "internal-error",
+              loadedSession.sessionId);
+    return false;
+  }
+
+  log.debug("EME: isSessionUsable: MediaKeySession is usable", loadedSession.sessionId);
+  return true;
 }


### PR DESCRIPTION
Previously, when loading a persistent session with keys deemed as not
usable, we just logged that the loaded MediaKeySession was "not usable".

To help debugging, this commit now clearly enounce which of the three
reasons are to blame:

  1. There are no keys
  2. At least one key has the "expired" status*
  3. At least one key has the "internal-error" status*

*On this subject, we might want to change that rule in the future.
Persisted licences might contain multiple keys, and we might only care
about some of them. The more sensible thing to do might be to check that
at least one can be used (even if it can also get more complicated, e.g.
we might want to re-request expired ones anyway).