### PR TITLE
Consider multiple accessibility descriptors

### DIFF
--- a/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
@@ -123,7 +123,7 @@ function parseAdaptationSetChildren(
       switch (currentElement.nodeName) {
 
         case "Accessibility":
-          if (children.accessibilities == null) {
+          if (children.accessibilities === undefined) {
             children.accessibilities = [parseScheme(currentElement)];
           } else {
             children.accessibilities.push(parseScheme(currentElement));

--- a/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/node_parsers/AdaptationSet.ts
@@ -58,7 +58,7 @@ export interface IAdaptationSetChildren {
   representations : IRepresentationIntermediateRepresentation[];
 
   // optional
-  accessibility? : IScheme;
+  accessibilities? : IScheme[];
   contentComponent? : IParsedContentComponent;
   contentProtections? : IParsedContentProtection[];
   essentialProperties? : IScheme[];
@@ -123,7 +123,11 @@ function parseAdaptationSetChildren(
       switch (currentElement.nodeName) {
 
         case "Accessibility":
-          children.accessibility = parseScheme(currentElement);
+          if (children.accessibilities == null) {
+            children.accessibilities = [parseScheme(currentElement)];
+          } else {
+            children.accessibilities.push(parseScheme(currentElement));
+          }
           break;
 
         case "BaseURL":

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -87,7 +87,7 @@ interface IAdaptationSwitchingInfos  {
 /**
  * Detect if the accessibility given defines an adaptation for the visually
  * impaired.
- * Based on DVB Document A168 (DVB-DASH).
+ * Based on DVB Document A168 (DVB-DASH) and DASH-IF 4.3.
  * @param {Object} accessibility
  * @returns {Boolean}
  */
@@ -98,8 +98,17 @@ function isVisuallyImpaired(
     return false;
   }
 
-  return (accessibility.schemeIdUri === "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
-          accessibility.value === "1");
+  const isVisuallyImpairedAudioDvbDash = (
+    accessibility.schemeIdUri === "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
+    accessibility.value === "1"
+  );
+
+  const isVisuallyImpairedDashIf = (
+    accessibility.schemeIdUri === "urn:mpeg:dash:role:2011" &&
+    accessibility.value === "description"
+  );
+
+  return isVisuallyImpairedAudioDvbDash || isVisuallyImpairedDashIf;
 }
 
 /**

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -32,6 +32,7 @@ import {
   IAdaptationSetIntermediateRepresentation,
 } from "./node_parsers/AdaptationSet";
 import { IParsedSegmentTemplate } from "./node_parsers/SegmentTemplate";
+import { IScheme } from "./node_parsers/utils";
 import parseRepresentations, {
   IAdaptationInfos,
 } from "./parse_representations";
@@ -325,7 +326,7 @@ export default function parseAdaptationSets(
       videoMainAdaptation.representations.push(...representations);
       newID = videoMainAdaptation.id;
     } else {
-      const { accessibility } = adaptationChildren;
+      const { accessibilities } = adaptationChildren;
 
       let isDub : boolean|undefined;
       if (roles !== undefined &&
@@ -334,19 +335,23 @@ export default function parseAdaptationSets(
         isDub = true;
       }
 
-      const isClosedCaption = type === "text" &&
+      const isClosedCaptionPredicate = (accessibility: IScheme) => type === "text" &&
                               accessibility != null &&
                               isHardOfHearing(accessibility) ? true :
                                                                undefined;
-      const isAudioDescription = type === "audio" &&
+      const isClosedCaption = accessibilities?.some(isClosedCaptionPredicate);
+
+      const isAudioDescriptionPredicate = (accessibility: IScheme) => type === "audio" &&
                                  accessibility != null &&
                                  isVisuallyImpaired(accessibility) ? true :
                                                                      undefined;
+      const isAudioDescription = accessibilities?.some(isAudioDescriptionPredicate);
 
-      const isSignInterpreted = type === "video" &&
+      const isSignInterpretedPredicate = (accessibility: IScheme) => type === "video" &&
                                 accessibility != null &&
                                 hasSignLanguageInterpretation(accessibility) ? true :
                                                                                undefined;
+      const isSignInterpreted = accessibilities?.some(isSignInterpretedPredicate);
 
       let adaptationID = getAdaptationID(adaptation,
                                          { isAudioDescription,

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -32,7 +32,6 @@ import {
   IAdaptationSetIntermediateRepresentation,
 } from "./node_parsers/AdaptationSet";
 import { IParsedSegmentTemplate } from "./node_parsers/SegmentTemplate";
-import { IScheme } from "./node_parsers/utils";
 import parseRepresentations, {
   IAdaptationInfos,
 } from "./parse_representations";
@@ -344,18 +343,11 @@ export default function parseAdaptationSets(
         isDub = true;
       }
 
-      const isClosedCaptionPredicate = (accessibility: IScheme) =>
-        type === "text" && isHardOfHearing(accessibility) ? true : undefined;
-      const isClosedCaption = accessibilities?.some(isClosedCaptionPredicate);
+      const isClosedCaption = accessibilities?.some(isHardOfHearing);
 
-      const isAudioDescriptionPredicate = (accessibility: IScheme) =>
-        type === "audio" && isVisuallyImpaired(accessibility) ? true : undefined;
-      const isAudioDescription = accessibilities?.some(isAudioDescriptionPredicate);
+      const isAudioDescription = accessibilities?.some(isVisuallyImpaired);
 
-      const isSignInterpretedPredicate = (accessibility: IScheme) =>
-        type === "video" && hasSignLanguageInterpretation(accessibility) ?
-        true : undefined;
-      const isSignInterpreted = accessibilities?.some(isSignInterpretedPredicate);
+      const isSignInterpreted = accessibilities?.some(hasSignLanguageInterpretation);
 
       let adaptationID = getAdaptationID(adaptation,
                                          { isAudioDescription,

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -343,11 +343,26 @@ export default function parseAdaptationSets(
         isDub = true;
       }
 
-      const isClosedCaption = type === "text" && accessibilities?.some(isHardOfHearing);
+      let isClosedCaption;
+      if (type !== "text") {
+        isClosedCaption = false;
+      } else if (accessibilities !== undefined) {
+        isClosedCaption = accessibilities.some(isHardOfHearing);
+      }
 
-      const isAudioDescription = type === "audio" && accessibilities?.some(isVisuallyImpaired);
+      let isAudioDescription;
+      if (type !== "audio") {
+        isAudioDescription = false;
+      } else if (accessibilities !== undefined) {
+        isAudioDescription = accessibilities.some(isVisuallyImpaired);
+      }
 
-      const isSignInterpreted = type === "video" && accessibilities?.some(hasSignLanguageInterpretation);
+      let isSignInterpreted;
+      if (type !== "video") {
+        isSignInterpreted = false;
+      } else if (accessibilities !== undefined) {
+        isSignInterpreted = accessibilities.some(hasSignLanguageInterpretation);
+      }
 
       let adaptationID = getAdaptationID(adaptation,
                                          { isAudioDescription,

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -344,22 +344,17 @@ export default function parseAdaptationSets(
         isDub = true;
       }
 
-      const isClosedCaptionPredicate = (accessibility: IScheme) => type === "text" &&
-                              accessibility != null &&
-                              isHardOfHearing(accessibility) ? true :
-                                                               undefined;
+      const isClosedCaptionPredicate = (accessibility: IScheme) =>
+        type === "text" && isHardOfHearing(accessibility) ? true : undefined;
       const isClosedCaption = accessibilities?.some(isClosedCaptionPredicate);
 
-      const isAudioDescriptionPredicate = (accessibility: IScheme) => type === "audio" &&
-                                 accessibility != null &&
-                                 isVisuallyImpaired(accessibility) ? true :
-                                                                     undefined;
+      const isAudioDescriptionPredicate = (accessibility: IScheme) =>
+        type === "audio" && isVisuallyImpaired(accessibility) ? true : undefined;
       const isAudioDescription = accessibilities?.some(isAudioDescriptionPredicate);
 
-      const isSignInterpretedPredicate = (accessibility: IScheme) => type === "video" &&
-                                accessibility != null &&
-                                hasSignLanguageInterpretation(accessibility) ? true :
-                                                                               undefined;
+      const isSignInterpretedPredicate = (accessibility: IScheme) =>
+        type === "video" && hasSignLanguageInterpretation(accessibility) ?
+        true : undefined;
       const isSignInterpreted = accessibilities?.some(isSignInterpretedPredicate);
 
       let adaptationID = getAdaptationID(adaptation,

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -343,11 +343,11 @@ export default function parseAdaptationSets(
         isDub = true;
       }
 
-      const isClosedCaption = accessibilities?.some(isHardOfHearing);
+      const isClosedCaption = type === "text" && accessibilities?.some(isHardOfHearing);
 
-      const isAudioDescription = accessibilities?.some(isVisuallyImpaired);
+      const isAudioDescription = type === "audio" && accessibilities?.some(isVisuallyImpaired);
 
-      const isSignInterpreted = accessibilities?.some(hasSignLanguageInterpretation);
+      const isSignInterpreted = type === "video" && accessibilities?.some(hasSignLanguageInterpretation);
 
       let adaptationID = getAdaptationID(adaptation,
                                          { isAudioDescription,


### PR DESCRIPTION
Hello,

We have manifests where multiple accessibility tags are defined to signal the same accessibility feature (in this case audio description) in order to support a wider range of players.

```
<Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value="1"/>
<Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value="description"/>
```

As you only consider a singe `Accessibility` descriptor, this change opens up for the possibility to use multiple ones. It also extends the definition of `isVisuallyImpaired` to consider also the DASH-IF 4.3 specification of audio description. One could also easily extend the other `is{Accessibility}` functions to consider both specs, but I started with just one.

Let me know what you think!