### PR TITLE
skip init segment's pssh boxes when encryption data is in the Manifest

### DIFF
--- a/src/core/eme/__tests__/__global__/get_license.test.ts
+++ b/src/core/eme/__tests__/__global__/get_license.test.ts
@@ -405,5 +405,5 @@ function checkGetLicense(
         throw new Error(`Unexpected error: ${error}`);
       }
     });
-  initDataSubject.next({ type: "cenc", data: initData });
+  initDataSubject.next({ type: "cenc", values: [ { systemId: "15", data: initData } ] });
 }

--- a/src/core/eme/__tests__/__global__/init_data.test.ts
+++ b/src/core/eme/__tests__/__global__/init_data.test.ts
@@ -116,7 +116,8 @@ describe("core - eme - global tests - init data", () => {
             throw new Error("Unexpected event");
         }
       });
-    initDataSubject.next({ type: "cenc", data: initData });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData } ] });
   });
 
   /* eslint-disable max-len */
@@ -172,10 +173,14 @@ describe("core - eme - global tests - init data", () => {
             throw new Error("Unexpected event");
         }
       });
-    initDataSubject.next({ type: "cenc", data: initData });
-    initDataSubject.next({ type: "cenc", data: initData });
-    initDataSubject.next({ type: "cenc", data: initData });
-    initDataSubject.next({ type: "cenc", data: initData });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData } ] });
   });
 
   /* eslint-disable max-len */
@@ -246,11 +251,16 @@ describe("core - eme - global tests - init data", () => {
             throw new Error("Unexpected event");
         }
       });
-    initDataSubject.next({ type: "cenc", data: initData1 });
-    initDataSubject.next({ type: "cenc", data: initData1 });
-    initDataSubject.next({ type: "cenc", data: initData2 });
-    initDataSubject.next({ type: "cenc", data: initData1 });
-    initDataSubject.next({ type: "cenc", data: initData2 });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData1 } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData1 } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData2 } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData1 } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData2 } ] });
   });
 
   /* eslint-disable max-len */
@@ -327,10 +337,14 @@ describe("core - eme - global tests - init data", () => {
             throw new Error("Unexpected event");
         }
       });
-    initDataSubject.next({ type: "cenc", data: initData1 });
-    initDataSubject.next({ type: "cenc2", data: initData1 });
-    initDataSubject.next({ type: "cenc", data: initData2 });
-    initDataSubject.next({ type: "cenc2", data: initData2 });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData1 } ] });
+    initDataSubject.next({ type: "cenc2",
+                           values: [ { systemId: "15", data: initData1 } ] });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData2 } ] });
+    initDataSubject.next({ type: "cenc2",
+                           values: [ { systemId: "15", data: initData2 } ] });
   });
 
   /* eslint-disable max-len */
@@ -781,13 +795,17 @@ describe("core - eme - global tests - init data", () => {
         }
       });
     triggerEncrypted.next(initDataEvent1);
-    initDataSubject.next({ type: "cenc", data: initData1 });
+    initDataSubject.next({ type: "cenc",
+                           values: [ { systemId: "15", data: initData1 } ] });
     setTimeout(() => {
-      initDataSubject.next({ type: "cenc2", data: initData1 });
+      initDataSubject.next({ type: "cenc2",
+                             values: [ { systemId: "15", data: initData1 } ] });
       triggerEncrypted.next(initDataEvent2);
-      initDataSubject.next({ type: "cenc", data: initData1 });
+      initDataSubject.next({ type: "cenc",
+                             values: [ { systemId: "15", data: initData1 } ] });
       triggerEncrypted.next(initDataEvent3);
-      initDataSubject.next({ type: "cenc", data: initData2 });
+      initDataSubject.next({ type: "cenc",
+                             values: [ { systemId: "15", data: initData2 } ] });
       triggerEncrypted.next(initDataEvent4);
     }, 5);
   });

--- a/src/core/eme/__tests__/__global__/server_certificate.test.ts
+++ b/src/core/eme/__tests__/__global__/server_certificate.test.ts
@@ -90,14 +90,16 @@ describe("core - eme - global tests - server certificate", () => {
             expect(createSessionSpy).not.toHaveBeenCalled();
             expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
             expect(serverCertificateSpy).toHaveBeenCalledWith(serverCertificate);
-            initDataSubject.next({ type: "cenc", data: initData });
+            initDataSubject.next({ type: "cenc",
+                                   values: [ { systemId: "15", data: initData } ] });
             break;
           case 3:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
-              initDataSubject.next({ type: "cenc2", data: initData });
+              initDataSubject.next({ type: "cenc2",
+                                     values: [ { systemId: "15", data: initData } ] });
             }, 10);
             break;
           case 4:
@@ -162,14 +164,16 @@ describe("core - eme - global tests - server certificate", () => {
             expect(evt.type).toEqual("attached-media-keys");
             expect(createSessionSpy).not.toHaveBeenCalled();
             expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
-            initDataSubject.next({ type: "cenc", data: initData });
+            initDataSubject.next({ type: "cenc",
+                                   values: [ { systemId: "15", data: initData } ] });
             break;
           case 4:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
-              initDataSubject.next({ type: "cenc2", data: initData });
+              initDataSubject.next({ type: "cenc2",
+                                     values: [ { systemId: "15", data: initData } ] });
             }, 10);
             break;
           case 5:
