### PR TITLE
Take into account rounding errors for indexes computing and comparisons

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1072,4 +1072,22 @@ export default {
 
   /** Interval we will use to poll for checking if an event shall be emitted */
   STREAM_EVENT_EMITTER_POLL_INTERVAL: 250,
+
+  /**
+   * In Javascript, numbers are encoded in a way that a floating number may be
+   * represented internally with a rounding error. When multiplying times in
+   * seconds by the timescale, we've encoutered cases were the rounding error
+   * was amplified by a factor which is about the timescale.
+   * Example :
+   * (192797480.641122).toFixed(20) = 192797480.64112201333045959473
+   * (error is 0.0000000133...)
+   * 192797480.641122 * 10000000 = 1927974806411220.2 (error is 0.2)
+   * 192797480.641122 * 10000000 * 4 = 7711899225644881 (error is 1)
+   * The error is much more significant here, once the timescale has been
+   * applied.
+   * Thus, we consider that our max tolerable rounding error is 1ms.
+   * It is much more than max rounding errors when seen into practice,
+   * and not significant from the media loss perspective.
+   */
+  DEFAULT_MAXIMUM_TIME_ROUNDING_ERROR: 1 / 1000,
 };

--- a/src/parsers/manifest/dash/indexes/is_period_fulfilled.ts
+++ b/src/parsers/manifest/dash/indexes/is_period_fulfilled.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import config from "../../../../config";
+
+const { DEFAULT_MAXIMUM_TIME_ROUNDING_ERROR } = config;
+
+/**
+ * In Javascript, numbers are encoded in a way that a floating number may be
+ * represented internally with a rounding error.
+ *
+ * As the period end is the result of a multiplication between a floating or integer
+ * number (period end * timescale), this function takes into account the potential
+ * rounding error to tell if the period is fulfilled with content.
+ * @param {number} timescale
+ * @param {number} lastSegmentEnd
+ * @param {number} periodEnd
+ * @returns {boolean}
+ */
+export default function isPeriodFulfilled(
+  timescale: number,
+  lastSegmentEnd: number,
+  periodEnd: number
+): boolean {
+  const scaledRoundingError =
+    DEFAULT_MAXIMUM_TIME_ROUNDING_ERROR * timescale;
+  return (lastSegmentEnd + scaledRoundingError) >= periodEnd;
+}
+

--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -396,9 +396,24 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     }
     const lastSegmentEnd = lastSegmentStart + this._index.duration;
 
-    // (1 / 60 for possible rounding errors)
-    const roundingError = (1 / 60) * timescale;
-    return (lastSegmentEnd + roundingError) >=
+    // The scaled period end is the result of a multiplication between a floating
+    // or integer number : the period end, and an integer : the timescale.
+    // In Javascript, numbers are encoded in a way that a floating number may be
+    // represented internally with a rounding error. When multiplying the period
+    // end by the timescale, we've encoutered cases were the rounding error was
+    // amplified by a factor which is about the timescale
+    // Example :
+    // (192797480.641122).toFixed(20) = 192797480.64112201333045959473
+    // (error is 0.0000000133...)
+    // 192797480.641122 * 10000000 = 1927974806411220.2 (error is 0.2)
+    // 192797480.641122 * 10000000 * 4 = 7711899225644881 (error is 1)
+    // The error is much more significant here, once the timescale has been
+    // applied.
+    // Thus, we consider that our max tolerable rounding error is 1ms.
+    // It is much more than max rounding errors when seen into practice,
+    // and not significant from the media loss perspective.
+    const scaledRoundingError = (1 / 1000) * timescale;
+    return (lastSegmentEnd + scaledRoundingError) >=
            (this._relativePeriodEnd * timescale);
   }
 

--- a/src/parsers/manifest/dash/indexes/template.ts
+++ b/src/parsers/manifest/dash/indexes/template.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../../manifest";
 import ManifestBoundsCalculator from "../manifest_bounds_calculator";
 import getInitSegment from "./get_init_segment";
+import isPeriodFulfilled from "./is_period_fulfilled";
 import {
   createDashUrlDetokenizer,
   createIndexURLs,
@@ -144,8 +145,8 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
   private _manifestBoundsCalculator : ManifestBoundsCalculator;
   /** Absolute start of the Period, in seconds. */
   private _periodStart : number;
-  /** Difference between the end time of the Period and its start time, in seconds. */
-  private _relativePeriodEnd? : number;
+  /** Difference between the end time of the Period and its start time, in timescale. */
+  private _scaledPeriodEnd? : number;
   /** Minimum availabilityTimeOffset concerning the segments of this Representation. */
   private _availabilityTimeOffset? : number;
   /** Whether the corresponding Manifest can be updated and changed. */
@@ -204,8 +205,8 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                     startNumber: index.startNumber };
     this._isDynamic = isDynamic;
     this._periodStart = periodStart;
