### PR TITLE
EME: small EMEManager adjustements

### DIFF
--- a/src/compat/eme/generate_key_request.ts
+++ b/src/compat/eme/generate_key_request.ts
@@ -28,6 +28,14 @@ import castToObservable from "../../utils/cast_to_observable";
 import { PSSH_TO_INTEGER } from "./constants";
 import { ICustomMediaKeySession } from "./custom_media_keys";
 
+/** Information about the encryption initialization data. */
+export interface IInitializationDataInfo {
+  /** The initialization data type. */
+  type : string | undefined;
+  /** Initialization data itself. */
+  data : Uint8Array;
+}
+
 /**
  * Modify "initialization data" sent to a `generateKeyRequest` EME call to
  * improve the player's browser compatibility:
@@ -139,19 +147,17 @@ export function patchInitData(initData : Uint8Array) : Uint8Array {
  */
 export default function generateKeyRequest(
   session: MediaKeySession|ICustomMediaKeySession,
-  initData: Uint8Array,
-  initDataType: string|undefined
+  initializationData : IInitializationDataInfo
 ) : Observable<unknown> {
   return observableDefer(() => {
     log.debug("Compat: Calling generateRequest on the MediaKeySession");
     let patchedInit : Uint8Array;
     try {
-      patchedInit = patchInitData(initData);
+      patchedInit = patchInitData(initializationData.data);
     } catch (_e) {
-      patchedInit = initData;
+      patchedInit = initializationData.data;
     }
-    return castToObservable(session.generateRequest(initDataType == null ? "" :
-                                                                           initDataType,
-                                                    patchedInit));
+    const initDataType = initializationData.type ?? "";
+    return castToObservable(session.generateRequest(initDataType, patchedInit));
   });
 }

--- a/src/core/eme/__tests__/__global__/get_license.test.ts
+++ b/src/core/eme/__tests__/__global__/get_license.test.ts
@@ -360,16 +360,16 @@ function checkGetLicense(
         if (!licenseReceived) {
           if (ignoreLicenseRequests) {
             expect(evt.type).toEqual("no-update");
-            expect(evt.value.initData).toEqual(initData);
-            expect(evt.value.initDataType).toEqual("cenc");
+            expect(evt.value.initializationData.data).toEqual(initData);
+            expect(evt.value.initializationData.type).toEqual("cenc");
             expect(updateSpy).toHaveBeenCalledTimes(0);
           } else {
             const license = concat(challenge, challenge);
             expect(evt.type).toEqual("session-updated");
             expect(evt.value.session).toEqual(mediaKeySession);
             expect(evt.value.license).toEqual(license);
-            expect(evt.value.initData).toEqual(initData);
-            expect(evt.value.initDataType).toEqual("cenc");
+            expect(evt.value.initializationData.data).toEqual(initData);
+            expect(evt.value.initializationData.type).toEqual("cenc");
             expect(updateSpy).toHaveBeenCalledTimes(1);
             expect(updateSpy).toHaveBeenCalledWith(license);
           }

--- a/src/core/eme/__tests__/__global__/init_data.test.ts
+++ b/src/core/eme/__tests__/__global__/init_data.test.ts
@@ -108,7 +108,7 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenCalledWith("temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
               expect(generateKeyRequestSpy)
-                .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                .toHaveBeenCalledWith(mediaKeySession, { data: initData, type: "cenc" });
               done();
             }, 10);
             break;
@@ -162,7 +162,8 @@ describe("core - eme - global tests - init data", () => {
                 expect(createSessionSpy).toHaveBeenCalledWith("temporary");
                 expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
                 expect(generateKeyRequestSpy)
-                  .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                  .toHaveBeenCalledWith(mediaKeySession, { data: initData,
+                                                           type: "cenc" });
                 done();
               }, 10);
             }
@@ -233,9 +234,11 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(1, mediaKeySession1, initData1, "cenc");
+                .toHaveBeenNthCalledWith(1, mediaKeySession1, { data: initData1,
+                                                                type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(2, mediaKeySession2, initData2, "cenc");
+                .toHaveBeenNthCalledWith(2, mediaKeySession2, { data: initData2,
+                                                                type: "cenc" });
               done();
             }, 10);
             break;
@@ -306,13 +309,17 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], { data: initData1,
+                                                                   type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], { data: initData1,
+                                                                   type: "cenc2" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], { data: initData2,
+                                                                   type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], { data: initData2,
+                                                                   type: "cenc2" });
               done();
             }, 10);
             break;
@@ -369,7 +376,8 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenCalledWith("temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
               expect(generateKeyRequestSpy)
-                .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                .toHaveBeenCalledWith(mediaKeySession, { data: initData,
+                                                         type: "cenc" });
               done();
             }, 10);
             break;
@@ -432,7 +440,8 @@ describe("core - eme - global tests - init data", () => {
                 expect(createSessionSpy).toHaveBeenCalledWith("temporary");
                 expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
                 expect(generateKeyRequestSpy)
-                  .toHaveBeenCalledWith(mediaKeySession, initData, "cenc");
+                  .toHaveBeenCalledWith(mediaKeySession, { data: initData,
+                                                           type: "cenc" });
                 done();
               }, 10);
             }
@@ -516,9 +525,11 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(1, mediaKeySession1, initData1, "cenc");
+                .toHaveBeenNthCalledWith(1, mediaKeySession1, { data: initData1,
+                                                                type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(2, mediaKeySession2, initData2, "cenc");
+                .toHaveBeenNthCalledWith(2, mediaKeySession2, { data: initData2,
+                                                                type: "cenc" });
               done();
             }, 10);
             break;
@@ -603,13 +614,17 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+                .toHaveBeenNthCalledWith(1, mediaKeySessions[0], { data: initData1,
+                                                                   type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+                .toHaveBeenNthCalledWith(2, mediaKeySessions[1], { data: initData1,
+                                                                   type: "cenc2" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+                .toHaveBeenNthCalledWith(3, mediaKeySessions[2], { data: initData2,
+                                                                   type: "cenc" });
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], { data: initData2,
+                                                                   type: "cenc2" });
               done();
             }, 10);
             break;
