### PR TITLE
compat: throw a better error when no EME API is found

### DIFF
--- a/src/compat/eme/custom_media_keys/index.ts
+++ b/src/compat/eme/custom_media_keys/index.ts
@@ -92,6 +92,8 @@ let _setMediaKeys :
  * Therefore, we prefer not to use requestMediaKeySystemAccess on Safari when webkit API
  * is available.
  */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 if (isNode ||
     (navigator.requestMediaKeySystemAccess != null && !shouldFavourCustomSafariEME())
 ) {
@@ -100,13 +102,8 @@ if (isNode ||
     b : MediaKeySystemConfiguration[]
   ) : Observable<MediaKeySystemAccess> =>
     castToObservable(navigator.requestMediaKeySystemAccess(a, b));
-} else {
-  /* eslint-disable @typescript-eslint/no-unsafe-call */
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+} else if (MediaKeys_.isTypeSupported !== undefined) {
   let isTypeSupported = (keyType: string): boolean => {
-    if ((MediaKeys_ as any).isTypeSupported === undefined) {
-      throw new Error("No isTypeSupported on MediaKeys.");
-    }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return (MediaKeys_ as any).isTypeSupported(keyType);
   };
@@ -178,6 +175,16 @@ if (isNode ||
     }
 
     return observableThrow(undefined);
+  };
+} else {
+  requestMediaKeySystemAccess = (
+    _a : string,
+    _b : MediaKeySystemConfiguration[]
+  ) : Observable<MediaKeySystemAccess> => {
+    const message = "This browser seems to be unable to play encrypted contents " +
+                    "currently. Note: Some browsers do not allow decryption " +
+                    "in some situations, like when not using HTTPS.";
+    return observableThrow(new Error(message));
   };
 }
 


### PR DESCRIPTION
While testing playback of encrypted contents in an HTTP page on Edge (on Edge and Chrome, EME APIs are only available on an HTTPS page), I noticed that the error message was not explicit at all:

`"No isTypeSupported on MediaKeys"`.

This is because we were in a specific case, where the RxPlayer tried to ponyfill the `requestMediaKeySystemAccess` API with another since-deprecated API, `MediaKeys.isTypeSupported`.

This commit now checks if the `MediaKeys.isTypeSupported` API exists before fallbacking to that ponyfill, and no longer throw that error.
Now when neither the `requestMediaKeySystemAccess` nor the `MediaKeys.isTypeSupported` API exist, the following error is thrown instead when wanting to play encrypted contents:

`"This browser seems to be unable to play encrypted contents currently (are you using HTTPS?)"`