### PR TITLE
init: re-throw `MEDIA_IS_ENCRYPTED_ERROR` when a pssh is found

### DIFF
--- a/src/core/init/create_eme_manager.ts
+++ b/src/core/init/create_eme_manager.ts
@@ -54,9 +54,11 @@ export default function createEMEManager(
   keySystems : IKeySystemOption[],
   contentProtections$ : Observable<IContentProtection>
 ) : Observable<IEMEManagerEvent|IEMEDisabledEvent> {
+  const encryptedEvents$ = observableMerge(onEncrypted$(mediaElement),
+                                           contentProtections$);
   if (features.emeManager == null) {
     return observableMerge(
-      onEncrypted$(mediaElement).pipe(map(() => {
+      encryptedEvents$.pipe(map(() => {
         log.error("Init: Encrypted event but EME feature not activated");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
                                       "EME feature not activated.");
@@ -66,7 +68,7 @@ export default function createEMEManager(
 
   if (keySystems.length === 0) {
     return observableMerge(
-      onEncrypted$(mediaElement).pipe(map(() => {
+      encryptedEvents$.pipe(map(() => {
         log.error("Init: Ciphered media and no keySystem passed");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
                                       "Media is encrypted and no `keySystems` given");
@@ -76,7 +78,7 @@ export default function createEMEManager(
 
   if (!hasEMEAPIs()) {
     return observableMerge(
-      onEncrypted$(mediaElement).pipe(map(() => {
+      encryptedEvents$.pipe(map(() => {
         log.error("Init: Encrypted event but no EME API available");
         throw new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR",
                                       "Encryption APIs not found.");


### PR DESCRIPTION
Since extracting PSSH to emit them without going through the usual
"encrypted" events, we do not send the `MEDIA_IS_ENCRYPTED_ERROR` error
when an encrypted content is played without a `keySystems` `loadVideo`
option.

This commit fixes that.