### PR TITLE
HDR Support

### DIFF
--- a/doc/api/hdr.md
+++ b/doc/api/hdr.md
@@ -1,0 +1,90 @@
+# HDR support ##################################################################
+
+## Overview ####################################################################
+
+HDR (High Dynamic Range) is a video technology that improves the way light is
+represented by permitting to render brighter highlights, darker shadows and
+more details beetwen both ends. Sometimes, it allows to reproduce richer colors
+than with the standard dynamic range.
+
+## API #########################################################################
+
+Behind this principle, several formats exists (HDR10, HLG, Dolby Vision) and
+implements specific media and stream encoding and packaging technologies. When
+using streaming technologies, both streaming manifest and codecs strings can
+provide information about the technical HDR characteristics of the content.
+
+These information are parsed and exposed through the ``hdrInfo`` attribute that
+can be found in the periods/adaptation/representation path of the RxPlayer
+manifest object. Also, the ``getAvailableVideoTracks`` and ``getVideoTrack``
+functions and the ``videoTrackChange`` event carries the ``hdrInfo``.
+
+<a name="hdrinfo"></a>
+### hdrInfo ####################################################################
+
+- colorDepth: ``number|undefined`` : It is the bit depth used for encoding the
+  color for a pixel. The more bits are used for encoding, the more color shades
+  could be rendered. It allows to increase rendering dynamic range without color
+  banding.
+- eotf: ``string|undefined`` : It is the HDR eotf. It is the transfer function
+  having the video signal as input and converting it into the linear light
+  output of the display.
+  For example, pq (published as standard SMPTE2084) is an eotf developped by
+  Dolby for HDR contents and capable of rendering brightness until 10000 nits
+  (the derived SI unit of luminance).
+- colorSpace: ``string|undefined`` : It is the video color space used for
+  encoding. An HDR content may not have a wide color gamut.
+  HD TV standards define the use of the rec709 color space for content. Most of
+  HDR standards define the use of rec2020, which is a color space that contains
+  rec709 color space and more. In other words, rec2020 can reproduce colors that
+  cannot be shown with the rec709. 
+
+## Exploiting the API ##########################################################
+
+HDR do not specify new display's capabilities. However, it allows to make better
+use of the display brightness, contrast and color capabilities. HDR will not be
+rendered the same way on each used display. It is possible through several APIs
+to query the browser about its screen characteristics, to speculate about the
+quality of the HDR rendering. Here are the available APIs now :
+
+### Color depth ################################################################
+
+In HDR, more colors and brightness levels have to be encoded. More than 8 bits
+par component are used in most of standards. It is possible to check how many
+bits are used for reproducing colors on the output display, to ensure the color
+shades could be rendered.
+
+```js
+/**
+ * It is the bit depth used for encoding one color. Example :
+ * screen.colorDepth = 48 :
+ * - 12 bits for the red component
+ * - 12 bits for the blue component
+ * - 12 bits for the green component
+ * - 12 bits for the alpha component (optional)
+ */
+const colorDepth = screen.colorDepth;
+
+/**
+ * The media query tells if the current output device is compatible
+ * with the given media characteristics.
+ * Here, it tells if the given color depth for one component is supported.
+ */
+const is10bitsSupported = window.matchMedia("(min-color: 10)").matches;
+```
+
+### Color gamut ################################################################
+
+It is possible to check if the output device is capable of displaying standard
+color gamut that are used in HDR formats.
+
+```js
+/**
+ * The media query tells if the current output device is compatible
+ * with the given media characteristics.
+ * Here, it tells if the output device is capable of displaying approximatively
+ * the given color space.
+ */
+const isRec2020Supported = window.matchMedia("(color-gamut: rec2020)").matches;
+
+```

--- a/doc/api/index.md
+++ b/doc/api/index.md
@@ -1197,6 +1197,10 @@ return an object with the following properties:
 
     - ``frameRate`` (``string|undefined``): The video frame rate.
 
