### PR TITLE
Consider finished a timeline rep whose end is near period end, if manifest max time is after

### DIFF
--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -475,16 +475,16 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     // We can never be truly sure if a SegmentTimeline-based index is finished
     // or not
     // We consider a possible rounding error on lastTime (1 / 60)
-    const roundError = 1 / 60;
+    const lastTimeWithError = lastTime + 1 / 60;
     const lastPosition = this._manifestBoundsCalculator.getMaximumBound();
     if (lastPosition === undefined) {
-      return (lastTime + roundError) >= this._scaledPeriodEnd;
+      return lastTimeWithError >= this._scaledPeriodEnd;
     }
     // If the last position is defined and after period end, and a small gap
-    // exists between last index position and scaled period end, then consider
-    // that timeline index may be finished.
-    const lastTimeGapTolerance = 0.1 /* 100ms */ * (this._index.timescale ?? 1);
-    return (lastTime + roundError + lastTimeGapTolerance) >= this._scaledPeriodEnd &&
+    // exists between last index position and scaled period end (max 100ms),
+    // then consider that timeline index may be finished.
+    const maxGapBetweenPeriodAndIdxEnd = 0.1 * (this._index.timescale ?? 1);
+    return (lastTimeWithError + maxGapBetweenPeriodAndIdxEnd) >= this._scaledPeriodEnd &&
            (lastPosition * (this._index.timescale ?? 1) > this._scaledPeriodEnd);
   }
 

--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -480,8 +480,9 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     if (lastPosition === undefined) {
       return (lastTime + roundError) >= this._scaledPeriodEnd;
     }
-    // If the last position is defined, and a small gap exists between last index position
-    // and scaled period end, then consider that timeline index may be finished.
+    // If the last position is defined and after period end, and a small gap
+    // exists between last index position and scaled period end, then consider
+    // that timeline index may be finished.
     const lastTimeGapTolerance = 0.1 /* 100ms */ * (this._index.timescale ?? 1);
     return (lastTime + roundError + lastTimeGapTolerance) >= this._scaledPeriodEnd &&
            (lastPosition * (this._index.timescale ?? 1) > this._scaledPeriodEnd);


### PR DESCRIPTION
Some segment timeline representation ends a little before actual period end. Until now, we considered that the representation was not considered as finished, because some chunks may not be generated. However, if the max manifest time is upper the period end, the index may be finished.

We now consider this to establish if it finished or not.