### PR TITLE
Request initialization segment in parallel of the first media segment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,14 @@ directory) by calling `npm run lint:tests`.
 <a name="code-types"></a>
 ### Types ######################################################################
 
+#### General TypeScript rules ##################################################
+
 We try to be as strict as possible with types:
 
   - the `any` type should be avoided
 
-  - the `as` keyword should also be avoided as much as possible.
+  - the `as` TypeScript keyword, used for type casting, should also be avoided
+    as much as possible.
 
   - the `is` keyword is fine in some situations, but simpler solutions should be
     preferred.
@@ -94,8 +97,70 @@ We try to be as strict as possible with types:
 This is to be sure we can detect as much as possible type errors automatically
 with TypeScript.
 
-Also, created TypeScript's `type` and `interface` should all be named beginning
-with the letter I, for easier identification purposes.
+### `type` and `interface` typing
+
+TypeScript's `type` and `interface` should all be named beginning with the
+letter `I`, for easier identification purposes\*:
+```
+interface IMyObject {
+  someKey: string;
+}
+
+type IStringOrNumber = string |
+                       number;
+```
+
+\*We know that this rule is a controversial subject amongst TypeScript
+developpers, yet we still decide to enforce it for now.
+
+#### Generic parameters typing #################################################
+
+Generic parameters are usually named in order `T` (for the first generic
+parameter), then `U` (if there's two), then `V` (if there's three):
+
+Examples:
+```
+type IMyGenericType<T> = Array<T>;
+
+type IMyGenericType2<T, U> = Promise<T> |
+                             U;
+
+function mergeThree<T, U, V>(
+  arg1: T,
+  arg2: U,
+  arg3: V
+) : T & U & V {
+  return Object.assign({}, arg1, arg2, arg3);
+}
+```
+
+Some exceptions exist like for things like key-values couples, which can be named
+respectively `K` and `V`:
+```
+type IMyMap<K, V> = Map<K, V>;
+```
+
+This is a general convention for generic parameters inherited from Java, and
+re-used by TypeScript, and it helps identifying which type is a generic
+parameter vs which type is a real type (no prefix) vs which type is a type
+definition (prefixed by `I`).
+
+If what they correspond to is not obvious (and if there's more than one, it
+might well be), you're encouraged to add a more verbose and clear name, that you
+should prefix by `T`:
+```
+function loadResource<TResourceFormat>(
+  url : string
+) : Promise<TResourceFormat> {
+  // ...
+}
+```
+
+However note that typing rules for generic parameters is a very minor
+consideration and may not always need to be respected depending on the code it
+is applied on.
+In the end, it will be up to the RxPlayer's maintainers to decide that those
+rules should be enforced or not on a given code.
 
 
 <a name="code-forbidden"></a>

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -780,7 +780,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                                                     maxRetryOffline: offlineRetry });
 
       /** Interface used to download segments. */
