### PR TITLE
text/ttml: allow multiple cues to be displayed at the same time

### DIFF
--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -136,11 +136,10 @@ export default class HTMLTextSourceBuffer
   private _clearSizeUpdates$ : Subject<void>;
 
   // Information on the cue currently displayed in `_textTrackElement`.
-  private _currentCue : { element : HTMLElement;
-                          resolution : { columns : number;
-                                         rows : number; } |
-                                       null; } |
-                        null;
+  private _currentCues : Array<{ element : HTMLElement;
+                                 resolution : { columns : number;
+                                                rows : number; } |
+                                              null; }>;
 
   /**
    * @param {HTMLMediaElement} videoElement
@@ -157,14 +156,14 @@ export default class HTMLTextSourceBuffer
     this._clearSizeUpdates$ = new Subject();
     this._destroy$ = new Subject();
     this._buffer = new TextTrackCuesStore();
-    this._currentCue = null;
+    this._currentCues = [];
 
     // update text tracks
     generateClock(this._videoElement)
       .pipe(takeUntil(this._destroy$))
       .subscribe((shouldDisplay) => {
         if (!shouldDisplay) {
-          this._hideCurrentCue();
+          this._disableCurrentCues();
           return;
         }
 
@@ -172,11 +171,11 @@ export default class HTMLTextSourceBuffer
         const time = Math.max(this._videoElement.currentTime +
                               (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
                               0);
-        const cue = this._buffer.get(time);
-        if (cue === undefined) {
-          this._hideCurrentCue();
+        const cues = this._buffer.get(time);
+        if (cues.length === 0) {
+          this._disableCurrentCues();
         } else {
-          this._displayCue(cue.element);
+          this._displayCues(cues);
         }
       });
   }
@@ -282,7 +281,7 @@ export default class HTMLTextSourceBuffer
    */
   _abort() : void {
     log.debug("HTSB: Aborting html text track SourceBuffer");
-    this._hideCurrentCue();
+    this._disableCurrentCues();
     this._remove(0, Infinity);
     this._destroy$.next();
     this._destroy$.complete();
@@ -291,11 +290,13 @@ export default class HTMLTextSourceBuffer
   /**
    * Remove the current cue from being displayed.
    */
-  private _hideCurrentCue() : void {
+  private _disableCurrentCues() : void {
     this._clearSizeUpdates$.next();
-    if (this._currentCue !== null) {
-      safelyRemoveChild(this._textTrackElement, this._currentCue.element);
-      this._currentCue = null;
+    if (this._currentCues.length > 0) {
+      for (let i = 0; i < this._currentCues.length; i++) {
+        safelyRemoveChild(this._textTrackElement, this._currentCues[i].element);
+      }
+      this._currentCues = [];
     }
   }
 
@@ -303,35 +304,43 @@ export default class HTMLTextSourceBuffer
    * Display a new Cue. If one was already present, it will be replaced.
    * @param {HTMLElement} element
    */
-  private _displayCue(element : HTMLElement) : void {
-    if (this._currentCue !== null && this._currentCue.element === element) {
-      return; // we're already good
+  private _displayCues(elements : HTMLElement[]) : void {
+    const nothingChanged = this._currentCues.length === elements.length &&
+      this._currentCues.every((current, index) => current.element === elements[index]);
+
+    if (nothingChanged) {
+      return;
     }
+
+    // Remove and re-display everything
+    // TODO More intelligent handling
 
     this._clearSizeUpdates$.next();
-    if (this._currentCue !== null) {
-      safelyRemoveChild(this._textTrackElement, this._currentCue.element);
+    for (let i = 0; i < this._currentCues.length; i++) {
+      safelyRemoveChild(this._textTrackElement, this._currentCues[i].element);
     }
 
-    const resolution = getElementResolution(element);
-    this._currentCue = { element, resolution };
-    if (resolution !== null) {
+    this._currentCues = [];
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      const resolution = getElementResolution(element);
+      this._currentCues.push({ element, resolution });
+      this._textTrackElement.appendChild(element);
+    }
+
+    if (this._currentCues.some(cue => cue.resolution !== null)) {
       // update propertionally-sized elements periodically
       onHeightWidthChange(this._textTrackElement, TEXT_TRACK_SIZE_CHECKS_INTERVAL)
         .pipe(takeUntil(this._clearSizeUpdates$),
               takeUntil(this._destroy$))
         .subscribe(({ height, width }) => {
-          if (this._currentCue !== null && this._currentCue.resolution !== null) {
-            const hasProport = updateProportionalElements(height,
-                                                          width,
-                                                          this._currentCue.resolution,
-                                                          this._currentCue.element);
-            if (!hasProport) {
-              this._clearSizeUpdates$.next();
+          for (let i = 0; i < this._currentCues.length; i++) {
+            const { resolution, element } = this._currentCues[i];
+            if (resolution !== null) {
+              updateProportionalElements(height, width, resolution, element);
             }
           }
         });
-    }
-    this._textTrackElement.appendChild(element);
+      }
   }
 }

--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -335,17 +335,20 @@ export default class HTMLTextSourceBuffer
       this._textTrackElement.appendChild(element);
     }
 
-    if (this._currentCues.some(cue => cue.resolution !== null)) {
+    const proportionalCues = this._currentCues
+      .filter((cue) : cue is { resolution: { rows : number;
+                                             columns : number; };
+                                element : HTMLElement; } => cue.resolution !== null);
+
+    if (proportionalCues.length > 0) {
       // update propertionally-sized elements periodically
       onHeightWidthChange(this._textTrackElement, TEXT_TRACK_SIZE_CHECKS_INTERVAL)
         .pipe(takeUntil(this._clearSizeUpdates$),
               takeUntil(this._destroy$))
         .subscribe(({ height, width }) => {
-          for (let i = 0; i < this._currentCues.length; i++) {
-            const { resolution, element } = this._currentCues[i];
-            if (resolution !== null) {
-              updateProportionalElements(height, width, resolution, element);
-            }
+          for (let i = 0; i < proportionalCues.length; i++) {
+            const { resolution, element } = proportionalCues[i];
+            updateProportionalElements(height, width, resolution, element);
           }
         });
       }

--- a/src/custom_source_buffers/text/html/html_text_source_buffer.ts
+++ b/src/custom_source_buffers/text/html/html_text_source_buffer.ts
@@ -135,11 +135,18 @@ export default class HTMLTextSourceBuffer
   // regular check.
   private _clearSizeUpdates$ : Subject<void>;
 
-  // Information on the cue currently displayed in `_textTrackElement`.
-  private _currentCues : Array<{ element : HTMLElement;
-                                 resolution : { columns : number;
-                                                rows : number; } |
-                                              null; }>;
+  /** Information on cues currently displayed. */
+  private _currentCues : Array<{
+    /** The HTMLElement containing the cues, appended to `_textTrackElement`. */
+    element : HTMLElement;
+    /**
+     * Anounced resolution for this element.
+     * Necessary to properly render proportional sizes.
+     */
+    resolution : { columns : number;
+                   rows : number; } |
+                 null;
+  }>;
 
   /**
    * @param {HTMLMediaElement} videoElement

--- a/src/custom_source_buffers/text/html/text_track_cues_store.ts
+++ b/src/custom_source_buffers/text/html/text_track_cues_store.ts
@@ -54,7 +54,8 @@ export default class TextTrackCuesStore {
    * updated, for example).
    *
    * @param {Number} time
-   * @returns {HTMLElement|undefined} - The cue to display
+   * @returns {Array.<HTMLElement>} - The cues that need to be displayed at that
+   * time.
    */
   get(time : number) : HTMLElement[] {
     const cuesBuffer = this._cuesBuffer;

--- a/src/custom_source_buffers/text/html/text_track_cues_store.ts
+++ b/src/custom_source_buffers/text/html/text_track_cues_store.ts
@@ -39,7 +39,7 @@ export default class TextTrackCuesStore {
   }
 
   /**
-   * Get corresponding cue for the given time.
+   * Get corresponding cue(s) for the given time.
    * A cue is an object with three properties:
    *   - start {Number}: start time for which the cue should be displayed.
    *   - end {Number}: end time for which the cue should be displayed.
@@ -56,25 +56,25 @@ export default class TextTrackCuesStore {
    * @param {Number} time
    * @returns {HTMLElement|undefined} - The cue to display
    */
-  get(time : number) : IHTMLCue|undefined {
+  get(time : number) : HTMLElement[] {
     const cuesBuffer = this._cuesBuffer;
+    const ret = [];
 
     // begins at the end as most of the time the player will ask for the last
     // CuesGroup
     for (let i = cuesBuffer.length - 1; i >= 0; i--) {
-      const cues = cuesBuffer[i].cues;
-      for (let j = cues.length - 1; j >= 0; j--) {
-        const cue = cues[j];
-        if (time >= cue.start) {
-          if (time < cue.end) {
-            return cue;
-          } else {
-            return undefined;
+      const segment = cuesBuffer[i];
+      if (time < segment.end && time >= segment.start) {
+        const cues = segment.cues;
+        for (let j = 0; j < cues.length; j++) {
+          if (time >= cues[j].start && time < cues[j].end) {
+            ret.push(cues[j].element);
           }
         }
+        return ret;
       }
     }
-    return undefined;
+    return [];
   }
 
   /**

--- a/src/parsers/texttracks/ttml/html/apply_origin.ts
+++ b/src/parsers/texttracks/ttml/html/apply_origin.ts
@@ -41,10 +41,8 @@ export default function applyOrigin(
         firstOrigin[2] === "%" ||
         firstOrigin[2] === "em")
     {
-      element.style.position = "relative";
       element.style.left = firstOrigin[1] + firstOrigin[2];
     } else if (firstOrigin[2] === "c") {
-      element.style.position = "relative";
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-left", firstOrigin[1]);
     } else {
@@ -55,10 +53,8 @@ export default function applyOrigin(
         secondOrigin[2] === "%" ||
         secondOrigin[2] === "em")
     {
-      element.style.position = "relative";
       element.style.top = secondOrigin[1] + secondOrigin[2];
     } else if (secondOrigin[2] === "c") {
-      element.style.position = "relative";
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-top", secondOrigin[1]);
     } else {

--- a/src/parsers/texttracks/ttml/html/create_element.ts
+++ b/src/parsers/texttracks/ttml/html/create_element.ts
@@ -225,6 +225,8 @@ function applyGeneralStyle(
   // Set default text color. It can be overrided by text element color.
   element.style.color = "white";
 
+  element.style.position = "absolute";
+
   // applies to tt, region
   const extent = style.extent;
   if (isNonEmptyString(extent)) {


### PR DESCRIPTION
Previously, the RxPlayer didn't consider cases where multiple cues, each with their own temporalities, could be displayed at overlapping times.
It only chose one single cue for a given time (which might contain multiple subtitles).

However, having multiple cues at overlapping times happen to be a frequent occurence when dealing with closed captions.

The gist of this commit is not very complicated: functions and methods that were previously given a single HTML element are now given an array of HTML elements.

However, just displaying the multiple elements as is on the screen led to positionning issues when mutiple cues were displayed at the same time: the first cue "pushed" the other cues below it.

Setting the corresponding cues' position to `absolute` instead of `relative` appears to fix the issue.
I did not see any side-effects in test contents after doing that but I'm as far as possible from an expert in CSS.

So I may just as well have broken everything there!

Good luck with the review!