### PR TITLE
No need for server certificate when not using fairplay on WebKitMediaKeys

### DIFF
--- a/src/compat/eme/custom_media_keys/webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys.ts
@@ -224,7 +224,7 @@ class WebKitCustomMediaKeys implements ICustomWebKitMediaKeys {
 
   createSession(/* sessionType */): ICustomMediaKeySession {
     if (this._videoElement === undefined ||
-      this._mediaKeys === undefined) {
+        this._mediaKeys === undefined) {
       throw new Error("Video not attached to the MediaKeys");
     }
     return new WebkitMediaKeySession(this._videoElement,


### PR DESCRIPTION
Until now, when using WebKitMediaKeys for deciphering content, we did not authorize to create a ponyfill media keys session without any server certificate. In that case, the RxPlayer was throwing an error.
We realized that we only need the server certificate when using fairplay CDM.

Now, the ponyfill session can be created without server certificate. The RxPlayer will throw an error if trying to create a native webkit session without a server certificate with fairplay drm.