### PR TITLE
DetectionHDCP can break cause of a miss interpreted error handling

### DIFF
--- a/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
@@ -95,7 +95,7 @@ function probeMediaConfiguration(
           }
         }
       }).catch((error: Error) =>
-        log.debug(error.message === undefined ? error : error.message)));
+        log.debug(error?.message === undefined ? error : error.message)));
     }
   }
 

--- a/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
@@ -94,8 +94,11 @@ function probeMediaConfiguration(
               break;
           }
         }
-      }).catch((error: Error) =>
-        log.debug(error?.message === undefined ? error : error.message)));
+      }).catch((error: unknown) => {
+        if (error instanceof Error) {
+          log.debug(error.message);
+        }
+      }));
     }
   }
 


### PR DESCRIPTION
For some reasons on Safari desktop environment this following line can break because the `error` variable is set to `undefined`.

```js
log.debug(error.message === undefined ? error : error.message);
```

This is an outcast behaviour cause on Webkit browser it did not happens.

