### PR TITLE
[Proposal] Simplify segment parsers types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,11 +82,14 @@ directory) by calling `npm run lint:tests`.
 <a name="code-types"></a>
 ### Types ######################################################################
 
+#### General TypeScript rules ##################################################
+
 We try to be as strict as possible with types:
 
   - the `any` type should be avoided
 
-  - the `as` keyword should also be avoided as much as possible.
+  - the `as` TypeScript keyword, used for type casting, should also be avoided
+    as much as possible.
 
   - the `is` keyword is fine in some situations, but simpler solutions should be
     preferred.
@@ -94,8 +97,70 @@ We try to be as strict as possible with types:
 This is to be sure we can detect as much as possible type errors automatically
 with TypeScript.
 
-Also, created TypeScript's `type` and `interface` should all be named beginning
-with the letter I, for easier identification purposes.
+### `type` and `interface` typing
+
+TypeScript's `type` and `interface` should all be named beginning with the
+letter `I`, for easier identification purposes\*:
+```
+interface IMyObject {
+  someKey: string;
+}
+
+type IStringOrNumber = string |
+                       number;
+```
+
+\*We know that this rule is a controversial subject amongst TypeScript
+developpers, yet we still decide to enforce it for now.
+
+#### Generic parameters typing #################################################
+
+Generic parameters are usually named in order `T` (for the first generic
+parameter), then `U` (if there's two), then `V` (if there's three):
+
+Examples:
+```
+type IMyGenericType<T> = Array<T>;
+
+type IMyGenericType2<T, U> = Promise<T> |
+                             U;
+
+function mergeThree<T, U, V>(
+  arg1: T,
+  arg2: U,
+  arg3: V
+) : T & U & V {
+  return Object.assign({}, arg1, arg2, arg3);
+}
+```
+
+Some exceptions exist like for things like key-values couples, which can be named
+respectively `K` and `V`:
+```
+type IMyMap<K, V> = Map<K, V>;
+```
+
+This is a general convention for generic parameters inherited from Java, and
+re-used by TypeScript, and it helps identifying which type is a generic
+parameter vs which type is a real type (no prefix) vs which type is a type
+definition (prefixed by `I`).
+
+If what they correspond to is not obvious (and if there's more than one, it
+might well be), you're encouraged to add a more verbose and clear name, that you
+should prefix by `T`:
+```
+function loadResource<TResourceFormat>(
+  url : string
+) : Promise<TResourceFormat> {
+  // ...
+}
+```
+
+However note that typing rules for generic parameters is a very minor
+consideration and may not always need to be respected depending on the code it
+is applied on.
+In the end, it will be up to the RxPlayer's maintainers to decide that those
+rules should be enforced or not on a given code.
 
 
 <a name="code-forbidden"></a>

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -773,7 +773,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
                                                     maxRetryOffline: offlineRetry });
 
       /** Interface used to download segments. */
