### PR TITLE
Do not consider that there is an init segment when only a BaseURL is available

### DIFF
--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -31,7 +31,8 @@ import {
 import { formatError } from "../../../errors";
 import { ISegment } from "../../../manifest";
 import {
-  ISegmentParserResponse,
+  ISegmentParserInitSegment,
+  ISegmentParserSegment,
   ITransportPipelines,
 } from "../../../transports";
 import arrayIncludes from "../../../utils/array_includes";
@@ -67,7 +68,8 @@ export type ISegmentFetcherWarning = ISegmentLoaderWarning;
 export interface ISegmentFetcherChunkEvent<T> {
   type : "chunk";
   /** Parse the downloaded chunk. */
-  parse : (initTimescale? : number) => Observable<ISegmentParserResponse<T>>;
+  parse : (initTimescale? : number) => Observable<ISegmentParserInitSegment<T> |
+                                                  ISegmentParserSegment<T>>;
 }
 
 /**
@@ -206,7 +208,8 @@ export default function createSegmentFetcher<T>(
            * @param {Object} [initTimescale]
            * @returns {Observable}
            */
-          parse(initTimescale? : number) : Observable<ISegmentParserResponse<T>> {
+          parse(initTimescale? : number) : Observable<ISegmentParserInitSegment<T> |
+                                                      ISegmentParserSegment<T>> {
             const response = { data: evt.value.responseData, isChunked };
             /* eslint-disable @typescript-eslint/no-unsafe-call */
             /* eslint-disable @typescript-eslint/no-unsafe-member-access */

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -226,6 +226,9 @@ class Representation {
    * Returns `false` if none has been added (e.g. because it was already known).
    *
    * /!\ Mutates the current Representation
+   *
+   * TODO better handle use cases like key rotation by not always grouping
+   * every protection data together? To check.
    * @param {string} initDataArr
    * @param {string} systemId
    * @param {Uint8Array} data

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -125,7 +125,23 @@ export interface IPrivateInfos {
 export interface ISegment {
   /** ID of the Segment. Should be unique for this Representation. */
   id : string;
-  /** If true, this Segment contains initialization data. */
+  /**
+   * If true, this segment is an initialization segment with no decodable data.
+   *
+   * Those types of segment contain no decodable data and are only there for
+   * initialization purposes, such as giving initial infos to the decoder on
+   * subsequent media segments that will be pushed.
+   *
+   * Note that if `isInit` is false, it only means that the segment contains
+   * decodable media, it can also contain important initialization information.
+   *
+   * Also, a segment which would contain both all initialization data and the
+   * decodable data would have `isInit` set to `false` as it is not purely an
+   * initialization segment.
+   *
+   * Segments which are not purely an initialization segments are called "media
+   * segments" in the code.
+   */
   isInit : boolean;
   /** URLs where this segment is available. From the most to least prioritary. */
   mediaURLs : string[]|null;
@@ -158,7 +174,7 @@ export interface ISegment {
    * Manifest says and what the content really is might make that time not
    * exact.
    *
-   * `0` for initialization segments without media data.
+   * `0` for initialization segments.
    */
   time : number;
   /**
@@ -167,7 +183,7 @@ export interface ISegment {
    * Manifest says and what the content really is might make that time not
    * exact.
    *
-   * `0` for initialization segments without media data.
+   * `0` for initialization segments.
    */
   end : number;
   /**
@@ -176,7 +192,7 @@ export interface ISegment {
    * Manifest says and what the content really is might make that time not
    * exact.
    *
-   * `0` for initialization segments without media data.
+   * `0` for initialization segments.
    */
   duration : number;
   /**
@@ -194,6 +210,8 @@ export interface IRepresentationIndex {
   /**
    * Returns Segment object for the initialization segment, allowing to do the
    * Init Segment request.
+   *
+   * `null` if there's no initialization segment.
    * @returns {Object}
    */
   getInitSegment() : ISegment|null;

--- a/src/parsers/manifest/dash/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/parse_representation_index.ts
@@ -168,7 +168,6 @@ export default function parseRepresentationIndex(
         duration: Number.MAX_VALUE,
         timescale: 1,
         startNumber: 0,
-        initialization: { media: "" },
         media: "",
       }, context);
     }

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -80,7 +80,8 @@ export function imageParser(
                                    chunkInfos: { duration: segment.duration,
                                                  time: segment.time },
                                    chunkOffset,
-                                   appendWindow: [period.start, period.end] } });
+                                   appendWindow: [period.start, period.end],
+                                   protectionDataUpdate: false } });
   }
 
   const bifObject = features.imageParser(new Uint8Array(data));
