### PR TITLE
Clean-up BaseRepresentationIndex and SmoothRepresentationIndex code

### DIFF
--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -270,6 +270,11 @@ export interface IRepresentationIndex {
    * If that's the case, return the next available position where a segment
    * should be available.
    * If that's not the case, return `null`.
+   * @param {number} time - The time to check if it's in a discontinuity, in
+   * seconds.
+   * @returns {number | null} - If `null`, no discontinuity is encountered at
+   * `time`. If this is a number instead, there is one and that number is the
+   * position for which a segment is available in seconds.
    */
   checkDiscontinuity(time : number) : number | null;
 
@@ -324,6 +329,11 @@ export interface IRepresentationIndex {
    * initialization has been loaded. In those case, it should return `false`
    * until the corresponding segment list is known, at which point it can return
    * `true`.
+   *
+   * You can use any ad-hoc mean you want to "initialize" an index.
+   * This is usually done by adding supplementary methods (like one named
+   * `initialize`) to that `RepresentationIndex` and calling it directly in the
+   * segment parsing code.
    * @returns {boolean}
    */
   isInitialized() : boolean;
@@ -336,6 +346,9 @@ export interface IRepresentationIndex {
 
   /**
    * Update the current index with a new, partial, version.
+   * Unlike `replace`, this method do not completely overwrite the information
+   * about this index's segments, it should mainly add new information about new
+   * announced segments.
    * @param {Object} newIndex
    */
   _update(newIndex : IRepresentationIndex) : void;

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -71,11 +71,6 @@ export interface ISidxSegment {
   time : number;
   /** This segment difference between its end and start time, timescaled. */
   duration : number;
-  /**
-   * Amount of time this segment repeats, always , always 0.
-   * TODO Remove.
-   */
-  count : 0;
   /** Dividing `time` or `duration` with this value allows to obtain seconds. */
   timescale : number;
   /**
@@ -163,7 +158,6 @@ function getSegmentsFromSidx(
 
     segments.push({ time,
                     duration,
-                    count: 0,
                     timescale,
                     range: [offset, offset + refSize - 1] });
 

--- a/src/parsers/containers/matroska/utils.ts
+++ b/src/parsers/containers/matroska/utils.ts
@@ -28,7 +28,6 @@ const CUE_CLUSTER_POSITIONS_ID = 0xF1;
 
 export interface ICuesSegment { time : number;
                                 duration : number;
-                                count : 0;
                                 timescale : number;
                                 range : [number, number]; }
 
@@ -203,7 +202,6 @@ export function getSegmentsFromCues(
     if (i === rawInfos.length - 1) {
       segments.push({
         time: currentSegment.time,
-        count: 0,
         timescale,
         duration: i === 0 ? duration :
                             duration - currentSegment.time,
@@ -212,7 +210,6 @@ export function getSegmentsFromCues(
     } else {
       segments.push({
         time: currentSegment.time,
-        count: 0,
         timescale,
         duration: rawInfos[i + 1].time - currentSegment.time,
         range: [currentSegment.rangeStart, rawInfos[i + 1].rangeStart - 1],

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -352,9 +352,6 @@ function createSmoothStreamingParser(
         media: replaceRepresentationSmoothTokens(path,
                                                  qualityLevel.bitrate,
                                                  qualityLevel.customAttributes),
-        isLive,
-        timeShiftBufferDepth,
-        manifestReceivedTime,
       };
       const mimeType = isNonEmptyString(qualityLevel.mimeType) ?
         qualityLevel.mimeType :
@@ -399,7 +396,9 @@ function createSmoothStreamingParser(
         parserOptions.aggressiveMode;
       const reprIndex = new RepresentationIndex(repIndex, { aggressiveMode,
                                                             isLive,
-                                                            segmentPrivateInfos });
+                                                            manifestReceivedTime,
+                                                            segmentPrivateInfos,
+                                                            timeShiftBufferDepth });
       const representation : IParsedRepresentation = objectAssign({},
                                                                   qualityLevel,
                                                                   { index: reprIndex,

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -154,9 +154,9 @@ export interface ISmoothRepresentationIndexContextInformation {
    * if `true`, the `SmoothRepresentationIndex` will return segments even if
    * we're not sure they had time to be generated on the server side.
    *
-   * This is a somewhat ugly option, only here for very specific Canal+
-   * use-cases for now (most of all for Peer-to-Peer efficiency), scheduled to
-   * be removed in a next major version.
+   * TODO(Paul B.) This is a somewhat ugly option, only here for very specific
+   * Canal+ use-cases for now (most of all for Peer-to-Peer efficiency),
+   * scheduled to be removed in a next major version.
    */
   aggressiveMode : boolean;
   /**
@@ -625,8 +625,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
   }
 
   /**
-   * Add new segments to a `SmoothRepresentationIndex`, usually parsed from a
-   * tftf ISOBMFF box.
+   * Add new segments to a `SmoothRepresentationIndex`.
    * @param {Array.<Object>} nextSegments - The segment information parsed.
    * @param {Object} segment - Information on the segment which contained that
    * new segment information.

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -149,7 +149,7 @@ export default function generateAudioVideoSegmentParser(
         nextSegments !== null &&
         nextSegments.length > 0)
     {
-      representation.index._addSegments(nextSegments);
+      representation.index.initializeIndex(nextSegments);
     }
 
     const timescale = isWEBM ? getTimeCodeScale(chunkData, 0) :

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -90,7 +90,7 @@ function parseISOBMFFEmbeddedTextTrack(
         sidxSegments !== null &&
         sidxSegments.length > 0)
     {
-      representation.index._addSegments(sidxSegments);
+      representation.index.initializeIndex(sidxSegments);
     }
     return observableOf({ type: "parsed-init-segment",
                           value: { initializationData: null,

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -88,8 +88,8 @@ function addNextSegments(
     if (representation.index instanceof SmoothRepresentationIndex &&
         dlSegment?.privateInfos?.smoothMediaSegment !== undefined)
     {
-      representation.index._addSegments(nextSegments,
-                                        dlSegment.privateInfos.smoothMediaSegment);
+      representation.index.addNewSegments(nextSegments,
+                                          dlSegment.privateInfos.smoothMediaSegment);
     } else {
       log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
     }


### PR DESCRIPTION
This commit was initially just to rename the BaseRepresentationIndex's `_addSegments` methods to a more clear `initializeIndex` method but I also profited to clean-up comments and improve the logic behind Smooth constructor arguments.