### PR TITLE
Avoid re-setting same server certificate for a MediaKeys

### DIFF
--- a/src/core/eme/dispose_eme.ts
+++ b/src/core/eme/dispose_eme.ts
@@ -16,10 +16,12 @@
 
 import noop from "../../utils/noop";
 import disposeMediaKeys from "./dispose_media_keys";
+import ServerCertificateHashStore from "./server_certificate_hash_store";
 
 /**
  * Free up all ressources taken by the EME management.
  */
 export default function disposeEME(mediaElement : HTMLMediaElement) : void {
+  ServerCertificateHashStore.clear();
   disposeMediaKeys(mediaElement).subscribe(noop);
 }

--- a/src/core/eme/dispose_eme.ts
+++ b/src/core/eme/dispose_eme.ts
@@ -16,12 +16,12 @@
 
 import noop from "../../utils/noop";
 import disposeMediaKeys from "./dispose_media_keys";
-import ServerCertificateHashStore from "./server_certificate_hash_store";
+import ServerCertificateStore from "./server_certificate_store";
 
 /**
  * Free up all ressources taken by the EME management.
  */
 export default function disposeEME(mediaElement : HTMLMediaElement) : void {
-  ServerCertificateHashStore.clear();
+  ServerCertificateStore.clear();
   disposeMediaKeys(mediaElement).subscribe(noop);
 }

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -36,12 +36,14 @@ import {
   events,
   generateKeyRequest,
   getInitData,
+  ICustomMediaKeys,
 } from "../../compat/";
 import config from "../../config";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import assertUnreachable from "../../utils/assert_unreachable";
 import filterMap from "../../utils/filter_map";
+import hashBuffer from "../../utils/hash_buffer";
 import objectAssign from "../../utils/object_assign";
 import cleanOldStoredPersistentInfo from "./clean_old_stored_persistent_info";
 import getSession, {
@@ -97,6 +99,12 @@ export default function EMEManager(
    * the same `BlacklistedSessionError`.
    */
   const blacklistedInitData = new InitDataStore<BlacklistedSessionError>();
+
+  /**
+   * Keep track of server certificate which have been set for a MediaKeys.
+   */
+  const serverCertificateForMediaKeys =
+    new WeakMap<MediaKeys | ICustomMediaKeys, number>();
 
   /** Emit the MediaKeys instance and its related information when ready. */
   const mediaKeysInfos$ = initMediaKeys(mediaElement, keySystemsConfigs)
@@ -183,13 +191,27 @@ export default function EMEManager(
           };
         }));
 
-      if (i === 0) { // first encrypted event for the current content
-        return observableMerge(
-          serverCertificate != null ?
-            observableConcat(setServerCertificate(mediaKeys, serverCertificate),
-                             session$) :
-            session$
-        );
+      // first encrypted event for the current content
+      if (i === 0 && serverCertificate !== undefined) {
+        const formattedServerCertificate: Uint8Array =
+          serverCertificate instanceof Uint8Array ?
+            serverCertificate :
+            new Uint8Array(
+              serverCertificate instanceof ArrayBuffer ? serverCertificate :
+                                                         serverCertificate.buffer);
+        const currentServerCertificateHash = hashBuffer(formattedServerCertificate);
+        const oldServerCertificateHash = serverCertificateForMediaKeys.get(mediaKeys);
+        if (oldServerCertificateHash !== currentServerCertificateHash) {
+          return observableConcat(
+            setServerCertificate(mediaKeys, serverCertificate).pipe(
+              tap(() => {
+                serverCertificateForMediaKeys.set(mediaKeys,
+                                                  currentServerCertificateHash);
+              })
+            ),
+            session$);
+        }
+        return session$;
       }
 
       return session$;

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -183,7 +183,8 @@ export default function EMEManager(
           };
         }));
 
