### PR TITLE
Download Init segment in parralel of the first media segment

### DIFF
--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -1,0 +1,357 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BehaviorSubject,
+  defer as observableDefer,
+  Observable,
+  of as observableOf,
+  merge as observableMerge,
+  EMPTY,
+  ReplaySubject,
+  Subject,
+} from "rxjs";
+import {
+  filter,
+  finalize,
+  map,
+  mergeMap,
+  share,
+  switchMap,
+} from "rxjs/operators";
+import { ICustomError } from "../../../errors";
+import log from "../../../log";
+import Manifest, {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../../manifest";
+import {
+  ISegmentParserInitSegment,
+  ISegmentParserSegment,
+} from "../../../transports";
+import assertUnreachable from "../../../utils/assert_unreachable";
+import objectAssign from "../../../utils/object_assign";
+import {
+  IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
+} from "../../fetchers";
+import {
+  IQueuedSegment,
+} from "../types";
+
+/** Event sent by the DownloadingQueue. */
+export type IDownloadingQueueEvent<T> = IParsedSegmentEvent<T> |
+                                        IParsedInitSegmentEvent<T> |
+                                        IEndOfSegmentEvent |
+                                        ILoaderRetryEvent |
+                                        IEndOfQueueEvent;
+
+/** Notify that the initialization segment has been parsed. */
+export type IParsedInitSegmentEvent<T> = ISegmentParserInitSegment<T> &
+                                         { segment : ISegment };
+
+/** Notify that a media segment has been parsed. */
+export type IParsedSegmentEvent<T> = ISegmentParserSegment<T> &
+                                     { segment : ISegment };
+
+/** Notify that a segment has been fully-loaded. */
+export interface IEndOfSegmentEvent { type : "end-of-segment";
+                                      value: { segment : ISegment }; }
+
+/** Notify that a segment request is retried. */
+export interface ILoaderRetryEvent { type : "retry";
+                                     value : { segment : ISegment;
+                                               error : ICustomError; }; }
+
+/** Notify that the media segment queue is now empty. */
+export interface IEndOfQueueEvent { type : "end-of-queue"; value : null }
+
+/**
+ * Items emitted through the "downloadQueue$" observable, passed to the
+ * DownloadingQueue.
+ */
+export interface IDownloadQueueItem {
+  /**
+   * Set when an initialization segment needs to be loaded.
+   * It is generally requested in parralel of any media segment.
+   */
+  initSegment : IQueuedSegment | null;
+
+  /** The queue of segments currently needed for download.  */
+  segmentQueue : IQueuedSegment[];
+}
+
+/** Object describing a pending Segment request. */
+interface ISegmentRequestObject<T> {
+  /** The segment the request is for. */
+  segment : ISegment; // The Segment the request is for
+  /** The request Observable itself. Can be used to update its priority. */
+  request$ : Observable<IPrioritizedSegmentFetcherEvent<T>>;
+  /** Last set priority of the segment request (lower number = higher priority). */
+  priority : number; // The current priority of the request
+}
+
+/** Context for segments downloaded through the DownloadingQueue. */
+export interface IContent {
+  adaptation : Adaptation;
+  manifest : Manifest;
+  period : Period;
+  representation : Representation;
+}
+
+/**
+ * Class scheduling segment downloads for a single Representation according the given
+ * `downloadQueue$`.
+ * @class DownloadingQueue
+ */
+export default class DownloadingQueue<T> {
+  /** Context of the Representation that will be loaded through this DownloadingQueue. */
+  private _content : IContent;
+  /**
+   * DownloadingQueue Observable.
+   * We only can have maximum one at a time.
+   * `null` when `start` has never been called.
+   */
+  private _currentObs$ : Observable<IDownloadingQueueEvent<T>> | null;
+  /** Queue of segments scheduled for download. */
+  private _downloadQueue$ : BehaviorSubject<IDownloadQueueItem>;
+  /**
+   * Pending request for the initialization segment.
+   * `null` if no request is pending for it.
+   */
+  private _initSegmentRequest : ISegmentRequestObject<T>|null;
+  /**
+   * Pending request for a media (i.e. non-initialization) segment.
+   * `null` if no request is pending for it.
+   */
+  private _mediaSegmentRequest : ISegmentRequestObject<T>|null;
+  /** Interface used to load segments. */
+  private _segmentFetcher : IPrioritizedSegmentFetcher<T>;
+
+  /**
+   * Create a new DownloadingQueue.
+   * @param {Object} content - The context of the Representation you want to
+   * load segments for.
+   * @param {BehaviorSubject} downloadQueue$ - Emit the queue of segments you
+   * want to load.
+   * @param {Object} segmentFetcher - Interface to facilitate the download of
+   * segments.
+   */
+  constructor(
+    content: IContent,
+    downloadQueue$ : BehaviorSubject<IDownloadQueueItem>,
+    segmentFetcher : IPrioritizedSegmentFetcher<T>
+  ) {
+    this._content = content;
+    this._currentObs$ = null;
+    this._downloadQueue$ = downloadQueue$;
+    this._initSegmentRequest = null;
+    this._mediaSegmentRequest = null;
+    this._segmentFetcher = segmentFetcher;
+  }
+
+  /**
+   * Returns the initialization segment currently being requested.
+   * Returns `null` if no initialization segment request is pending.
+   * @returns {Object}
+   */
+  public getCurrentInitRequest() : ISegment | null {
+    return this._initSegmentRequest === null ? null :
+                                               this._initSegmentRequest.segment;
+  }
+
+  /**
+   * Returns the media segment currently being requested.
+   * Returns `null` if no media segment request is pending.
+   * @returns {Object}
+   */
+  public getCurrentMediaRequest() : ISegment | null {
+    return this._mediaSegmentRequest === null ? null :
+                                                this._mediaSegmentRequest.segment;
+  }
+
+  public start() : Observable<IDownloadingQueueEvent<T>> {
+    if (this._currentObs$ !== null) {
+      return this._currentObs$;
+    }
+    /** Emit the timescale anounced in the initialization segment when parsed. */
+    const initSegmentTimescale$ = new ReplaySubject<number|undefined>(1);
+    const obs = observableDefer(() => {
+      const mediaQueue$ = this._downloadQueue$.pipe(
+        filter(({ segmentQueue }) => {
+          const currentSegmentRequest = this._mediaSegmentRequest;
+          if (segmentQueue.length === 0) {
+            return currentSegmentRequest !== null;
+          } else if (currentSegmentRequest === null) {
+            return true;
+          }
+          if (currentSegmentRequest.segment.id !== segmentQueue[0].segment.id) {
+            return true;
+          }
+          if (currentSegmentRequest.priority !== segmentQueue[0].priority) {
+            this._segmentFetcher.updatePriority(currentSegmentRequest.request$,
+                                                segmentQueue[0].priority);
+          }
+          return false;
+        }),
+        switchMap(({ segmentQueue }) =>
+          segmentQueue.length > 0 ? this._requestMediaSegments(initSegmentTimescale$) :
+                                    EMPTY));
+
+      const initSegmentPush$ = this._downloadQueue$.pipe(
+        filter((next) => {
+          const initSegmentRequest = this._initSegmentRequest;
+          if (next.initSegment !== null && initSegmentRequest !== null) {
+            if (next.initSegment.priority !== initSegmentRequest.priority) {
+              this._segmentFetcher.updatePriority(initSegmentRequest.request$,
+                                                  next.initSegment.priority);
+            }
+            return false;
+          } else {
+            return next.initSegment === null || initSegmentRequest === null;
+          }
+        }),
+        switchMap((nextQueue) => {
+          if (nextQueue.initSegment === null) {
+            return EMPTY;
+          }
+          return this._requestInitSegment(nextQueue.initSegment, initSegmentTimescale$);
+        }));
+
+      return observableMerge(initSegmentPush$, mediaQueue$);
+    }).pipe(share());
+
+    this._currentObs$ = obs;
+
+    return obs;
+  }
+
+  /**
+   * @param {BehaviorSubject} initSegmentTimescale$
+   * @returns {Observable}
+   */
+  private _requestMediaSegments(
+    initSegmentTimescale$ : Subject<number|undefined>
+  ) : Observable<IDownloadingQueueEvent<T>> {
+    const { segmentQueue } = this._downloadQueue$.getValue();
+    const currentNeededSegment = segmentQueue[0];
+    const recursivelyRequestSegments = (
+      startingSegment : IQueuedSegment | undefined
+    ) : Observable<IDownloadingQueueEvent<T>> => {
+      if (startingSegment === undefined) {
+        return observableOf({ type : "end-of-queue",
+                              value : null });
+      }
+      const { segment, priority } = startingSegment;
+      const context = objectAssign({ segment }, this._content);
+      const request$ = this._segmentFetcher.createRequest(context, priority);
+
+      this._mediaSegmentRequest = { segment, priority, request$ };
+      return request$
+        .pipe(mergeMap((evt) : Observable<IDownloadingQueueEvent<T>> => {
+          switch (evt.type) {
+            case "warning":
+              return observableOf({ type: "retry" as const,
+                                    value: { segment, error: evt.value } });
+            case "interrupted":
+              log.info("Stream: segment request interrupted temporarly.", segment);
+              return EMPTY;
+
+            case "ended":
+              this._mediaSegmentRequest = null;
+              const lastQueue = this._downloadQueue$.getValue().segmentQueue;
+              if (lastQueue.length === 0) {
+                return observableOf({ type : "end-of-queue",
+                                      value : null });
+              } else if (lastQueue[0].segment.id === segment.id) {
+                lastQueue.shift();
+              }
+              return recursivelyRequestSegments(lastQueue[0]);
+
+            case "chunk":
+            case "chunk-complete":
+              return initSegmentTimescale$.pipe(
+                mergeMap((initTimescale) => {
+                  if (evt.type === "chunk-complete") {
+                    return observableOf({ type: "end-of-segment" as const,
+                                          value: { segment } });
+                  }
+                  return evt.parse(initTimescale).pipe(map(parserResponse => {
+                    return objectAssign({ segment }, parserResponse);
+                  }));
+                }));
+
+            default:
+              assertUnreachable(evt);
+          }
+        }));
+    };
+
+    return observableDefer(() =>
+      recursivelyRequestSegments(currentNeededSegment)
+    ).pipe(finalize(() => { this._mediaSegmentRequest = null; }));
+  }
+
+  /**
+   * @param {Object} queuedInitSegment
+   * @param {BehaviorSubject} initSegmentTimescale$
+   * @returns {Observable}
+   */
+  private _requestInitSegment(
+    queuedInitSegment : IQueuedSegment | null,
+    initSegmentTimescale$ : Subject<number | undefined>
+  ) : Observable<IDownloadingQueueEvent<T>> {
+    if (queuedInitSegment === null) {
+      this._initSegmentRequest = null;
+      return EMPTY;
+    }
+    const { segment, priority } = queuedInitSegment;
+    const context = objectAssign({ segment }, this._content);
+    const request$ = this._segmentFetcher.createRequest(context, priority);
+
+    this._initSegmentRequest = { segment, priority, request$ };
+    return request$
+      .pipe(mergeMap((evt) : Observable<IDownloadingQueueEvent<T>> => {
+        switch (evt.type) {
+          case "warning":
+            return observableOf({ type: "retry" as const,
+                                  value: { segment, error: evt.value } });
+          case "interrupted":
+            log.info("Stream: init segment request interrupted temporarly.", segment);
+            return EMPTY;
+
+          case "chunk":
+            return evt.parse(undefined).pipe(map(parserResponse => {
+              if (parserResponse.type === "parsed-init-segment") {
+                initSegmentTimescale$.next(parserResponse.value.initTimescale);
+              }
+              return objectAssign({ segment }, parserResponse);
+            }));
+
+          case "chunk-complete":
+            return observableOf({ type: "end-of-segment" as const,
+                                  value: { segment } });
+
+          case "ended":
+            return EMPTY; // Do nothing, just here to check every case
+          default:
+            assertUnreachable(evt);
+        }
+      })).pipe(finalize(() => { this._initSegmentRequest = null; }));
+  }
+}

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -170,7 +170,7 @@ export default class DownloadingQueue<T> {
    * Returns `null` if no initialization segment request is pending.
    * @returns {Object}
    */
-  public getCurrentInitRequest() : ISegment | null {
+  public getRequestedInitSegment() : ISegment | null {
     return this._initSegmentRequest === null ? null :
                                                this._initSegmentRequest.segment;
   }
@@ -180,7 +180,7 @@ export default class DownloadingQueue<T> {
    * Returns `null` if no media segment request is pending.
    * @returns {Object}
    */
-  public getCurrentMediaRequest() : ISegment | null {
+  public getRequestedMediaSegment() : ISegment | null {
     return this._mediaSegmentRequest === null ? null :
                                                 this._mediaSegmentRequest.segment;
   }

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -280,8 +280,8 @@ export default function RepresentationStream<T>({
       }
 
       const mostNeededSegment = neededSegments[0];
-      const initSegmentRequest = downloadingQueue.getCurrentInitRequest();
-      const currentSegmentRequest = downloadingQueue.getCurrentMediaRequest();
+      const initSegmentRequest = downloadingQueue.getRequestedInitSegment();
+      const currentSegmentRequest = downloadingQueue.getRequestedMediaSegment();
 
       if (terminate === null) {
         downloadQueue$.next({ initSegment: neededInitSegment,

--- a/tests/integration/scenarios/initial_playback.js
+++ b/tests/integration/scenarios/initial_playback.js
@@ -225,12 +225,12 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest
     await xhrMock.flush();
     await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // init segments
+
+    // init segments first media segments
+    expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // first two segments
-    await xhrMock.flush(); // first two segments
-    await sleep(1);
+    await sleep(100);
+
     expect(xhrMock.getLockedXHR().length).to.equal(0); // nada
     expect(player.getVideoLoadedTime()).to.be.above(4);
     expect(player.getVideoLoadedTime()).to.be.below(5);
@@ -248,15 +248,16 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest
     await xhrMock.flush();
     await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // init segments
+
+    // init segments first media segments
+    expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // first two segments
-    await xhrMock.flush(); // first two segments
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // still
+    await sleep(100);
+
+    expect(xhrMock.getLockedXHR().length).to.equal(2); // next 2
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
+
     expect(player.getVideoLoadedTime()).to.be.above(7);
     expect(player.getVideoLoadedTime()).to.be.below(9);
   });

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -398,14 +398,7 @@ describe("loadVideo Options", () => {
         await xhrMock.flush(); // Manifest request
         await sleep(1);
         expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(2); // Segment requests
-        nbVideoSegmentRequests += xhrMock.getLockedXHR()
-          .filter(r => r.url && r.url.includes("ateam-video"))
-          .length;
-        await xhrMock.flush();
-        await sleep(1);
-        expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(4); // Segment requests
+          .to.equal(4); // init + media Segment requests
         nbVideoSegmentRequests += xhrMock.getLockedXHR()
           .filter(r => r.url && r.url.includes("ateam-video"))
           .length;

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -124,11 +124,8 @@ export default function launchTestsForContent(manifestInfos) {
             (videoRepresentationInfos && videoRepresentationInfos.index.init)
           ) {
             expect(xhrMock.getLockedXHR().length)
-              .to.equal(2, "should request two init segments");
-            const requestsDone = [
-              xhrMock.getLockedXHR()[0].url,
-              xhrMock.getLockedXHR()[1].url,
-            ];
+              .to.be.at.least(2, "should request two init segments");
+            const requestsDone = xhrMock.getLockedXHR().map(({ url }) => url);
             expect(requestsDone)
               .to.include(videoRepresentationInfos.index.init.mediaURLs[0]);
             expect(requestsDone)

--- a/tests/utils/waitForPlayerState.js
+++ b/tests/utils/waitForPlayerState.js
@@ -41,7 +41,10 @@ export default function waitForState(player, wantedState, whitelist) {
         player.removeEventListener("playerStateChange", onPlayerStateChange);
         resolve();
       } else if (whitelist && !whitelist.includes(state)) {
-        reject("invalid state: " + state);
+        if (state === "STOPPED" && player.getError() !== null) {
+          console.error("!!!!!!!!!", player.getError().toString());
+        }
+        reject(new Error("invalid state: " + state));
       }
     }
     player.addEventListener("playerStateChange", onPlayerStateChange);


### PR DESCRIPTION
In the previous logic, we always awaited the initialization segment request before loading any media segment.

There was two main reasons why:

  1. It was difficult to write the code running them in parallel, due to some edge cases

  2. It may not save any time in most real use-cases, as most contents we play are encrypted and we rely on the initialization segment to take the encryption initialization data.
      Running their requests in parallel of other requests would only postpone their responses, which might in the end lead to a slower loading time.

For 1/, nothing changed much but the second inconvenient may disappear now that we're considering relying only on the encryption initialization data found in a Manifest file if found there (and if not, which would arguably be the minority case, we could take the hit).

So, I tried to implement that logic.
I had to do some refactoring in the `RepresentationStream` and to factorize the code a little by moving its segment-request code in its own `downloading_queue.ts` file. 
I'm relatively happy with the result code-wise (I even prefer it to what was before, even if it adds a whole another file and concept), so I'm ready to include in a next release if you think it looks good. 

Performance-wise, the license-fetching operation is often done after the first media segments are pushed, so it may not change that much for the loading time of encrypted contents (though it should on unencrypted contents) for which the `MediaKeySession` is not yet in our cache.
Still, other events necessitating to load new initialization and media segments (switching bitrate, tracks, periods etc.) should gain from this.


Note: I added the `DASH` label as it is unlikely that Smooth contents will gain from this - considering its initialization segments are synchronously generated from the Manifest.