### PR TITLE
Propose to user to try to reload before throwing an error

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -205,6 +205,8 @@ interface IPublicAPIEvent {
   seeked : null;
   streamEvent : IStreamEvent;
   streamEventSkip : IStreamEvent;
+  safeguardError : { error: ICustomError;
+                     tryToReload: () => void; };
 }
 
 /**
@@ -2043,6 +2045,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   private _priv_onPlaybackEvent(event : IInitEvent) : void {
     switch (event.type) {
+      case "init-error":
+        this.trigger("safeguardError", event.value);
+        break;
       case "stream-event":
         this.trigger("streamEvent", event.value);
         break;

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -205,8 +205,9 @@ interface IPublicAPIEvent {
   seeked : null;
   streamEvent : IStreamEvent;
   streamEventSkip : IStreamEvent;
-  safeguardError : { error: ICustomError;
-                     tryToReload: () => void; };
+  beforeError : { error: ICustomError;
+                  tryToReload: (startAt?: { position?: number;
+                                            relative?: number; }) => void; };
 }
 
 /**
@@ -2046,7 +2047,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_onPlaybackEvent(event : IInitEvent) : void {
     switch (event.type) {
       case "init-error":
-        this.trigger("safeguardError", event.value);
+        this.trigger("beforeError", event.value);
         break;
       case "stream-event":
         this.trigger("streamEvent", event.value);

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -123,6 +123,10 @@ export interface ILoadedEvent { type : "loaded";
                                   segmentBuffersStore: SegmentBuffersStore | null;
                                 }; }
 
+export interface IInitErrorEvent { type: "init-error";
+                                     value: { error: ICustomError;
+                                              tryToReload: () => void; }; }
+
 export { IRepresentationChangeEvent };
 
 /** Events emitted by a `MediaSourceLoader`. */
@@ -156,6 +160,7 @@ export type IInitEvent = IManifestReadyEvent |
                          IDecipherabilityUpdateEvent |
                          IWarningEvent |
                          IEMEDisabledEvent |
+                         IInitErrorEvent |
 
                          // Coming from the `EMEManager`
 


### PR DESCRIPTION
This PR proposes a partial solution for issue #859.

Just before emitting a fatal error, the Init part of the RxPlayer first send an event that carries both the error and a callback that can be used to reload the media source and reinit the streams with current track choices. The EME and ABR will not be initialized again.

If the user tries to reload, the content will be reloaded at a start time provided by the user, with the reload function. The start time can either be absolute of relative of current media time.

Still missing from PR :
- Maximum number of reloads
- doc