@@ -233,14 +237,16 @@ describe("core - eme - global tests - server certificate", () => {
             expect(evt.type).toEqual("attached-media-keys");
             expect(createSessionSpy).not.toHaveBeenCalled();
             expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
-            initDataSubject.next({ type: "cenc", data: initData });
+            initDataSubject.next({ type: "cenc",
+                                   values: [ { systemId: "15", data: initData } ] });
             break;
           case 4:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(1);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
-              initDataSubject.next({ type: "cenc2", data: initData });
+              initDataSubject.next({ type: "cenc2",
+                                     values: [ { systemId: "15", data: initData } ] });
             }, 10);
             break;
           case 5:
@@ -298,14 +304,16 @@ describe("core - eme - global tests - server certificate", () => {
             expect(evt.type).toEqual("attached-media-keys");
             expect(createSessionSpy).not.toHaveBeenCalled();
             expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
-            initDataSubject.next({ type: "cenc", data: initData });
+            initDataSubject.next({ type: "cenc",
+                                   values: [ { systemId: "15", data: initData } ] });
             break;
           case 3:
             expectLicenseRequestMessage(evt, initData, "cenc");
             setTimeout(() => {
               expect(serverCertificateSpy).toHaveBeenCalledTimes(0);
               expect(createSessionSpy).toHaveBeenCalledTimes(1);
-              initDataSubject.next({ type: "cenc2", data: initData });
+              initDataSubject.next({ type: "cenc2",
+                                     values: [ { systemId: "15", data: initData } ] });
             }, 10);
             break;
           case 4:

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -38,11 +38,11 @@ import {
   IAdaptationChangeEvent,
   IBitrateEstimationChangeEvent,
   ICompletedStreamEvent,
+  IEncryptionDataEncounteredEvent,
   INeedsDecipherabilityFlush,
   INeedsMediaSourceReload,
   IPeriodStreamClearedEvent,
   IPeriodStreamReadyEvent,
-  IProtectedSegmentEvent,
   IRepresentationChangeEvent,
   IStreamEventAddedSegment,
   IStreamManifestMightBeOutOfSync,
@@ -147,7 +147,7 @@ export type IMediaSourceLoaderEvent = IStalledEvent |
                                       INeedsDecipherabilityFlush |
                                       IRepresentationChangeEvent |
                                       IStreamEventAddedSegment<unknown> |
-                                      IProtectedSegmentEvent |
+                                      IEncryptionDataEncounteredEvent |
                                       IStreamManifestMightBeOutOfSync |
                                       IStreamNeedsManifestRefresh;
 

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -304,8 +304,12 @@ export default function AdaptationStream<T>({
       observableOf(EVENTS.representationChange(adaptation.type,
                                                period,
                                                representation));
-
+    const protectedEvents$ = observableOf(
+      ...representation.getProtectionsInitializationData().map(segmentProt => {
+        return EVENTS.protectedSegment(segmentProt);
+      }));
     return observableConcat(representationChange$,
+                            protectedEvents$,
                             createRepresentationStream(representation,
                                                        terminateCurrentStream$,
                                                        fastSwitchThreshold$)).pipe(

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -22,18 +22,19 @@ import {
   Period,
   Representation,
 } from "../../manifest";
+import { IContentProtection } from "../eme";
 import { IBufferType } from "../segment_buffers";
 import {
   IActivePeriodChangedEvent,
   IAdaptationChangeEvent,
   IBitrateEstimationChangeEvent,
   ICompletedStreamEvent,
+  IEncryptionDataEncounteredEvent,
   IEndOfStreamEvent,
   INeedsDecipherabilityFlush,
   INeedsMediaSourceReload,
   IPeriodStreamClearedEvent,
   IPeriodStreamReadyEvent,
-  IProtectedSegmentEvent,
   IRepresentationChangeEvent,
   IResumeStreamEvent,
   IStreamEventAddedSegment,
@@ -148,10 +149,10 @@ const EVENTS = {
              value: { type, period } };
   },
 
-  protectedSegment(initDataInfo : { type : string;
-                                    data : Uint8Array; }
-  ) : IProtectedSegmentEvent {
-    return { type: "protected-segment",
+  encryptionDataEncountered(
+    initDataInfo : IContentProtection
+  ) : IEncryptionDataEncounteredEvent {
+    return { type: "encryption-data-encountered",
              value: initDataInfo };
   },
 

--- a/src/core/stream/representation/index.ts
+++ b/src/core/stream/representation/index.ts
@@ -17,6 +17,7 @@
 import RepresentationStream, {
   IRepresentationStreamArguments,
   IRepresentationStreamClockTick,
+  IRepresentationStreamOptions,
   ITerminationOrder,
 } from "./representation_stream";
 
@@ -24,5 +25,6 @@ export default RepresentationStream;
 export {
   IRepresentationStreamArguments,
   IRepresentationStreamClockTick,
+  IRepresentationStreamOptions,
   ITerminationOrder,
 };

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -22,6 +22,7 @@ import {
   Period,
   Representation,
 } from "../../manifest";
+import { IContentProtection } from "../eme";
 import { IBufferType } from "../segment_buffers";
 
 /** Information about a Segment waiting to be loaded by the Stream. */
@@ -151,21 +152,10 @@ export interface IStreamManifestMightBeOutOfSync {
   value : undefined;
 }
 
-/** Parsed DRM information detected in an initialization segment. */
-export interface ISegmentProtection {
-  /**
-   * The "format" of the DRM initialization data, as specified in:
-   * https://www.w3.org/TR/eme-initdata-registry/
-   */
-  type : string;
-  /** The DRM initialization data itself. */
-  data : Uint8Array;
-}
-
 /** Emitted when a segment with protection information has been encountered. */
-export interface IProtectedSegmentEvent {
-  type : "protected-segment";
-  value : ISegmentProtection;
+export interface IEncryptionDataEncounteredEvent {
+  type : "encryption-data-encountered";
+  value : IContentProtection;
 }
 
 /**
@@ -395,7 +385,7 @@ export interface INeedsDecipherabilityFlush {
 /** Event sent by a `RepresentationStream`. */
 export type IRepresentationStreamEvent<T> = IStreamStatusEvent |
                                             IStreamEventAddedSegment<T> |
-                                            IProtectedSegmentEvent |
+                                            IEncryptionDataEncounteredEvent |
                                             IStreamManifestMightBeOutOfSync |
                                             IStreamTerminatingEvent |
                                             IStreamNeedsManifestRefresh |
@@ -411,7 +401,7 @@ export type IAdaptationStreamEvent<T> = IBitrateEstimationChangeEvent |
 
                                         IStreamStatusEvent |
                                         IStreamEventAddedSegment<T> |
-                                        IProtectedSegmentEvent |
+                                        IEncryptionDataEncounteredEvent |
                                         IStreamManifestMightBeOutOfSync |
                                         IStreamNeedsManifestRefresh |
                                         IStreamWarningEvent;
@@ -432,7 +422,7 @@ export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
 
                                  IStreamStatusEvent |
                                  IStreamEventAddedSegment<unknown> |
-                                 IProtectedSegmentEvent |
+                                 IEncryptionDataEncounteredEvent |
                                  IStreamManifestMightBeOutOfSync |
                                  IStreamNeedsManifestRefresh |
                                  IStreamWarningEvent;
@@ -458,7 +448,7 @@ export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
 
                                           IStreamStatusEvent |
                                           IStreamEventAddedSegment<unknown> |
-                                          IProtectedSegmentEvent |
+                                          IEncryptionDataEncounteredEvent |
                                           IStreamManifestMightBeOutOfSync |
                                           IStreamNeedsManifestRefresh |
                                           IStreamWarningEvent;
@@ -487,7 +477,7 @@ export type IStreamOrchestratorEvent = IActivePeriodChangedEvent |
 
                                        IStreamStatusEvent |
                                        IStreamEventAddedSegment<unknown> |
-                                       IProtectedSegmentEvent |
+                                       IEncryptionDataEncounteredEvent |
                                        IStreamManifestMightBeOutOfSync |
                                        IStreamNeedsManifestRefresh |
                                        IStreamWarningEvent;

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -18,6 +18,7 @@ import { Observable } from "rxjs";
 // eslint-disable-next-line max-len
 import MediaElementTrackChoiceManager from "../core/api/media_element_track_choice_manager";
 import {
+  IContentProtection,
   IEMEManagerEvent,
   IKeySystemOption,
 } from "../core/eme";
@@ -34,9 +35,6 @@ import { ITransportFunction } from "../transports";
 
 export type IDirectFileInit = (args : IDirectFileOptions) =>
                                 Observable<IDirectfileEvent>;
-
-interface IContentProtection { type : string;
-                               data : Uint8Array; }
 
 export type IEMEManager = (mediaElement : HTMLMediaElement,
                            keySystems: IKeySystemOption[],

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -25,7 +25,9 @@ import Manifest, {
   ISupplementaryTextTrack,
 } from "./manifest";
 import Period from "./period";
-import Representation from "./representation";
+import Representation, {
+  IContentProtections,
+} from "./representation";
 import {
   IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
@@ -33,7 +35,9 @@ import {
   ISegment,
   StaticRepresentationIndex,
 } from "./representation_index";
-import { IAdaptationType } from "./types";
+import {
+  IAdaptationType,
+} from "./types";
 
 export default Manifest;
 export {
@@ -48,6 +52,7 @@ export {
   // types
   IAdaptationType,
   IBaseContentInfos,
+  IContentProtections,
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,
   IRepresentationFilter,

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -495,37 +495,38 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     }
   }
 
-  /**
-   * Look in the Manifest for Representations linked to the given content
-   * protection initialization data and mark them as being impossible to
-   * decrypt.
-   * Then trigger a "blacklist-update" event to notify everyone of the changes
-   * performed.
-   * @param {Array.<ArrayBuffer>} keyIDs
-   */
-  public addUndecipherableProtectionData(
-    initDataType : string,
-    initData : Uint8Array
-  ) : void {
-    const updates = updateDeciperability(this, (representation) => {
-      if (representation.decipherable === false) {
-        return true;
-      }
-      const segmentProtections = representation.getProtectionsInitializationData();
-      for (let i = 0; i < segmentProtections.length; i++) {
-        if (segmentProtections[i].type === initDataType) {
-          if (areArraysOfNumbersEqual(initData, segmentProtections[i].data)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    });
+  // XXX TODO find a way to blacklist based on initializationData
+  // /**
+  //  * Look in the Manifest for Representations linked to the given content
+  //  * protection initialization data and mark them as being impossible to
+  //  * decrypt.
+  //  * Then trigger a "blacklist-update" event to notify everyone of the changes
+  //  * performed.
+  //  * @param {Array.<ArrayBuffer>} keyIDs
+  //  */
+  // public addUndecipherableProtectionData(
+  //   initDataType : string,
+  //   initData : Uint8Array
+  // ) : void {
+  //   const updates = updateDeciperability(this, (representation) => {
+  //     if (representation.decipherable === false) {
+  //       return true;
+  //     }
+  //     const segmentProtections = representation.contentProtections?.initData ?? [];
+  //     for (let i = 0; i < segmentProtections.length; i++) {
+  //       if (segmentProtections[i].type === initDataType) {
+  //         if (areArraysOfNumbersEqual(initData, segmentProtections[i].data)) {
+  //           return false;
+  //         }
+  //       }
+  //     }
+  //     return true;
+  //   });
 
-    if (updates.length > 0) {
-      this.trigger("decipherabilityUpdate", updates);
-    }
-  }
+  //   if (updates.length > 0) {
+  //     this.trigger("decipherabilityUpdate", updates);
+  //   }
+  // }
 
   /**
    * @deprecated only returns adaptations for the first period

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -15,20 +15,18 @@
  */
 
 import { isCodecSupported } from "../compat";
-import log from "../log";
 import {
   IContentProtections,
+  IContentProtectionKID,
   IParsedRepresentation,
 } from "../parsers/manifest";
-import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
-import { concat } from "../utils/byte_parsing";
 import { IRepresentationIndex } from "./representation_index";
 import { IAdaptationType } from "./types";
 
-export interface IContentProtectionsInitDataObject {
-  type : string;
-  data : Uint8Array;
-}
+export {
+  IContentProtectionKID,
+  IContentProtections,
+};
 
 /**
  * Normalized Representation structure.
@@ -137,69 +135,6 @@ class Representation {
    */
   getMimeTypeString() : string {
     return `${this.mimeType ?? ""};codecs="${this.codec ?? ""}"`;
-  }
-
-  /**
-   * Returns every protection initialization data concatenated.
-   * This data can then be used through the usual EME APIs.
-   * `null` if this Representation has no detected protection initialization
-   * data.
-   * @returns {Array.<Object>|null}
-   */
-  getProtectionsInitializationData() : IContentProtectionsInitDataObject[] {
-    const contentProtections = this.contentProtections;
-    if (contentProtections === undefined) {
-      return [];
-    }
-    return Object.keys(contentProtections.initData)
-      .reduce<IContentProtectionsInitDataObject[]>((acc, initDataType) => {
-        const initDataArr = contentProtections.initData[initDataType];
-        if (initDataArr === undefined || initDataArr.length === 0) {
-          return acc;
-        }
-        const initData = concat(...initDataArr.map(({ data }) => data));
-        acc.push({ type: initDataType,
-                   data: initData });
-        return acc;
-      }, []);
-  }
-
-  /**
-   * Add protection data to the Representation to be able to properly blacklist
-   * it if that data is.
-   * /!\ Mutates the current Representation
-   * @param {string} initDataArr
-   * @param {string} systemId
-   * @param {Uint8Array} data
-   */
-  _addProtectionData(
-    initDataType : string,
-    systemId : string,
-    data : Uint8Array
-  ) : void {
-    const newElement = { systemId, data };
-    if (this.contentProtections === undefined) {
-      this.contentProtections = { keyIds: [],
-                                  initData: { [initDataType] : [newElement] } };
-      return;
-    }
-
-    const initDataArr = this.contentProtections.initData[initDataType];
-
-    if (initDataArr === undefined) {
-      this.contentProtections.initData[initDataType] = [newElement];
-      return;
-    }
-
-    for (let i = initDataArr.length - 1; i >= 0; i--) {
-      if (initDataArr[i].systemId === systemId) {
-        if (areArraysOfNumbersEqual(initDataArr[i].data, data)) {
-          return;
-        }
-        log.warn("Manifest: Two PSSH for the same system ID");
-      }
-    }
-    initDataArr.push(newElement);
   }
 }
 

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -42,13 +42,7 @@ export interface ISmoothInitSegmentPrivateInfos {
   channels? : number;
   packetSize? : number;
   samplingRate? : number;
-  protection? : {
-    keyId : Uint8Array;
-    keySystems : Array<{
-      systemId : string;
-      privateData : Uint8Array;
-    }>;
-  };
+  protection? : { keyId : Uint8Array };
 }
 
 /**

--- a/src/parsers/containers/isobmff/take_pssh_out.ts
+++ b/src/parsers/containers/isobmff/take_pssh_out.ts
@@ -25,7 +25,7 @@ import {
 /** Information related to a PSSH box. */
 export interface IISOBMFFPSSHInfo {
   /** Corresponding DRM's system ID, as an hexadecimal string. */
-  systemID : string;
+  systemId : string;
   /** Additional data contained in the PSSH Box. */
   data : Uint8Array;
 }
@@ -59,9 +59,9 @@ export default function takePSSHOut(data : Uint8Array) : IISOBMFFPSSHInfo[] {
       return psshBoxes;
     }
     const pssh = sliceUint8Array(moov, psshOffsets[0], psshOffsets[2]);
-    const systemID = getSystemID(pssh, psshOffsets[1] - psshOffsets[0]);
-    if (systemID !== null) {
-      psshBoxes.push({ systemID, data: pssh });
+    const systemId = getSystemID(pssh, psshOffsets[1] - psshOffsets[0]);
+    if (systemId !== null) {
+      psshBoxes.push({ systemId, data: pssh });
     }
 
     // replace by `free` box.
@@ -75,7 +75,7 @@ export default function takePSSHOut(data : Uint8Array) : IISOBMFFPSSHInfo[] {
 }
 
 /**
- * Parse systemID from a "pssh" box into an hexadecimal string.
+ * Parse systemId from a "pssh" box into an hexadecimal string.
  * @param {Uint8Array} buff - The pssh box
  * @param {number} initialDataOffset - offset of the first byte after the size
  * and name in this pssh box.

--- a/src/parsers/manifest/dash/parse_representations.ts
+++ b/src/parsers/manifest/dash/parse_representations.ts
@@ -16,6 +16,7 @@
 
 import log from "../../../log";
 import { Adaptation } from "../../../manifest";
+import arrayFind from "../../../utils/array_find";
 import objectAssign from "../../../utils/object_assign";
 import {
   IContentProtections,
@@ -190,16 +191,23 @@ export default function parseRepresentations(
           }
           if (systemId !== undefined) {
             const { cencPssh } = cp.children;
+            const values : Array<{ systemId: string;
+                                   data: Uint8Array; }> = [];
             for (let i = 0; i < cencPssh.length; i++) {
               const data = cencPssh[i];
-              if (acc.initData.cenc === undefined) {
-                acc.initData.cenc = [];
+              values.push({ systemId, data });
+            }
+            if (values.length > 0) {
+              const cencInitData = arrayFind(acc.initData, (i) => i.type === "cenc");
+              if (cencInitData === undefined) {
+                acc.initData.push({ type: "cenc", values });
+              } else {
+                cencInitData.values.push(...values);
               }
-              acc.initData.cenc.push({ systemId, data });
             }
           }
           return acc;
-        }, { keyIds: [], initData: {} });
+        }, { keyIds: [], initData: [] });
       if (Object.keys(contentProtections.initData).length > 0 ||
           contentProtections.keyIds.length > 0)
       {

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { IContentProtection as IEMEContentProtection } from "../../../core/eme";
 import idGenerator from "../../../utils/id_generator";
-
 import {
+  IContentProtections,
   IParsedAdaptation,
   IParsedManifest,
   IParsedPeriod,
@@ -24,6 +25,8 @@ import {
 } from "../types";
 import LocalRepresentationIndex from "./representation_index";
 import {
+  IContentProtectionInitData,
+  IContentProtections as ILocalContentProtections,
   ILocalAdaptation,
   ILocalManifest,
   ILocalPeriod,
@@ -136,6 +139,9 @@ function parseRepresentation(
 ) : IParsedRepresentation {
   const { isFinished } = ctxt;
   const id = "representation-" + ctxt.representationIdGenerator();
+  const contentProtections = representation.contentProtections === undefined ?
+    undefined :
+    formatContentProtections(representation.contentProtections);
   return { id,
            bitrate: representation.bitrate,
            height: representation.height,
@@ -143,5 +149,25 @@ function parseRepresentation(
            codecs: representation.codecs,
            mimeType: representation.mimeType,
            index: new LocalRepresentationIndex(representation.index, id, isFinished),
-           contentProtections: representation.contentProtections };
+           contentProtections };
+}
+
+/**
+ * Translate Local Manifest's `contentProtections` attribute to the one defined
+ * for a `Manifest` structure.
+ * @param {Object} localContentProtections
+ * @returns {Object}
+ */
+function formatContentProtections(
+  localContentProtections : ILocalContentProtections
+) : IContentProtections {
+  const keyIds = localContentProtections.keyIds;
+  const initData : IEMEContentProtection[] =
+    Object.keys(localContentProtections.initData).map((currType) => {
+      const localInitData = localContentProtections
+        .initData[currType] as IContentProtectionInitData[];
+      return { type: currType,
+               values: localInitData };
+    });
+  return { keyIds, initData };
 }

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -407,16 +407,22 @@ function createSmoothStreamingParser(
                                                                     codecs,
                                                                     id });
       if (keyIDs.length > 0 || firstProtection !== undefined) {
-        const initData = firstProtection === undefined ?
-          [] :
-          firstProtection.keySystems.map((keySystemData) => {
-            const { systemId, privateData } = keySystemData;
-            const cleanedSystemId = systemId.replace(/-/g, "");
-            const pssh = createPSSHBox(cleanedSystemId, privateData);
-            return { systemId: cleanedSystemId, data: pssh };
-          });
-        representation.contentProtections = { keyIds: keyIDs,
-                                              initData: { cenc: initData } };
+        const initDataValues : Array<{ systemId: string;
+                                       data: Uint8Array; }> =
+          firstProtection === undefined ?
+            [] :
+            firstProtection.keySystems.map((keySystemData) => {
+              const { systemId, privateData } = keySystemData;
+              const cleanedSystemId = systemId.replace(/-/g, "");
+              const pssh = createPSSHBox(cleanedSystemId, privateData);
+              return { systemId: cleanedSystemId, data: pssh };
+            });
+        if (initDataValues.length > 0) {
+          const initData = [{ type: "cenc", values: initDataValues }];
+          representation.contentProtections = { keyIds: keyIDs, initData };
+        } else {
+          representation.contentProtections = { keyIds: keyIDs, initData: [] };
+        }
       }
       return representation;
     });

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -17,12 +17,18 @@
 import log from "../../../log";
 import arrayIncludes from "../../../utils/array_includes";
 import assert from "../../../utils/assert";
+import {
+  concat,
+  itobe4,
+} from "../../../utils/byte_parsing";
 import isNonEmptyString from "../../../utils/is_non_empty_string";
 import objectAssign from "../../../utils/object_assign";
 import resolveURL, {
   normalizeBaseURL,
 } from "../../../utils/resolve_url";
+import { hexToBytes } from "../../../utils/string_parsing";
 import takeFirstSet from "../../../utils/take_first_set";
+import { createBox } from "../../containers/isobmff";
 import {
   IContentProtectionKID,
   IParsedAdaptation,
@@ -386,7 +392,6 @@ function createSmoothStreamingParser(
                                     // instead of the first one
                                     protection: firstProtection != null ? {
                                       keyId: firstProtection.keyId,
-                                      keySystems: firstProtection.keySystems,
                                     } : undefined };
 
       const aggressiveMode = parserOptions.aggressiveMode == null ?
@@ -401,9 +406,17 @@ function createSmoothStreamingParser(
                                                                     mimeType,
                                                                     codecs,
                                                                     id });
-      if (keyIDs.length > 0) {
+      if (keyIDs.length > 0 || firstProtection !== undefined) {
+        const initData = firstProtection === undefined ?
+          [] :
+          firstProtection.keySystems.map((keySystemData) => {
+            const { systemId, privateData } = keySystemData;
+            const cleanedSystemId = systemId.replace(/-/g, "");
+            const pssh = createPSSHBox(cleanedSystemId, privateData);
+            return { systemId: cleanedSystemId, data: pssh };
+          });
         representation.contentProtections = { keyIds: keyIDs,
-                                              initData: {} };
+                                              initData: { cenc: initData } };
       }
       return representation;
     });
@@ -629,5 +642,29 @@ function createSmoothStreamingParser(
 
   return parseFromDocument;
 }
+
+/**
+ * @param {string} systemId - Hex string representing the CDM, 16 bytes.
+ * @param {Uint8Array|undefined} privateData - Data associated to protection
+ * specific system.
+ * @returns {Uint8Array}
+ */
+function createPSSHBox(
+  systemId : string,
+  privateData : Uint8Array
+) : Uint8Array {
+  if (systemId.length !== 32) {
+    throw new Error("HSS: wrong system id length");
+  }
+  const version = 0;
+  return createBox("pssh", concat(
+    [version, 0, 0, 0],
+    hexToBytes(systemId),
+    /** To put there KIDs if it exists (necessitate PSSH v1) */
+    itobe4(privateData.length),
+    privateData
+  ));
+}
+
 
 export default createSmoothStreamingParser;

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -125,9 +125,7 @@ interface ISmoothInitSegmentPrivateInfos {
   codecPrivateData? : string;
   packetSize? : number;
   samplingRate? : number;
-  protection? : { keyId : Uint8Array;
-                  keySystems: Array<{ systemId : string;
-                                      privateData : Uint8Array; }>; };
+  protection? : { keyId : Uint8Array };
 }
 
 /**
@@ -146,11 +144,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
                                 packetSize? : number;
                                 samplingRate? : number;
                                 timescale : number;
-                                protection? : { keyId : Uint8Array;
-                                                keySystems: Array<{
-                                                  systemId : string;
-                                                  privateData : Uint8Array;
-                                                }>; }; };
+                                protection? : { keyId : Uint8Array }; };
 
   // if true, this class will return segments even if we're not sure they had
   // time to be generated on the server side.

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -1,3 +1,6 @@
+import {
+  IContentProtection as IEMEContentProtection,
+} from "../../core/eme";
 /**
  * Copyright 2015 CANAL+ Group
  *
@@ -30,15 +33,12 @@ export interface IContentProtectionKID { keyId : Uint8Array;
  * Describes information about the encryption initialization data of a given
  * media.
  */
-export interface IContentProtectionInitData { systemId : string;
-                                              data : Uint8Array; }
-
 /** Describes every encryption protection parsed for a given media. */
 export interface IContentProtections {
   /** The different encryption key IDs associated with that content. */
   keyIds : IContentProtectionKID[];
   /** The different encryption initialization data associated with that content. */
-  initData : Partial<Record<string, IContentProtectionInitData[]>>;
+  initData : IEMEContentProtection[];
 }
 
 /** Representation of a "quality" available in an Adaptation. */

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -55,10 +55,9 @@ export default function generateAudioVideoSegmentParser(
 
     if (data === null) {
       if (segment.isInit) {
-        const _segmentProtections = representation.getProtectionsInitializationData();
         return observableOf({ type: "parsed-init-segment" as const,
                               value: { initializationData: null,
-                                       segmentProtections: _segmentProtections,
+                                       segmentProtections: [],
                                        initTimescale: undefined } });
       }
       return observableOf({ type: "parsed-segment" as const,
@@ -125,11 +124,18 @@ export default function generateAudioVideoSegmentParser(
                                getMDHDTimescale(chunkData);
     const parsedTimescale = isNullOrUndefined(timescale) ? undefined :
                                                            timescale;
-    if (!isWEBM) { // TODO extract webm protection information
+
+    // TODO also extract webm protection information
+    if (!isWEBM) {
       const psshInfo = takePSSHOut(chunkData);
-      for (let i = 0; i < psshInfo.length; i++) {
-        const { systemID, data: psshData } = psshInfo[i];
-        representation._addProtectionData("cenc", systemID, psshData);
+
+      // we only want to add segment protection data if we didn't have any
+      // associated to the Representation before,
+      if (representation.getProtectionsInitializationData().length === 0) {
+        for (let i = 0; i < psshInfo.length; i++) {
+          const { systemID, data: psshData } = psshInfo[i];
+          representation._addProtectionData("cenc", systemID, psshData);
+        }
       }
     }
 

--- a/src/transports/local/segment_parser.ts
+++ b/src/transports/local/segment_parser.ts
@@ -59,7 +59,10 @@ export default function segmentParser({
 
   if (!isWEBM) {
     const psshInfo = takePSSHOut(chunkData);
-    if (psshInfo.length > 0) {
+
+    // we only want to add segment protection data if we didn't have any
+    // associated to the Representation before,
+    if (representation.getProtectionsInitializationData().length === 0) {
       for (let i = 0; i < psshInfo.length; i++) {
         const { systemID, data: psshData } = psshInfo[i];
         representation._addProtectionData("cenc", systemID, psshData);

--- a/src/transports/smooth/isobmff/create_audio_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_audio_init_segment.ts
@@ -28,10 +28,6 @@ import {
 import createInitSegment from "./create_init_segment";
 import getAacesHeader from "./get_aaces_header";
 
-type IPSSList = Array<{ systemId : string;
-                        privateData? : Uint8Array;
-                        keyIds? : Uint8Array; }>;
-
 /**
  * Return full audio initialization segment as Uint8Array.
  * @param {Number} timescale
@@ -52,8 +48,7 @@ export default function createAudioInitSegment(
   packetSize : number,
   sampleRate : number,
   codecPrivateData : string,
-  keyId? : Uint8Array,
-  pssList : IPSSList = []
+  keyId? : Uint8Array
 ) : Uint8Array {
   const _codecPrivateData = codecPrivateData.length === 0 ?
     getAacesHeader(2, sampleRate, channelsCount) :
@@ -61,7 +56,7 @@ export default function createAudioInitSegment(
 
   const esds = createESDSBox(1, _codecPrivateData);
   const stsd : Uint8Array = (() => {
-    if (pssList.length === 0 || keyId === undefined) {
+    if (keyId === undefined) {
       const mp4a = createMP4ABox(1,
                                  channelsCount,
                                  sampleSize,
@@ -85,5 +80,5 @@ export default function createAudioInitSegment(
     return createSTSDBox([enca]);
   })();
 
-  return createInitSegment(timescale, "audio", stsd, createSMHDBox(), 0, 0, pssList);
+  return createInitSegment(timescale, "audio", stsd, createSMHDBox(), 0, 0);
 }

--- a/src/transports/smooth/isobmff/create_boxes.ts
+++ b/src/transports/smooth/isobmff/create_boxes.ts
@@ -346,45 +346,6 @@ function createMVHDBox(timescale : number, trackId : number) : Uint8Array {
 }
 
 /**
- * @param {string} systemId - Hex string representing the CDM, 16 bytes.
- * @param {Uint8Array|undefined} privateData - Data associated to protection
- * specific system.
- * @param {Array.<Uint8Array>} keyIds - List of key ids contained in the PSSH
- * @returns {Uint8Array}
- */
-function createPSSHBox(
-  systemId : string,
-  privateData : Uint8Array = new Uint8Array(0),
-  keyIds : Uint8Array = new Uint8Array(0)
-) : Uint8Array {
-  const _systemId = systemId.replace(/-/g, "");
-
-  if (_systemId.length !== 32) {
-    throw new Error("HSS: wrong system id length");
-  }
-
-  let version;
-  let kidList;
-  const kidCount = keyIds.length;
-  if (kidCount > 0) {
-    version = 1;
-    kidList = concat(...[itobe4(kidCount)].concat(keyIds));
-  }
-  else {
-    version = 0;
-    kidList = [];
-  }
-
-  return createBox("pssh", concat(
-    [version, 0, 0, 0],
-    hexToBytes(_systemId),
-    kidList,
-    itobe4(privateData.length),
-    privateData
-  ));
-}
-
-/**
  * @param {Uint8Array} mfhd
  * @param {Uint8Array} tfhd
  * @param {Uint8Array} tfdt
@@ -509,7 +470,6 @@ export {
   createMDHDBox,
   createMP4ABox,
   createMVHDBox,
-  createPSSHBox,
   createSAIOBox,
   createSAIZBox,
   createSCHMBox,

--- a/src/transports/smooth/isobmff/create_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_init_segment.ts
@@ -25,7 +25,6 @@ import {
   createHDLRBox,
   createMDHDBox,
   createMVHDBox,
-  createPSSHBox,
   createTKHDBox,
   createTREXBox,
 } from "./create_boxes";
@@ -40,20 +39,14 @@ export type IPSSList = Array<{
  * @param {Uint8Array} mvhd
  * @param {Uint8Array} mvex
  * @param {Uint8Array} trak
- * @param {Object} pssList
  * @returns {Array.<Uint8Array>}
  */
 function createMOOVBox(
   mvhd : Uint8Array,
   mvex : Uint8Array,
-  trak : Uint8Array,
-  pssList : IPSSList
+  trak : Uint8Array
 ) : Uint8Array {
   const children = [mvhd, mvex, trak];
-  pssList.forEach((pss) => {
-    const pssh = createPSSHBox(pss.systemId, pss.privateData, pss.keyIds);
-    children.push(pssh);
-  });
   return createBoxWithChildren("moov", children);
 }
 
@@ -75,8 +68,7 @@ export default function createInitSegment(
   stsd : Uint8Array,
   mhd : Uint8Array,
   width : number,
-  height : number,
-  pssList : IPSSList
+  height : number
 ) : Uint8Array {
 
   const stbl = createBoxWithChildren("stbl", [
@@ -101,7 +93,7 @@ export default function createInitSegment(
   const mvhd = createMVHDBox(timescale, 1); // in fact, we don't give a sh** about
                                             // this value :O
 
-  const moov = createMOOVBox(mvhd, mvex, trak, pssList);
+  const moov = createMOOVBox(mvhd, mvex, trak);
   const ftyp = createFTYPBox("isom", ["isom", "iso2", "iso6", "avc1", "dash"]);
 
   return concat(ftyp, moov);

--- a/src/transports/smooth/isobmff/create_video_init_segment.ts
+++ b/src/transports/smooth/isobmff/create_video_init_segment.ts
@@ -28,12 +28,6 @@ import {
 } from "./create_boxes";
 import createInitSegment from "./create_init_segment";
 
-type IPSSList = Array<{
-  systemId : string;
-  privateData? : Uint8Array;
-  keyIds? : Uint8Array;
-}>;
-
 /**
  * Return full video Init segment as Uint8Array
  * @param {Number} timescale - lowest number, this one will be set into mdhd
@@ -58,11 +52,8 @@ export default function createVideoInitSegment(
   vRes : number,
   nalLength : number,
   codecPrivateData : string,
-  keyId? : Uint8Array,
-  pssList? : IPSSList
+  keyId? : Uint8Array
 ) : Uint8Array {
-  const _pssList = pssList === undefined ? [] :
-                                           pssList;
   const [, spsHex, ppsHex] = codecPrivateData.split("00000001");
   if (spsHex === undefined || ppsHex === undefined) {
     throw new Error("Smooth: unsupported codec private data.");
@@ -73,7 +64,7 @@ export default function createVideoInitSegment(
   // TODO NAL length is forced to 4
   const avcc = createAVCCBox(sps, pps, nalLength);
   let stsd;
-  if (_pssList.length === 0 || keyId === undefined) {
+  if (keyId === undefined) {
     const avc1 = createAVC1Box(width, height, hRes, vRes, "AVC Coding", 24, avcc);
     stsd = createSTSDBox([avc1]);
   } else {
@@ -86,7 +77,5 @@ export default function createVideoInitSegment(
     stsd = createSTSDBox([encv]);
   }
 
-  return createInitSegment(
-    timescale, "video", stsd, createVMHDBox(), width, height, _pssList
-  );
+  return createInitSegment(timescale, "video", stsd, createVMHDBox(), width, height);
 }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -29,10 +29,7 @@ import Manifest, {
   ISegment,
   Representation,
 } from "../../manifest";
-import {
-  getMDAT,
-  takePSSHOut,
-} from "../../parsers/containers/isobmff";
+import { getMDAT } from "../../parsers/containers/isobmff";
 import createSmoothManifestParser, {
   SmoothRepresentationIndex,
 } from "../../parsers/manifest/smooth";
@@ -181,14 +178,13 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       initTimescale,
     } : ISegmentParserArguments< ArrayBuffer | Uint8Array | null >
     ) : IAudioVideoParserObservable {
-      const { segment, representation, adaptation, manifest } = content;
+      const { segment, adaptation, manifest } = content;
       const { data, isChunked } = response;
       if (data === null) {
         if (segment.isInit) {
-          const segmentProtections = representation.getProtectionsInitializationData();
           return observableOf({ type: "parsed-init-segment",
                                 value: { initializationData: null,
-                                         segmentProtections,
+                                         segmentProtections: [],
                                          initTimescale: undefined } });
         }
         return observableOf({ type: "parsed-segment",
@@ -202,21 +198,13 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                           new Uint8Array(data);
 
       if (segment.isInit) {
-        const psshInfo = takePSSHOut(responseBuffer);
-        if (psshInfo.length > 0) {
-          for (let i = 0; i < psshInfo.length; i++) {
-            const { systemID, data: psshData } = psshInfo[i];
-            representation._addProtectionData("cenc", systemID, psshData);
-          }
-        }
-        const segmentProtections = representation.getProtectionsInitializationData();
         const timescale = segment.privateInfos?.smoothInitSegment?.timescale;
         return observableOf({ type: "parsed-init-segment",
                               value: { initializationData: data,
                                        // smooth init segments are crafted by hand.
                                        // Their timescale is the one from the manifest.
                                        initTimescale: timescale,
-                                       segmentProtections } });
+                                       segmentProtections: [] } });
       }
 
       const timingInfos = initTimescale !== undefined ?

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -101,8 +101,7 @@ const generateSegmentLoader = (
                                               height,
                                               72, 72, 4, // vRes, hRes, nal
                                               codecPrivateData,
-                                              protection.keyId,
-                                              protection.keySystems);
+                                              protection.keyId);
         break;
       }
       case "audio": {
@@ -116,8 +115,7 @@ const generateSegmentLoader = (
                                               packetSize,
                                               samplingRate,
                                               codecPrivateData,
-                                              protection.keyId,
-                                              protection.keySystems);
+                                              protection.keyId);
         break;
       }
       default:

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -332,6 +332,8 @@ export interface ISegmentProtection {
    * (https://www.w3.org/TR/encrypted-media/#initialization-data-type)
    */
   type : string;
+  /** Hex-encoded system ID identifying the key system used. */
+  systemId : string;
   /** The segment protection information. */
   data : Uint8Array;
 }


### PR DESCRIPTION
EME APIs - to play encrypted contents - necessitate the communication of "initialization data". This usually takes the form of a PSSH - metadata found on initialization segment - but can more often than not also be found in a Manifest file.

The previous RxPlayer behavior was to merge both the initialization data found in the initialization segment and in the Manifest, before communicating it.
This meant waiting for the initialization segment to be downloaded, so we can merge them when both are known.

Yet in most cases, the same initialization data is available in both places. Waiting for the initialization data to be loaded would here just be an unnecessary delay added to decryption negociations, which is usually the last step before a content starts to load.

This commit only uses the initialization data found in a Manifest when there, and if not, it uses the initialization data in the initialization segment.

It could potentially break cases where different initialization data is defined in the Manifest and in the initialization segment, where the initialization data actually wanted is in the latter.

But this should be an extremely rare case.