### PR TITLE
[Proposal] segment parsers now return their result synchronously

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,14 @@ directory) by calling `npm run lint:tests`.
 <a name="code-types"></a>
 ### Types ######################################################################
 
+#### General TypeScript rules ##################################################
+
 We try to be as strict as possible with types:
 
   - the `any` type should be avoided
 
-  - the `as` keyword should also be avoided as much as possible.
+  - the `as` TypeScript keyword, used for type casting, should also be avoided
+    as much as possible.
 
   - the `is` keyword is fine in some situations, but simpler solutions should be
     preferred.
@@ -94,8 +97,70 @@ We try to be as strict as possible with types:
 This is to be sure we can detect as much as possible type errors automatically
 with TypeScript.
 
-Also, created TypeScript's `type` and `interface` should all be named beginning
-with the letter I, for easier identification purposes.
+### `type` and `interface` typing
+
+TypeScript's `type` and `interface` should all be named beginning with the
+letter `I`, for easier identification purposes\*:
+```
+interface IMyObject {
+  someKey: string;
+}
+
+type IStringOrNumber = string |
+                       number;
+```
+
+\*We know that this rule is a controversial subject amongst TypeScript
+developpers, yet we still decide to enforce it for now.
+
+#### Generic parameters typing #################################################
+
+Generic parameters are usually named in order `T` (for the first generic
+parameter), then `U` (if there's two), then `V` (if there's three):
+
+Examples:
+```
+type IMyGenericType<T> = Array<T>;
+
+type IMyGenericType2<T, U> = Promise<T> |
+                             U;
+
+function mergeThree<T, U, V>(
+  arg1: T,
+  arg2: U,
+  arg3: V
+) : T & U & V {
+  return Object.assign({}, arg1, arg2, arg3);
+}
+```
+
+Some exceptions exist like for things like key-values couples, which can be named
+respectively `K` and `V`:
+```
+type IMyMap<K, V> = Map<K, V>;
+```
+
+This is a general convention for generic parameters inherited from Java, and
+re-used by TypeScript, and it helps identifying which type is a generic
+parameter vs which type is a real type (no prefix) vs which type is a type
+definition (prefixed by `I`).
+
+If what they correspond to is not obvious (and if there's more than one, it
+might well be), you're encouraged to add a more verbose and clear name, that you
+should prefix by `T`:
+```
+function loadResource<TResourceFormat>(
+  url : string
+) : Promise<TResourceFormat> {
+  // ...
+}
+```
+
+However note that typing rules for generic parameters is a very minor
+consideration and may not always need to be respected depending on the code it
+is applied on.
+In the end, it will be up to the RxPlayer's maintainers to decide that those
+rules should be enforced or not on a given code.
 
 
 <a name="code-forbidden"></a>

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -780,7 +780,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                                                     maxRetryOffline: offlineRetry });
 
       /** Interface used to download segments. */