-      // first encrypted event for the current content
+      // set server certificate when it is defined, at first received encrypted
+      // event
       if (i === 0 && serverCertificate !== undefined) {
           return observableConcat(
             setServerCertificate(mediaKeys, serverCertificate),

--- a/src/core/eme/server_certificate_hash_store.ts
+++ b/src/core/eme/server_certificate_hash_store.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ICustomMediaKeys } from "../../compat";
+
+/**
+ * Keep track of server certificate which have been set for a MediaKeys.
+ */
+let serverCertificateForMediaKeys: WeakMap<MediaKeys | ICustomMediaKeys, number> =
+    new WeakMap<MediaKeys | ICustomMediaKeys, number>();
+
+export default {
+  add(mediaKeys: MediaKeys | ICustomMediaKeys, hash: number): void {
+    serverCertificateForMediaKeys.set(mediaKeys, hash);
+  },
+  get(mediaKeys: MediaKeys | ICustomMediaKeys): number | undefined {
+    return serverCertificateForMediaKeys.get(mediaKeys);
+  },
+  clear() {
+    serverCertificateForMediaKeys = new WeakMap<MediaKeys | ICustomMediaKeys, number>();
+  },
+};

--- a/src/core/eme/server_certificate_hash_store.ts
+++ b/src/core/eme/server_certificate_hash_store.ts
@@ -18,18 +18,37 @@ import { ICustomMediaKeys } from "../../compat";
 
 /**
  * Keep track of server certificate which have been set for a MediaKeys.
+ * As it is impossible for a MediaKeys to have his server certificate set
+ * to a nullish value, we consider that once it has been set, it will remain
+ * set until the MediaKeys instance is killed.
+ *
+ * So, a WeakMap helps keeping a trace of which server certificate (identified
+ * with a unique hash) is set on a MediaKeys.
  */
-let serverCertificateForMediaKeys: WeakMap<MediaKeys | ICustomMediaKeys, number> =
+let serverCertificateHashesMap: WeakMap<MediaKeys | ICustomMediaKeys, number> =
     new WeakMap<MediaKeys | ICustomMediaKeys, number>();
 
+/** ServerCertificateHashStore */
 export default {
+  /**
+   * @param {MediaKeys | Object} mediaKeys
+   * @param {number} hash
+   */
   add(mediaKeys: MediaKeys | ICustomMediaKeys, hash: number): void {
-    serverCertificateForMediaKeys.set(mediaKeys, hash);
+    serverCertificateHashesMap.set(mediaKeys, hash);
   },
-  get(mediaKeys: MediaKeys | ICustomMediaKeys): number | undefined {
-    return serverCertificateForMediaKeys.get(mediaKeys);
+  /**
+   * @param {MediaKeys | Object} mediaKeys
+   * @returns {number | null}
+   */
+  get(mediaKeys: MediaKeys | ICustomMediaKeys): number | null {
+    const serverCertificateHash = serverCertificateHashesMap.get(mediaKeys);
+    if (serverCertificateHash === undefined) {
+      return null;
+    }
+    return serverCertificateHash;
   },
   clear() {
-    serverCertificateForMediaKeys = new WeakMap<MediaKeys | ICustomMediaKeys, number>();
+    serverCertificateHashesMap = new WeakMap<MediaKeys | ICustomMediaKeys, number>();
   },
 };

--- a/src/core/eme/server_certificate_hash_store.ts
+++ b/src/core/eme/server_certificate_hash_store.ts
@@ -39,6 +39,12 @@ export default {
   },
   /**
    * @param {MediaKeys | Object} mediaKeys
+   */
+  delete(mediaKeys: MediaKeys | ICustomMediaKeys): void {
+    serverCertificateHashesMap.delete(mediaKeys);
+  },
+  /**
+   * @param {MediaKeys | Object} mediaKeys
    * @returns {number | null}
    */
   get(mediaKeys: MediaKeys | ICustomMediaKeys): number | null {

--- a/src/core/eme/server_certificate_store.ts
+++ b/src/core/eme/server_certificate_store.ts
@@ -31,7 +31,7 @@ let serverCertificateHashesMap: WeakMap<MediaKeys | ICustomMediaKeys,
   new WeakMap<MediaKeys | ICustomMediaKeys,
               { hash: number; serverCertificate: Uint8Array }>();
 
-/** ServerCertificateHashStore */
+/** ServerCertificateStore */
 export default {
   /**
    * @param {MediaKeys | Object} mediaKeys

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -30,7 +30,7 @@ import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
 import tryCatch from "../../utils/rx-try_catch";
-import ServerCertificateHashStore from "./server_certificate_hash_store";
+import ServerCertificateStore from "./server_certificate_store";
 import { IEMEWarningEvent } from "./types";
 
 /**
@@ -83,7 +83,7 @@ export default function trySettingServerCertificate(
       return EMPTY;
     }
 
-    if (ServerCertificateHashStore.has(mediaKeys, serverCertificate)) {
+    if (ServerCertificateStore.has(mediaKeys, serverCertificate)) {
       log.debug("EME: Server certificate already set on the MediaKeys");
       return EMPTY;
     }
@@ -93,10 +93,9 @@ export default function trySettingServerCertificate(
     // server certificate setting, we might delete the mediaKeys entrance in the
     // server certificate store. Next time we'll try to set server certificate,
     // in case of doubt, we will consider the certificate not to be set on mediaKeys.
-    ServerCertificateHashStore.delete(mediaKeys);
+    ServerCertificateStore.delete(mediaKeys);
     return setServerCertificate(mediaKeys, serverCertificate).pipe(
-      tap(() => { ServerCertificateHashStore.add(mediaKeys,
-                                                 serverCertificate); }),
+      tap(() => { ServerCertificateStore.add(mediaKeys, serverCertificate); }),
       ignoreElements(),
       catchError(error => observableOf({ type: "warning" as const, value: error })));
   });

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -99,6 +99,11 @@ export default function trySettingServerCertificate(
     }
 
     log.debug("EME: Setting server certificate on the MediaKeys");
+    // Because of browser errors, or a user action that can lead to interrupting
+    // server certificate setting, we might delete the mediaKeys entrance in the
+    // server certificate store. Next time we'll try to set server certificate,
+    // in case of doubt, we will consider the certificate not to be set on mediaKeys.
+    ServerCertificateHashStore.delete(mediaKeys);
     return setServerCertificate(mediaKeys, serverCertificate).pipe(
       tap(() => { ServerCertificateHashStore.add(mediaKeys,
                                                  currentServerCertificateHash); }),

--- a/src/core/eme/set_server_certificate.ts
+++ b/src/core/eme/set_server_certificate.ts
@@ -23,12 +23,15 @@ import {
 import {
   catchError,
   ignoreElements,
+  tap,
 } from "rxjs/operators";
 import { ICustomMediaKeys } from "../../compat";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import castToObservable from "../../utils/cast_to_observable";
+import hashBuffer from "../../utils/hash_buffer";
 import tryCatch from "../../utils/rx-try_catch";
+import ServerCertificateHashStore from "./server_certificate_hash_store";
 import { IEMEWarningEvent } from "./types";
 
 /**
@@ -81,8 +84,24 @@ export default function trySettingServerCertificate(
       return EMPTY;
     }
 
+    const formattedServerCertificate: Uint8Array =
+    serverCertificate instanceof Uint8Array ?
+      serverCertificate :
+      new Uint8Array(
+        serverCertificate instanceof ArrayBuffer ? serverCertificate :
+                                                   serverCertificate.buffer);
+    const currentServerCertificateHash = hashBuffer(formattedServerCertificate);
+    const oldServerCertificateHash = ServerCertificateHashStore.get(mediaKeys);
+
+    if (currentServerCertificateHash === oldServerCertificateHash) {
+      log.debug("EME: Server certificate already set on the MediaKeys");
+      return EMPTY;
+    }
+
     log.debug("EME: Setting server certificate on the MediaKeys");
     return setServerCertificate(mediaKeys, serverCertificate).pipe(
+      tap(() => { ServerCertificateHashStore.add(mediaKeys,
+                                                 currentServerCertificateHash); }),
       ignoreElements(),
       catchError(error => observableOf({ type: "warning" as const, value: error })));
   });


### PR DESCRIPTION
Before this PR, a server certificate was set on MediaKeys once per loadVideo, when a session is created for the first initData.
At each loadVideo call for an encrypted content, the server certificate, even if already set, was set again.

Now, we keep a trace of what server certificate has been set for which MediaKeys. We use the hash to identify a server certificate.