### PR TITLE
DRM: In a singleLicensePer content mode, blacklist the first kid if not encountered

### DIFF
--- a/src/core/stream/adaptation/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/create_representation_estimator.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  concat as observableConcat,
   merge as observableMerge,
   Observable,
   of as observableOf,
@@ -89,9 +88,11 @@ export default function createRepresentationEstimator(
                                        IABRRequestEndEvent>();
   const abrEvents$ = observableMerge(streamFeedback$, requestFeedback$);
 
-  const estimator$ = observableConcat(
-    observableOf(null), // Emit directly a first time on subscription
-    fromEvent(manifest, "decipherabilityUpdate") // then each time this event is triggered
+  const estimator$ = observableMerge(
+    // subscribe "first" (hack as it is a merge here) to event
+    fromEvent(manifest, "decipherabilityUpdate"),
+    // Emit directly a first time on subscription (after subscribing to event)
+    observableOf(null)
   ).pipe(
     map(() : Representation[] => {
       /** Representations for which a `RepresentationStream` can be created. */

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -303,11 +303,12 @@ export default function StreamOrchestrator(
     const handleDecipherabilityUpdate$ = fromEvent(manifest, "decipherabilityUpdate")
       .pipe(mergeMap((updates) => {
         const segmentBufferStatus = segmentBuffersStore.getStatus(bufferType);
-        const hasType = updates.some(update => update.adaptation.type === bufferType);
-        if (!hasType || segmentBufferStatus.type !== "initialized") {
+        const ofCurrentType = updates
+          .filter(update => update.adaptation.type === bufferType);
+        if (ofCurrentType.length === 0 || segmentBufferStatus.type !== "initialized") {
           return EMPTY; // no need to stop the current Streams.
         }
-        const undecipherableUpdates = updates.filter(update =>
+        const undecipherableUpdates = ofCurrentType.filter(update =>
           update.representation.decipherable === false);
         const segmentBuffer = segmentBufferStatus.value;
         const rangesToClean = getBlacklistedRanges(segmentBuffer, undecipherableUpdates);


### PR DESCRIPTION
We had a bug in our implementation of the `singleLicensePer` API (not yet released, hopefully), where we would not fallback from a quality linked to a key id not found in the licence, only if that key id was the first encountered.

This is because the check we (I) added to do that only did it on subsequent key ids, not the first one that triggered the license-fetching process.

I tried to add a fix but it is not as simple as it looks, because if we're doing that in a `singleLicensePer`: "content"` mode, why not
always (as it would make sense to always fallback when the wanted key id is not found in the corresponding license).

However I prefer not to do that due to both not break the API and the possible compatibilities issues as explained in the code.

So I was left doing it only if `singleLicensePer` was not set to the default value, and putting that code in `eme_manager.ts` instead of where I would have preferred to put it, initially, in `check_key_statuses.ts`.