-      const segmentFetcherCreator = new SegmentFetcherCreator<any>(
+      const segmentFetcherCreator = new SegmentFetcherCreator(
         transportPipelines,
         { lowLatencyMode,
           maxRetryOffline: offlineRetry,

--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -70,8 +70,7 @@ export interface ISegmentLoaderData<T> { type : "data";
  * ISegmentLoaderChunkComplete event is received.
  */
 export interface ISegmentLoaderChunk { type : "chunk";
-                                       value : { responseData : null |
-                                                                ArrayBuffer |
+                                       value : { responseData : ArrayBuffer |
                                                                 Uint8Array; }; }
 
 /** The data has been entirely sent through "chunk" events. */

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -40,19 +40,23 @@ export interface ISegmentFetcherInterruptedEvent { type : "interrupted" }
 export interface IEndedTaskEvent { type : "ended" }
 
 /** Event sent by a `IPrioritizedSegmentFetcher`. */
-export type IPrioritizedSegmentFetcherEvent<T> = ISegmentFetcherEvent<T> |
-                                                 ISegmentFetcherInterruptedEvent |
-                                                 IEndedTaskEvent;
+export type IPrioritizedSegmentFetcherEvent<TSegmentDataType> =
+  ISegmentFetcherEvent<TSegmentDataType> |
+  ISegmentFetcherInterruptedEvent |
+  IEndedTaskEvent;
 
 /** Oject returned by `applyPrioritizerToSegmentFetcher`. */
-export interface IPrioritizedSegmentFetcher<T> {
+export interface IPrioritizedSegmentFetcher<TSegmentDataType> {
   /** Create a new request for a segment with a given priority. */
   createRequest : (content : ISegmentLoaderContent,
-                   priority? : number) => Observable<IPrioritizedSegmentFetcherEvent<T>>;
+                   priority? : number) =>
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>;
 
   /** Update priority of a request created through `createRequest`. */
-  updatePriority : (observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
-                    priority : number) => void;
+  updatePriority : (
+    observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+    priority : number
+  ) => void;
 }
 
 /**
@@ -65,18 +69,19 @@ export interface IPrioritizedSegmentFetcher<T> {
  * @param {Object} fetcher
  * @returns {Object}
  */
-export default function applyPrioritizerToSegmentFetcher<T>(
-  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<T>>,
-  fetcher : ISegmentFetcher<T>
-) : IPrioritizedSegmentFetcher<T> {
+export default function applyPrioritizerToSegmentFetcher<TSegmentDataType>(
+  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+  fetcher : ISegmentFetcher<TSegmentDataType>
+) : IPrioritizedSegmentFetcher<TSegmentDataType> {
   /**
    * The Observables returned by `createRequest` are not exactly the same than
    * the one created by the `ObservablePrioritizer`. Because we still have to
    * keep a handle on that value.
    */
-  const taskHandlers =
-    new WeakMap<Observable<IPrioritizedSegmentFetcherEvent<T>>,
-                           Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<T>>>>();
+  const taskHandlers = new WeakMap<
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+    Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>>
+  >();
   return {
     /**
      * Create a Segment request with a given priority.
@@ -88,7 +93,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
     createRequest(
       content : ISegmentLoaderContent,
       priority : number = 0
-    ) : Observable<IPrioritizedSegmentFetcherEvent<T>> {
+    ) : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>> {
       const task = prioritizer.create(fetcher(content), priority);
       const flattenTask = task.pipe(
         map((evt) => {
@@ -107,7 +112,7 @@ export default function applyPrioritizerToSegmentFetcher<T>(
      * @param {Number} priority - The new priority value.
      */
     updatePriority(
-      observable : Observable<IPrioritizedSegmentFetcherEvent<T>>,
+      observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
       priority : number
     ) : void {
       const correspondingTask = taskHandlers.get(observable);

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -30,8 +30,8 @@ import {
 import { formatError } from "../../../errors";
 import { ISegment } from "../../../manifest";
 import {
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITransportPipelines,
 } from "../../../transports";
 import arrayIncludes from "../../../utils/array_includes";
@@ -77,8 +77,8 @@ export interface ISegmentFetcherChunkEvent<T> {
    * @param {number} initTimescale
    * @returns {Object}
    */
-  parse(initTimescale? : number) : ISegmentParserInitSegment<T> |
-                                   ISegmentParserSegment<T>;
+  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
+                                   ISegmentParserParsedSegment<T>;
 }
 
 /**
@@ -217,8 +217,8 @@ export default function createSegmentFetcher<T>(
            * @param {Object} [initTimescale]
            * @returns {Observable}
            */
-          parse(initTimescale? : number) : ISegmentParserInitSegment<T> |
-                                           ISegmentParserSegment<T> {
+          parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
+                                           ISegmentParserParsedSegment<T> {
             const response = { data: evt.value.responseData, isChunked };
             try {
               /* eslint-disable @typescript-eslint/no-unsafe-call */

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -32,7 +32,7 @@ import { ISegment } from "../../../manifest";
 import {
   ISegmentParserParsedInitSegment,
   ISegmentParserParsedSegment,
-  ITransportPipelines,
+  ISegmentPipeline,
 } from "../../../transports";
 import arrayIncludes from "../../../utils/array_includes";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -64,7 +64,7 @@ export type ISegmentFetcherWarning = ISegmentLoaderWarning;
  * Event sent when a new "chunk" of the segment is available.
  * A segment can contain n chunk(s) for n >= 0.
  */
-export interface ISegmentFetcherChunkEvent<T> {
+export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
   type : "chunk";
   /**
    * Parse the downloaded chunk.
@@ -77,8 +77,8 @@ export interface ISegmentFetcherChunkEvent<T> {
    * @param {number} initTimescale
    * @returns {Object}
    */
-  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
-                                   ISegmentParserParsedSegment<T>;
+  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<TSegmentDataType> |
+                                   ISegmentParserParsedSegment<TSegmentDataType>;
 }
 
 /**
@@ -88,12 +88,13 @@ export interface ISegmentFetcherChunkEvent<T> {
 export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete" }
 
 /** Event sent by the SegmentFetcher when fetching a segment. */
-export type ISegmentFetcherEvent<T> = ISegmentFetcherChunkCompleteEvent |
-                                      ISegmentFetcherChunkEvent<T> |
-                                      ISegmentFetcherWarning;
+export type ISegmentFetcherEvent<TSegmentDataType> =
+  ISegmentFetcherChunkCompleteEvent |
+  ISegmentFetcherChunkEvent<TSegmentDataType> |
+  ISegmentFetcherWarning;
 
-export type ISegmentFetcher<T> = (content : ISegmentLoaderContent) =>
-                                   Observable<ISegmentFetcherEvent<T>>;
+export type ISegmentFetcher<TSegmentDataType> = (content : ISegmentLoaderContent) =>
+  Observable<ISegmentFetcherEvent<TSegmentDataType>>;
 
 const generateRequestID = idGenerator();
 
@@ -105,23 +106,23 @@ const generateRequestID = idGenerator();
  * @param {Object} options
  * @returns {Function}
  */
-export default function createSegmentFetcher<T>(
+export default function createSegmentFetcher<
+  LoadedFormat,
+  TSegmentDataType
+>(
   bufferType : IBufferType,
-  transport : ITransportPipelines,
+  segmentPipeline : ISegmentPipeline<LoadedFormat, TSegmentDataType>,
   requests$ : Subject<IABRMetricsEvent |
                       IABRRequestBeginEvent |
                       IABRRequestProgressEvent |
                       IABRRequestEndEvent>,
   options : IBackoffOptions
-) : ISegmentFetcher<T> {
+) : ISegmentFetcher<TSegmentDataType> {
   const cache = arrayIncludes(["audio", "video"], bufferType) ?
     new InitializationSegmentCache<any>() :
     undefined;
-  const segmentLoader = createSegmentLoader<any>(transport[bufferType].loader,
-                                                 cache,
-                                                 options);
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const segmentParser = transport[bufferType].parser as any; // deal with it
+  const segmentLoader = createSegmentLoader(segmentPipeline.loader, cache, options);
+  const segmentParser = segmentPipeline.parser;
 
   /**
    * Process the segmentLoader observable to adapt it to the the rest of the
@@ -134,7 +135,7 @@ export default function createSegmentFetcher<T>(
    */
   return function fetchSegment(
     content : ISegmentLoaderContent
-  ) : Observable<ISegmentFetcherEvent<T>> {
+  ) : Observable<ISegmentFetcherEvent<TSegmentDataType>> {
     const id = generateRequestID();
     let requestBeginSent = false;
     return segmentLoader(content).pipe(
@@ -185,7 +186,7 @@ export default function createSegmentFetcher<T>(
 
       filter((e) : e is ISegmentLoaderChunk |
                         ISegmentLoaderChunkComplete |
-                        ISegmentLoaderData<T> |
+                        ISegmentLoaderData<LoadedFormat> |
                         ISegmentFetcherWarning => {
         switch (e.type) {
           case "warning":
@@ -217,17 +218,13 @@ export default function createSegmentFetcher<T>(
            * @param {Object} [initTimescale]
            * @returns {Observable}
            */
-          parse(initTimescale? : number) : ISegmentParserParsedInitSegment<T> |
-                                           ISegmentParserParsedSegment<T> {
+          parse(initTimescale? : number) :
+            ISegmentParserParsedInitSegment<TSegmentDataType> |
+            ISegmentParserParsedSegment<TSegmentDataType>
+          {
             const response = { data: evt.value.responseData, isChunked };
             try {
-              /* eslint-disable @typescript-eslint/no-unsafe-call */
-              /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-              /* eslint-disable @typescript-eslint/no-unsafe-return */
               return segmentParser({ response, initTimescale, content });
-              /* eslint-enable @typescript-eslint/no-unsafe-call */
-              /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-              /* eslint-enable @typescript-eslint/no-unsafe-return */
             } catch (error : unknown) {
               throw formatError(error, { defaultCode: "PIPELINE_PARSE_ERROR",
                                          defaultReason: "Unknown parsing error" });

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -126,7 +126,7 @@ export interface IInitializeArguments {
   /** Limit the frequency of Manifest updates. */
   minimumManifestUpdateInterval : number;
   /** Interface allowing to load segments */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /** Perform an internal seek */
   setCurrentTime: (time: number) => void;
   /** Emit the playback rate (speed) set by the user. */

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -66,7 +66,7 @@ export interface IMediaSourceLoaderArguments {
   /** Media Element on which the content will be played. */
   mediaElement : HTMLMediaElement;
   /** Module to facilitate segment fetching. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * Observable emitting the wanted playback rate as it changes.
    * Replay the last value on subscription.

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -109,7 +109,7 @@ export interface IAdaptationStreamArguments<T> {
   /** SourceBuffer wrapper - needed to push media segments. */
   segmentBuffer : SegmentBuffer<T>;
   /** Module used to fetch the wanted media segments. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * "Buffer goal" wanted, or the ideal amount of time ahead of the current
    * position in the current SegmentBuffer. When this amount has been reached

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -114,7 +114,7 @@ export default function StreamOrchestrator(
   clock$ : Observable<IStreamOrchestratorClockTick>,
   abrManager : ABRManager,
   segmentBuffersStore : SegmentBuffersStore,
-  segmentFetcherCreator : SegmentFetcherCreator<any>,
+  segmentFetcherCreator : SegmentFetcherCreator,
   options: IStreamOrchestratorOptions
 ) : Observable<IStreamOrchestratorEvent> {
   const { manifest, initialPeriod } = content;

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -87,7 +87,7 @@ export interface IPeriodStreamArguments {
   content : { manifest : Manifest;
               period : Period; };
   garbageCollectors : WeakMapMemory<SegmentBuffer<unknown>, Observable<never>>;
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   segmentBuffersStore : SegmentBuffersStore;
   options: IPeriodStreamOptions;
   wantedBufferAhead$ : BehaviorSubject<number>;

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -27,7 +27,7 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../manifest";
-import { ISegmentParserSegmentPayload } from "../../../transports";
+import { ISegmentParserParsedSegment } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
 import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
@@ -56,7 +56,7 @@ export default function pushMediaSegment<T>(
                                    period : Period;
                                    representation : Representation; };
                         initSegmentData : T | null;
-                        parsedSegment : ISegmentParserSegmentPayload<T>;
+                        parsedSegment : ISegmentParserParsedSegment<T>;
                         segment : ISegment;
                         segmentBuffer : SegmentBuffer<T>; }
 ) : Observable< IStreamEventAddedSegment<T> > {

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -27,7 +27,7 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../manifest";
-import { ISegmentParserParsedSegment } from "../../../transports";
+import { ISegmentParserSegmentPayload } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
 import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
@@ -56,7 +56,7 @@ export default function pushMediaSegment<T>(
                                    period : Period;
                                    representation : Representation; };
                         initSegmentData : T | null;
-                        parsedSegment : ISegmentParserParsedSegment<T>;
+                        parsedSegment : ISegmentParserSegmentPayload<T>;
                         segment : ISegment;
                         segmentBuffer : SegmentBuffer<T>; }
 ) : Observable< IStreamEventAddedSegment<T> > {

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -119,7 +119,7 @@ export interface ITerminationOrder {
 }
 
 /** Arguments to give to the RepresentationStream. */
-export interface IRepresentationStreamArguments<T> {
+export interface IRepresentationStreamArguments<TSegmentDataType> {
   /** Periodically emits the current playback conditions. */
   clock$ : Observable<IRepresentationStreamClockTick>;
   /** The context of the Representation you want to load. */
@@ -128,9 +128,9 @@ export interface IRepresentationStreamArguments<T> {
              period : Period;
              representation : Representation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
-  segmentBuffer : SegmentBuffer<T>;
+  segmentBuffer : SegmentBuffer<TSegmentDataType>;
   /** Interface used to load new segments. */
-  segmentFetcher : IPrioritizedSegmentFetcher<T>;
+  segmentFetcher : IPrioritizedSegmentFetcher<TSegmentDataType>;
   /**
    * Observable emitting when the RepresentationStream should "terminate".
    *
@@ -218,7 +218,7 @@ export default function RepresentationStream<T>({
    * Saved initialization segment state for this representation.
    * `null` if the initialization segment hasn't been loaded yet.
    */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T> | null =
+  let initSegmentObject : ISegmentParserParsedInitSegment<T | null> | null =
     initSegment === null ? { segmentType: "init",
                              initializationData: null,
                              protectionDataUpdate: false,

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -38,7 +38,6 @@ import {
 import {
   finalize,
   ignoreElements,
-  map,
   mergeMap,
   share,
   startWith,
@@ -57,7 +56,7 @@ import Manifest, {
 } from "../../../manifest";
 import {
   ISegmentParserInitSegment,
-  ISegmentParserParsedInitSegment,
+  ISegmentParserInitSegmentPayload,
   ISegmentParserSegment,
 } from "../../../transports";
 import assertUnreachable from "../../../utils/assert_unreachable";
@@ -254,7 +253,7 @@ export default function RepresentationStream<T>({
    * Saved initialization segment state for this representation.
    * `null` if the initialization segment hasn't been loaded yet.
    */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T> | null =
+  let initSegmentObject : ISegmentParserInitSegmentPayload<T> | null =
     initSegment === null ? { initializationData: null,
                              protectionDataUpdate: false,
                              initTimescale: undefined } :
@@ -461,9 +460,8 @@ export default function RepresentationStream<T>({
 
               case "chunk":
                 const initTimescale = initSegmentObject?.initTimescale;
-                return evt.parse(initTimescale).pipe(map(parserResponse => {
-                  return objectAssign({ segment }, parserResponse);
-                }));
+                const parsed = evt.parse(initTimescale);
+                return observableOf(objectAssign({ segment }, parsed));
 
               case "ended":
                 return requestNextSegment$;

--- a/src/experimental/tools/VideoThumbnailLoader/types.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/types.ts
@@ -33,5 +33,4 @@ export type ILoaders = Partial<Record<string, ITransportPipelines>>;
 
 export type IThumbnailLoaderSegmentParser =
   ISegmentParser<Uint8Array | ArrayBuffer | null,
-                 Uint8Array | ArrayBuffer | null,
                  Uint8Array | ArrayBuffer | null>;

--- a/src/transports/README.md
+++ b/src/transports/README.md
@@ -130,12 +130,16 @@ Its concept can be illustrated as such:
                              +--------+
 ```
 
-The parser returns an Observable which will emit the parsed resource when done.
+Depending on the type of parser (e.g. Manifest parser or segment parser), that
+task can be synchronous or asynchronous.
 
-This Observable will throw if the resource is corrupted or miss crucial
-information.
+In asynchronous cases, the parser will return an Observable emitting a unique
+time the result when done and throwing if an error is encountered.
 
-[1] the parser could also need to perform requests (e.g. it needs to fetch the
+In synchronous cases, the parser returns directly the result, and can throw
+directly when/if an error is encountered.
+
+[1] a parser could also need to perform requests (e.g. it needs to fetch the
 current time from a server).
 In such cases, the parser is given a special callback, which allows it to
 receive the same error-handling perks than a loader, such as multiple retries,

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -35,8 +35,8 @@ export default function addSegmentIntegrityChecks(
   segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 ) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null>;
 export default function addSegmentIntegrityChecks(
-  segmentLoader : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
-) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
+  segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
+) : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 {
   return (content) => segmentLoader(content).pipe(tap((res) => {
     if ((res.type === "data-loaded" || res.type === "data-chunk") &&

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -55,17 +55,17 @@ export function imageLoader(
 export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<IImageTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<IImageTrackSegmentData>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;
 
   if (content.segment.isInit) { // image init segment has no use
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: undefined } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: undefined } };
   }
 
   if (isChunked) {
@@ -76,27 +76,26 @@ export function imageParser(
 
   // TODO image Parsing should be more on the buffer side, no?
   if (data === null || features.imageParser === null) {
-    return observableOf({ type: "parsed-segment",
-                          value: { chunkData: null,
-                                   chunkInfos: { duration: segment.duration,
-                                                 time: segment.time },
-                                   chunkOffset,
-                                   appendWindow: [period.start, period.end],
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-segment",
+             value: { chunkData: null,
+                      chunkInfos: { duration: segment.duration,
+                                    time: segment.time },
+                      chunkOffset,
+                      appendWindow: [period.start, period.end],
+                      protectionDataUpdate: false } };
   }
 
   const bifObject = features.imageParser(new Uint8Array(data));
   const thumbsData = bifObject.thumbs;
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData: { data: thumbsData,
-                                              start: 0,
-                                              end: Number.MAX_VALUE,
-                                              timescale: 1,
-                                              type: "bif" },
-                                 chunkInfos: { time: 0,
-                                               duration: Number.MAX_VALUE,
-                                               timescale: bifObject.timescale },
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData: { data: thumbsData,
+                                 start: 0,
+                                 end: Number.MAX_VALUE,
+                                 timescale: 1,
+                                 type: "bif" },
+                    chunkInfos: { time: 0,
+                                  duration: Number.MAX_VALUE },
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -26,8 +26,8 @@ import {
   ISegmentLoaderArguments,
   ISegmentLoaderEvent,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
 } from "../types";
 
 /**
@@ -55,17 +55,17 @@ export function imageLoader(
 export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-) : ISegmentParserInitSegment<null> |
-    ISegmentParserSegment<IImageTrackSegmentData>
+) : ISegmentParserParsedInitSegment<null> |
+    ISegmentParserParsedSegment<IImageTrackSegmentData>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;
 
   if (content.segment.isInit) { // image init segment has no use
-    return { type: "parsed-init-segment",
-             value: { initializationData: null,
-                      protectionDataUpdate: false,
-                      initTimescale: undefined } };
+    return { segmentType: "init",
+             initializationData: null,
+             protectionDataUpdate: false,
+             initTimescale: undefined };
   }
 
   if (isChunked) {
@@ -76,26 +76,26 @@ export function imageParser(
 
   // TODO image Parsing should be more on the buffer side, no?
   if (data === null || features.imageParser === null) {
-    return { type: "parsed-segment",
-             value: { chunkData: null,
-                      chunkInfos: { duration: segment.duration,
-                                    time: segment.time },
-                      chunkOffset,
-                      appendWindow: [period.start, period.end],
-                      protectionDataUpdate: false } };
+    return { segmentType: "media",
+             chunkData: null,
+             chunkInfos: { duration: segment.duration,
+                           time: segment.time },
+             chunkOffset,
+             protectionDataUpdate: false,
+             appendWindow: [period.start, period.end] };
   }
 
   const bifObject = features.imageParser(new Uint8Array(data));
   const thumbsData = bifObject.thumbs;
-  return { type: "parsed-segment",
-           value: { chunkData: { data: thumbsData,
-                                 start: 0,
-                                 end: Number.MAX_VALUE,
-                                 timescale: 1,
-                                 type: "bif" },
-                    chunkInfos: { time: 0,
-                                  duration: Number.MAX_VALUE },
-                    chunkOffset,
-                    protectionDataUpdate: false,
-                    appendWindow: [period.start, period.end] } };
+  return { segmentType: "media",
+           chunkData: { data: thumbsData,
+                        start: 0,
+                        end: Number.MAX_VALUE,
+                        timescale: 1,
+                        type: "bif" },
+           chunkInfos: { time: 0,
+                         duration: Number.MAX_VALUE },
+           chunkOffset,
+           protectionDataUpdate: false,
+           appendWindow: [period.start, period.end] };
 }

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -56,7 +56,7 @@ export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<IImageTrackSegmentData>
+    ISegmentParserParsedSegment<IImageTrackSegmentData | null>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
-import {
   getMDHDTimescale,
   getSegmentsFromSidx,
   takePSSHOut,
@@ -53,25 +49,25 @@ export default function generateAudioVideoSegmentParser(
       initTimescale } : ISegmentParserArguments< Uint8Array |
                                                  ArrayBuffer |
                                                  null >
-  ) : Observable<ISegmentParserInitSegment<Uint8Array | ArrayBuffer | null> |
-                 ISegmentParserSegment< Uint8Array | ArrayBuffer | null>> {
+  ) : ISegmentParserInitSegment<Uint8Array | ArrayBuffer | null> |
+      ISegmentParserSegment< Uint8Array | ArrayBuffer | null> {
     const { period, adaptation, representation, segment, manifest } = content;
     const { data, isChunked } = response;
     const appendWindow : [number, number | undefined] = [ period.start, period.end ];
 
     if (data === null) {
       if (segment.isInit) {
-        return observableOf({ type: "parsed-init-segment" as const,
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment" as const,
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
-      return observableOf({ type: "parsed-segment" as const,
-                            value: { chunkData: null,
-                                     chunkInfos: null,
-                                     chunkOffset: 0,
-                                     appendWindow,
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment" as const,
+               value: { chunkData: null,
+                        chunkInfos: null,
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow } };
     }
 
     const chunkData = data instanceof Uint8Array ? data :
@@ -112,24 +108,24 @@ export default function generateAudioVideoSegmentParser(
                                              manifest.publishTime);
           if (events !== undefined) {
             const { needsManifestRefresh, inbandEvents } = events;
-            return observableOf({ type: "parsed-segment",
-                                  value: { chunkData,
-                                           chunkInfos,
-                                           chunkOffset,
-                                           appendWindow,
-                                           inbandEvents,
-                                           needsManifestRefresh,
-                                           protectionDataUpdate } });
+            return { type: "parsed-segment",
+                     value: { chunkData,
+                              chunkInfos,
+                              chunkOffset,
+                              appendWindow,
+                              inbandEvents,
+                              protectionDataUpdate,
+                              needsManifestRefresh } };
           }
         }
       }
 
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData,
-                                     chunkInfos,
-                                     chunkOffset,
-                                     appendWindow,
-                                     protectionDataUpdate } });
+      return { type: "parsed-segment",
+               value: { chunkData,
+                        chunkInfos,
+                        chunkOffset,
+                        protectionDataUpdate,
+                        appendWindow } };
     }
     // we're handling an initialization segment
     const { indexRange } = segment;
@@ -174,9 +170,9 @@ export default function generateAudioVideoSegmentParser(
     const parsedTimescale = isNullOrUndefined(timescale) ? undefined :
                                                            timescale;
 
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: chunkData,
-                                   protectionDataUpdate,
-                                   initTimescale: parsedTimescale } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: chunkData,
+                      protectionDataUpdate,
+                      initTimescale: parsedTimescale } };
   };
 }

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -15,10 +15,6 @@
  */
 
 import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
-import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
@@ -53,8 +49,8 @@ function parseISOBMFFEmbeddedTextTrack(
                                                ArrayBuffer |
                                                string >,
   __priv_patchLastSegmentInSidx? : boolean
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, representation, segment } = content;
   const { isInit, indexRange } = segment;
@@ -92,10 +88,10 @@ function parseISOBMFFEmbeddedTextTrack(
     {
       representation.index.initializeIndex(sidxSegments);
     }
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: mdhdTimescale } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: mdhdTimescale } };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
@@ -106,12 +102,12 @@ function parseISOBMFFEmbeddedTextTrack(
                                                     chunkInfos,
                                                     isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -124,16 +120,16 @@ function parsePlainTextTrack(
     content } : ISegmentParserArguments< Uint8Array |
                                          ArrayBuffer |
                                          string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   const { timestampOffset = 0 } = segment;
   if (segment.isInit) {
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   protectionDataUpdate: false,
-                                   initTimescale: undefined } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      protectionDataUpdate: false,
+                      initTimescale: undefined } };
   }
 
   const { data, isChunked } = response;
@@ -146,12 +142,12 @@ function parsePlainTextTrack(
     textTrackData = data;
   }
   const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos: null,
-                                 chunkOffset: timestampOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos: null,
+                    chunkOffset: timestampOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -173,25 +169,25 @@ export default function generateTextTrackParser(
                                                  ArrayBuffer |
                                                  string |
                                                  null >
-  ) : Observable<ISegmentParserInitSegment<null> |
-                 ISegmentParserSegment<ITextTrackSegmentData>>
+  ) : ISegmentParserInitSegment<null> |
+      ISegmentParserSegment<ITextTrackSegmentData>
   {
     const { period, adaptation, representation, segment } = content;
     const { timestampOffset = 0 } = segment;
     const { data, isChunked } = response;
     if (data === null) { // No data, just return empty infos
       if (segment.isInit) {
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: null,
-                                     chunkInfos: null,
-                                     chunkOffset: timestampOffset,
-                                     appendWindow: [period.start, period.end],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData: null,
+                        chunkInfos: null,
+                        chunkOffset: timestampOffset,
+                        protectionDataUpdate: false,
+                        appendWindow: [period.start, period.end] } };
     }
 
     const containerType = inferSegmentContainer(adaptation.type, representation);

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  Observable,
-  of as observableOf,
-} from "rxjs";
 import { getMDHDTimescale } from "../../parsers/containers/isobmff";
 import {
   strToUtf8,
@@ -48,8 +44,8 @@ function parseISOBMFFEmbeddedTextTrack(
     initTimescale } : ISegmentParserArguments< Uint8Array |
                                                ArrayBuffer |
                                                string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   const { data, isChunked } = response;
@@ -59,10 +55,10 @@ function parseISOBMFFEmbeddedTextTrack(
                                                   new Uint8Array(data);
   if (segment.isInit) {
     const mdhdTimescale = getMDHDTimescale(chunkBytes);
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   initTimescale: mdhdTimescale,
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      initTimescale: mdhdTimescale,
+                      protectionDataUpdate: false } };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
@@ -73,12 +69,12 @@ function parseISOBMFFEmbeddedTextTrack(
                                                     chunkInfos,
                                                     isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -91,15 +87,15 @@ function parsePlainTextTrack(
     content } : ISegmentParserArguments< Uint8Array |
                                          ArrayBuffer |
                                          string >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, segment } = content;
   if (segment.isInit) {
-    return observableOf({ type: "parsed-init-segment",
-                          value: { initializationData: null,
-                                   initTimescale: undefined,
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-init-segment",
+             value: { initializationData: null,
+                      initTimescale: undefined,
+                      protectionDataUpdate: false } };
   }
 
   const { data, isChunked } = response;
@@ -113,12 +109,12 @@ function parsePlainTextTrack(
   }
   const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-  return observableOf({ type: "parsed-segment",
-                        value: { chunkData,
-                                 chunkInfos: null,
-                                 chunkOffset,
-                                 appendWindow: [period.start, period.end],
-                                 protectionDataUpdate: false } });
+  return { type: "parsed-segment",
+           value: { chunkData,
+                    chunkInfos: null,
+                    chunkOffset,
+                    protectionDataUpdate: false,
+                    appendWindow: [period.start, period.end] } };
 }
 
 /**
@@ -133,25 +129,25 @@ export default function textTrackParser(
                                       ArrayBuffer |
                                       string |
                                       null >
-) : Observable<ISegmentParserInitSegment<null> |
-               ISegmentParserSegment<ITextTrackSegmentData>>
+) : ISegmentParserInitSegment<null> |
+    ISegmentParserSegment<ITextTrackSegmentData>
 {
   const { period, adaptation, representation, segment } = content;
   const { data, isChunked } = response;
   if (data === null) { // No data, just return empty infos
     if (segment.isInit) {
-      return observableOf({ type: "parsed-init-segment",
-                            value: { initializationData: null,
-                                     protectionDataUpdate: false,
-                                     initTimescale: undefined } });
+      return { type: "parsed-init-segment",
+               value: { initializationData: null,
+                        protectionDataUpdate: false,
+                        initTimescale: undefined } };
     }
     const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
-    return observableOf({ type: "parsed-segment",
-                          value: { chunkData: null,
-                                   chunkInfos: null,
-                                   chunkOffset,
-                                   appendWindow: [period.start, period.end],
-                                   protectionDataUpdate: false } });
+    return { type: "parsed-segment",
+             value: { chunkData: null,
+                      chunkInfos: null,
+                      chunkOffset,
+                      protectionDataUpdate: false,
+                      appendWindow: [period.start, period.end] } };
   }
 
   const containerType = inferSegmentContainer(adaptation.type, representation);

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+import Manifest, {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../manifest";
 import { getMDHDTimescale } from "../../parsers/containers/isobmff";
 import {
   strToUtf8,
@@ -35,20 +41,34 @@ import {
 
 /**
  * Parse TextTrack data when it is embedded in an ISOBMFF file.
- * @param {Object} infos
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
+ * @param {number|undefined} initTimescale - `timescale` value - encountered
+ * in this linked initialization segment (if it exists) - that may also apply
+ * to that segment if no new timescale is defined in it.
+ * Can be `undefined` if no timescale was defined, if it is not known, or if
+ * no linked initialization segment was yet parsed.
  * @returns {Observable.<Object>}
  */
 function parseISOBMFFEmbeddedTextTrack(
-  { response,
-    content,
-    initTimescale } : ISegmentParserArguments< Uint8Array |
-                                               ArrayBuffer |
-                                               string >
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; },
+  initTimescale : number | undefined,
+  __priv_patchLastSegmentInSidx? : boolean
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
-  const { data, isChunked } = response;
 
   const chunkBytes = typeof data === "string" ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -78,17 +98,26 @@ function parseISOBMFFEmbeddedTextTrack(
 }
 
 /**
- * Parse TextTrack data in plain text form.
- * @param {Object} infos
+ * Parse TextTrack data when it is in plain text form.
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
  * @returns {Observable.<Object>}
  */
 function parsePlainTextTrack(
-  { response,
-    content } : ISegmentParserArguments< Uint8Array |
-                                         ArrayBuffer |
-                                         string >
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; }
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
   if (segment.isInit) {
@@ -98,7 +127,6 @@ function parsePlainTextTrack(
              protectionDataUpdate: false };
   }
 
-  const { data, isChunked } = response;
   let textTrackData : string;
   if (typeof data !== "string") {
     const bytesData = data instanceof Uint8Array ? data :
@@ -130,18 +158,20 @@ export default function textTrackParser(
                                       string |
                                       null >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, adaptation, representation, segment } = content;
   const { data, isChunked } = response;
-  if (data === null) { // No data, just return empty infos
+
+  if (data === null) {
+    // No data, just return an empty placeholder object
     if (segment.isInit) {
       return { segmentType: "init",
                initializationData: null,
                protectionDataUpdate: false,
                initTimescale: undefined };
     }
-    const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
+    const chunkOffset = segment.timestampOffset ?? 0;
     return { segmentType: "media",
              chunkData: null,
              chunkInfos: null,
@@ -157,10 +187,8 @@ export default function textTrackParser(
     // TODO Handle webm containers
     throw new Error("Text tracks with a WEBM container are not yet handled.");
   } else if (containerType === "mp4") {
-    return parseISOBMFFEmbeddedTextTrack({ response: { data, isChunked },
-                                           content,
-                                           initTimescale });
+    return parseISOBMFFEmbeddedTextTrack(data, isChunked, content, initTimescale);
   } else {
-    return parsePlainTextTrack({ response: { data, isChunked }, content });
+    return parsePlainTextTrack(data, isChunked, content);
   }
 }

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -304,7 +304,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -328,7 +328,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -352,9 +352,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args: ISegmentParserArguments<ArrayBuffer|string|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+      args: ISegmentParserArguments< ArrayBuffer | string | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<ITextTrackSegmentData | null> |
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;
@@ -376,9 +376,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+      args : ISegmentParserArguments<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<IImageTrackSegmentData | null>  |
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -50,9 +50,8 @@ import {
   IManifestParserWarningEvent,
   ISegmentLoaderArguments,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
-  ISegmentParserSegmentPayload,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITextTrackSegmentData,
   ITransportOptions,
   ITransportPipelines,
@@ -262,7 +261,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
   function offsetTimeInfos(
     contentOffset : number,
     contentEnd : number | undefined,
-    segmentResponse : ISegmentParserSegmentPayload<unknown>
+    segmentResponse : ISegmentParserParsedSegment<unknown>
   ) : { chunkInfos : IChunkTimeInfo | null;
         chunkOffset : number;
         appendWindow : [ number | undefined, number | undefined ]; } {
@@ -306,22 +305,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { audio } = getTransportPipelinesFromSegment(segment);
       const parsed = audio.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -333,22 +329,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { video } = getTransportPipelinesFromSegment(segment);
       const parsed = video.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -360,22 +353,19 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args: ISegmentParserArguments<ArrayBuffer|string|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null> |
-        ISegmentParserSegment<ITextTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null> |
+        ISegmentParserParsedSegment<ITextTrackSegmentData>
     {
       const { content } = args;
       const { segment } = content;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { text } = getTransportPipelinesFromSegment(segment);
       const parsed = text.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 
@@ -387,8 +377,8 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
     parser(
       args : ISegmentParserArguments<ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null>  |
-        ISegmentParserSegment<IImageTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null>  |
+        ISegmentParserParsedSegment<IImageTrackSegmentData>
     {
       const { content } = args;
       const { segment } = content;
@@ -396,14 +386,11 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { image } = getTransportPipelinesFromSegment(segment);
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       const parsed = image.parser(getParserArguments(args, segment));
-      if (parsed.type === "parsed-init-segment") {
+      if (parsed.segmentType === "init") {
         return parsed;
       }
-      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed.value);
-      // TODO check why this is unsafe for TypeScript
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      return objectAssign({ type: "parsed-segment",
-                            value: objectAssign({}, parsed.value, timeInfos) });
+      const timeInfos = offsetTimeInfos(contentStart, contentEnd, parsed);
+      return objectAssign({}, parsed, timeInfos);
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -48,8 +48,8 @@ import {
   ISegmentLoaderArguments,
   ISegmentLoaderEvent,
   ISegmentParserArguments,
-  ISegmentParserInitSegment,
-  ISegmentParserSegment,
+  ISegmentParserParsedInitSegment,
+  ISegmentParserParsedSegment,
   ITextTrackSegmentData,
   ITransportOptions,
   ITransportPipelines,
@@ -180,24 +180,24 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments< ArrayBuffer | Uint8Array | null >
-    ) : ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
-        ISegmentParserSegment<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>
     {
       const { segment, adaptation, manifest } = content;
       const { data, isChunked } = response;
       if (data === null) {
         if (segment.isInit) {
-          return { type: "parsed-init-segment",
-                   value: { initializationData: null,
-                            protectionDataUpdate: false,
-                            initTimescale: undefined } };
+          return { segmentType: "init",
+                   initializationData: null,
+                   protectionDataUpdate: false,
+                   initTimescale: undefined };
         }
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       const responseBuffer = data instanceof Uint8Array ? data :
@@ -205,12 +205,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       if (segment.isInit) {
         const timescale = segment.privateInfos?.smoothInitSegment?.timescale;
-        return { type: "parsed-init-segment",
-                 value: { initializationData: data,
-                          // smooth init segments are crafted by hand.
-                          // Their timescale is the one from the manifest.
-                          initTimescale: timescale,
-                          protectionDataUpdate: false } };
+        return { segmentType: "init",
+                 initializationData: data,
+                 // smooth init segments are crafted by hand.
+                 // Their timescale is the one from the manifest.
+                 initTimescale: timescale,
+                 protectionDataUpdate: false };
       }
 
       const timingInfos = initTimescale !== undefined ?
@@ -231,12 +231,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       if (nextSegments.length > 0) {
         addNextSegments(adaptation, nextSegments, segment);
       }
-      return { type: "parsed-segment",
-               value: { chunkData,
-                        chunkInfos,
-                        chunkOffset: 0,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData,
+               chunkInfos,
+               chunkOffset: 0,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] };
     },
   };
 
@@ -272,8 +272,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserInitSegment<null>  |
-        ISegmentParserSegment<ITextTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null>  |
+        ISegmentParserParsedSegment<ITextTrackSegmentData>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -281,18 +281,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       const { mimeType = "", codec = "" } = representation;
       const { data, isChunked } = response;
       if (segment.isInit) { // text init segment has no use in HSS
-        return { type: "parsed-init-segment",
-                 value: { initializationData: null,
-                          protectionDataUpdate: false,
-                          initTimescale: undefined } };
+        return { segmentType: "init",
+                 initializationData: null,
+                 protectionDataUpdate: false,
+                 initTimescale: undefined };
       }
       if (data === null) {
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       let nextSegments;
@@ -395,16 +395,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
 
       const chunkOffset = segmentStart ?? 0;
-      return { type: "parsed-segment",
-               value: { chunkData: { type: _sdType,
-                                     data: _sdData,
-                                     start: segmentStart,
-                                     end: segmentEnd,
-                                     language },
-                        chunkInfos,
-                        chunkOffset,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData: { type: _sdType,
+                            data: _sdData,
+                            start: segmentStart,
+                            end: segmentEnd,
+                            language },
+               chunkInfos,
+               chunkOffset,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] };
     },
   };
 
@@ -426,16 +426,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : ISegmentParserInitSegment<null> |
-        ISegmentParserSegment<IImageTrackSegmentData>
+    ) : ISegmentParserParsedInitSegment<null> |
+        ISegmentParserParsedSegment<IImageTrackSegmentData>
     {
       const { data, isChunked } = response;
 
       if (content.segment.isInit) { // image init segment has no use
-        return { type: "parsed-init-segment",
-                 value: { initializationData: null,
-                          protectionDataUpdate: false,
-                          initTimescale: undefined } };
+        return { segmentType: "init",
+                 initializationData: null,
+                 protectionDataUpdate: false,
+                 initTimescale: undefined };
       }
 
       if (isChunked) {
@@ -444,27 +444,27 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       // TODO image Parsing should be more on the buffer side, no?
       if (data === null || features.imageParser === null) {
-        return { type: "parsed-segment",
-                 value: { chunkData: null,
-                          chunkInfos: null,
-                          chunkOffset: 0,
-                          protectionDataUpdate: false,
-                          appendWindow: [undefined, undefined] } };
+        return { segmentType: "media",
+                 chunkData: null,
+                 chunkInfos: null,
+                 chunkOffset: 0,
+                 protectionDataUpdate: false,
+                 appendWindow: [undefined, undefined] };
       }
 
       const bifObject = features.imageParser(new Uint8Array(data));
       const thumbsData = bifObject.thumbs;
-      return { type: "parsed-segment",
-               value: { chunkData: { data: thumbsData,
-                                     start: 0,
-                                     end: Number.MAX_VALUE,
-                                     timescale: 1,
-                                     type: "bif" },
-                        chunkInfos: { time: 0,
-                                      duration: Number.MAX_VALUE },
-                        chunkOffset: 0,
-                        protectionDataUpdate: false,
-                        appendWindow: [undefined, undefined] } };
+      return { segmentType: "media",
+               chunkData: { data: thumbsData,
+                            start: 0,
+                            end: Number.MAX_VALUE,
+                            timescale: 1,
+                            type: "bif" },
+               chunkInfos: { time: 0,
+                             duration: Number.MAX_VALUE },
+               chunkOffset: 0,
+               protectionDataUpdate: false,
+               appendWindow: [undefined, undefined] } ;
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -180,24 +180,24 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments< ArrayBuffer | Uint8Array | null >
-    ) : Observable<ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
-                   ISegmentParserSegment<ArrayBuffer | Uint8Array | null>>
+    ) : ISegmentParserInitSegment<ArrayBuffer | Uint8Array | null>  |
+        ISegmentParserSegment<ArrayBuffer | Uint8Array | null>
     {
       const { segment, adaptation, manifest } = content;
       const { data, isChunked } = response;
       if (data === null) {
         if (segment.isInit) {
-          return observableOf({ type: "parsed-init-segment",
-                                value: { initializationData: null,
-                                         protectionDataUpdate: false,
-                                         initTimescale: undefined } });
+          return { type: "parsed-init-segment",
+                   value: { initializationData: null,
+                            protectionDataUpdate: false,
+                            initTimescale: undefined } };
         }
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       const responseBuffer = data instanceof Uint8Array ? data :
@@ -205,12 +205,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       if (segment.isInit) {
         const timescale = segment.privateInfos?.smoothInitSegment?.timescale;
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: data,
-                                       // smooth init segments are crafted by hand.
-                                       // Their timescale is the one from the manifest.
-                                       initTimescale: timescale,
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: data,
+                          // smooth init segments are crafted by hand.
+                          // Their timescale is the one from the manifest.
+                          initTimescale: timescale,
+                          protectionDataUpdate: false } };
       }
 
       const timingInfos = initTimescale !== undefined ?
@@ -231,12 +231,12 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       if (nextSegments.length > 0) {
         addNextSegments(adaptation, nextSegments, segment);
       }
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData,
-                                     chunkInfos,
-                                     chunkOffset: 0,
-                                     appendWindow: [undefined, undefined],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData,
+                        chunkInfos,
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 
@@ -272,8 +272,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       response,
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
-    ) : Observable<ISegmentParserInitSegment<null>  |
-                   ISegmentParserSegment<ITextTrackSegmentData>>
+    ) : ISegmentParserInitSegment<null>  |
+        ISegmentParserSegment<ITextTrackSegmentData>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -281,18 +281,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       const { mimeType = "", codec = "" } = representation;
       const { data, isChunked } = response;
       if (segment.isInit) { // text init segment has no use in HSS
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
       if (data === null) {
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       let nextSegments;
@@ -395,16 +395,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
 
       const chunkOffset = segmentStart ?? 0;
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: { type: _sdType,
-                                                  data: _sdData,
-                                                  start: segmentStart,
-                                                  end: segmentEnd,
-                                                  language },
-                                     chunkInfos,
-                                     chunkOffset,
-                                     appendWindow: [undefined, undefined],
-                                     protectionDataUpdate: false } });
+      return { type: "parsed-segment",
+               value: { chunkData: { type: _sdType,
+                                     data: _sdData,
+                                     start: segmentStart,
+                                     end: segmentEnd,
+                                     language },
+                        chunkInfos,
+                        chunkOffset,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 
@@ -426,16 +426,16 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
-    ) : Observable<ISegmentParserInitSegment<null>  |
-                   ISegmentParserSegment<IImageTrackSegmentData>>
+    ) : ISegmentParserInitSegment<null> |
+        ISegmentParserSegment<IImageTrackSegmentData>
     {
       const { data, isChunked } = response;
 
       if (content.segment.isInit) { // image init segment has no use
-        return observableOf({ type: "parsed-init-segment",
-                              value: { initializationData: null,
-                                       protectionDataUpdate: false,
-                                       initTimescale: undefined } });
+        return { type: "parsed-init-segment",
+                 value: { initializationData: null,
+                          protectionDataUpdate: false,
+                          initTimescale: undefined } };
       }
 
       if (isChunked) {
@@ -444,28 +444,27 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
       // TODO image Parsing should be more on the buffer side, no?
       if (data === null || features.imageParser === null) {
-        return observableOf({ type: "parsed-segment",
-                              value: { chunkData: null,
-                                       chunkInfos: null,
-                                       chunkOffset: 0,
-                                       appendWindow: [undefined, undefined],
-                                       protectionDataUpdate: false } });
+        return { type: "parsed-segment",
+                 value: { chunkData: null,
+                          chunkInfos: null,
+                          chunkOffset: 0,
+                          protectionDataUpdate: false,
+                          appendWindow: [undefined, undefined] } };
       }
 
       const bifObject = features.imageParser(new Uint8Array(data));
       const thumbsData = bifObject.thumbs;
-      return observableOf({ type: "parsed-segment",
-                            value: { chunkData: { data: thumbsData,
-                                                  start: 0,
-                                                  end: Number.MAX_VALUE,
-                                                  timescale: 1,
-                                                  type: "bif" },
-                                     chunkInfos: { time: 0,
-                                                   duration: Number.MAX_VALUE,
-                                                   timescale: bifObject.timescale },
-                                     chunkOffset: 0,
-                                     protectionDataUpdate: false,
-                                     appendWindow: [undefined, undefined] } });
+      return { type: "parsed-segment",
+               value: { chunkData: { data: thumbsData,
+                                     start: 0,
+                                     end: Number.MAX_VALUE,
+                                     timescale: 1,
+                                     type: "bif" },
+                        chunkInfos: { time: 0,
+                                      duration: Number.MAX_VALUE },
+                        chunkOffset: 0,
+                        protectionDataUpdate: false,
+                        appendWindow: [undefined, undefined] } };
     },
   };
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -273,7 +273,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
     ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -427,7 +427,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
     ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { data, isChunked } = response;
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -142,8 +142,8 @@ export type ISegmentParser<
   ParsedMediaDataFormat
 > = (
   x : ISegmentParserArguments< LoadedFormat >
-) => Observable<ISegmentParserInitSegment<ParsedInitDataFormat>  |
-                ISegmentParserSegment<ParsedMediaDataFormat>>;
+) => ISegmentParserInitSegment<ParsedInitDataFormat>  |
+     ISegmentParserSegment<ParsedMediaDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {
@@ -427,7 +427,7 @@ export interface IChunkTimeInfo {
 }
 
 /** Payload sent when an initialization segment has been parsed. */
-export interface ISegmentParserParsedInitSegment<T> {
+export interface ISegmentParserInitSegmentPayload<T> {
   /**
    * Initialization segment that can be directly pushed to the corresponding
    * buffer.
@@ -453,7 +453,7 @@ export interface ISegmentParserParsedInitSegment<T> {
 }
 
 /** Payload sent when an media segment has been parsed. */
-export interface ISegmentParserParsedSegment<T> {
+export interface ISegmentParserSegmentPayload<T> {
   /** Data to decode. */
   chunkData : T | null;
   /** Time information about the segment. */
@@ -504,7 +504,7 @@ export interface ISegmentParserParsedSegment<T> {
  */
 export interface ISegmentParserInitSegment<T> {
   type : "parsed-init-segment";
-  value : ISegmentParserParsedInitSegment<T>;
+  value : ISegmentParserInitSegmentPayload<T>;
 }
 
 /**
@@ -513,7 +513,7 @@ export interface ISegmentParserInitSegment<T> {
  */
 export interface ISegmentParserSegment<T> {
   type : "parsed-segment";
-  value : ISegmentParserParsedSegment<T>;
+  value : ISegmentParserSegmentPayload<T>;
 }
 
 // format under which audio / video data / initialization data is decodable

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -50,20 +50,16 @@ export interface ITransportPipelines {
   manifest : ITransportManifestPipeline;
   /** Functions allowing to load an parse audio segments. */
   audio : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse video segments. */
   video : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse text (e.g. subtitles) segments. */
   text : ISegmentPipeline<Uint8Array | ArrayBuffer | string | null,
-                          null,
-                          ITextTrackSegmentData>;
+                          ITextTrackSegmentData | null>;
   /** Functions allowing to load an parse image (e.g. thumbnails) segments. */
   image : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           null,
-                           IImageTrackSegmentData>;
+                           IImageTrackSegmentData | null>;
 }
 
 /** Functions allowing to load and parse the Manifest. */
@@ -112,14 +108,12 @@ export type IManifestParserFunction = (
 
 /** Functions allowing to load and parse segments of any type. */
 export interface ISegmentPipeline<
-  LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat,
+  TLoadedFormat,
+  TParsedSegmentDataFormat,
 > {
-  loader : ISegmentLoader<LoadedFormat>;
-  parser : ISegmentParser<LoadedFormat,
-                          ParsedInitDataFormat,
-                          ParsedMediaDataFormat>;
+  loader : ISegmentLoader<TLoadedFormat>;
+  parser : ISegmentParser<TLoadedFormat,
+                          TParsedSegmentDataFormat>;
 }
 
 /**
@@ -127,9 +121,9 @@ export interface ISegmentPipeline<
  * @param {Object} x
  * @returns {Observable.<Object>}
  */
-export type ISegmentLoader<LoadedFormat> = (
+export type ISegmentLoader<TLoadedFormat> = (
   x : ISegmentLoaderArguments
-) => Observable<ISegmentLoaderEvent<LoadedFormat>>;
+) => Observable<ISegmentLoaderEvent<TLoadedFormat>>;
 
 /**
  * Segment parser function, allowing to parse a segment of any type.
@@ -137,11 +131,10 @@ export type ISegmentLoader<LoadedFormat> = (
  * @returns {Observable.<Object>}
  */
 export type ISegmentParser<
-  LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat
+  TLoadedFormat,
+  TParsedSegmentDataFormat
 > = (
-  x : ISegmentParserArguments< LoadedFormat >
+  x : ISegmentParserArguments< TLoadedFormat >
 ) =>
   /**
    * The parsed data.
@@ -155,8 +148,8 @@ export type ISegmentParser<
    *     segment.
    *     Such segments generally contain decodable media data.
    */
-  ISegmentParserParsedInitSegment<ParsedInitDataFormat> |
-  ISegmentParserParsedSegment<ParsedMediaDataFormat>;
+  ISegmentParserParsedInitSegment<TParsedSegmentDataFormat> |
+  ISegmentParserParsedSegment<TParsedSegmentDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {
@@ -234,8 +227,10 @@ export interface IManifestLoaderDataLoadedEvent {
 }
 
 /** Event emitted by a segment loader when the data has been fully loaded. */
-export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
-                                                    value : ILoaderDataLoadedValue<T>; }
+export interface ISegmentLoaderDataLoadedEvent<T> {
+  type : "data-loaded";
+  value : ILoaderDataLoadedValue<T>;
+}
 
 /**
  * Event emitted by a segment loader when the data is available without needing
@@ -244,8 +239,10 @@ export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
  * Such data are for example directly generated from already-available data,
  * such as properties of a Manifest.
  */
-export interface ISegmentLoaderDataCreatedEvent<T> { type : "data-created";
-                                                     value : { responseData : T }; }
+export interface ISegmentLoaderDataCreatedEvent<T> {
+  type : "data-created";
+  value : { responseData : T };
+}
 
 /**
  * Event emitted by a segment loader when new information on a pending request
@@ -363,8 +360,13 @@ export interface IManifestParserArguments {
 export interface ISegmentParserArguments<T> {
   /** Attributes of the corresponding loader's response. */
   response : {
-    /** The loaded data. */
-    data: T;
+    /**
+     * The loaded data.
+     *
+     * Possibly in Uint8Array or ArrayBuffer form if chunked (see `isChunked`
+     * property) or loaded through custom loaders.
+     */
+    data: T | Uint8Array | ArrayBuffer;
     /**
      * If `true`,`data` is only a "chunk" of the whole segment (which potentially
      * will contain multiple chunks).
@@ -446,7 +448,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
    * Initialization segment that can be directly pushed to the corresponding
    * buffer.
    */
-  initializationData : DataType | null;
+  initializationData : DataType;
   /**
    * Timescale metadata found inside this initialization segment.
    * That timescale might be useful when parsing further merdia segments.
@@ -473,7 +475,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
 export interface ISegmentParserParsedSegment<DataType> {
   segmentType : "media";
   /** Parsed chunk of data that can be decoded. */
-  chunkData : DataType | null;
+  chunkData : DataType;
   /** Time information on this parsed chunk. */
   chunkInfos : IChunkTimeInfo | null;
   /**

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -23,7 +23,10 @@ import isNullOrUndefined from "./is_null_or_undefined";
  * @param {string} [message] - Optional message property for the AssertionError.
  * @throws AssertionError - Throws if the assertion given is false
  */
-export default function assert(assertion : boolean, message? : string) : void {
+export default function assert(
+  assertion : boolean,
+  message? : string
+) : asserts assertion {
   if (!assertion) {
     throw new AssertionError(message === undefined ? "invalid assertion" :
                                                      message);


### PR DESCRIPTION
Every segment parser in `src/transports`, which allows to parse things like data, encryption metadata and time information from loaded segments according to the current streaming protocol, do so synchronously.

However, those are typed as [possibly asynchronous] Observables.

My guess (this was before my time on the project) is that it was mainly for two reasons:

  1. Manifest parsing can be asynchronous (for example to fetch MPD xlinks or the clock) and it follows the same pipeline architecture (a loader and a parser) than segments.

     Letting segment parser be asynchronous thus allows to harmonize all resource-fetching code to a similar interface.

  2. Theorically, segment parsing could be asynchronous. As far as I can see for now, this could be because of two reasons:

       - We need to perform an HTTPS request to fully parse segment information.

         We already encountered such case when trying to implement the "sidx ref type 1" feature (#754). However we did not merge that work for now due to the complexity and most of all because no real DASH MPD seems to rely on this feature (nor are we able to envisage a real use-case for it).

       - segment parsing is performed in a Worker.
         But we do not feel the need to do that for now as the CPU footprint of parsing segments is really low.

So theorically, there are good reasons to make the parsing operation asynchronous, but reastically for now, there's none.

Meanwhile, making that operation asynchronous leads to big headaches:

  - it is one of the main reasons why the PR on making the init and first media segment's requests in parallel [#918] was not merged.
    Subtle bugs, some that would only be seen in a case where the  parsing is asynchronous (so not really existant for now) could arise because of that.
    Those bugs were here in the first place because asynchronous tasks are much harder to reason about than synchronous ones.

  - Even if the response of the parser is wrapped in an Observable, it wasn't lazy (the code would be called even if the parser was not subscribed to). We could fix that by wrapping all parsers in a `defer` call from RxJS, but it would complexify even more the code.

  - Handling Observables is a LOT harder than just using directly a response in general. There's pending work about not depending so much on RxJS in the future [#916] and I think beginning to remove it where it is not even needed is a good first step.

If it become needed again in the future (e.g. to support the "sidx ref type 1" feature), we could always revert that work, maybe even with a more Promise-based solution which might be much easier to reason about.

Thoughts?