@@ -95,5 +96,6 @@ export function imageParser(
                                                duration: Number.MAX_VALUE,
                                                timescale: bifObject.timescale },
                                  chunkOffset,
-                                 appendWindow: [period.start, period.end] } });
+                                 appendWindow: [period.start, period.end],
+                                 protectionDataUpdate: false } });
 }

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -110,7 +110,8 @@ function parseISOBMFFEmbeddedTextTrack(
                         value: { chunkData,
                                  chunkInfos,
                                  chunkOffset,
-                                 appendWindow: [period.start, period.end] } });
+                                 appendWindow: [period.start, period.end],
+                                 protectionDataUpdate: false } });
 }
 
 /**
@@ -149,7 +150,8 @@ function parsePlainTextTrack(
                         value: { chunkData,
                                  chunkInfos: null,
                                  chunkOffset: timestampOffset,
-                                 appendWindow: [period.start, period.end] } });
+                                 appendWindow: [period.start, period.end],
+                                 protectionDataUpdate: false } });
 }
 
 /**
@@ -188,7 +190,8 @@ export default function generateTextTrackParser(
                             value: { chunkData: null,
                                      chunkInfos: null,
                                      chunkOffset: timestampOffset,
-                                     appendWindow: [period.start, period.end] } });
+                                     appendWindow: [period.start, period.end],
+                                     protectionDataUpdate: false } });
     }
 
     const isMP4 = isMP4EmbeddedTextTrack(representation);

--- a/src/transports/local/segment_parser.ts
+++ b/src/transports/local/segment_parser.ts
@@ -63,7 +63,7 @@ export default function segmentParser({
   const chunkData = new Uint8Array(data);
   const isWEBM = isWEBMEmbeddedTrack(representation);
   let protectionDataUpdate = false;
-  if (isWEBM) {
+  if (!isWEBM) {
     const psshInfo = takePSSHOut(chunkData);
     if (psshInfo.length > 0) {
       protectionDataUpdate = representation._addProtectionData("cenc", psshInfo);

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -77,7 +77,8 @@ function parseISOBMFFEmbeddedTextTrack(
                         value: { chunkData,
                                  chunkInfos,
                                  chunkOffset,
-                                 appendWindow: [period.start, period.end] } });
+                                 appendWindow: [period.start, period.end],
+                                 protectionDataUpdate: false } });
 }
 
 /**
@@ -116,7 +117,8 @@ function parsePlainTextTrack(
                         value: { chunkData,
                                  chunkInfos: null,
                                  chunkOffset,
-                                 appendWindow: [period.start, period.end] } });
+                                 appendWindow: [period.start, period.end],
+                                 protectionDataUpdate: false } });
 }
 
 /**
@@ -148,7 +150,8 @@ export default function textTrackParser(
                           value: { chunkData: null,
                                    chunkInfos: null,
                                    chunkOffset,
-                                   appendWindow: [period.start, period.end] } });
+                                   appendWindow: [period.start, period.end],
+                                   protectionDataUpdate: false } });
   }
 
   const isMP4 = isMP4EmbeddedTextTrack(representation);

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -195,7 +195,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                               value: { chunkData: null,
                                        chunkInfos: null,
                                        chunkOffset: 0,
-                                       appendWindow: [undefined, undefined] } });
+                                       appendWindow: [undefined, undefined],
+                                       protectionDataUpdate: false } });
       }
 
       const responseBuffer = data instanceof Uint8Array ? data :
@@ -233,7 +234,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                             value: { chunkData,
                                      chunkInfos,
                                      chunkOffset: 0,
-                                     appendWindow: [undefined, undefined] } });
+                                     appendWindow: [undefined, undefined],
+                                     protectionDataUpdate: false } });
     },
   };
 
@@ -288,7 +290,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                               value: { chunkData: null,
                                        chunkInfos: null,
                                        chunkOffset: 0,
-                                       appendWindow: [undefined, undefined] } });
+                                       appendWindow: [undefined, undefined],
+                                       protectionDataUpdate: false } });
       }
 
       let nextSegments;
@@ -399,7 +402,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                   language },
                                      chunkInfos,
                                      chunkOffset,
-                                     appendWindow: [undefined, undefined] } });
+                                     appendWindow: [undefined, undefined],
+                                     protectionDataUpdate: false } });
     },
   };
 
@@ -443,7 +447,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                               value: { chunkData: null,
                                        chunkInfos: null,
                                        chunkOffset: 0,
-                                       appendWindow: [undefined, undefined] } });
+                                       appendWindow: [undefined, undefined],
+                                       protectionDataUpdate: false } });
       }
 
       const bifObject = features.imageParser(new Uint8Array(data));

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -418,7 +418,7 @@ export interface IChunkTimeInfo {
    * Difference between the latest and the earliest presentation time
    * available in that segment, in seconds.
    *
-   * Either `undefined` or set to `0` for initialization segment.
+   * Either `undefined` or set to `0` for an initialization segment.
    */
   duration : number | undefined;
   /** Earliest presentation time available in that segment, in seconds. */
