### PR TITLE
Limit the postponment of a Manifest refresh to an acceptable value (regular delay * 6)

### DIFF
--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -220,31 +220,33 @@ export default function manifestUpdateScheduler({
         actualRefreshInterval = regularRefreshDelay;
       } else if (manifest.lifetime < 3 && totalUpdateTime >= 100) {
         // If Manifest update is very frequent and we take time to update it,
-        // postpone it according to the maximum value between:
-        actualRefreshInterval = Math.max(
-          // Take 3 seconds as a default safe value for a base interval.
-          3000 - timeSinceRequest,
+        // postpone it.
+        actualRefreshInterval = Math.min(
+          Math.max(
+            // Take 3 seconds as a default safe value for a base interval.
+            3000 - timeSinceRequest,
+            // Add update time to the original interval.
+            Math.max(regularRefreshDelay, 0) + totalUpdateTime
+          ),
 
-          // Add update time to the original interval.
-          Math.max(regularRefreshDelay, 0) + totalUpdateTime,
-
-          // Limit the postponment to a very high value relative to
-          // `regularRefreshDelay`.
+          // Limit the postponment's higher bound to a very high value relative
+          // to `regularRefreshDelay`.
           // This avoid perpetually postponing a Manifest update when
           // performance seems to have been abysmal one time.
-          regularRefreshDelay * 6);
+          regularRefreshDelay * 6
+        );
         log.info("MUS: Manifest update rythm is too frequent. Postponing next request.",
                  regularRefreshDelay,
                  actualRefreshInterval);
       } else if (totalUpdateTime >= (manifest.lifetime * 1000) / 10) {
         // If Manifest updating time is very long relative to its lifetime,
         // postpone it:
-        actualRefreshInterval = Math.max(
+        actualRefreshInterval = Math.min(
           // Just add the update time to the original waiting time
           Math.max(regularRefreshDelay, 0) + totalUpdateTime,
 
-          // Limit the postponment to a very high value relative to
-          // `regularRefreshDelay`.
+          // Limit the postponment's higher bound to a very high value relative
+          // to `regularRefreshDelay`.
           // This avoid perpetually postponing a Manifest update when
           // performance seems to have been abysmal one time.
           regularRefreshDelay * 6);


### PR DESCRIPTION
Manifest files, in particular for live contents, may need to be refreshed at a regular interval.

The logic behind scheduling Manifest refresh is actually complex.
This is because even if a "normal" refreshing delay is indicated in the Manifest, the RxPlayer might prefer to postpone its update instead because it judges that it is too frequent when compared with the time it takes to parse it.

However, there were no higher limit to this postponment, which could theorically lead to a very high delay before an update\*, and as such to potential long buffering time (this could only happen if Manifest parsing takes a lot of time though, but we could imagine some exceptional conditions where this would be the case or even unrelated reasons, like someone adding a breakpoint when inside the parsing logic).

This commit set a high limit to the postponment of this "automatic" refresh logic. For now it cannot by default\** go higher than 6 times the original calculated delay.

Even with this, there can be many other causes for Manifest updates (e.g. the RxPlayer suspects that it is de-synchronized or an `emsg` box declares that a new MPD should be obtained) which are not for now impacted by this modification.

\* This is not linked to any bug we know of for now.
We did have some recent issue concerning the Manifest not refreshing, but our investigation led to a poor implementation of a `manifestLoader` function done by the application instead.

\** The `minimumManifestUpdateInterval` `transportOptions` given to the `loadVideo` API is not impacted by this and thus the delay can still be higher.

---

I also found the `manifestUpdateScheduler` code to be difficult to follow so decided to move some code around.