### PR TITLE
eme/api: stop sending eme-related events twice

### DIFF
--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -26,6 +26,7 @@ import {
 import {
   exhaustMap,
   finalize,
+  ignoreElements,
   map,
   mapTo,
   mergeMap,
@@ -346,16 +347,18 @@ export default function InitializeOnMediaSource(
         fromEvent(manifest, "decipherabilityUpdate")
           .pipe(map(EVENTS.decipherabilityUpdate)));
 
-      const setUndecipherableRepresentations$ = emeManager$.pipe(tap((evt) => {
-        if (evt.type === "blacklist-keys") {
-          log.info("Init: blacklisting Representations based on keyIDs");
-          manifest.addUndecipherableKIDs(evt.value);
-        } else if (evt.type === "blacklist-protection-data") {
-          log.info("Init: blacklisting Representations based on protection data.");
-          manifest.addUndecipherableProtectionData(evt.value.type,
-                                                   evt.value.data);
-        }
-      }));
+      const setUndecipherableRepresentations$ = emeManager$.pipe(
+        tap((evt) => {
+          if (evt.type === "blacklist-keys") {
+            log.info("Init: blacklisting Representations based on keyIDs");
+            manifest.addUndecipherableKIDs(evt.value);
+          } else if (evt.type === "blacklist-protection-data") {
+            log.info("Init: blacklisting Representations based on protection data.");
+            manifest.addUndecipherableProtectionData(evt.value.type,
+                                                     evt.value.data);
+          }
+        }),
+        ignoreElements());
 
       return observableMerge(manifestEvents$,
                              manifestUpdate$,


### PR DESCRIPTION
EME-related events (only EME-related `warning` events and possibly `decipherabilityUpdate` events) were sent two times in a row because we forgot to ignore the items emitted by one of the Observable subscribed in `initialize_media_source.ts`.

As another Observable in that file already emitted EME-related events to the API, each of those would be sent twice.

Thankfully that's the only bug here. The EMEManager being properly shared, the real EME APIs are only called once and only the resulting events emitted to the API (which is only used to trigger events for the application) is sent twice.