### PR TITLE
improve content switching performance by loading the Manifest ASAP

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -41,6 +41,7 @@ import {
   mergeMapTo,
   publish,
   share,
+  shareReplay,
   skipWhile,
   startWith,
   switchMapTo,
@@ -807,7 +808,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       // Load the Manifest right now and share it with every subscriber until
       // the content is stopped
       manifest$ = manifest$.pipe(takeUntil(stopContent$),
-                                 share());
+                                 shareReplay());
       manifest$.subscribe();
 
       // now that the Manifest is loading, stop previous content and reset state


### PR DESCRIPTION
The previous RxPlayer logic waited for a possible previous content to be "cleaned-up" (its buffers removed, previous encryption sessions closed if the right options are set etc.) before considering a new content.

We found that in some target, that clean-up can take time.
Depending on the options set and the content previously played (e.g. with multiple keys and options to close all sessions) we noticed up to 500ms only to clean-up the previous content.

This PR attempts to optimize that time by fetching the Manifest early on, even before stopping the previous content.

Sadly this implies to move the `ManifestFetcher` from the `Init` to the `API`. It is kind of odd to see it there.
Because there was no reason to now let the `SegmentFetcherCreator` in the `Init` I moved it to the `API` as well.

This had the nice side-effect of globally removing options from the `Init` (as many of those were only there to creates those two instances).

But now, having some instances created in the `Init` (most of all the `ABRManager`) and some of those in the `API` may be difficult to follow.
I don't really know what to do about that for now.

Also, there was no point to define the `fetchManifest` callback directly in the `InitializeOnMediaSource` function instead of the now only place where it is used: the `manifestUpdateScheduler`. So I moved it there.

I tested that PR and it works well.

Thoughts?