@@ -451,50 +451,69 @@ export interface ISegmentParserParsedInitSegment<T> {
   protectionDataUpdate : boolean;
 }
 
-// Format of a parsed regular (non-initialization) segment
+/** Payload sent when an media segment has been parsed. */
 export interface ISegmentParserParsedSegment<T> {
-  chunkData : T | null; // Data to decode
-  chunkInfos : IChunkTimeInfo | null; // Time information about the segment
-  chunkOffset : number; // time offset, in seconds, to add to the absolute
-                        // timed data defined in `chunkData` to obtain the
-                        // "real" wanted effective time.
-                        //
-                        // For example:
-                        //   If `chunkData` announce that the segment begins at
-                        //   32 seconds, and `chunkOffset` equals to `4`, then
-                        //   the segment should really begin at 36 seconds
-                        //   (32 + 4).
-                        //
-                        // Note that `chunkInfos` needs not to be offseted as
-                        // it should already contain the correct time
-                        // information.
-  appendWindow : [ number | undefined, // start window for the segment
-                                       // (part of the segment before that time
-                                       // will be ignored)
-                   number | undefined ]; // end window for the segment
-                                         // (part of the segment after that time
-                                         // will be ignored)
-  inbandEvents? : IInbandEvent[]; // Inband events parsed from segment data
-  needsManifestRefresh?: boolean; // Tells if the result of the parsing shows
-                                  // that the manifest should be refreshed
+  /** Data to decode. */
+  chunkData : T | null;
+  /** Time information about the segment. */
+  chunkInfos : IChunkTimeInfo | null;
+  /**
+   * Time offset, in seconds, to add to the absolute timed data defined in
+   * `chunkData` to obtain the "real" wanted effective time.
+   *
+   * For example:
+   *   If `chunkData` announce that the segment begins at 32 seconds, and
+   *   `chunkOffset` equals to `4`, then the segment should really begin at 36
+   *   seconds (32 + 4).
+   *
+   * Note that `chunkInfos` needs not to be offseted as it should already
+   * contain the correct time information.
+   */
+  chunkOffset : number;
+  /**
+   * Start and end windows at which this segment applies (part of the segment
+   * respectively before and after that time will be ignored).
+   */
+  appendWindow : [ number | undefined,
+                   number | undefined ];
+  /** Inband events parsed from segment data. */
+  inbandEvents? : IInbandEvent[];
+  /** Tells if the result of the parsing shows that the manifest should be refreshed */
+  needsManifestRefresh?: boolean;
+  /**
+   * If set to `true`, some protection information has been found in this
+   * media segment and lead the corresponding `Representation` object to be
+   * updated with that new information.
+   *
+   * In that case, you can re-check any encryption-related information with the
+   * `Representation` linked to that segment.
+   *
+   * In the great majority of cases, this is set to `true` when new content
+   * protection initialization data to have been encountered.
+   */
+  protectionDataUpdate : boolean;
 }
 
-// What a segment parser returns when parsing an init segment
+/**
+ * What a segment parser returns when parsing an initialization segment.
+ *
+ * Those types of segment contain no decodable data and are only there for
+ * initialization purposes, such as giving initial infos to the decoder on
+ * subsequent media segments that will be pushed.
+ */
 export interface ISegmentParserInitSegment<T> {
   type : "parsed-init-segment";
   value : ISegmentParserParsedInitSegment<T>;
 }
 
