### PR TITLE
fix(directfile-eme): Fix a bug where the CDM will never know when the media key will be attached in directfile

### DIFF
--- a/src/core/eme/init_media_keys.ts
+++ b/src/core/eme/init_media_keys.ts
@@ -48,7 +48,7 @@ export default function initMediaKeys(
 ): Observable<ICreatedMediaKeysEvent|IAttachedMediaKeysEvent> {
   return getMediaKeysInfos(mediaElement, keySystemsConfigs)
     .pipe(mergeMap((mediaKeysInfos) => {
-      const attachMediaKeys$ = (new ReplaySubject<void>(1));
+      const attachMediaKeys$ = new ReplaySubject<void>(1);
       const shouldDisableOldMediaKeys =
         mediaElement.mediaKeys !== null &&
         mediaElement.mediaKeys !== undefined &&

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -184,11 +184,11 @@ export default function initializeDirectfileContent({
   // Manage "loaded" event and warn if autoplay is blocked on the current browser
   const loadedEvent$ = emeManager$.pipe(
     filter(function isEMEReady(evt) {
-      return evt.type === "eme-disabled" ||
-             evt.type === "attached-media-keys" ||
-             (evt.type === "created-media-keys" &&
-              evt.value.mediaKeysInfos.keySystemOptions
-                .disableMediaKeysAttachmentLock === true);
+      if (evt.type === "created-media-keys") {
+        evt.value.attachMediaKeys$.next();
+        return true;
+      }
+      return evt.type === "eme-disabled" || evt.type === "attached-media-keys";
     }),
     take(1),
     mergeMapTo(load$),


### PR DESCRIPTION
This MR is related to the opened issue #827 

This is was a bug encountered in **directfile** mode on trying to play HLS encrypted content.

Basically, the player went in a **LOADING** infinite-state until a media error is thrown after a long period.

From what I understood, the problem came from the fact that we don't have to wait for the Media source to be open to attach the media keys in **directfile**, but for some reasons, the media keys didn't get attached because of the condition was always false and the statement was not present.

I also got rid of `disableMediaKeysAttachmentLock`, from what I understood it's to prevent deadlock on peculiar devices where it might be needed in order to play encrypted content.
I don't know if we still need it in **directfile**, and I think, he was miss used, that's why I deleted it from the code for now.