### PR TITLE
eme: do not set any server certificate if the option is set to `null`

### DIFF
--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -42,6 +42,7 @@ import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
 import assertUnreachable from "../../utils/assert_unreachable";
 import filterMap from "../../utils/filter_map";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
 import cleanOldStoredPersistentInfo from "./clean_old_stored_persistent_info";
 import getSession, {
@@ -185,7 +186,7 @@ export default function EMEManager(
 
       // set server certificate when it is defined, at first received encrypted
       // event
-      if (i === 0 && serverCertificate !== undefined) {
+      if (i === 0 && !isNullOrUndefined(serverCertificate)) {
           return observableConcat(
             setServerCertificate(mediaKeys, serverCertificate),
             session$);


### PR DESCRIPTION
The documentation for the `keySystems[].serverCertificate` option clearly states that it can only be set to some binary data or `undefined` (or just... not be defined, which is not exactly the same thing as `undefined` :p).

But we found out that some applications preferred to set it to `null` instead!

When setting it to `null`, we still call the `setServerCertificate` API but with `null`, which can have various behaviors.
In the tested cases, it fails.

This is not very problematic as this API is only here as an optimization measure anyway. When it fails, we just ignore it and go on.

But since the `v3.22.0`, an error at the `setServerCertificate` step means that we will most likely re-create a MediaKeys instance on the next `loadVideo` with a `keySystems` option set, because we cannot know the real status of the old MediaKeys instance regarding its attached `serverCertificate`.

And again, there is no problem with that as we can create new MediaKeys if we wish to do so, or can we...?

If we now consider the fact that the PlayStation 5 has problems when creating more than one MediaKeys instance on the same `MediaKeySystemAccess` (it just fails), we obtain a very twisted issue where it becomes impossible to play more than one encrypted content on the PS5 since the `v3.22.0`.

All things considered it appears more as an issue on the application-side, as they should not give us a `serverCertificate` set
to `null` in the first place (and also a PS5 bug, for only authorizing a single MediaKeys instance).

But by going deeper, we can also consider that this is an acceptable value technically and that it is more of a problem with our API
_\<rant>or even with JavaScript as having both `null` and `undefined` can just be too confusing, even more when you consider that the former is the only one that is authorized in JSON (often used by config files where that `serverCertificate` value seemed to come from) but that is the latter that is often used by default in JS.\</rant>_

So, I decided to authorize a `null` value for the `serverCertificate` in the corresponding TypeScript type (but not in the API documentation!) and to properly test its value.

I also added documentation to every `keySystems` property because I found that it was missing.