### PR TITLE
compat/eme: wait a small delay after loading session in some conditions

### DIFF
--- a/src/compat/eme/index.ts
+++ b/src/compat/eme/index.ts
@@ -26,12 +26,14 @@ import {
 } from "./custom_media_keys";
 import generateKeyRequest from "./generate_key_request";
 import getInitData from "./get_init_data";
+import loadSession from "./load_session";
 
 export {
   closeSession,
   CustomMediaKeySystemAccess,
   generateKeyRequest,
   getInitData,
+  loadSession,
   ICustomMediaKeySession,
   ICustomMediaKeySystemAccess,
   ICustomMediaKeys,

--- a/src/compat/eme/load_session.ts
+++ b/src/compat/eme/load_session.ts
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defer as observableDefer,
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import { mergeMap } from "rxjs/operators";
+import log from "../../log";
+import castToObservable from "../../utils/cast_to_observable";
+import tryCatch from "../../utils/rx-try_catch";
+import { ICustomMediaKeySession } from "./custom_media_keys";
+
+/**
+ * Load a persistent session, based on its `sessionId`, on the given
+ * MediaKeySession.
+ *
+ * Returns an Observable which emits:
+ *   - true if the persistent MediaKeySession was found and loaded
+ *   - false if no persistent MediaKeySession was found with that `sessionId`.
+ * Then completes.
+ *
+ * The Observable throws if anything goes wrong in the process.
+ * @param {MediaKeySession} session
+ * @param {string} sessionId
+ * @returns {Observable}
+ */
+export default function loadSession(
+  session : MediaKeySession | ICustomMediaKeySession,
+  sessionId : string
+) : Observable<boolean> {
+  return observableDefer(() => {
+    log.info("Compat/EME: Load persisted session", sessionId);
+    return tryCatch<undefined, boolean>(() => castToObservable(session.load(sessionId)),
+                                        undefined);
+  }).pipe(mergeMap((isLoaded : boolean) : Observable<boolean> => {
+    if (!isLoaded || session.keyStatuses.size > 0) {
+      return observableOf(isLoaded);
+    }
+
+    // A browser race condition exists for example in some old Chromium/Chrome
+    // versions where the `keyStatuses` property from a loaded MediaKeySession
+    // would not be populated directly as the load answer but asynchronously
+    // after.
+    //
+    // Even a delay of `0` millisecond is sufficient, letting us think that it
+    // just happens just after and what is required is just to wait the next
+    // event loop turn.
+    // We found out that creating a micro-task (for example by calling
+    // `Promise.resolve.then`) was not sufficient, that's why we're using the
+    // somewhat less elegant `setTimeout` solution instead.
+    // This is also the reason why I didn't use RxJS's `timer` function, as I'm
+    // unsure of possible optimizations (or future optimizations), when the
+    // delay to wait is set to `0`.
+    return new Observable((subscriber) => {
+      const timer = setTimeout(() => {
+        subscriber.next(isLoaded);
+        subscriber.complete();
+      }, 0);
+      return () => {
+        clearTimeout(timer);
+      };
+    });
+  }));
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -35,6 +35,7 @@ import {
   ICustomMediaKeys,
   ICustomMediaKeySession,
   ICustomMediaKeySystemAccess,
+  loadSession,
   requestMediaKeySystemAccess,
   setMediaKeys,
 } from "./eme";
@@ -90,6 +91,7 @@ export {
   isOffline,
   isPlaybackStuck,
   isVTTCue,
+  loadSession,
   makeVTTCue,
   MediaSource_,
   onHeightWidthChange,


### PR DESCRIPTION
During our test on some set-top boxes, we found out a race condition in some old versions of Chromium/Chrome/CEF where the `keyStatuses` property was not properly populated right after we get the answer from a `mediaKeySession.load` call.

This made us believe that the MediaKeySession that was persisted did not yet have any key stored, which is today a legitimate case, and consequently the RxPlayer would close that MediaKeySession and re-create a new one instead.

We found out that waiting a small delay, even 0 millisecond (through the `setTimeout` native function), was enough to have the `keyStatuses` property right in that case (Note: scheduling a microtask was not enough however).

The resolution proposed in this commit is that, everytime the `keyStatuses` property is empty, we should call `setTimeout(0)` before communicating the MediaKeySession.

That resolution has the disadvantage of adding a small delay (as this `0` millisecond translate sometimes to multiple real milliseconds) for MediaKeySessions which have legitimately an empty `keyStatuses` property (and thus should be closed then re-created).

As discussed, we might want to put that behind an option because of that situation. But I'm still unsure about it.
The corresponding set-top-boxes might not be the only concerned by that issue and I'm wondering if we didn't encounter that case on Chrome Desktop some years back when we were first testing offline playback.
By running that code in every cases, we can fix the issue on every such targets without needing to perform debug sessions and/or advertise about the option in the already very complicated EME documentation. The only downside being a fairly small cost of performance (some milliseconds for a rare case).

We could also improve on that in the future by making sure we store information on persistent MediaKeySession only when `keyStatuses` begin to have its first entry.
That way, `keyStatuses` would very rarely be empty and the delay would not be incurred on functional targets.