### PR TITLE
No video bitrate throttling when video is hidden or video size changes, on Firefox (version >= 67)

### DIFF
--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -589,8 +589,10 @@ fullscreen, specific environments), you might not want to activate this limit.
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) because of the lack of trust concerning
-the current video element size.
+- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
+mode is enabled and we can't know PIP window size. Thus we can't rely on video
+element size attributes, that may not reflect the real video size when PIP is
+enabled.
 
 
 <a name="prop-throttleVideoBitrateWhenHidden"></a>
@@ -617,8 +619,9 @@ const player = Player({
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) because of the lack of trust concerning
-the current video element hiddenness.
+- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
+mode is enabled. Thus we can't rely on document hiddenness attributes, as the
+video may be visible, through the PIP window.
 
 <a name="prop-stopAtEnd"></a>
 ### stopAtEnd ##################################################################
@@ -677,5 +680,6 @@ const player = Player({
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) because of the lack of trust concerning
-the current video element hiddenness.
+- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
+mode is enabled. Thus we can't rely on document hiddenness attributes, as the
+video may be visible, through the PIP window.

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -589,10 +589,10 @@ fullscreen, specific environments), you might not want to activate this limit.
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
-mode is enabled and we can't know PIP window size. Thus we can't rely on video
-element size attributes, that may not reflect the real video size when PIP is
-enabled.
+- On Firefox browsers (version >= 67) : We can't know if the Picture-In-Picture
+feature or window is enabled and we can't know PIP window size. Thus we can't
+rely on video element size attributes, that may not reflect the real video size
+when PIP is enabled.
 
 
 <a name="prop-throttleVideoBitrateWhenHidden"></a>
@@ -619,9 +619,9 @@ const player = Player({
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
-mode is enabled. Thus we can't rely on document hiddenness attributes, as the
-video may be visible, through the PIP window.
+- On Firefox browsers (version >= 67) : We can't know if the Picture-In-Picture
+feature or window is enabled. Thus we can't rely on document hiddenness
+attributes, as the video may be visible, through the PIP window.
 
 <a name="prop-stopAtEnd"></a>
 ### stopAtEnd ##################################################################
@@ -680,6 +680,6 @@ const player = Player({
 :warning: This option will have no effect for contents loaded :
 - In _DirectFile_ mode (see [loadVideo options]
 (./loadVideo_options.md#prop-transport)).
-- On Firefox browsers (version > 71) : We can't know if the Picture-In-Picture
-mode is enabled. Thus we can't rely on document hiddenness attributes, as the
-video may be visible, through the PIP window.
+- On Firefox browsers (version >= 67) : We can't know if the Picture-In-Picture
+feature or window is enabled. Thus we can't rely on document hiddenness
+attributes, as the video may be visible, through the PIP window.

--- a/doc/api/player_options.md
+++ b/doc/api/player_options.md
@@ -586,8 +586,11 @@ fullscreen, specific environments), you might not want to activate this limit.
 
 --
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+:warning: This option will have no effect for contents loaded :
+- In _DirectFile_ mode (see [loadVideo options]
+(./loadVideo_options.md#prop-transport)).
+- On Firefox browsers (version > 71) because of the lack of trust concerning
+the current video element size.
 
 
 <a name="prop-throttleVideoBitrateWhenHidden"></a>
@@ -611,9 +614,11 @@ const player = Player({
 
 --
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
-
+:warning: This option will have no effect for contents loaded :
+- In _DirectFile_ mode (see [loadVideo options]
+(./loadVideo_options.md#prop-transport)).
+- On Firefox browsers (version > 71) because of the lack of trust concerning
+the current video element hiddenness.
 
 <a name="prop-stopAtEnd"></a>
 ### stopAtEnd ##################################################################
@@ -669,5 +674,8 @@ const player = Player({
 
 --
 
-:warning: This option will have no effect for contents loaded in _DirectFile_
-mode (see [loadVideo options](./loadVideo_options.md#prop-transport)).
+:warning: This option will have no effect for contents loaded :
+- In _DirectFile_ mode (see [loadVideo options]
+(./loadVideo_options.md#prop-transport)).
+- On Firefox browsers (version > 71) because of the lack of trust concerning
+the current video element hiddenness.

--- a/src/compat/__tests__/browser_version.test.ts
+++ b/src/compat/__tests__/browser_version.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+describe("Compat - Browser version", () => {
+  const origUserAgent = navigator.userAgent;
+  Object.defineProperty(navigator,
+                        "userAgent",
+                        ((value: string) => ({
+                          get() { return value; },
+                          /* eslint-disable no-param-reassign */
+                          set(v: string) { value = v; },
+                          /* eslint-enable no-param-reassign */
+                        }))(navigator.userAgent));
+
+  const nav: any = navigator;
+
+  afterEach(() => {
+    nav.userAgent = origUserAgent;
+    jest.resetModules();
+  });
+
+  it("Should return correct Firefox version (60)", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    const { getFirefoxVersion } = require("../browser_version");
+    nav.userAgent = "Firefox/60.0";
+    const version = getFirefoxVersion();
+    expect(version).toBe(60);
+  });
+
+  it("Should return correct Firefox version (80)", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    const { getFirefoxVersion } = require("../browser_version");
+    nav.userAgent = "Firefox/80.0";
+    const version = getFirefoxVersion();
+    expect(version).toBe(80);
+  });
+
+  it("Should return null when not on Firefox", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: false };
+    });
+    const { getFirefoxVersion } = require("../browser_version");
+    const version = getFirefoxVersion();
+    expect(version).toBe(null);
+  });
+
+  it("Should return null when obscure Firefox user agent", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    const { getFirefoxVersion } = require("../browser_version");
+    nav.userAgent = "FireFennec/80.0";
+    const version = getFirefoxVersion();
+    expect(version).toBe(-1);
+  });
+});

--- a/src/compat/__tests__/can_rely_on_video_visibility_and_size.test.ts
+++ b/src/compat/__tests__/can_rely_on_video_visibility_and_size.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+describe("Compat - canRelyOnVideoVisibilityAndSize", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("should return true on any browser but Firefox", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: false };
+    });
+    const canRelyOnVideoVisibilityAndSize =
+      require("../can_rely_on_video_visibility_and_size.ts");
+    expect(canRelyOnVideoVisibilityAndSize.default()).toBe(true);
+  });
+
+  it("should return true on Firefox but the version is unknown", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    jest.mock("../browser_version", () => {
+      return { __esModule: true as const,
+               getFirefoxVersion: () => -1 };
+    });
+    const canRelyOnVideoVisibilityAndSize =
+      require("../can_rely_on_video_visibility_and_size.ts");
+    expect(canRelyOnVideoVisibilityAndSize.default()).toBe(true);
+  });
+
+  it("should return true on Firefox < 71>", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    jest.mock("../browser_version", () => {
+      return { __esModule: true as const,
+               getFirefoxVersion: () => 60 };
+    });
+    const canRelyOnVideoVisibilityAndSize =
+      require("../can_rely_on_video_visibility_and_size.ts");
+    expect(canRelyOnVideoVisibilityAndSize.default()).toBe(true);
+  });
+
+  it("should return false on Firefox >= 71", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isFirefox: true };
+    });
+    jest.mock("../browser_version", () => {
+      return { __esModule: true as const,
+               getFirefoxVersion: () => 83 };
+    });
+    const canRelyOnVideoVisibilityAndSize =
+      require("../can_rely_on_video_visibility_and_size.ts");
+    expect(canRelyOnVideoVisibilityAndSize.default()).toBe(false);
+  });
+});

