### PR TITLE
Remove "progress" event from being listened by the clock

### DIFF
--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -45,7 +45,6 @@ import { getRange } from "../../utils/ranges";
 export type IMediaInfosState = "init" | // set once on first emit
                                "canplay" | // HTML5 Event
                                "play" | // HTML5 Event
-                               "progress" | // HTML5 Event
                                "seeking" | // HTML5 Event
                                "seeked" | // HTML5 Event
                                "loadedmetadata" | // HTML5 Event
@@ -115,7 +114,6 @@ const { SAMPLING_INTERVAL_MEDIASOURCE,
  */
 const SCANNED_MEDIA_ELEMENTS_EVENTS : IMediaInfosState[] = [ "canplay",
                                                              "play",
-                                                             "progress",
                                                              "seeking",
                                                              "seeked",
                                                              "loadedmetadata",


### PR DESCRIPTION
The clock, an internal RxPlayer mechanism running the main player logic on different playback events (seek, loading, playback rate change, or at a regular interval if none of those happen) was listening to the `"progress"` event from the HTMLMediaElement.

This appears to be unnecessary, as `progress` doesn't seem to be an important milestone enough to justify re-checking everything.
What this event is for on contents with a MediaSource is a little blurry but it seems to be linked to when a new chunk is added.

On some CPU-constrained devices, each tick have been observed to take between 5 and 30 ms. Progress events being one of the events the most often emitted, this could consume in the hundred of milliseconds before the content loads on those devices.