### PR TITLE
EME: Fix possible leaks of MediaKeySessions if closed at the wrong time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1002,6 +1002,36 @@ export default {
   EME_MAX_STORED_PERSISTENT_SESSION_INFORMATION: 1000,
 
   /**
+   * Attempts to closing a MediaKeySession can fail, most likely because the
+   * MediaKeySession was not initialized yet.
+   * When we consider that we're in one of these case, we will retry to close it.
+   *
+   * To avoid going into an infinite loop of retry, this number indicates a
+   * maximum number of attemps we're going to make (`0` meaning no retry at all,
+   * `1` only one retry and so on).
+   */
+  EME_SESSION_CLOSING_MAX_RETRY: 5,
+
+  /**
+   * When closing a MediaKeySession failed due to the reasons explained for the
+   * `EME_SESSION_CLOSING_MAX_RETRY` config property, we may (among other
+   * triggers) choose to wait a delay raising exponentially at each retry before
+   * that new attempt.
+   * This value indicates the initial value for this delay, in milliseconds.
+   */
+  EME_SESSION_CLOSING_INITIAL_DELAY: 100,
+
+  /**
+   * When closing a MediaKeySession failed due to the reasons explained for the
+   * `EME_SESSION_CLOSING_MAX_RETRY` config property, we may (among other
+   * triggers) choose to wait a delay raising exponentially at each retry before
+   * that new attempt.
+   * This value indicates the maximum possible value for this delay, in
+   * milliseconds.
+   */
+  EME_SESSION_CLOSING_MAX_DELAY: 1000,
+
+  /**
    * The player relies on browser events and properties to update its status to
    * "ENDED".
    *

--- a/src/core/eme/utils/close_session.ts
+++ b/src/core/eme/utils/close_session.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Observable,
+  of as observableOf,
+  timer,
+  race as observableRace,
+} from "rxjs";
+import {
+  catchError,
+  mergeMap,
+  take,
+  tap,
+} from "rxjs/operators";
+import {
+  closeSession,
+  ICustomMediaKeySession,
+} from "../../../compat";
+import { onKeyMessage$, onKeyStatusesChange$ } from "../../../compat/event_listeners";
+import config from "../../../config";
+import log from "../../../log";
+
+const { EME_SESSION_CLOSING_MAX_RETRY,
+        EME_SESSION_CLOSING_INITIAL_DELAY,
+        EME_SESSION_CLOSING_MAX_DELAY } = config;
+
+/**
+ * Close a MediaKeySession with multiple attempts if needed and do not throw if
+ * this action throws an error.
+ * Emits then complete when done.
+ * @param {MediaKeySession} mediaKeySession
+ * @returns {Observable}
+ */
+export default function safelyCloseMediaKeySession(
+  mediaKeySession : MediaKeySession | ICustomMediaKeySession
+) : Observable<unknown> {
+  return recursivelyTryToCloseMediaKeySession(0);
+
+  /**
+   * Perform a new attempt at closing the MediaKeySession.
+   * If this operation fails due to a not-"callable" (an EME term)
+   * MediaKeySession, retry based on either a timer or on MediaKeySession
+   * events, whichever comes first.
+   * Emits then complete when done.
+   * @param {number} retryNb - The attempt number starting at 0.
+   * @returns {Observable}
+   */
+  function recursivelyTryToCloseMediaKeySession(
+    retryNb : number
+  ) : Observable<unknown> {
+    log.debug("EME: Trying to close a MediaKeySession", mediaKeySession, retryNb);
+    return closeSession(mediaKeySession).pipe(
+      tap(() => { log.debug("EME: Succeeded to close MediaKeySession"); }),
+      catchError((err : unknown) => {
+        // Unitialized MediaKeySession may not close properly until their
+        // corresponding `generateRequest` or `load` call are handled by the
+        // browser.
+        // In that case the EME specification tells us that the browser is
+        // supposed to reject the `close` call with an InvalidStateError.
+        if (!(err instanceof Error) || err.name !== "InvalidStateError" ||
+            mediaKeySession.sessionId !== "")
+        {
+          return failToCloseSession(err);
+        }
+
+        // We will retry either:
+        //   - when an event indicates that the MediaKeySession is
+        //     initialized (`callable` is the proper EME term here)
+        //   - after a delay, raising exponentially
+        const nextRetryNb = retryNb + 1;
+        if (nextRetryNb > EME_SESSION_CLOSING_MAX_RETRY) {
+          return failToCloseSession(err);
+        }
+        const delay = Math.min(Math.pow(2, retryNb) * EME_SESSION_CLOSING_INITIAL_DELAY,
+                               EME_SESSION_CLOSING_MAX_DELAY);
+        log.warn("EME: attempt to close a mediaKeySession failed, " +
+                 "scheduling retry...", delay);
+        return observableRace([timer(delay),
+                               onKeyStatusesChange$(mediaKeySession),
+                               onKeyMessage$(mediaKeySession)])
+          .pipe(
+            take(1),
+            mergeMap(() => recursivelyTryToCloseMediaKeySession(nextRetryNb)));
+      }));
+  }
+
+  /**
+   * Log error anouncing that we could not close the MediaKeySession and emits
+   * then complete through Observable.
+   * TODO Emit warning?
+   * @returns {Observable}
+   */
+  function failToCloseSession(err : unknown) : Observable<null> {
+    log.error("EME: Could not close MediaKeySession: " +
+              (err instanceof Error ? err.toString() :
+                                      "Unknown error"));
+    return observableOf(null);
+  }
+}

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -22,12 +22,8 @@ import {
   Observable,
   of as observableOf,
 } from "rxjs";
+import { ignoreElements } from "rxjs/operators";
 import {
-  catchError,
-  ignoreElements,
-} from "rxjs/operators";
-import {
-  closeSession,
   ICustomMediaKeys,
   ICustomMediaKeySession,
 } from "../../../compat";
@@ -35,6 +31,7 @@ import { EncryptedMediaError } from "../../../errors";
 import log from "../../../log";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import { IInitializationDataInfo } from "../types";
+import safelyCloseMediaKeySession from "./close_session";
 import InitDataStore from "./init_data_store";
 
 /** Stored MediaKeySession data assiociated to an initialization data. */
@@ -219,22 +216,4 @@ export default class LoadedSessionsStore {
     });
   }
 