-// What a segment parser returns when parsing a regular (non-init) segment
+/**
+ * What a segment parser returns when parsing a media segment.
+ * Those types of segment contain decodable data.
+ */
 export interface ISegmentParserSegment<T> {
   type : "parsed-segment";
   value : ISegmentParserParsedSegment<T>;
 }
-
-// generic segment parser response
-export type ISegmentParserResponse<T> =
-  ISegmentParserInitSegment<T> |
-  ISegmentParserSegment<T>;
 
 // format under which audio / video data / initialization data is decodable
 /** Text track segment data, once parsed. */

--- a/tests/contents/DASH_static_SegmentBase/multi_codecs.js
+++ b/tests/contents/DASH_static_SegmentBase/multi_codecs.js
@@ -225,7 +225,7 @@ export default {
                 mimeType: "text/vtt",
                 index: {
                   init: {
-                    mediaURLs: [BASE_URL + "s-en.webvtt"],
+                    mediaURLs: null,
                   },
                   segments: [
                     {
@@ -250,7 +250,7 @@ export default {
                 mimeType: "text/vtt",
                 index: {
                   init: {
-                    mediaURLs: [BASE_URL + "s-el.webvtt"],
+                    mediaURLs: null,
                   },
                   segments: [
                     {
@@ -275,7 +275,7 @@ export default {
                 mimeType: "text/vtt",
                 index: {
                   init: {
-                    mediaURLs: [BASE_URL + "s-fr.webvtt"],
+                    mediaURLs: null,
                   },
                   segments: [
                     {
@@ -300,7 +300,7 @@ export default {
                 mimeType: "text/vtt",
                 index: {
                   init: {
-                    mediaURLs: [BASE_URL + "s-pt-BR.webvtt"],
+                    mediaURLs: null,
                   },
                   segments: [
                     {


### PR DESCRIPTION
This commit fixes an issue I encoutered while investigating #945 where I noticed that the player loaded two times in a row the same text segment anounced in the tested MPD.

---

The reason is that the RxPlayer has a peculiar behavior when no `SegmentBase`, `SegmentList` nor `SegmentTemplate` element are found to be linked to a given Representation.

In that situation, it creates a `TemplateRepresentationIndex` with both an initialization segment and a media segment linked to that Representation's URL.

For example, let's consider the following AdaptationSet:
```
<AdaptationSet id="2" contentType="text" mimeType="text/vtt"
lang="tlh">
  <Role schemeIdUri="urn:mpeg:dash:role:2011" value="caption"/>
  <Representation id="nuqneh" bandwidth="0">
    <BaseURL>https://retservilo.eo/qapla.vtt</BaseURL>
  </Representation>
</AdaptationSet>
```

Based on the `BaseURL` element, we infer the Representation's URL to be `https://retservilo.eo/qapla.vtt`.

And because there's no `SegmentList`, `SegmentBase` nor `SegmentTemplate` here (nor in its parent elements), we fall on the
default behavior which is to create a `TemplateRepresentationIndex`, and that there is both an initialization segment and a media segment with that URL: "https://retservilo.eo/qapla.vtt".

---

This means that in the case where this `Representation` is chosen, we will download 2 times that segment. Once as an initialization segment, the second time as a media segment.

From there, the question is: why loading both? Shouldn't we only consider a media segment but no initialization segment in that situation?

I think (it was before I worked on this project) the original reason this was done was to be safe, because that segment CAN in the end contain initialization data. The solution would be to loading it first as purely an initialization segment (and parsing initialization information from it) and then as purely a media segment, ensuring that we're not missing on anything.

But a better solution to me would be to consider it as a media segment, and handle cases where the media segment also contain initialization data.

---

For now, the only important initialization data I found that we should parse there (there's less important ones, for eample the timescale anounced in a mdhd ISOBMFF box, but I didn't bother yet) was a possible PSSH box (to properly handle it then in the `RepresentationStream`).

Doing that was very straightforward, I didn't encounter any issue there.

In the end, parsing PSSH from media segments might even help us to better implement advanced encryption use cases such as key rotation and key hierarchy as it seems to rely on this.