### PR TITLE
eme: wait at most 100ms after a session is loaded to check on its keyStatuses

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1032,6 +1032,21 @@ export default {
   EME_SESSION_CLOSING_MAX_DELAY: 1000,
 
   /**
+   * After loading a persistent MediaKeySession, the RxPlayer needs to ensure
+   * that its keys still allow to decrypt a content.
+   *
+   * However on some browsers, the `keyStatuses` property that we used to check
+   * the keys' satuses linked to that session can be empty for some time after
+   * the loading operation is done.
+   *
+   * This value allows to configure a delay in milliseconds that will be the
+   * maximum time we will wait after a persistent session is loaded.
+   * If after that time, the `keyStatuses` property is still empty, we will
+   * consider that session as not usable.
+   */
+  EME_WAITING_DELAY_LOADED_SESSION_EMPTY_KEYSTATUSES: 100,
+
+  /**
    * The player relies on browser events and properties to update its status to
    * "ENDED".
    *


### PR DESCRIPTION
After loading a persistent MediaKeySession, the RxPlayer needs to ensure that its keys still allow to decrypt a content.
To do so, we check on its `keyStatuses` property.

However, on some browsers (detected on set-top-boxes for example), the `keyStatuses` property is empty for some time after the loading operation is done, and is only filled after an impossible to predict delay.

This PR will now allow to wait up to 100ms after a session is loaded (if its `keyStatuses` property is empty) before that session is actually used.

Sadly, this also mean that that delay is incurred for when the session legitimately has no key linked to it. This last problem can be attenuated by only adding session that we know have at least one key attached to them to the `PersistentSessionsStore`.

This second behavior is done in #926.