### PR TITLE
Mark decipherable Representations as decipherable even if they were undecipherable before

### DIFF
--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -324,8 +324,7 @@ export default function InitializeOnMediaSource(
       const setUndecipherableRepresentations$ = emeManager$.pipe(
         tap((evt) => {
           if (evt.type === "keys-update") {
-            log.info("Init: blacklisting Representations based on keyIDs");
-            manifest.addUndecipherableKIDs(evt.value.blacklistedKeyIDs);
+            manifest.updateDeciperabilitiesBasedOnKeyIds(evt.value);
           } else if (evt.type === "blacklist-protection-data") {
             log.info("Init: blacklisting Representations based on protection data.");
             manifest.addUndecipherableProtectionData(evt.value);

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -197,7 +197,7 @@ export default function AdaptationStream<T>({
   const bufferGoalRatioMap: Partial<Record<string, number>> = {};
 
   const { estimator$, requestFeedback$, streamFeedback$ } =
-    createRepresentationEstimator(adaptation, abrManager, clock$);
+    createRepresentationEstimator(content, abrManager, clock$);
 
   /** Allows the `RepresentationStream` to easily fetch media segments. */
   const segmentFetcher = segmentFetcherCreator.createSegmentFetcher(adaptation.type,

--- a/src/core/stream/orchestrator/get_blacklisted_ranges.ts
+++ b/src/core/stream/orchestrator/get_blacklisted_ranges.ts
@@ -36,6 +36,9 @@ export default function getBlacklistedRanges(
                      period : Period;
                      representation : Representation; }>
 ) : IRange[] {
+  if (contents.length === 0) {
+    return [];
+  }
   segmentBuffer.synchronizeInventory();
   const accumulator : IRange[] = [];
   const inventory = segmentBuffer.getInventory();

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -110,13 +110,6 @@ export default class Adaptation {
    */
   public manuallyAdded? : boolean;
 
-  /**
-   * `false` if from all Representation from this Adaptation, none is decipherable.
-   * `true` if at least one is known to be decipherable.
-   * `undefined` if this is not known for at least a single Representation.
-   */
-  public decipherable? : boolean;
-
   /** `true` if at least one Representation is in a supported codec. `false` otherwise. */
   public isSupported : boolean;
 
@@ -169,7 +162,6 @@ export default class Adaptation {
 
     const argsRepresentations = parsedAdaptation.representations;
     const representations : Representation[] = [];
-    let decipherable : boolean | undefined = false;
     let isSupported : boolean = false;
     for (let i = 0; i < argsRepresentations.length; i++) {
       const representation = new Representation(argsRepresentations[i],
@@ -186,9 +178,6 @@ export default class Adaptation {
                                isSignInterpreted: this.isSignInterpreted });
       if (shouldAdd) {
         representations.push(representation);
-        if (decipherable === false && representation.decipherable !== false) {
-          decipherable = representation.decipherable;
-        }
         if (!isSupported && representation.isSupported) {
           isSupported = true;
         }
@@ -197,7 +186,6 @@ export default class Adaptation {
     representations.sort((a, b) => a.bitrate - b.bitrate);
     this.representations = representations;
 
-    this.decipherable = decipherable;
     this.isSupported = isSupported;
 
     // for manuallyAdded adaptations (not in the manifest)

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -487,27 +487,36 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   /**
    * Look in the Manifest for Representations linked to the given key ID,
    * and mark them as being impossible to decrypt.
-   * Then trigger a "blacklist-update" event to notify everyone of the changes
-   * performed.
-   * @param {Array.<ArrayBuffer>} keyIDs
+   * Then trigger a "decipherabilityUpdate" event to notify everyone of the
+   * changes performed.
+   * @param {Object} keyUpdates
    */
-  public addUndecipherableKIDs(keyIDs : Uint8Array[]) : void {
+  public updateDeciperabilitiesBasedOnKeyIds(
+    { whitelistedKeyIds,
+      blacklistedKeyIDs } : { whitelistedKeyIds : Uint8Array[];
+                              blacklistedKeyIDs : Uint8Array[]; }
+  ) : void {
     const updates = updateDeciperability(this, (representation) => {
       if (representation.decipherable === false ||
           representation.contentProtections === undefined)
       {
-        return true;
+        return representation.decipherable;
       }
       const contentKIDs = representation.contentProtections.keyIds;
       for (let i = 0; i < contentKIDs.length; i++) {
         const elt = contentKIDs[i];
-        for (let j = 0; j < keyIDs.length; j++) {
-          if (areArraysOfNumbersEqual(keyIDs[j], elt.keyId)) {
+        for (let j = 0; j < blacklistedKeyIDs.length; j++) {
+          if (areArraysOfNumbersEqual(blacklistedKeyIDs[j], elt.keyId)) {
             return false;
           }
         }
+        for (let j = 0; j < whitelistedKeyIds.length; j++) {
+          if (areArraysOfNumbersEqual(whitelistedKeyIds[j], elt.keyId)) {
+            return true;
+          }
+        }
       }
-      return true;
+      return representation.decipherable;
     });
 
     if (updates.length > 0) {
@@ -519,16 +528,14 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * Look in the Manifest for Representations linked to the given content
    * protection initialization data and mark them as being impossible to
    * decrypt.
-   * Then trigger a "blacklist-update" event to notify everyone of the changes
-   * performed.
-   * @param {Array.<ArrayBuffer>} keyIDs
+   * Then trigger a "decipherabilityUpdate" event to notify everyone of the
+   * changes performed.
+   * @param {Object} initData
    */
-  public addUndecipherableProtectionData(
-    initData : IInitializationDataInfo
-  ) : void {
+  public addUndecipherableProtectionData(initData : IInitializationDataInfo) : void {
     const updates = updateDeciperability(this, (representation) => {
       if (representation.decipherable === false) {
-        return true;
+        return false;
       }
       const segmentProtections = representation.contentProtections?.initData ?? [];
       for (let i = 0; i < segmentProtections.length; i++) {
@@ -548,7 +555,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
           }
         }
       }
-      return true;
+      return representation.decipherable;
     });
 
     if (updates.length > 0) {
@@ -751,17 +758,19 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
 }
 
 /**
- * Update decipherability based on a predicate given.
- * Do nothing for a Representation when the predicate returns false, mark as
- * undecipherable when the predicate returns false. Returns every updates in
- * an array.
+ * Update `decipherable` property of every `Representation` found in the
+ * Manifest based on the result of a `isDecipherable` callback:
+ *   - When that callback returns `true`, update `decipherable` to `true`
+ *   - When that callback returns `false`, update `decipherable` to `false`
+ *   - When that callback returns `undefined`, update `decipherable` to
+ *     `undefined`
  * @param {Manifest} manifest
- * @param {Function} predicate
+ * @param {Function} isDecipherable
  * @returns {Array.<Object>}
  */
 function updateDeciperability(
   manifest : Manifest,
-  predicate : (rep : Representation) => boolean
+  isDecipherable : (rep : Representation) => boolean | undefined
 ) : IDecipherabilityUpdateElement[] {
   const updates : IDecipherabilityUpdateElement[] = [];
   for (let i = 0; i < manifest.periods.length; i++) {
@@ -772,9 +781,10 @@ function updateDeciperability(
       const representations = adaptation.representations;
       for (let k = 0; k < representations.length; k++) {
         const representation = representations[k];
-        if (!predicate(representation)) {
+        const result = isDecipherable(representation);
+        if (result !== representation.decipherable) {
           updates.push({ manifest, period, adaptation, representation });
-          representation.decipherable = false;
+          representation.decipherable = result;
         }
       }
     }

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -175,7 +175,7 @@ export default class Period {
   getPlayableAdaptations(type? : IAdaptationType) : Adaptation[] {
     if (type === undefined) {
       return this.getAdaptations().filter(ada => {
-        return ada.isSupported && ada.decipherable !== false;
+        return ada.getPlayableRepresentations().length > 0;
       });
     }
     const adaptationsForType = this.adaptations[type];
@@ -183,7 +183,7 @@ export default class Period {
       return [];
     }
     return adaptationsForType.filter(ada => {
-      return ada.isSupported && ada.decipherable !== false;
+      return ada.getPlayableRepresentations().length > 0;
     });
   }
 }


### PR DESCRIPTION
This PR is based on the multiple-keys-per-license commits (in #904) and add on top of it a new behavior.

Representations which have their key-id added to one of the `MediaKeyStatusMap` linked to the current content and which are not fallbacked from, will now have their `decipherable` property updated to `true` - even if it was set to `false` before (and thus even if we had fallbacked from it in the past).

This development was made a lot easier by the work done to support the `singleLicensePer` option (#904) with now the concept of "whitelisted key ids", in opposition of the "blacklisted key ids" we fallback from.

When a key id is found to be whitelisted (technically this means currently that its `MediaKeyStatus` is not either: `"internal-error"`, `"output-restricted"` or `"expired"`, the last one depending on `keySystems options) we will now:

  - update the related `Representation`'s `decipherable` property to `true` - regardless of its previous state

  - schedule a `decipherabilityUpdate` event with that update through the API (and through the `Manifest` object with the event of the same name)

  - In the `AdaptationStream` - only if the updates changed the list of available Representations for that Adaptation - re-construct the list of the Representations the ABR has to choose from

---

To note that this has never been tested in real conditions.