### PR TITLE
Fix Uint8Array believed to be an ArrayBuffer when blacklisting based on key-id

### DIFF
--- a/src/core/eme/check_key_statuses.ts
+++ b/src/core/eme/check_key_statuses.ts
@@ -61,9 +61,9 @@ export default function checkKeyStatuses(
   session : MediaKeySession | ICustomMediaKeySession,
   options: IKeyStatusesCheckingOptions,
   keySystem: string
-) : [IEMEWarningEvent[], ArrayBuffer[]] {
+) : [IEMEWarningEvent[], Uint8Array[]] {
   const warnings : IEMEWarningEvent[] = [];
-  const blacklistedKeyIDs : ArrayBuffer[] = [];
+  const blacklistedKeyIDs : Uint8Array[] = [];
   const { fallbackOn = {}, throwOnLicenseExpiration } = options;
 
   /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -152,7 +152,7 @@ export interface ISessionUpdatedEvent {
 // blacklisted.
 // Emit the corresponding keyIDs as payload.
 export interface IBlacklistKeysEvent { type : "blacklist-keys";
-                                       value: ArrayBuffer[]; }
+                                       value: Uint8Array[]; }
 
 /**
  * Event Emitted when specific "protection data" cannot be deciphered and is thus

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -18,7 +18,6 @@ import { ICustomError } from "../errors";
 import { IParsedManifest } from "../parsers/manifest";
 import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
 import arrayFind from "../utils/array_find";
-import { isABEqualBytes } from "../utils/byte_parsing";
 import EventEmitter from "../utils/event_emitter";
 import idGenerator from "../utils/id_generator";
 import warnOnce from "../utils/warn_once";
@@ -472,7 +471,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * performed.
    * @param {Array.<ArrayBuffer>} keyIDs
    */
-  public addUndecipherableKIDs(keyIDs : ArrayBuffer[]) : void {
+  public addUndecipherableKIDs(keyIDs : Uint8Array[]) : void {
     const updates = updateDeciperability(this, (representation) => {
       if (representation.decipherable === false ||
           representation.contentProtections === undefined)
@@ -483,7 +482,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
       for (let i = 0; i < contentKIDs.length; i++) {
         const elt = contentKIDs[i];
         for (let j = 0; j < keyIDs.length; j++) {
-          if (isABEqualBytes(keyIDs[j], elt.keyId)) {
+          if (areArraysOfNumbersEqual(keyIDs[j], elt.keyId)) {
             return false;
           }
         }


### PR DESCRIPTION
Since at least the v3.21.1 release, we had an issue that appeared when blacklisting Representation based on the keyID (e.g. when a `keystatuseschange` event indicates us that we are "output-restricted and when fallbacking is enabled through the related `keySystems` options).

This issue prevented from fallbacking, it just threw an Error message along the lines of:
`TypeError: DataView: expected ArrayBuffer, got Uint8Array`

The root cause was linked to typing issues (we will consequently cleverly redirect all wrong-doing to typescript, not our fault at all here :p) where an Uint8Array was considered to be a valid ArrayBuffer.

At some point, a `new DataView(whatIThoughtToBeAnArrayBufferWhichIsInRealityAUint8Array)` was done, leading to the aforementioned error.

The fix here is to now consider the type to be an Uint8Array and to do Uint8Array things instead (i.e. no DataView anymore).