### PR TITLE
[Proposal] Warn user when autoplay is enabled on the media element but not on RxPlayer

### DIFF
--- a/src/core/init/initial_seek_and_play.ts
+++ b/src/core/init/initial_seek_and_play.ts
@@ -153,6 +153,10 @@ export default function seekAndLoadOnMediaEvents(
         mergeMap((evt) => {
           if (evt === "can-play") {
             if (!mustAutoPlay) {
+              if (mediaElement.autoplay) {
+                log.warn("Init: autoplay is enabled on HTML media element. " +
+                         "Media will play as soon as possible.");
+              }
               return observableOf("loaded" as const);
             }
             return autoPlay$(mediaElement);


### PR DESCRIPTION
The RxPlayer autoPlay option determines the way the player will handle the playback just after it has started loading content.
If it is enabled, the playback will start after the JS has called the media element play function. If not, the player is supposed to stay paused. However, the HTML media element has an autoplay attribute that, if enabled, will start playback ASAP. It means that if the autoPlay is set to false in the RxPlayer, playback may start anyway if the autoplay is enabled on the video tag.

This PR proposes to warn the user about the fact that media may play, even if the autoPlay is set to false, if the autoplay is enabled on the media element.