### PR TITLE
Avoid seeking over discontinuities when the browser seeks back

### DIFF
--- a/src/compat/__tests__/is_seeking_approximate.test.ts
+++ b/src/compat/__tests__/is_seeking_approximate.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+describe("isSeekingApproximate", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("should be true if on Tizen", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isTizen: true };
+    });
+    const shouldAppendBufferAfterPadding =
+      require("../is_seeking_approximate").default;
+    expect(shouldAppendBufferAfterPadding).toBe(true);
+  });
+
+  it("should be false if not on tizen", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isTizen: false };
+    });
+    const shouldAppendBufferAfterPadding =
+      require("../is_seeking_approximate").default;
+    expect(shouldAppendBufferAfterPadding).toBe(false);
+  });
+});

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -42,6 +42,9 @@ const isFirefox : boolean = !isNode &&
 const isSamsungBrowser : boolean = !isNode &&
                                    /SamsungBrowser/.test(navigator.userAgent);
 
+const isTizen : boolean = !isNode &&
+                          /Tizen/.test(navigator.userAgent);
+
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 const isSafari : boolean =
@@ -65,4 +68,5 @@ export {
   isSafari,
   isSafariMobile,
   isSamsungBrowser,
+  isTizen,
 };

--- a/src/compat/is_seeking_approximate.ts
+++ b/src/compat/is_seeking_approximate.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isTizen } from "./browser_detection";
+
+/**
+ * On some devices (right now only seen on Tizen), seeking through the
+ * `currentTime` property can lead to the browser re-seeking once the
+ * segments have been loaded to improve seeking performances (for
+ * example, by seeking right to an intra video frame).
+ *
+ * This can lead to conflicts with the RxPlayer code.
+ *
+ * This boolean is only `true` on the devices where this behavior has been
+ * observed.
+ */
+const isSeekingApproximate : boolean = isTizen;
+
+export default isSeekingApproximate;

--- a/src/config.ts
+++ b/src/config.ts
@@ -336,6 +336,23 @@ export default {
   BUFFER_DISCONTINUITY_THRESHOLD: 0.2,
 
   /**
+   * When encountering small discontinuities, the RxPlayer may want, in specific
+   * conditions, ignore those and let the browser seek over them iself (this
+   * allows for example to avoid conflicts when both the browser and the
+   * RxPlayer want to seek at a different position, sometimes leading to a
+   * seeking loop).
+   * In this case, we however still want to seek it ourselves if the browser
+   * doesn't take the opportunity soon enough.
+   *
+   * This value specifies a delay after which a discontinuity ignored by the
+   * RxPlayer is finally considered.
+   * We want to maintain high enough to be sure the browser will not seek yet
+   * small enough so this (arguably rare) situation won't lead to too much
+   * waiting time.
+   */
+  FORCE_DISCONTINUITY_SEEK_DELAY: 2000,
+
+  /**
    * Ratio used to know if an already loaded segment should be re-buffered.
    * We re-load the given segment if the current one times that ratio is
    * inferior to the new one.

--- a/src/core/init/stall_avoider.ts
+++ b/src/core/init/stall_avoider.ts
@@ -21,6 +21,7 @@ import {
   withLatestFrom,
 } from "rxjs/operators";
 import { isPlaybackStuck } from "../../compat";
+import isSeekingApproximate from "../../compat/is_seeking_approximate";
 import config from "../../config";
 import { MediaError } from "../../errors";
 import log from "../../log";
@@ -178,7 +179,8 @@ export default function StallAvoider(
         if (ignoredStallTimeStamp === null) {
           ignoredStallTimeStamp = now;
         }
-        if (tick.position < lastSeekingPosition &&
+        if (isSeekingApproximate &&
+            tick.position < lastSeekingPosition &&
             now - ignoredStallTimeStamp < FORCE_DISCONTINUITY_SEEK_DELAY)
         {
           return { type: "stalled" as const,


### PR DESCRIPTION
This commit fixes a problematic behavior on Tizen (mostly Samsung TVs) where we could have an infinite seeking loop.

This issue is due to the fact that after seeking to a specific position Tizen may actually seek to the closest intra video frame as a performance tweak.

This is an unexpected behavior (I would argue that it goes against the HTML5 specification) which may actually lead to a huge problem that is difficult to work-around.

---

Let's say that the RxPlayer seek at at a position `T1`.
After loading the first video media segment, samsung sees that the first intra frame is actually at a position `T2`, which is inferior to `T1`.

```
                            segment
video |--------------------|====|======|
                          T2   T1

current position => T1
```

In that condition, the browser seeks back to T2.

Now let's imagine we loaded the audio segment, that starts at `T3`, a position after `T2`.

```
                            segment
video |--------------------|===========|
                          T2

audio |----------------------|=========|
                            T3

current position => T2
```

Here, the RxPlayer will seek automatically to T3 because there's no audio data at T2, the current position.

However, the browser will then bring us back to T2, because that's where the closest intra video frame is.
And, you might have guessed it, the RxPlayer will again seek to T3.

We will this way keep alternating between T2 and T3 multiple times (we only are able to go outside this infernal loop when we're lucky and the next clock tick - an RxPlayer interval - starts after we've reached T3).

---

The main problem is that those seek are very difficult to detect (they seem to happen after a delay, for example).

We cannot just "do nothing", because this would mean not skipping discontinuities that the browser will not be able to seek (we have no way to know in advance which is which).

The solution I've found is to store the position we're currently seeking to and then detecting if we're before that position when the seek is finished, and to avoid skipping discontinuities in that case.
Then I added a timer for when the browser does not perform the seek by itself for too long, in which case the RxPlayer performs it iself.

This seems to work.

Because this is not a risky behavior (usually we won't be before a seeked position after we seeked), I chose to generalize this new behavior, so any new platform with the same weird concepts will be automatically handled.

__EDIT: After discussion, I only perform that new behavior on Tizen to minimize risks__