### PR TITLE
stream: change wording of events about "active" and "full" stream

### DIFF
--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -44,10 +44,10 @@ import {
   IPeriodStreamReadyEvent,
   IProtectedSegmentEvent,
   IRepresentationChangeEvent,
+  IStreamDownloadingActive,
   IStreamEventAddedSegment,
   IStreamManifestMightBeOutOfSync,
   IStreamNeedsManifestRefresh,
-  IStreamStateActive,
 } from "../stream";
 import { IEMEDisabledEvent } from "./create_eme_manager";
 import { IStallingItem } from "./get_stalled_events";
@@ -145,7 +145,7 @@ export type IMediaSourceLoaderEvent = IStalledEvent |
                                       IRepresentationChangeEvent |
                                       IStreamEventAddedSegment<unknown> |
                                       IProtectedSegmentEvent |
-                                      IStreamStateActive |
+                                      IStreamDownloadingActive |
                                       IStreamManifestMightBeOutOfSync |
                                       IStreamNeedsManifestRefresh;
 
@@ -186,7 +186,7 @@ export type IInitEvent = IManifestReadyEvent |
                          IBitrateEstimationChangeEvent |
                          IRepresentationChangeEvent |
                          IStreamEventAddedSegment<unknown> |
-                         IStreamStateActive;
+                         IStreamDownloadingActive;
 
 /** Events emitted by the `Init` module for directfile contents. */
 export type IDirectfileEvent = IStalledEvent |

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -65,11 +65,11 @@ import RepresentationStream, {
 import {
   IAdaptationStreamEvent,
   IRepresentationStreamEvent,
+  IStreamDownloadFinished,
+  IStreamDownloadingActive,
   IStreamEventAddedSegment,
   IStreamNeedsDiscontinuitySeek,
   IStreamNeedsManifestRefresh,
-  IStreamStateActive,
-  IStreamStateFull,
 } from "../types";
 import createRepresentationEstimator from "./create_representation_estimator";
 
@@ -399,6 +399,6 @@ export {
   IStreamEventAddedSegment,
   IStreamNeedsDiscontinuitySeek,
   IStreamNeedsManifestRefresh,
-  IStreamStateActive,
-  IStreamStateFull,
+  IStreamDownloadingActive,
+  IStreamDownloadFinished,
 };

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -36,22 +36,17 @@ import {
   IProtectedSegmentEvent,
   IRepresentationChangeEvent,
   IResumeStreamEvent,
+  IStreamDownloadFinished,
+  IStreamDownloadingActive,
   IStreamEventAddedSegment,
   IStreamManifestMightBeOutOfSync,
   IStreamNeedsDiscontinuitySeek,
   IStreamNeedsManifestRefresh,
-  IStreamStateActive,
-  IStreamStateFull,
   IStreamTerminatingEvent,
   IStreamWarningEvent,
 } from "./types";
 
 const EVENTS = {
-  activeStream(bufferType: IBufferType) : IStreamStateActive {
-    return { type: "active-stream",
-             value: { bufferType } };
-  },
-
   activePeriodChanged(period : Period) : IActivePeriodChangedEvent {
     return { type : "activePeriodChanged",
              value : { period } };
@@ -104,14 +99,19 @@ const EVENTS = {
              value : { bufferType, gap } };
   },
 
+  downloadFinished(bufferType : IBufferType) : IStreamDownloadFinished {
+    return { type: "download-finished",
+             value: { bufferType } };
+  },
+
+  downloadingActive(bufferType: IBufferType) : IStreamDownloadingActive {
+    return { type: "downloading-segments",
+             value: { bufferType } };
+  },
+
   endOfStream() : IEndOfStreamEvent {
     return { type: "end-of-stream",
              value: undefined };
-  },
-
-  fullStream(bufferType : IBufferType) : IStreamStateFull {
-    return { type: "full-stream",
-             value: { bufferType } };
   },
 
   needsManifestRefresh() : IStreamNeedsManifestRefresh {

--- a/src/core/stream/orchestrator/are_streams_complete.ts
+++ b/src/core/stream/orchestrator/are_streams_complete.ts
@@ -57,7 +57,7 @@ export default function areStreamsComplete(
       return stream.pipe(
         filter((evt) => {
           return evt.type === "complete-stream" ||
-                 evt.type === "active-stream";
+                 evt.type === "downloading-segments";
         }),
         map((evt) => evt.type === "complete-stream"),
         startWith(false),

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -411,7 +411,7 @@ export default function StreamOrchestrator(
                                          wantedBufferAhead$, }
     ).pipe(
       mergeMap((evt : IPeriodStreamEvent) : Observable<IMultiplePeriodStreamsEvent> => {
-        if (evt.type === "full-stream") {
+        if (evt.type === "download-finished") {
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
           if (nextPeriod === null) {
             return observableOf(EVENTS.streamComplete(bufferType));
@@ -420,7 +420,7 @@ export default function StreamOrchestrator(
           // current Stream is full, create the next one if not
           createNextPeriodStream$.next(nextPeriod);
           return EMPTY;
-        } else if (evt.type === "active-stream") {
+        } else if (evt.type === "downloading-segments") {
           // current Stream is active, destroy next Stream if created
           destroyNextStreams$.next();
         }

--- a/src/core/stream/period/create_empty_adaptation_stream.ts
+++ b/src/core/stream/period/create_empty_adaptation_stream.ts
@@ -25,7 +25,8 @@ import {
 import log from "../../../log";
 import { Period } from "../../../manifest";
 import { IBufferType } from "../../segment_buffers";
-import { IStreamStateFull } from "../types";
+import EVENTS from "../events_generators";
+import { IStreamDownloadFinished } from "../types";
 
 /**
  * Create empty AdaptationStream Observable, linked to a Period.
@@ -43,7 +44,7 @@ export default function createEmptyAdaptationStream(
   wantedBufferAhead$ : Observable<number>,
   bufferType : IBufferType,
   content : { period : Period }
-) : Observable<IStreamStateFull> {
+) : Observable<IStreamDownloadFinished> {
   const { period } = content;
   return observableCombineLatest([streamClock$, wantedBufferAhead$]).pipe(
     filter(([clockTick, wantedBufferAhead]) =>
@@ -51,8 +52,7 @@ export default function createEmptyAdaptationStream(
     ),
     map(() => {
       log.debug("Stream: full \"empty\" AdaptationStream", bufferType);
-      return { type: "full-stream" as "full-stream",
-               value: { bufferType } };
+      return EVENTS.downloadFinished(bufferType);
     })
   );
 }

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -85,8 +85,8 @@ export interface IStreamNeedsDiscontinuitySeek {
  * Event emitted when a `RepresentationStream` is scheduling new segments to be
  * loaded.
  */
-export interface IStreamStateActive {
-  type : "active-stream";
+export interface IStreamDownloadingActive {
+  type : "downloading-segments";
   value : {
     /** The type of the Representation concerned. */
     bufferType : IBufferType;
@@ -94,11 +94,14 @@ export interface IStreamStateActive {
 }
 
 /**
- * Event emitted when a `RepresentationStream` has pushed segments its SegmentBuffer
- * filling until the end of the associated Period.
+ * Event emitted when a `RepresentationStream` has finished downloading every
+ * segments it needs to download to the end of the corresponding Period.
+ * You will know if it needs to re-download segments in the future (e.g.
+ * because of a seek or of garbage collection) thanks to the
+ * `IStreamDownloadingActive` event being sent.
  */
-export interface IStreamStateFull {
-  type : "full-stream";
+export interface IStreamDownloadFinished {
+  type : "download-finished";
   value : {
    /** The type of the Representation concerned. */
     bufferType : IBufferType;
@@ -356,8 +359,8 @@ export interface INeedsDecipherabilityFlush {
 /** Event sent by a `RepresentationStream`. */
 export type IRepresentationStreamEvent<T> = IStreamEventAddedSegment<T> |
                                             IProtectedSegmentEvent |
-                                            IStreamStateFull |
-                                            IStreamStateActive |
+                                            IStreamDownloadFinished |
+                                            IStreamDownloadingActive |
                                             IStreamManifestMightBeOutOfSync |
                                             IStreamNeedsDiscontinuitySeek |
                                             IStreamNeedsManifestRefresh |
@@ -374,8 +377,8 @@ export type IAdaptationStreamEvent<T> = IBitrateEstimationChangeEvent |
 
                                         IStreamEventAddedSegment<T> |
                                         IProtectedSegmentEvent |
-                                        IStreamStateFull |
-                                        IStreamStateActive |
+                                        IStreamDownloadFinished |
+                                        IStreamDownloadingActive |
                                         IStreamManifestMightBeOutOfSync |
                                         IStreamNeedsDiscontinuitySeek |
                                         IStreamNeedsManifestRefresh |
@@ -397,8 +400,8 @@ export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
 
                                  IStreamEventAddedSegment<unknown> |
                                  IProtectedSegmentEvent |
-                                 IStreamStateFull |
-                                 IStreamStateActive |
+                                 IStreamDownloadFinished |
+                                 IStreamDownloadingActive |
                                  IStreamManifestMightBeOutOfSync |
                                  IStreamNeedsDiscontinuitySeek |
                                  IStreamNeedsManifestRefresh |
@@ -425,7 +428,7 @@ export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
 
                                           IStreamEventAddedSegment<unknown> |
                                           IProtectedSegmentEvent |
-                                          IStreamStateActive |
+                                          IStreamDownloadingActive |
                                           IStreamManifestMightBeOutOfSync |
                                           IStreamNeedsDiscontinuitySeek |
                                           IStreamNeedsManifestRefresh |
@@ -456,7 +459,7 @@ export type IStreamOrchestratorEvent = IActivePeriodChangedEvent |
 
                                        IStreamEventAddedSegment<unknown> |
                                        IProtectedSegmentEvent |
-                                       IStreamStateActive |
+                                       IStreamDownloadingActive |
                                        IStreamManifestMightBeOutOfSync |
                                        IStreamNeedsDiscontinuitySeek |
                                        IStreamNeedsManifestRefresh |


### PR DESCRIPTION
The `RepresentationStream` previously sent ambiguous events such as `"active-stream"` and `"full-stream"` which in effect were used to know if the `RepresentationStream` was still downloading segments, to for example allow a clever pre-loading of the next Period when the previous one did not rely on network resources anymore.

The notion of an "active" and "full" Stream is ambiguous as even a "full" stream could still be pushing already-loaded segments.

I thus chose to rename the "active-stream" event to a "downloading-segments" event and the "full-stream" event to a `"download-finished"` event.