-      const segmentFetcherCreator = new SegmentFetcherCreator<any>(
+      const segmentFetcherCreator = new SegmentFetcherCreator(
         transportPipelines,
         { lowLatencyMode,
           maxRetryOffline: offlineRetry,

--- a/src/core/fetchers/segment/create_segment_loader.ts
+++ b/src/core/fetchers/segment/create_segment_loader.ts
@@ -70,8 +70,7 @@ export interface ISegmentLoaderData<T> { type : "data";
  * ISegmentLoaderChunkComplete event is received.
  */
 export interface ISegmentLoaderChunk { type : "chunk";
-                                       value : { responseData : null |
-                                                                ArrayBuffer |
+                                       value : { responseData : ArrayBuffer |
                                                                 Uint8Array; }; }
 
 /** The data has been entirely sent through "chunk" events. */

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -40,21 +40,21 @@ export interface ISegmentFetcherInterruptedEvent { type : "interrupted" }
 export interface IEndedTaskEvent { type : "ended" }
 
 /** Event sent by a `IPrioritizedSegmentFetcher`. */
-export type IPrioritizedSegmentFetcherEvent<SegmentDataType> =
-  ISegmentFetcherEvent<SegmentDataType> |
+export type IPrioritizedSegmentFetcherEvent<TSegmentDataType> =
+  ISegmentFetcherEvent<TSegmentDataType> |
   ISegmentFetcherInterruptedEvent |
   IEndedTaskEvent;
 
 /** Oject returned by `applyPrioritizerToSegmentFetcher`. */
-export interface IPrioritizedSegmentFetcher<SegmentDataType> {
+export interface IPrioritizedSegmentFetcher<TSegmentDataType> {
   /** Create a new request for a segment with a given priority. */
   createRequest : (content : ISegmentLoaderContent,
                    priority? : number) =>
-    Observable<IPrioritizedSegmentFetcherEvent<SegmentDataType>>;
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>;
 
   /** Update priority of a request created through `createRequest`. */
   updatePriority : (
-    observable : Observable<IPrioritizedSegmentFetcherEvent<SegmentDataType>>,
+    observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
     priority : number
   ) => void;
 }
@@ -69,18 +69,18 @@ export interface IPrioritizedSegmentFetcher<SegmentDataType> {
  * @param {Object} fetcher
  * @returns {Object}
  */
-export default function applyPrioritizerToSegmentFetcher<SegmentDataType>(
-  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<SegmentDataType>>,
-  fetcher : ISegmentFetcher<SegmentDataType>
-) : IPrioritizedSegmentFetcher<SegmentDataType> {
+export default function applyPrioritizerToSegmentFetcher<TSegmentDataType>(
+  prioritizer : ObservablePrioritizer<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+  fetcher : ISegmentFetcher<TSegmentDataType>
+) : IPrioritizedSegmentFetcher<TSegmentDataType> {
   /**
    * The Observables returned by `createRequest` are not exactly the same than
    * the one created by the `ObservablePrioritizer`. Because we still have to
    * keep a handle on that value.
    */
   const taskHandlers = new WeakMap<
-    Observable<IPrioritizedSegmentFetcherEvent<SegmentDataType>>,
-    Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<SegmentDataType>>>
+    Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
+    Observable<ITaskEvent<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>>
   >();
   return {
     /**
@@ -93,7 +93,7 @@ export default function applyPrioritizerToSegmentFetcher<SegmentDataType>(
     createRequest(
       content : ISegmentLoaderContent,
       priority : number = 0
-    ) : Observable<IPrioritizedSegmentFetcherEvent<SegmentDataType>> {
+    ) : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>> {
       const task = prioritizer.create(fetcher(content), priority);
       const flattenTask = task.pipe(
         map((evt) => {
@@ -112,7 +112,7 @@ export default function applyPrioritizerToSegmentFetcher<SegmentDataType>(
      * @param {Number} priority - The new priority value.
      */
     updatePriority(
-      observable : Observable<IPrioritizedSegmentFetcherEvent<SegmentDataType>>,
+      observable : Observable<IPrioritizedSegmentFetcherEvent<TSegmentDataType>>,
       priority : number
     ) : void {
       const correspondingTask = taskHandlers.get(observable);

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -64,7 +64,7 @@ export type ISegmentFetcherWarning = ISegmentLoaderWarning;
  * Event sent when a new "chunk" of the segment is available.
  * A segment can contain n chunk(s) for n >= 0.
  */
-export interface ISegmentFetcherChunkEvent<SegmentDataType> {
+export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
   type : "chunk";
   /**
    * Parse the downloaded chunk.
@@ -77,8 +77,8 @@ export interface ISegmentFetcherChunkEvent<SegmentDataType> {
    * @param {number} initTimescale
    * @returns {Object}
    */
-  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<SegmentDataType> |
-                                   ISegmentParserParsedSegment<SegmentDataType>;
+  parse(initTimescale? : number) : ISegmentParserParsedInitSegment<TSegmentDataType> |
+                                   ISegmentParserParsedSegment<TSegmentDataType>;
 }
 
 /**
@@ -88,13 +88,13 @@ export interface ISegmentFetcherChunkEvent<SegmentDataType> {
 export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete" }
 
 /** Event sent by the SegmentFetcher when fetching a segment. */
-export type ISegmentFetcherEvent<SegmentDataType> =
+export type ISegmentFetcherEvent<TSegmentDataType> =
   ISegmentFetcherChunkCompleteEvent |
-  ISegmentFetcherChunkEvent<SegmentDataType> |
+  ISegmentFetcherChunkEvent<TSegmentDataType> |
   ISegmentFetcherWarning;
 
-export type ISegmentFetcher<SegmentDataType> = (content : ISegmentLoaderContent) =>
-  Observable<ISegmentFetcherEvent<SegmentDataType>>;
+export type ISegmentFetcher<TSegmentDataType> = (content : ISegmentLoaderContent) =>
+  Observable<ISegmentFetcherEvent<TSegmentDataType>>;
 
 const generateRequestID = idGenerator();
 
@@ -108,16 +108,16 @@ const generateRequestID = idGenerator();
  */
 export default function createSegmentFetcher<
   LoadedFormat,
-  SegmentDataType
+  TSegmentDataType
 >(
   bufferType : IBufferType,
-  segmentPipeline : ISegmentPipeline<LoadedFormat, SegmentDataType>,
+  segmentPipeline : ISegmentPipeline<LoadedFormat, TSegmentDataType>,
   requests$ : Subject<IABRMetricsEvent |
                       IABRRequestBeginEvent |
                       IABRRequestProgressEvent |
                       IABRRequestEndEvent>,
   options : IBackoffOptions
-) : ISegmentFetcher<SegmentDataType> {
+) : ISegmentFetcher<TSegmentDataType> {
   const cache = arrayIncludes(["audio", "video"], bufferType) ?
     new InitializationSegmentCache<any>() :
     undefined;
@@ -135,7 +135,7 @@ export default function createSegmentFetcher<
    */
   return function fetchSegment(
     content : ISegmentLoaderContent
-  ) : Observable<ISegmentFetcherEvent<SegmentDataType>> {
+  ) : Observable<ISegmentFetcherEvent<TSegmentDataType>> {
     const id = generateRequestID();
     let requestBeginSent = false;
     return segmentLoader(content).pipe(
@@ -219,8 +219,8 @@ export default function createSegmentFetcher<
            * @returns {Observable}
            */
           parse(initTimescale? : number) :
-            ISegmentParserParsedInitSegment<SegmentDataType> |
-            ISegmentParserParsedSegment<SegmentDataType>
+            ISegmentParserParsedInitSegment<TSegmentDataType> |
+            ISegmentParserParsedSegment<TSegmentDataType>
           {
             const response = { data: evt.value.responseData, isChunked };
             try {

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -126,7 +126,7 @@ export interface IInitializeArguments {
   /** Limit the frequency of Manifest updates. */
   minimumManifestUpdateInterval : number;
   /** Interface allowing to load segments */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /** Perform an internal seek */
   setCurrentTime: (time: number) => void;
   /** Emit the playback rate (speed) set by the user. */

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -66,7 +66,7 @@ export interface IMediaSourceLoaderArguments {
   /** Media Element on which the content will be played. */
   mediaElement : HTMLMediaElement;
   /** Module to facilitate segment fetching. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * Observable emitting the wanted playback rate as it changes.
    * Replay the last value on subscription.

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -109,7 +109,7 @@ export interface IAdaptationStreamArguments<T> {
   /** SourceBuffer wrapper - needed to push media segments. */
   segmentBuffer : SegmentBuffer<T>;
   /** Module used to fetch the wanted media segments. */
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   /**
    * "Buffer goal" wanted, or the ideal amount of time ahead of the current
    * position in the current SegmentBuffer. When this amount has been reached

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -110,7 +110,7 @@ export default function StreamOrchestrator(
   clock$ : Observable<IStreamOrchestratorClockTick>,
   abrManager : ABRManager,
   segmentBuffersStore : SegmentBuffersStore,
-  segmentFetcherCreator : SegmentFetcherCreator<any>,
+  segmentFetcherCreator : SegmentFetcherCreator,
   options: IStreamOrchestratorOptions
 ) : Observable<IStreamOrchestratorEvent> {
   const { manifest, initialPeriod } = content;

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -87,7 +87,7 @@ export interface IPeriodStreamArguments {
   content : { manifest : Manifest;
               period : Period; };
   garbageCollectors : WeakMapMemory<SegmentBuffer<unknown>, Observable<never>>;
-  segmentFetcherCreator : SegmentFetcherCreator<any>;
+  segmentFetcherCreator : SegmentFetcherCreator;
   segmentBuffersStore : SegmentBuffersStore;
   options: IPeriodStreamOptions;
   wantedBufferAhead$ : BehaviorSubject<number>;

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -119,7 +119,7 @@ export interface ITerminationOrder {
 }
 
 /** Arguments to give to the RepresentationStream. */
-export interface IRepresentationStreamArguments<T> {
+export interface IRepresentationStreamArguments<SegmentDataType> {
   /** Periodically emits the current playback conditions. */
   clock$ : Observable<IRepresentationStreamClockTick>;
   /** The context of the Representation you want to load. */
@@ -128,9 +128,9 @@ export interface IRepresentationStreamArguments<T> {
              period : Period;
              representation : Representation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
-  segmentBuffer : SegmentBuffer<T>;
+  segmentBuffer : SegmentBuffer<SegmentDataType>;
   /** Interface used to load new segments. */
-  segmentFetcher : IPrioritizedSegmentFetcher<T>;
+  segmentFetcher : IPrioritizedSegmentFetcher<SegmentDataType>;
   /**
    * Observable emitting when the RepresentationStream should "terminate".
    *
@@ -218,7 +218,7 @@ export default function RepresentationStream<T>({
    * Saved initialization segment state for this representation.
    * `null` if the initialization segment hasn't been loaded yet.
    */
-  let initSegmentObject : ISegmentParserParsedInitSegment<T> | null =
+  let initSegmentObject : ISegmentParserParsedInitSegment<T | null> | null =
     initSegment === null ? { segmentType: "init",
                              initializationData: null,
                              protectionDataUpdate: false,

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -119,7 +119,7 @@ export interface ITerminationOrder {
 }
 
 /** Arguments to give to the RepresentationStream. */
-export interface IRepresentationStreamArguments<SegmentDataType> {
+export interface IRepresentationStreamArguments<TSegmentDataType> {
   /** Periodically emits the current playback conditions. */
   clock$ : Observable<IRepresentationStreamClockTick>;
   /** The context of the Representation you want to load. */
@@ -128,9 +128,9 @@ export interface IRepresentationStreamArguments<SegmentDataType> {
              period : Period;
              representation : Representation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
-  segmentBuffer : SegmentBuffer<SegmentDataType>;
+  segmentBuffer : SegmentBuffer<TSegmentDataType>;
   /** Interface used to load new segments. */
-  segmentFetcher : IPrioritizedSegmentFetcher<SegmentDataType>;
+  segmentFetcher : IPrioritizedSegmentFetcher<TSegmentDataType>;
   /**
    * Observable emitting when the RepresentationStream should "terminate".
    *

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -35,8 +35,8 @@ export default function addSegmentIntegrityChecks(
   segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 ) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null>;
 export default function addSegmentIntegrityChecks(
-  segmentLoader : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
-) : ISegmentLoader< ArrayBuffer | Uint8Array | string | null >
+  segmentLoader : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
+) : ISegmentLoader<ArrayBuffer | Uint8Array | string | null>
 {
   return (content) => segmentLoader(content).pipe(tap((res) => {
     if ((res.type === "data-loaded" || res.type === "data-chunk") &&

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -55,7 +55,7 @@ export function imageParser(
   { response,
     content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<IImageTrackSegmentData>
+    ISegmentParserParsedSegment<IImageTrackSegmentData | null>
 {
   const { segment, period } = content;
   const { data, isChunked } = response;

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -19,6 +19,7 @@ import {
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
 import { BaseRepresentationIndex } from "../../parsers/manifest/dash";
+import assert from "../../utils/assert";
 import {
   strToUtf8,
   utf8ToStr,
@@ -50,11 +51,15 @@ function parseISOBMFFEmbeddedTextTrack(
                                                string >,
   __priv_patchLastSegmentInSidx? : boolean
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, representation, segment } = content;
   const { isInit, indexRange } = segment;
   const { data, isChunked } = response;
+
+  // Should already have been taken care of
+  // TODO better use TypeScript here?
+  assert(data !== null);
 
   const chunkBytes = typeof data === "string"   ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -120,7 +125,7 @@ function parsePlainTextTrack(
                                          ArrayBuffer |
                                          string >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
   const { timestampOffset = 0 } = segment;
@@ -134,6 +139,11 @@ function parsePlainTextTrack(
   const { data, isChunked } = response;
   let textTrackData : string;
   if (typeof data !== "string") {
+
+    // Should already have been taken care of
+    // TODO better use TypeScript here?
+    assert(data !== null);
+
     const bytesData = data instanceof Uint8Array ? data :
                                                    new Uint8Array(data);
     textTrackData = utf8ToStr(bytesData);
@@ -168,7 +178,7 @@ export default function generateTextTrackParser(
                                                  string |
                                                  null >
   ) : ISegmentParserParsedInitSegment<null> |
-      ISegmentParserParsedSegment<ITextTrackSegmentData>
+      ISegmentParserParsedSegment<ITextTrackSegmentData | null>
   {
     const { period, representation, segment } = content;
     const { timestampOffset = 0 } = segment;

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+import Manifest, {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../manifest";
 import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
 import { BaseRepresentationIndex } from "../../parsers/manifest/dash";
-import assert from "../../utils/assert";
 import {
   strToUtf8,
   utf8ToStr,
@@ -40,26 +45,38 @@ import {
 
 /**
  * Parse TextTrack data when it is embedded in an ISOBMFF file.
- * @param {Object} infos
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
+ * @param {number|undefined} initTimescale - `timescale` value - encountered
+ * in this linked initialization segment (if it exists) - that may also apply
+ * to that segment if no new timescale is defined in it.
+ * Can be `undefined` if no timescale was defined, if it is not known, or if
+ * no linked initialization segment was yet parsed.
+ * @param {boolean} __priv_patchLastSegmentInSidx - Enable ugly Canal+-specific
+ * fix for an issue people on the content-packaging side could not fix.
+ * For more information on that, look at the code using it.
  * @returns {Observable.<Object>}
  */
 function parseISOBMFFEmbeddedTextTrack(
-  { response,
-    content,
-    initTimescale } : ISegmentParserArguments< Uint8Array |
-                                               ArrayBuffer |
-                                               string >,
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; },
+  initTimescale : number | undefined,
   __priv_patchLastSegmentInSidx? : boolean
 ) : ISegmentParserParsedInitSegment<null> |
     ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, representation, segment } = content;
   const { isInit, indexRange } = segment;
-  const { data, isChunked } = response;
-
-  // Should already have been taken care of
-  // TODO better use TypeScript here?
-  assert(data !== null);
 
   const chunkBytes = typeof data === "string"   ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -115,15 +132,24 @@ function parseISOBMFFEmbeddedTextTrack(
 }
 
 /**
- * Parse TextTrack data in plain text form.
- * @param {Object} infos
+ * Parse TextTrack data when it is in plain text form.
+ *
+ * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
+ * @param {boolean} isChunked - If `true`, the `data` may contain only a
+ * decodable subpart of the full data in the linked segment.
+ * @param {Object} content - Object describing the context of the given
+ * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
+ * `Manifest` it is a part of etc.
  * @returns {Observable.<Object>}
  */
 function parsePlainTextTrack(
-  { response,
-    content } : ISegmentParserArguments< Uint8Array |
-                                         ArrayBuffer |
-                                         string >
+  data : Uint8Array | ArrayBuffer | string,
+  isChunked : boolean,
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation;
+              representation : Representation;
+              segment : ISegment; }
 ) : ISegmentParserParsedInitSegment<null> |
     ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
@@ -136,14 +162,8 @@ function parsePlainTextTrack(
              initTimescale: undefined };
   }
 
-  const { data, isChunked } = response;
   let textTrackData : string;
   if (typeof data !== "string") {
-
-    // Should already have been taken care of
-    // TODO better use TypeScript here?
-    assert(data !== null);
-
     const bytesData = data instanceof Uint8Array ? data :
                                                    new Uint8Array(data);
     textTrackData = utf8ToStr(bytesData);
@@ -159,6 +179,8 @@ function parsePlainTextTrack(
 }
 
 /**
+ * Generate a "segment parser" for DASH text tracks.
+ *
  * @param {Object} config
  * @returns {Function}
  */
@@ -181,30 +203,28 @@ export default function generateTextTrackParser(
       ISegmentParserParsedSegment<ITextTrackSegmentData | null>
   {
     const { period, representation, segment } = content;
-    const { timestampOffset = 0 } = segment;
     const { data, isChunked } = response;
-    if (data === null) { // No data, just return empty infos
-      if (segment.isInit) {
-        return { segmentType: "init",
-                 initializationData: null,
-                 protectionDataUpdate: false,
-                 initTimescale: undefined };
-      }
-      return { segmentType: "media",
-               chunkData: null,
-               chunkInfos: null,
-               chunkOffset: timestampOffset,
-               appendWindow: [period.start, period.end] };
+
+    if (data === null) {
+      // No data, just return an empty placeholder object
+      return segment.isInit ? { segmentType: "init",
+                                initializationData: null,
+                                protectionDataUpdate: false,
+                                initTimescale: undefined } :
+
+                              { segmentType: "media",
+                                chunkData: null,
+                                chunkInfos: null,
+                                chunkOffset: segment.timestampOffset ?? 0,
+                                appendWindow: [period.start, period.end] };
     }
 
-    const isMP4 = isMP4EmbeddedTextTrack(representation);
-    if (isMP4) {
-      return parseISOBMFFEmbeddedTextTrack({ response: { data, isChunked },
-                                             content,
-                                             initTimescale },
-                                           __priv_patchLastSegmentInSidx);
-    } else {
-      return parsePlainTextTrack({ response: { data, isChunked }, content });
-    }
+    return isMP4EmbeddedTextTrack(representation) ?
+      parseISOBMFFEmbeddedTextTrack(data,
+                                    isChunked,
+                                    content,
+                                    initTimescale,
+                                    __priv_patchLastSegmentInSidx) :
+      parsePlainTextTrack(data, isChunked, content);
   };
 }

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -15,6 +15,7 @@
  */
 
 import { getMDHDTimescale } from "../../parsers/containers/isobmff";
+import assert from "../../utils/assert";
 import {
   strToUtf8,
   utf8ToStr,
@@ -45,10 +46,14 @@ function parseISOBMFFEmbeddedTextTrack(
                                                ArrayBuffer |
                                                string >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
   const { data, isChunked } = response;
+
+  // Should already have been taken care of
+  // TODO better use TypeScript here?
+  assert(data !== null);
 
   const chunkBytes = typeof data === "string" ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -87,7 +92,7 @@ function parsePlainTextTrack(
                                          ArrayBuffer |
                                          string >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, segment } = content;
   if (segment.isInit) {
@@ -100,6 +105,10 @@ function parsePlainTextTrack(
   const { data, isChunked } = response;
   let textTrackData : string;
   if (typeof data !== "string") {
+    // Should already have been taken care of
+    // TODO better use TypeScript here?
+    assert(data !== null);
+
     const bytesData = data instanceof Uint8Array ? data :
                                                    new Uint8Array(data);
     textTrackData = utf8ToStr(bytesData);
@@ -128,7 +137,7 @@ export default function textTrackParser(
                                       string |
                                       null >
 ) : ISegmentParserParsedInitSegment<null> |
-    ISegmentParserParsedSegment<ITextTrackSegmentData>
+    ISegmentParserParsedSegment<ITextTrackSegmentData | null>
 {
   const { period, representation, segment } = content;
   const { data, isChunked } = response;

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -304,7 +304,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -328,7 +328,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
+      args : ISegmentParserArguments<Uint8Array | ArrayBuffer | null>
     ) : ISegmentParserParsedSegment<ArrayBuffer | Uint8Array | null>  |
         ISegmentParserParsedInitSegment<ArrayBuffer | Uint8Array | null>
     {
@@ -352,9 +352,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args: ISegmentParserArguments<ArrayBuffer|string|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+      args: ISegmentParserArguments< ArrayBuffer | string | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<ITextTrackSegmentData | null> |
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;
@@ -376,9 +376,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
     },
 
     parser(
-      args : ISegmentParserArguments<ArrayBuffer|Uint8Array|null>
-    ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+      args : ISegmentParserArguments<ArrayBuffer | Uint8Array | null>
+    ) : ISegmentParserParsedInitSegment<IImageTrackSegmentData | null>  |
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { content } = args;
       const { segment } = content;

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -270,7 +270,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       initTimescale,
     } : ISegmentParserArguments<string|ArrayBuffer|Uint8Array|null>
     ) : ISegmentParserParsedInitSegment<null>  |
-        ISegmentParserParsedSegment<ITextTrackSegmentData>
+        ISegmentParserParsedSegment<ITextTrackSegmentData | null>
     {
       const { manifest, adaptation, representation, segment } = content;
       const { language } = adaptation;
@@ -422,7 +422,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     parser(
       { response, content } : ISegmentParserArguments<Uint8Array|ArrayBuffer|null>
     ) : ISegmentParserParsedInitSegment<null> |
-        ISegmentParserParsedSegment<IImageTrackSegmentData>
+        ISegmentParserParsedSegment<IImageTrackSegmentData | null>
     {
       const { data, isChunked } = response;
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -108,12 +108,12 @@ export type IManifestParserFunction = (
 
 /** Functions allowing to load and parse segments of any type. */
 export interface ISegmentPipeline<
-  LoadedFormat,
-  ParsedSegmentDataFormat,
+  TLoadedFormat,
+  TParsedSegmentDataFormat,
 > {
-  loader : ISegmentLoader<LoadedFormat>;
-  parser : ISegmentParser<LoadedFormat,
-                          ParsedSegmentDataFormat>;
+  loader : ISegmentLoader<TLoadedFormat>;
+  parser : ISegmentParser<TLoadedFormat,
+                          TParsedSegmentDataFormat>;
 }
 
 /**
@@ -121,9 +121,9 @@ export interface ISegmentPipeline<
  * @param {Object} x
  * @returns {Observable.<Object>}
  */
-export type ISegmentLoader<LoadedFormat> = (
+export type ISegmentLoader<TLoadedFormat> = (
   x : ISegmentLoaderArguments
-) => Observable<ISegmentLoaderEvent<LoadedFormat>>;
+) => Observable<ISegmentLoaderEvent<TLoadedFormat>>;
 
 /**
  * Segment parser function, allowing to parse a segment of any type.
@@ -131,10 +131,10 @@ export type ISegmentLoader<LoadedFormat> = (
  * @returns {Observable.<Object>}
  */
 export type ISegmentParser<
-  LoadedFormat,
-  ParsedSegmentDataFormat
+  TLoadedFormat,
+  TParsedSegmentDataFormat
 > = (
-  x : ISegmentParserArguments< LoadedFormat >
+  x : ISegmentParserArguments< TLoadedFormat >
 ) =>
   /**
    * The parsed data.
@@ -148,8 +148,8 @@ export type ISegmentParser<
    *     segment.
    *     Such segments generally contain decodable media data.
    */
-  ISegmentParserParsedInitSegment<ParsedSegmentDataFormat> |
-  ISegmentParserParsedSegment<ParsedSegmentDataFormat>;
+  ISegmentParserParsedInitSegment<TParsedSegmentDataFormat> |
+  ISegmentParserParsedSegment<TParsedSegmentDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -50,20 +50,16 @@ export interface ITransportPipelines {
   manifest : ITransportManifestPipeline;
   /** Functions allowing to load an parse audio segments. */
   audio : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse video segments. */
   video : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           Uint8Array | ArrayBuffer | null,
                            Uint8Array | ArrayBuffer | null>;
   /** Functions allowing to load an parse text (e.g. subtitles) segments. */
   text : ISegmentPipeline<Uint8Array | ArrayBuffer | string | null,
-                          null,
-                          ITextTrackSegmentData>;
+                          ITextTrackSegmentData | null>;
   /** Functions allowing to load an parse image (e.g. thumbnails) segments. */
   image : ISegmentPipeline<Uint8Array | ArrayBuffer | null,
-                           null,
-                           IImageTrackSegmentData>;
+                           IImageTrackSegmentData | null>;
 }
 
 /** Functions allowing to load and parse the Manifest. */
@@ -113,13 +109,11 @@ export type IManifestParserFunction = (
 /** Functions allowing to load and parse segments of any type. */
 export interface ISegmentPipeline<
   LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat,
+  ParsedSegmentDataFormat,
 > {
   loader : ISegmentLoader<LoadedFormat>;
   parser : ISegmentParser<LoadedFormat,
-                          ParsedInitDataFormat,
-                          ParsedMediaDataFormat>;
+                          ParsedSegmentDataFormat>;
 }
 
 /**
@@ -138,8 +132,7 @@ export type ISegmentLoader<LoadedFormat> = (
  */
 export type ISegmentParser<
   LoadedFormat,
-  ParsedInitDataFormat,
-  ParsedMediaDataFormat
+  ParsedSegmentDataFormat
 > = (
   x : ISegmentParserArguments< LoadedFormat >
 ) =>
@@ -155,8 +148,8 @@ export type ISegmentParser<
    *     segment.
    *     Such segments generally contain decodable media data.
    */
-  ISegmentParserParsedInitSegment<ParsedInitDataFormat> |
-  ISegmentParserParsedSegment<ParsedMediaDataFormat>;
+  ISegmentParserParsedInitSegment<ParsedSegmentDataFormat> |
+  ISegmentParserParsedSegment<ParsedSegmentDataFormat>;
 
 /** Arguments for the loader of the manifest pipeline. */
 export interface IManifestLoaderArguments {
@@ -233,8 +226,10 @@ export interface IManifestLoaderDataLoadedEvent {
 }
 
 /** Event emitted by a segment loader when the data has been fully loaded. */
-export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
-                                                    value : ILoaderDataLoadedValue<T>; }
+export interface ISegmentLoaderDataLoadedEvent<T> {
+  type : "data-loaded";
+  value : ILoaderDataLoadedValue<T>;
+}
 
 /**
  * Event emitted by a segment loader when the data is available without needing
@@ -243,8 +238,10 @@ export interface ISegmentLoaderDataLoadedEvent<T> { type : "data-loaded";
  * Such data are for example directly generated from already-available data,
  * such as properties of a Manifest.
  */
-export interface ISegmentLoaderDataCreatedEvent<T> { type : "data-created";
-                                                     value : { responseData : T }; }
+export interface ISegmentLoaderDataCreatedEvent<T> {
+  type : "data-created";
+  value : { responseData : T };
+}
 
 /**
  * Event emitted by a segment loader when new information on a pending request
@@ -362,8 +359,13 @@ export interface IManifestParserArguments {
 export interface ISegmentParserArguments<T> {
   /** Attributes of the corresponding loader's response. */
   response : {
-    /** The loaded data. */
-    data: T;
+    /**
+     * The loaded data.
+     *
+     * Possibly in Uint8Array or ArrayBuffer form if chunked (see `isChunked`
+     * property) or loaded through custom loaders.
+     */
+    data: T | Uint8Array | ArrayBuffer;
     /**
      * If `true`,`data` is only a "chunk" of the whole segment (which potentially
      * will contain multiple chunks).
@@ -445,7 +447,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
    * Initialization segment that can be directly pushed to the corresponding
    * buffer.
    */
-  initializationData : DataType | null;
+  initializationData : DataType;
   /**
    * Timescale metadata found inside this initialization segment.
    * That timescale might be useful when parsing further merdia segments.
@@ -472,7 +474,7 @@ export interface ISegmentParserParsedInitSegment<DataType> {
 export interface ISegmentParserParsedSegment<DataType> {
   segmentType : "media";
   /** Parsed chunk of data that can be decoded. */
-  chunkData : DataType | null;
+  chunkData : DataType;
   /** Time information on this parsed chunk. */
   chunkInfos : IChunkTimeInfo | null;
   /**

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -23,7 +23,10 @@ import isNullOrUndefined from "./is_null_or_undefined";
  * @param {string} [message] - Optional message property for the AssertionError.
  * @throws AssertionError - Throws if the assertion given is false
  */
-export default function assert(assertion : boolean, message? : string) : void {
+export default function assert(
+  assertion : boolean,
+  message? : string
+) : asserts assertion {
   if (!assertion) {
     throw new AssertionError(message === undefined ? "invalid assertion" :
                                                      message);


### PR DESCRIPTION
Based on #950

This PR proposes a simplification of types used by the segment parsers by defining a unique segment data type instead of two: one for the init segment and the other for media segments.

As `SegmentBuffers` - on which those segment data will be pushed - are only generic based on a single segment data type, this is not really necessary anyway.

The real reason behind creating two types was to better indicate that text and image Representation had no initialization segment (by setting their type to `null`) but considering that a parsed media segment could theoretically be `null` as well, nothing is lost by using the same type for both.

Being generic over a single type simplify the way we approach segment parsers in my opinion. Now we're thinking: "which type is the parsed segment data in?" not "which type is a parsed init segment data and which type is a media segment data?". Both should generally be in the same format and the only difference until now was that one could be always `null`.
Also, considering that media segments could theorically contain initialization data themselves, this is one more argument in the direction of only defining a single type.

Thoughts?

---

Another improvement in that PR is to limit `any` typings to the small `segment_fetcher_creator.ts` file. Doing this there should reduce possible typing errors as segment loader and parsers are now properly type-checked (both their inputs and outputs).