### PR TITLE
Add segment's time information on parsed plain-text segments

### DIFF
--- a/src/transports/utils/parse_text_track.ts
+++ b/src/transports/utils/parse_text_track.ts
@@ -155,12 +155,20 @@ export function getPlainTextTrackData(
   if (segment.isInit) {
     return null;
   }
+
+  let start;
+  let end;
   if (isChunked) {
     log.warn("Transport: Unavailable time data for current text track.");
+  } else {
+    start = segment.time;
+    end = segment.time + segment.duration;
   }
 
   const type = getPlainTextTrackFormat(representation);
   return { data: textTrackData,
            type,
-           language: adaptation.language };
+           language: adaptation.language,
+           start,
+           end };
 }


### PR DESCRIPTION
Fixes #945

This fix adds start and end information for plain-text segments of the "dash" and "local" transport types by taking it from the corresponding `segment` object (itself taken from the Manifest).

This information was actually removed in 50768ae094935fabba868c4a50ceaa849cafcc87, and I believed that is was not done on purpose (it may be an oversight).

The absence of that information was provoking an issue where text segments could be loaded in the loop.

---

I copy here the analysis I already wrote in #945:

When parsing those text segments (in src/transports/dash etc.), we omitted to add information about the start and end times at which those segments apply.

When those segments were then pushed to the buffer (in src/core/segment_buffers), it didn't find any start and end time and
thus based itself on the start time of the first cue and on the end time of the last cue instead (this is for resilience purposes).

Because the first cue starts a 2 seconds, the Stream (the code deciding which segments to download, in src/core/stream) thought that the text segment has been partially garbage collected at the start (even if it had just been pushed, we consider that this can happen for now). It thus re-asks for that segment to be loaded and so on.