### PR TITLE
drm: perform setServerCertificate before init data has been received

### DIFF
--- a/src/core/eme/__tests__/__global__/server_certificate.test.ts
+++ b/src/core/eme/__tests__/__global__/server_certificate.test.ts
@@ -56,7 +56,7 @@ describe("core - eme - global tests - server certificate", () => {
   });
 
   /* eslint-disable max-len */
-  it("should set the serverCertificate after receiving the first encrypted event", (done) => {
+  it("should set the serverCertificate only after the MediaKeys is attached", (done) => {
   /* eslint-enable max-len */
 
     // == mocks ==
@@ -88,14 +88,14 @@ describe("core - eme - global tests - server certificate", () => {
           case 2:
             expect(evt.type).toEqual("attached-media-keys");
             expect(createSessionSpy).not.toHaveBeenCalled();
-            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+            expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
             initDataSubject.next({ type: "cenc", data: initData });
             break;
           case 3:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
-              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
               initDataSubject.next({ type: "cenc2", data: initData });
             }, 10);
@@ -146,13 +146,10 @@ describe("core - eme - global tests - server certificate", () => {
             evt.value.attachMediaKeys$.next();
             break;
           case 2:
-            expect(evt.type).toEqual("attached-media-keys");
-            expect(createSessionSpy).not.toHaveBeenCalled();
-            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
-            initDataSubject.next({ type: "cenc", data: initData });
-            break;
-          case 3:
             expect(evt.type).toEqual("warning");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+            expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
             expect(evt.value.name).toEqual("EncryptedMediaError");
             expect(evt.value.type).toEqual("ENCRYPTED_MEDIA_ERROR");
             expect(evt.value.code).toEqual("LICENSE_SERVER_CERTIFICATE_ERROR");
@@ -161,11 +158,16 @@ describe("core - eme - global tests - server certificate", () => {
                 "EncryptedMediaError (LICENSE_SERVER_CERTIFICATE_ERROR) " +
                 "`setServerCertificate` error");
             break;
+          case 3:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
           case 4:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
-              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
               initDataSubject.next({ type: "cenc2", data: initData });
             }, 10);
@@ -216,13 +218,9 @@ describe("core - eme - global tests - server certificate", () => {
             evt.value.attachMediaKeys$.next();
             break;
           case 2:
-            expect(evt.type).toEqual("attached-media-keys");
-            expect(createSessionSpy).not.toHaveBeenCalled();
-            expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
-            initDataSubject.next({ type: "cenc", data: initData });
-            break;
-          case 3:
             expect(evt.type).toEqual("warning");
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+            expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
             expect(evt.value.name).toEqual("EncryptedMediaError");
             expect(evt.value.type).toEqual("ENCRYPTED_MEDIA_ERROR");
             expect(evt.value.code).toEqual("LICENSE_SERVER_CERTIFICATE_ERROR");
@@ -231,11 +229,16 @@ describe("core - eme - global tests - server certificate", () => {
                 "EncryptedMediaError (LICENSE_SERVER_CERTIFICATE_ERROR) Error: some error"
               );
             break;
+          case 3:
+            expect(evt.type).toEqual("attached-media-keys");
+            expect(createSessionSpy).not.toHaveBeenCalled();
+            expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
+            initDataSubject.next({ type: "cenc", data: initData });
+            break;
           case 4:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
-              expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
               initDataSubject.next({ type: "cenc2", data: initData });
             }, 10);


### PR DESCRIPTION
This is both a performance-related improvement and a fix of a small issue (which may have had no possible impact).

___

For the performance improvement:

Previously we awaited for the first encrypted event before calling the `setServerCertificate` API. This may have been to avoid calling unnecessary APIs when the content is not really encrypted (or perhaps even not YET encrypted at this point).

Doing this may have been a nice improvement for when a `setServerCertificate` was done each time a `serverCertificate` was given as an option, but we now have an optimization which avoid re-doing a `setServerCertificate` when we KNOW that we're already using that server certificate.

Now, it can also be looked the other way: it penalizes the charging time by waiting for the initialization data first.
Also, it could further improve charging time by setting that option even when playing an unencrypted content first.
This will now still perform `setServerCertificate` (which will not be necessary to play the content here), so it will be ready for a future encrypted content.

___

Also there was a possible issue (though all tested CDM appeared to not be affected by that, even on our STBs) where a `generateRequest` - to generate a challenge - might be called before the `setServerCertificate` API had answered.

This only could happened on contents with multiple keys, as we only waited for the `setServerCertificate` response for the first init data received.
Also, we would either need to be very unlucky about timings or need to have a very long `setServerCertificate` call to reproduce that behavior.

Technically, this issue might lead to a challenge generated without using that certificate (though by reading the EME spec, this should not be a real issue, as the server certificate is only meant as an optimization anyway).

However, some CDMs seems to wait by themselves until the `setServerCertificate` respond before actually generating a challenge (and it would be called before in any case).

Still that commit fixes that by always performing `setServerCertificate` before any initialization data is processed.