### PR TITLE
Only begin to play when the optimal quality is available

### DIFF
--- a/src/core/abr/bandwidth_estimator.ts
+++ b/src/core/abr/bandwidth_estimator.ts
@@ -91,6 +91,28 @@ export default class BandwidthEstimator {
   }
 
   /**
+   * Returns a number indicating the "level of confidence" we have on our
+   * current estimate:
+   *   - a level of `0` indicates that we have no data yet and as such, we have
+   *     no idea of the current estimate.
+   *   - a level of `1` indicates that we have some data, but not enough to give
+   *     an estimate with enough confidence.
+   *   - a level of `2` indicates that the estimate given is based on enough
+   *     data.
+   *
+   * XXX TODO I thought that while `_bytesSampled` was inferior to
+   * `ABR_MINIMUM_TOTAL_BYTES`, we didn't give an estimate (see `getEstimate`).
+   * To double-check.
+   * XXX TODO merge with `getEstimate`?
+   * @returns {number}
+   */
+  public getConfidenceLevel() : 0 | 1 | 2 {
+    return this._bytesSampled >= ABR_MINIMUM_TOTAL_BYTES ? 2 :
+           this._bytesSampled > 0                        ? 1 :
+                                                           0;
+  }
+
+  /**
    * Reset the bandwidth estimation.
    */
   public reset() : void {

--- a/src/core/segment_buffers/implementations/index.ts
+++ b/src/core/segment_buffers/implementations/index.ts
@@ -15,6 +15,10 @@
  */
 
 import AudioVideoSegmentBuffer from "./audio_video";
+import TemporarySegmentBuffer from "./temporary_segment_buffer";
 export * from "./types";
 
-export { AudioVideoSegmentBuffer };
+export {
+  AudioVideoSegmentBuffer,
+  TemporarySegmentBuffer,
+};

--- a/src/core/segment_buffers/implementations/temporary_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/temporary_segment_buffer.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  defer as observableDefer,
+  Observable,
+  ReplaySubject,
+} from "rxjs";
+import {
+  IBufferType,
+  IEndOfSegmentInfos,
+  IPushChunkInfos,
+  ISBOperation,
+  SegmentBuffer,
+  SegmentBufferOperation,
+} from "./types";
+import ManualTimeRanges from "./utils/manual_time_ranges";
+
+export default class TemporarySegmentBuffer<T> extends SegmentBuffer<T> {
+  /** "Type" of the buffer concerned. */
+  public readonly bufferType : IBufferType;
+
+  private readonly _currentQueue : Array<ISBOperation<T>>;
+
+  private readonly _emptyTimeRanges : ManualTimeRanges;
+
+  private readonly _destroy$ : ReplaySubject<void>;
+
+  /**
+   * @constructor
+   * @param {string} bufferType
+   * @param {string} codec
+   * @param {SourceBuffer} sourceBuffer
+   */
+  constructor(bufferType : IBufferType) {
+    super();
+    this.bufferType = bufferType;
+    this._currentQueue = [];
+    this._emptyTimeRanges = new ManualTimeRanges();
+    this._destroy$ = new ReplaySubject<void>(1);
+  }
+
+  /**
+   * @param {Object} infos
+   * @returns {Observable}
+   */
+  public pushChunk(infos : IPushChunkInfos<T>) : Observable<void> {
+    return observableDefer(() => {
+      this._currentQueue.push({ type: SegmentBufferOperation.Push,
+                                value: infos });
+      return this._destroy$;
+    });
+  }
+
+  /**
+   * @param {number} start - start position, in seconds
+   * @param {number} end - end position, in seconds
+   * @returns {Observable}
+   */
+  public removeBuffer(start : number, end : number) : Observable<void> {
+    return observableDefer(() => {
+      this._currentQueue.push({ type: SegmentBufferOperation.Remove,
+                                value: { start, end } });
+      return this._destroy$;
+    });
+  }
+
+  /**
+   * @param {Object} infos
+   * @returns {Observable}
+   */
+  public endOfSegment(infos : IEndOfSegmentInfos) : Observable<void> {
+    return observableDefer(() => {
+      this._currentQueue.push({ type: SegmentBufferOperation.EndOfSegment,
+                                value: infos });
+      return this._destroy$;
+    });
+  }
+
+  /**
+   * @returns {TimeRanges}
+   */
+  public getBufferedRanges() : TimeRanges {
+    return this._emptyTimeRanges;
+  }
+
+  /**
+   * @returns {Array.<Object>}
+   */
+  public getPendingOperations() : Array<ISBOperation<T>> {
+    return this._currentQueue;
+  }
+
+  public dispose() : void {
+    this._currentQueue.length = 0;
+    this._destroy$.next();
+  }
+}

