### PR TITLE
fix memory leak in RepresentationStream

### DIFF
--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -31,6 +31,7 @@ import {
   mergeMap,
   share,
   switchMap,
+  take,
 } from "rxjs/operators";
 import { ICustomError } from "../../../errors";
 import log from "../../../log";
@@ -319,6 +320,7 @@ export default class DownloadingQueue<T> {
             case "chunk":
             case "chunk-complete":
               return initSegmentTimescale$.pipe(
+                take(1),
                 mergeMap((initTimescale) => {
                   if (evt.type === "chunk-complete") {
                     return observableOf({ type: "end-of-segment" as const,

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -376,8 +376,9 @@ export default function RepresentationStream<T>({
         return observableMerge(protectedEvents$, pushEvent$);
 
       case "parsed-segment":
-        return initSegmentState.segmentData$
-          .pipe(mergeMap((initSegmentData) =>
+        return initSegmentState.segmentData$.pipe(
+          take(1),
+          mergeMap((initSegmentData) =>
             pushMediaSegment({ clock$,
                                content,
                                initSegmentData,


### PR DESCRIPTION
This commit fixes memory leaks present in the RepresentationStream since a6b6f64f39f5a4fcb4509177ee3172415520ce85.

Note that this commit is not yet part of a release (thankfully!).

The reasons for those leaks are linked to how we implemented parallel download of the initialization and media segments while still pushing the former before the latter.

We basically created `ReplaySubjects` containing data related to the initialization segment and listened to that ReplaySubject before parsing or pushing any media segment (to be sure this was done only once the corresponding init segment data was known).

However, we didn't stop listening to either of those `ReplaySubject`s after they emitted once, thus leaking memory each time a new media segment is loaded/parsed (the returned observable will never be unsubscribed from, as it would be waiting on potential new data coming from that `ReplaySubject`, which is both unnecessary - it will never emit again - and wasteful).

Putting a `take(1)` at the right places, to indicate that we only care about the first (and only) value those Observables emit fixes the leak.