### PR TITLE
Seek back a consistent amount of time when switching track/bitrate

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -109,7 +109,22 @@ export default {
   DELTA_POSITION_AFTER_RELOAD: {
     /** Relative position when switching the bitrate */
     bitrateSwitch: -0.1,
-    /** Relative position when switching the track */
+    /**
+     * Relative position when switching the track.
+     *
+     * From tests, I noticed that seeking back was only really "pleasant" when
+     * switching the audio track.
+     *
+     * E.g. switching the video track often means changing the camera angle or
+     * even totally changing what is being seen and rely much less on temporal
+     * context than when an audio track is switched.
+     * As such, I decided to only set a sensible seek-back behavior when
+     * switching the audio track, and only a minimal one (to still ensure
+     * nothing was missed) for video.
+     *
+     * "Other" mainly concern text track, where seeking back could even be
+     * annoying, so that behavior has been disabled in that case.
+     */
     trackSwitch: { audio: -0.7,
                    video: -0.1,
                    other: 0 },

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,32 @@ export default {
                                                     "direct",
 
   /**
+   * In some cases after switching the current track or bitrate, the RxPlayer
+   * could be led to go into the `"RELOADING"` state, which corresponds to
+   * visually a black screen (with nothing audible) before restarting playback.
+   *
+   * We could want to seek back some milliseconds when doing that.
+   * For example, when switching the current audio track, it might make sense
+   * to restart some time before, so the beginning of the sentence can be heard
+   * again in the new language.
+   *
+   * This config property allows to set the relative position the RxPlayer will
+   * seek to after reloading, in seconds.
+   *
+   * For example: a value of `-0.7` means that will seek back 700 milliseconds
+   * when reloading due to a track or bitrate switch with necessitated a
+   * reloading.
+   */
+  DELTA_POSITION_AFTER_RELOAD: {
+    /** Relative position when switching the bitrate */
+    bitrateSwitch: -0.1,
+    /** Relative position when switching the track */
+    trackSwitch: { audio: -0.7,
+                   video: -0.1,
+                   other: 0 },
+  },
+
+  /**
    * If set to true, video through loadVideo will auto play by default
    * @type {Boolean}
    */

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -380,7 +380,7 @@ export default function InitializeOnMediaSource(
         shouldPlay : boolean
       ) : Observable<IInitEvent> {
         const reloadMediaSource$ = new Subject<{ position : number;
-                                                 isPaused : boolean; }>();
+                                                 autoPlay : boolean; }>();
         const mediaSourceLoader$ = mediaSourceLoader(mediaSource, startingPos, shouldPlay)
           .pipe(filterMap<IMediaSourceLoaderEvent, IInitEvent, null>((evt) => {
             switch (evt.type) {
@@ -428,11 +428,11 @@ export default function InitializeOnMediaSource(
           mediaSourceLoader$.pipe(takeUntil(reloadMediaSource$));
 
         const handleReloads$ = reloadMediaSource$.pipe(
-          switchMap(({ position, isPaused }) => {
+          switchMap((reloadOrder) => {
             return openMediaSource(mediaElement).pipe(
               mergeMap(newMS => recursivelyLoadOnMediaSource(newMS,
-                                                             position,
-                                                             !isPaused)),
+                                                             reloadOrder.position,
+                                                             reloadOrder.autoPlay)),
               startWith(EVENTS.reloadingMediaSource())
             );
           }));

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -44,6 +44,7 @@ import {
   take,
   tap,
 } from "rxjs/operators";
+import config from "../../../config";
 import { formatError } from "../../../errors";
 import log from "../../../log";
 import Manifest, {
@@ -71,7 +72,10 @@ import {
   IStreamStateActive,
   IStreamStateFull,
 } from "../types";
+import reloadAfterSwitch from "../utils";
 import createRepresentationEstimator from "./create_representation_estimator";
+
+const { DELTA_POSITION_AFTER_RELOAD } = config;
 
 /** `Clock tick` information needed by the AdaptationStream. */
 export interface IAdaptationStreamClockTick extends IRepresentationStreamClockTick {
@@ -82,6 +86,8 @@ export interface IAdaptationStreamClockTick extends IRepresentationStreamClockTi
   bufferGap : number;
   /** `duration` property of the HTMLMediaElement on which the content plays. */
   duration : number;
+  /** Allows to fetch the current position at any time. */
+  getCurrentTime : () => number;
   /** If true, the player has been put on pause. */
   isPaused: boolean;
   /** Last "playback rate" asked by the user. */
@@ -265,7 +271,7 @@ export default function AdaptationStream<T>({
         fromEstimate.manual &&
         !isFirstEstimate)
     {
-      return clock$.pipe(map(t => EVENTS.needsMediaSourceReload(period, t)));
+      return reloadAfterSwitch(period, clock$, DELTA_POSITION_AFTER_RELOAD.bitrateSwitch);
     }
 
     /**

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -139,19 +139,17 @@ const EVENTS = {
   ) : INeedsMediaSourceReload {
     return { type: "needs-media-source-reload",
              value: { position : reloadAt,
-                      isPaused : reloadOnPause,
+                      autoPlay : reloadOnPause,
                       period } };
   },
 
   needsDecipherabilityFlush(
-    { position,
-      isPaused,
-      duration } : { position : number;
-                     isPaused : boolean;
-                     duration : number; }
+    position : number,
+    autoPlay : boolean,
+    duration : number
   ) : INeedsDecipherabilityFlush {
     return { type: "needs-decipherability-flush",
-             value: { position, isPaused, duration } };
+             value: { position, autoPlay, duration } };
   },
 
   periodStreamReady(

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -124,14 +124,23 @@ const EVENTS = {
              value : undefined };
   },
 
+  /**
+   * @param {Object} period - The Period to which the stream logic asking for a
+   * media source reload is linked.
+   * @param {number} reloadAt - Position at which we should reload
+   * @param {boolean} reloadOnPause - If `false`, stay on pause after reloading.
+   * if `true`, automatically play once reloaded.
+   * @returns {Object}
+   */
   needsMediaSourceReload(
     period : Period,
-    { position,
-      isPaused } : { position : number;
-                     isPaused : boolean; }
+    reloadAt : number,
+    reloadOnPause : boolean
   ) : INeedsMediaSourceReload {
     return { type: "needs-media-source-reload",
-             value: { position, isPaused, period } };
+             value: { position : reloadAt,
+                      isPaused : reloadOnPause,
+                      period } };
   },
 
   needsDecipherabilityFlush(

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -309,7 +309,9 @@ export default function StreamOrchestrator(
             segmentBuffer.removeBuffer(start, end).pipe(ignoreElements())),
           clock$.pipe(take(1), mergeMap((lastTick) => {
             return observableConcat(
-              observableOf(EVENTS.needsDecipherabilityFlush(lastTick)),
+              observableOf(EVENTS.needsDecipherabilityFlush(lastTick.position,
+                                                            !lastTick.isPaused,
+                                                            lastTick.duration)),
               observableDefer(() => {
                 const lastPosition = lastTick.position + lastTick.wantedTimeOffset;
                 const newInitialPeriod = manifest.getPeriodForTime(lastPosition);

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -291,18 +291,11 @@ export interface INeedsMediaSourceReload {
      */
     position : number;
     /**
-     * If `true`, the HTMLMediaElement was paused when this event was sent.
-     * Otherwise, it is set to `false`.
-     *
-     * This should be considered when reloading the MediaSource:
-     *
-     *   - if set to `true` the element should be immediately paused once the
-     *     MediaSource has been reloaded.
-     *
-     *   - if set to `false` it should play as soon as possible after the
-     *     MediaSource has been reloaded.
+     * If `true`, we want the HTMLMediaElement to play right after the reload is
+     * done.
+     * If `false`, we want to stay in a paused state at that point.
      */
-    isPaused : boolean;
+    autoPlay : boolean;
 
     /**
      * A `INeedsMediaSourceReload` is an event sent by a Stream (e.g. a
@@ -339,11 +332,11 @@ export interface INeedsDecipherabilityFlush {
      */
     position : number;
     /**
-     * If `true` the HTMLMediaElement is currently paused.
-     * This is indicated in the case where the MediaSource has to be reloaded,
-     * in which case the paused status has to be restored once reloaded.
+     * If `true`, we want the HTMLMediaElement to play right after the flush is
+     * done.
+     * If `false`, we want to stay in a paused state at that point.
      */
-    isPaused : boolean;
+    autoPlay : boolean;
     /**
      * The duration (maximum seekable position) of the content.
      * This is indicated in the case where a seek has to be performed, to avoid

--- a/src/core/stream/utils.ts
+++ b/src/core/stream/utils.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Observable,
+  of as observableOf,
+} from "rxjs";
+import {
+  map,
+  mergeMap,
+  take,
+} from "rxjs/operators";
+import { Period } from "../../manifest";
+import EVENTS from "./events_generators";
+import { INeedsMediaSourceReload } from "./types";
+
+/**
+ * Switching to another `Adaptation` and or `Representation` can necessitate a
+ * complete reload of the MediaSource.
+ *
+ * This is done through the `INeedsMediaSourceReload` event which among other
+ * things indicate the position the player should seek to after "reloading".
+ * That position depends on the playback conditions at the time of the switch.
+ *
+ * When you already know you have to reload, you can call this function to take
+ * care of that complex behavior:
+ *
+ *   - If `period` is not being played when that function is called, this
+ *     function will emit regularly the `INeedsMediaSourceReload` event after
+ *     applying the given `deltaPos` value to the reloading position.
+ *
+ *   - If `period` is not being when that function is called, it emits regularly
+ *     the `INeedsMediaSourceReload` without applying the given `deltaPos` value
+ *     to the reloading position.
+ *     This is because that value is only applied when the previous Adaptation
+ *     or Representation for the current Period was being played and should not
+ *     be for cases like entering the current Period, or seeking _into_ th
+ *     current Period.
+ *     The main point of that configuration variable being to give back some
+ *     context, there is no context to give back on those cases (as the Period
+ *     was not already playing).
+ *
+ * @param {Object} period - The Period linked to the Adaptation or
+ * Representation that you want to switch to.
+ * @param {Observable} clock$ - Observable emitting playback conditions.
+ * Has to emit last playback conditions immediately on subscribe.
+ * @param {number} deltaPos - If the concerned Period is playing at the time
+ * this function is called, we will add this value, in seconds, to the current
+ * position to indicate the position we should reload at.
+ * This value allows to give back context (by replaying some media data) after
+ * a switch.
+ * @returns {Observable}
+ */
+export default function reloadAfterSwitch(
+  period : Period,
+  clock$ : Observable<{
+    getCurrentTime : () => number;
+    position : number;
+    isPaused : boolean;
+  }>,
+  deltaPos : number
+) : Observable<INeedsMediaSourceReload> {
+  return clock$.pipe(
+    take(1), // only the first (current) event interests us here
+    mergeMap((initialTick) => {
+      if (period.start <= initialTick.position &&
+          (period.end === undefined || period.end > initialTick.position))
+      {
+        // if the Period was playing at the time of the switch
+        const pos = initialTick.getCurrentTime() + deltaPos;
+        const reloadAt = Math.min(Math.max(period.start, pos),
+                                  period.end ?? Infinity);
+        return observableOf(EVENTS.needsMediaSourceReload(period,
+                                                          reloadAt,
+                                                          initialTick.isPaused));
+      }
+
+      // If the Period was not playing, just ask to reload to the exact same position
+      return clock$.pipe(
+        map(tick => EVENTS.needsMediaSourceReload(period,
+                                                  tick.getCurrentTime(),
+                                                  tick.isPaused)));
+    }));
+}

--- a/src/core/stream/utils.ts
+++ b/src/core/stream/utils.ts
@@ -85,13 +85,13 @@ export default function reloadAfterSwitch(
                                   period.end ?? Infinity);
         return observableOf(EVENTS.needsMediaSourceReload(period,
                                                           reloadAt,
-                                                          initialTick.isPaused));
+                                                          !initialTick.isPaused));
       }
 
       // If the Period was not playing, just ask to reload to the exact same position
       return clock$.pipe(
         map(tick => EVENTS.needsMediaSourceReload(period,
                                                   tick.getCurrentTime(),
-                                                  tick.isPaused)));
+                                                  !tick.isPaused)));
     }));
 }


### PR DESCRIPTION
In some cases after switching the current track or bitrate, the RxPlayer could be led to go into the `"RELOADING"` state, which corresponds to visually a black screen (with nothing audible) before restarting playback.

We could want to seek back some milliseconds when doing that.
For example, when switching the current audio track, it might make sense to restart some time before, so the beginning of the sentence can be heard again with the new track - which might be in another language.
Before, we were seeking back at the last position emitted by the clock, which can be anywhere between the current position and 1 second before.

This commit allows to seek back some hundreds of milliseconds configured in `src/config.ts`. That delay depends on whether the track or the bitrate is switched:
  - in case the bitrate is switched, we switch back 100 milliseconds
  - in case the audio track is switched, we switch back 700 milliseconds
  - in case the video track is switched, we switch back 100 milliseconds

I chose different values for audio and video due to both how they could functionally be used (switching audio track needing generally to re-hear what was being said, switching video track - to see another camera for example - needs less context) as well as result of some tests I did on my side:

  - For multiple audio tracks, I tested on:
    https://dash.akamaized.net/dash264/TestCasesIOP41/MultiTrack/alternative_content/6/manifest_alternative_lang.mpd

  - For multiple video tracks:
    https://dash.akamaized.net/dash264/TestCasesIOP41/MultiTrack/associative_content/1/manifest_associated_content_live.mpd

_Both are listed as DASH-IF test vectors._

We could make them configurable values in the future (through the RxPlayer's API), because I can see that making sense functionally (to find out if it could be needed).

I'm still unsure on whether this delay should also be applied in the future when we will perform a `"direct"` audio track switch without `"RELOADING"`, but just by "flushing" the buffers.
It could make sense to stay consistent but that type of interruption is not of the same scale: we re-begin to play much faster.

To discuss for this last point.