### PR TITLE
DRM: add maxSessionCacheSize option to limit maximum number of stored EME sessions

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -370,6 +370,23 @@ useful depending on your needs):
     MediaError with a `NO_PLAYABLE_REPRESENTATION` code, as documented [in
     the errors documentation](./errors.md#types-media_error).
 
+  - __maxSessionCacheSize__ (`number|undefined`): The RxPlayer maintains a cache
+    of recently opened `MediaKeySession` (and consequently of recently fetched
+    licenses) as an optimization measure.
+    That way, loading a content whose license had already been fetched won't
+    necessitate a new license request, leading to shorter loading times and less
+    requests.
+
+    The size of this cache is usually kept relatively low (in the 10s) by the
+    player.
+    We found out however that some devices have an event lower limit for the
+    number of `MediaKeySession` that can be created at the same time.
+
+    The `maxSessionCacheSize` option allows to configure the maximum number of
+    `MediaKeySession` that should be kept "alive" at the same time. Any
+    supplementary older `MediaKeySession` will be closed, at least when the time
+    comes to create a new one.
+
   - __closeSessionsOnStop__ (``Boolean|undefined``): If set to ``true``, the
     ``MediaKeySession`` created for a content will be immediately closed when
     the content stops its playback.
@@ -379,6 +396,10 @@ useful depending on your needs):
 
     If set to ``false`` or not set, the ``MediaKeySession`` can be reused if the
     same content needs to be re-decrypted.
+
+    If you want to set this property because the current device has a limited
+    number of `MediaKeySession` that can be created at the same time, prefer
+    using `maxSessionCacheSize` instead.
 
   - __singleLicensePer__ (``string|undefined``): Allows to use optimally a
     single license for multiple decryption keys.

--- a/src/config.ts
+++ b/src/config.ts
@@ -977,13 +977,17 @@ export default {
   DASH_FALLBACK_LIFETIME_WHEN_MINIMUM_UPDATE_PERIOD_EQUAL_0: 3,
 
   /**
-   * Max simultaneous MediaKeySessions that will be kept as a cache to avoid
-   * doing superfluous license requests.
+   * Default value for the maximum number of simultaneous MediaKeySessions that
+   * will be kept in a cache (linked to the MediaKeys instance) to avoid doing
+   * superfluous license requests.
+   *
    * If this number is reached, any new session creation will close the oldest
    * one.
+   * Another value can be configured through the API, in which case this default
+   * will be overwritten.
    * @type {Number}
    */
-  EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS: 15,
+  EME_DEFAULT_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS: 15,
 
   /**
    * When playing contents with a persistent license, we will usually store some

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -65,7 +65,7 @@ import {
 } from "./types";
 import InitDataStore from "./utils/init_data_store";
 
-const { EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS,
+const { EME_DEFAULT_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS,
         EME_MAX_STORED_PERSISTENT_SESSION_INFORMATION } = config;
 const { onEncrypted$ } = events;
 
@@ -232,7 +232,7 @@ export default function EMEManager(
 
       const maxSessionCacheSize = typeof options.maxSessionCacheSize === "number" ?
         options.maxSessionCacheSize :
-        EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS;
+        EME_DEFAULT_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS;
       return getSession(initializationData,
                         stores,
                         wantedSessionType,

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -65,7 +65,8 @@ import {
 } from "./types";
 import InitDataStore from "./utils/init_data_store";
 
-const { EME_MAX_STORED_PERSISTENT_SESSION_INFORMATION } = config;
+const { EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS,
+        EME_MAX_STORED_PERSISTENT_SESSION_INFORMATION } = config;
 const { onEncrypted$ } = events;
 
 /**
@@ -229,7 +230,13 @@ export default function EMEManager(
         wantedSessionType = "persistent-license";
       }
 
-      return getSession(initializationData, stores, wantedSessionType)
+      const maxSessionCacheSize = typeof options.maxSessionCacheSize === "number" ?
+        options.maxSessionCacheSize :
+        EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS;
+      return getSession(initializationData,
+                        stores,
+                        wantedSessionType,
+                        maxSessionCacheSize)
         .pipe(mergeMap((sessionEvt) =>  {
           switch (sessionEvt.type) {
             case "cleaning-old-session":

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -543,6 +543,11 @@ export interface IKeySystemOption {
 
   singleLicensePer? : "content" |
                       "init-data";
+  /**
+   * Maximum number of `MediaKeySession` that should be created on the same
+   * MediaKeys.
+   */
+  maxSessionCacheSize? : number;
   /** Callback called when one of the key's status change. */
   onKeyStatusesChange? : (evt : Event, session : MediaKeySession |
                                                  ICustomMediaKeySession)


### PR DESCRIPTION
This PR adds a `keySystems[].maxSessionCacheSize` option to configure the maximum number of `MediaKeySession` that can be kept in our cache (the `LoadedSessionStore`) in parallel.

This seems necessary because some platforms do not support more than a very few `MediaKeySession` being kept alive at the same time (e.g. less than 10) whereas other have a much higher limit.
We prefer right now to set a higher limit by default to improve content loading performance (when re-loading an already-loaded content) on PCs.

We initially wanted to add that feature in an earlier release but we postponed it because it was unclear which form that option should take in cases where there were multiple keys per sessions: should we make the number of keys configurable or still keep track of the number of sessions?

After some brainstorming, we still decided to make the number of `MediaKeySession` configurable, largely due to the fact that the RxPlayer cannot reliably know in advance how many keys are going to be in a license (and thus cannot close older sessions when that limit of keys might be reached in the next `MediaKeySession`).

If it's the number of keys which cause issues on the given platform, it would thus be in the application's responsibility to guess how many keys maximum could be linked to a session (so typically, a license) so it can set `maxSessionCacheSize` equal to: `device_key_limit / absolute_max_keys_per_session`.

If that's not technically feasible, it could still be setting that value to `1` or just use the `keySystems[].closeSessionsOnStop` property, which was the option usually used in that type of situation before.