--- a/src/core/segment_buffers/index.ts
+++ b/src/core/segment_buffers/index.ts
@@ -26,6 +26,7 @@ import {
   ISBOperation,
   SegmentBuffer,
   SegmentBufferOperation,
+  TemporarySegmentBuffer,
 } from "./implementations";
 import SegmentBuffersStore, {
   ISegmentBufferOptions,
@@ -41,6 +42,7 @@ export {
   ITextTrackSegmentBufferOptions,
 
   SegmentBuffer,
+  TemporarySegmentBuffer,
 
   IBufferType,
   IBufferedChunk,

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -83,6 +83,9 @@ import {
 } from "../types";
 import createRepresentationEstimator from "./create_representation_estimator";
 
+// XXX TODO
+const MAX_PRELOADING_BUFFER = 10;
+
 /** `Clock tick` information needed by the AdaptationStream. */
 export interface IAdaptationStreamClockTick extends IRepresentationStreamClockTick {
   /**
@@ -259,7 +262,7 @@ export default function AdaptationStream<T>({
           const { representation } = estimate;
           const fastSwitchThreshold$ = observableOf(0); // disabled
           const bufferGoal$ = wantedBufferAhead$.pipe(
-            map((wba) => Math.min(wba, 15 /** XXX TODO */)));
+            map((wba) => Math.min(wba, MAX_PRELOADING_BUFFER)));
           if (lastSegmentBuffer !== null) {
             lastSegmentBuffer.segmentBuffer.dispose();
           }

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -63,7 +63,7 @@ describe("Memory tests", () => {
     expect(heapDifference).to.be.below(1e7);
   });
 
-  it("should not have a sensible memory leak after 1000 LOADED states and adaptive streaming", async function() {
+  it.only("should not have a sensible memory leak after 1000 LOADED states and adaptive streaming", async function() {
     if (window.performance == null ||
         window.performance.memory == null ||
         window.gc == null)
@@ -72,7 +72,7 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(5 * 60 * 1000);
+    this.timeout(10 * 60 * 1000);
     player = new RxPlayer({ initialVideoBitrate: Infinity,
                             initialaudiobitrate: Infinity,
                             preferredtexttracks: [{ language: "fra",

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -72,7 +72,7 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(10 * 60 * 1000);
+    this.timeout(20 * 60 * 1000);
     player = new RxPlayer({ initialVideoBitrate: Infinity,
                             initialaudiobitrate: Infinity,
                             preferredtexttracks: [{ language: "fra",


### PR DESCRIPTION
The adaptive logic of the RxPlayer is based on a mix of bandwidth estimates and on buffer size observations.

Because the former might be unknown when first loading a content*, we usually start with the lowest quality in that case.
This means that the user might see a very low quality on the first seconds of the video, even with an excellent bandwidth.

Some optimizations, such as fast-switching can improve on those problems but:
  1. On some targets (Chromecast, some STBs), this optimization does not work well enough. We still notice many seconds with a different quality than the last one pushed.
  2. Even when it does work, it is still possible to have a few seconds not replaced by a better quality

This commit is a proposal to allow loading a content directly at the most adapted (a.k.a. optimal) quality.

This idea is implemented at two different locations in the code:
  - ABR: Here, the idea is that we need to be able to communicate when the "optimal" quality is known.

    The `ABRManager`, which regularly gives estimates helping the player to know which Representation to choose, will now also pass a new boolean, `isStable`.

    This boolean will be set to `false` until it is confident than the estimate given is stable enough.
    An estimate is stable in one of the following conditions:
      1. The `Representation` has been choosen manually by the user (through APIs such as `setVideoBitrate`).
      2. There is only one `Representation` possible.
      3. Enough data has been loaded for trusting the current bandwidth calculation to be stable.

  - Stream: Here the idea is to only really push the segments when they are known to be at the right quality.

    In the implemented logic, an `AdaptationStream` will first create mock audio and video `SegmentBuffer` instances. Those, instead of pushing segments to a `SourceBuffer`, will just store them in-JS.

    Every time a new estimate - for a different Representation - is chosen and is not considered as stable by the `ABRManager`, the  previous mock is thrown away (and segments it stored with it) and a new one is created.

    When the first stable estimate arrives, we look at the last mock created:
      1. If it corresponds to the same `Representation` we really push those segments in the "real" `SegmentBuffer` (an action I called "commiting" in the code).
      2. If it corresponds to another `Representation` we throw the mock and every segments it stored with it.

    We then continue with the real `SegmentBuffer`, as we did before.

This logic seems to be working well, but there are still some questions to answer:
  1. What to do when `wantedBufferAhead` is too low, and as such we won't reach a `stable` estimate when the Stream loaded all needed segments? Here we risk a deadlock (Stream waiting for the ABRManager to anounce a stable estimate and ABRManager waiting for the Stream to load new segments).
  2. We might want to be careful of the amount of memory taken by our mocked `SegmentBuffer`s, as they don't have clever garbage collection like native SourceBuffers have.
  3. We also might want to be careful for when the user's bandwidth is very low. E.g. we might need to put a timeout there to avoid taking too much time too load when only a very low bandwidth is available.
  4. I am afraid the adding all that code in the `AdaptationStream` lead to ugly code bloat. Even more true when we consider that this option won't be enabled most of the time.
     What are your opinions?

\* Even if another content has already been loaded before, the initial calculated bandwidth will be the last one calculated from the previous content, which might be very different than the current bandwidth.
As such, the logic explained here can be used in any cases: each time a content is loaded.