### PR TITLE
set a much lower duration by default for live contents

### DIFF
--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -102,9 +102,7 @@ export default function createMediaSourceLoader(
     autoPlay : boolean
   ) {
     // TODO Update the duration if it evolves?
-    const duration = manifest.isLive ? Infinity :
-                                       manifest.getMaximumPosition();
-    setDurationToMediaSource(mediaSource, duration);
+    setDurationToMediaSource(mediaSource, manifest);
 
     const initialPeriod = manifest.getPeriodForTime(initialTime) ??
                           manifest.getNextPeriod(initialTime);


### PR DESCRIPTION
Tizen seems to have issues with setting a very high value as a duration due to that value overflowing when they perform time conversions.

As a compromise, it's not that much to sacrifice the maximum position we can seek to in a live content at 2^32 (which is much lower than what we could actually put it at, but might save us from other compatibility issues and is what the shaka-player is doing).

With an exception for those rare cases where the maximum position goes close to or over 2^32 (which should not normally happen, at least not until 2096, but we never know, some weird contents should exist somewhere).

In this last scenario, we set it to the current maximum position + 1 year, which should still be pretty safe (still, we never know what future usages will bring us)!

Also, I decided not to limit that work-around to only Tizen, because:
  - it is easy imagining other platforms having that type of issue.
  - that work-around should very rarely be problematic