### PR TITLE
VideoThumbnailLoader demo improvements

### DIFF
--- a/demo/full/scripts/components/VideoThumbnail.jsx
+++ b/demo/full/scripts/components/VideoThumbnail.jsx
@@ -14,6 +14,20 @@ import withModulesState from "../lib/withModulesState";
 class VideoThumbnail extends React.Component {
   constructor(...args) {
     super(...args);
+    this.isMounted = true;
+
+    /**
+     * Timeout before loading a thumbnail, to avoid triggering to many requests
+     * in a row.
+     */
+    this._loadThumbnailTimeout = null;
+
+    /**
+     * Timeout before displaying the spinner, for when loading a thumbnail takes
+     * too much time.
+     */
+    this._spinnerTimeout = null;
+
     this.positionIsCorrected = false;
     this.state = {
       style: {},
@@ -55,13 +69,39 @@ class VideoThumbnail extends React.Component {
     this.setState({ style });
   }
 
-  showSpinner() {
-    if (this.state.displaySpinner !== true) {
-      this.setState({ displaySpinner: true });
+  /**
+   * Display a spinner after some delay if `stopSpinnerTimeout` hasn't been
+   * called since.
+   * This function allows to schedule a spinner if the request to display a
+   * thumbnail takes too much time.
+   */
+  startSpinnerTimeoutIfNotAlreadyStarted() {
+    if (this._spinnerTimeout !== null) {
+      return;
     }
+
+    // Wait a little before displaying spinner, to
+    // be sure loading takes time
+    this._spinnerTimeout = setTimeout(() => {
+      this._spinnerTimeout = null;
+      if (this.state.displaySpinner !== true) {
+        this.setState({ displaySpinner: true });
+      }
+    }, 150);
   }
 
+  /**
+   * Hide the spinner if one is active and stop the last started spinner
+   * timeout.
+   * Allow to avoid showing a spinner when the thumbnail we were waiting for
+   * was succesfully loaded.
+   */
   hideSpinner() {
+    if (this._spinnerTimeout !== null) {
+      clearTimeout(this._spinnerTimeout);
+      this._spinnerTimeout = null;
+    }
+
     if (this.state.displaySpinner !== false) {
       this.setState({ displaySpinner: false });
     }
@@ -85,39 +125,48 @@ class VideoThumbnail extends React.Component {
   componentWillUnmount() {
     const { player, attachedVideoThumbnailLoader } = this.props;
     const videoThumbnailLoader = attachedVideoThumbnailLoader;
+    this.hideSpinner();
     if (videoThumbnailLoader) {
       videoThumbnailLoader.dispose();
       player.dispatch("REMOVE_VIDEO_THUMBNAIL_LOADER");
     }
     this._videoElement = undefined;
+    this.isMounted = false;
   }
 
   render() {
     const { style, divSpinnerStyle, spinnerStyle } = this.state;
 
     const videoThumbnailLoader = this.props.attachedVideoThumbnailLoader;
-    if (videoThumbnailLoader) {
-      const { time } = this.props;
-      const roundedTime = Math.round(time);
-      let spinnerTimeout;
-      // Only show spinner when time has changed
-      if (this.lastSetTime !== roundedTime) {
-        // Wait a little before displaying spinner, to
-        // be sure loading takes time
-        spinnerTimeout = setTimeout(() => {
-          this.showSpinner();
-        }, 300);
+
+    const { time } = this.props;
+    const roundedTime = Math.round(time);
+
+    if (videoThumbnailLoader && this.lastSetTime !== roundedTime) {
+      this.startSpinnerTimeoutIfNotAlreadyStarted();
+
+      if (this._loadThumbnailTimeout !== null) {
+        clearTimeout(this._loadThumbnailTimeout);
       }
-      this.lastSetTime = roundedTime;
-      videoThumbnailLoader.setTime(roundedTime)
-        .then(() => {
-          clearTimeout(spinnerTimeout);
-          this.hideSpinner();
-        })
-        .catch(() => {
-          clearTimeout(spinnerTimeout);
-          this.hideSpinner();
-        });
+
+      // load thumbnail after a 40ms timer to avoid doing too many requests
+      // when the user quickly moves its pointer or whatever is calling this
+      this._loadThumbnailTimeout = setTimeout(() => {
+        this._loadThumbnailTimeout = null;
+        videoThumbnailLoader.setTime(roundedTime)
+          .then(() => {
+            if (time !== this.props.time || !this.isMounted) {
+              return;
+            }
+            this.hideSpinner();
+          })
+          .catch(() => {
+            if (time !== this.props.time || !this.isMounted) {
+              return;
+            }
+            this.hideSpinner();
+          });
+      }, 40);
     }
 
     const divToDisplay = <div

--- a/demo/full/scripts/components/VideoThumbnail.jsx
+++ b/demo/full/scripts/components/VideoThumbnail.jsx
@@ -14,7 +14,7 @@ import withModulesState from "../lib/withModulesState";
 class VideoThumbnail extends React.Component {
   constructor(...args) {
     super(...args);
-    this.isMounted = true;
+    this._isMounted = true;
 
     /**
      * Timeout before loading a thumbnail, to avoid triggering to many requests
@@ -32,14 +32,14 @@ class VideoThumbnail extends React.Component {
     this.state = {
       style: {},
       divSpinnerStyle: {
-        "background-color": "gray",
+        "backgroundColor": "gray",
         "position": "absolute",
         "width": "100%",
         "height": "100%",
         "opacity": "50%",
         "display": "flex",
-        "justify-content": "center",
-        "align-items": "center",
+        "justifyContent": "center",
+        "alignItems": "center",
       },
       spinnerStyle: {
         "width": "50%",
@@ -129,7 +129,7 @@ class VideoThumbnail extends React.Component {
 
   componentWillUnmount() {
     this.hideSpinner();
-    this.isMounted = false;
+    this._isMounted = false;
   }
 
   render() {
@@ -153,13 +153,13 @@ class VideoThumbnail extends React.Component {
         this._loadThumbnailTimeout = null;
         thumbnailsData.videoThumbnailLoader.setTime(roundedTime)
           .then(() => {
-            if (time !== this.props.time || !this.isMounted) {
+            if (time !== this.props.time || !this._isMounted) {
               return;
             }
             this.hideSpinner();
           })
           .catch(() => {
-            if (time !== this.props.time || !this.isMounted) {
+            if (time !== this.props.time || !this._isMounted) {
               return;
             }
             this.hideSpinner();

--- a/demo/full/scripts/components/VideoThumbnail.jsx
+++ b/demo/full/scripts/components/VideoThumbnail.jsx
@@ -48,7 +48,9 @@ class VideoThumbnail extends React.Component {
       displaySpinner : true,
     };
     this.lastSetTime = undefined;
-    this._videoElement = undefined;
+    if (this.props.videoThumbnailsData === null) {
+      this.props.player.dispatch("ATTACH_VIDEO_THUMBNAIL_LOADER");
+    }
   }
 
   correctImagePosition() {
@@ -112,37 +114,33 @@ class VideoThumbnail extends React.Component {
   }
 
   componentDidMount() {
-    this.correctImagePosition();
-    if (this._videoElement !== undefined) {
-      this.props.player.dispatch("ATTACH_VIDEO_THUMBNAIL_LOADER", this._videoElement);
+    if (this.props.videoThumbnailsData !== null && this.element !== undefined) {
+      this.element.appendChild(this.props.videoThumbnailsData.videoElement);
     }
+    this.correctImagePosition();
   }
 
   componentDidUpdate() {
+    if (this.props.videoThumbnailsData !== null && this.element !== undefined) {
+      this.element.appendChild(this.props.videoThumbnailsData.videoElement);
+    }
     this.correctImagePosition();
   }
 
   componentWillUnmount() {
-    const { player, attachedVideoThumbnailLoader } = this.props;
-    const videoThumbnailLoader = attachedVideoThumbnailLoader;
     this.hideSpinner();
-    if (videoThumbnailLoader) {
-      videoThumbnailLoader.dispose();
-      player.dispatch("REMOVE_VIDEO_THUMBNAIL_LOADER");
-    }
-    this._videoElement = undefined;
     this.isMounted = false;
   }
 
   render() {
     const { style, divSpinnerStyle, spinnerStyle } = this.state;
 
-    const videoThumbnailLoader = this.props.attachedVideoThumbnailLoader;
+    const thumbnailsData = this.props.videoThumbnailsData;
 
     const { time } = this.props;
     const roundedTime = Math.round(time);
 
-    if (videoThumbnailLoader && this.lastSetTime !== roundedTime) {
+    if (thumbnailsData !== null && this.lastSetTime !== roundedTime) {
       this.startSpinnerTimeoutIfNotAlreadyStarted();
 
       if (this._loadThumbnailTimeout !== null) {
@@ -153,7 +151,7 @@ class VideoThumbnail extends React.Component {
       // when the user quickly moves its pointer or whatever is calling this
       this._loadThumbnailTimeout = setTimeout(() => {
         this._loadThumbnailTimeout = null;
-        videoThumbnailLoader.setTime(roundedTime)
+        thumbnailsData.videoThumbnailLoader.setTime(roundedTime)
           .then(() => {
             if (time !== this.props.time || !this.isMounted) {
               return;
@@ -184,11 +182,6 @@ class VideoThumbnail extends React.Component {
           </div> :
           null
       }
-      <video ref={(videoElement) => {
-        if (videoElement !== null) {
-          this._videoElement = videoElement;
-        }
-      }}></video>
     </div>;
 
     return (
@@ -199,6 +192,6 @@ class VideoThumbnail extends React.Component {
 
 export default React.memo(withModulesState({
   player: {
-    attachedVideoThumbnailLoader: "attachedVideoThumbnailLoader"
+    videoThumbnailsData: "videoThumbnailsData"
   },
 })(VideoThumbnail));

--- a/demo/full/scripts/modules/player/index.js
+++ b/demo/full/scripts/modules/player/index.js
@@ -70,8 +70,19 @@ const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
     volume: player.getVolume(),
     wallClockDiff: undefined,
     manifest: undefined,
+    /**
+     * If `true`, the currently set video track has a linked "trickmode" track.
+     * @type {boolean}
+     */
     videoTrackHasTrickMode: false,
-    attachedVideoThumbnailLoader: undefined,
+    /**
+     * Either `null` when no VideoThumbnailLoader is instanciated.
+     * Either an object containing two property:
+     *   - `videoThumbnailLoader`: The VideoThumbnailLoader instance
+     *   - `videoElement`: The video element on which thumbnails are displayed
+     * @type {Object|null}
+     */
+    videoThumbnailsData: null,
   });
 
   linkPlayerEventsToState(player, state, $destroy);
@@ -84,15 +95,32 @@ const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
   // dispose of the RxPlayer when destroyed
   $destroy.subscribe(() => player.dispose());
 
+  function dettachVideoThumbnailLoader() {
+    const { videoThumbnailsData } = state.get();
+    if (videoThumbnailsData !== null) {
+      videoThumbnailsData.videoThumbnailLoader.dispose();
+      state.set({ videoThumbnailsData: null });
+    }
+  }
   return {
-    ATTACH_VIDEO_THUMBNAIL_LOADER: (thumbnailVideoElement) => {
-      const vtl = new VideoThumbnailLoader(thumbnailVideoElement, player);
-      vtl.addLoader(DASH_LOADER);
-      state.set({ attachedVideoThumbnailLoader: vtl });
-    },
+    ATTACH_VIDEO_THUMBNAIL_LOADER: () => {
+      const prevVideoThumbnailsData = state.get().videoThumbnailsData;
+      if (prevVideoThumbnailsData !== null) {
+        prevVideoThumbnailsData.videoThumbnailLoader.dispose();
+      }
 
-    REMOVE_VIDEO_THUMBNAIL_LOADER: () => {
-      state.set({ attachedVideoThumbnailLoader: undefined });
+      const thumbnailVideoElement = document.createElement("video");
+      const videoThumbnailLoader = new VideoThumbnailLoader(
+        thumbnailVideoElement,
+        player
+      );
+      videoThumbnailLoader.addLoader(DASH_LOADER);
+      state.set({
+        videoThumbnailsData: {
+          videoThumbnailLoader,
+          videoElement: thumbnailVideoElement,
+        },
+      });
     },
 
     SET_VOLUME: (volume) => {
@@ -100,6 +128,7 @@ const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
     },
 
     LOAD: (arg) => {
+      dettachVideoThumbnailLoader();
       player.loadVideo(Object.assign({
         textTrackElement,
         networkConfig: {
@@ -135,6 +164,7 @@ const PLAYER = ({ $destroy, state }, { videoElement, textTrackElement }) => {
     },
 
     STOP: () => {
+      dettachVideoThumbnailLoader();
       player.stop();
     },
 


### PR DESCRIPTION
This is a small demo update based on the `feat/vtl` branch (#647).

In this update, I only ask for a thumbnail after 40 milliseconds, if no other thumbnail was requested since.
Without that timer, I saw too many thumbnail requests when hovering the progress bar with my trackpoint (the red pointer thingie on thinkpads). The previous behavior may even result in more latency before a thumbnail is shown as a lot of requests could be run/aborted in a row, which has its own cost (both in bandwidth and in CPU).

To avoid subtle race conditions I had also to add some more state in the VideoThumbnail component.