--- a/src/compat/__tests__/can_rely_on_video_visibility_and_size.test.ts
+++ b/src/compat/__tests__/can_rely_on_video_visibility_and_size.test.ts
@@ -48,7 +48,7 @@ describe("Compat - canRelyOnVideoVisibilityAndSize", () => {
     expect(canRelyOnVideoVisibilityAndSize.default()).toBe(true);
   });
 
-  it("should return true on Firefox < 71>", () => {
+  it("should return true on Firefox < 67>", () => {
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isFirefox: true };
@@ -62,7 +62,7 @@ describe("Compat - canRelyOnVideoVisibilityAndSize", () => {
     expect(canRelyOnVideoVisibilityAndSize.default()).toBe(true);
   });
 
-  it("should return false on Firefox >= 71", () => {
+  it("should return false on Firefox >= 67", () => {
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isFirefox: true };

--- a/src/compat/browser_version.ts
+++ b/src/compat/browser_version.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../log";
+import { isFirefox } from "./browser_detection";
+
+/**
+ * Returns either :
+ * - 'null' when the current browser is not Firefox.
+ * - '-1' when it is impossible to get the Firefox version
+ * - A number above 0 that is the Firefox version number
+ * @returns {number|null}
+ */
+function getFirefoxVersion(): number|null {
+  if (!isFirefox) {
+    log.warn("Compat: Can't access Firefox version on no firefox browser.");
+    return null;
+  }
+  const userAgent = navigator.userAgent;
+  const match = /Firefox\/([0-9]+)\./.exec(userAgent);
+  if (match === null) {
+    return -1;
+  }
+  const result = parseInt(match[1], 10);
+  if (isNaN(result)) {
+    return -1;
+  }
+  return result;
+}
+
+export { getFirefoxVersion };

--- a/src/compat/can_rely_on_video_visibility_and_size.ts
+++ b/src/compat/can_rely_on_video_visibility_and_size.ts
@@ -21,19 +21,21 @@ import { getFirefoxVersion } from "./browser_version";
  * This functions tells if the RxPlayer can trust on any browser data
  * about video element visibility and size.
  *
- * On Firefox (version > 71) :
+ * On Firefox (version >= 67) :
+ * - The PIP feature exists but can be disabled by default according
+ * to the OS and the channel used for updating / getting Firefox binaries.
  * - There is no API to know if the Picture-in-picture (PIP) is enabled
  * - There is no API to get the width of the PIP window
  *
- * Thus, when the video element is displayed in picture-in-picture, the element
- * clientWidth still tells the width of the original video element, and no PIP
- * Window API exists to determine its presence or width. There are no way to
- * determine the real width of the video window, as we can't know when the PIP
- * is enabled, and we can't have access to its size information.
+ * The element clientWidth tells the width of the original video element, and
+ * no PIP window API exists to determine its presence or width. Thus, there are
+ * no way to determine the real width of the video window, as we can't know when
+ * the PIP feature or window is enabled, and we can't have access to the windo
+ * size information.
  *
  * Moreover, when the document is considered as hidden (e.g. in case of hidden
- * tab), as there is no way to know if the PIP is enabled, we can't know if
- * the video window is visible or not.
+ * tab), as there is no way to know if the PIP feature or window is enabled,
+ * we can't know if the video window is visible or not.
  * @returns {boolean}
  */
 export default function canRelyOnVideoVisibilityAndSize(): boolean {
@@ -42,7 +44,7 @@ export default function canRelyOnVideoVisibilityAndSize(): boolean {
     return true;
   }
   const firefoxVersion = getFirefoxVersion();
-  if (firefoxVersion === null || firefoxVersion < 71) {
+  if (firefoxVersion === null || firefoxVersion < 67) {
     return true;
   }
   return (HTMLVideoElement as any)?.prototype?.requirePictureInPicture !== undefined;

--- a/src/compat/can_rely_on_video_visibility_and_size.ts
+++ b/src/compat/can_rely_on_video_visibility_and_size.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isFirefox } from "./browser_detection";
+import { getFirefoxVersion } from "./browser_version";
+
+/**
+ * This functions tells if the RxPlayer can trust on any browser data
+ * about video element visibility and size.
+ *
+ * On Firefox (version > 71) :
+ * - There is no API to know if the Picture-in-picture (PIP) is enabled
+ * - There is no API to get the width of the PIP window
+ *
+ * Thus, when the video element is displayed in picture-in-picture, the element
+ * clientWidth still tells the width of the original video element, and no PIP
+ * Window API exists to determine its presence or width. There are no way to
+ * determine the real width of the video element, as we can't know when the PIP
+ * is enabled, and we can't have access to its size information.
+ *
+ * Moreover, when the document is considered as hidden (e.g. in case of hidden
+ * tab), as there i s no way to know if the PIP is enabled, we can't know if
+ * the video element is visible or not.
+ * @returns {boolean}
+ */
+export default function canRelyOnVideoVisibilityAndSize(): boolean {
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  if (!isFirefox) {
+    return true;
+  }
+  const firefoxVersion = getFirefoxVersion();
+  if (firefoxVersion === null || firefoxVersion === -1) {
+    return true;
+  }
+  return firefoxVersion < 71 ||
+         (HTMLVideoElement as any)?.prototype?.requirePictureInPicture !== undefined;
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+}

--- a/src/compat/can_rely_on_video_visibility_and_size.ts
+++ b/src/compat/can_rely_on_video_visibility_and_size.ts
@@ -28,12 +28,12 @@ import { getFirefoxVersion } from "./browser_version";
  * Thus, when the video element is displayed in picture-in-picture, the element
  * clientWidth still tells the width of the original video element, and no PIP
  * Window API exists to determine its presence or width. There are no way to
- * determine the real width of the video element, as we can't know when the PIP
+ * determine the real width of the video window, as we can't know when the PIP
  * is enabled, and we can't have access to its size information.
  *
  * Moreover, when the document is considered as hidden (e.g. in case of hidden
- * tab), as there i s no way to know if the PIP is enabled, we can't know if
- * the video element is visible or not.
+ * tab), as there is no way to know if the PIP is enabled, we can't know if
+ * the video window is visible or not.
  * @returns {boolean}
  */
 export default function canRelyOnVideoVisibilityAndSize(): boolean {
@@ -42,10 +42,9 @@ export default function canRelyOnVideoVisibilityAndSize(): boolean {
     return true;
   }
   const firefoxVersion = getFirefoxVersion();
-  if (firefoxVersion === null || firefoxVersion === -1) {
+  if (firefoxVersion === null || firefoxVersion < 71) {
     return true;
   }
-  return firefoxVersion < 71 ||
-         (HTMLVideoElement as any)?.prototype?.requirePictureInPicture !== undefined;
+  return (HTMLVideoElement as any)?.prototype?.requirePictureInPicture !== undefined;
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -51,9 +51,8 @@ import {
   isFullscreen,
   requestFullscreen,
 } from "../../compat";
-/* eslint-disable max-len */
+/* eslint-disable-next-line max-len */
 import canRelyOnVideoVisibilityAndSize from "../../compat/can_rely_on_video_visibility_and_size";
-/* eslint-enable max-len */
 import config from "../../config";
 import {
   ErrorCodes,


### PR DESCRIPTION
On Firefox (version >= 67) :
- The PIP feature exists but can be disabled by default according to the OS and the channel used for updating / getting Firefox binaries.
- There is no API to know if the Picture-in-picture (PIP) is enabled
- There is no API to get the width of the PIP window

If we want to know the video window size, we can't rely on video element size attributes, that may not reflect the real video size when PIP is enabled. Also, when we want to know if the video window is visible, we can't rely on document hiddenness attributes, as the video may be visible, through the PIP window.

--------------

Thus, using `throttleVideoBitrateWhenHidden`, `throttleVideoBitrate` options may cause video bandwidth falls when the PIP is enabled. It means that even if the video window is visible, but not the tab, the video quality would still be low.
Using `limitVideoWidth` options may cause video bandwidth falls when the PIP is enabled. It means that the video quality would still be low, regardless of the video PIP size, if the original video element size implies that the chosen quality would be low.

--------------

This PR proposes :
If the Firefox version is higher than or equal to 67, the bitrate throttling options do not have any effect. We consider it is preferable to keep a good video quality on these targets, rather than lowering the quality despite sufficient network conditions.