### PR TITLE
Adaptation Switch Changes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -927,8 +927,8 @@ export default {
    * @type {Object}
    */
   ADAPTATION_SWITCH_BUFFER_PADDINGS: {
-    video: { before: 0.5, after: 1 },
-    audio: { before: 0.5, after: 2 },
+    video: { before: 1, after: 1 },
+    audio: { before: 1, after: 2 },
     text: { before: 0, after: 0 }, // not managed natively, so no problem here
     image: { before: 0, after: 0 }, // not managed natively, so no problem here
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -927,8 +927,8 @@ export default {
    * @type {Object}
    */
   ADAPTATION_SWITCH_BUFFER_PADDINGS: {
-    video: { before: 1, after: 1 },
-    audio: { before: 1, after: 2 },
+    video: { before: 2, after: 2.5 },
+    audio: { before: 2, after: 2.5 },
     text: { before: 0, after: 0 }, // not managed natively, so no problem here
     image: { before: 0, after: 0 }, // not managed natively, so no problem here
   },

--- a/src/core/abr/network_analyzer.ts
+++ b/src/core/abr/network_analyzer.ts
@@ -40,7 +40,7 @@ interface IPlaybackConditionsInfo {
    */
   bufferGap : number;
   /** Current playback position on the concerned media element, in seconds. */
-  currentTime : number;
+  position : number;
   /**
    * Last "playback rate" set by the user. This is the ideal "playback rate" at
    * which the media should play.
@@ -146,7 +146,7 @@ function estimateStarvationModeBitrate(
   currentRepresentation : Representation | null,
   lastEstimatedBitrate : number|undefined
 ) : number|undefined {
-  const nextNeededPosition = playbackInfo.currentTime + playbackInfo.bufferGap;
+  const nextNeededPosition = playbackInfo.position + playbackInfo.bufferGap;
   const concernedRequests = getConcernedRequests(pendingRequests, nextNeededPosition);
 
   if (concernedRequests.length !== 1) { // 0  == no request
@@ -212,7 +212,7 @@ function shouldDirectlySwitchToLowBitrate(
   playbackInfo : IPlaybackConditionsInfo,
   requests : IRequestInfo[]
 ) : boolean {
-  const nextNeededPosition = playbackInfo.currentTime + playbackInfo.bufferGap;
+  const nextNeededPosition = playbackInfo.position + playbackInfo.bufferGap;
   const nextRequest = arrayFind(requests, (r) =>
     r.duration > 0 && (r.time + r.duration) > nextNeededPosition);
 
@@ -290,11 +290,11 @@ export default class NetworkAnalyzer {
     let newBitrateCeil; // bitrate ceil for the chosen Representation
     let bandwidthEstimate;
     const localConf = this._config;
-    const { bufferGap, currentTime, duration } = playbackInfo;
+    const { bufferGap, position, duration } = playbackInfo;
 
     // check if should get in/out of starvation mode
     if (isNaN(duration) ||
-        bufferGap + currentTime < duration - ABR_STARVATION_DURATION_DELTA)
+        bufferGap + position < duration - ABR_STARVATION_DURATION_DELTA)
     {
       if (!this._inStarvationMode && bufferGap <= localConf.starvationGap) {
         log.info("ABR: enter starvation mode.");

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -119,8 +119,8 @@ export interface IRepresentationEstimatorClockTick {
    * position where no segment data is available and the current position.
    */
   bufferGap : number;
-  /** Current playback position on the concerned media element, in seconds. */
-  currentTime : number;
+  /** The position, in seconds, the media element was in at the time of the tick. */
+  position : number;
   /**
    * Last "playback rate" set by the user. This is the ideal "playback rate" at
    * which the media should play.
@@ -497,9 +497,9 @@ export default function RepresentationEstimator({
       const bufferBasedClock$ = streamEvents$.pipe(
         filter((e) : e is IABRAddedSegmentEvent => e.type === "added-segment"),
         withLatestFrom(clock$),
-        map(([{ value: evtValue }, { speed, currentTime } ]) => {
+        map(([{ value: evtValue }, { speed, position } ]) => {
           const timeRanges = evtValue.buffered;
-          const bufferGap = getLeftSizeOfRange(timeRanges, currentTime);
+          const bufferGap = getLeftSizeOfRange(timeRanges, position);
           const { representation } = evtValue.content;
           const currentScore = scoreCalculator.getEstimate(representation);
           const currentBitrate = representation.bitrate;

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -65,8 +65,8 @@ interface IMediaInfos {
   currentRange : { start : number;
                    end : number; } |
                  null;
-  /** Current `currentTime` (position) set on the media element. */
-  currentTime : number;
+  /** `currentTime` (position) set on the media element at the time of the tick. */
+  position : number;
   /** Current `duration` set on the media element. */
   duration : number;
   /** Current `ended` set on the media element. */
@@ -187,7 +187,7 @@ function getMediaInfos(
   return { bufferGap: getLeftSizeOfRange(buffered, currentTime),
            buffered,
            currentRange: getRange(buffered, currentTime),
-           currentTime,
+           position: currentTime,
            duration,
            ended,
            paused,
@@ -215,7 +215,7 @@ function getStalledStatus(
   { withMediaSource, lowLatencyMode } : IClockOptions
 ) : IStalledStatus {
   const { state: currentState,
-          currentTime,
+          position: currentTime,
           bufferGap,
           currentRange,
           duration,
@@ -225,7 +225,7 @@ function getStalledStatus(
 
   const { stalled: prevStalled,
           state: prevState,
-          currentTime: prevTime } = prevTimings;
+          position: prevTime } = prevTimings;
 
   const fullyLoaded = hasLoadedUntilTheEnd(currentRange, duration, lowLatencyMode);
 
@@ -360,7 +360,7 @@ function createClock(
           if (log.getLevel() === "DEBUG") {
             log.debug("API: current playback timeline:\n" +
                       prettyPrintBuffered(lastTimings.buffered,
-                                          lastTimings.currentTime),
+                                          lastTimings.position),
                       `\n${state}`);
           }
           return lastTimings;

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -100,6 +100,7 @@ export type IStalledStatus =
 export interface IClockTick extends IMediaInfos {
   /** Set if the player is stalled. */
   stalled : IStalledStatus;
+  getCurrentTime : () => number;
 }
 
 const { SAMPLING_INTERVAL_MEDIASOURCE,
@@ -329,15 +330,18 @@ function createClock(
   options : IClockOptions
 ) : Observable<IClockTick> {
   return observableDefer(() : Observable<IClockTick> => {
-    let lastTimings : IClockTick = objectAssign(getMediaInfos(mediaElement, "init"),
-                                                { stalled: null });
+    let lastTimings : IClockTick = objectAssign(
+      getMediaInfos(mediaElement, "init"),
+      { stalled: null, getCurrentTime: () => mediaElement.currentTime });
 
     function getCurrentClockTick(state : IMediaInfosState) : IClockTick {
       const mediaTimings = getMediaInfos(mediaElement, state);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, options);
 
       // /!\ Mutate mediaTimings
-      return objectAssign(mediaTimings, { stalled: stalledState });
+      return objectAssign(mediaTimings,
+                          { stalled: stalledState,
+                            getCurrentTime: () => mediaElement.currentTime });
     }
 
     const eventObs : Array< Observable< IMediaInfosState > > =

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2552,7 +2552,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const maximumPosition = manifest !== null ? manifest.getMaximumPosition() :
                                                 undefined;
     const positionData : IPositionUpdateItem = {
-      position: clockTick.currentTime,
+      position: clockTick.position,
       duration: clockTick.duration,
       playbackRate: clockTick.playbackRate,
       maximumBufferTime: maximumPosition,
@@ -2565,11 +2565,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (manifest !== null &&
         maximumPosition !== undefined &&
         manifest.isLive &&
-        clockTick.currentTime > 0
+        clockTick.position > 0
     ) {
       const ast = manifest.availabilityStartTime ?? 0;
-      positionData.wallClockTime = clockTick.currentTime + ast;
-      positionData.liveGap = maximumPosition - clockTick.currentTime;
+      positionData.wallClockTime = clockTick.position + ast;
+      positionData.liveGap = maximumPosition - clockTick.position;
     }
 
     this.trigger("positionUpdate", positionData);

--- a/src/core/init/create_stream_clock.ts
+++ b/src/core/init/create_stream_clock.ts
@@ -69,6 +69,7 @@ export default function createStreamClock(
         const { isLive } = manifest;
         return {
           position: tick.position,
+          getCurrentTime: tick.getCurrentTime,
           duration: tick.duration,
           isPaused: initialPlayPerformed ? tick.paused :
                                            !autoPlay,

--- a/src/core/init/create_stream_clock.ts
+++ b/src/core/init/create_stream_clock.ts
@@ -68,11 +68,11 @@ export default function createStreamClock(
       .pipe(map(([tick, speed]) => {
         const { isLive } = manifest;
         return {
-          currentTime: tick.currentTime,
+          position: tick.position,
           duration: tick.duration,
           isPaused: initialPlayPerformed ? tick.paused :
                                            !autoPlay,
-          liveGap: isLive ? manifest.getMaximumPosition() - tick.currentTime :
+          liveGap: isLive ? manifest.getMaximumPosition() - tick.position :
                             Infinity,
           readyState: tick.readyState,
           speed,
@@ -85,7 +85,7 @@ export default function createStreamClock(
           // effective starting position will be _startTime_.
           // Thus we initially set a wantedTimeOffset equal to startTime.
           wantedTimeOffset: initialSeekPerformed ? 0 :
-                                                   startTime - tick.currentTime,
+                                                   startTime - tick.position,
         };
       }));
 

--- a/src/core/init/get_discontinuities.ts
+++ b/src/core/init/get_discontinuities.ts
@@ -42,16 +42,16 @@ export default function getDiscontinuities(
   return clock$.pipe(
     filter(({ stalled }) => stalled !== null),
     map((tick) : [number, number] | undefined => {
-      const { buffered, currentTime, currentRange, state, stalled } = tick;
-      const nextBufferRangeGap = getNextRangeGap(buffered, currentTime);
+      const { buffered, position, currentRange, state, stalled } = tick;
+      const nextBufferRangeGap = getNextRangeGap(buffered, position);
       // 1: Is it a browser bug? -> force seek at the same current time
-      if (isPlaybackStuck(currentTime,
+      if (isPlaybackStuck(position,
                           currentRange,
                           state,
                           stalled !== null)
       ) {
-        log.warn("Init: After freeze seek", currentTime, currentRange);
-        return [currentTime, currentTime];
+        log.warn("Init: After freeze seek", position, currentRange);
+        return [position, position];
 
       // 2. Is it a short discontinuity in buffer ? -> Seek at the beginning of the
       //                                               next range
@@ -61,20 +61,20 @@ export default function getDiscontinuities(
       // implementation that might drop an injected segment, or in
       // case of small discontinuity in the content.
       } else if (nextBufferRangeGap < BUFFER_DISCONTINUITY_THRESHOLD) {
-        const seekTo = (currentTime + nextBufferRangeGap + 1 / 60);
-        return [currentTime, seekTo];
+        const seekTo = (position + nextBufferRangeGap + 1 / 60);
+        return [position, seekTo];
       }
 
       // 3. Is it a discontinuity between periods ? -> Seek at the beginning of the
       //                                               next period
-      const currentPeriod = manifest.getPeriodForTime(currentTime);
+      const currentPeriod = manifest.getPeriodForTime(position);
       if (currentPeriod != null) {
         const nextPeriod = manifest.getPeriodAfter(currentPeriod);
         if (currentPeriod != null &&
             currentPeriod.end != null &&
             nextPeriod != null &&
-            currentTime > (currentPeriod.end - 1) &&
-            currentTime <= nextPeriod.start &&
+            position > (currentPeriod.end - 1) &&
+            position <= nextPeriod.start &&
             nextPeriod.start - currentPeriod.end === 0) {
           return [currentPeriod.end, nextPeriod.start];
         }

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -27,6 +27,7 @@ import { IStallingItem } from "./get_stalled_events";
 
 // Object emitted when the clock ticks
 export interface IInitClockTick { position : number;
+                                  getCurrentTime : () => number;
                                   buffered : TimeRanges;
                                   duration : number;
                                   bufferGap : number;

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -26,7 +26,7 @@ import { IRepresentationChangeEvent } from "../stream";
 import { IStallingItem } from "./get_stalled_events";
 
 // Object emitted when the clock ticks
-export interface IInitClockTick { currentTime : number;
+export interface IInitClockTick { position : number;
                                   buffered : TimeRanges;
                                   duration : number;
                                   bufferGap : number;

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -126,23 +126,23 @@ const EVENTS = {
 
   needsMediaSourceReload(
     period : Period,
-    { currentTime,
-      isPaused } : { currentTime : number;
+    { position,
+      isPaused } : { position : number;
                      isPaused : boolean; }
   ) : INeedsMediaSourceReload {
     return { type: "needs-media-source-reload",
-             value: { currentTime, isPaused, period } };
+             value: { position, isPaused, period } };
   },
 
   needsDecipherabilityFlush(
-    { currentTime,
+    { position,
       isPaused,
-      duration } : { currentTime : number;
+      duration } : { position : number;
                      isPaused : boolean;
                      duration : number; }
   ) : INeedsDecipherabilityFlush {
     return { type: "needs-decipherability-flush",
-             value: { currentTime, isPaused, duration } };
+             value: { position, isPaused, duration } };
   },
 
   periodStreamReady(

--- a/src/core/stream/period/create_empty_adaptation_stream.ts
+++ b/src/core/stream/period/create_empty_adaptation_stream.ts
@@ -39,7 +39,7 @@ import { IStreamStateFull } from "../types";
  * @returns {Observable}
  */
 export default function createEmptyAdaptationStream(
-  streamClock$ : Observable<{ currentTime : number }>,
+  streamClock$ : Observable<{ position : number }>,
   wantedBufferAhead$ : Observable<number>,
   bufferType : IBufferType,
   content : { period : Period }
@@ -47,7 +47,7 @@ export default function createEmptyAdaptationStream(
   const { period } = content;
   return observableCombineLatest([streamClock$, wantedBufferAhead$]).pipe(
     filter(([clockTick, wantedBufferAhead]) =>
-      period.end != null && clockTick.currentTime + wantedBufferAhead >= period.end
+      period.end != null && clockTick.position + wantedBufferAhead >= period.end
     ),
     map(() => {
       log.debug("Stream: full \"empty\" AdaptationStream", bufferType);

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -49,7 +49,7 @@ export default function getAdaptationSwitchStrategy(
   queuedSourceBuffer : QueuedSourceBuffer<unknown>,
   period : Period,
   adaptation : Adaptation,
-  playbackInfo : { position : number; readyState : number }
+  playbackInfo : { currentTime : number; readyState : number }
 ) : IAdaptationSwitchStrategy {
   const buffered = queuedSourceBuffer.getBufferedRanges();
   if (buffered.length === 0) {
@@ -68,12 +68,12 @@ export default function getAdaptationSwitchStrategy(
   const adaptationInBuffer = getBufferedRangesFromAdaptation(queuedSourceBuffer,
                                                              period,
                                                              adaptation);
-  const { position } = playbackInfo;
+  const { currentTime } = playbackInfo;
   if (adaptation.type === "video" &&
       playbackInfo.readyState > 1 &&
-      isTimeInRange({ start, end }, position) &&
-      (isTimeInRanges(bufferedRanges, position) &&
-       !isTimeInRanges(adaptationInBuffer, position)))
+      isTimeInRange({ start, end }, currentTime) &&
+      (isTimeInRanges(bufferedRanges, currentTime) &&
+       !isTimeInRanges(adaptationInBuffer, currentTime)))
   {
     return { type: "needs-reload", value: undefined };
   }
@@ -89,8 +89,8 @@ export default function getAdaptationSwitchStrategy(
     paddingAfter = 0;
   }
   const toRemove = excludeFromRanges(unwantedData, [{
-    start: Math.max(position - paddingBefore, start),
-    end: Math.min(position + paddingAfter, end),
+    start: Math.max(currentTime - paddingBefore, start),
+    end: Math.min(currentTime + paddingAfter, end),
   }]);
 
   return toRemove.length > 0 ?  { type: "clean-buffer", value: toRemove } :

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -27,7 +27,7 @@ import {
   isTimeInRanges,
   keepRangeIntersection,
 } from "../../../utils/ranges";
-import { QueuedSourceBuffer } from "../../source_buffers";
+import { IBufferedChunk, QueuedSourceBuffer } from "../../source_buffers";
 
 const { ADAPTATION_SWITCH_BUFFER_PADDINGS } = config;
 
@@ -37,7 +37,7 @@ export type IAdaptationSwitchStrategy =
   { type: "needs-reload"; value: undefined };
 
 /**
- * Find out what to do when switching adaptation, based on the current
+ * Find out what to do when switching Adaptation, based on the current
  * situation.
  * @param {Object} queuedSourceBuffer
  * @param {Object} period
@@ -64,22 +64,68 @@ export default function getAdaptationSwitchStrategy(
     return { type: "continue", value: undefined };
   }
 
-  // remove from that intersection what we know to be the right Adaptation
-  const adaptationInBuffer = getBufferedRangesFromAdaptation(queuedSourceBuffer,
-                                                             period,
-                                                             adaptation);
+  queuedSourceBuffer.synchronizeInventory();
+  const inventory = queuedSourceBuffer.getInventory();
+
+  // Continue if we have no other Adaptation buffered in the current Period
+  if (!inventory.some(buf => buf.infos.period.id === period.id &&
+                             buf.infos.adaptation.id !== adaptation.id))
+  {
+    return { type: "continue", value: undefined };
+  }
+
+  /** Data already in the right Adaptation */
+  const adaptationInBuffer =
+    getBufferedRangesFromAdaptation(inventory, period, adaptation);
+
+  /**
+   * Data different from the wanted Adaptation in the Period's range.
+   * /!\ Could contain some data at the end of the previous Period or at the
+   * beginning of the next one.
+   */
+  const unwantedRange = excludeFromRanges(intersection, adaptationInBuffer);
+
+  if (unwantedRange.length === 0) {
+    return { type: "continue", value: undefined };
+  }
+
   const { currentTime } = playbackInfo;
   if (adaptation.type === "video" &&
-      playbackInfo.readyState > 1 &&
+      // We're playing the current Period
       isTimeInRange({ start, end }, currentTime) &&
-      (isTimeInRanges(bufferedRanges, currentTime) &&
-       !isTimeInRanges(adaptationInBuffer, currentTime)))
+      // There is data for the current position
+      playbackInfo.readyState > 1 &&
+      // We're not playing the current wanted video Adaptation
+      !isTimeInRanges(adaptationInBuffer, currentTime))
   {
     return { type: "needs-reload", value: undefined };
   }
 
-  const unwantedData = excludeFromRanges(intersection, adaptationInBuffer);
+  // From here, clean-up data from the previous Adaptation, if one
+
+  const rangesToExclude = [];
+
+  // First, if we are currently playing before or right at the beginning of the
+  // current Period, we don't want to accidentally remove some segments from the
+  // previous Period (which overlap a little with this one)
+  if (currentTime < (period.start + 2)) {
+    /** Last segment before one for the current period. */
+    const lastSegmentBefore = getLastSegmentBeforePeriod(inventory, period);
+    if (lastSegmentBefore !== null &&
+        (lastSegmentBefore.bufferedEnd === undefined ||
+         period.start - lastSegmentBefore.bufferedEnd < 1)) // Close to Period's start
+    {
+      // Exclude data close to the period's start to avoid cleaning
+      // to much
+      rangesToExclude.push({ start: 0,
+                             end: period.start + 1 });
+    }
+  }
+
+  // Next, exclude data around current position to avoid decoding issues
   const bufferType = adaptation.type;
+
+  /** Ranges that won't be cleaned from the current buffer. */
   let paddingBefore = ADAPTATION_SWITCH_BUFFER_PADDINGS[bufferType].before;
   if (paddingBefore == null) {
     paddingBefore = 0;
@@ -88,13 +134,26 @@ export default function getAdaptationSwitchStrategy(
   if (paddingAfter == null) {
     paddingAfter = 0;
   }
-  const toRemove = excludeFromRanges(unwantedData, [{
-    start: Math.max(currentTime - paddingBefore, start),
-    end: Math.min(currentTime + paddingAfter, end),
-  }]);
+  rangesToExclude.push({ start: currentTime - paddingBefore,
+                         end: currentTime + paddingAfter });
 
-  return toRemove.length > 0 ?  { type: "clean-buffer", value: toRemove } :
-                                { type: "continue", value: undefined };
+  // Now remove possible small range from the end if there is a segment from the
+  // next Period
+  if (period.end !== undefined && period.end - currentTime < 2) {
+    /** first segment after for the current period. */
+    const firstSegmentAfter = getFirstSegmentAfterPeriod(inventory, period);
+    if (firstSegmentAfter !== null &&
+        (firstSegmentAfter.bufferedStart === undefined ||
+         (firstSegmentAfter.bufferedStart - period.end) < 1)) // Close to Period's start
+    {
+      rangesToExclude.push({ start: period.end - 1,
+                             end: Number.MAX_VALUE });
+    }
+  }
+  const toRemove = excludeFromRanges(unwantedRange, rangesToExclude);
+
+  return toRemove.length > 0 ? { type: "clean-buffer", value: toRemove } :
+                               { type: "continue", value: undefined };
 }
 
 /**
@@ -106,23 +165,63 @@ export default function getAdaptationSwitchStrategy(
  * @returns {Array.<Object>}
  */
 function getBufferedRangesFromAdaptation(
-  queuedSourceBuffer : QueuedSourceBuffer<unknown>,
+  inventory : IBufferedChunk[],
   period : Period,
   adaptation : Adaptation
 ) : IRange[] {
-  queuedSourceBuffer.synchronizeInventory();
-  return queuedSourceBuffer.getInventory()
-    .reduce<IRange[]>((acc : IRange[], chunk) : IRange[] => {
-      if (chunk.infos.period.id !== period.id ||
-          chunk.infos.adaptation.id !== adaptation.id)
-      {
-        return acc;
-      }
-      const { bufferedStart, bufferedEnd } = chunk;
-      if (bufferedStart === undefined || bufferedEnd === undefined) {
-        return acc;
-      }
-      acc.push({ start: bufferedStart, end: bufferedEnd });
+  return inventory.reduce<IRange[]>((acc : IRange[], chunk) : IRange[] => {
+    if (chunk.infos.period.id !== period.id ||
+        chunk.infos.adaptation.id !== adaptation.id)
+    {
       return acc;
-    }, []);
+    }
+    const { bufferedStart, bufferedEnd } = chunk;
+    if (bufferedStart === undefined || bufferedEnd === undefined) {
+      return acc;
+    }
+    acc.push({ start: bufferedStart, end: bufferedEnd });
+    return acc;
+  }, []);
+}
+
+/**
+ * Returns the last segment in the `inventory` which is linked to a Period
+ * before `period`.
+ * @param {Array.<Object>} inventory
+ * @param {Object} period
+ * @returns {Object|null}
+ */
+function getLastSegmentBeforePeriod(
+  inventory : IBufferedChunk[],
+  period : Period
+) : IBufferedChunk | null {
+  for (let i = 0; i < inventory.length; i++) {
+    if (inventory[i].infos.period.start >= period.start) {
+      if (i > 0) {
+        return inventory[i - 1];
+      }
+      return null;
+    }
+  }
+  return inventory.length > 0 ? inventory[inventory.length - 1] :
+                                null;
+}
+
+/**
+ * Returns the first segment in the `inventory` which is linked to a Period
+ * after `period`.
+ * @param {Array.<Object>} inventory
+ * @param {Object} period
+ * @returns {Object|null}
+ */
+function getFirstSegmentAfterPeriod(
+  inventory : IBufferedChunk[],
+  period : Period
+) : IBufferedChunk | null {
+  for (let i = 0; i < inventory.length; i++) {
+    if (inventory[i].infos.period.start > period.start) {
+      return inventory[i];
+    }
+  }
+  return null;
 }

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -142,7 +142,7 @@ export default function getAdaptationSwitchStrategy(
     const firstSegmentAfter = getFirstSegmentAfterPeriod(inventory, period);
     if (firstSegmentAfter !== null &&
         (firstSegmentAfter.bufferedStart === undefined ||
-         (firstSegmentAfter.bufferedStart - period.end) < 1)) // Close to Period's start
+         (firstSegmentAfter.bufferedStart - period.end) < 1)) // Close to Period's end
     {
       rangesToExclude.push({ start: period.end - 1,
                              end: Number.MAX_VALUE });

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -42,14 +42,14 @@ export type IAdaptationSwitchStrategy =
  * @param {Object} queuedSourceBuffer
  * @param {Object} period
  * @param {Object} adaptation
- * @param {Object} clockTick
+ * @param {Object} playbackInfo
  * @returns {Object}
  */
 export default function getAdaptationSwitchStrategy(
   queuedSourceBuffer : QueuedSourceBuffer<unknown>,
   period : Period,
   adaptation : Adaptation,
-  clockTick : { currentTime : number; readyState : number }
+  playbackInfo : { position : number; readyState : number }
 ) : IAdaptationSwitchStrategy {
   const buffered = queuedSourceBuffer.getBufferedRanges();
   if (buffered.length === 0) {
@@ -68,12 +68,12 @@ export default function getAdaptationSwitchStrategy(
   const adaptationInBuffer = getBufferedRangesFromAdaptation(queuedSourceBuffer,
                                                              period,
                                                              adaptation);
-  const { currentTime } = clockTick;
+  const { position } = playbackInfo;
   if (adaptation.type === "video" &&
-      clockTick.readyState > 1 &&
-      isTimeInRange({ start, end }, currentTime) &&
-      (isTimeInRanges(bufferedRanges, currentTime) &&
-       !isTimeInRanges(adaptationInBuffer, currentTime)))
+      playbackInfo.readyState > 1 &&
+      isTimeInRange({ start, end }, position) &&
+      (isTimeInRanges(bufferedRanges, position) &&
+       !isTimeInRanges(adaptationInBuffer, position)))
   {
     return { type: "needs-reload", value: undefined };
   }
@@ -89,8 +89,8 @@ export default function getAdaptationSwitchStrategy(
     paddingAfter = 0;
   }
   const toRemove = excludeFromRanges(unwantedData, [{
-    start: Math.max(currentTime - paddingBefore, start),
-    end: Math.min(currentTime + paddingAfter, end),
+    start: Math.max(position - paddingBefore, start),
+    end: Math.min(position + paddingAfter, end),
   }]);
 
   return toRemove.length > 0 ?  { type: "clean-buffer", value: toRemove } :

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -105,21 +105,19 @@ export default function getAdaptationSwitchStrategy(
 
   const rangesToExclude = [];
 
-  // First, if we are currently playing before or right at the beginning of the
-  // current Period, we don't want to accidentally remove some segments from the
-  // previous Period (which overlap a little with this one)
-  if (currentTime < (period.start + 2)) {
-    /** Last segment before one for the current period. */
-    const lastSegmentBefore = getLastSegmentBeforePeriod(inventory, period);
-    if (lastSegmentBefore !== null &&
-        (lastSegmentBefore.bufferedEnd === undefined ||
-         period.start - lastSegmentBefore.bufferedEnd < 1)) // Close to Period's start
-    {
-      // Exclude data close to the period's start to avoid cleaning
-      // to much
-      rangesToExclude.push({ start: 0,
-                             end: period.start + 1 });
-    }
+  // First, we don't want to accidentally remove some segments from the previous
+  // Period (which overlap a little with this one)
+
+  /** Last segment before one for the current period. */
+  const lastSegmentBefore = getLastSegmentBeforePeriod(inventory, period);
+  if (lastSegmentBefore !== null &&
+    (lastSegmentBefore.bufferedEnd === undefined ||
+      period.start - lastSegmentBefore.bufferedEnd < 1)) // Close to Period's start
+  {
+    // Exclude data close to the period's start to avoid cleaning
+    // to much
+    rangesToExclude.push({ start: 0,
+      end: period.start + 1 });
   }
 
   // Next, exclude data around current position to avoid decoding issues
@@ -139,7 +137,7 @@ export default function getAdaptationSwitchStrategy(
 
   // Now remove possible small range from the end if there is a segment from the
   // next Period
-  if (period.end !== undefined && period.end - currentTime < 2) {
+  if (period.end !== undefined) {
     /** first segment after for the current period. */
     const firstSegmentAfter = getFirstSegmentAfterPeriod(inventory, period);
     if (firstSegmentAfter !== null &&
@@ -150,6 +148,7 @@ export default function getAdaptationSwitchStrategy(
                              end: Number.MAX_VALUE });
     }
   }
+
   const toRemove = excludeFromRanges(unwantedRange, rangesToExclude);
 
   return toRemove.length > 0 ? { type: "clean-buffer", value: toRemove } :

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -61,7 +61,7 @@ import createEmptyStream from "./create_empty_adaptation_stream";
 import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
 
 export interface IPeriodStreamClockTick {
-  currentTime : number; // the current position we are in the video in s
+  position : number; // the position we are in the video in s at the time of the tic
   duration : number; // duration of the HTMLMediaElement
   isPaused: boolean; // If true, the player is on pause
   liveGap? : number; // gap between the current position and the edge of a
@@ -69,7 +69,7 @@ export interface IPeriodStreamClockTick {
   readyState : number; // readyState of the HTMLMediaElement
   speed : number; // playback rate at which the content plays
   stalled : IStalledStatus|null; // if set, the player is currently stalled
-  wantedTimeOffset : number; // offset in s to add to currentTime to obtain the
+  wantedTimeOffset : number; // offset in s to add to the time to obtain the
                              // position we actually want to download from
 }
 
@@ -208,7 +208,7 @@ export default function PeriodStream({
       return objectAssign({},
                           tick,
                           { bufferGap: getLeftSizeOfRange(buffered,
-                                                          tick.currentTime) });
+                                                          tick.position) });
     }));
     return AdaptationStream({ abrManager,
                               clock$: adaptationStreamClock$,

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -62,6 +62,7 @@ import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
 
 export interface IPeriodStreamClockTick {
   position : number; // the position we are in the video in s at the time of the tic
+  getCurrentTime : () => number; // fetch the current time
   duration : number; // duration of the HTMLMediaElement
   isPaused: boolean; // If true, the player is on pause
   liveGap? : number; // gap between the current position and the edge of a
@@ -161,10 +162,12 @@ export default function PeriodStream({
                                                                 bufferType,
                                                                 adaptation,
                                                                 options);
+          const playbackInfos = { currentTime: tick.getCurrentTime(),
+                                  readyState: tick.readyState };
           const strategy = getAdaptationSwitchStrategy(qSourceBuffer,
                                                        period,
                                                        adaptation,
-                                                       tick);
+                                                       playbackInfos);
           if (strategy.type === "needs-reload") {
             return observableOf(EVENTS.needsMediaSourceReload(period, tick));
           }

--- a/src/core/stream/representation/append_segment_to_source_buffer.ts
+++ b/src/core/stream/representation/append_segment_to_source_buffer.ts
@@ -44,7 +44,7 @@ import forceGarbageCollection from "./force_garbage_collection";
  * @returns {Observable}
  */
 export default function appendSegmentToSourceBuffer<T>(
-  clock$ : Observable<{ currentTime : number }>,
+  clock$ : Observable<{ position : number }>,
   queuedSourceBuffer : QueuedSourceBuffer<T>,
   dataInfos : IPushChunkInfos<T>
 ) : Observable<unknown> {

--- a/src/core/stream/representation/get_segment_priority.ts
+++ b/src/core/stream/representation/get_segment_priority.ts
@@ -34,7 +34,7 @@ const { SEGMENT_PRIORITIES_STEPS } = config;
  */
 export default function getSegmentPriority(
   segment : ISegment,
-  clockTick : { currentTime : number;
+  clockTick : { position : number;
                 wantedTimeOffset : number; }
 ) : number {
   const segmentStart = segment.time / segment.timescale;
@@ -55,10 +55,10 @@ export default function getSegmentPriority(
  */
 export function getPriorityForTime(
   timeWanted : number,
-  clockTick : { currentTime : number;
+  clockTick : { position : number;
                 wantedTimeOffset : number; }
 ) : number {
-  const currentTime = clockTick.currentTime + clockTick.wantedTimeOffset;
+  const currentTime = clockTick.position + clockTick.wantedTimeOffset;
   const distance = timeWanted - currentTime;
 
   for (let priority = 0;

--- a/src/core/stream/representation/get_wanted_range.ts
+++ b/src/core/stream/representation/get_wanted_range.ts
@@ -15,7 +15,7 @@
  */
 
 export interface IClockTick {
-  currentTime : number;
+  position : number;
   wantedTimeOffset : number;
   liveGap? : number;
 }
@@ -35,7 +35,7 @@ export default function getWantedRange(
   tick : IClockTick,
   bufferGoal : number
 ) : { start : number; end : number } {
-  const currentTime = tick.currentTime + tick.wantedTimeOffset;
+  const currentTime = tick.position + tick.wantedTimeOffset;
   const startHardLimit = hardLimits.start == null ? 0 :
                                                     hardLimits.start;
   const endHardLimit = hardLimits.end == null ? Infinity :

--- a/src/core/stream/representation/push_init_segment.ts
+++ b/src/core/stream/representation/push_init_segment.ts
@@ -48,7 +48,7 @@ export default function pushInitSegment<T>(
     content,
     segment,
     segmentData,
-    queuedSourceBuffer } : { clock$ : Observable<{ currentTime : number }>;
+    queuedSourceBuffer } : { clock$ : Observable<{ position : number }>;
                              content: { adaptation : Adaptation;
                                         manifest : Manifest;
                                         period : Period;

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -47,7 +47,7 @@ export default function pushMediaSegment<T>(
     initSegmentData,
     parsedSegment,
     segment,
-    queuedSourceBuffer } : { clock$ : Observable<{ currentTime : number }>;
+    queuedSourceBuffer } : { clock$ : Observable<{ position : number }>;
                              content: { adaptation : Adaptation;
                                         manifest : Manifest;
                                         period : Period;

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -91,8 +91,8 @@ import pushMediaSegment from "./push_media_segment";
 
 /** Object emitted by the Stream's clock$ at each tick. */
 export interface IRepresentationStreamClockTick {
-  /** The current position, in seconds the media element is in, in seconds. */
-  currentTime : number;
+  /** The position, in seconds, the media element was in at the time of the tick. */
+  position : number;
  /**
   * Gap between the current position and the edge of a live content.
   * Not set for non-live contents.
@@ -101,7 +101,7 @@ export interface IRepresentationStreamClockTick {
   /** If set, the player is currently stalled (blocked). */
   stalled : IStalledStatus|null;
   /**
-   * Offset in seconds to add to `currentTime` to obtain the position we
+   * Offset in seconds to add to the time to obtain the position we
    * actually want to download from.
    * This is mostly useful when starting to play a content, where `currentTime`
    * might still be equal to `0` but you actually want to download from a
@@ -275,7 +275,7 @@ export default function RepresentationStream<T>({
       const neededRange = getWantedRange(period, timing, bufferGoal);
 
       const discontinuity = timing.stalled != null ?
-        representation.index.checkDiscontinuity(timing.currentTime) :
+        representation.index.checkDiscontinuity(timing.position) :
         -1;
 
       const shouldRefreshManifest =
@@ -296,7 +296,7 @@ export default function RepresentationStream<T>({
         }
       } else {
         neededSegments = getNeededSegments({ content,
-                                             currentPlaybackTime: timing.currentTime,
+                                             currentPlaybackTime: timing.position,
                                              knownStableBitrate,
                                              neededRange,
                                              queuedSourceBuffer })

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -296,10 +296,10 @@ export interface INeedsMediaSourceReload {
   type: "needs-media-source-reload";
   value: {
     /**
-     * The current position in seconds and the time at which the MediaSource
-     * should be reset once it has been reloaded.
+     * The position in seconds and the time at which the MediaSource should be
+     * reset once it has been reloaded.
      */
-    currentTime : number;
+    position : number;
     /**
      * If `true`, the HTMLMediaElement was paused when this event was sent.
      * Otherwise, it is set to `false`.
@@ -343,12 +343,11 @@ export interface INeedsDecipherabilityFlush {
   type: "needs-decipherability-flush";
   value: {
     /**
-     * The current position in seconds.
-     * This is indicated in the case where the MediaSource has to be reloaded,
+     * Indicated in the case where the MediaSource has to be reloaded,
      * in which case the time of the HTMLMediaElement should be reset to that
-     * value once reloaded.
+     * position, in seconds, once reloaded.
      */
-    currentTime : number;
+    position : number;
     /**
      * If `true` the HTMLMediaElement is currently paused.
      * This is indicated in the case where the MediaSource has to be reloaded,


### PR DESCRIPTION
This PR fix multiple things around the clock and Adaptation switching.

The need for it came to me while doing a review for #806. It also seems to fix issues we had with some ad-switching streams.

Basically, three different things are done here:
  1. rename `currentTime` to `position`

     I renamed the `currentTime` property from a clock tick to `position`, as the old name made believe that this time was always up-to-date (current) whereas it is very linked to the time the tick was started at (which can be different from the time when it is used)

  2. add `getCurrentTime` to a clock tick to obtain a more precize position
      I added the `getCurrentTime` function to the clock's ticks, which allows to ask for the real current position at any time

  3. Refacto Adaptation switch strategy

      We now uses the new `getCurrentTime` function where precision matters in the Adaptation switching logic.

       I also spotted a possible issue with Adaptation switching which could led to some "freeze" like those we saw with some multi-Period contents.
       Basically, it all happens in the `getAdaptationSwitchStrategy` function, which is also called for the first chosen Adaptation. In some conditions (often on multi-Period contents), this function can ask to "clean" the buffer before switching.
       This "cleaning" task was actually performed by removing the data corresponding to the time interval linked to the concerned Period, minus some data around the current position to avoid decoding issues.

      This behavior could lead to an issue for multi-Period contents. For example in cases where the last segment from a previous Period overlap a little with the Period considered there, we could remove the end of that segment's data, leading to decoding issues. In the same manner we could also remove some segment's data from the start of the next Period.

      What I've done here to try to fix that:
        1. we choose to clean the buffer in less occasions (we need to have another Adaptation from the same Period)
        2. we apply paddings at the start and end of the current Period if there are segment from other Periods close to those