-      const segmentFetcherCreator = new SegmentFetcherCreator<any>(
+      const segmentFetcherCreator = new SegmentFetcherCreator(
         transportPipelines,
         { lowLatencyMode,
           maxRetryOffline: offlineRetry,

--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -70,8 +70,7 @@ export interface ISegmentLoaderData<T> { type : "data";
  * ISegmentLoaderChunkComplete event is received.
  */
 export interface ISegmentLoaderChunk { type : "chunk";
-                                       value : { responseData : null |
-                                                                ArrayBuffer |
+                                       value : { responseData : ArrayBuffer |
                                                                 Uint8Array; }; }
 
 /** The data has been entirely sent through "chunk" events. */

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -40,19 +40,23 @@ export interface ISegmentFetcherInterruptedEvent { type : "interrupted" }
 export interface IEndedTaskEvent { type : "ended" }
 
 /** Event sent by a `IPrioritizedSegmentFetcher`. */
-export type IPrioritizedSegmentFetcherEvent<T> = ISegmentFetcherEvent<T> |
-                                                 ISegmentFetcherInterruptedEvent |
-                                                 IEndedTaskEvent;
+export type IPrioritizedSegmentFetcherEvent<TSegmentDataType> =
+  ISegmentFetcherEvent<TSegmentDataType> |
+  ISegmentFetcherInterruptedEvent |
+  IEndedTaskEvent;
 
 /** Oject returned by `applyPrioritizerToSegmentFetcher`. */
-export interface IPrioritizedSegmentFetcher<T> {
+export interface IPrioritizedSegmentFetcher<TSegmentDataType> {
   /** Create a new request for a segment with a given priority. */
   createRequest : (content : ISegmentLoaderContent,
-                   priority? : number) => Observable<IPrioritizedSegmentFetcherEvent<T>>;
+                   priority? : number) =>
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>;
 
   /** Update priority of a request created through `createRequest`. */
-  updatePriority : (observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
-                    priority : number) => void;
+  updatePriority : (
+    observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+    priority : number
+  ) => void;
 }
 
 /**
@@ -65,18 +69,19 @@ export interface IPrioritizedSegmentFetcher<T> {
  * @param {Object} fetcher
  * @returns {Object}
  */
-export default function applyPrioritizerToSegmentFetcher<T>(
-  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<T>>,
-  fetcher : ISegmentFetcher<T>
-) : IPrioritizedSegmentFetcher<T> {
+export default function applyPrioritizerToSegmentFetcher<TSegmentDataType>(
+  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+  fetcher : ISegmentFetcher<TSegmentDataType>
+) : IPrioritizedSegmentFetcher<TSegmentDataType> {
   /**
    * The Observables returned by `createRequest` are not exactly the same than
    * the one created by the `ObservablePrioritizer`. Because we still have to
    * keep a handle on that value.
    */
-  const taskHandlers =
-    new WeakMap<Observable<IPrioritizedSegmentFetcherEvent<T>>,
-                           Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<T>>>>();
+  const taskHandlers = new WeakMap<
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+    Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>>
+  >();
   return {
     /**
      * Create a Segment request with a given priority.
@@ -88,7 +93,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
     createRequest(
       content : ISegmentLoaderContent,
       priority : number = 0
-    ) : Observable<IPrioritizedSegmentFetcherEvent<T>> {
+    ) : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>> {
       const task = prioritizer.create(fetcher(content), priority);
       const flattenTask = task.pipe(
         map((evt) => {
@@ -107,7 +112,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
      * @param {Number} priority - The new priority value.
      */
     updatePriority(
-      observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
+      observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
       priority : number
     ) : void {
       const correspondingTask = taskHandlers.get(observable);

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -30,8 +30,8 @@ import {
 import { formatError } from "../../../errors";
 import { ISegment } from "../../../manifest";
 import {
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITransportPipelines,
 } from "../../../transports";
 import arrayIncludes from "../../../utils/array_includes";
@@ -77,8 +77,8 @@ export interface ISegmentFetcherChunkEvent<T> {
    * @param {number} initTimescale
    * @returns {Object}
    */
-  parse(initTimescale? : number) : ISegmentParserInitSegment<T> |
-                                   ISegmentParserSegment<T>;
+  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
+                                   ISegmentParserParsedSegment<T>;
 }
 
 /**
@@ -217,8 +217,8 @@ export default function createSegmentFetcher<T>(
            * @param {Object} [initTimescale]
            * @returns {Observable}
            */
-          parse(initTimescale? : number) : ISegmentParserInitSegment<T> |
-                                           ISegmentParserSegment<T> {
+          parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
+                                           ISegmentParserParsedSegment<T> {
             const response = { data: evt.value.responseData, isChunked };
             try {
               /* eslint-disable @typescript-eslint/no-unsafe-call */

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -32,7 +32,7 @@ import { ISegment } from "../../../manifest";
 import {
   ISegmentParserParsedInitSegment,
   ISegmentParserParsedSegment,
-  ITransportPipelines,
+  ISegmentPipeline,
 } from "../../../transports";
 import arrayIncludes from "../../../utils/array_includes";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -64,7 +64,7 @@ export type ISegmentFetcherWarning = ISegmentLoaderWarning;
  * Event sent when a new "chunk" of the segment is available.
  * A segment can contain n chunk(s) for n >= 0.
  */
-export interface ISegmentFetcherChunkEvent<T> {
+export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
   type : "chunk";
   /**
    * Parse the downloaded chunk.
@@ -77,8 +77,8 @@ export interface ISegmentFetcherChunkEvent<T> {
    * @param {number} initTimescale
    * @returns {Object}
    */
-  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
-                                   ISegmentParserParsedSegment<T>;
+  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<TSegmentDataType> |
+                                   ISegmentParserParsedSegment<TSegmentDataType>;
 }
 
 /**
@@ -88,12 +88,13 @@ export interface ISegmentFetcherChunkEvent<T> {
 export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete" }
 
 /** Event sent by the SegmentFetcher when fetching a segment. */
-export type ISegmentFetcherEvent<T> = ISegmentFetcherChunkCompleteEvent |
-                                      ISegmentFetcherChunkEvent<T> |
-                                      ISegmentFetcherWarning;
+export type ISegmentFetcherEvent<TSegmentDataType> =
+  ISegmentFetcherChunkCompleteEvent |
+  ISegmentFetcherChunkEvent<TSegmentDataType> |
+  ISegmentFetcherWarning;
 
-export type ISegmentFetcher<T> = (content : ISegmentLoaderContent) =>
-                                   Observable<ISegmentFetcherEvent<T>>;
+export type ISegmentFetcher<TSegmentDataType> = (content : ISegmentLoaderContent) =>
+  Observable<ISegmentFetcherEvent<TSegmentDataType>>;
 
 const generateRequestID = idGenerator();
 
@@ -105,23 +106,23 @@ const generateRequestID = idGenerator();
  * @param {Object} options
  * @returns {Function}
  */
-export default function createSegmentFetcher<T>(
+export default function createSegmentFetcher<
+  LoadedFormat,
+  TSegmentDataType
+>(
   bufferType : IBufferType,
-  transport : ITransportPipelines,
+  segmentPipeline : ISegmentPipeline<LoadedFormat, TSegmentDataType>,
   requests$ : Subject<IABRMetricsEvent |
                       IABRRequestBeginEvent |
                       IABRRequestProgressEvent |
                       IABRRequestEndEvent>,
   options : IBackoffOptions
-) : ISegmentFetcher<T> {
+) : ISegmentFetcher<TSegmentDataType> {
   const cache = arrayIncludes(["audio", "video"], bufferType) ?
     new InitializationSegmentCache<any>() :
     undefined;
-  const segmentLoader = createSegmentLoader<any>(transport[bufferType].loader,
-                                                 cache,
-                                                 options);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const segmentParser = transport[bufferType].parser as any; // deal with it
+  const segmentLoader = createSegmentLoader(segmentPipeline.loader, cache, options);
+  const segmentParser = segmentPipeline.parser;
 
   /**
    * Process the segmentLoader observable to adapt it to the the rest of the
@@ -134,7 +135,7 @@ export default function createSegmentFetcher<T>(
    */
   return function fetchSegment(
     content : ISegmentLoaderContent
-  ) : Observable<ISegmentFetcherEvent<T>> {
+  ) : Observable<ISegmentFetcherEvent<TSegmentDataType>> {
     const id = generateRequestID();
     let requestBeginSent = false;
     return segmentLoader(content).pipe(
@@ -185,7 +186,7 @@ export default function createSegmentFetcher<T>(
 
       filter((e) : e is ISegmentLoaderChunk |
                         ISegmentLoaderChunkComplete |
-                        ISegmentLoaderData<T> |
+                        ISegmentLoaderData<LoadedFormat> |
                         ISegmentFetcherWarning => {
         switch (e.type) {
           case "warning":
@@ -217,17 +218,13 @@ export default function createSegmentFetcher<T>(
            * @param {Object} [initTimescale]
            * @returns {Observable}
            */
-          parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
-                                           ISegmentParserParsedSegment<T> {
+          parse(initTimescale? : number) :
+            ISegmentParserParsedInitSegment<TSegmentDataType> |
+            ISegmentParserParsedSegment<TSegmentDataType>
+          {
             const response = { data: evt.value.responseData, isChunked };
             try {
-              /* eslint-disable @typescript-eslint/no-unsafe-call */
-              /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-              /* eslint-disable @typescript-eslint/no-unsafe-return */
               return segmentParser({ response, initTimescale, content });
-              /* eslint-enable @typescript-eslint/no-unsafe-call */
-              /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-              /* eslint-enable @typescript-eslint/no-unsafe-return */
             } catch (error : unknown) {
               throw formatError(error, { defaultCode: "PIPELINE_PARSE_ERROR",
                                          defaultReason: "Unknown parsing error" });

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -66,6 +66,7 @@ export type ISegmentFetcherWarning = ISegmentLoaderWarning;
  */
 export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
   type : "chunk";
+  segment : ISegment;
   /**
    * Parse the downloaded chunk.
    *
@@ -85,7 +86,10 @@ export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
  * Event sent when all "chunk" of the segments have been communicated through
  * `ISegmentFetcherChunkEvent` events.
  */
-export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete" }
+export interface ISegmentFetcherChunkCompleteEvent {
+  type: "chunk-complete";
+  segment : ISegment;
+}
 
 /** Event sent by the SegmentFetcher when fetching a segment. */
 export type ISegmentFetcherEvent<TSegmentDataType> =
@@ -207,12 +211,14 @@ export default function createSegmentFetcher<
           return observableOf(evt);
         }
         if (evt.type === "chunk-complete") {
-          return observableOf({ type: "chunk-complete" as const });
+          return observableOf({ type: "chunk-complete" as const,
+                                segment: content.segment });
         }
 
         const isChunked = evt.type === "chunk";
         const data = {
           type: "chunk" as const,
+          segment: content.segment,
           /**
            * Parse the loaded data.
            * @param {Object} [initTimescale]
@@ -236,7 +242,8 @@ export default function createSegmentFetcher<
           return observableOf(data);
         }
         return observableConcat(observableOf(data),
-                                observableOf({ type: "chunk-complete" as const }));
+                                observableOf({ type: "chunk-complete" as const,
+                                               segment: content.segment }));
       }),
       share() // avoid multiple side effects if multiple subs
     );

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -126,7 +126,7 @@ export interface IInitializeArguments {
   /** Limit the frequency of Manifest updates. */
   minimumManifestUpdateInterval : number;
   /** Interface allowing to load segments */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /** Perform an internal seek */
   setCurrentTime: (time: number) => void;
   /** Emit the playback rate (speed) set by the user. */

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -66,7 +66,7 @@ export interface IMediaSourceLoaderArguments {
   /** Media Element on which the content will be played. */
   mediaElement : HTMLMediaElement;
   /** Module to facilitate segment fetching. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * Observable emitting the wanted playback rate as it changes.
    * Replay the last value on subscription.

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -109,7 +109,7 @@ export interface IAdaptationStreamArguments<T> {
   /** SourceBuffer wrapper - needed to push media segments. */
   segmentBuffer : SegmentBuffer<T>;
   /** Module used to fetch the wanted media segments. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * "Buffer goal" wanted, or the ideal amount of time ahead of the current
    * position in the current SegmentBuffer. When this amount has been reached

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -114,7 +114,7 @@ export default function StreamOrchestrator(
   clock$ : Observable<IStreamOrchestratorClockTick>,
   abrManager : ABRManager,
   segmentBuffersStore : SegmentBuffersStore,
-  segmentFetcherCreator : SegmentFetcherCreator<any>,
+  segmentFetcherCreator : SegmentFetcherCreator,
   options: IStreamOrchestratorOptions
 ) : Observable<IStreamOrchestratorEvent> {
   const { manifest, initialPeriod } = content;

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -87,7 +87,7 @@ export interface IPeriodStreamArguments {
   content : { manifest : Manifest;
               period : Period; };
   garbageCollectors : WeakMapMemory<SegmentBuffer<unknown>, Observable<never>>;
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   segmentBuffersStore : SegmentBuffersStore;
   options: IPeriodStreamOptions;
   wantedBufferAhead$ : BehaviorSubject<number>;

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -174,7 +174,7 @@ export default class DownloadingQueue<T> {
    * Returns `null` if no initialization segment request is pending.
    * @returns {Object}
    */
-  public getCurrentInitRequest() : ISegment | null {
+  public getRequestedInitSegment() : ISegment | null {
     return this._initSegmentRequest === null ? null :
                                                this._initSegmentRequest.segment;
   }
@@ -184,7 +184,7 @@ export default class DownloadingQueue<T> {
    * Returns `null` if no media segment request is pending.
    * @returns {Object}
    */
-  public getCurrentMediaRequest() : ISegment | null {
+  public getRequestedMediaSegment() : ISegment | null {
     return this._mediaSegmentRequest === null ? null :
                                                 this._mediaSegmentRequest.segment;
   }

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -63,40 +63,72 @@ export type IDownloadingQueueEvent<T> = IParsedSegmentEvent<T> |
                                         ILoaderRetryEvent |
                                         IEndOfQueueEvent;
 
-/** Notify that the initialization segment has been parsed. */
+/**
+ * Notify that the initialization segment has been fully loaded and parsed.
+ *
+ * You can now push that segment to its corresponding buffer and use its parsed
+ * metadata.
+ */
 export type IParsedInitSegmentEvent<T> = ISegmentParserParsedInitSegment<T> &
                                          { segment : ISegment;
                                            type : "parsed-init"; };
 
-/** Notify that a media segment has been parsed. */
+/**
+ * Notify that a media chunk (decodable sub-part of a media segment) has been
+ * loaded and parsed.
+ *
+ * It can now be pushed to its corresponding buffer. Note that there might be
+ * multiple `IParsedSegmentEvent` for a single segment, if that segment is
+ * divided into multiple decodable chunks.
+ * You will know that all `IParsedSegmentEvent` have been loaded for a given
+ * segment once you received the `IEndOfSegmentEvent` for that segment.
+ */
 export type IParsedSegmentEvent<T> = ISegmentParserParsedSegment<T> &
                                      { segment : ISegment;
                                        type : "parsed-media"; };
 
-/** Notify that a segment has been fully-loaded. */
+/** Notify that a media or initialization segment has been fully-loaded. */
+// TODO Shouldn't that event anounce when the segment has been fully loaded AND
+// parsed? There is technically a risk here if parsing takes too much
+// (asynchronous) time leading to that event being sent before a
+// `IParsedSegmentEvent` for that same segment.
+// In that case we could have all sorts of funny issues.
 export interface IEndOfSegmentEvent { type : "end-of-segment";
                                       value: { segment : ISegment }; }
 
-/** Notify that a segment request is retried. */
+/**
+ * Notify that a media or initialization segment request is retried.
+ * This happened most likely because of an HTTP error.
+ */
 export interface ILoaderRetryEvent { type : "retry";
                                      value : { segment : ISegment;
                                                error : ICustomError; }; }
 
-/** Notify that the media segment queue is now empty. */
+/**
+ * Notify that the media segment queue is now empty.
+ * This can be used to re-check if any segment are now needed.
+ */
 export interface IEndOfQueueEvent { type : "end-of-queue"; value : null }
 
 /**
- * Items emitted through the "downloadQueue$" observable, passed to the
- * DownloadingQueue.
+ * Structure of the object that has to be emitted through the `downloadQueue$`
+ * Observable, to signal which segments are currently needed.
  */
 export interface IDownloadQueueItem {
   /**
-   * Set when an initialization segment needs to be loaded.
-   * It is generally requested in parralel of any media segment.
+   * A potential initialization segment that needs to be loaded and parsed.
+   * It will generally be requested in parralel of any media segment.
+   *
+   * Can be set to `null` if you don't need to load the initialization segment
+   * (e.g. because you already have it or because there is none here).
    */
   initSegment : IQueuedSegment | null;
 
-  /** The queue of segments currently needed for download.  */
+  /**
+   * The queue of media segments currently needed for download.
+   * Those will be loaded from the first element in that queue to the last
+   * element in it.
+   */
   segmentQueue : IQueuedSegment[];
 }
 
@@ -111,10 +143,14 @@ interface ISegmentRequestObject<T> {
 }
 
 /** Context for segments downloaded through the DownloadingQueue. */
-export interface IContent {
+export interface IDownloadingQueueContext {
+  /** Adaptation linked to the segments you want to load. */
   adaptation : Adaptation;
+  /** Manifest linked to the segments you want to load. */
   manifest : Manifest;
+  /** Period linked to the segments you want to load. */
   period : Period;
+  /** Representation linked to the segments you want to load. */
   representation : Representation;
 }
 
@@ -125,7 +161,7 @@ export interface IContent {
  */
 export default class DownloadingQueue<T> {
   /** Context of the Representation that will be loaded through this DownloadingQueue. */
-  private _content : IContent;
+  private _content : IDownloadingQueueContext;
   /**
    * DownloadingQueue Observable.
    * We only can have maximum one at a time.
@@ -157,7 +193,7 @@ export default class DownloadingQueue<T> {
    * segments.
    */
   constructor(
-    content: IContent,
+    content: IDownloadingQueueContext,
     downloadQueue$ : BehaviorSubject<IDownloadQueueItem>,
     segmentFetcher : IPrioritizedSegmentFetcher<T>
   ) {
@@ -189,6 +225,13 @@ export default class DownloadingQueue<T> {
                                                 this._mediaSegmentRequest.segment;
   }
 
+  /**
+   * Start the current downloading queue, emitting events as it loads
+   * initialization and media segments.
+   *
+   * If it was already started, returns the same - shared - Observable.
+   * @returns {Observable}
+   */
   public start() : Observable<IDownloadingQueueEvent<T>> {
     if (this._currentObs$ !== null) {
       return this._currentObs$;
@@ -374,4 +417,14 @@ export default class DownloadingQueue<T> {
         }
       })).pipe(finalize(() => { this._initSegmentRequest = null; }));
   }
+}
+
+/** Object describing a pending Segment request. */
+interface ISegmentRequestObject<T> {
+  /** The segment the request is for. */
+  segment : ISegment; // The Segment the request is for
+  /** The request Observable itself. Can be used to update its priority. */
+  request$ : Observable<IPrioritizedSegmentFetcherEvent<T>>;
+  /** Last set priority of the segment request (lower number = higher priority). */
+  priority : number; // The current priority of the request
 }

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -1,0 +1,377 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BehaviorSubject,
+  concat as observableConcat,
+  defer as observableDefer,
+  Observable,
+  of as observableOf,
+  merge as observableMerge,
+  EMPTY,
+  ReplaySubject,
+  Subject,
+} from "rxjs";
+import {
+  filter,
+  finalize,
+  map,
+  mergeMap,
+  share,
+  switchMap,
+} from "rxjs/operators";
+import { ICustomError } from "../../../errors";
+import log from "../../../log";
+import Manifest, {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../../manifest";
+import {
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
+} from "../../../transports";
+import assert from "../../../utils/assert";
+import assertUnreachable from "../../../utils/assert_unreachable";
+import objectAssign from "../../../utils/object_assign";
+import {
+  IPrioritizedSegmentFetcher,
+  IPrioritizedSegmentFetcherEvent,
+} from "../../fetchers";
+import {
+  IQueuedSegment,
+} from "../types";
+
+/** Event sent by the DownloadingQueue. */
+export type IDownloadingQueueEvent<T> = IParsedSegmentEvent<T> |
+                                        IParsedInitSegmentEvent<T> |
+                                        IEndOfSegmentEvent |
+                                        ILoaderRetryEvent |
+                                        IEndOfQueueEvent;
+
+/** Notify that the initialization segment has been parsed. */
+export type IParsedInitSegmentEvent<T> = ISegmentParserParsedInitSegment<T> &
+                                         { segment : ISegment;
+                                           type : "parsed-init"; };
+
+/** Notify that a media segment has been parsed. */
+export type IParsedSegmentEvent<T> = ISegmentParserParsedSegment<T> &
+                                     { segment : ISegment;
+                                       type : "parsed-media"; };
+
+/** Notify that a segment has been fully-loaded. */
+export interface IEndOfSegmentEvent { type : "end-of-segment";
+                                      value: { segment : ISegment }; }
+
+/** Notify that a segment request is retried. */
+export interface ILoaderRetryEvent { type : "retry";
+                                     value : { segment : ISegment;
+                                               error : ICustomError; }; }
+
+/** Notify that the media segment queue is now empty. */
+export interface IEndOfQueueEvent { type : "end-of-queue"; value : null }
+
+/**
+ * Items emitted through the "downloadQueue$" observable, passed to the
+ * DownloadingQueue.
+ */
+export interface IDownloadQueueItem {
+  /**
+   * Set when an initialization segment needs to be loaded.
+   * It is generally requested in parralel of any media segment.
+   */
+  initSegment : IQueuedSegment | null;
+
+  /** The queue of segments currently needed for download.  */
+  segmentQueue : IQueuedSegment[];
+}
+
+/** Object describing a pending Segment request. */
+interface ISegmentRequestObject<T> {
+  /** The segment the request is for. */
+  segment : ISegment;
+  /** The request Observable itself. Can be used to update its priority. */
+  request$ : Observable<IPrioritizedSegmentFetcherEvent<T>>;
+  /** Last set priority of the segment request (lower number = higher priority). */
+  priority : number;
+}
+
+/** Context for segments downloaded through the DownloadingQueue. */
+export interface IContent {
+  adaptation : Adaptation;
+  manifest : Manifest;
+  period : Period;
+  representation : Representation;
+}
+
+/**
+ * Class scheduling segment downloads for a single Representation according the given
+ * `downloadQueue$`.
+ * @class DownloadingQueue
+ */
+export default class DownloadingQueue<T> {
+  /** Context of the Representation that will be loaded through this DownloadingQueue. */
+  private _content : IContent;
+  /**
+   * DownloadingQueue Observable.
+   * We only can have maximum one at a time.
+   * `null` when `start` has never been called.
+   */
+  private _currentObs$ : Observable<IDownloadingQueueEvent<T>> | null;
+  /** Queue of segments scheduled for download. */
+  private _downloadQueue$ : BehaviorSubject<IDownloadQueueItem>;
+  /**
+   * Pending request for the initialization segment.
+   * `null` if no request is pending for it.
+   */
+  private _initSegmentRequest : ISegmentRequestObject<T>|null;
+  /**
+   * Pending request for a media (i.e. non-initialization) segment.
+   * `null` if no request is pending for it.
+   */
+  private _mediaSegmentRequest : ISegmentRequestObject<T>|null;
+  /** Interface used to load segments. */
+  private _segmentFetcher : IPrioritizedSegmentFetcher<T>;
+
+  /**
+   * Create a new DownloadingQueue.
+   * @param {Object} content - The context of the Representation you want to
+   * load segments for.
+   * @param {BehaviorSubject} downloadQueue$ - Emit the queue of segments you
+   * want to load.
+   * @param {Object} segmentFetcher - Interface to facilitate the download of
+   * segments.
+   */
+  constructor(
+    content: IContent,
+    downloadQueue$ : BehaviorSubject<IDownloadQueueItem>,
+    segmentFetcher : IPrioritizedSegmentFetcher<T>
+  ) {
+    this._content = content;
+    this._currentObs$ = null;
+    this._downloadQueue$ = downloadQueue$;
+    this._initSegmentRequest = null;
+    this._mediaSegmentRequest = null;
+    this._segmentFetcher = segmentFetcher;
+  }
+
+  /**
+   * Returns the initialization segment currently being requested.
+   * Returns `null` if no initialization segment request is pending.
+   * @returns {Object}
+   */
+  public getCurrentInitRequest() : ISegment | null {
+    return this._initSegmentRequest === null ? null :
+                                               this._initSegmentRequest.segment;
+  }
+
+  /**
+   * Returns the media segment currently being requested.
+   * Returns `null` if no media segment request is pending.
+   * @returns {Object}
+   */
+  public getCurrentMediaRequest() : ISegment | null {
+    return this._mediaSegmentRequest === null ? null :
+                                                this._mediaSegmentRequest.segment;
+  }
+
+  public start() : Observable<IDownloadingQueueEvent<T>> {
+    if (this._currentObs$ !== null) {
+      return this._currentObs$;
+    }
+    /** Emit the timescale anounced in the initialization segment once parsed. */
+    const parsedInitSegment$ = new ReplaySubject<number|undefined>(1);
+    const obs = observableDefer(() => {
+      const mediaQueue$ = this._downloadQueue$.pipe(
+        filter(({ segmentQueue }) => {
+          const currentSegmentRequest = this._mediaSegmentRequest;
+          if (segmentQueue.length === 0) {
+            return currentSegmentRequest !== null;
+          } else if (currentSegmentRequest === null) {
+            return true;
+          }
+          if (currentSegmentRequest.segment.id !== segmentQueue[0].segment.id) {
+            return true;
+          }
+          if (currentSegmentRequest.priority !== segmentQueue[0].priority) {
+            this._segmentFetcher.updatePriority(currentSegmentRequest.request$,
+                                                segmentQueue[0].priority);
+          }
+          return false;
+        }),
+        switchMap(({ segmentQueue }) =>
+          segmentQueue.length > 0 ? this._requestMediaSegments(parsedInitSegment$) :
+                                    EMPTY));
+
+      const initSegmentPush$ = this._downloadQueue$.pipe(
+        filter((next) => {
+          const initSegmentRequest = this._initSegmentRequest;
+          if (next.initSegment !== null && initSegmentRequest !== null) {
+            if (next.initSegment.priority !== initSegmentRequest.priority) {
+              this._segmentFetcher.updatePriority(initSegmentRequest.request$,
+                                                  next.initSegment.priority);
+            }
+            return false;
+          } else {
+            return next.initSegment === null || initSegmentRequest === null;
+          }
+        }),
+        switchMap((nextQueue) => {
+          if (nextQueue.initSegment === null) {
+            return EMPTY;
+          }
+          return this._requestInitSegment(nextQueue.initSegment, parsedInitSegment$);
+        }));
+
+      return observableMerge(initSegmentPush$, mediaQueue$);
+    }).pipe(share());
+
+    this._currentObs$ = obs;
+
+    return obs;
+  }
+
+  /**
+   * @param {BehaviorSubject} parsedInitSegment$
+   * @returns {Observable}
+   */
+  private _requestMediaSegments(
+    parsedInitSegment$ : Subject<number|undefined>
+  ) : Observable<IDownloadingQueueEvent<T>> {
+    const { segmentQueue } = this._downloadQueue$.getValue();
+    const currentNeededSegment = segmentQueue[0];
+    const recursivelyRequestSegments = (
+      startingSegment : IQueuedSegment | undefined
+    ) : Observable<IDownloadingQueueEvent<T>> => {
+      if (startingSegment === undefined) {
+        return observableOf({ type : "end-of-queue",
+                              value : null });
+      }
+      const { segment, priority } = startingSegment;
+      const context = objectAssign({ segment }, this._content);
+      const request$ = this._segmentFetcher.createRequest(context, priority);
+
+      this._mediaSegmentRequest = { segment, priority, request$ };
+      return request$
+        .pipe(mergeMap((evt) : Observable<IDownloadingQueueEvent<T>> => {
+          switch (evt.type) {
+            case "warning":
+              return observableOf({ type: "retry" as const,
+                                    value: { segment, error: evt.value } });
+            case "interrupted":
+              log.info("Stream: segment request interrupted temporarly.", segment);
+              return EMPTY;
+
+            case "ended":
+              this._mediaSegmentRequest = null;
+              const lastQueue = this._downloadQueue$.getValue().segmentQueue;
+              if (lastQueue.length === 0) {
+                return observableOf({ type : "end-of-queue",
+                                      value : null });
+              } else if (lastQueue[0].segment.id === segment.id) {
+                lastQueue.shift();
+              }
+              return recursivelyRequestSegments(lastQueue[0]);
+
+            case "chunk":
+            case "chunk-complete":
+              return parsedInitSegment$.pipe(
+                map((initTimescale) => {
+                  if (evt.type === "chunk-complete") {
+                    return { type: "end-of-segment" as const,
+                             value: { segment } };
+                  }
+                  const parsed = evt.parse(initTimescale);
+                  assert(parsed.segmentType === "media",
+                         "Should have loaded a media segment.");
+                  return objectAssign({},
+                                      parsed,
+                                      { type: "parsed-media" as const,
+                                        segment });
+                }));
+
+            default:
+              assertUnreachable(evt);
+          }
+        }));
+    };
+
+    return observableDefer(() =>
+      recursivelyRequestSegments(currentNeededSegment)
+    ).pipe(finalize(() => { this._mediaSegmentRequest = null; }));
+  }
+
+  /**
+   * @param {Object} queuedInitSegment
+   * @param {BehaviorSubject} parsedInitSegment$
+   * @returns {Observable}
+   */
+  private _requestInitSegment(
+    queuedInitSegment : IQueuedSegment | null,
+    parsedInitSegment$ : Subject<number | undefined>
+  ) : Observable<IDownloadingQueueEvent<T>> {
+    if (queuedInitSegment === null) {
+      this._initSegmentRequest = null;
+      return EMPTY;
+    }
+    const { segment, priority } = queuedInitSegment;
+    const context = objectAssign({ segment }, this._content);
+    const request$ = this._segmentFetcher.createRequest(context, priority);
+
+    this._initSegmentRequest = { segment, priority, request$ };
+    return request$
+      .pipe(mergeMap((evt) : Observable<IDownloadingQueueEvent<T>> => {
+        switch (evt.type) {
+          case "warning":
+            return observableOf({ type: "retry" as const,
+                                  value: { segment, error: evt.value } });
+          case "interrupted":
+            log.info("Stream: init segment request interrupted temporarly.", segment);
+            return EMPTY;
+
+          case "chunk":
+            const parsed = evt.parse(undefined);
+            assert(parsed.segmentType === "init",
+                   "Should have loaded an init segment.");
+            return observableConcat(
+              observableOf(objectAssign({},
+                                        parsed,
+                                        { type: "parsed-init" as const,
+                                          segment })),
+
+              // We want to emit parsing information strictly AFTER the
+              // initialization segment is emitted. Hence why we perform this
+              // side-effect a posteriori in a concat operator
+              observableDefer(() => {
+                if (parsed.segmentType === "init") {
+                  parsedInitSegment$.next(parsed.initTimescale);
+                }
+                return EMPTY;
+              }));
+
+          case "chunk-complete":
+            return observableOf({ type: "end-of-segment" as const,
+                                  value: { segment } });
+
+          case "ended":
+            return EMPTY; // Do nothing, just here to check every case
+          default:
+            assertUnreachable(evt);
+        }
+      })).pipe(finalize(() => { this._initSegmentRequest = null; }));
+  }
+}

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -27,7 +27,7 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../manifest";
-import { ISegmentParserSegmentPayload } from "../../../transports";
+import { ISegmentParserParsedSegment } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
 import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
@@ -56,7 +56,7 @@ export default function pushMediaSegment<T>(
                                    period : Period;
                                    representation : Representation; };
                         initSegmentData : T | null;
-                        parsedSegment : ISegmentParserSegmentPayload<T>;
+                        parsedSegment : ISegmentParserParsedSegment<T>;
                         segment : ISegment;
                         segmentBuffer : SegmentBuffer<T>; }
 ) : Observable< IStreamEventAddedSegment<T> > {

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -27,7 +27,7 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../manifest";
-import { ISegmentParserParsedSegment } from "../../../transports";
+import { ISegmentParserSegmentPayload } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
 import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
@@ -56,7 +56,7 @@ export default function pushMediaSegment<T>(
                                    period : Period;
                                    representation : Representation; };
                         initSegmentData : T | null;
-                        parsedSegment : ISegmentParserParsedSegment<T>;
+                        parsedSegment : ISegmentParserSegmentPayload<T>;
                         segment : ISegment;
                         segmentBuffer : SegmentBuffer<T>; }
 ) : Observable< IStreamEventAddedSegment<T> > {

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -110,3 +110,4 @@ export default function pushMediaSegment<T>(
       }));
   });
 }
+

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -119,7 +119,7 @@ export interface ITerminationOrder {
 }
 
 /** Arguments to give to the RepresentationStream. */
-export interface IRepresentationStreamArguments<T> {
+export interface IRepresentationStreamArguments<TSegmentDataType> {
   /** Periodically emits the current playback conditions. */
   clock$ : Observable<IRepresentationStreamClockTick>;
   /** The context of the Representation you want to load. */
@@ -128,9 +128,9 @@ export interface IRepresentationStreamArguments<T> {
              period : Period;
              representation : Representation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
-  segmentBuffer : SegmentBuffer<T>;
+  segmentBuffer : SegmentBuffer<TSegmentDataType>;
   /** Interface used to load new segments. */
-  segmentFetcher : IPrioritizedSegmentFetcher<T>;
+  segmentFetcher : IPrioritizedSegmentFetcher<TSegmentDataType>;
   /**
    * Observable emitting when the RepresentationStream should "terminate".
    *
@@ -218,7 +218,7 @@ export default function RepresentationStream<T>({
    * Saved initialization segment state for this representation.
    * `null` if the initialization segment hasn't been loaded yet.
    */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T> | null =
+  let initSegmentObject : ISegmentParserParsedInitSegment<T | null> | null =
     initSegment === null ? { segmentType: "init",
                              initializationData: null,
                              protectionDataUpdate: false,

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -38,7 +38,6 @@ import {
 import {
   finalize,
   ignoreElements,
-  map,
   mergeMap,
   share,
   startWith,
@@ -57,7 +56,7 @@ import Manifest, {
 } from "../../../manifest";
 import {
   ISegmentParserInitSegment,
-  ISegmentParserParsedInitSegment,
+  ISegmentParserInitSegmentPayload,
   ISegmentParserSegment,
 } from "../../../transports";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -254,7 +253,7 @@ export default function RepresentationStream<T>({
    * Saved initialization segment state for this representation.
    * `null` if the initialization segment hasn't been loaded yet.
    */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T> | null =
+  let initSegmentObject : ISegmentParserInitSegmentPayload<T> | null =
     initSegment === null ? { initializationData: null,
                              protectionDataUpdate: false,
                              initTimescale: undefined } :
@@ -461,9 +460,8 @@ export default function RepresentationStream<T>({
 
               case "chunk":
                 const initTimescale = initSegmentObject?.initTimescale;
-                return evt.parse(initTimescale).pipe(map(parserResponse => {
-                  return objectAssign({ segment }, parserResponse);
-                }));
+                const parsed = evt.parse(initTimescale);
+                return observableOf(objectAssign({ segment }, parsed));
 
               case "ended":
                 return requestNextSegment$;

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -25,6 +25,7 @@
 
 import nextTick from "next-tick";
 import {
+  BehaviorSubject,
   combineLatest as observableCombineLatest,
   concat as observableConcat,
   defer as observableDefer,
@@ -36,17 +37,14 @@ import {
   Subject,
 } from "rxjs";
 import {
-  finalize,
   ignoreElements,
   mergeMap,
   share,
   startWith,
-  switchMap,
   take,
   takeWhile,
   withLatestFrom,
 } from "rxjs/operators";
-import { ICustomError } from "../../../errors";
 import log from "../../../log";
 import Manifest, {
   Adaptation,
@@ -54,16 +52,11 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../manifest";
-import {
-  ISegmentParserParsedInitSegment,
-  ISegmentParserParsedSegment,
-} from "../../../transports";
 import assertUnreachable from "../../../utils/assert_unreachable";
 import objectAssign from "../../../utils/object_assign";
 import { IStalledStatus } from "../../api";
 import {
   IPrioritizedSegmentFetcher,
-  IPrioritizedSegmentFetcherEvent,
   ISegmentFetcherWarning,
 } from "../../fetchers";
 import { SegmentBuffer } from "../../segment_buffers";
@@ -79,6 +72,12 @@ import {
   IStreamTerminatingEvent,
   IInbandEventsEvent,
 } from "../types";
+import DownloadingQueue, {
+  IDownloadingQueueEvent,
+  IDownloadQueueItem,
+  IParsedInitSegmentEvent,
+  IParsedSegmentEvent,
+} from "./downloading_queue";
 import getBufferStatus from "./get_buffer_status";
 import getSegmentPriority from "./get_segment_priority";
 import pushInitSegment from "./push_init_segment";
@@ -190,6 +189,22 @@ export interface IRepresentationStreamOptions {
 }
 
 /**
+ * Information about the initialization segment linked to the Representation
+ * which the RepresentationStream try to download segments for.
+ */
+interface IInitSegmentState<T> {
+  /**
+   * Segment Object describing that initialization segment.
+   * `null` if there's no initialization segment for that Representation.
+   */
+  segment : ISegment | null;
+  /** Initialization segment data, once loaded.  */
+  segmentData$ : ReplaySubject<T | null>;
+  /** `true` if the initialization segment has been loaded and parsed. */
+  isLoaded : boolean;
+}
+
+/**
  * Build up buffer for a single Representation.
  *
  * Download and push segments linked to the given Representation according
@@ -209,44 +224,48 @@ export default function RepresentationStream<T>({
   terminate$,
   options,
 } : IRepresentationStreamArguments<T>) : Observable<IRepresentationStreamEvent<T>> {
-  const { manifest, period, adaptation, representation } = content;
+  const { period, adaptation, representation } = content;
   const { bufferGoal$, drmSystemId, fastSwitchThreshold$ } = options;
   const bufferType = adaptation.type;
-  const initSegment = representation.index.getInitSegment();
 
-  /**
-   * Saved initialization segment state for this representation.
-   * `null` if the initialization segment hasn't been loaded yet.
-   */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T | null> | null =
-    initSegment === null ? { segmentType: "init",
-                             initializationData: null,
-                             protectionDataUpdate: false,
-                             initTimescale: undefined } :
-                           null;
+  /** Saved initialization segment state for this representation. */
+  const initSegmentState : IInitSegmentState<T> = {
+    segment: representation.index.getInitSegment(),
+    segmentData$: new ReplaySubject<T | null>(1),
+    isLoaded: false,
+  };
 
-  /** Segments queued for download in this RepresentationStream. */
-  let downloadQueue : IQueuedSegment[] = [];
+  if (initSegmentState.segment === null) {
+    // There's no init segment here, we can bypass loading it and parsing it
+    initSegmentState.segmentData$.next(null);
+    initSegmentState.isLoaded = true;
+  }
 
-  /** Emit to start/restart a downloading Queue. */
-  const startDownloadingQueue$ = new ReplaySubject<void>(1);
-
-  /** Emit when the RepresentationStream asks to re-check which segments are needed. */
+  /** Allows to manually re-check which segments are needed. */
   const reCheckNeededSegments$ = new Subject<void>();
 
-  /**
-   * Keep track of the information about the pending segment request.
-   * `null` if no segment request is pending in that RepresentationStream.
-   */
-  let currentSegmentRequest : ISegmentRequestObject<T>|null = null;
+  /** Emit the last scheduled downloading queue for segments. */
+  const lastSegmentQueue$ =
+    new BehaviorSubject<IDownloadQueueItem>({ initSegment: null,
+                                              segmentQueue: [] });
 
+  /** Will load every segments in `lastSegmentQueue$` */
+  const downloadingQueue = new DownloadingQueue(content,
+                                                lastSegmentQueue$,
+                                                segmentFetcher);
+
+  /** Observable loading and pushing segments scheduled through `lastSegmentQueue$`. */
+  const queue$ = downloadingQueue.start()
+    .pipe(mergeMap(onQueueEvent));
+
+  /** Observable emitting the stream "status" and filling `lastSegmentQueue$`. */
   const status$ = observableCombineLatest([
     clock$,
     bufferGoal$,
     terminate$.pipe(take(1),
                     startWith(null)),
-    reCheckNeededSegments$.pipe(startWith(undefined)) ]
-  ).pipe(
+    reCheckNeededSegments$.pipe(startWith(undefined)),
+  ]).pipe(
     withLatestFrom(fastSwitchThreshold$),
     mergeMap(function (
       [ [ tick, bufferGoal, terminate ],
@@ -262,78 +281,61 @@ export default function RepresentationStream<T>({
                                      segmentBuffer);
       const { neededSegments } = status;
 
+      // XXX TODO
+      let neededInitSegment : IQueuedSegment | null = null;
+
       // Add initialization segment if required
       if (!representation.index.isInitialized()) {
-        if (initSegment === null) {
+        if (initSegmentState.segment === null) {
           log.warn("Stream: Uninitialized index without an initialization segment");
-        } else if (initSegmentObject !== null) {
+        } else if (initSegmentState.isLoaded) {
           log.warn("Stream: Uninitialized index with an already loaded " +
                    "initialization segment");
         } else {
-          neededSegments.unshift({ segment: initSegment,
-                                   priority: getSegmentPriority(period.start, tick) });
+          neededInitSegment = { segment: initSegmentState.segment,
+                                priority: getSegmentPriority(period.start, tick) };
         }
       } else if (neededSegments.length > 0 &&
-                 initSegment !== null &&
-                 initSegmentObject === null)
+                 !initSegmentState.isLoaded &&
+                 initSegmentState.segment !== null)
       {
         // prepend initialization segment
         const initSegmentPriority = neededSegments[0].priority;
-        neededSegments.unshift({ segment: initSegment,
-                                 priority: initSegmentPriority });
+        neededInitSegment = { segment: initSegmentState.segment,
+                              priority: initSegmentPriority };
       }
 
       const mostNeededSegment = neededSegments[0];
+      const initSegmentRequest = downloadingQueue.getCurrentInitRequest();
+      const currentSegmentRequest = downloadingQueue.getCurrentMediaRequest();
 
-      if (terminate !== null) {
-        downloadQueue = [];
-        if (terminate.urgent) {
-          log.debug("Stream: urgent termination request, terminate.", bufferType);
-          startDownloadingQueue$.next(); // interrupt current requests
-          startDownloadingQueue$.complete(); // complete the downloading queue
-          return observableOf(EVENTS.streamTerminating());
-        } else if (
-          currentSegmentRequest === null ||
-          mostNeededSegment === undefined ||
-          currentSegmentRequest.segment.id !== mostNeededSegment.segment.id
-        ) {
-          log.debug("Stream: cancel request and terminate.",
-                    currentSegmentRequest === null,
-                    bufferType);
-          startDownloadingQueue$.next(); // interrupt the current request
-          startDownloadingQueue$.complete(); // complete the downloading queue
-          return observableOf(EVENTS.streamTerminating());
-        } else if (currentSegmentRequest.priority !== mostNeededSegment.priority) {
-          const { request$ } = currentSegmentRequest;
-          currentSegmentRequest.priority = mostNeededSegment.priority;
-          segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
-        }
-        log.debug("Stream: terminate after request.", bufferType);
-      } else if (mostNeededSegment === undefined) {
-        if (currentSegmentRequest !== null) {
-          log.debug("Stream: interrupt segment request.", bufferType);
-        }
-        downloadQueue = [];
-        startDownloadingQueue$.next(); // (re-)start with an empty queue
-      } else if (currentSegmentRequest === null) {
-        log.debug("Stream: start downloading queue.", bufferType);
-        downloadQueue = neededSegments;
-        startDownloadingQueue$.next(); // restart the queue
-      } else if (currentSegmentRequest.segment.id !== mostNeededSegment.segment.id) {
-        log.debug("Stream: restart download queue.", bufferType);
-        downloadQueue = neededSegments;
-        startDownloadingQueue$.next(); // restart the queue
-      } else if (currentSegmentRequest.priority !== mostNeededSegment.priority) {
-        log.debug("Stream: update request priority.", bufferType);
-        const { request$ } = currentSegmentRequest;
-        currentSegmentRequest.priority = mostNeededSegment.priority;
-        segmentFetcher.updatePriority(request$, mostNeededSegment.priority);
+      if (terminate === null) {
+        lastSegmentQueue$.next({ initSegment: neededInitSegment,
+                                 segmentQueue: neededSegments });
       } else {
-        log.debug("Stream: update downloading queue", bufferType);
+        const { urgent } = terminate;
+        if (urgent) {
+          log.debug("Stream: Urgent switch, terminate now.", bufferType);
+          lastSegmentQueue$.next({ initSegment: null, segmentQueue: [] });
+          lastSegmentQueue$.complete();
+          return observableOf(EVENTS.streamTerminating());
+        } else {
+          const nextQueue = currentSegmentRequest === null ||
+                            mostNeededSegment === undefined ||
+                            currentSegmentRequest.id !== mostNeededSegment.segment.id ?
+            [] :
+            [mostNeededSegment];
 
-        // Update the previous queue to be all needed segments but the first one,
-        // for which a request is already pending
-        downloadQueue = neededSegments.slice().splice(1, neededSegments.length);
+          const nextInit = initSegmentRequest === null ? null :
+                                                         neededInitSegment;
+          lastSegmentQueue$.next({ initSegment: nextInit,
+                                   segmentQueue: nextQueue });
+          if (nextQueue.length === 0 && nextInit === null) {
+            log.debug("Stream: No request left, terminate", bufferType);
+            lastSegmentQueue$.complete();
+            return observableOf(EVENTS.streamTerminating());
+          }
+        }
       }
 
       const bufferStatusEvt : Observable<IStreamStatusEvent> =
@@ -368,89 +370,15 @@ export default function RepresentationStream<T>({
       hasSentEncryptionData = true;
     }
   }
+  return observableMerge(status$, queue$, encryptionEvent$).pipe(share());
 
   /**
-   * Stream Queue:
-   *   - download every segments queued sequentially
-   *   - when a segment is loaded, append it to the SegmentBuffer
-   */
-  const streamQueue$ = startDownloadingQueue$.pipe(
-    switchMap(() => downloadQueue.length > 0 ? loadSegmentsFromQueue() : EMPTY),
-    mergeMap(onLoaderEvent));
-
-  return observableConcat(encryptionEvent$,
-                          observableMerge(status$, streamQueue$).pipe(share()));
-
-  /**
-   * Request every Segment in the ``downloadQueue`` on subscription.
-   * Emit the data of a segment when a request succeeded.
-   *
-   * Important side-effects:
-   *   - Mutates `currentSegmentRequest` when doing and finishing a request.
-   *   - Will emit from reCheckNeededSegments$ Subject when it's done.
-   *
-   * Might emit warnings when a request is retried.
-   *
-   * Throws when the request will not be retried (configuration or un-retryable
-   * error).
-   * @returns {Observable}
-   */
-  function loadSegmentsFromQueue() : Observable<ISegmentLoadingEvent<T>> {
-    const requestNextSegment$ =
-      observableDefer(() : Observable<ISegmentLoadingEvent<T>> => {
-        const currentNeededSegment = downloadQueue.shift();
-        if (currentNeededSegment === undefined) {
-          nextTick(() => { reCheckNeededSegments$.next(); });
-          return EMPTY;
-        }
-
-        const { segment, priority } = currentNeededSegment;
-        const context = { manifest, period, adaptation, representation, segment };
-        const request$ = segmentFetcher.createRequest(context, priority);
-
-        currentSegmentRequest = { segment, priority, request$ };
-        return request$
-          .pipe(mergeMap((evt) : Observable<ISegmentLoadingEvent<T>> => {
-            switch (evt.type) {
-              case "warning":
-                return observableOf({ type: "retry" as const,
-                                      segment,
-                                      error: evt.value });
-              case "chunk-complete":
-                currentSegmentRequest = null;
-                return observableOf({ type: "end-of-segment", segment });
-
-              case "interrupted":
-                log.info("Stream: segment request interrupted temporarly.", segment);
-                return EMPTY;
-
-              case "chunk":
-                const initTimescale = initSegmentObject?.initTimescale;
-                const parsed = evt.parse(initTimescale);
-                return observableOf({ type: "parsed",
-                                      segment,
-                                      payload: parsed });
-
-              case "ended":
-                return requestNextSegment$;
-
-              default:
-                assertUnreachable(evt);
-            }
-          }));
-      });
-
-    return requestNextSegment$
-      .pipe(finalize(() => { currentSegmentRequest = null; }));
-  }
-
-  /**
-   * React to event from `loadSegmentsFromQueue`.
+   * React to event from the `DownloadingQueue`.
    * @param {Object} evt
    * @returns {Observable}
    */
-  function onLoaderEvent(
-    evt : ISegmentLoadingEvent<T>
+  function onQueueEvent(
+    evt : IDownloadingQueueEvent<T>
   ) : Observable<IStreamEventAddedSegment<T> |
                  ISegmentFetcherWarning |
                  IEncryptionDataEncounteredEvent |
@@ -461,26 +389,31 @@ export default function RepresentationStream<T>({
     switch (evt.type) {
       case "retry":
         return observableConcat(
-          observableOf({ type: "warning" as const, value: evt.error }),
+          observableOf({ type: "warning" as const, value: evt.value.error }),
           observableDefer(() => { // better if done after warning is emitted
-            const retriedSegment = evt.segment;
+            const retriedSegment = evt.value.segment;
             const { index } = representation;
             if (index.isSegmentStillAvailable(retriedSegment) === false) {
               reCheckNeededSegments$.next();
-            } else if (index.canBeOutOfSyncError(evt.error, retriedSegment)) {
+            } else if (index.canBeOutOfSyncError(evt.value.error, retriedSegment)) {
               return observableOf(EVENTS.manifestMightBeOufOfSync());
             }
             return EMPTY; // else, ignore.
           }));
 
-      case "parsed":
+      case "parsed-init":
+      case "parsed-media":
         return onParsedChunk(evt);
 
       case "end-of-segment": {
-        const { segment } = evt;
+        const { segment } = evt.value;
         return segmentBuffer.endOfSegment(objectAssign({ segment }, content))
           .pipe(ignoreElements());
       }
+
+      case "end-of-queue":
+        reCheckNeededSegments$.next();
+        return EMPTY;
 
       default:
         assertUnreachable(evt);
@@ -494,16 +427,20 @@ export default function RepresentationStream<T>({
    * @returns {Observable}
    */
   function onParsedChunk(
-    evt : IParsedSegmentEvent<T>
+    evt : IParsedInitSegmentEvent<T> |
+          IParsedSegmentEvent<T>
   ) : Observable<IStreamEventAddedSegment<T> |
                  IEncryptionDataEncounteredEvent |
                  IInbandEventsEvent |
                  IStreamNeedsManifestRefresh |
                  IStreamManifestMightBeOutOfSync>
   {
-    const parsed = evt.payload;
-    if (parsed.segmentType === "init") {
-      initSegmentObject = parsed;
+    if (evt.segmentType === "init") {
+      nextTick(() => {
+        reCheckNeededSegments$.next();
+      });
+      initSegmentState.segmentData$.next(evt.initializationData);
+      initSegmentState.isLoaded = true;
 
       // Now that the initialization segment has been parsed - which may have
       // included encryption information - take care of the encryption event
@@ -517,15 +454,14 @@ export default function RepresentationStream<T>({
       const pushEvent$ = pushInitSegment({ clock$,
                                            content,
                                            segment: evt.segment,
-                                           segmentData: parsed.initializationData,
+                                           segmentData: evt.initializationData,
                                            segmentBuffer });
       return observableMerge(initEncEvt$, pushEvent$);
 
     } else {
-      const initSegmentData = initSegmentObject?.initializationData ?? null;
       const { inbandEvents,
               needsManifestRefresh,
-              protectionDataUpdate } = parsed;
+              protectionDataUpdate } = evt;
 
       // TODO better handle use cases like key rotation by not always grouping
       // every protection data together? To check.
@@ -543,45 +479,21 @@ export default function RepresentationStream<T>({
         observableOf({ type: "inband-events" as const,
                        value: inbandEvents }) :
         EMPTY;
+
+      const pushMediaSegment$ = initSegmentState.segmentData$
+        .pipe(mergeMap((initSegmentData) =>
+          pushMediaSegment({ clock$,
+                             content,
+                             initSegmentData,
+
+                             // XXX TODO
+                             parsedSegment: evt,
+                             segment: evt.segment,
+                             segmentBuffer })));
       return observableConcat(segmentEncryptionEvent$,
                               manifestRefresh$,
                               inbandEvents$,
-                              pushMediaSegment({ clock$,
-                                                 content,
-                                                 initSegmentData,
-                                                 parsedSegment: parsed,
-                                                 segment: evt.segment,
-                                                 segmentBuffer }));
+                              pushMediaSegment$);
     }
   }
-}
-
-/** Internal event used to notify that a chunk has just been parsed. */
-interface IParsedSegmentEvent<T> { type: "parsed";
-                                   payload: ISegmentParserParsedInitSegment<T> |
-                                            ISegmentParserParsedSegment<T>;
-                                   segment : ISegment; }
-
-/** Internal event used to notify that a segment has been fully-loaded. */
-interface IEndOfSegmentEvent { type : "end-of-segment";
-                               segment : ISegment; }
-
-/** Internal event used to notify that a segment request is retried. */
-interface ILoaderRetryEvent { type : "retry";
-                              segment : ISegment;
-                              error : ICustomError; }
-
-/** Internal event sent when loading a segment. */
-type ISegmentLoadingEvent<T> = IParsedSegmentEvent<T> |
-                               IEndOfSegmentEvent |
-                               ILoaderRetryEvent;
-
-/** Object describing a pending Segment request. */
-interface ISegmentRequestObject<T> {
-  /** The segment the request is for. */
-  segment : ISegment; // The Segment the request is for
-  /** The request Observable itself. Can be used to update its priority. */
-  request$ : Observable<IPrioritizedSegmentFetcherEvent<T>>;
-  /** Last set priority of the segment request (lower number = higher priority). */
-  priority : number; // The current priority of the request
 }

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -448,7 +448,6 @@ export default function RepresentationStream<T>({
       nextTick(() => {
         reCheckNeededSegments$.next();
       });
-      console.warn("III", evt.segment.mediaURLs?.[0]);
       initSegmentState.segmentData = evt.initializationData;
       initSegmentState.isLoaded = true;
 
@@ -473,7 +472,6 @@ export default function RepresentationStream<T>({
               needsManifestRefresh,
               protectionDataUpdate } = evt;
 
-      console.warn("OOO", evt.segment.mediaURLs?.[0]);
       // TODO better handle use cases like key rotation by not always grouping
       // every protection data together? To check.
       const segmentEncryptionEvent$ = protectionDataUpdate &&

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -306,8 +306,8 @@ export default function RepresentationStream<T>({
       }
 
       const mostNeededSegment = neededSegments[0];
-      const initSegmentRequest = downloadingQueue.getCurrentInitRequest();
-      const currentSegmentRequest = downloadingQueue.getCurrentMediaRequest();
+      const initSegmentRequest = downloadingQueue.getRequestedInitSegment();
+      const currentSegmentRequest = downloadingQueue.getRequestedMediaSegment();
 
       if (terminate === null) {
         lastSegmentQueue$.next({ initSegment: neededInitSegment,

--- a/src/experimental/tools/VideoThumbnailLoader/types.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/types.ts
@@ -33,5 +33,4 @@ export type ILoaders = Partial<Record<string, ITransportPipelines>>;
 
 export type IThumbnailLoaderSegmentParser =
   ISegmentParser<Uint8Array | ArrayBuffer | null,
-                 Uint8Array | ArrayBuffer | null,
                  Uint8Array | ArrayBuffer | null>;

--- a/src/transports/README.md
+++ b/src/transports/README.md
@@ -130,12 +130,16 @@ Its concept can be illustrated as such:
                              +--------+
 ```
 
-The parser returns an Observable which will emit the parsed resource when done.
+Depending on the type of parser (e.g. Manifest parser or segment parser), that
+task can be synchronous or asynchronous.
 
-This Observable will throw if the resource is corrupted or miss crucial
-information.
+In asynchronous cases, the parser will return an Observable emitting a unique
+time the result when done and throwing if an error is encountered.
 
-[1] the parser could also need to perform requests (e.g. it needs to fetch the
+In synchronous cases, the parser returns directly the result, and can throw
+directly when/if an error is encountered.
+
+[1] a parser could also need to perform requests (e.g. it needs to fetch the
 current time from a server).
 In such cases, the parser is given a special callback, which allows it to
 receive the same error-handling perks than a loader, such as multiple retries,

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -35,8 +35,8 @@ export default function addSegmentIntegrityChecks(
   segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 ) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null>;
 export default function addSegmentIntegrityChecks(
-  segmentLoader : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
-) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
+  segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
+) : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 {
   return (content) => segmentLoader(content).pipe(tap((res) => {
     if ((res.type === "data-loaded" || res.type === "data-chunk") &&

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -55,17 +55,17 @@ export function imageLoader(
 export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<IImageTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<IImageTrackSegmentData>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;
 
   if (content.segment.isInit) { // image init segment has no use
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: undefined } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: undefined } };
   }
 
   if (isChunked) {
@@ -76,27 +76,26 @@ export function imageParser(
 
   // TODO image Parsing should be more on the buffer side, no?
   if (data === null || features.imageParser === null) {
-    return observableOf({ type: "parsed-segment",
-                          value: { chunkData: null,
-                                   chunkInfos: { duration: segment.duration,
-                                                 time: segment.time },
-                                   chunkOffset,
-                                   appendWindow: [period.start, period.end],
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-segment",
+             value: { chunkData: null,
+                      chunkInfos: { duration: segment.duration,
+                                    time: segment.time },
+                      chunkOffset,
+                      appendWindow: [period.start, period.end],
+                      protectionDataUpdate: false } };
   }
 
   const bifObject = features.imageParser(new Uint8Array(data));
   const thumbsData = bifObject.thumbs;
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData: { data: thumbsData,
-                                              start: 0,
-                                              end: Number.MAX_VALUE,
-                                              timescale: 1,
-                                              type: "bif" },
-                                 chunkInfos: { time: 0,
-                                               duration: Number.MAX_VALUE,
-                                               timescale: bifObject.timescale },
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData: { data: thumbsData,
+                                 start: 0,
+                                 end: Number.MAX_VALUE,
+                                 timescale: 1,
+                                 type: "bif" },
+                    chunkInfos: { time: 0,
+                                  duration: Number.MAX_VALUE },
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -26,8 +26,8 @@ import {
   ISegmentLoaderArguments,
   ISegmentLoaderEvent,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
 } from "../types";
 
 /**
@@ -55,17 +55,17 @@ export function imageLoader(
 export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-) : ISegmentParserInitSegment<null> |
-    ISegmentParserSegment<IImageTrackSegmentData>
+) : ISegmentParserParsedInitSegment<null> |
+    ISegmentParserParsedSegment<IImageTrackSegmentData>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;
 
   if (content.segment.isInit) { // image init segment has no use
-    return { type: "parsed-init-segment",
-             value: { initializationData: null,
-                      protectionDataUpdate: false,
-                      initTimescale: undefined } };
+    return { segmentType: "init",
+             initializationData: null,
+             protectionDataUpdate: false,
+             initTimescale: undefined };
   }
 
   if (isChunked) {
@@ -76,26 +76,26 @@ export function imageParser(
 
   // TODO image Parsing should be more on the buffer side, no?
   if (data === null || features.imageParser === null) {
-    return { type: "parsed-segment",
-             value: { chunkData: null,
-                      chunkInfos: { duration: segment.duration,
-                                    time: segment.time },
-                      chunkOffset,
-                      appendWindow: [period.start, period.end],
-                      protectionDataUpdate: false } };
+    return { segmentType: "media",
+             chunkData: null,
+             chunkInfos: { duration: segment.duration,
+                           time: segment.time },
+             chunkOffset,
+             protectionDataUpdate: false,
+             appendWindow: [period.start, period.end] };
   }
 
   const bifObject = features.imageParser(new Uint8Array(data));
   const thumbsData = bifObject.thumbs;
-  return { type: "parsed-segment",
-           value: { chunkData: { data: thumbsData,
-                                 start: 0,
-                                 end: Number.MAX_VALUE,
-                                 timescale: 1,
-                                 type: "bif" },
-                    chunkInfos: { time: 0,
-                                  duration: Number.MAX_VALUE },
-                    chunkOffset,
-                    protectionDataUpdate: false,
-                    appendWindow: [period.start, period.end] } };
+  return { segmentType: "media",
+           chunkData: { data: thumbsData,
+                        start: 0,
+                        end: Number.MAX_VALUE,
+                        timescale: 1,
+                        type: "bif" },
+           chunkInfos: { time: 0,
+                         duration: Number.MAX_VALUE },
+           chunkOffset,
+           protectionDataUpdate: false,
+           appendWindow: [period.start, period.end] };
 }

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -56,7 +56,7 @@ export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<IImageTrackSegmentData>
+    ISegmentParserParsedSegment<IImageTrackSegmentData | null>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
-import {
   getMDHDTimescale,
   getSegmentsFromSidx,
   takePSSHOut,
@@ -53,25 +49,25 @@ export default function generateAudioVideoSegmentParser(
       initTimescale } : ISegmentParserArguments< Uint8Array |
                                                  ArrayBuffer |
                                                  null >
-  ) : Observable<ISegmentParserInitSegment<Uint8Array | ArrayBuffer | null> |
-                 ISegmentParserSegment< Uint8Array | ArrayBuffer | null>> {
+  ) : ISegmentParserInitSegment<Uint8Array | ArrayBuffer | null> |
+      ISegmentParserSegment< Uint8Array | ArrayBuffer | null> {
     const { period, adaptation, representation, segment, manifest } = content;
     const { data, isChunked } = response;
     const appendWindow : [number, number | undefined] = [ period.start, period.end ];
 
     if (data === null) {
       if (segment.isInit) {
-        return observableOf({ type: "parsed-init-segment" as const,
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment" as const,
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
-      return observableOf({ type: "parsed-segment" as const,
-                            value: { chunkData: null,
-                                     chunkInfos: null,
-                                     chunkOffset: 0,
-                                     appendWindow,
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment" as const,
+               value: { chunkData: null,
+                        chunkInfos: null,
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow } };
     }
 
     const chunkData = data instanceof Uint8Array ? data :
@@ -112,24 +108,24 @@ export default function generateAudioVideoSegmentParser(
                                              manifest.publishTime);
           if (events !== undefined) {
             const { needsManifestRefresh, inbandEvents } = events;
-            return observableOf({ type: "parsed-segment",
-                                  value: { chunkData,
-                                           chunkInfos,
-                                           chunkOffset,
-                                           appendWindow,
-                                           inbandEvents,
-                                           needsManifestRefresh,
-                                           protectionDataUpdate } });
+            return { type: "parsed-segment",
+                     value: { chunkData,
+                              chunkInfos,
+                              chunkOffset,
+                              appendWindow,
+                              inbandEvents,
+                              protectionDataUpdate,
+                              needsManifestRefresh } };
           }
         }
       }
 
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData,
-                                     chunkInfos,
-                                     chunkOffset,
-                                     appendWindow,
-                                     protectionDataUpdate } });
+      return { type: "parsed-segment",
+               value: { chunkData,
+                        chunkInfos,
+                        chunkOffset,
+                        protectionDataUpdate,
+                        appendWindow } };
     }
     // we're handling an initialization segment
     const { indexRange } = segment;
@@ -174,9 +170,9 @@ export default function generateAudioVideoSegmentParser(
     const parsedTimescale = isNullOrUndefined(timescale) ? undefined :
                                                            timescale;
 
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: chunkData,
-                                   protectionDataUpdate,
-                                   initTimescale: parsedTimescale } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: chunkData,
+                      protectionDataUpdate,
+                      initTimescale: parsedTimescale } };
   };
 }

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
-import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
@@ -53,8 +49,8 @@ function parseISOBMFFEmbeddedTextTrack(
                                                ArrayBuffer |
                                                string >,
   __priv_patchLastSegmentInSidx? : boolean
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, representation, segment } = content;
   const { isInit, indexRange } = segment;
@@ -92,10 +88,10 @@ function parseISOBMFFEmbeddedTextTrack(
     {
       representation.index.initializeIndex(sidxSegments);
     }
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: mdhdTimescale } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: mdhdTimescale } };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
@@ -106,12 +102,12 @@ function parseISOBMFFEmbeddedTextTrack(
                                                     chunkInfos,
                                                     isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -124,16 +120,16 @@ function parsePlainTextTrack(
     content } : ISegmentParserArguments< Uint8Array |
                                          ArrayBuffer |
                                          string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   const { timestampOffset = 0 } = segment;
   if (segment.isInit) {
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: undefined } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: undefined } };
   }
 
   const { data, isChunked } = response;
@@ -146,12 +142,12 @@ function parsePlainTextTrack(
     textTrackData = data;
   }
   const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos: null,
-                                 chunkOffset: timestampOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos: null,
+                    chunkOffset: timestampOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -173,25 +169,25 @@ export default function generateTextTrackParser(
                                                  ArrayBuffer |
                                                  string |
                                                  null >
-  ) : Observable<ISegmentParserInitSegment<null> |
-                 ISegmentParserSegment<ITextTrackSegmentData>>
+  ) : ISegmentParserInitSegment<null> |
+      ISegmentParserSegment<ITextTrackSegmentData>
   {
     const { period, adaptation, representation, segment } = content;
     const { timestampOffset = 0 } = segment;
     const { data, isChunked } = response;
     if (data === null) { // No data, just return empty infos
       if (segment.isInit) {
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: null,
-                                     chunkInfos: null,
-                                     chunkOffset: timestampOffset,
-                                     appendWindow: [period.start, period.end],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData: null,
+                        chunkInfos: null,
+                        chunkOffset: timestampOffset,
+                        protectionDataUpdate: false,
+                        appendWindow: [period.start, period.end] } };
     }
 
     const containerType = inferSegmentContainer(adaptation.type, representation);

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
 import { getMDHDTimescale } from "../../parsers/containers/isobmff";
 import {
   strToUtf8,
@@ -48,8 +44,8 @@ function parseISOBMFFEmbeddedTextTrack(
     initTimescale } : ISegmentParserArguments< Uint8Array |
                                                ArrayBuffer |
                                                string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   const { data, isChunked } = response;
@@ -59,10 +55,10 @@ function parseISOBMFFEmbeddedTextTrack(
                                                   new Uint8Array(data);
   if (segment.isInit) {
     const mdhdTimescale = getMDHDTimescale(chunkBytes);
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   initTimescale: mdhdTimescale,
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      initTimescale: mdhdTimescale,
+                      protectionDataUpdate: false } };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
@@ -73,12 +69,12 @@ function parseISOBMFFEmbeddedTextTrack(
                                                     chunkInfos,
                                                     isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -91,15 +87,15 @@ function parsePlainTextTrack(
     content } : ISegmentParserArguments< Uint8Array |
                                          ArrayBuffer |
                                          string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   if (segment.isInit) {
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   initTimescale: undefined,
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      initTimescale: undefined,
+                      protectionDataUpdate: false } };
   }
 
   const { data, isChunked } = response;
@@ -113,12 +109,12 @@ function parsePlainTextTrack(
   }
   const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos: null,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos: null,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -133,25 +129,25 @@ export default function textTrackParser(
                                       ArrayBuffer |
                                       string |
                                       null >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, adaptation, representation, segment } = content;
   const { data, isChunked } = response;
   if (data === null) { // No data, just return empty infos
     if (segment.isInit) {
-      return observableOf({ type: "parsed-init-segment",
-                            value: { initializationData: null,
-                                     protectionDataUpdate: false,
-                                     initTimescale: undefined } });
+      return { type: "parsed-init-segment",
+               value: { initializationData: null,
+                        protectionDataUpdate: false,
+                        initTimescale: undefined } };
     }
     const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-    return observableOf({ type: "parsed-segment",
-                          value: { chunkData: null,
-                                   chunkInfos: null,
-                                   chunkOffset,
-                                   appendWindow: [period.start, period.end],
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-segment",
+             value: { chunkData: null,
+                      chunkInfos: null,
+                      chunkOffset,
+                      protectionDataUpdate: false,
+                      appendWindow: [period.start, period.end] } };
   }
 
   const containerType = inferSegmentContainer(adaptation.type, representation);

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import Manifest, {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../manifest";
 import { getMDHDTimescale } from "../../parsers/containers/isobmff";
 import {
   strToUtf8,
@@ -35,20 +41,34 @@ import {
 
 /**
  * Parse TextTrack data when it is embedded in an ISOBMFF file.
- * @param {Object} infos
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
+ * @param {number|undefined} initTimescale - `timescale` value - encountered
+ * in this linked initialization segment (if it exists) - that may also apply
+ * to that segment if no new timescale is defined in it.
+ * Can be `undefined` if no timescale was defined, if it is not known, or if
+ * no linked initialization segment was yet parsed.
  * @returns {Observable.<Object>}
  */
 function parseISOBMFFEmbeddedTextTrack(
-  { response,
-    content,
-    initTimescale } : ISegmentParserArguments< Uint8Array |
-                                               ArrayBuffer |
-                                               string >
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; },
+  initTimescale : number | undefined,
+  __priv_patchLastSegmentInSidx? : boolean
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
-  const { data, isChunked } = response;
 
   const chunkBytes = typeof data === "string" ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -78,17 +98,26 @@ function parseISOBMFFEmbeddedTextTrack(
 }
 
 /**
- * Parse TextTrack data in plain text form.
- * @param {Object} infos
+ * Parse TextTrack data when it is in plain text form.
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
  * @returns {Observable.<Object>}
  */
 function parsePlainTextTrack(
-  { response,
-    content } : ISegmentParserArguments< Uint8Array |
-                                         ArrayBuffer |
-                                         string >
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; }
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
   if (segment.isInit) {
@@ -98,7 +127,6 @@ function parsePlainTextTrack(
              protectionDataUpdate: false };
   }
 
-  const { data, isChunked } = response;
   let textTrackData : string;
   if (typeof data !== "string") {
     const bytesData = data instanceof Uint8Array ? data :
@@ -130,18 +158,20 @@ export default function textTrackParser(
                                       string |
                                       null >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, adaptation, representation, segment } = content;
   const { data, isChunked } = response;
-  if (data === null) { // No data, just return empty infos
+
+  if (data === null) {
+    // No data, just return an empty placeholder object
     if (segment.isInit) {
       return { segmentType: "init",
                initializationData: null,
                protectionDataUpdate: false,
                initTimescale: undefined };
     }
-    const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
+    const chunkOffset = segment.timestampOffset ?? 0;
     return { segmentType: "media",
              chunkData: null,
              chunkInfos: null,
@@ -157,10 +187,8 @@ export default function textTrackParser(
     // TODO Handle webm containers
     throw new Error("Text tracks with a WEBM container are not yet handled.");
   } else if (containerType === "mp4") {
-    return parseISOBMFFEmbeddedTextTrack({ response: { data, isChunked },
-                                           content,
-                                           initTimescale });
+    return parseISOBMFFEmbeddedTextTrack(data, isChunked, content, initTimescale);
   } else {
-    return parsePlainTextTrack({ response: { data, isChunked }, content });
+    return parsePlainTextTrack(data, isChunked, content);
   }
 }

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -304,7 +304,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -328,7 +328,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -352,9 +352,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args: ISegmentParserArguments<ArrayBuffer|string|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+      args: ISegmentParserArguments< ArrayBuffer | string | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<ITextTrackSegmentData | null> |
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;
@@ -376,9 +376,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+      args : ISegmentParserArguments<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<IImageTrackSegmentData | null>  |
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -50,9 +50,8 @@ import {
   IManifestParserWarningEvent,
   ISegmentLoaderArguments,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
-  ISegmentParserSegmentPayload,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITextTrackSegmentData,
   ITransportOptions,
   ITransportPipelines,
@@ -262,7 +261,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
   function offsetTimeInfos(
     contentOffset : number,
     contentEnd : number | undefined,
-    segmentResponse : ISegmentParserSegmentPayload<unknown>
+    segmentResponse : ISegmentParserParsedSegment<unknown>
   ) : { chunkInfos : IChunkTimeInfo | null;
         chunkOffset : number;
         appendWindow : [ number | undefined, number | undefined ]; } {
@@ -306,22 +305,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { audio } = getTransportPipelinesFromSegment(segment);
       const parsed = audio.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -333,22 +329,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { video } = getTransportPipelinesFromSegment(segment);
       const parsed = video.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -360,22 +353,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args: ISegmentParserArguments<ArrayBuffer|string|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null> |
-        ISegmentParserSegment<ITextTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null> |
+        ISegmentParserParsedSegment<ITextTrackSegmentData>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { text } = getTransportPipelinesFromSegment(segment);
       const parsed = text.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -387,8 +377,8 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null>  |
-        ISegmentParserSegment<IImageTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null>  |
+        ISegmentParserParsedSegment<IImageTrackSegmentData>
     {
       const { content } = args;
       const { segment } = content;
@@ -396,14 +386,11 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { image } = getTransportPipelinesFromSegment(segment);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       const parsed = image.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -48,8 +48,8 @@ import {
   ISegmentLoaderArguments,
   ISegmentLoaderEvent,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITextTrackSegmentData,
   ITransportOptions,
   ITransportPipelines,
@@ -180,24 +180,24 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments< ArrayBuffer | Uint8Array | null >
-    ) : ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>
     {
       const { segment, adaptation, manifest } = content;
       const { data, isChunked } = response;
       if (data === null) {
         if (segment.isInit) {
-          return { type: "parsed-init-segment",
-                   value: { initializationData: null,
-                            protectionDataUpdate: false,
-                            initTimescale: undefined } };
+          return { segmentType: "init",
+                   initializationData: null,
+                   protectionDataUpdate: false,
+                   initTimescale: undefined };
         }
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       const responseBuffer = data instanceof Uint8Array ? data :
@@ -205,12 +205,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       if (segment.isInit) {
         const timescale = segment.privateInfos?.smoothInitSegment?.timescale;
-        return { type: "parsed-init-segment",
-                 value: { initializationData: data,
-                          // smooth init segments are crafted by hand.
-                          // Their timescale is the one from the manifest.
-                          initTimescale: timescale,
-                          protectionDataUpdate: false } };
+        return { segmentType: "init",
+                 initializationData: data,
+                 // smooth init segments are crafted by hand.
+                 // Their timescale is the one from the manifest.
+                 initTimescale: timescale,
+                 protectionDataUpdate: false };
       }
 
       const timingInfos = initTimescale !== undefined ?
@@ -231,12 +231,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       if (nextSegments.length > 0) {
         addNextSegments(adaptation, nextSegments, segment);
       }
-      return { type: "parsed-segment",
-               value: { chunkData,
-                        chunkInfos,
-                        chunkOffset: 0,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData,
+               chunkInfos,
+               chunkOffset: 0,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] };
     },
   };
 
@@ -272,8 +272,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null>  |
-        ISegmentParserSegment<ITextTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null>  |
+        ISegmentParserParsedSegment<ITextTrackSegmentData>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -281,18 +281,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       const { mimeType = "", codec = "" } = representation;
       const { data, isChunked } = response;
       if (segment.isInit) { // text init segment has no use in HSS
-        return { type: "parsed-init-segment",
-                 value: { initializationData: null,
-                          protectionDataUpdate: false,
-                          initTimescale: undefined } };
+        return { segmentType: "init",
+                 initializationData: null,
+                 protectionDataUpdate: false,
+                 initTimescale: undefined };
       }
       if (data === null) {
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       let nextSegments;
@@ -395,16 +395,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
 
       const chunkOffset = segmentStart ?? 0;
-      return { type: "parsed-segment",
-               value: { chunkData: { type: _sdType,
-                                     data: _sdData,
-                                     start: segmentStart,
-                                     end: segmentEnd,
-                                     language },
-                        chunkInfos,
-                        chunkOffset,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData: { type: _sdType,
+                            data: _sdData,
+                            start: segmentStart,
+                            end: segmentEnd,
+                            language },
+               chunkInfos,
+               chunkOffset,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] };
     },
   };
 
@@ -426,16 +426,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserInitSegment<null> |
-        ISegmentParserSegment<IImageTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null> |
+        ISegmentParserParsedSegment<IImageTrackSegmentData>
     {
       const { data, isChunked } = response;
 
       if (content.segment.isInit) { // image init segment has no use
-        return { type: "parsed-init-segment",
-                 value: { initializationData: null,
-                          protectionDataUpdate: false,
-                          initTimescale: undefined } };
+        return { segmentType: "init",
+                 initializationData: null,
+                 protectionDataUpdate: false,
+                 initTimescale: undefined };
       }
 
       if (isChunked) {
@@ -444,27 +444,27 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       // TODO image Parsing should be more on the buffer side, no?
       if (data === null || features.imageParser === null) {
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       const bifObject = features.imageParser(new Uint8Array(data));
       const thumbsData = bifObject.thumbs;
-      return { type: "parsed-segment",
-               value: { chunkData: { data: thumbsData,
-                                     start: 0,
-                                     end: Number.MAX_VALUE,
-                                     timescale: 1,
-                                     type: "bif" },
-                        chunkInfos: { time: 0,
-                                      duration: Number.MAX_VALUE },
-                        chunkOffset: 0,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData: { data: thumbsData,
+                            start: 0,
+                            end: Number.MAX_VALUE,
+                            timescale: 1,
+                            type: "bif" },
+               chunkInfos: { time: 0,
+                             duration: Number.MAX_VALUE },
+               chunkOffset: 0,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] } ;
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -180,24 +180,24 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments< ArrayBuffer | Uint8Array | null >
-    ) : Observable<ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
-                   ISegmentParserSegment<ArrayBuffer | Uint8Array | null>>
+    ) : ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserSegment<ArrayBuffer | Uint8Array | null>
     {
       const { segment, adaptation, manifest } = content;
       const { data, isChunked } = response;
       if (data === null) {
         if (segment.isInit) {
-          return observableOf({ type: "parsed-init-segment",
-                                value: { initializationData: null,
-                                         protectionDataUpdate: false,
-                                         initTimescale: undefined } });
+          return { type: "parsed-init-segment",
+                   value: { initializationData: null,
+                            protectionDataUpdate: false,
+                            initTimescale: undefined } };
         }
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       const responseBuffer = data instanceof Uint8Array ? data :
@@ -205,12 +205,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       if (segment.isInit) {
         const timescale = segment.privateInfos?.smoothInitSegment?.timescale;
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: data,
-                                       // smooth init segments are crafted by hand.
-                                       // Their timescale is the one from the manifest.
-                                       initTimescale: timescale,
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: data,
+                          // smooth init segments are crafted by hand.
+                          // Their timescale is the one from the manifest.
+                          initTimescale: timescale,
+                          protectionDataUpdate: false } };
       }
 
       const timingInfos = initTimescale !== undefined ?
@@ -231,12 +231,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       if (nextSegments.length > 0) {
         addNextSegments(adaptation, nextSegments, segment);
       }
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData,
-                                     chunkInfos,
-                                     chunkOffset: 0,
-                                     appendWindow: [undefined, undefined],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData,
+                        chunkInfos,
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 
@@ -272,8 +272,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
-    ) : Observable<ISegmentParserInitSegment<null>  |
-                   ISegmentParserSegment<ITextTrackSegmentData>>
+    ) : ISegmentParserInitSegment<null>  |
+        ISegmentParserSegment<ITextTrackSegmentData>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -281,18 +281,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       const { mimeType = "", codec = "" } = representation;
       const { data, isChunked } = response;
       if (segment.isInit) { // text init segment has no use in HSS
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
       if (data === null) {
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       let nextSegments;
@@ -395,16 +395,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
 
       const chunkOffset = segmentStart ?? 0;
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: { type: _sdType,
-                                                  data: _sdData,
-                                                  start: segmentStart,
-                                                  end: segmentEnd,
-                                                  language },
-                                     chunkInfos,
-                                     chunkOffset,
-                                     appendWindow: [undefined, undefined],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData: { type: _sdType,
+                                     data: _sdData,
+                                     start: segmentStart,
+                                     end: segmentEnd,
+                                     language },
+                        chunkInfos,
+                        chunkOffset,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 
@@ -426,16 +426,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : Observable<ISegmentParserInitSegment<null>  |
-                   ISegmentParserSegment<IImageTrackSegmentData>>
+    ) : ISegmentParserInitSegment<null> |
+        ISegmentParserSegment<IImageTrackSegmentData>
     {
       const { data, isChunked } = response;
 
       if (content.segment.isInit) { // image init segment has no use
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
 
       if (isChunked) {
@@ -444,28 +444,27 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       // TODO image Parsing should be more on the buffer side, no?
       if (data === null || features.imageParser === null) {
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       const bifObject = features.imageParser(new Uint8Array(data));
       const thumbsData = bifObject.thumbs;
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: { data: thumbsData,
-                                                  start: 0,
-                                                  end: Number.MAX_VALUE,
-                                                  timescale: 1,
-                                                  type: "bif" },
-                                     chunkInfos: { time: 0,
-                                                   duration: Number.MAX_VALUE,
-                                                   timescale: bifObject.timescale },
-                                     chunkOffset: 0,
-                                     protectionDataUpdate: false,
-                                     appendWindow: [undefined, undefined] } });
+      return { type: "parsed-segment",
+               value: { chunkData: { data: thumbsData,
+                                     start: 0,
+                                     end: Number.MAX_VALUE,
+                                     timescale: 1,
+                                     type: "bif" },
+                        chunkInfos: { time: 0,
+                                      duration: Number.MAX_VALUE },
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -273,7 +273,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
     ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -427,7 +427,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
     ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { data, isChunked } = response;
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -142,8 +142,8 @@ export type ISegmentParser<
   ParsedMediaDataFormat
 > = (
   x : ISegmentParserArguments< LoadedFormat >
-) => Observable<ISegmentParserInitSegment<ParsedInitDataFormat>  |
-                ISegmentParserSegment<ParsedMediaDataFormat>>;
+) => ISegmentParserInitSegment<ParsedInitDataFormat>  |
+     ISegmentParserSegment<ParsedMediaDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {
@@ -427,7 +427,7 @@ export interface IChunkTimeInfo {
 }
 
 /** Payload sent when an initialization segment has been parsed. */
-export interface ISegmentParserParsedInitSegment<T> {
+export interface ISegmentParserInitSegmentPayload<T> {
   /**
    * Initialization segment that can be directly pushed to the corresponding
    * buffer.
@@ -453,7 +453,7 @@ export interface ISegmentParserParsedInitSegment<T> {
 }
 
 /** Payload sent when an media segment has been parsed. */
-export interface ISegmentParserParsedSegment<T> {
+export interface ISegmentParserSegmentPayload<T> {
   /** Data to decode. */
   chunkData : T | null;
   /** Time information about the segment. */
@@ -504,7 +504,7 @@ export interface ISegmentParserParsedSegment<T> {
  */
 export interface ISegmentParserInitSegment<T> {
   type : "parsed-init-segment";
-  value : ISegmentParserParsedInitSegment<T>;
+  value : ISegmentParserInitSegmentPayload<T>;
 }
 
 /**
@@ -513,7 +513,7 @@ export interface ISegmentParserInitSegment<T> {
  */
 export interface ISegmentParserSegment<T> {
   type : "parsed-segment";
-  value : ISegmentParserParsedSegment<T>;
+  value : ISegmentParserSegmentPayload<T>;
 }
 
 // format under which audio / video data / initialization data is decodable

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -50,20 +50,16 @@ export interface ITransportPipelines {
   manifest : ITransportManifestPipeline;
   /** Functions allowing to load an parse audio segments. */
   audio : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse video segments. */
   video : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse text (e.g. subtitles) segments. */
   text : ISegmentPipeline<Uint8Array | ArrayBuffer | string | null,
-                          null,
-                          ITextTrackSegmentData>;
+                          ITextTrackSegmentData | null>;
   /** Functions allowing to load an parse image (e.g. thumbnails) segments. */
   image : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           null,
-                           IImageTrackSegmentData>;
+                           IImageTrackSegmentData | null>;
 }
 
 /** Functions allowing to load and parse the Manifest. */
@@ -112,14 +108,12 @@ export type IManifestParserFunction = (
 
 /** Functions allowing to load and parse segments of any type. */
 export interface ISegmentPipeline<
-  LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat,
+  TLoadedFormat,
+  TParsedSegmentDataFormat,
 > {
-  loader : ISegmentLoader<LoadedFormat>;
-  parser : ISegmentParser<LoadedFormat,
-                          ParsedInitDataFormat,
-                          ParsedMediaDataFormat>;
+  loader : ISegmentLoader<TLoadedFormat>;
+  parser : ISegmentParser<TLoadedFormat,
+                          TParsedSegmentDataFormat>;
 }
 
 /**
@@ -127,9 +121,9 @@ export interface ISegmentPipeline<
  * @param {Object} x
  * @returns {Observable.<Object>}
  */
-export type ISegmentLoader<LoadedFormat> = (
+export type ISegmentLoader<TLoadedFormat> = (
   x : ISegmentLoaderArguments
-) => Observable<ISegmentLoaderEvent<LoadedFormat>>;
+) => Observable<ISegmentLoaderEvent<TLoadedFormat>>;
 
 /**
  * Segment parser function, allowing to parse a segment of any type.
@@ -137,11 +131,10 @@ export type ISegmentLoader<LoadedFormat> = (
  * @returns {Observable.<Object>}
  */
 export type ISegmentParser<
-  LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat
+  TLoadedFormat,
+  TParsedSegmentDataFormat
 > = (
-  x : ISegmentParserArguments< LoadedFormat >
+  x : ISegmentParserArguments< TLoadedFormat >
 ) =>
   /**
    * The parsed data.
@@ -155,8 +148,8 @@ export type ISegmentParser<
    *     segment.
    *     Such segments generally contain decodable media data.
    */
-  ISegmentParserParsedInitSegment<ParsedInitDataFormat> |
-  ISegmentParserParsedSegment<ParsedMediaDataFormat>;
+  ISegmentParserParsedInitSegment<TParsedSegmentDataFormat> |
+  ISegmentParserParsedSegment<TParsedSegmentDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {
@@ -234,8 +227,10 @@ export interface IManifestLoaderDataLoadedEvent {
 }
 
 /** Event emitted by a segment loader when the data has been fully loaded. */
-export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
-                                                    value : ILoaderDataLoadedValue<T>; }
+export interface ISegmentLoaderDataLoadedEvent<T> {
+  type : "data-loaded";
+  value : ILoaderDataLoadedValue<T>;
+}
 
 /**
  * Event emitted by a segment loader when the data is available without needing
@@ -244,8 +239,10 @@ export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
  * Such data are for example directly generated from already-available data,
  * such as properties of a Manifest.
  */
-export interface ISegmentLoaderDataCreatedEvent<T> { type : "data-created";
-                                                     value : { responseData : T }; }
+export interface ISegmentLoaderDataCreatedEvent<T> {
+  type : "data-created";
+  value : { responseData : T };
+}
 
 /**
  * Event emitted by a segment loader when new information on a pending request
@@ -363,8 +360,13 @@ export interface IManifestParserArguments {
 export interface ISegmentParserArguments<T> {
   /** Attributes of the corresponding loader's response. */
   response : {
-    /** The loaded data. */
-    data: T;
+    /**
+     * The loaded data.
+     *
+     * Possibly in Uint8Array or ArrayBuffer form if chunked (see `isChunked`
+     * property) or loaded through custom loaders.
+     */
+    data: T | Uint8Array | ArrayBuffer;
     /**
      * If `true`,`data` is only a "chunk" of the whole segment (which potentially
      * will contain multiple chunks).
@@ -446,7 +448,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
    * Initialization segment that can be directly pushed to the corresponding
    * buffer.
    */
-  initializationData : DataType | null;
+  initializationData : DataType;
   /**
    * Timescale metadata found inside this initialization segment.
    * That timescale might be useful when parsing further merdia segments.
@@ -473,7 +475,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
 export interface ISegmentParserParsedSegment<DataType> {
   segmentType : "media";
   /** Parsed chunk of data that can be decoded. */
-  chunkData : DataType | null;
+  chunkData : DataType;
   /** Time information on this parsed chunk. */
   chunkInfos : IChunkTimeInfo | null;
   /**

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -23,7 +23,10 @@ import isNullOrUndefined from "./is_null_or_undefined";
  * @param {string} [message] - Optional message property for the AssertionError.
  * @throws AssertionError - Throws if the assertion given is false
  */
-export default function assert(assertion : boolean, message? : string) : void {
+export default function assert(
+  assertion : boolean,
+  message? : string
+) : asserts assertion {
   if (!assertion) {
     throw new AssertionError(message === undefined ? "invalid assertion" :
                                                      message);

--- a/src/utils/future_data.ts
+++ b/src/utils/future_data.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from "./assert";
+
+/**
+ * Wrapper for data which may be obtained later.
+ *
+ * This class contains method to await for future data, check if data has been
+ * set yet and to set that data.
+ *
+ * The reason behind creating this class was to obtain an easier to-grasp and to
+ * use ReplaySubject (from the RxJS library) when an synchronous unique data is
+ * needed, without needing a Promise overhead when it's not needed.
+ *
+ * @class FutureData
+ */
+export default class FutureData<T> {
+  private _innerProm : {
+    promise : Promise<T>;
+    resolve : (arg : T) => void;
+    reject : (e : Error) => void;
+  };
+  private _innerData : { data: T } | null;
+  constructor() {
+    this._innerData = null;
+    let resolve : ((arg : T) => void) | undefined;
+    let reject : ((e : Error) => void) | undefined;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    // The previous callback should have been called synchronously
+    assert(resolve !== undefined);
+    assert(reject !== undefined);
+    this._innerProm = { promise,
+                        resolve,
+                        reject };
+  }
+
+  public hasData() : boolean {
+    return this._innerData !== null;
+  }
+
+  public unwrap() : T {
+    if (this._innerData === null) {
+      throw new Error("Unwrapping a not-yet set FutureData");
+    }
+    return this._innerData.data;
+  }
+
+  public awaitData() : Promise<T> {
+    return this._innerProm.promise;
+  }
+
+  public setIfNone(data : T) : boolean {
+    if (this._innerData !== null) {
+      return false;
+    }
+    this._innerData = { data };
+    this._innerProm.resolve(data);
+    return true;
+  }
+
+  public dispose() : void {
+    if (this._innerData !== null) {
+      this._innerProm.reject(new Error("FutureData has been disposed"));
+    }
+  }
+}
+

--- a/tests/integration/scenarios/initial_playback.js
+++ b/tests/integration/scenarios/initial_playback.js
@@ -23,7 +23,7 @@ import waitForState, {
 } from "../../utils/waitForPlayerState";
 import XHRMock from "../../utils/request_mock";
 
-describe.only("basic playback use cases: non-linear DASH SegmentTimeline", function () {
+describe("basic playback use cases: non-linear DASH SegmentTimeline", function () {
   let player;
   let xhrMock;
 
@@ -216,7 +216,7 @@ describe.only("basic playback use cases: non-linear DASH SegmentTimeline", funct
     expect(player.getPlayerState()).to.equal("PAUSED");
   });
 
-  it.only("should download first segment when wanted buffer ahead is under first segment duration", async function () {
+  it("should download first segment when wanted buffer ahead is under first segment duration", async function () {
     xhrMock.lock();
     player.setWantedBufferAhead(2);
     player.loadVideo({
@@ -230,12 +230,10 @@ describe.only("basic playback use cases: non-linear DASH SegmentTimeline", funct
     await sleep(1);
 
     // init segments first media segments
-    console.log("BEF", JSON.stringify(xhrMock.getLockedXHR().map(e => e.url)));
     expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
     await sleep(100);
 
-    console.log("AFT", JSON.stringify(xhrMock.getLockedXHR().map(e => e.url)));
     expect(xhrMock.getLockedXHR().length).to.equal(0); // nada
     expect(player.getVideoLoadedTime()).to.be.above(4);
     expect(player.getVideoLoadedTime()).to.be.below(5);

--- a/tests/integration/scenarios/initial_playback.js
+++ b/tests/integration/scenarios/initial_playback.js
@@ -23,7 +23,7 @@ import waitForState, {
 } from "../../utils/waitForPlayerState";
 import XHRMock from "../../utils/request_mock";
 
-describe("basic playback use cases: non-linear DASH SegmentTimeline", function () {
+describe.only("basic playback use cases: non-linear DASH SegmentTimeline", function () {
   let player;
   let xhrMock;
 
@@ -216,7 +216,7 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     expect(player.getPlayerState()).to.equal("PAUSED");
   });
 
-  it("should download first segment when wanted buffer ahead is under first segment duration", async function () {
+  it.only("should download first segment when wanted buffer ahead is under first segment duration", async function () {
     xhrMock.lock();
     player.setWantedBufferAhead(2);
     player.loadVideo({
@@ -230,10 +230,12 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     await sleep(1);
 
     // init segments first media segments
+    console.log("BEF", JSON.stringify(xhrMock.getLockedXHR().map(e => e.url)));
     expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
     await sleep(100);
 
+    console.log("AFT", JSON.stringify(xhrMock.getLockedXHR().map(e => e.url)));
     expect(xhrMock.getLockedXHR().length).to.equal(0); // nada
     expect(player.getVideoLoadedTime()).to.be.above(4);
     expect(player.getVideoLoadedTime()).to.be.below(5);

--- a/tests/integration/scenarios/initial_playback.js
+++ b/tests/integration/scenarios/initial_playback.js
@@ -228,12 +228,12 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest
     await xhrMock.flush();
     await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // init segments
+
+    // init segments first media segments
+    expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // first two segments
-    await xhrMock.flush(); // first two segments
-    await sleep(1);
+    await sleep(100);
+
     expect(xhrMock.getLockedXHR().length).to.equal(0); // nada
     expect(player.getVideoLoadedTime()).to.be.above(4);
     expect(player.getVideoLoadedTime()).to.be.below(5);
@@ -251,15 +251,16 @@ describe("basic playback use cases: non-linear DASH SegmentTimeline", function (
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest
     await xhrMock.flush();
     await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // init segments
+
+    // init segments first media segments
+    expect(xhrMock.getLockedXHR().length).to.equal(4);
     await xhrMock.flush();
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // first two segments
-    await xhrMock.flush(); // first two segments
-    await sleep(1);
-    expect(xhrMock.getLockedXHR().length).to.equal(2); // still
+    await sleep(100);
+
+    expect(xhrMock.getLockedXHR().length).to.equal(2); // next 2
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
+
     expect(player.getVideoLoadedTime()).to.be.above(7);
     expect(player.getVideoLoadedTime()).to.be.below(9);
   });

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -398,14 +398,7 @@ describe("loadVideo Options", () => {
         await xhrMock.flush(); // Manifest request
         await sleep(1);
         expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(2); // Segment requests
-        nbVideoSegmentRequests += xhrMock.getLockedXHR()
-          .filter(r => r.url && r.url.includes("ateam-video"))
-          .length;
-        await xhrMock.flush();
-        await sleep(1);
-        expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(4); // Segment requests
+          .to.equal(4); // init + media Segment requests
         nbVideoSegmentRequests += xhrMock.getLockedXHR()
           .filter(r => r.url && r.url.includes("ateam-video"))
           .length;

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -124,11 +124,8 @@ export default function launchTestsForContent(manifestInfos) {
             (videoRepresentationInfos && videoRepresentationInfos.index.init)
           ) {
             expect(xhrMock.getLockedXHR().length)
-              .to.equal(2, "should request two init segments");
-            const requestsDone = [
-              xhrMock.getLockedXHR()[0].url,
-              xhrMock.getLockedXHR()[1].url,
-            ];
+              .to.be.at.least(2, "should request two init segments");
+            const requestsDone = xhrMock.getLockedXHR().map(({ url }) => url);
             expect(requestsDone)
               .to.include(videoRepresentationInfos.index.init.mediaURLs[0]);
             expect(requestsDone)

--- a/tests/utils/waitForPlayerState.js
+++ b/tests/utils/waitForPlayerState.js
@@ -41,7 +41,10 @@ export default function waitForState(player, wantedState, whitelist) {
         player.removeEventListener("playerStateChange", onPlayerStateChange);
         resolve();
       } else if (whitelist && !whitelist.includes(state)) {
-        reject("invalid state: " + state);
+        if (state === "STOPPED" && player.getError() !== null) {
+          console.error("!!!!!!!!!", player.getError().toString());
+        }
+        reject(new Error("invalid state: " + state));
       }
     }
     player.addEventListener("playerStateChange", onPlayerStateChange);


### PR DESCRIPTION
This PR can basically be seen as a retry of #898!

After merging the former, we noticed subtle timing issues which could lead to requesting multiple times the same media segments.

After initially trying to fix those issues on master, I realized that:
  - fixing those issues does not seem easy
  - we've already too much things going on for the next release (`v3.24.0`)
  - it was not the biggest performance improvement anyway
 
So I decided to revert all code related to this improvement from master and to re-open this PR as a work-in-progress with a lower-priority (not required for the `v3.24.0` release).