### PR TITLE
api: add `onCodecSwitch` option to loadVideo to reload on codec switch

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -15,6 +15,7 @@
     - [textTrackElement](#prop-textTrackElement)
     - [audioTrackSwitchingMode](#prop-audioTrackSwitchingMode)
     - [manualBitrateSwitchingMode](#prop-manualBitrateSwitchingMode)
+    - [onCodecSwitch](#prop-onCodecSwitch)
     - [lowLatencyMode](#prop-lowLatencyMode)
     - [networkConfig](#prop-networkConfig)
     - [enableFastSwitching](#prop-enableFastSwitching)
@@ -974,6 +975,50 @@ There is two possible values:
 
     [1] More information about the ``"RELOADING"`` state can be found in [the
     player states documentation](./states).
+
+
+<a name="prop-onCodecSwitch"></a>
+### onCodecSwitch ##############################################################
+
+_type_: ``string``
+
+_defaults_: ``"continue"``
+
+---
+
+:warning: This option has no effect in _DirectFile_ mode (see [transport
+option](#prop-transport)).
+
+---
+
+Behavior taken by the player when switching to either an audio or video track
+which has a codec "incompatible" with the previous one (for example going from
+avc, a.k.a h264 to hevc, a.k.a. h265).
+
+This switch can either after the user switches from one track to another or
+after encountering a new Period in some transport technologies (concept existing
+for DASH, "local" and MetaPlaylist contents).
+
+Can be set to one of those two values:
+
+  - ``"continue"``: try to have a seamless transition between both codecs.
+    This behavior works on most modern browsers but might lead to problems like
+    infinite buffering and decoding errors on older browsers and peculiar
+    platforms.
+    This is the default behavior.
+
+  - ``"reload"``: When switching from one codec to another - incompatible - one,
+    the RxPlayer will "reload" the content: the player will go into the
+    `"RELOADING"` state for a small amount of time, during which the video will
+    disappear and many APIs will become unavailable, before playing the track
+    with the new codec.
+    That behavior has the advantage of working on any platform but disadvantage
+    of having a visible transition when those type of codec switches happen.
+
+    Use it if you have issues with codec switching on some platforms.
+
+    _More information about the ``"RELOADING"`` state can be found in [the
+    player states documentation](./states)._
 
 
 <a name="prop-lowLatencyMode"></a>

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ export default {
    *
    * Can be either:
    *
-   *    - "do-nothing": Segments linked to the new codec will continue to be
+   *    - "continue": Segments linked to the new codec will continue to be
    *      pushed to that same SourceBuffer. The RxPlayer will still try to call
    *      the `changeType` API on the SourceBuffer before pushing those
    *      segments but continue even if this call failed.
@@ -103,8 +103,8 @@ export default {
    *    - "reload": Every time a new incompatible codec is encountered on a
    *      given SourceBuffer, we will reload the MediaSource.
    */
-  DEFAULT_CODEC_SWITCHING_BEHAVIOR: "do-nothing" as "do-nothing" |
-                                                    "reload",
+  DEFAULT_CODEC_SWITCHING_BEHAVIOR: "continue" as "continue" |
+                                                  "reload",
 
   /**
    * If set to true, video through loadVideo will auto play by default

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,23 @@ export default {
                                                     "direct",
 
   /**
+   * Behavior of the RxPlayer when encountering a whole other codec on a already
+   * existing audio or video SourceBuffer.
+   *
+   * Can be either:
+   *
+   *    - "do-nothing": Segments linked to the new codec will continue to be
+   *      pushed to that same SourceBuffer. The RxPlayer will still try to call
+   *      the `changeType` API on the SourceBuffer before pushing those
+   *      segments but continue even if this call failed.
+   *
+   *    - "reload": Every time a new incompatible codec is encountered on a
+   *      given SourceBuffer, we will reload the MediaSource.
+   */
+  DEFAULT_CODEC_SWITCHING_BEHAVIOR: "do-nothing" as "do-nothing" |
+                                                    "reload",
+
+  /**
    * If set to true, video through loadVideo will auto play by default
    * @type {Boolean}
    */

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -433,7 +433,7 @@ describe("API - parseLoadVideoOptions", () => {
     lowLatencyMode: false,
     manualBitrateSwitchingMode: "seamless",
     minimumManifestUpdateInterval: 0,
-    onCodecSwitch: "do-nothing",
+    onCodecSwitch: "continue",
     networkConfig: {},
     startAt: undefined,
     textTrackElement: undefined,
@@ -898,18 +898,19 @@ If badly set, seamless strategy will be used as default`);
     });
 
     expect(parseLoadVideoOptions({
-      onCodecSwitch: "do-nothing",
+      onCodecSwitch: "continue",
       url: "foo",
       transport: "bar",
     })).toEqual({
       ...defaultLoadVideoOptions,
       url: "foo",
       transport: "bar",
-      onCodecSwitch: "do-nothing",
+      onCodecSwitch: "continue",
     });
   });
 
-  it("should set a 'do-nothing' onCodecSwitch when the parameter is invalid or not specified", () => {
+  /* eslint-disable-next-line max-len */
+  it("should set a 'continue' onCodecSwitch when the parameter is invalid or not specified", () => {
     logWarnMock.mockReturnValue(undefined);
     expect(parseLoadVideoOptions({
       onCodecSwitch: "foo-bar" as any,
@@ -919,13 +920,15 @@ If badly set, seamless strategy will be used as default`);
       ...defaultLoadVideoOptions,
       url: "foo",
       transport: "bar",
-      onCodecSwitch: "do-nothing",
+      onCodecSwitch: "continue",
     });
     expect(logWarnMock).toHaveBeenCalledTimes(1);
-    expect(logWarnMock).toHaveBeenCalledWith(`The \`onCodecSwitch\` loadVideo option must match one of the following string:
-- \`do-nothing\`
+    expect(logWarnMock)
+      .toHaveBeenCalledWith("The `onCodecSwitch` loadVideo option must match one " +
+                            `of the following string: \
+- \`continue\`
 - \`reload\`
-If badly set, do-nothing will be used as default`);
+If badly set, continue will be used as default`);
     logWarnMock.mockReset();
     logWarnMock.mockReturnValue(undefined);
 
@@ -936,7 +939,7 @@ If badly set, do-nothing will be used as default`);
       ...defaultLoadVideoOptions,
       url: "foo",
       transport: "bar",
-      onCodecSwitch: "do-nothing",
+      onCodecSwitch: "continue",
     });
     expect(logWarnMock).not.toHaveBeenCalled();
   });

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -433,6 +433,7 @@ describe("API - parseLoadVideoOptions", () => {
     lowLatencyMode: false,
     manualBitrateSwitchingMode: "seamless",
     minimumManifestUpdateInterval: 0,
+    onCodecSwitch: "do-nothing",
     networkConfig: {},
     startAt: undefined,
     textTrackElement: undefined,
@@ -880,6 +881,62 @@ If badly set, seamless strategy will be used as default`);
       url: "foo",
       transport: "bar",
       audioTrackSwitchingMode: "seamless",
+    });
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("should authorize setting a valid onCodecSwitch option", () => {
+    expect(parseLoadVideoOptions({
+      onCodecSwitch: "reload",
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      onCodecSwitch: "reload",
+    });
+
+    expect(parseLoadVideoOptions({
+      onCodecSwitch: "do-nothing",
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      onCodecSwitch: "do-nothing",
+    });
+  });
+
+  it("should set a 'do-nothing' onCodecSwitch when the parameter is invalid or not specified", () => {
+    logWarnMock.mockReturnValue(undefined);
+    expect(parseLoadVideoOptions({
+      onCodecSwitch: "foo-bar" as any,
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      onCodecSwitch: "do-nothing",
+    });
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalledWith(`The \`onCodecSwitch\` loadVideo option must match one of the following string:
+- \`do-nothing\`
+- \`reload\`
+If badly set, do-nothing will be used as default`);
+    logWarnMock.mockReset();
+    logWarnMock.mockReturnValue(undefined);
+
+    expect(parseLoadVideoOptions({
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      onCodecSwitch: "do-nothing",
     });
     expect(logWarnMock).not.toHaveBeenCalled();
   });

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -249,7 +249,7 @@ export interface ILoadVideoOptions {
   manualBitrateSwitchingMode? : "seamless"|"direct";
   enableFastSwitching? : boolean;
   audioTrackSwitchingMode? : "seamless"|"direct";
-  onCodecSwitch? : "do-nothing"|"reload";
+  onCodecSwitch? : "continue"|"reload";
 
   /* eslint-disable import/no-deprecated */
   supplementaryTextTracks? : ISupplementaryTextTrackOption[];
@@ -280,7 +280,7 @@ interface IParsedLoadVideoOptionsBase {
   manualBitrateSwitchingMode : "seamless"|"direct";
   enableFastSwitching : boolean;
   audioTrackSwitchingMode : "seamless"|"direct";
-  onCodecSwitch : "do-nothing"|"reload";
+  onCodecSwitch : "continue"|"reload";
 }
 
 /**
@@ -612,11 +612,13 @@ function parseLoadVideoOptions(
   let onCodecSwitch = isNullOrUndefined(options.onCodecSwitch)
                         ? DEFAULT_CODEC_SWITCHING_BEHAVIOR
                         : options.onCodecSwitch;
-  if (!arrayIncludes(["do-nothing", "reload"], onCodecSwitch)) {
-    log.warn("The `onCodecSwitch` loadVideo option must match one of the following string:\n" +
-             "- `do-nothing`\n" +
+  if (!arrayIncludes(["continue", "reload"], onCodecSwitch)) {
+    log.warn("The `onCodecSwitch` loadVideo option must match one of " +
+             "the following string:\n" +
+             "- `continue`\n" +
              "- `reload`\n" +
-             "If badly set, " + DEFAULT_CODEC_SWITCHING_BEHAVIOR + " will be used as default");
+             "If badly set, " + DEFAULT_CODEC_SWITCHING_BEHAVIOR +
+             " will be used as default");
     onCodecSwitch = DEFAULT_CODEC_SWITCHING_BEHAVIOR;
   }
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -690,6 +690,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             manifestUpdateUrl,
             minimumManifestUpdateInterval,
             networkConfig,
+            onCodecSwitch,
             startAt,
             transport,
             transportOptions,
@@ -803,9 +804,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         { textTrackMode: "html" as const,
           textTrackElement: options.textTrackElement };
 
-      const bufferOptions = objectAssign({ enableFastSwitching,
+      const bufferOptions = objectAssign({ audioTrackSwitchingMode,
+                                           enableFastSwitching,
                                            manualBitrateSwitchingMode,
-                                           audioTrackSwitchingMode },
+                                           onCodecSwitch },
                                          this._priv_bufferOptions);
 
       // We've every options set up. Start everything now

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -111,7 +111,7 @@ export interface IInitializeArguments {
     /** Strategy when switching of audio track. */
     audioTrackSwitchingMode : "seamless" | "direct";
     /** Behavior when a new video and/or audio codec is encountered. */
-    onCodecSwitch : "do-nothing" | "reload";
+    onCodecSwitch : "continue" | "reload";
   };
   /** Regularly emit current playback conditions. */
   clock$ : Observable<IInitClockTick>;

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -110,6 +110,8 @@ export interface IInitializeArguments {
     enableFastSwitching : boolean;
     /** Strategy when switching of audio track. */
     audioTrackSwitchingMode : "seamless" | "direct";
+    /** Behavior when a new video and/or audio codec is encountered. */
+    onCodecSwitch : "do-nothing" | "reload";
   };
   /** Regularly emit current playback conditions. */
   clock$ : Observable<IInitClockTick>;

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -75,7 +75,7 @@ export abstract class SegmentBuffer<T> {
    * Depending on the implementation, segments with a different codecs could be
    * incompatible.
    *
-   * `undefined` either if unknown or if the codec does not matter for this
+   * `undefined` if unknown and if this property does not matter for this
    * SegmentBuffer implementation.
    */
   public codec : string | undefined;

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -153,17 +153,6 @@ export interface IAdaptationStreamOptions {
    * those devices.
    */
   enableFastSwitching : boolean;
-  /**
-   * Strategy to adopt when manually switching of audio adaptation.
-   * Can be either:
-   *    - "seamless": transitions are smooth but could be not immediate.
-   *    - "direct": strategy will be "smart", if the mimetype and the codec,
-   *    change, we will perform a hard reload of the media source, however, if it
-   *    doesn't change, we will just perform a small flush by removing buffered range
-   *    and performing, a small seek on the media element.
-   *    Transitions are faster, but, we could see appear a reloading or seeking state.
-   */
-  audioTrackSwitchingMode : "seamless" | "direct";
 }
 
 /**

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -55,7 +55,7 @@ export interface IAdaptationSwitchOptions {
   audioTrackSwitchingMode : "seamless" | "direct";
 
   /** Behavior when a new video and/or audio codec is encountered. */
-  onCodecSwitch : "do-nothing" | "reload";
+  onCodecSwitch : "continue" | "reload";
 }
 
 /**

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -106,7 +106,7 @@ export type IPeriodStreamOptions =
     audioTrackSwitchingMode : "seamless" | "direct";
 
     /** Behavior when a new video and/or audio codec is encountered. */
-    onCodecSwitch : "do-nothing" | "reload";
+    onCodecSwitch : "continue" | "reload";
 
     /** Options specific to the text SegmentBuffer. */
     textTrackOptions? : ITextTrackSegmentBufferOptions;


### PR DESCRIPTION
At the time of v3.0.0, proper multi-codec handling was not integrated and as such we never really asked ourselves the question of what to do when we go from an audio and/or video in a codec A to an audio and/or video in a _incompatible_ codec B.

Thankfully, the non-standard yet `SourceBuffer.changeType` API got implemented at least in Chrome and Firefox, allowing to seamlessly switch between codecs on the same SourceBuffer.

But this API is not implemented everywhere and even on targets where it is, its effectiveness seems to vary.

As such, we still have to find a solution for those other targets so they can play multi-codecs content reliably without hacks.

The obvious solution would be to just create a new SourceBuffer on those targets, which requires to open a new MediaSource (what is called in RxPlayer linguo as a "reloading").

But we might not want to do it in every cases, as written earlier, codec switching can work fine on some targets.
To have an efficient codec switching strategy on all targets, we are thus left with the following choice:

  1. only reload in the absence of specific APIs such as  `changeType` (and browser detection?)

  2. always reload on codec switch, even on targets implementing the `changeType` API

  3. set an option allowing to choose between reloading or not.

This commit implements the third choice.
I also want to implement an "auto" mode in the future, which would be equivalent to the first choice here, but I first need to check on some targets that have those APIs, if `changeType` seems reliable enough.