### PR TITLE
Log media timings at each clock tick

### DIFF
--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -336,10 +336,11 @@ function createClock(
 
     function getCurrentClockTick(state : IMediaInfosState) : IClockTick {
       const mediaTimings = getMediaInfos(mediaElement, state);
-      log.debug("API: current media element state", mediaTimings);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, options);
+      log.debug("API: current media element state", objectAssign({}, { stalled: stalledState }, mediaTimings));
 
-      return objectAssign({ stalled: stalledState,
+      return objectAssign({},
+                          { stalled: stalledState,
                             getCurrentTime: () => mediaElement.currentTime },
                           mediaTimings);
     }

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -339,10 +339,9 @@ function createClock(
       log.debug("API: current media element state", mediaTimings);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, options);
 
-      return objectAssign({},
-                          mediaTimings,
-                          { stalled: stalledState,
-                            getCurrentTime: () => mediaElement.currentTime });
+      return objectAssign({ stalled: stalledState,
+                            getCurrentTime: () => mediaElement.currentTime },
+                          mediaTimings);
     }
 
     const eventObs : Array< Observable< IMediaInfosState > > =

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -337,12 +337,12 @@ function createClock(
     function getCurrentClockTick(state : IMediaInfosState) : IClockTick {
       const mediaTimings = getMediaInfos(mediaElement, state);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, options);
-      log.debug("API: current media element state", objectAssign({}, { stalled: stalledState }, mediaTimings));
-
-      return objectAssign({},
-                          { stalled: stalledState,
-                            getCurrentTime: () => mediaElement.currentTime },
-                          mediaTimings);
+      const timings = objectAssign({},
+                                   { stalled: stalledState,
+                                     getCurrentTime: () => mediaElement.currentTime },
+                                   mediaTimings);
+      log.debug("API: current media element state", timings);
+      return timings;
     }
 
     const eventObs : Array< Observable< IMediaInfosState > > =

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -336,10 +336,11 @@ function createClock(
 
     function getCurrentClockTick(state : IMediaInfosState) : IClockTick {
       const mediaTimings = getMediaInfos(mediaElement, state);
+      log.debug("API: current media element state", mediaTimings);
       const stalledState = getStalledStatus(lastTimings, mediaTimings, options);
 
-      // /!\ Mutate mediaTimings
-      return objectAssign(mediaTimings,
+      return objectAssign({},
+                          mediaTimings,
                           { stalled: stalledState,
                             getCurrentTime: () => mediaElement.currentTime });
     }


### PR DESCRIPTION
At each clock tick, log media timings (various infos extracted from media element).
This can be needed for debugging purposes.