+    - ``hdrInfo`` (``Object|undefined``) Information about the hdr
+      characteristics of the track.
+      (see [HDR support documentation](./hdr.md#hdrinfo))
+
   - ``signInterpreted`` (``Boolean|undefined``): If set to `true`, the track is
     known to contain an interpretation in sign language.
     If set to `false`, the track is known to not contain that type of content.
@@ -1376,6 +1380,10 @@ Each of the objects in the returned array have the following properties:
       in, as announced in the corresponding Manifest.
 
     - ``frameRate`` (``string|undefined``): The video framerate.
+
+    - ``hdrInfo`` (``Object|undefined``) Information about the hdr
+      characteristics of the track.
+      (see [HDR support documentation](./hdr.md#hdrinfo))
 
   - ``signInterpreted`` (``Boolean|undefined``): If set to `true`, the track is
     known to contain an interpretation in sign language.

--- a/doc/api/manifest.md
+++ b/doc/api/manifest.md
@@ -345,6 +345,13 @@ _type_: ``string|undefined``
 The represesentation frame rate for this Representation. It defines either the
 number of frames per second as an integer (24), or as a ratio (24000 / 1000).
 
+#### hdrInfo
+
+_type_: ``Object|undefined``
+
+Information about the hdr characteristics of the track.
+(see [HDR support documentation](./hdr.md#hdrinfo))
+
 <a name="representation-index"></a>
 ## Structure of a RepresentationIndex Object ###################################
 

--- a/doc/api/player_events.md
+++ b/doc/api/player_events.md
@@ -357,6 +357,10 @@ properties:
 
     - ``frameRate`` (``string|undefined``): The video framerate.
 
+    - ``hdrInfo`` (``Object|undefined``) Information about the hdr
+      characteristics of the track.
+      (see [HDR support documentation](./hdr.md#hdrinfo))
+
 A `null` payload means that video track has been disabled.
 
 This event only concerns the currently-playing Period.

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -26,6 +26,7 @@ import {
   Period,
   Representation,
 } from "../../manifest";
+import { IHDRInformation } from "../../manifest/types";
 import arrayFind from "../../utils/array_find";
 import arrayIncludes from "../../utils/array_includes";
 import normalizeLanguage from "../../utils/languages";
@@ -86,7 +87,8 @@ interface ITMVideoRepresentation { id : string|number;
                                    width? : number;
                                    height? : number;
                                    codec? : string;
-                                   frameRate? : string; }
+                                   frameRate? : string;
+                                   hdrInfo?: IHDRInformation; }
 
 /** Video track returned by the TrackChoiceManager. */
 export interface ITMVideoTrack { id : number|string;
@@ -1245,9 +1247,9 @@ function getPeriodItem(
  * @returns {Object}
  */
 function parseVideoRepresentation(
-  { id, bitrate, frameRate, width, height, codec } : Representation
+  { id, bitrate, frameRate, width, height, codec, hdrInfo } : Representation
 ) : ITMVideoRepresentation {
-  return { id, bitrate, frameRate, width, height, codec };
+  return { id, bitrate, frameRate, width, height, codec, hdrInfo };
 }
 
 /**

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -23,7 +23,10 @@ import {
 } from "../parsers/manifest";
 import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
 import { IRepresentationIndex } from "./representation_index";
-import { IAdaptationType } from "./types";
+import {
+  IAdaptationType,
+  IHDRInformation,
+} from "./types";
 
 /**
  * Normalized Representation structure.
@@ -77,6 +80,11 @@ class Representation {
   public contentProtections? : IContentProtections;
 
   /**
+   * If the track is HDR, give the characteristics of the content
+   */
+  public hdrInfo?: IHDRInformation;
+
+  /**
    * Whether we are able to decrypt this Representation / unable to decrypt it or
    * if we don't know yet:
    *   - if `true`, it means that we know we were able to decrypt this
@@ -98,15 +106,15 @@ class Representation {
     this.bitrate = args.bitrate;
     this.codec = args.codecs;
 
-    if (args.height != null) {
+    if (args.height !== undefined) {
       this.height = args.height;
     }
 
-    if (args.width != null) {
+    if (args.width !== undefined) {
       this.width = args.width;
     }
 
-    if (args.mimeType != null) {
+    if (args.mimeType !== undefined) {
       this.mimeType = args.mimeType;
     }
 
@@ -114,8 +122,12 @@ class Representation {
       this.contentProtections = args.contentProtections;
     }
 
-    if (args.frameRate != null) {
+    if (args.frameRate !== undefined) {
       this.frameRate = args.frameRate;
+    }
+
+    if (args.hdrInfo !== undefined) {
+      this.hdrInfo = args.hdrInfo;
     }
 
     this.index = args.index;

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -31,3 +31,28 @@ export enum MANIFEST_UPDATE_TYPE {
 
 /** Every possible value for the Adaptation's `type` property. */
 export type IAdaptationType = "video" | "audio" | "text" | "image";
+
+export interface IHDRInformation {
+  /**
+   * It is the bit depth used for encoding color for a pixel.
+   *
+   * It is used to ask to the user agent if the color depth is supported by the
+   * output device.
+   */
+  colorDepth?: number;
+  /**
+   * It is the HDR eotf. It is the transfer function having the video signal as
+   * input and converting it into the linear light output of the display. The
+   * conversion is done within the display device.
+   *
+   * It may be used here to ask the MediaSource if it supported.
+   */
+  eotf?: string;
+  /**
+   * It is the video color space used for encoding. An HDR content may not have
+   * a wide color gamut.
+   *
+   * It may be used to ask about output device color space support.
+   */
+  colorSpace?: string;
+}

--- a/src/parsers/manifest/dash/get_hdr_information.ts
+++ b/src/parsers/manifest/dash/get_hdr_information.ts
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Information about the HDR characteristic of a content.
+ */
+export interface IParsedWEBMHDRInformation {
+  /**
+   * It is the bit depth used for encoding color for a pixel.
+   *
+   * It is used to ask to the user agent if the color depth is supported by the
+   * output device.
+   */
+  colorDepth: number;
+  /**
+   * It is the HDR eotf. It is the transfer function having the video signal as
+   * input and converting it into the linear light output of the display. The
+   * conversion is done within the display device.
+   *
+   * It may be used here to ask the MediaSource if it supported.
+   */
+  eotf: "pq" | "hlg";
+  /**
+   * It is the video color space used for encoding. An HDR content may not have
+   * a wide color gamut.
+   *
+   * It may be used to ask about output device color space support.
+   */
+  colorSpace?: "rec2020";
+}
+
+/**
+ * Extract the webm HDR information out of the codec string.
+ * The syntax of the codec string is defined in VP Codec ISO Media File Format
+ * Binding, in the section Codecs Parameter String.
+ * @param {string} codecString
+ * @returns {Object | undefined}
+ */
+export function getWEBMHDRInformation(
+  codecString: string
+): undefined | IParsedWEBMHDRInformation {
+  // cccc.PP.LL.DD.CC[.cp[.tc[.mc[.FF]]]]
+  const [cccc, _PP, _LL, DD, _CC, cp, tc, mc] = codecString.split(".");
+  if (cccc !== "vp08" &&
+      cccc !== "vp09" &&
+      cccc !== "vp10") {
+    return undefined;
+  }
+
+  let colorDepth: number | undefined;
+  let eotf: "pq" | "hlg" | undefined;
+  let colorSpace: "rec2020" | undefined;
+
+  if (DD !== undefined &&
+      DD === "10" ||
+      DD === "12") {
+    colorDepth = parseInt(DD, 10);
+  }
+
+  if (tc !== undefined) {
+    if (tc === "16") {
+      eotf = "pq";
+    } else if (tc === "18") {
+      eotf = "hlg";
+    }
+  }
+
+  if (cp !== undefined &&
+      mc !== undefined &&
+      cp === "09" &&
+      mc === "09") {
+    colorSpace = "rec2020";
+  }
+
+  if (colorDepth === undefined ||
+      eotf === undefined) {
+    return undefined;
+  }
+
+  return { colorDepth, eotf, colorSpace };
+}

--- a/src/parsers/manifest/dash/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/parse_adaptation_sets.ts
@@ -51,6 +51,8 @@ export interface IAdaptationSetsContextInfos {
   end? : number;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
+  /** Manifest DASH profiles used for signaling some features */
+  manifestProfiles?: string;
   /**
    * Time (in terms of `performance.now`) at which the XML file containing
    * this AdaptationSet was received.
@@ -310,6 +312,7 @@ export default function parseAdaptationSets(
       manifestBoundsCalculator: periodInfos.manifestBoundsCalculator,
       end: periodInfos.end,
       isDynamic: periodInfos.isDynamic,
+      manifestProfiles: periodInfos.manifestProfiles,
       parentSegmentTemplates,
       receivedTime: periodInfos.receivedTime,
       start: periodInfos.start,

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -247,6 +247,7 @@ function parseCompleteIntermediateRepresentation(
                           clockOffset,
                           duration: rootAttributes.duration,
                           isDynamic,
+                          manifestProfiles: mpdIR.attributes.profiles,
                           receivedTime: args.manifestReceivedTime,
                           timeShiftBufferDepth,
                           unsafelyBaseOnPreviousManifest,

--- a/src/parsers/manifest/dash/parse_periods.ts
+++ b/src/parsers/manifest/dash/parse_periods.ts
@@ -55,6 +55,7 @@ export interface IPeriodsContextInfos {
   clockOffset? : number;
   duration? : number;
   isDynamic : boolean;
+  manifestProfiles?: string;
   /**
    * Time (in terms of `performance.now`) at which the XML file containing this
    * Period was received.
@@ -140,6 +141,7 @@ export default function parsePeriods(
                           manifestBoundsCalculator,
                           end: periodEnd,
                           isDynamic,
+                          manifestProfiles: contextInfos.manifestProfiles,
                           receivedTime,
                           segmentTemplate: periodIR.children.segmentTemplate,
                           start: periodStart,

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -15,6 +15,7 @@
  */
 
 import { IRepresentationIndex } from "../../manifest";
+import { IHDRInformation } from "../../manifest/types";
 import { IParsedStreamEventData } from "./dash/node_parsers/EventStream";
 
 export interface IManifestStreamEvent { start: number;
@@ -110,6 +111,10 @@ export interface IParsedRepresentation {
    * Not set if unknown or if it makes no sense (e.g. for audio).
    */
   width?: number;
+  /**
+   * Information about the HDR characteristic of a content.
+   */
+  hdrInfo?: IHDRInformation;
 }
 
 /** Every possible types an Adaptation can have. */
@@ -290,3 +295,4 @@ export interface IParsedManifest {
   /** URIs where the manifest can be refreshed by order of importance. */
   uris?: string[];
 }
+


### PR DESCRIPTION
This PR adds two features : 

- HDR track signaling in RxPlayer's manifest : 
If a track is recognized as HDR, a boolean is now present on the representation. For so, the RxPlayer should be aware that the track has characteristics that mean that it is an HDR track:
    - high color depth: SDR video codecs uses 8 bits by color for encoding it. HDR allows using 10 or more.
    - wide color gamut (facultative): The color gamut is a range of colors. HDR implies that a wider gamut should be used for video.
    - HDR gamma (EOTF): it is the transfer function that has the video signal as input and converts it into the linear light output of the display.

- HDR display support :
If a track is recognized as HDR, we may be able to tell to the user that HDR features may be exploited on the current output device. Therefore, we may confirm that the features can't be exploited, but we will not be sure (for the moment) that they can be. Why? Because :
    - We may not have any way to check if the decoder supports the given HDR eotf, or color space, or color depth, or HDR metadata. (e.g. HEVC HDR has a mimeType that does not tell anything about the HDR).
    - We use sometimes a specific mimeType attribute (eotf) to specify that a track is in HDR, before probing the support with the MediaSource isTypeSupported function (if the codec is not sufficient, and if we don't know the eotf). There is no documentation on how it should be interpreted on browsers, but some players use it (some whose parent company also develop a browser :p ) and at worst, the parameter seems not to be taken into account when probing (instead of explicitly returning false because the parameter is not recognized).
    - We can't know the screen peak luminance and contrast, and even if we could know it, it may still be compatible whatever its value because HDR allows retro-compatibility through color space or gamma adjustments (under HDR standard/metadata directives or even because decoders do it).
    - We may not know the color gamut. Thus, if it is a wide one, we won't check for output device support.