### PR TITLE
Update stream events when updating the manifest

### DIFF
--- a/src/manifest/update_period_in_place.ts
+++ b/src/manifest/update_period_in_place.ts
@@ -32,6 +32,7 @@ export default function updatePeriodInPlace(oldPeriod : Period,
   oldPeriod.start = newPeriod.start;
   oldPeriod.end = newPeriod.end;
   oldPeriod.duration = newPeriod.duration;
+  oldPeriod.streamEvents = newPeriod.streamEvents;
 
   const oldAdaptations = oldPeriod.getAdaptations();
   const newAdaptations = newPeriod.getAdaptations();


### PR DESCRIPTION
We've noticed that some stream events from manifests were never emitted, although they are present in the original manifest file.

The reason is that, when the manifest is updated, the stream events in the periods where never replaced.
Typically, even if Event were added in the manifest for a Period, we parsed them but never replaced the old ones.

Now, the stream events are replaced. I don't consider usefull to code a more complex implementation were we would just add the new ones, and "patch" the old ones.