### PR TITLE
Avoid loading segments in a loop when in "native" textTrackMode

### DIFF
--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -35,6 +35,7 @@ import {
 } from "../../../../../compat";
 import config from "../../../../../config";
 import log from "../../../../../log";
+import { ITextTrackSegmentData } from "../../../../../transports";
 import {
   IEndOfSegmentInfos,
   IPushChunkInfos,
@@ -48,23 +49,6 @@ import updateProportionalElements from "./update_proportional_elements";
 const { onEnded$,
         onSeeked$,
         onSeeking$ } = events;
-
-/** Format of the data pushed to the `HTMLTextSegmentBuffer`. */
-export interface IHTMLTextTrackData {
-  /** The text track content. Should be a string in the format indicated by `type`. */
-  data : string;
-  /** The format the text track is in (e.g. "ttml" or "vtt") */
-  type : string;
-  /** Exact beginning time to which the track applies, in seconds. */
-  start? : number;
-  /** Exact end time to which the track applies, in seconds. */
-  end? : number;
-  /**
-   * Language the texttrack is in. This is sometimes needed to properly parse
-   * the text track. For example for tracks in the "sami" format.
-   */
-  language? : string;
-}
 
 const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL,
         TEXT_TRACK_SIZE_CHECKS_INTERVAL } = config;
@@ -127,7 +111,9 @@ function getElementResolution(
  * HTML element.
  * @class HTMLTextSegmentBuffer
  */
-export default class HTMLTextSegmentBuffer extends SegmentBuffer<IHTMLTextTrackData> {
+export default class HTMLTextSegmentBuffer
+  extends SegmentBuffer<ITextTrackSegmentData>
+{
   readonly bufferType : "text";
 
   /**
@@ -219,7 +205,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer<IHTMLTextTrackD
    * @param {Object} infos
    * @returns {Observable}
    */
-  public pushChunk(infos : IPushChunkInfos<IHTMLTextTrackData>) : Observable<void> {
+  public pushChunk(infos : IPushChunkInfos<ITextTrackSegmentData>) : Observable<void> {
     return observableDefer(() => {
       this.pushChunkSync(infos);
       return observableOf(undefined);
@@ -287,7 +273,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer<IHTMLTextTrackD
    * @param {Object} data
    * @returns {boolean}
    */
-  public pushChunkSync(infos : IPushChunkInfos<IHTMLTextTrackData>) : void {
+  public pushChunkSync(infos : IPushChunkInfos<ITextTrackSegmentData>) : void {
     log.debug("HTSB: Appending new html text tracks");
     const { timestampOffset,
             appendWindow,

--- a/src/core/segment_buffers/implementations/text/html/index.ts
+++ b/src/core/segment_buffers/implementations/text/html/index.ts
@@ -19,9 +19,6 @@
  * It always should be imported through the `features` object.
  */
 
-import HTMLTextSegmentBuffer, {
-  IHTMLTextTrackData,
-} from "./html_text_segment_buffer";
+import HTMLTextSegmentBuffer from "./html_text_segment_buffer";
 
 export default HTMLTextSegmentBuffer;
-export { IHTMLTextTrackData };

--- a/src/core/segment_buffers/implementations/text/native/index.ts
+++ b/src/core/segment_buffers/implementations/text/native/index.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import NativeTextSegmentBuffer, {
-  INativeTextTrackData,
-} from "./native_text_segment_buffer";
+import NativeTextSegmentBuffer from "./native_text_segment_buffer";
 
 export default NativeTextSegmentBuffer;
-export { INativeTextTrackData };


### PR DESCRIPTION
This PR fixes a regression brought in v3.22.0 where text track segments would be loaded in a loop when in the native `textTrackMode` (they would still be displayed at the right time, the issue just being a lot of segment requests).

_Thankfully most (if not all) applications use the HTML textTrackMode.
As we do not test the native mode before release normally, this issue was not spotted sooner._

The issue is due to a discrepancy between the format of the text track data parsed by `transports` and the one accepted by the
`NativeTextSegmentBuffer`: the latter expected a `timescale` property which was not communicated by the former (as the `timescale` is always assumed to be equal to `1` since the last release).

This was not catched by TypeScript because there's some `any` type between the two (to facilitate the creation of generic `PeriodStream`s, each with its own generic `SegmentBuffer` linked to it).

I fixed it with a longer term solution than just fixing the corresponding lines:
 now both text SegmentBuffers directly rely on the type defined by `transports`. There's still the `any` between the two so there's still no automatic check of the coherency, but at least for now we're sure there's no difference in format between both places.