### PR TITLE
Single license per content implementation

### DIFF
--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -201,7 +201,7 @@ export class MediaKeySessionImpl extends EventEmitter<any> {
       if (this.onkeystatuseschange !== null && this.onkeystatuseschange !== undefined) {
         this.onkeystatuseschange(event);
       }
-    }, 0);
+    }, 50);
     return Promise.resolve();
   }
 }

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -196,10 +196,12 @@ export class MediaKeySessionImpl extends EventEmitter<any> {
     this.keyStatuses._setKeyStatus(new Uint8Array([0, 1, 2, this._currentKeyId++]),
                                    "usable");
     const event = new CustomEvent("keystatuseschange");
-    this.trigger("keyStatusesChange", event);
-    if (this.onkeystatuseschange !== null && this.onkeystatuseschange !== undefined) {
-      this.onkeystatuseschange(event);
-    }
+    setTimeout(() => {
+      this.trigger("keyStatusesChange", event);
+      if (this.onkeystatuseschange !== null && this.onkeystatuseschange !== undefined) {
+        this.onkeystatuseschange(event);
+      }
+    }, 0);
     return Promise.resolve();
   }
 }

--- a/src/core/eme/check_key_statuses.ts
+++ b/src/core/eme/check_key_statuses.ts
@@ -55,7 +55,7 @@ export interface IKeyStatusesCheckingOptions {
  * will be checked.
  * @param {Object} options
  * @param {String} keySystem - The configuration keySystem used for deciphering
- * @returns {Array} - Warnings to send, whitelisted and blacklisted key ids.
+ * @returns {Object} - Warnings to send, whitelisted and blacklisted key ids.
  */
 export default function checkKeyStatuses(
   session : MediaKeySession | ICustomMediaKeySession,

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -193,7 +193,7 @@ export default function EMEManager(
               if (areArraysOfNumbersEqual(evt.whitelistedKeyIds[i], keyIds[j])) {
                 // Move corresponding session on top of the cache if it exists
                 const { loadedSessionsStore } = mediaKeysEvent.value.stores;
-                loadedSessionsStore.moveOnTop(firstSession.initializationData);
+                loadedSessionsStore.reuse(firstSession.initializationData);
                 return observableOf({ type: "init-data-ignored" as const,
                                       value: { initializationData } });
               }

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -20,6 +20,7 @@ import {
   merge as observableMerge,
   Observable,
   of as observableOf,
+  ReplaySubject,
   throwError,
 } from "rxjs";
 import {
@@ -41,6 +42,7 @@ import {
 import config from "../../config";
 import { EncryptedMediaError } from "../../errors";
 import log from "../../log";
+import areArraysOfNumbersEqual from "../../utils/are_arrays_of_numbers_equal";
 import arrayIncludes from "../../utils/array_includes";
 import assertUnreachable from "../../utils/assert_unreachable";
 import { concat } from "../../utils/byte_parsing";
@@ -59,6 +61,7 @@ import {
   IEMEManagerEvent,
   IInitializationDataInfo,
   IKeySystemOption,
+  IKeyUpdateValue,
 } from "./types";
 import InitDataStore from "./utils/init_data_store";
 
@@ -86,15 +89,19 @@ export default function EMEManager(
   log.debug("EME: Starting EMEManager logic.");
 
    /**
-    * Keep track of all initialization data handled for the current `EMEManager`
-    * instance.
-    * This allows to avoid handling multiple times the same encrypted events.
+    * Keep track of all decryption keys currently handled by the `EMEManager`.
+    * This allows to avoid creating multiple MediaKeySessions handling the same
+    * decryption keys.
     */
-  const handledInitData = new InitDataStore<boolean>();
+  const handledSessions = new InitDataStore<{
+    /** Initialization data which triggered the creation of this session. */
+    initializationData : IInitializationDataInfo;
+    /** Last key update event received for that session. */
+    lastKeyUpdate$ : ReplaySubject<IKeyUpdateValue>;
+  }>();
 
   /**
-   * Keep track of which initialization data have been blacklisted (linked to
-   * non-decypherable content).
+   * Keep track of which initialization data have been blacklisted.
    * If the same initialization data is encountered again, we can directly emit
    * the same `BlacklistedSessionError`.
    */
@@ -168,7 +175,33 @@ export default function EMEManager(
                               value: initializationData });
       }
 
-      if (!handledInitData.storeIfNone(initializationData, true)) {
+      const lastKeyUpdate$ = new ReplaySubject<IKeyUpdateValue>(1);
+
+      // First, check that this initialization data is not already handled
+      const keyIds = initializationData.keyIds;
+      if (options.singleLicensePer === "content" &&
+          handledSessions.getLength() > 0 &&
+          keyIds !== undefined)
+      {
+        const firstSession = handledSessions.getAll()[0];
+        return firstSession.lastKeyUpdate$.pipe(mergeMap((evt) => {
+          for (let i = 0; i < evt.whitelistedKeyIds.length; i++) {
+            for (let j = 0; j < keyIds.length; j++) {
+              if (areArraysOfNumbersEqual(evt.whitelistedKeyIds[i], keyIds[j])) {
+                // Move corresponding session on top of the cache if it exists
+                const { loadedSessionsStore } = mediaKeysEvent.value.stores;
+                loadedSessionsStore.moveOnTop(firstSession.initializationData);
+                return observableOf({ type: "init-data-ignored" as const,
+                                      value: { initializationData } });
+              }
+            }
+          }
+          return observableOf({ type: "keys-update" as const,
+                                value: { blacklistedKeyIDs: keyIds,
+                                         whitelistedKeyIds: [] } });
+        }));
+      } else if (!handledSessions.storeIfNone(initializationData, { initializationData,
+                                                                    lastKeyUpdate$ })) {
         log.debug("EME: Init data already received. Skipping it.");
         return observableOf({ type: "init-data-ignored" as const,
                               value: { initializationData } });
@@ -188,7 +221,7 @@ export default function EMEManager(
         .pipe(mergeMap((sessionEvt) =>  {
           switch (sessionEvt.type) {
             case "cleaning-old-session":
-              handledInitData.remove(sessionEvt.value.initializationData);
+              handledSessions.remove(sessionEvt.value.initializationData);
               return EMPTY;
 
             case "cleaned-old-session":
@@ -240,27 +273,33 @@ export default function EMEManager(
                                                        mediaKeySystemAccess.keySystem,
                                                        initializationData),
                                  generateRequest$)
-            .pipe(catchError(err => {
-              if (!(err instanceof BlacklistedSessionError)) {
-                throw err;
-              }
+            .pipe(
+              tap((evt) => {
+                if (evt.type === "keys-update") {
+                  lastKeyUpdate$.next(evt.value);
+                }
+              }),
+              catchError(err => {
+                if (!(err instanceof BlacklistedSessionError)) {
+                  throw err;
+                }
 
-              blacklistedInitData.store(initializationData, err);
+                blacklistedInitData.store(initializationData, err);
 
-              const { sessionError } = err;
-              if (initializationData.type === undefined) {
-                log.error("EME: Current session blacklisted and content not known. " +
-                          "Throwing.");
-                sessionError.fatal = true;
-                throw sessionError;
-              }
+                const { sessionError } = err;
+                if (initializationData.type === undefined) {
+                  log.error("EME: Current session blacklisted and content not known. " +
+                            "Throwing.");
+                  sessionError.fatal = true;
+                  throw sessionError;
+                }
 
-              log.warn("EME: Current session blacklisted. Blacklisting content.");
-              return observableOf({ type: "warning" as const,
-                                    value: sessionError },
-                                  { type: "blacklist-protection-data" as const,
-                                    value: initializationData });
-            }));
+                log.warn("EME: Current session blacklisted. Blacklisting content.");
+                return observableOf({ type: "warning" as const,
+                                      value: sessionError },
+                                    { type: "blacklist-protection-data" as const,
+                                      value: initializationData });
+              }));
         }));
     }));
 

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -178,11 +178,14 @@ export default function EMEManager(
       const lastKeyUpdate$ = new ReplaySubject<IKeyUpdateValue>(1);
 
       // First, check that this initialization data is not already handled
-      const keyIds = initializationData.keyIds;
-      if (options.singleLicensePer === "content" &&
-          handledSessions.getLength() > 0 &&
-          keyIds !== undefined)
-      {
+      if (options.singleLicensePer === "content" && handledSessions.getLength() > 0) {
+        const keyIds = initializationData.keyIds;
+        if (keyIds === undefined) {
+          log.warn("EME: Initialization data linked to unknown key id, we'll" +
+                   "not able to fallback from it.");
+          return observableOf({ type: "init-data-ignored" as const,
+                                value: { initializationData } });
+        }
         const firstSession = handledSessions.getAll()[0];
         return firstSession.lastKeyUpdate$.pipe(mergeMap((evt) => {
           for (let i = 0; i < evt.whitelistedKeyIds.length; i++) {

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -181,7 +181,7 @@ export default function EMEManager(
       if (options.singleLicensePer === "content" && handledSessions.getLength() > 0) {
         const keyIds = initializationData.keyIds;
         if (keyIds === undefined) {
-          log.warn("EME: Initialization data linked to unknown key id, we'll" +
+          log.warn("EME: Initialization data linked to unknown key id, we'll " +
                    "not able to fallback from it.");
           return observableOf({ type: "init-data-ignored" as const,
                                 value: { initializationData } });

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -89,11 +89,12 @@ export default function EMEManager(
   log.debug("EME: Starting EMEManager logic.");
 
    /**
-    * Keep track of all decryption keys currently handled by the `EMEManager`.
+    * Keep track of all decryption keys handled by this instance of the
+    * `EMEManager`.
     * This allows to avoid creating multiple MediaKeySessions handling the same
     * decryption keys.
     */
-  const handledSessions = new InitDataStore<{
+  const contentSessions = new InitDataStore<{
     /** Initialization data which triggered the creation of this session. */
     initializationData : IInitializationDataInfo;
     /** Last key update event received for that session. */
@@ -101,7 +102,8 @@ export default function EMEManager(
   }>();
 
   /**
-   * Keep track of which initialization data have been blacklisted.
+   * Keep track of which initialization data have been blacklisted in the
+   * current instance of the `EMEManager`.
    * If the same initialization data is encountered again, we can directly emit
    * the same `BlacklistedSessionError`.
    */
@@ -178,7 +180,7 @@ export default function EMEManager(
       const lastKeyUpdate$ = new ReplaySubject<IKeyUpdateValue>(1);
 
       // First, check that this initialization data is not already handled
-      if (options.singleLicensePer === "content" && handledSessions.getLength() > 0) {
+      if (options.singleLicensePer === "content" && !contentSessions.isEmpty()) {
         const keyIds = initializationData.keyIds;
         if (keyIds === undefined) {
           log.warn("EME: Initialization data linked to unknown key id, we'll " +
@@ -186,7 +188,7 @@ export default function EMEManager(
           return observableOf({ type: "init-data-ignored" as const,
                                 value: { initializationData } });
         }
-        const firstSession = handledSessions.getAll()[0];
+        const firstSession = contentSessions.getAll()[0];
         return firstSession.lastKeyUpdate$.pipe(mergeMap((evt) => {
           for (let i = 0; i < evt.whitelistedKeyIds.length; i++) {
             for (let j = 0; j < keyIds.length; j++) {
@@ -203,7 +205,7 @@ export default function EMEManager(
                                 value: { blacklistedKeyIDs: keyIds,
                                          whitelistedKeyIds: [] } });
         }));
-      } else if (!handledSessions.storeIfNone(initializationData, { initializationData,
+      } else if (!contentSessions.storeIfNone(initializationData, { initializationData,
                                                                     lastKeyUpdate$ })) {
         log.debug("EME: Init data already received. Skipping it.");
         return observableOf({ type: "init-data-ignored" as const,
@@ -224,7 +226,7 @@ export default function EMEManager(
         .pipe(mergeMap((sessionEvt) =>  {
           switch (sessionEvt.type) {
             case "cleaning-old-session":
-              handledSessions.remove(sessionEvt.value.initializationData);
+              contentSessions.remove(sessionEvt.value.initializationData);
               return EMPTY;
 
             case "cleaned-old-session":

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -46,6 +46,10 @@ export interface IInitializationDataInfo {
     /**
      * Hex encoded system id, which identifies the key system.
      * https://dashif.org/identifiers/content_protection/
+     *
+     * If `undefined`, we don't know the system id for that initialization data.
+     * In that case, the initialization data might even be a concatenation of
+     * the initialization data from multiple system ids.
      */
     systemId: string | undefined;
     /**

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -20,19 +20,42 @@ import {
   ICustomMediaKeySession,
   ICustomMediaKeySystemAccess,
 } from "../../compat";
-import { IEncryptedEventData } from "../../compat/eme/";
 import { ICustomError } from "../../errors";
 import LoadedSessionsStore from "./utils/loaded_sessions_store";
 import PersistentSessionsStore from "./utils/persistent_sessions_store";
 
-/**
- * Information about the encryption initialization data.
- * Here equal to `IEncryptedEventData` because it is the one with the most
- * restrictions when compared to `IContentProtection`.
- * Using a union type between the two would be best, but it is poorly handled
- * by TypeScript.
- */
-export type IInitializationDataInfo = IEncryptedEventData;
+/** Information about the encryption initialization data. */
+export interface IInitializationDataInfo {
+  /**
+   * The initialization data type - or the format of the `data` attribute (e.g.
+   * "cenc").
+   * `undefined` if unknown.
+   */
+  type : string | undefined;
+  /**
+   * The key ids linked to those initialization data.
+   * This should be the key ids for the key concerned by the media which have
+   * the present initialization data.
+   *
+   * `undefined` when not known (different from an empty array - which would
+   * just mean that there's no key id involved).
+   */
+  keyIds? : Uint8Array[];
+  /** Every initialization data for that type. */
+  values: Array<{
+    /**
+     * Hex encoded system id, which identifies the key system.
+     * https://dashif.org/identifiers/content_protection/
+     */
+    systemId: string | undefined;
+    /**
+     * The initialization data itself for that type and systemId.
+     * For example, with "cenc" initialization data found in an ISOBMFF file,
+     * this will be the whole PSSH box.
+     */
+     data: Uint8Array;
+  }>;
+}
 
 /** Event emitted when a minor - recoverable - error happened. */
 export interface IEMEWarningEvent { type : "warning";
@@ -160,6 +183,51 @@ export interface INoUpdateEvent {
 }
 
 /**
+ * Some key ids have updated their status.
+ *
+ * We put them in two different list:
+ *
+ *   - `blacklistedKeyIDs`: Those key ids won't be used for decryption and the
+ *     corresponding media it decrypts should not be pushed to the buffer
+ *     Note that a blacklisted key id can become whitelisted in the future.
+ *
+ *   - `whitelistedKeyIds`: Those key ids were found and their corresponding
+ *     keys are now being considered for decryption.
+ *     Note that a whitelisted key id can become blacklisted in the future.
+ *
+ * Note that each `IKeysUpdateEvent` is independent of any other.
+ *
+ * A new `IKeysUpdateEvent` does not completely replace a previously emitted
+ * one, as it can for example be linked to a whole other decryption session.
+ *
+ * However, if a key id is encountered in both an older and a newer
+ * `IKeysUpdateEvent`, only the older status should be considered.
+ */
+export interface IKeysUpdateEvent {
+  type: "keys-update";
+  value: IKeyUpdateValue;
+}
+
+/** Information on key ids linked to a MediaKeySession. */
+export interface IKeyUpdateValue {
+  /**
+   * The list of key ids that are blacklisted.
+   * As such, their corresponding keys won't be used by that session, despite
+   * the fact that they were part of the pushed license.
+   *
+   * Reasons for blacklisting a keys depend on options, but mainly involve unmet
+   * output restrictions and CDM internal errors linked to that key id.
+   */
+  blacklistedKeyIDs : Uint8Array[];
+  /*
+   * The list of key id linked to that session which are not blacklisted.
+   * Together with `blacklistedKeyIDs` it regroups all key ids linked to the
+   * session.
+   */
+  whitelistedKeyIds : Uint8Array[];
+}
+
+/**
  * Emitted after the `MediaKeySession.prototype.update` function resolves.
  * This function is called when the `getLicense` callback resolves with a data
  * different than `null`.
@@ -172,12 +240,6 @@ export interface ISessionUpdatedEvent {
                     null;
            initializationData : IInitializationDataInfo; };
 }
-
-// Emitted when individual keys are considered undecipherable and are thus
-// blacklisted.
-// Emit the corresponding keyIDs as payload.
-export interface IBlacklistKeysEvent { type : "blacklist-keys";
-                                       value: Uint8Array[]; }
 
 /**
  * Event Emitted when specific "protection data" cannot be deciphered and is thus
@@ -197,8 +259,8 @@ export type IEMEManagerEvent = IEMEWarningEvent | // minor error
                                IInitDataIgnoredEvent | // initData already handled
                                ISessionMessageEvent | // MediaKeySession event
                                INoUpdateEvent | // `getLicense` returned `null`
+                               IKeysUpdateEvent | // Status of keys changed
                                ISessionUpdatedEvent | // `update` call resolved
-                               IBlacklistKeysEvent | // keyIDs undecipherable
                                IBlacklistProtectionDataEvent; // initData undecipherable
 
 export type ILicense = BufferSource |
@@ -213,6 +275,15 @@ export interface IContentProtection {
    * https://www.w3.org/TR/eme-initdata-registry/
    */
   type: string;
+  /**
+   * The key ids linked to those initialization data.
+   * This should be the key ids for the key concerned by the media which have
+   * the present initialization data.
+   *
+   * `undefined` when not known (different from an empty array - which would
+   * just mean that there's no key id involved).
+   */
+  keyIds? : Uint8Array[];
   /** Every initialization data for that type. */
   values: Array<{
     /**
@@ -465,6 +536,9 @@ export interface IKeySystemOption {
    * closed when the current playback stops.
    */
   closeSessionsOnStop? : boolean;
+
+  singleLicensePer? : "content" |
+                      "init-data";
   /** Callback called when one of the key's status change. */
   onKeyStatusesChange? : (evt : Event, session : MediaKeySession |
                                                  ICustomMediaKeySession)

--- a/src/core/eme/utils/init_data_store.ts
+++ b/src/core/eme/utils/init_data_store.ts
@@ -69,6 +69,16 @@ export default class InitDataStore<T> {
   }
 
   /**
+   * Returns `true` if no initialization data is stored yet in this
+   * InitDataStore.
+   * Returns `false` otherwise.
+   * @returns {boolean}
+   */
+  public isEmpty() : boolean {
+    return this._storage.length === 0;
+  }
+
+  /**
    * Returns the element associated with the given initData and initDataType.
    * Returns `undefined` if not found.
    * @param {Uint8Array} initData

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -83,8 +83,7 @@ export default class LoadedSessionsStore {
    * Returns the stored MediaKeySession information related to the
    * given initDataType and initData if found.
    * Returns `null` if no such MediaKeySession is stored.
-   * @param {Uint8Array} initData
-   * @param {string|undefined} initDataType
+   * @param {Object} initializationData
    * @returns {Object|null}
    */
   public get(initializationData : IInitializationDataInfo) : IStoredSessionData | null {
@@ -102,8 +101,7 @@ export default class LoadedSessionsStore {
    * initialization data is re-used to then be able to implement a caching
    * replacement algorithm based on the least-recently-used values by just
    * evicting the first values returned by `getAll`.
-   * @param {Uint8Array} initData
-   * @param {string|undefined} initDataType
+   * @param {Object} initializationData
    * @returns {Object|null}
    */
   public getAndReuse(
@@ -123,6 +121,11 @@ export default class LoadedSessionsStore {
    * re-used to then be able to implement a caching replacement algorithm based
    * on the least-recently-used values by just evicting the first values
    * returned by `getAll`.
+   *
+   * Returns `true` if the corresponding session was found in the store, `false`
+   * otherwise.
+   * @param {Object} initializationData
+   * @returns {boolean}
    */
   public reuse(
     initializationData : IInitializationDataInfo
@@ -133,8 +136,7 @@ export default class LoadedSessionsStore {
   /**
    * Create a new MediaKeySession and store it in this store.
    * @throws {EncryptedMediaError}
-   * @param {Uint8Array} initData
-   * @param {string|undefined} initDataType
+   * @param {Object} initializationData
    * @param {string} sessionType
    * @returns {MediaKeySession}
    */
@@ -174,8 +176,7 @@ export default class LoadedSessionsStore {
    * Close a MediaKeySession corresponding to an initialization data and remove
    * its related stored information from the LoadedSessionsStore.
    * Emit when done.
-   * @param {Uint8Array} initData
-   * @param {string|undefined} initDataType
+   * @param {Object} initializationData
    * @returns {Observable}
    */
   public closeSession(

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -99,7 +99,7 @@ export default class LoadedSessionsStore {
    * its internal storage, as returned by the `getAll` method.
    *
    * This can be used for example to tell when a previously-stored
-   * MediaKeySession is re-used to then be able to implement a caching
+   * initialization data is re-used to then be able to implement a caching
    * replacement algorithm based on the least-recently-used values by just
    * evicting the first values returned by `getAll`.
    * @param {Uint8Array} initData
@@ -113,6 +113,21 @@ export default class LoadedSessionsStore {
     return entry === undefined ? null :
                                  { mediaKeySession: entry.mediaKeySession,
                                    sessionType: entry.sessionType };
+  }
+
+  /**
+   * Moves the corresponding MediaKeySession to the end of its internal storage,
+   * as returned by the `getAll` method.
+   *
+   * This can be used to signal that a previously-stored initialization data is
+   * re-used to then be able to implement a caching replacement algorithm based
+   * on the least-recently-used values by just evicting the first values
+   * returned by `getAll`.
+   */
+  public moveOnTop(
+    initializationData : IInitializationDataInfo
+  ) : boolean {
+    return this._storage.getAndReuse(initializationData) !== undefined;
   }
 
   /**

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -124,7 +124,7 @@ export default class LoadedSessionsStore {
    * on the least-recently-used values by just evicting the first values
    * returned by `getAll`.
    */
-  public moveOnTop(
+  public reuse(
     initializationData : IInitializationDataInfo
   ) : boolean {
     return this._storage.getAndReuse(initializationData) !== undefined;

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -323,9 +323,9 @@ export default function InitializeOnMediaSource(
 
       const setUndecipherableRepresentations$ = emeManager$.pipe(
         tap((evt) => {
-          if (evt.type === "blacklist-keys") {
+          if (evt.type === "keys-update") {
             log.info("Init: blacklisting Representations based on keyIDs");
-            manifest.addUndecipherableKIDs(evt.value);
+            manifest.addUndecipherableKIDs(evt.value.blacklistedKeyIDs);
           } else if (evt.type === "blacklist-protection-data") {
             log.info("Init: blacklisting Representations based on protection data.");
             manifest.addUndecipherableProtectionData(evt.value);

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -26,11 +26,11 @@ import {
 } from "../api";
 import {
   IAttachedMediaKeysEvent,
-  IBlacklistKeysEvent,
   IBlacklistProtectionDataEvent,
   ICreatedMediaKeysEvent,
   IEncryptedEvent,
   IInitDataIgnoredEvent,
+  IKeysUpdateEvent,
   INoUpdateEvent,
   ISessionMessageEvent,
   ISessionUpdatedEvent,
@@ -171,9 +171,9 @@ export type IInitEvent = IManifestReadyEvent |
                          IAttachedMediaKeysEvent |
                          IInitDataIgnoredEvent |
                          ISessionMessageEvent |
+                         IKeysUpdateEvent |
                          INoUpdateEvent |
                          ISessionUpdatedEvent |
-                         IBlacklistKeysEvent |
                          IBlacklistProtectionDataEvent |
 
                          // Coming from the `MediaSourceLoader`
@@ -210,7 +210,7 @@ export type IDirectfileEvent = IStalledEvent |
                                IAttachedMediaKeysEvent |
                                IInitDataIgnoredEvent |
                                ISessionMessageEvent |
+                               IKeysUpdateEvent |
                                INoUpdateEvent |
                                ISessionUpdatedEvent |
-                               IBlacklistKeysEvent |
                                IBlacklistProtectionDataEvent;

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -25,10 +25,7 @@ import Manifest, {
   ISupplementaryTextTrack,
 } from "./manifest";
 import Period from "./period";
-import Representation, {
-  IContentProtections,
-  IContentProtectionInitData,
-} from "./representation";
+import Representation from "./representation";
 import {
   IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
@@ -51,8 +48,6 @@ export {
   // types
   IAdaptationType,
   IBaseContentInfos,
-  IContentProtections,
-  IContentProtectionInitData,
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,
   IRepresentationFilter,


### PR DESCRIPTION
# Single license per content implementation

resolves #863 

## The need

 ### What is this?

This PR implements a `singleLicensePer` option, which allows an application to tell the RxPlayer that the current content only has a single license for the whole content, even when it has multiple keys associated to different tracks or qualities.

The RxPlayer will then be able to perform a single license request and, if the right options are set, to fallback from non-decryptable contents, which will be both:

  1. keys which have the wrong key-status ("output-restricted" if `fallbackOn.keyOutputRestricted` is set and "internal-error" if `fallbackOn.keyInternalError` is set).

  2. keys which were not included in that license. Those will be fallbacked from, without needing to set any API.

The idea is also to be able to make evolutions to that API to implement for example a single license per Period in the future.

 ### Why doing that?

The idea here is to perform a single license request, initially for a single quality, which will in response return a license (technically it could be multiple concatenated licenses in the CDM's point of view depending of the key system, but it is still a single request and data structure in the player's point of view) allowing to decrypt all encrypted media from that same content.

The advantages of doing that are multiple. Most of all:

  1. it allows to only perform a single license request instead of multiple ones.
     Reducing possible server loads but also reducing network latencies.

  2. We could be able to tell much sooner which key are not supported and thus avoid switching to an undecipherable Representation to only later fallback from it.

  3. some other players not being compatible with contents necessitating multiple license requests, putting all keys in a single license can improve compatibility for when streams are used with multiple players.

  4. it reduces interactions with EME APIs, which we found to be very slow on some devices (we for example found out that generating a challenge can take more than 1 second on some embedded devices).

And surely many others.

Before that commit, the RxPlayer would already play those contents, but would still perform multiple license requests reducing the potential gains.

 ### What it means technically

Technically, the description of this feature is simple:

When `singleLicensePer` is set to `"content"`:

  - we should only perform a single license request, event when there's multiple initialization data encountered in the MPD and
initialization segments

  - we should fallback from `Representation`s whose corresponding  key ids are either:
      1. Not signaled in the license
      2. Signaled in the license but have to be fallbacked from according to the `fallbackOn` options

 ## Implementation

 ### Re-purposing `handledInitData`

To implement that, the main idea is to re-purpose the `handledInitData` cache (in the `EMEManager`), which stores initialization data that has already been encountered.

The only goal of that structure before being to avoid creating multiple MediaKeySessions for the same initialization data, it isn't a stretch to redefine it as a structure avoiding creating multiple MediaKeySessions linked to the same key ids.

I changed the way it is used in two ways:

  1. When `singleLicensePer` is set to `"content"` we can simply check when it's empty to only create a session on the first
     initialization data encountered (we can imagine also adding several IDs to that structure to easily implement `"period"` etc.).

  2. As we still need to fallback from any initialization data that has no corresponding key in the license when the latter is loaded, I had to add to that structure an Observable emitting `"blacklisted"` key ids from the corresponding `MediaKeySession` and the other key ids, now considered by opposition as `"whitelisted"`.

     Simply said, every key ids linked to a MediaKeySession which are not present blacklisted (because of the usual `fallbackOn` options) will be whitelisted.

     By listening to that Observable every time new initialization data is encountered, we can just compare the linked key id with whitelisted key ids that Observable emits - which will be once the license is pushed.
     If the license has already been pushed, the Observable will emit immediately.

 ### Adding the key id to `contentProtections$` event

Because we are using key ids here to detect which keys are not in a given license, we have to emit those alongside the initialization data to the `EMEManager`.
This is done through the already-existing `contentProtections$` Observable.

In the hypothesis that no key id is anounced in the Manifest, we may thus have to parse initialization data to extract it from there, so we can support multi-key per license mode with such contents.
This is not done here for the moment, but I'm working on it now.


 ## Does it work?

I tested it with success on:

  - Widevine L2 on STBs
  - Widevine L3 on Linux - Chrome
  - Widevine L3 on Linux - Firefox
  - Widevine L3 on Mac - Chrome
  - Widevine L3 on Windows - Edge
  - PlayReady SL3000 on Windows - Edge

I know it doesn't work yet on some set-top boxes, but this seems more an exception than the norm. We've still scheduled a meeting to learn more about this issue.
Depending on the result, we may want to perform updates on that code.