### PR TITLE
Only use concerned encryption systemId when found in the Manifest

### DIFF
--- a/src/core/eme/__tests__/init_media_keys.test.ts
+++ b/src/core/eme/__tests__/init_media_keys.test.ts
@@ -34,7 +34,7 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("should emit `created-media-keys` event once MediaKeys has been created", done => {
-    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+    const fakeResult = { mediaKeySystemAccess: { a: 5, keySystem: "toto" },
                          mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },
@@ -83,7 +83,7 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("should return MediaKeys information after media keys has been attached", (done) => {
-    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+    const fakeResult = { mediaKeySystemAccess: { a: 5, keySystem: "toto" },
                          mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },
@@ -177,7 +177,7 @@ describe("core - eme - initMediaKeys", () => {
   });
 
   it("Should throw if attachMediaKeys throws", (done) => {
-    const fakeResult = { mediaKeySystemAccess: { a: 5 },
+    const fakeResult = { mediaKeySystemAccess: { a: 5, keySystem: "toto" },
                          mediaKeys: { b: 4 },
                          stores: { loadedSessionsStore: { c: 3 },
                                    persistentSessionsStore: { d: 2 } },

--- a/src/core/eme/get_drm_system_id.ts
+++ b/src/core/eme/get_drm_system_id.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import startsWith from "../../utils/starts_with";
+
+/**
+ * @param {string} keySystem
+ * @returns {string|undefined}
+ */
+export default function getDrmSystemId(
+  keySystem : string
+) : string | undefined {
+  if (startsWith(keySystem, "com.microsoft.playready") ||
+      keySystem === "com.chromecast.playready" ||
+      keySystem === "com.youtube.playready")
+  {
+    return "9a04f07998404286ab92e65be0885f95";
+  }
+  if (keySystem === "com.widevine.alpha") {
+    return "edef8ba979d64acea3c827dcd51d21ed";
+  }
+  if (startsWith(keySystem, "com.apple.fps")) {
+    return "94ce86fb07ff4f43adb893d2fa968ca2";
+  }
+  if (startsWith(keySystem, "com.nagra.")) {
+    return "adb41c242dbf4a6d958b4457c0d27b95";
+  }
+  return undefined;
+}

--- a/src/core/eme/init_media_keys.ts
+++ b/src/core/eme/init_media_keys.ts
@@ -26,9 +26,11 @@ import {
   take,
 } from "rxjs/operators";
 import log from "../../log";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import attachMediaKeys, {
   disableMediaKeys,
 } from "./attach_media_keys";
+import getDrmSystemId from "./get_drm_system_id";
 import getMediaKeysInfos from "./get_media_keys";
 import {
   IAttachedMediaKeysEvent,
@@ -48,6 +50,23 @@ export default function initMediaKeys(
 ): Observable<ICreatedMediaKeysEvent|IAttachedMediaKeysEvent> {
   return getMediaKeysInfos(mediaElement, keySystemsConfigs)
     .pipe(mergeMap(({ mediaKeys, mediaKeySystemAccess, stores, options }) => {
+
+      /**
+       * String identifying the key system, allowing the rest of the code to
+       * only advertise the required initialization data for license requests.
+       *
+       * Note that we only set this value if retro-compatibility to older
+       * persistent logic in the RxPlayer is not important, as the optimizations
+       * this property unlocks can break the loading of MediaKeySessions
+       * persisted in older RxPlayer's versions.
+       */
+      let initializationDataSystemId : string | undefined;
+      if (isNullOrUndefined(options.licenseStorage) ||
+          options.licenseStorage.disableRetroCompatibility === true)
+      {
+        initializationDataSystemId = getDrmSystemId(mediaKeySystemAccess.keySystem);
+      }
+
       const attachMediaKeys$ = new ReplaySubject<void>(1);
       const shouldDisableOldMediaKeys =
         mediaElement.mediaKeys !== null &&
@@ -75,6 +94,7 @@ export default function initMediaKeys(
                     value: { mediaKeySystemAccess, mediaKeys, stores, options } }),
             startWith({ type: "created-media-keys" as const,
                         value: { mediaKeySystemAccess,
+                                 initializationDataSystemId,
                                  mediaKeys,
                                  stores,
                                  options,

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -60,6 +60,31 @@ export interface ICreatedMediaKeysEvent {
     /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
     mediaKeySystemAccess: MediaKeySystemAccess |
                           ICustomMediaKeySystemAccess;
+
+    /**
+     * Hex-encoded identifier for the key system used.
+     * A list of available IDs can be found here:
+     * https://dashif.org/identifiers/content_protection/
+     *
+     * This ID can be used to select the encryption initialization data to send
+     * to the EMEManager.
+     *
+     * Note that this is only for optimization purposes (e.g. to not
+     * unnecessarily wait for new encryption initialization data to arrive when
+     * those linked to the right key system is already available) as sending all
+     * available encryption initialization data should also work in all cases.
+     *
+     * Can be `undefined` in two cases:
+     *
+     *   - the current system ID is not known
+     *
+     *   - the current system ID is known, but we don't want to communicate it
+     *     to ensure all encryption initialization data is still sent.
+     *     This is usually done to work-around retro-compatibility issues with
+     *     older persisted decryption session.
+     */
+    initializationDataSystemId : string | undefined;
+
     /** The MediaKeys instance. */
     mediaKeys : MediaKeys |
                 ICustomMediaKeys;
@@ -380,6 +405,18 @@ export interface IPersistentSessionStorage {
    * The given argument should be returned by the next `load` call.
    */
   save(x : IPersistentSessionInfo[]) : void;
+  /**
+   * By default, MediaKeySessions persisted through an older version of the
+   * RxPlayer will still be available under this version.
+   *
+   * By setting this value to `true`, we can disable that condition in profit of
+   * multiple optimizations (to load a content faster, use less CPU resources
+   * etc.).
+   *
+   * As such, if being able to load MediaKeySession persisted via older version
+   * is not important to you, we recommend setting that value to `true`.
+   */
+  disableRetroCompatibility? : boolean;
 }
 
 /** Options related to a single key system. */

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -124,6 +124,18 @@ export interface IAdaptationStreamArguments<T> {
  */
 export interface IAdaptationStreamOptions {
   /**
+   * Hex-encoded DRM "system ID" as found in:
+   * https://dashif.org/identifiers/content_protection/
+   *
+   * Allows to identify which DRM system is currently used, to allow potential
+   * optimizations.
+   *
+   * Set to `undefined` in two cases:
+   *   - no DRM system is used (e.g. the content is unencrypted).
+   *   - We don't know which DRM system is currently used.
+   */
+  drmSystemId : string | undefined;
+  /**
    * Strategy taken when the user switch manually the current Representation:
    *   - "seamless": the switch will happen smoothly, with the Representation
    *     with the new bitrate progressively being pushed alongside the old
@@ -349,8 +361,9 @@ export default function AdaptationStream<T>({
                                     segmentBuffer,
                                     segmentFetcher,
                                     terminate$: terminateCurrentStream$,
-                                    bufferGoal$,
-                                    fastSwitchThreshold$ })
+                                    options: { bufferGoal$,
+                                               drmSystemId: options.drmSystemId,
+                                               fastSwitchThreshold$ } })
         .pipe(catchError((err : unknown) => {
           const formattedError = formatError(err, {
             defaultCode: "NONE",


### PR DESCRIPTION
This PR is based on #911 and allows a performance optimization where the license request for encrypted contents can be performed sooner.

The idea is to:
  - determine, from the key system currently used, which encryption initialization data is needed based on this data's "systemId"
  - if the Manifest contains that data directly embedded within it, send only that data as soon as the content in question is considered for download (instead of waiting for the initialization segment to be loaded and parsed as we did before) and do not send other encryption data for that same content
  - if the Manifest does not contain that data - or if we couldn't determine the system data - just send all encryption data like before (from both the Manifest and the initialization segment, implying that both requests have to be done before)

When encryption data is present in the Manifest, as it is most often the case, this allows theoretically to perform the license request parallely to the request of the initialization segment.
Before, we had to perform the latter before the former.

---

I tried a similar idea in #901 but the behavior proposed (just taking only encryption data from the Manifest when it exists there) was judged to be too much of a change when compared to older RxPlayer versions.

---

Important note: Sadly this optimization can break persistent sessions persisted from an older RxPlayer version.

This is because the ID used to identify those, was the hash of the concatenation of all initialization data.
As the whole point of that PR is to not wait for all initialization data to be available, this PR completely break this logic.

I'm unsure if that should be considered as a breaking change, but it could break some usage, for example when persistent sessions were used to play encrypted contents offline (and thus were we cannot afford just re-doing the request).

In doubt, this PR adds a `keySystems[].licenseStorage.disableRetroCompatibility` boolean.
If persistent MediaKeySessions are used, we will only perform that optimization (by emitting or not the `systemId`) if that boolean is set to `true`.
I find this solution to not be perfect because this is very implicit (the fact that we're hiding the `systemId` is set to `true` and not just explicitely telling not to perform any optimization) but I considered it still good enough!

Maybe another behavior to break for a v4?