@@ -685,7 +700,8 @@ describe("core - eme - global tests - init data", () => {
             expect(createSessionSpy).toHaveBeenNthCalledWith(1, "temporary");
             expect(generateKeyRequestSpy).toHaveBeenCalledTimes(1);
             expect(generateKeyRequestSpy)
-              .toHaveBeenNthCalledWith(1, mediaKeySessions[0], initData1, "cenc");
+              .toHaveBeenNthCalledWith(1, mediaKeySessions[0], { data: initData1,
+                                                                 type: "cenc" });
             break;
           case 5:
             expectInitDataIgnored(evt, initData1, "cenc");
@@ -699,7 +715,8 @@ describe("core - eme - global tests - init data", () => {
             expect(createSessionSpy).toHaveBeenNthCalledWith(2, "temporary");
             expect(generateKeyRequestSpy).toHaveBeenCalledTimes(2);
             expect(generateKeyRequestSpy)
-              .toHaveBeenNthCalledWith(2, mediaKeySessions[1], initData1, "cenc2");
+              .toHaveBeenNthCalledWith(2, mediaKeySessions[1], { data: initData1,
+                                                                 type: "cenc2" });
             break;
           case 7:
             checkEncryptedEventReceived(evt, initDataEvent2, initData1, 2);
@@ -731,7 +748,8 @@ describe("core - eme - global tests - init data", () => {
             expect(createSessionSpy).toHaveBeenNthCalledWith(3, "temporary");
             expect(generateKeyRequestSpy).toHaveBeenCalledTimes(3);
             expect(generateKeyRequestSpy)
-              .toHaveBeenNthCalledWith(3, mediaKeySessions[2], initData2, "cenc");
+              .toHaveBeenNthCalledWith(3, mediaKeySessions[2], { data: initData2,
+                                                                 type: "cenc" });
             break;
           case 12:
             expectInitDataIgnored(evt, initData2, "cenc");
@@ -752,7 +770,8 @@ describe("core - eme - global tests - init data", () => {
               expect(createSessionSpy).toHaveBeenNthCalledWith(4, "temporary");
               expect(generateKeyRequestSpy).toHaveBeenCalledTimes(4);
               expect(generateKeyRequestSpy)
-                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], initData2, "cenc2");
+                .toHaveBeenNthCalledWith(4, mediaKeySessions[3], { data: initData2,
+                                                                   type: "cenc2" });
               kill$.next();
               done();
             }, 5);

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -269,11 +269,12 @@ export function mockCompat(exportedFunctions = {}) {
   const setMediaKeysSpy = jest.fn(() => observableOf(null));
   const generateKeyRequestSpy = jest.fn((
     mks : MediaKeySessionImpl,
-    initData : BufferSource,
-    initDataType : string
+    initializationData: { data : BufferSource;
+                          type : string; }
   ) => {
     return observableDefer(() => {
-      return castToObservable(mks.generateRequest(initDataType, initData));
+      return castToObservable(mks.generateRequest(initializationData.type,
+                                                  initializationData.data));
     });
   });
 
@@ -348,8 +349,8 @@ export function expectLicenseRequestMessage(
 ) : void {
   expect(evt.type).toEqual("session-message");
   expect(evt.value.messageType).toEqual("license-request");
-  expect(evt.value.initData).toEqual(initData);
-  expect(evt.value.initDataType).toEqual(initDataType);
+  expect(evt.value.initializationData.data).toEqual(initData);
+  expect(evt.value.initializationData.type).toEqual(initDataType);
 }
 
 /**
@@ -363,8 +364,8 @@ export function expectInitDataIgnored(
   initDataType : string | undefined
 ) : void {
   expect(evt.type).toEqual("init-data-ignored");
-  expect(evt.value.data).toEqual(initData);
-  expect(evt.value.type).toEqual(initDataType);
+  expect(evt.value.initializationData.data).toEqual(initData);
+  expect(evt.value.initializationData.type).toEqual(initDataType);
 }
 
 /**
@@ -378,8 +379,8 @@ export function expectEncryptedEventReceived(
   initDataType : string | undefined
 ) : void {
   expect(evt.type).toEqual("encrypted-event-received");
-  expect(evt.value.type).toEqual(initDataType);
   expect(evt.value.data).toEqual(initData);
+  expect(evt.value.type).toEqual(initDataType);
 }
 
 /**

--- a/src/core/eme/__tests__/clean_old_loaded_sessions.test.ts
+++ b/src/core/eme/__tests__/clean_old_loaded_sessions.test.ts
@@ -26,14 +26,20 @@ import cleanOldLoadedSessions from "../clean_old_loaded_sessions";
 import LoadedSessionsStore from "../utils/loaded_sessions_store";
 
 
-const entry1 = [ { initData: new Uint8Array([1, 6, 9]),
-                   initDataType: "test" } ];
+const entry1 = { initializationData: { data: new Uint8Array([1, 6, 9]),
+                                       type: "test" },
+                 mediaKeySession: {},
+                 sessionType: "" };
 
-const entry2 = [ { initData: new Uint8Array([4, 8]),
-                   initDataType: "foo" } ];
+const entry2 = { initializationData: { data: new Uint8Array([4, 8]),
+                                       type: "foo" },
+                 mediaKeySession: {},
+                 sessionType: "" };
 
-const entry3 = [ { initData: new Uint8Array([7, 3, 121, 87]),
-                   initDataType: "bar" } ];
+const entry3 = { initializationData: { data: new Uint8Array([7, 3, 121, 87]),
+                                       type: "bar" },
+                 mediaKeySession: {},
+                 sessionType: "" };
 
 function createLoadedSessionsStore() : LoadedSessionsStore {
   return {
@@ -134,9 +140,7 @@ function checkEntriesCleaned(
   expect(closeSessionSpy).toHaveBeenCalledTimes(entries.length);
   for (let i = 0; i < entries.length; i++) {
     expect(closeSessionSpy)
-      .toHaveBeenNthCalledWith(i + 1,
-                               entries[i].initData,
-                               entries[i].initDataType);
+      .toHaveBeenNthCalledWith(i + 1, entries[i].initializationData);
   }
   closeSessionSpy.mockRestore();
 }

--- a/src/core/eme/__tests__/init_media_keys.test.ts
+++ b/src/core/eme/__tests__/init_media_keys.test.ts
@@ -34,9 +34,13 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("should emit `created-media-keys` event once MediaKeys has been created", done => {
-    const falseMediaKeys = { key: "test" };
+    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
+                                      mediaKeys: { b: 4 } },
+                         stores: { loadedSessionsStore: { c: 3 },
+                                   persistentSessionsStore: { d: 2 } },
+                         options: { e: 1 } };
     const spyGetMediaKeysInfos = jest.fn(() => {
-      return observableOf(falseMediaKeys);
+      return observableOf(fakeResult);
     });
     jest.mock("../get_media_keys", () => ({
       __esModule: true as const,
@@ -61,7 +65,9 @@ describe("core - eme - initMediaKeys", () => {
       .pipe(take(1))
       .subscribe((result : any) => {
         expect(result.type).toEqual("created-media-keys");
-        expect(result.value.mediaKeysInfos).toEqual(falseMediaKeys);
+        expect(result.value.instances).toEqual(fakeResult.instances);
+        expect(result.value.stores).toEqual(fakeResult.stores);
+        expect(result.value.options).toEqual(fakeResult.options);
         expect(isObservable(result.value.attachMediaKeys$) &&
                typeof result.value.attachMediaKeys$.next === "function").toBeTruthy();
 
@@ -74,10 +80,14 @@ describe("core - eme - initMediaKeys", () => {
       });
   });
 
-  it("should return mediaKeysInfos after media keys has been attached", (done) => {
-    const falseMediaKeys = { key: "test" };
+  it("should return MediaKeys information after media keys has been attached", (done) => {
+    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
+                                      mediaKeys: { b: 4 } },
+                         stores: { loadedSessionsStore: { c: 3 },
+                                   persistentSessionsStore: { d: 2 } },
+                         options: { e: 1 } };
     const spyGetMediaKeysInfos = jest.fn(() => {
-      return observableOf(falseMediaKeys);
+      return observableOf(fakeResult);
     });
     jest.mock("../get_media_keys", () => ({
       __esModule: true as const,
@@ -110,7 +120,7 @@ describe("core - eme - initMediaKeys", () => {
       .subscribe((result : unknown) => {
         expect(result).toEqual({
           type: "attached-media-keys",
-          value: falseMediaKeys,
+          value: fakeResult,
         });
 
         expect(spyGetMediaKeysInfos).toHaveBeenCalledTimes(1);
@@ -119,7 +129,10 @@ describe("core - eme - initMediaKeys", () => {
 
         expect(spyAttachMediaKeys).toHaveBeenCalledTimes(1);
         expect(spyAttachMediaKeys)
-          .toHaveBeenCalledWith(falseMediaKeys, mediaElement);
+          .toHaveBeenCalledWith(fakeResult.stores.loadedSessionsStore,
+                                fakeResult.instances,
+                                mediaElement,
+                                fakeResult.options);
 
         done();
       });
@@ -161,9 +174,13 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("Should throw if attachMediaKeys throws", (done) => {
-    const falseMediaKeys = { key: "test" };
+    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
+                                      mediaKeys: { b: 4 } },
+                         stores: { loadedSessionsStore: { c: 3 },
+                                   persistentSessionsStore: { d: 2 } },
+                         options: { e: 1 } };
     const spyGetMediaKeysInfos = jest.fn(() => {
-      return observableOf(falseMediaKeys);
+      return observableOf(fakeResult);
     });
     jest.mock("../get_media_keys", () => ({
       __esModule: true as const,
@@ -188,7 +205,9 @@ describe("core - eme - initMediaKeys", () => {
     initMediaKeys(mediaElement, keySystemsConfigs)
       .subscribe((evt : any) => {
         expect(evt.type).toEqual("created-media-keys");
-        expect(evt.value.mediaKeysInfos).toEqual(falseMediaKeys);
+        expect(evt.value.instances).toEqual(fakeResult.instances);
+        expect(evt.value.stores).toEqual(fakeResult.stores);
+        expect(evt.value.options).toEqual(fakeResult.options);
         expect(isObservable(evt.value.attachMediaKeys$) &&
                typeof evt.value.attachMediaKeys$.next === "function").toBeTruthy();
         evt.value.attachMediaKeys$.next();
@@ -197,13 +216,16 @@ describe("core - eme - initMediaKeys", () => {
         expect(eventReceived).toEqual(true);
         expect(e).toBe(err);
 
-        expect(spyAttachMediaKeys).toHaveBeenCalledTimes(1);
+        expect(spyGetMediaKeysInfos).toHaveBeenCalledTimes(1);
         expect(spyGetMediaKeysInfos)
           .toHaveBeenCalledWith(mediaElement, keySystemsConfigs);
 
-        expect(spyGetMediaKeysInfos).toHaveBeenCalledTimes(1);
+        expect(spyAttachMediaKeys).toHaveBeenCalledTimes(1);
         expect(spyAttachMediaKeys)
-          .toHaveBeenCalledWith(falseMediaKeys, mediaElement);
+          .toHaveBeenCalledWith(fakeResult.stores.loadedSessionsStore,
+                                fakeResult.instances,
+                                mediaElement,
+                                fakeResult.options);
 
         done();
       });

--- a/src/core/eme/__tests__/init_media_keys.test.ts
+++ b/src/core/eme/__tests__/init_media_keys.test.ts
@@ -34,8 +34,8 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("should emit `created-media-keys` event once MediaKeys has been created", done => {
-    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
-                                      mediaKeys: { b: 4 } },
+    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+                         mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },
                          options: { e: 1 } };
@@ -65,7 +65,9 @@ describe("core - eme - initMediaKeys", () => {
       .pipe(take(1))
       .subscribe((result : any) => {
         expect(result.type).toEqual("created-media-keys");
-        expect(result.value.instances).toEqual(fakeResult.instances);
+        expect(result.value.mediaKeys).toEqual(fakeResult.mediaKeys);
+        expect(result.value.mediaKeySystemAccess)
+          .toEqual(fakeResult.mediaKeySystemAccess);
         expect(result.value.stores).toEqual(fakeResult.stores);
         expect(result.value.options).toEqual(fakeResult.options);
         expect(isObservable(result.value.attachMediaKeys$) &&
@@ -81,8 +83,8 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("should return MediaKeys information after media keys has been attached", (done) => {
-    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
-                                      mediaKeys: { b: 4 } },
+    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+                         mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },
                          options: { e: 1 } };
@@ -129,11 +131,12 @@ describe("core - eme - initMediaKeys", () => {
 
         expect(spyAttachMediaKeys).toHaveBeenCalledTimes(1);
         expect(spyAttachMediaKeys)
-          .toHaveBeenCalledWith(fakeResult.stores.loadedSessionsStore,
-                                fakeResult.instances,
-                                mediaElement,
-                                fakeResult.options);
-
+          .toHaveBeenCalledWith(
+            mediaElement,
+            { mediaKeySystemAccess: fakeResult.mediaKeySystemAccess,
+              mediaKeys: fakeResult.mediaKeys,
+              loadedSessionsStore: fakeResult.stores.loadedSessionsStore,
+              keySystemOptions: fakeResult.options });
         done();
       });
   });
@@ -174,8 +177,8 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("Should throw if attachMediaKeys throws", (done) => {
-    const fakeResult = { instances: { mediaKeySystemAccess: { a: 5 },
-                                      mediaKeys: { b: 4 } },
+    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+                         mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },
                          options: { e: 1 } };
@@ -205,7 +208,8 @@ describe("core - eme - initMediaKeys", () => {
     initMediaKeys(mediaElement, keySystemsConfigs)
       .subscribe((evt : any) => {
         expect(evt.type).toEqual("created-media-keys");
-        expect(evt.value.instances).toEqual(fakeResult.instances);
+        expect(evt.value.mediaKeys).toEqual(fakeResult.mediaKeys);
+        expect(evt.value.mediaKeySystemAccess).toEqual(fakeResult.mediaKeySystemAccess);
         expect(evt.value.stores).toEqual(fakeResult.stores);
         expect(evt.value.options).toEqual(fakeResult.options);
         expect(isObservable(evt.value.attachMediaKeys$) &&
@@ -222,11 +226,12 @@ describe("core - eme - initMediaKeys", () => {
 
         expect(spyAttachMediaKeys).toHaveBeenCalledTimes(1);
         expect(spyAttachMediaKeys)
-          .toHaveBeenCalledWith(fakeResult.stores.loadedSessionsStore,
-                                fakeResult.instances,
-                                mediaElement,
-                                fakeResult.options);
-
+          .toHaveBeenCalledWith(
+            mediaElement,
+            { mediaKeySystemAccess: fakeResult.mediaKeySystemAccess,
+              mediaKeys: fakeResult.mediaKeys,
+              loadedSessionsStore: fakeResult.stores.loadedSessionsStore,
+              keySystemOptions: fakeResult.options });
         done();
       });
   });

--- a/src/core/eme/attach_media_keys.ts
+++ b/src/core/eme/attach_media_keys.ts
@@ -23,7 +23,11 @@ import { mergeMap, tap } from "rxjs/operators";
 import { setMediaKeys } from "../../compat";
 import log from "../../log";
 import MediaKeysInfosStore from "./media_keys_infos_store";
-import { IMediaKeysInfos } from "./types";
+import {
+  IKeySystemOption,
+  IMediaKeysContext,
+} from "./types";
+import LoadedSessionsStore from "./utils/loaded_sessions_store";
 
 /**
  * Dispose the media keys on media element.
@@ -49,14 +53,13 @@ export function disableMediaKeys(
  * @returns {Observable}
  */
 export default function attachMediaKeys(
-  mediaKeysInfos: IMediaKeysInfos,
-  mediaElement : HTMLMediaElement
+  loadedSessionsStore : LoadedSessionsStore,
+  instances : IMediaKeysContext,
+  mediaElement : HTMLMediaElement,
+  keySystemOptions : IKeySystemOption
 ) : Observable<unknown> {
   return observableDefer(() => {
-    const { keySystemOptions,
-            mediaKeySystemAccess,
-            mediaKeys,
-            loadedSessionsStore } = mediaKeysInfos;
+    const { mediaKeySystemAccess, mediaKeys } = instances;
 
     const previousState = MediaKeysInfosStore.getState(mediaElement);
     const closeAllSessions$ = previousState !== null &&

--- a/src/core/eme/attach_media_keys.ts
+++ b/src/core/eme/attach_media_keys.ts
@@ -20,12 +20,15 @@ import {
   of as observableOf,
 } from "rxjs";
 import { mergeMap, tap } from "rxjs/operators";
-import { setMediaKeys } from "../../compat";
+import {
+  ICustomMediaKeys,
+  ICustomMediaKeySystemAccess,
+  setMediaKeys,
+} from "../../compat";
 import log from "../../log";
 import MediaKeysInfosStore from "./media_keys_infos_store";
 import {
   IKeySystemOption,
-  IMediaKeysContext,
 } from "./types";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 
@@ -43,9 +46,22 @@ export function disableMediaKeys(
   });
 }
 
+/** MediaKeys and associated state attached to a media element. */
+export interface IMediaKeysState {
+  /** Options set when the MediaKeys has been attached. */
+  keySystemOptions : IKeySystemOption;
+  /** LoadedSessionsStore associated to the MediaKeys instance. */
+  loadedSessionsStore : LoadedSessionsStore;
+  /** The MediaKeySystemAccess allowing to create MediaKeys instances. */
+  mediaKeySystemAccess: MediaKeySystemAccess |
+                        ICustomMediaKeySystemAccess;
+  /** The MediaKeys instance to attach to the media element. */
+  mediaKeys : MediaKeys |
+              ICustomMediaKeys;
+}
+
 /**
- * Set the MediaKeys object on the HTMLMediaElement if it is not already on the
- * element.
+ * Attach MediaKeys and its associated state to an HTMLMediaElement.
  *
  * /!\ Mutates heavily MediaKeysInfosStore
  * @param {Object} mediaKeysInfos
@@ -53,14 +69,13 @@ export function disableMediaKeys(
  * @returns {Observable}
  */
 export default function attachMediaKeys(
-  loadedSessionsStore : LoadedSessionsStore,
-  instances : IMediaKeysContext,
   mediaElement : HTMLMediaElement,
-  keySystemOptions : IKeySystemOption
+  { keySystemOptions,
+    loadedSessionsStore,
+    mediaKeySystemAccess,
+    mediaKeys } : IMediaKeysState
 ) : Observable<unknown> {
   return observableDefer(() => {
-    const { mediaKeySystemAccess, mediaKeys } = instances;
-
     const previousState = MediaKeysInfosStore.getState(mediaElement);
     const closeAllSessions$ = previousState !== null &&
                               previousState.loadedSessionsStore !== loadedSessionsStore ?

--- a/src/core/eme/clean_old_loaded_sessions.ts
+++ b/src/core/eme/clean_old_loaded_sessions.ts
@@ -23,7 +23,7 @@ import {
   mapTo,
   startWith,
 } from "rxjs/operators";
-import { IMediaKeySessionInfo } from "./types";
+import { IMediaKeySessionContext } from "./types";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 
 /**
@@ -32,7 +32,7 @@ import LoadedSessionsStore from "./utils/loaded_sessions_store";
  */
 export interface ICleanedOldSessionEvent {
   type : "cleaned-old-session";
-  value : IMediaKeySessionInfo;
+  value : IMediaKeySessionContext;
 }
 
 /**
@@ -41,7 +41,7 @@ export interface ICleanedOldSessionEvent {
  */
 export interface ICleaningOldSessionEvent {
   type : "cleaning-old-session";
-  value : IMediaKeySessionInfo;
+  value : IMediaKeySessionContext;
 }
 
 /**
@@ -70,7 +70,7 @@ export default function cleanOldLoadedSessions(
   for (let i = 0; i < toDelete; i++) {
     const entry = entries[i];
     const cleaning$ = loadedSessionsStore
-      .closeSession(entry.initData, entry.initDataType)
+      .closeSession(entry.initializationData)
       .pipe(mapTo({ type: "cleaned-old-session" as const,
                     value: entry }),
             startWith({ type: "cleaning-old-session" as const,

--- a/src/core/eme/clean_old_loaded_sessions.ts
+++ b/src/core/eme/clean_old_loaded_sessions.ts
@@ -23,7 +23,8 @@ import {
   mapTo,
   startWith,
 } from "rxjs/operators";
-import { IMediaKeySessionContext } from "./types";
+import { ICustomMediaKeySession } from "../../compat";
+import { IInitializationDataInfo } from "./types";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 
 /**
@@ -32,7 +33,15 @@ import LoadedSessionsStore from "./utils/loaded_sessions_store";
  */
 export interface ICleanedOldSessionEvent {
   type : "cleaned-old-session";
-  value : IMediaKeySessionContext;
+  value : {
+    /** The MediaKeySession cleaned. */
+    mediaKeySession : MediaKeySession |
+                      ICustomMediaKeySession;
+    /** The type of MediaKeySession (e.g. "temporary"). */
+    sessionType : MediaKeySessionType;
+    /** Initialization data assiociated to this MediaKeySession. */
+    initializationData : IInitializationDataInfo;
+  };
 }
 
 /**
@@ -41,7 +50,15 @@ export interface ICleanedOldSessionEvent {
  */
 export interface ICleaningOldSessionEvent {
   type : "cleaning-old-session";
-  value : IMediaKeySessionContext;
+  value : {
+    /** The MediaKeySession that we are currently cleaning. */
+    mediaKeySession : MediaKeySession |
+                      ICustomMediaKeySession;
+    /** The type of MediaKeySession (e.g. "temporary"). */
+    sessionType : MediaKeySessionType;
+    /** Initialization data assiociated to this MediaKeySession. */
+    initializationData : IInitializationDataInfo;
+  };
 }
 
 /**

--- a/src/core/eme/create_session.ts
+++ b/src/core/eme/create_session.ts
@@ -29,9 +29,16 @@ import {
   loadSession,
 } from "../../compat";
 import log from "../../log";
-import arrayIncludes from "../../utils/array_includes";
-import { IMediaKeysInfos } from "./types";
+import {
+  IInitializationDataInfo,
+  IMediaKeySessionStores,
+} from "./types";
 import isSessionUsable from "./utils/is_session_usable";
+import LoadedSessionsStore from "./utils/loaded_sessions_store";
+import PersistentSessionsStore from "./utils/persistent_sessions_store";
+
+// XXX TODO Check MediaKeySystemAccess compatibility with persistent-license
+// MediaKeySession somewhere
 
 export interface INewSessionCreatedEvent {
   type : "created-session";
@@ -65,45 +72,73 @@ export type ICreateSessionEvent = INewSessionCreatedEvent |
  * @returns {Observable}
  */
 export default function createSession(
-  initData: Uint8Array,
-  initDataType: string|undefined,
-  mediaKeysInfos: IMediaKeysInfos
+  stores : IMediaKeySessionStores,
+  initializationData : IInitializationDataInfo,
+  wantedSessionType : MediaKeySessionType
 ) : Observable<ICreateSessionEvent> {
   return observableDefer(() => {
-    const { keySystemOptions,
-            mediaKeySystemAccess,
-            loadedSessionsStore,
-            persistentSessionsStore } = mediaKeysInfos;
+    const { loadedSessionsStore,
+            persistentSessionsStore } = stores;
 
-    const mksConfig = mediaKeySystemAccess.getConfiguration();
-    const sessionTypes = mksConfig.sessionTypes;
-    const hasPersistence = sessionTypes != null &&
-                           arrayIncludes(sessionTypes, "persistent-license");
+    if (wantedSessionType === "temporary") {
+      return createTemporarySession(loadedSessionsStore, initializationData);
+    } else if (persistentSessionsStore === null) {
+      log.warn("EME: Cannot create persistent MediaKeySession, " +
+               "PersistentSessionsStore not created.");
+      return createTemporarySession(loadedSessionsStore, initializationData);
+    }
+    return createAndTryToRetrievePersistentSession(loadedSessionsStore,
+                                                   persistentSessionsStore,
+                                                   initializationData);
+  });
+}
 
-    const sessionType : MediaKeySessionType =
-      hasPersistence &&
-      persistentSessionsStore != null &&
-      keySystemOptions.persistentLicense === true ? "persistent-license" :
-                                                    "temporary";
+/**
+ * Create a new temporary MediaKeySession linked to the given initData and
+ * initDataType.
+ * @param {Object} loadedSessionsStore
+ * @param {Uint8Array} initData
+ * @param {string|undefined} initDataType
+ * @returns {Observable}
+ */
+function createTemporarySession(
+  loadedSessionsStore : LoadedSessionsStore,
+  initData : IInitializationDataInfo
+) : Observable<INewSessionCreatedEvent> {
+  return observableDefer(() => {
+    log.info("EME: Creating a new temporary session");
+    const session = loadedSessionsStore.createSession(initData, "temporary");
+    return observableOf({ type: "created-session" as const,
+                          value: { mediaKeySession: session,
+                                   sessionType: "temporary" as const } });
+  });
+}
 
-    log.info(`EME: Create a new ${sessionType} session`);
+/**
+ * Create a persistent MediaKeySession and try to load on it a previous
+ * MediaKeySession linked to the same initData and initDataType.
+ * @param {Object} loadedSessionsStore
+ * @param {Object} persistentSessionsStore
+ * @param {Uint8Array} initData
+ * @param {string|undefined} initDataType
+ * @returns {Observable}
+ */
+function createAndTryToRetrievePersistentSession(
+  loadedSessionsStore : LoadedSessionsStore,
+  persistentSessionsStore : PersistentSessionsStore,
+  initData : IInitializationDataInfo
+) : Observable<INewSessionCreatedEvent | IPersistentSessionRecoveryEvent> {
+  return observableDefer(() => {
+    log.info("EME: Creating persistent MediaKeySession");
 
     const session = loadedSessionsStore
-      .createSession(initData, initDataType, sessionType);
+      .createSession(initData, "persistent-license");
+    const storedEntry = persistentSessionsStore.getAndReuse(initData);
 
-    // Re-check for Dumb typescript. Equivalent to `sessionType === "temporary"`.
-    if (!hasPersistence ||
-        persistentSessionsStore == null ||
-        keySystemOptions.persistentLicense !== true)
-    {
-      return observableOf({ type: "created-session" as const,
-                            value: { mediaKeySession: session, sessionType } });
-    }
-
-    const storedEntry = persistentSessionsStore.getAndReuse(initData, initDataType);
     if (storedEntry === null) {
       return observableOf({ type: "created-session" as const,
-                            value: { mediaKeySession: session, sessionType } });
+                            value: { mediaKeySession: session,
+                                     sessionType: "persistent-license" as const } });
     }
 
     /**
@@ -113,16 +148,16 @@ export default function createSession(
      */
     const recreatePersistentSession = () : Observable<INewSessionCreatedEvent> => {
       log.info("EME: Removing previous persistent session.");
-      if (persistentSessionsStore.get(initData, initDataType) !== null) {
-        persistentSessionsStore.delete(initData, initDataType);
+      if (persistentSessionsStore.get(initData) !== null) {
+        persistentSessionsStore.delete(initData);
       }
-      return loadedSessionsStore.closeSession(initData, initDataType)
+      return loadedSessionsStore.closeSession(initData)
         .pipe(map(() => {
           const newSession = loadedSessionsStore.createSession(initData,
-                                                               initDataType,
-                                                               sessionType);
+                                                               "persistent-license");
           return { type: "created-session" as const,
-                   value: { mediaKeySession: newSession, sessionType } };
+                   value: { mediaKeySession: newSession,
+                            sessionType: "persistent-license" } };
         }));
     };
 
@@ -130,16 +165,18 @@ export default function createSession(
       mergeMap((hasLoadedSession) : Observable<ICreateSessionEvent> => {
         if (!hasLoadedSession) {
           log.warn("EME: No data stored for the loaded session");
-          persistentSessionsStore.delete(initData, initDataType);
+          persistentSessionsStore.delete(initData);
           return observableOf({ type: "created-session" as const,
-                                value: { mediaKeySession: session, sessionType } });
+                                value: { mediaKeySession: session,
+                                         sessionType: "persistent-license" } });
         }
 
         if (hasLoadedSession && isSessionUsable(session)) {
-          persistentSessionsStore.add(initData, initDataType, session);
+          persistentSessionsStore.add(initData, session);
           log.info("EME: Succeeded to load persistent session.");
           return observableOf({ type: "loaded-persistent-session" as const,
-                                value: { mediaKeySession: session, sessionType } });
+                                value: { mediaKeySession: session,
+                                         sessionType: "persistent-license" } });
         }
 
         // Unusable persistent session: recreate a new session from scratch.

--- a/src/core/eme/create_session.ts
+++ b/src/core/eme/create_session.ts
@@ -37,9 +37,6 @@ import isSessionUsable from "./utils/is_session_usable";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 import PersistentSessionsStore from "./utils/persistent_sessions_store";
 
-// XXX TODO Check MediaKeySystemAccess compatibility with persistent-license
-// MediaKeySession somewhere
-
 export interface INewSessionCreatedEvent {
   type : "created-session";
   value : { mediaKeySession : MediaKeySession |

--- a/src/core/eme/create_session.ts
+++ b/src/core/eme/create_session.ts
@@ -94,8 +94,7 @@ export default function createSession(
  * Create a new temporary MediaKeySession linked to the given initData and
  * initDataType.
  * @param {Object} loadedSessionsStore
- * @param {Uint8Array} initData
- * @param {string|undefined} initDataType
+ * @param {Object} initData
  * @returns {Observable}
  */
 function createTemporarySession(
@@ -116,8 +115,7 @@ function createTemporarySession(
  * MediaKeySession linked to the same initData and initDataType.
  * @param {Object} loadedSessionsStore
  * @param {Object} persistentSessionsStore
- * @param {Uint8Array} initData
- * @param {string|undefined} initDataType
+ * @param {Object} initData
  * @returns {Observable}
  */
 function createAndTryToRetrievePersistentSession(

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -36,6 +36,7 @@ import {
   events,
   generateKeyRequest,
   getInitData,
+  ICustomMediaKeySystemAccess,
 } from "../../compat/";
 import config from "../../config";
 import { EncryptedMediaError } from "../../errors";
@@ -171,10 +172,7 @@ export default function EMEManager(
         EMPTY;
 
       let wantedSessionType : MediaKeySessionType;
-      const { sessionTypes } = instances.mediaKeySystemAccess.getConfiguration();
-      if (sessionTypes === undefined ||
-          !arrayIncludes(sessionTypes, "persistent-license"))
-      {
+      if (!canCreatePersistentSession(instances.mediaKeySystemAccess)) {
         log.warn("EME: Cannot create \"persistent-license\" session: not supported");
         wantedSessionType = "temporary";
       } else {
@@ -266,4 +264,18 @@ export default function EMEManager(
                            .pipe(map(evt => ({ type: "encrypted-event-received" as const,
                                                value: evt }))),
                          bindSession$);
+}
+
+/**
+ * Returns `true` if the given MediaKeySystemAccess can create
+ * "persistent-license" MediaKeySessions.
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess
+ * @returns {Boolean}
+ */
+function canCreatePersistentSession(
+  mediaKeySystemAccess : MediaKeySystemAccess | ICustomMediaKeySystemAccess
+) : boolean {
+  const { sessionTypes } = mediaKeySystemAccess.getConfiguration();
+  return sessionTypes !== undefined &&
+         arrayIncludes(sessionTypes, "persistent-license");
 }

--- a/src/core/eme/get_media_keys.ts
+++ b/src/core/eme/get_media_keys.ts
@@ -36,7 +36,8 @@ import getMediaKeySystemAccess from "./find_key_system";
 import MediaKeysInfosStore from "./media_keys_infos_store";
 import ServerCertificateStore from "./server_certificate_store";
 import {
-  IKeySystemOption, IMediaKeysContext, IMediaKeySessionStores,
+  IKeySystemOption,
+  IMediaKeySessionStores,
 } from "./types";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 import PersistentSessionsStore from "./utils/persistent_sessions_store";
@@ -65,8 +66,12 @@ function createPersistentSessionsStorage(
 
 /** Object returned by `getMediaKeysInfos`. */
 export interface IMediaKeysInfos {
-  /** MediaKeys and MediaKeySystemAccess created. */
-  instances : IMediaKeysContext;
+  /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
+  mediaKeySystemAccess: MediaKeySystemAccess |
+                        ICustomMediaKeySystemAccess;
+  /** The MediaKeys instance. */
+  mediaKeys : MediaKeys |
+              ICustomMediaKeys;
   /** Stores allowing to create and retrieve MediaKeySessions. */
   stores : IMediaKeySessionStores;
   /** IKeySystemOption compatible to the created MediaKeys instance. */
@@ -98,7 +103,8 @@ export default function getMediaKeysInfos(
             (!isNullOrUndefined(options.serverCertificate) &&
              ServerCertificateStore.has(mediaKeys, options.serverCertificate)))
         {
-          return observableOf({ instances: { mediaKeys, mediaKeySystemAccess },
+          return observableOf({ mediaKeys,
+                                mediaKeySystemAccess,
                                 stores: { loadedSessionsStore, persistentSessionsStore },
                                 options });
 
@@ -108,7 +114,8 @@ export default function getMediaKeysInfos(
       return createMediaKeys(mediaKeySystemAccess).pipe(map((mediaKeys) => {
         log.info("EME: MediaKeys created with success", mediaKeys);
         const loadedSessionsStore = new LoadedSessionsStore(mediaKeys);
-        return { instances: { mediaKeys, mediaKeySystemAccess },
+        return { mediaKeys,
+                 mediaKeySystemAccess,
                  stores: { loadedSessionsStore, persistentSessionsStore },
                  options };
       }));

--- a/src/core/eme/get_session.ts
+++ b/src/core/eme/get_session.ts
@@ -34,12 +34,22 @@ import cleanOldLoadedSessions, {
 import createSession from "./create_session";
 import {
   IInitializationDataInfo,
-  IMediaKeySessionContext,
   IMediaKeySessionStores,
 } from "./types";
 import isSessionUsable from "./utils/is_session_usable";
 
 const { EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS } = config;
+
+/** Information concerning a MediaKeySession. */
+export interface IMediaKeySessionContext {
+  /** The MediaKeySession itself. */
+  mediaKeySession : MediaKeySession |
+                    ICustomMediaKeySession;
+  /** The type of MediaKeySession (e.g. "temporary"). */
+  sessionType : MediaKeySessionType;
+  /** Initialization data assiociated to this MediaKeySession. */
+  initializationData : IInitializationDataInfo;
+}
 
 /** Event emitted when a new MediaKeySession has been created. */
 export interface ICreatedSession {

--- a/src/core/eme/session_events_listener.ts
+++ b/src/core/eme/session_events_listener.ts
@@ -51,7 +51,9 @@ import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import retryObsWithBackoff, {
   IBackoffOptions,
 } from "../../utils/rx-retry_with_backoff";
-import checkKeyStatuses from "./check_key_statuses";
+import checkKeyStatuses, {
+  IKeyStatusesCheckingOptions,
+} from "./check_key_statuses";
 import {
   IBlacklistKeysEvent,
   IInitializationDataInfo,
@@ -207,18 +209,18 @@ export default function SessionEventsListener(
  *    - emit warning events for recoverable errors
  *    - emit blacklist-keys events for key IDs that are not decipherable
  * @param {MediaKeySession} session - The MediaKeySession concerned.
- * @param {Object} keySystemOptions - The key system options.
- * @param {String} keySystem - The configuration keySystem used for deciphering
+ * @param {Object} options - Options related to key statuses checks.
+ * @param {String} keySystem - The name of the key system used for deciphering
  * @returns {Observable}
  */
 function getKeyStatusesEvents(
   session : MediaKeySession | ICustomMediaKeySession,
-  keySystemOptions : IKeySystemOption,
+  options : IKeyStatusesCheckingOptions,
   keySystem : string
 ) : Observable<IEMEWarningEvent | IBlacklistKeysEvent> {
   return observableDefer(() => {
     const [warnings, blacklistedKeyIDs] =
-      checkKeyStatuses(session, keySystemOptions, keySystem);
+      checkKeyStatuses(session, options, keySystem);
 
     const warnings$ = warnings.length > 0 ? observableOf(...warnings) :
       EMPTY;

--- a/src/core/eme/session_events_listener.ts
+++ b/src/core/eme/session_events_listener.ts
@@ -54,6 +54,7 @@ import retryObsWithBackoff, {
 import checkKeyStatuses from "./check_key_statuses";
 import {
   IBlacklistKeysEvent,
+  IInitializationDataInfo,
   IEMEWarningEvent,
   IKeyMessageHandledEvent,
   IKeyStatusChangeHandledEvent,
@@ -90,7 +91,7 @@ export class BlacklistedSessionError extends Error {
  * @param {MediaKeySession} session - The MediaKeySession concerned.
  * @param {Object} keySystemOptions - The key system options.
  * @param {String} keySystem - The configuration keySystem used for deciphering
- * @param {Object} initDataInfo - The initialization data linked to that
+ * @param {Object} initializationData - The initialization data linked to that
  * session.
  * @returns {Observable}
  */
@@ -98,7 +99,7 @@ export default function SessionEventsListener(
   session: MediaKeySession | ICustomMediaKeySession,
   keySystemOptions: IKeySystemOption,
   keySystem: string,
-  { initData, initDataType } : { initData : Uint8Array; initDataType? : string }
+  initializationData : IInitializationDataInfo
 ) : Observable<IEMEWarningEvent |
                ISessionMessageEvent |
                INoUpdateEvent |
@@ -161,7 +162,7 @@ export default function SessionEventsListener(
           throw formattedError;
         }),
         startWith({ type: "session-message" as const,
-                    value: { messageType, initData, initDataType } })
+                    value: { messageType, initializationData } })
       );
     }));
 
@@ -182,8 +183,7 @@ export default function SessionEventsListener(
         case "key-status-change-handled":
           return updateSessionWithMessage(session,
                                           evt.value.license,
-                                          initData,
-                                          initDataType);
+                                          initializationData);
         default:
           return observableOf(evt);
       }
@@ -259,20 +259,18 @@ function formatGetLicenseError(error: unknown) : ICustomError {
  * Returns the right event depending on the action taken.
  * @param {MediaKeySession} session
  * @param {ArrayBuffer|TypedArray|null} message
- * @param {Uint8Array} initData
- * @param {string|undefined} initDataType
+ * @param {Object} initializationData
  * @returns {Observable}
  */
 function updateSessionWithMessage(
   session : MediaKeySession | ICustomMediaKeySession,
   message : BufferSource | null,
-  initData : Uint8Array,
-  initDataType : string | undefined
+  initializationData : IInitializationDataInfo
 ) : Observable<INoUpdateEvent | ISessionUpdatedEvent> {
   if (isNullOrUndefined(message)) {
     log.info("EME: No message given, skipping session.update");
     return observableOf({ type: "no-update" as const,
-                          value: { initData, initDataType } });
+                          value: { initializationData } });
   }
 
   log.info("EME: Updating MediaKeySession with message");
@@ -284,7 +282,7 @@ function updateSessionWithMessage(
     }),
     tap(() => { log.info("EME: MediaKeySession update succeeded."); }),
     mapTo({ type: "session-updated" as const,
-            value: { session, license: message, initData, initDataType } })
+            value: { session, license: message, initializationData } })
   );
 }
 

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -32,17 +32,6 @@ export interface IInitializationDataInfo {
   data : Uint8Array;
 }
 
-/** Information concerning a MediaKeySession. */
-export interface IMediaKeySessionContext {
-  /** The MediaKeySession itself. */
-  mediaKeySession : MediaKeySession |
-                    ICustomMediaKeySession;
-  /** The type of MediaKeySession (e.g. "temporary"). */
-  sessionType : MediaKeySessionType;
-  /** Initialization data assiociated to this MediaKeySession. */
-  initializationData : IInitializationDataInfo;
-}
-
 /** Event emitted when a minor - recoverable - error happened. */
 export interface IEMEWarningEvent { type : "warning";
                                     value : ICustomError; }

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -67,10 +67,18 @@ export interface IEncryptedEvent { type: "encrypted-event-received";
  */
 export interface ICreatedMediaKeysEvent {
   type: "created-media-keys";
-  value: { instances : IMediaKeysContext;
-           stores : IMediaKeySessionStores;
-           options : IKeySystemOption;
-           attachMediaKeys$: Subject<void>; }; }
+  value: {
+    /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
+    mediaKeySystemAccess: MediaKeySystemAccess |
+                          ICustomMediaKeySystemAccess;
+    /** The MediaKeys instance. */
+    mediaKeys : MediaKeys |
+                ICustomMediaKeys;
+    stores : IMediaKeySessionStores;
+    options : IKeySystemOption;
+    attachMediaKeys$: Subject<void>;
+  };
+}
 
 /**
  * Sent when the created (or already created) MediaKeys is attached to the
@@ -82,9 +90,17 @@ export interface ICreatedMediaKeysEvent {
  */
 export interface IAttachedMediaKeysEvent {
   type: "attached-media-keys";
-  value: { instances : IMediaKeysContext;
-           stores : IMediaKeySessionStores;
-           options : IKeySystemOption; }; }
+  value: {
+    /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
+    mediaKeySystemAccess: MediaKeySystemAccess |
+                          ICustomMediaKeySystemAccess;
+    /** The MediaKeys instance. */
+    mediaKeys : MediaKeys |
+                ICustomMediaKeys;
+    stores : IMediaKeySessionStores;
+    options : IKeySystemOption;
+  };
+}
 
 /**
  * Emitted when the initialization data received through an encrypted event or
@@ -195,16 +211,6 @@ export interface IKeySystemAccessInfos {
   keySystemAccess: MediaKeySystemAccess |
                    ICustomMediaKeySystemAccess;
   keySystemOptions: IKeySystemOption;
-}
-
-/** Context behind a created MediaKeys instance. */
-export interface IMediaKeysContext {
-  /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
-  mediaKeySystemAccess: MediaKeySystemAccess |
-                        ICustomMediaKeySystemAccess;
-  /** The MediaKeys instance. */
-  mediaKeys : MediaKeys |
-              ICustomMediaKeys;
 }
 
 /** Stores helping to create and retrieve MediaKeySessions. */

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -286,7 +286,7 @@ export default function InitializeOnMediaSource(
           return openMediaSource$.pipe(mergeMap(() => {
             evt.value.attachMediaKeys$.next();
 
-            const shouldDisableLock = evt.value.mediaKeysInfos.keySystemOptions
+            const shouldDisableLock = evt.value.options
               .disableMediaKeysAttachmentLock === true;
             if (shouldDisableLock) {
               return observableOf(undefined);
@@ -353,8 +353,10 @@ export default function InitializeOnMediaSource(
             manifest.addUndecipherableKIDs(evt.value);
           } else if (evt.type === "blacklist-protection-data") {
             log.info("Init: blacklisting Representations based on protection data.");
-            manifest.addUndecipherableProtectionData(evt.value.type,
-                                                     evt.value.data);
+            if (evt.value.type !== undefined) {
+              manifest.addUndecipherableProtectionData(evt.value.type,
+                                                       evt.value.data);
+            }
           }
         }),
         ignoreElements());


### PR DESCRIPTION
While working on several big modifications of the `EMEManager` code, I saw several issues which made the code difficult to update:
  1. Most of all, a good chunk of the functions there wanted the whole world in argument.
      For example, `getSession` (which either create or retrieve an existing `MediaKeySession`) was given in argument an object containing the `MediaKeySystemAccess`, the `MediaKeys` and every `keySystems` options despite not needing any of those.

      The reason why we communicated all that is because it was easier to just define and pass around an object respecting the `IMediaKeysInfo` interface than to declare specific arguments for each function.
      
      This didn't create any real problem until now, but I recently encountered a relatively big downside of that strategy: 
      In my case, I wanted `getSession` to consider creating a "temporary" `MediaKeySession` even if the keySystems options tells us that the user want persistent ones.
      As `getSession` read the keySystems options to know which type of` MediaKeySession` to create, I had to add an argument which was named something along the lines of `forceTemporarySession`.

       This looks very backward. It is much more simple and maintainable to just communicate to `getSession` the wanted MediaKeySession's type and never the whole option object.

        I tried to apply that same strategy at several places in the eme code in this PR.

  2. Because the initialization data and its associated type are always used with one another (nothing use one without using the other), I defined an `IInitializationDataInfo` object.
       Where most functions using them needed both as two different arguments, I now replaced it by this single object so it looks more concise and easier to read.

  3. The main logic in `eme_manager.ts` (which basically, link the whole logic together) was unnecessarily difficult to follow. I tried to improve on that by moving Observables around and renaming variables.
      It is still not the most readable part of the code however, and there are still a lot of possible improvements there.

There are many more improvements we can work on on that code, but I find the current modifications good enough for its own PR.
New PRs relying on these modifications will come soon.