### PR TITLE
Use the main "Role" to decide between multiple AdaptationSets

### DIFF
--- a/tests/contents/DASH_static_SegmentBase/multi_codecs.js
+++ b/tests/contents/DASH_static_SegmentBase/multi_codecs.js
@@ -24,6 +24,44 @@ export default {
         audio: [
           {
             isAudioDescription: undefined,
+            language: "en",
+            normalizedLanguage: "eng",
+            representations: [
+              {
+                bitrate: 130107,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "a-eng-0128k-aac.mp4"],
+                    range: [0, 745],
+                  },
+                  segments: [],
+                },
+              },
+            ],
+          },
+          {
+            isAudioDescription: undefined,
+            language: "en",
+            normalizedLanguage: "eng",
+            representations: [
+              {
+                bitrate: 135879,
+                codec: "opus",
+                mimeType: "audio/webm",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "a-eng-0128k-libopus.webm"],
+                    range: [0, 319],
+                  },
+                  segments: [],
+                },
+              },
+            ],
+          },
+          {
+            isAudioDescription: undefined,
             language: "es",
             normalizedLanguage: "spa",
             representations: [
@@ -73,44 +111,6 @@ export default {
                   init: {
                     mediaURLs: [BASE_URL + "a-fra-0128k-aac.mp4"],
                     range: [0, 745],
-                  },
-                  segments: [],
-                },
-              },
-            ],
-          },
-          {
-            isAudioDescription: undefined,
-            language: "en",
-            normalizedLanguage: "eng",
-            representations: [
-              {
-                bitrate: 130107,
-                codec: "mp4a.40.2",
-                mimeType: "audio/mp4",
-                index: {
-                  init: {
-                    mediaURLs: [BASE_URL + "a-eng-0128k-aac.mp4"],
-                    range: [0, 745],
-                  },
-                  segments: [],
-                },
-              },
-            ],
-          },
-          {
-            isAudioDescription: undefined,
-            language: "en",
-            normalizedLanguage: "eng",
-            representations: [
-              {
-                bitrate: 135879,
-                codec: "opus",
-                mimeType: "audio/webm",
-                index: {
-                  init: {
-                    mediaURLs: [BASE_URL + "a-eng-0128k-libopus.webm"],
-                    range: [0, 319],
                   },
                   segments: [],
                 },
@@ -216,31 +216,6 @@ export default {
         text: [
           {
             isClosedCaption: undefined,
-            language: "el",
-            normalizedLanguage: "ell",
-            representations: [
-              {
-                bitrate: 256,
-                codec: undefined,
-                mimeType: "text/vtt",
-                index: {
-                  init: {
-                    mediaURLs: [BASE_URL + "s-el.webvtt"],
-                  },
-                  segments: [
-                    {
-                      mediaURLs: [BASE_URL + "s-el.webvtt"],
-                      time: 0,
-                      timescale: 1,
-                      duration: 60.022,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-          {
-            isClosedCaption: undefined,
             language: "en",
             normalizedLanguage: "eng",
             representations: [
@@ -255,6 +230,31 @@ export default {
                   segments: [
                     {
                       mediaURLs: [BASE_URL + "s-en.webvtt"],
+                      time: 0,
+                      timescale: 1,
+                      duration: 60.022,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            isClosedCaption: undefined,
+            language: "el",
+            normalizedLanguage: "ell",
+            representations: [
+              {
+                bitrate: 256,
+                codec: undefined,
+                mimeType: "text/vtt",
+                index: {
+                  init: {
+                    mediaURLs: [BASE_URL + "s-el.webvtt"],
+                  },
+                  segments: [
+                    {
+                      mediaURLs: [BASE_URL + "s-el.webvtt"],
                       time: 0,
                       timescale: 1,
                       duration: 60.022,

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
@@ -485,7 +485,28 @@
     </AdaptationSet>
 
 
-    <!-- audio sw mp4a.40.2 main priority 100 -->
+    <!-- audio be mp4a.40.2 main -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="be"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio sw mp4a.40.2 main -->
     <AdaptationSet
       group="1"
       contentType="audio"
@@ -494,7 +515,6 @@
       audioSamplingRate="44100"
       mimeType="audio/mp4"
       codecs="mp4a.40.2"
-      selectionPriority="100"
       startWithSAP="1">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
@@ -565,12 +585,28 @@
     </AdaptationSet>
 
 
-    <!-- text sw main hard-of-hearing priority 50 -->
+    <!-- text sw main hard-of-hearing -->
     <AdaptationSet
       id="0"
       contentType="text"
       lang="sw"
-      selectionPriority="50"
+      subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+
+    <!-- text be main hard-of-hearing -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="be"
       subsegmentAlignment="true">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
@@ -77,7 +77,6 @@
       selectionPriority="100"
       startWithSAP="1">
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline>
           <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
@@ -162,7 +161,6 @@
       startWithSAP="1">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline>
           <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
@@ -192,7 +190,6 @@
       lang="de"
       selectionPriority="20"
       subsegmentAlignment="true">
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
       </SegmentTemplate>
@@ -223,7 +220,6 @@
       selectionPriority="50"
       subsegmentAlignment="true">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
       </SegmentTemplate>
@@ -396,7 +392,6 @@
       selectionPriority="100"
       startWithSAP="1">
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline>
           <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
@@ -481,7 +476,28 @@
       startWithSAP="1">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio sw mp4a.40.2 main priority 100 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="sw"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="100"
+      startWithSAP="1">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
       <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline>
           <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
@@ -511,7 +527,6 @@
       lang="de"
       selectionPriority="20"
       subsegmentAlignment="true">
-      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
       <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
       </SegmentTemplate>
@@ -542,7 +557,23 @@
       selectionPriority="50"
       subsegmentAlignment="true">
       <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+    <!-- text sw main hard-of-hearing priority 50 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="sw"
+      selectionPriority="50"
+      subsegmentAlignment="true">
       <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
       <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
       </SegmentTemplate>

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -172,7 +172,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
 
     await goToSecondPeriod();
-    checkAudioTrack("sw", "swa", false);
+    checkAudioTrack("be", "bel", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
@@ -359,7 +359,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
 
     await goToSecondPeriod();
-    checkAudioTrack("sw", "swa", false);
+    checkAudioTrack("be", "bel", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
@@ -458,7 +458,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("sw", "swa", false);
+    checkAudioTrack("be", "bel", false);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -487,7 +487,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("sw", "swa", false);
+    checkAudioTrack("be", "bel", false);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -511,7 +511,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("sw", "swa", false);
+    checkAudioTrack("be", "bel", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -172,7 +172,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
 
     await goToSecondPeriod();
-    checkAudioTrack("de", "deu", false);
+    checkAudioTrack("sw", "swa", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
@@ -359,7 +359,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
 
     await goToSecondPeriod();
-    checkAudioTrack("de", "deu", false);
+    checkAudioTrack("sw", "swa", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
@@ -458,7 +458,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("de", "deu", false);
+    checkAudioTrack("sw", "swa", false);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -487,7 +487,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("de", "deu", false);
+    checkAudioTrack("sw", "swa", false);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -511,7 +511,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("de", "deu", false);
+    checkAudioTrack("sw", "swa", false);
     checkNoTextTrack();
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });


### PR DESCRIPTION
The previous code used several ways to settle between multiple AdaptationSets when there is a choice that need to be done.

In order:
  1. One that is supported by the current device
  2. One that corresponds to the user's preference
  3. If we're talking about the video only, the one having a "Role" set to "main".
  4. Based on the `selectionPriority` attribute
  5. Based on the order they are in the MPD

This commit changes two things:

  1. the Role" set to "main" (step 3), is now considered for any type of AdaptationSets not just for video.

     The DASH-IF IOP were a little unclear to me on that point (and it was the reason why this was not done at first), but that seems to be both a sane default and what other players are doing.

  2. between multiple AdaptationSets having a "main" Role, the order in the MPD is preserved.
     Previously all video "main" AdaptationSets were merged into one.

     Note that this was due to an old work-around and we might want to remove that old behavior now, even if that's the subject for another commit.