### PR TITLE
Seek at next period when discontinuity encountered between periods

### DIFF
--- a/src/core/init/get_current_discontinuity_end.ts
+++ b/src/core/init/get_current_discontinuity_end.ts
@@ -67,14 +67,13 @@ export default function getCurrentDiscontinuityEnd(
       // 3. Is it a discontinuity between periods ? -> Seek at the beginning of the
       //                                               next period
       const currentPeriod = manifest.getPeriodForTime(position);
-      if (currentPeriod != null) {
+      if (currentPeriod !== undefined) {
         const nextPeriod = manifest.getPeriodAfter(currentPeriod);
-        if (currentPeriod != null &&
-            currentPeriod.end != null &&
-            nextPeriod != null &&
+        if (currentPeriod.end !== undefined &&
+            nextPeriod !== undefined &&
             position > (currentPeriod.end - 1) &&
             position <= nextPeriod.start &&
-            nextPeriod.start - currentPeriod.end === 0) {
+            (nextPeriod.start - currentPeriod.end) < 0.5) {
           return nextPeriod.start;
         }
       }

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -43,7 +43,7 @@ import { setDurationToMediaSource } from "./create_media_source";
 import createStreamClock from "./create_stream_clock";
 import { maintainEndOfStream } from "./end_of_stream";
 import EVENTS from "./events_generators";
-import getDiscontinuities from "./get_discontinuities";
+import getCurrentDiscontinuityEnd from "./get_current_discontinuity_end";
 import getStalledEvents from "./get_stalled_events";
 import handleDiscontinuity from "./handle_discontinuity";
 import seekAndLoadOnMediaEvents from "./initial_seek_and_play";
@@ -183,11 +183,8 @@ export default function createMediaSourceLoader({
     const stalled$ = getStalledEvents(clock$)
       .pipe(map(EVENTS.stalled));
 
-    const handledDiscontinuities$ = getDiscontinuities(clock$, manifest).pipe(
-      tap((gap) => {
-        const seekTo = gap[1];
-        handleDiscontinuity(seekTo, mediaElement);
-      }),
+    const handledDiscontinuities$ = getCurrentDiscontinuityEnd(clock$, manifest).pipe(
+      tap((seekTo) => handleDiscontinuity(seekTo, mediaElement)),
       ignoreElements()
     );
 

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -370,20 +370,19 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * Returns the Period coming chronologically just after another given Period.
    * Returns `undefined` if not found.
    * @param {Object} period
-   * @returns {Object|null}
+   * @returns {Object|undefined}
    */
   public getPeriodAfter(
     period : Period
-  ) : Period | null {
+  ) : Period | undefined {
     const endOfPeriod = period.end;
     if (endOfPeriod === undefined) {
-      return null;
+      return undefined;
     }
-    const nextPeriod = arrayFind(this.periods, (_period) => {
+    return arrayFind(this.periods, (_period) => {
       return _period.end === undefined || endOfPeriod < _period.end;
     });
-    return nextPeriod === undefined ? null :
-                                      nextPeriod;
+
   }
 
   /**


### PR DESCRIPTION
When we look for a discontinuity in the stream when the player is stalled, we first check if a discontinuity exists in the HTML5 video element buffer, then, if not, we check if the video position is near the end of a period, in which case we consider that there may be a discontinuity until the start of next period. For that, the two periods may be consecutive.

What changes this PR is that, if there is a small gap between the two periods, while we previously considered that we shouldn't seek, we know consider that we should.