-}
-
-/**
- * Close a MediaKeySession and do not throw if this action throws an error.
- * @param {MediaKeySession} mediaKeySession
- * @returns {Observable}
- */
-function safelyCloseMediaKeySession(
-  mediaKeySession : MediaKeySession | ICustomMediaKeySession
-) : Observable<unknown> {
-  log.debug("EME-LSS: Close MediaKeySession", mediaKeySession);
-  return closeSession(mediaKeySession)
-    .pipe(catchError((err : unknown) => {
-      log.error("EME-LSS: Could not close MediaKeySession: " +
-                (err instanceof Error ? err.toString() :
-                                        "Unknown error"));
-      return observableOf(null);
-    }));
 }


### PR DESCRIPTION
This PR fixes a leak we only observed for now on some set-top-boxes where the call to `generateRequest` is very long (around 1 second).

This leak concerned MediaKeySessions, which were all closed when stopping a content due to the `closeSessionsOnStop` `keySystems` property being set to `true`.
Here, when loading then stopping multiple contents rapidly, we could observe some MediaKeySessions failing to be closed and thus can be kept "alive" by the user-agent despite being completely removed from the RxPlayer's point of view.

After investigation, it seems that we encountered the following case in the [EME spec for the `close` method](https://www.w3.org/TR/encrypted-media/#dom-mediakeysession-close):
`If this object's callable value is false, return a promise rejected with an InvalidStateError.`

A `MediaKeySession` has an attached `callable` value, known only by the user-agent (or at least it doesn't seem to be known as is on the JS-side) which stays to false from the MediaKeySession's creation to either the result of a `generateRequest` call or a `load` call.

Instead of putting in place a complex logic to only call `close` after either of those two were done, I chose to try an initial `close` call as soon as possible - like before - and handling the error when/if it happened.

If this error seems to be due to aforementioned case (an `InvalidStateError` on a MediaKeySession without a `sessionId` property, we will retry after the sooner of those events:
  - a delay raising exponentially (for now starting at 100 ms and multiplied by 2 at each attemps)
  - after a `keystatuseschange` event (which indicates that the MediaKeySession should now be "callable", especially after a `load` call
 - after a `message` event, for the same reason than the previous point only this time it is more adapted when a `generateRequest` call is pending.

To avoid an infinite loop of retry, we will retry a maximum of 5 times.