### PR TITLE
Skip parsing EMSG when version is different from 0

### DIFF
--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import log from "../../../log";
 import assert from "../../../utils/assert";
 import {
   be2toi,
@@ -434,6 +435,13 @@ function parseEmsgBoxes(buffer: Uint8Array) : IEMSG[] | undefined {
     if (emsg === null) {
       break;
     }
+
+    const version = emsg[0];
+    if (version !== 0) {
+      log.warn("ISOBMFF: EMSG version " + version.toString() + " not supported.");
+      break;
+    }
+
     const length = emsg.length;
     offset += length;
 


### PR DESCRIPTION
The "emsg" boxes are declined in two versions: 0 and 1.
We support version 0 in the RxPlayer.

This PR fixes the fact that we considered every box to be version 0. It skips parsing and warns when the version is different.