### PR TITLE
Skip discontinuities at the end of Periods even when we are in it

### DIFF
--- a/src/core/stream/representation/check_for_discontinuity.ts
+++ b/src/core/stream/representation/check_for_discontinuity.ts
@@ -68,7 +68,10 @@ export default function checkForDiscontinuity(
   let nextBufferedInRangeIdx;
   for (let bufIdx = 0; bufIdx < bufferedSegments.length; bufIdx++) {
     const bufSeg = bufferedSegments[bufIdx];
-    if (bufSeg.bufferedEnd === undefined) {
+    if (bufSeg.bufferedStart === undefined ||
+        bufSeg.bufferedEnd === undefined ||
+        bufSeg.bufferedStart >= checkedRange.end)
+    {
       break;
     }
     if (bufSeg.bufferedEnd > checkedRange.start) {
@@ -80,7 +83,7 @@ export default function checkForDiscontinuity(
   if (nextBufferedInRangeIdx === undefined) {
     // There's no segment currently buffered for the current range.
 
-    if (nextSegmentStart === null) { // No segment to load in it
+    if (nextSegmentStart === null) { // No segment to load in that range
       // Check if we are in a discontinuity at the end of the current Period
       if (hasFinishedLoading &&
           period.end !== undefined &&
@@ -97,104 +100,105 @@ export default function checkForDiscontinuity(
                  end: discontinuityEnd };
       }
     }
-  } else {
-    const nextBufferedSegment = bufferedSegments[nextBufferedInRangeIdx];
+    return null;
+  }
 
-    // Check if there is a hole that won't be filled before `nextSegmentStart`
-    if (nextBufferedSegment.bufferedStart !== undefined &&
-        nextBufferedSegment.bufferedStart > checkedRange.start &&
-        (nextSegmentStart === null ||
-         nextBufferedSegment.infos.segment.end <= nextSegmentStart))
+  const nextBufferedSegment = bufferedSegments[nextBufferedInRangeIdx];
+
+  // Check if there is a hole that won't be filled before `nextSegmentStart`
+  if (nextBufferedSegment.bufferedStart !== undefined &&
+      nextBufferedSegment.bufferedStart > checkedRange.start &&
+      (nextSegmentStart === null ||
+       nextBufferedSegment.infos.segment.end <= nextSegmentStart))
+  {
+    log.error("RS: current discontinuity encountered",
+              adaptation.type, nextBufferedSegment.bufferedStart);
+    return { start: undefined,
+             end: nextBufferedSegment.bufferedStart };
+  }
+
+  // Check if there's a discontinuity BETWEEN segments of the curent range
+  let nextHoleIdx;
+  for (
+    let bufIdx = nextBufferedInRangeIdx + 1;
+    bufIdx < bufferedSegments.length;
+    bufIdx++)
+  {
+    const currSegment = bufferedSegments[bufIdx];
+    const prevSegment = bufferedSegments[bufIdx - 1];
+    if (currSegment.bufferedStart === undefined ||
+        prevSegment.bufferedEnd === undefined ||
+        currSegment.bufferedStart >= checkedRange.end)
     {
-      log.error("RS: current discontinuity encountered",
-                adaptation.type, nextBufferedSegment.bufferedStart);
-      return { start: undefined,
-               end: nextBufferedSegment.bufferedStart };
+      break;
     }
-
-    // Check if there's a discontinuity BETWEEN segments of the curent range
-    let nextHoleIdx;
-    for (
-      let bufIdx = nextBufferedInRangeIdx + 1;
-      bufIdx < bufferedSegments.length;
-      bufIdx++)
-    {
-      const currSegment = bufferedSegments[bufIdx];
-      const prevSegment = bufferedSegments[bufIdx - 1];
-      if (currSegment.bufferedStart === undefined ||
-          prevSegment.bufferedEnd === undefined ||
-          currSegment.bufferedStart >= checkedRange.end)
-      {
-        break;
-      }
-      if (currSegment.bufferedStart - prevSegment.bufferedEnd > 0) {
-        nextHoleIdx = bufIdx;
-      }
+    if (currSegment.bufferedStart - prevSegment.bufferedEnd > 0) {
+      nextHoleIdx = bufIdx;
     }
+  }
 
-    if (nextHoleIdx !== undefined &&
-        (nextSegmentStart === null ||
-         bufferedSegments[nextHoleIdx].infos.segment.end <= nextSegmentStart))
-    {
-      const start = bufferedSegments[nextHoleIdx - 1].bufferedEnd as number;
-      const end = bufferedSegments[nextHoleIdx].bufferedStart as number;
-      log.error("RS: future discontinuity encountered", adaptation.type, start, end);
-      return { start, end };
-    } else if (nextSegmentStart === null) {
-      if (hasFinishedLoading && period.end !== undefined) {
-        if (checkedRange.end < period.end) {
-          return null;
-        }
-
-        // Check if the last buffered segment ends before this Period's end
-        // In which case there is a discontinuity between those
-        let lastBufferedInPeriodIdx;
-        for (let bufIdx = bufferedSegments.length - 1; bufIdx >= 0; bufIdx--) {
-          const bufSeg = bufferedSegments[bufIdx];
-          if (bufSeg.bufferedStart === undefined) {
-            break;
-          }
-          if (bufSeg.bufferedStart < period.end) {
-            lastBufferedInPeriodIdx = bufIdx;
-            break;
-          }
-        }
-        if (lastBufferedInPeriodIdx !== undefined) {
-          const lastSegment = bufferedSegments[lastBufferedInPeriodIdx];
-          if (lastSegment.bufferedEnd !== undefined &&
-              lastSegment.bufferedEnd < period.end)
-          {
-            log.error("RS: discontinuity encountered at the end of the current period",
-                      adaptation.type, lastSegment.bufferedEnd, period.end);
-            return { start: lastSegment.bufferedEnd,
-                     end: null };
-          }
-        }
+  if (nextHoleIdx !== undefined &&
+      (nextSegmentStart === null ||
+       bufferedSegments[nextHoleIdx].infos.segment.end <= nextSegmentStart))
+  {
+    const start = bufferedSegments[nextHoleIdx - 1].bufferedEnd as number;
+    const end = bufferedSegments[nextHoleIdx].bufferedStart as number;
+    log.error("RS: future discontinuity encountered", adaptation.type, start, end);
+    return { start, end };
+  } else if (nextSegmentStart === null) {
+    if (hasFinishedLoading && period.end !== undefined) {
+      if (checkedRange.end < period.end) {
+        return null;
       }
 
-      // consider last buffered segment in checkedRange
-      let lastBufferedInRangeIdx;
+      // Check if the last buffered segment ends before this Period's end
+      // In which case there is a discontinuity between those
+      let lastBufferedInPeriodIdx;
       for (let bufIdx = bufferedSegments.length - 1; bufIdx >= 0; bufIdx--) {
         const bufSeg = bufferedSegments[bufIdx];
         if (bufSeg.bufferedStart === undefined) {
           break;
         }
-        if (bufSeg.bufferedStart < checkedRange.end) {
-          lastBufferedInRangeIdx = bufIdx;
+        if (bufSeg.bufferedStart < period.end) {
+          lastBufferedInPeriodIdx = bufIdx;
           break;
         }
       }
-      if (lastBufferedInRangeIdx !== undefined) {
-        const lastSegmentInRange = bufferedSegments[lastBufferedInRangeIdx];
-        if (lastSegmentInRange.bufferedEnd !== undefined &&
-            lastSegmentInRange.bufferedEnd < checkedRange.end)
+      if (lastBufferedInPeriodIdx !== undefined) {
+        const lastSegment = bufferedSegments[lastBufferedInPeriodIdx];
+        if (lastSegment.bufferedEnd !== undefined &&
+            lastSegment.bufferedEnd < period.end)
         {
-          const discontinuityEnd = representation.index
-            .checkDiscontinuity(checkedRange.end);
-          if (discontinuityEnd !== null) {
-            return { start: lastSegmentInRange.bufferedEnd,
-                     end: discontinuityEnd };
-          }
+          log.error("RS: discontinuity encountered at the end of the current period",
+                    adaptation.type, lastSegment.bufferedEnd, period.end);
+          return { start: lastSegment.bufferedEnd,
+                   end: null };
+        }
+      }
+    }
+
+    // consider last buffered segment in checkedRange
+    let lastBufferedInRangeIdx;
+    for (let bufIdx = bufferedSegments.length - 1; bufIdx >= 0; bufIdx--) {
+      const bufSeg = bufferedSegments[bufIdx];
+      if (bufSeg.bufferedStart === undefined) {
+        break;
+      }
+      if (bufSeg.bufferedStart < checkedRange.end) {
+        lastBufferedInRangeIdx = bufIdx;
+        break;
+      }
+    }
+    if (lastBufferedInRangeIdx !== undefined) {
+      const lastSegmentInRange = bufferedSegments[lastBufferedInRangeIdx];
+      if (lastSegmentInRange.bufferedEnd !== undefined &&
+          lastSegmentInRange.bufferedEnd < checkedRange.end)
+      {
+        const discontinuityEnd = representation.index
+          .checkDiscontinuity(checkedRange.end);
+        if (discontinuityEnd !== null) {
+          return { start: lastSegmentInRange.bufferedEnd,
+                   end: discontinuityEnd };
         }
       }
     }

--- a/src/core/stream/representation/check_for_discontinuity.ts
+++ b/src/core/stream/representation/check_for_discontinuity.ts
@@ -134,6 +134,7 @@ export default function checkForDiscontinuity(
     }
     if (currSegment.bufferedStart - prevSegment.bufferedEnd > 0) {
       nextHoleIdx = bufIdx;
+      break;
     }
   }
 

--- a/src/core/stream/representation/check_for_discontinuity.ts
+++ b/src/core/stream/representation/check_for_discontinuity.ts
@@ -92,7 +92,7 @@ export default function checkForDiscontinuity(
         return { start: undefined, end: null }; // discontinuity to Period's end
       }
 
-      // Check that there is a discontinuity anounced in the Manifest there
+      // Check that there is a discontinuity announced in the Manifest there
       const discontinuityEnd = representation.index
         .checkDiscontinuity(checkedRange.start);
       if (discontinuityEnd !== null) {
@@ -193,7 +193,7 @@ export default function checkForDiscontinuity(
     }
 
     // At last, check if we don't have a discontinuity at the end of the current
-    // Period, anounced in the Manifest, that is too big to be detected through
+    // Period, announced in the Manifest, that is too big to be detected through
     // the previous checks (when the Period's end goes further than `checkedRange`).
 
     if (period.end !== undefined && checkedRange.end >= period.end) {


### PR DESCRIPTION
This PR regroups 3 fixes related to discontinuity management (fixes on a future releases).

---

1. `Skip discontinuities at the end of Periods even when we are in it`

This commit adds a condition to skip discontinuities we previously ignored.

Let's consider the following situation:
```
 = segment
 | Period boundary
 ^ current position
 - current checked range for segment download

|=======   --|====            |
 Period 1  ^   Period 2
```

Here we're at a position inside a "hole" at the end of the given Period. Now let's consider that we found out that there's no segment to load there.

In that situation, we previously just checked if there was a discontinuity anounced in the Manifest. If not, we did nothing.
But we can also reliably seek to the next Period in any case, when the Period is known to have ended.
This commit adds that supplementary logic.

As the logic in `check_for_discontinuity.ts` is very hard to follow I also added some comments and removed an indentation level where I could.

This is the source of most of the diff.

---

2. `For discontinuities, check that ``nextBufferedInRange`` is actually in range`

That one adds a check to the `nextBufferedInRangeIdx` variable, so that we're sure it concerns a segment that is not after the current range considered.

With the previous logic, we could avoid occasions to skip over discontinuities because there was a segment coming just after the current range considered.

---

3. `Set discontinuity for the first encoutered non-consecutive segment, not the last`

Because I forgot to add a `break` statement, `nextHoleIdx` actually contained the index of the last considered discontinuity in the current range, not the first one.

This has been fixed.