### PR TITLE
manifest: Rename Period.getPlayableAdaptations to getSupportedAdaptations

### DIFF
--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -292,7 +292,7 @@ export default class TrackChoiceManager {
     adaptation$ : Subject<Adaptation|null>
   ) : void {
     const periodItem = getPeriodItem(this._periods, period);
-    const adaptations = period.getPlayableAdaptations(bufferType);
+    const adaptations = period.getSupportedAdaptations(bufferType);
     if (periodItem != null) {
       if (periodItem[bufferType] != null) {
         log.warn(`TrackChoiceManager: ${bufferType} already added for period`, period);
@@ -367,7 +367,7 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const audioAdaptations = period.getPlayableAdaptations("audio");
+    const audioAdaptations = period.getSupportedAdaptations("audio");
     const chosenAudioAdaptation = this._audioChoiceMemory.get(period);
 
     if (chosenAudioAdaptation === null) {
@@ -403,7 +403,7 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const textAdaptations = period.getPlayableAdaptations("text");
+    const textAdaptations = period.getSupportedAdaptations("text");
     const chosenTextAdaptation = this._textChoiceMemory.get(period);
     if (chosenTextAdaptation === null) {
       // If the Period was previously without text, keep it that way
@@ -437,7 +437,7 @@ export default class TrackChoiceManager {
       throw new Error("TrackChoiceManager: Given Period not found.");
     }
 
-    const videoAdaptations = period.getPlayableAdaptations("video");
+    const videoAdaptations = period.getSupportedAdaptations("video");
     const chosenVideoAdaptation = this._videoChoiceMemory.get(period);
 
     if (chosenVideoAdaptation === null) {
@@ -837,7 +837,7 @@ export default class TrackChoiceManager {
 
       const { period,
               audio: audioItem } = periodItem;
-      const audioAdaptations = period.getPlayableAdaptations("audio");
+      const audioAdaptations = period.getSupportedAdaptations("audio");
       const chosenAudioAdaptation = this._audioChoiceMemory.get(period);
 
       if (chosenAudioAdaptation === null ||
@@ -891,7 +891,7 @@ export default class TrackChoiceManager {
 
       const { period,
               text: textItem } = periodItem;
-      const textAdaptations = period.getPlayableAdaptations("text");
+      const textAdaptations = period.getSupportedAdaptations("text");
       const chosenTextAdaptation = this._textChoiceMemory.get(period);
 
       if (chosenTextAdaptation === null ||
@@ -942,7 +942,7 @@ export default class TrackChoiceManager {
       }
 
       const { period, video: videoItem } = periodItem;
-      const videoAdaptations = period.getPlayableAdaptations("video");
+      const videoAdaptations = period.getSupportedAdaptations("video");
       const chosenVideoAdaptation = this._videoChoiceMemory.get(period);
 
       if (chosenVideoAdaptation === null ||

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -172,10 +172,16 @@ export default class Period {
     return arrayFind(this.getAdaptations(), ({ id }) => wantedId === id);
   }
 
-  getPlayableAdaptations(type? : IAdaptationType) : Adaptation[] {
+  /**
+   * Returns Adaptations that contain Representations in supported codecs.
+   * @param {string|undefined} type - If set filter on a specific Adaptation's
+   * type. Will return for all types if `undefined`.
+   * @returns {Array.<Adaptation>}
+   */
+  getSupportedAdaptations(type? : IAdaptationType) : Adaptation[] {
     if (type === undefined) {
       return this.getAdaptations().filter(ada => {
-        return ada.getPlayableRepresentations().length > 0;
+        return ada.isSupported;
       });
     }
     const adaptationsForType = this.adaptations[type];
@@ -183,7 +189,7 @@ export default class Period {
       return [];
     }
     return adaptationsForType.filter(ada => {
-      return ada.getPlayableRepresentations().length > 0;
+      return ada.isSupported;
     });
   }
 }


### PR DESCRIPTION
This method was only called by the `TrackChoiceManager` and a recent fix
ultimately led to the `NO_PLAYABLE_REPRESENTATIONS` not being thrown
anymore, as the `TrackChoiceManager` would just ignore tracks for which
all Representations are marked as not decipherable.

This could make sense, but I prefer to postpone such behavior change for
a future release.

This commit re-set the old behavior by just checking the codec support
through the `isSupported` property.