### PR TITLE
[audioTrackSwitchingMode] Perform a small seek to flush buffer instead of a reload

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,11 +80,10 @@ export default {
    * Strategy to adopt when manually switching of audio adaptation.
    * Can be either:
    *    - "seamless": transitions are smooth but could be not immediate.
-   *    - "direct": that strategy will be "smart", if the mimetype and the codec,
-   *    change, we will perform a hard reload of the media source, however, if it
-   *    doesn't change, we will just perform a small flush by removing buffered range,
-   *    and perform, a small seek on the media element.
-   *    Transitions are faster, but we could see appear a reloading or seeking state.
+   *    - "direct": that strategy will perform a very small seek that result
+   *    most of the time by a flush of the current buffered data, by doing
+   *    that we allow quicker transition between audio track, but we could
+   *    see appear a RELOADING or a SEEKING state.
    */
   DEFAULT_AUDIO_TRACK_SWITCHING_MODE: "seamless" as "seamless" |
                                                     "direct",

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -396,6 +396,9 @@ export default function InitializeOnMediaSource(
               case "encryption-data-encountered":
                 protectedSegments$.next(evt.value);
                 return null;
+              case "needs-buffer-flush":
+                setCurrentTime(mediaElement.currentTime + 0.001);
+                return null;
             }
             return evt;
           }, null));

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -112,6 +112,9 @@ export interface IWarningEvent { type : "warning";
 export interface IReloadingMediaSourceEvent { type: "reloading-media-source";
                                               value: undefined; }
 
+export interface INeedsBufferFlush { type: "needs-buffer-flush";
+                                     value: undefined; }
+
 /** Event sent after the player stalled, leading to buffering. */
 export interface IStalledEvent { type : "stalled";
                                  value : IStalledStatus; }
@@ -146,6 +149,7 @@ export type IMediaSourceLoaderEvent = IStalledEvent |
                                       ICompletedStreamEvent |
                                       IPeriodStreamReadyEvent |
                                       INeedsMediaSourceReload |
+                                      INeedsBufferFlush |
                                       IAdaptationChangeEvent |
                                       IBitrateEstimationChangeEvent |
                                       INeedsDecipherabilityFlush |
@@ -160,6 +164,7 @@ export type IMediaSourceLoaderEvent = IStalledEvent |
 export type IInitEvent = IManifestReadyEvent |
                          IManifestUpdateEvent |
                          IReloadingMediaSourceEvent |
+                         INeedsBufferFlush |
                          IDecipherabilityUpdateEvent |
                          IWarningEvent |
                          IEMEDisabledEvent |

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -23,6 +23,7 @@ import {
   Representation,
 } from "../../manifest";
 import { IContentProtection } from "../eme";
+import { INeedsBufferFlush } from "../init";
 import { IBufferType } from "../segment_buffers";
 import {
   IActivePeriodChangedEvent,
@@ -121,6 +122,10 @@ const EVENTS = {
              value: { position : reloadAt,
                       autoPlay : reloadOnPause,
                       period } };
+  },
+
+  needsBufferFlush(): INeedsBufferFlush {
+    return { type: "needs-buffer-flush", value: undefined };
   },
 
   needsDecipherabilityFlush(

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -24,6 +24,7 @@ import {
 } from "../../manifest";
 import { IEMSG } from "../../parsers/containers/isobmff";
 import { IContentProtection } from "../eme";
+import { INeedsBufferFlush } from "../init";
 import { IBufferType } from "../segment_buffers";
 
 /** Information about a Segment waiting to be loaded by the Stream. */
@@ -429,6 +430,7 @@ export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
 
                                  IBitrateEstimationChangeEvent |
                                  INeedsMediaSourceReload |
+                                 INeedsBufferFlush |
                                  INeedsDecipherabilityFlush |
                                  IRepresentationChangeEvent |
 
@@ -450,6 +452,7 @@ export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
 
                                           IPeriodStreamReadyEvent |
                                           INeedsMediaSourceReload |
+                                          INeedsBufferFlush |
                                           IAdaptationChangeEvent |
 
                                           // From an AdaptationStream
@@ -486,6 +489,7 @@ export type IStreamOrchestratorEvent = IActivePeriodChangedEvent |
 
                                        IBitrateEstimationChangeEvent |
                                        INeedsMediaSourceReload |
+                                       INeedsBufferFlush |
                                        INeedsDecipherabilityFlush |
                                        IRepresentationChangeEvent |
 


### PR DESCRIPTION
We introduced in a previous release the option [`audioTrackSwitchingMode`](https://github.com/canalplus/rx-player/pull/806/commits/006c0539a19a74b26e768e15da57e80a4d662327) that let the application side decide the kind of behaviour when it comes to switching from an audio track to another.

We decided to allow the end application to decide on this, cause we integrated few devices like PS5, where they experience a long effective switch between audio adaptation (6-7sec).

Previously, the behaviour was either 
- a `seamless` option, this means that we let the browser switch smoothly but could not be immediate.
- a `direct` behaviour, that was more `agressive`, because we decided to perform a complete `reload` that consist of recreating from scratch a MediaSource and pushing the new data on it.

This PR aims to adopt a less "agressive" behaviour in `direct` mode by no longer performing a `reload` but rather a small `seek` that will flush the buffer quicker.
