### PR TITLE
[Proposal] Change autoplay attribute in relation with the autoPlay option

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -721,6 +721,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       throw new Error("the attached video element is disposed");
     }
 
+    if (!autoPlay && this.videoElement.autoplay) {
+      log.warn("API: 'autoplay' is enabled on media element. Disabling it " +
+               "as content is loaded without the autoplay option enabled.");
+      this.videoElement.autoplay = false;
+    }
+
     const isDirectFile = transport === "directfile";
 
     /** Subject which will emit to stop the current content. */


### PR DESCRIPTION
The RxPlayer autoPlay option determines the way the player will handle the playback just after it has started loading content.
If it is enabled, the playback will start after the JS have called the media element play function. If not, the player is supposed to stay paused. However, the HTML media element has an autoplay attribute that, if enabled, will start playback ASAP. It means that if the autoPlay is set to false in the RxPlayer, playback may start anyway if the autoplay is enabled on the video tag.

This PR proposes to turn off autoplay on the media element if autoPlay is not enabled on the RxPlayer side.