-    this._relativePeriodEnd = periodEnd == null ? undefined :
-                                                  periodEnd - periodStart;
+    this._scaledPeriodEnd = periodEnd == null ? undefined :
+                                                (periodEnd - periodStart) * timescale;
   }
 
   /**
@@ -229,9 +230,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
             mediaURLs } = index;
 
     const scaledStart = this._periodStart * timescale;
-    const scaledEnd = this._relativePeriodEnd == null ?
-      undefined :
-      this._relativePeriodEnd * timescale;
+    const scaledEnd = this._scaledPeriodEnd;
 
     // Convert the asked position to the right timescales, and consider them
     // relatively to the Period's start.
@@ -382,7 +381,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     if (!this._isDynamic) {
       return true;
     }
-    if (this._relativePeriodEnd == null) {
+    if (this._scaledPeriodEnd === undefined) {
       return false;
     }
 
@@ -395,26 +394,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
       return false;
     }
     const lastSegmentEnd = lastSegmentStart + this._index.duration;
-
-    // The scaled period end is the result of a multiplication between a floating
-    // or integer number : the period end, and an integer : the timescale.
-    // In Javascript, numbers are encoded in a way that a floating number may be
-    // represented internally with a rounding error. When multiplying the period
-    // end by the timescale, we've encoutered cases were the rounding error was
-    // amplified by a factor which is about the timescale
-    // Example :
-    // (192797480.641122).toFixed(20) = 192797480.64112201333045959473
-    // (error is 0.0000000133...)
-    // 192797480.641122 * 10000000 = 1927974806411220.2 (error is 0.2)
-    // 192797480.641122 * 10000000 * 4 = 7711899225644881 (error is 1)
-    // The error is much more significant here, once the timescale has been
-    // applied.
-    // Thus, we consider that our max tolerable rounding error is 1ms.
-    // It is much more than max rounding errors when seen into practice,
-    // and not significant from the media loss perspective.
-    const scaledRoundingError = (1 / 1000) * timescale;
-    return (lastSegmentEnd + scaledRoundingError) >=
-           (this._relativePeriodEnd * timescale);
+    return isPeriodFulfilled(timescale, lastSegmentEnd, this._scaledPeriodEnd);
   }
 
   /**
@@ -432,7 +412,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     this._aggressiveMode = newIndex._aggressiveMode;
     this._isDynamic = newIndex._isDynamic;
     this._periodStart = newIndex._periodStart;
-    this._relativePeriodEnd = newIndex._relativePeriodEnd;
+    this._scaledPeriodEnd = newIndex._scaledPeriodEnd;
     this._manifestBoundsCalculator = newIndex._manifestBoundsCalculator;
   }
 
@@ -456,7 +436,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     }
 
     // 1 - check that this index is already available
-    if (this._relativePeriodEnd === 0 || this._relativePeriodEnd == null) {
+    if (this._scaledPeriodEnd === 0 || this._scaledPeriodEnd === undefined) {
       // /!\ The scaled max position augments continuously and might not
       // reflect exactly the real server-side value. As segments are
       // generated discretely.
@@ -497,13 +477,13 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
       }
       const agressiveModeOffset = this._aggressiveMode ? (duration / timescale) :
                                                          0;
-      if (this._relativePeriodEnd != null &&
-          this._relativePeriodEnd < (lastPos + agressiveModeOffset - this._periodStart)) {
-        const scaledRelativePeriodEnd = this._relativePeriodEnd * timescale;
-        if (scaledRelativePeriodEnd < duration) {
+      if (this._scaledPeriodEnd != null &&
+          this._scaledPeriodEnd <
+            (lastPos + agressiveModeOffset - this._periodStart) * this._index.timescale) {
+        if (this._scaledPeriodEnd < duration) {
           return null;
         }
-        return (Math.floor(scaledRelativePeriodEnd / duration) - 1)  * duration;
+        return (Math.floor(this._scaledPeriodEnd / duration) - 1)  * duration;
       }
       // /!\ The scaled last position augments continuously and might not
       // reflect exactly the real server-side value. As segments are
@@ -527,9 +507,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                null :
                (numberOfSegmentsAvailable - 1) * duration;
     } else {
-      const maximumTime = (this._relativePeriodEnd === undefined ?
-                             0 :
-                             this._relativePeriodEnd) * timescale;
+      const maximumTime = this._scaledPeriodEnd ?? 0;
       const numberIndexedToZero = Math.ceil(maximumTime / duration) - 1;
       const regularLastSegmentStart = numberIndexedToZero * duration;
 

--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -473,9 +473,24 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
                                         null,
                                         this._scaledPeriodEnd);
 
-    // We can never be truly sure if a SegmentTimeline-based index is finished
-    // or not (1 / 60 for possible rounding errors)
-    return (lastTime + 1 / 60) >= this._scaledPeriodEnd;
+    // The scaled period end is the result of a multiplication between a floating
+    // or integer number : the period end, and an integer : the timescale.
+    // In Javascript, numbers are encoded in a way that a floating number may be
+    // represented internally with a rounding error. When multiplying the period
+    // end by the timescale, we've encoutered cases were the rounding error was
+    // amplified by a factor which is about the timescale
+    // Example :
+    // (192797480.641122).toFixed(20) = 192797480.64112201333045959473
+    // (error is 0.0000000133...)
+    // 192797480.641122 * 10000000 = 1927974806411220.2 (error is 0.2)
+    // 192797480.641122 * 10000000 * 4 = 7711899225644881 (error is 1)
+    // The error is much more significant here, once the timescale has been
+    // applied.
+    // Thus, we consider that our max tolerable rounding error is 1ms.
+    // It is much more than max rounding errors when seen into practice,
+    // and not significant from the media loss perspective.
+    const scaledRoundingError = 1 / 1000 * this._index.timescale;
+    return (lastTime + scaledRoundingError) >= this._scaledPeriodEnd;
   }
 
   /**

--- a/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/indexes/timeline/timeline_representation_index.ts
@@ -38,6 +38,7 @@ import updateSegmentTimeline from "../../../utils/update_segment_timeline";
 import ManifestBoundsCalculator from "../../manifest_bounds_calculator";
 import getInitSegment from "../get_init_segment";
 import getSegmentsFromTimeline from "../get_segments_from_timeline";
+import isPeriodFulfilled from "../is_period_fulfilled";
 import { createIndexURLs } from "../tokens";
 import constructTimelineFromElements from "./construct_timeline_from_elements";
 // eslint-disable-next-line max-len
@@ -472,25 +473,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     const lastTime = getIndexSegmentEnd(lastTimelineElement,
                                         null,
                                         this._scaledPeriodEnd);
-
-    // The scaled period end is the result of a multiplication between a floating
-    // or integer number : the period end, and an integer : the timescale.
-    // In Javascript, numbers are encoded in a way that a floating number may be
-    // represented internally with a rounding error. When multiplying the period
-    // end by the timescale, we've encoutered cases were the rounding error was
-    // amplified by a factor which is about the timescale
-    // Example :
-    // (192797480.641122).toFixed(20) = 192797480.64112201333045959473
-    // (error is 0.0000000133...)
-    // 192797480.641122 * 10000000 = 1927974806411220.2 (error is 0.2)
-    // 192797480.641122 * 10000000 * 4 = 7711899225644881 (error is 1)
-    // The error is much more significant here, once the timescale has been
-    // applied.
-    // Thus, we consider that our max tolerable rounding error is 1ms.
-    // It is much more than max rounding errors when seen into practice,
-    // and not significant from the media loss perspective.
-    const scaledRoundingError = 1 / 1000 * this._index.timescale;
-    return (lastTime + scaledRoundingError) >= this._scaledPeriodEnd;
+    return isPeriodFulfilled(this._index.timescale, lastTime, this._scaledPeriodEnd);
   }
 
   /**


### PR DESCRIPTION
Numbers in JavaScript are encoded as double-precision floating-point numbers (64-bit encoding) specified by the IEEE 754 standard. One of the effects of this encoding is that these numbers are prone to rounding errors
The result of such unprecise representations is that some JS calculations may give bad results. As math operations are done frequently in the RxPlayer, on decimal numbers, there are various places in the code where the logic could go wrong. We've already introduced rounding error safeguards for some operations, but it seems that it may not be sufficient everywhere...

For example :
The isFinished function of the Timeline index checks if the last chunk of the timeline ends before the end of the period.
We've encountered a case in a DASH stream where the computed period end was wrong (above the expected value). So, the end of the period was considered higher than the last segment's end. The index was not considered as finished, and the stream didn't start loading next period content.

Thus, this PR tries to be more resilient and fair on timeline and template indexes :
We consider that a 1ms error can be tolerated because it is much more than every rounding error we have observed. And it is not significant as a potential content loss.