### PR TITLE
add quick links inside the RxPlayer API Page

### DIFF
--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1,5 +1,12 @@
 # RxPlayer API ################################################################
 
+## Quick links ################################################################
+
+- [Player Events](./player_events.md)
+- [Player errors and warning](./errors.md)
+- [Player Constructor options](./player_options.md)
+- [loadVideo method](./loadVideo_options.md)
+
 
 ## Table of Contents ###########################################################
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "demo": "Build the demo in demo/bundle.js",
     "demo:min": "Build the demo and minify it in demo/bundle.js",
     "demo:watch": "Build the demo in demo/bundle.js each times the files update.",
-    "doc": "Generate the HTML documentation in doc/pages",
+    "doc": "Generate the HTML documentation in doc/generated/pages",
     "info": "Display the description of all npm scripts for this project",
     "lint": "Lint rx-player source files",
     "lint:demo": "Lint demo source files",


### PR DESCRIPTION
Try to make the Doc API more practical to use by adding a small anchor to be able to access pages that are highly used by adding a category "Quick links" inside the RxPlayer API page.

![image](https://user-images.githubusercontent.com/14330374/109279075-9a1c6600-7819-11eb-8ab5-a02a13362b44.png)
 