### PR TITLE
Detect freezing playback and try to unfreeze

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -42,6 +42,9 @@ const isFirefox : boolean = !isNode &&
 const isSamsungBrowser : boolean = !isNode &&
                                    /SamsungBrowser/.test(navigator.userAgent);
 
+const isTizen : boolean = !isNode &&
+                          /Tizen/.test(navigator.userAgent);
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 const isSafari : boolean =
@@ -65,4 +68,5 @@ export {
   isSafari,
   isSafariMobile,
   isSamsungBrowser,
+  isTizen,
 };

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -62,6 +62,7 @@ import shouldRenewMediaKeys from "./should_renew_media_keys";
 import shouldUnsetMediaKeys from "./should_unset_media_keys";
 import shouldValidateMetadata from "./should_validate_metadata";
 import shouldWaitForDataBeforeLoaded from "./should_wait_for_data_before_loaded";
+import tryToUnfreeze from "./try_to_unfreeze";
 import whenLoadedMetadata$ from "./when_loaded_metadata";
 import whenMediaSourceOpen$ from "./when_media_source_open";
 
@@ -109,6 +110,7 @@ export {
   shouldValidateMetadata,
   shouldWaitForDataBeforeLoaded,
   tryToChangeSourceBufferType,
+  tryToUnfreeze,
   VTTCue_,
   whenLoadedMetadata$,
   whenMediaSourceOpen$,

--- a/src/compat/is_playback_stuck.ts
+++ b/src/compat/is_playback_stuck.ts
@@ -14,29 +14,20 @@
  * limitations under the License.
  */
 
-import { isFirefox } from "./browser_detection";
+import { IStalledStatus } from "../core/api";
 
 /**
- * firefox fix: sometimes playback can be stalled, even if we are in a buffer.
- * TODO This seems to be about an old Firefox version. Delete it?
- * @param {number} time
- * @param {Object|null} currentRange
- * @param {string} state
- * @param {Boolean} isStalled
+ * Consider playback to be stuck if is has been freezing for a long time.
+ * @param {Object | null} stalledStatus
  * @returns {Boolean}
  */
 export default function isPlaybackStuck(
-  time : number,
-  currentRange : { start: number;
-                   end: number; } |
-                 null,
-  state : string,
-  isStalled : boolean
+  stalledStatus: IStalledStatus
 ) : boolean {
-  const FREEZE_THRESHOLD = 10; // freeze threshold in seconds
-  return (isFirefox &&
-          isStalled &&
-          state === "timeupdate" &&
-          currentRange != null &&
-          currentRange.end - time > FREEZE_THRESHOLD);
+  const now = performance.now();
+  if (stalledStatus.reason === "freezing" &&
+      now - stalledStatus.timestamp >= 1000) {
+    return true;
+  }
+  return false;
 }

--- a/src/compat/try_to_unfreeze.ts
+++ b/src/compat/try_to_unfreeze.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import log from "../log";
+import {
+  isFirefox,
+  isTizen,
+} from "./browser_detection";
+
+/**
+ * Try to unfreeze playback by chosing between different methods.
+ * @param {HTMLMediaElement} mediaElement
+ * @param {string} state
+ */
+export default function tryToUnfreeze(mediaElement: HTMLMediaElement,
+                                      state: string): void {
+  // firefox fix: sometimes playback can be stalled, even if we are in a buffer.
+  // TODO This seems to be about an old Firefox version. Delete it?
+  if (isFirefox) {
+    if (state === "timeupdate") {
+      log.warn("Init: Trying to unfreeze by seeking", mediaElement.currentTime);
+      mediaElement.currentTime = mediaElement.currentTime;
+      return;
+    }
+  } else if (isTizen && !mediaElement.paused) {
+    log.warn("Init: Trying to unfreeze by pausing and playing", mediaElement.currentTime);
+    mediaElement.pause();
+    /* eslint-disable-next-line @typescript-eslint/no-floating-promises */
+    mediaElement.play();
+    return;
+  }
+  // Default behavior to avoid freezing is trying to seek a little far from current
+  // position.
+  log.warn("Init: Trying to unfreeze by seeking", mediaElement.currentTime + 0.01);
+  mediaElement.currentTime += 0.01;
+}

--- a/src/core/api/clock.ts
+++ b/src/core/api/clock.ts
@@ -262,7 +262,12 @@ function getStalledStatus(
                     ) &&
                     (playbackRate !== 0 && prevPlaybackRate !== 0) &&
                     currentRange !== null;
-  const isFreezing = (currentTime === prevTime) && canFreeze;
+
+  const minBufferGapToFreeze = 5;
+  const isFreezing = (currentTime === prevTime) &&
+                     canFreeze &&
+                     bufferGap !== Infinity &&
+                     bufferGap >= minBufferGapToFreeze;
 
   let shouldStall : boolean | undefined;
   let shouldUnstall : boolean | undefined;

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -52,7 +52,8 @@ export const PLAYER_STATES =
 export default function getLoadedContentState(
   mediaElement : HTMLMediaElement,
   isPlaying : boolean,
-  stalledStatus : { reason : "seeking" |
+  stalledStatus : { reason : "freezing" |
+                             "seeking" |
                              "not-ready" |
                              "buffering"; } |
                   null


### PR DESCRIPTION
On some platforms, playback may be stuck while the buffer is full and the media element seems to be able to play content. It has been observed on old Firefox browsers, or on Tizen TVs.

-------------------------------------------

The logic here is to detect first when the playback is freezing. When it is considered as stalled, we check if media element attributes seem to tell us if it supposed to play. If it is, and the playback is stalled, then consider that playback freezes.

Then, the stall avoider considers the playback to be stuck if it has been freezing for at least 1 second.

Then, depending on the used browser, try to unfreeze using several methods.

-------------------------------------------

For now, I've not handled the play / pause events that will result from the function calls that are made to unfreeze.