### PR TITLE
segment_buffers: add `codec` property to SegmentBuffers

### DIFF
--- a/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
@@ -172,20 +172,6 @@ export default class AudioVideoSegmentBuffer
                              null;
 
   /**
-   * Current `type` of the underlying SourceBuffer.
-   * Might be changed for codec-switching purposes.
-   */
-  private _currentCodec : string;
-
-  /**
-   * Public access to the SourceBuffer's current codec.
-   * @returns {string}
-   */
-  public get codec() : string {
-    return this._currentCodec;
-  }
-
-  /**
    * @constructor
    * @param {string} bufferType
    * @param {string} codec
@@ -206,7 +192,7 @@ export default class AudioVideoSegmentBuffer
     this._queue = [];
     this._pendingTask = null;
     this._lastInitSegment = null;
-    this._currentCodec = codec;
+    this.codec = codec;
 
     // Some browsers (happened with firefox 66) sometimes "forget" to send us
     // `update` or `updateend` events.
@@ -517,14 +503,14 @@ export default class AudioVideoSegmentBuffer
             timestampOffset,
             appendWindow,
             codec } = data;
-    if (this._currentCodec !== codec) {
+    if (this.codec !== codec) {
       log.debug("AVSB: updating codec");
       const couldUpdateType = tryToChangeSourceBufferType(this._sourceBuffer,
                                                           codec);
       if (couldUpdateType) {
-        this._currentCodec = codec;
+        this.codec = codec;
       } else {
-        log.warn("AVSB: could not update codec", codec, this._currentCodec);
+        log.warn("AVSB: could not update codec", codec, this.codec);
       }
     }
 

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -70,6 +70,16 @@ export abstract class SegmentBuffer<T> {
   /** Default implementation of an inventory of segment metadata. */
   protected _segmentInventory : SegmentInventory;
 
+  /**
+   * Mimetype+codec combination the SegmentBuffer is currently working with.
+   * Depending on the implementation, segments with a different codecs could be
+   * incompatible.
+   *
+   * `undefined` either if unknown or if the codec does not matter for this
+   * SegmentBuffer implementation.
+   */
+  public codec : string | undefined;
+
   constructor() {
     // Use SegmentInventory by default for inventory purposes
     this._segmentInventory = new SegmentInventory();


### PR DESCRIPTION
Some logic in the RxPlayer might rely on the codec currently decoded by the SegmentBuffers (for example for the audio and video SegmentBuffers, where we might need to reload the MediaSource when the codec is totally different, like in the  `audioTrackSwitchingMode` feature).

This commit adds a `codec` property to SegmentBuffers which can be set to a string or `undefined`. It is for now set to undefined (or really, not set at all) for SegmentBuffers where it doesn't matter (text and image) but to the codec of the SourceBuffer or - if it exists - of the last pushed segment for an audio or video SegmentBuffer.

Note that this property already existed in previous versions but was removed (because not useful until now) in the whole SegmentBuffer refacto.