### PR TITLE
Trigger the end of stream only when the last period of the content is known

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -188,8 +188,7 @@ export default function StreamOrchestrator(
   // Emits a 'resume-stream" when it's not
   const endOfStream$ = combineLatest([areStreamsComplete(...streamsArray),
                                       isLastPeriodKnown$])
-    .pipe(map(([areComplete, isLastPeriodKnown]) => (areComplete &&
-                                                     isLastPeriodKnown === true)),
+    .pipe(map(([areComplete, isLastPeriodKnown]) => areComplete && isLastPeriodKnown),
           distinctUntilChanged(),
           map((emitEndOfStream) =>
             emitEndOfStream ? EVENTS.endOfStream() : EVENTS.resumeStream()));

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -178,6 +178,12 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    */
   public isLive : boolean;
 
+  /**
+   * If true, no more periods will be added after the last manifest period.
+   * The attribute is undefined if there is no way to know if the last period is known.
+   */
+  public isLastPeriodKnown? : boolean;
+
   /*
    * Every URI linking to that Manifest.
    * They can be used for refreshing the Manifest.
@@ -344,6 +350,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     this._timeBounds = parsedManifest.timeBounds;
     this.isDynamic = parsedManifest.isDynamic;
     this.isLive = parsedManifest.isLive;
+    this.isLastPeriodKnown = parsedManifest.isLastPeriodKnown;
     this.uris = parsedManifest.uris === undefined ? [] :
                                                     parsedManifest.uris;
 
@@ -715,6 +722,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
     this.expired = newManifest.expired;
     this.isDynamic = newManifest.isDynamic;
     this.isLive = newManifest.isLive;
+    this.isLastPeriodKnown = newManifest.isLastPeriodKnown;
     this.lifetime = newManifest.lifetime;
     this.parsingErrors = newManifest.parsingErrors;
     this.suggestedPresentationDelay = newManifest.suggestedPresentationDelay;

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -179,10 +179,11 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   public isLive : boolean;
 
   /**
-   * If true, no more periods will be added after the last manifest period.
-   * The attribute is undefined if there is no way to know if the last period is known.
+   * If `true`, no more periods will be added after the current last manifest's
+   * Period.
+   * `false` if we know that more Period is coming or if we don't know.
    */
-  public isLastPeriodKnown? : boolean;
+  public isLastPeriodKnown : boolean;
 
   /*
    * Every URI linking to that Manifest.

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -320,6 +320,13 @@ function parseCompleteIntermediateRepresentation(
     }
   }
 
+  // `isLastPeriodKnown` should be `true` in two cases for DASH contents:
+  //   1. When the content is static, because we know that no supplementary
+  //      Period will be added.
+  //   2. If the content is dynamic, only when both the duration is known and
+  //      the `minimumUpdatePeriod` is not set. This corresponds to the case
+  //      explained in "4.6.4. Transition Phase between Live and On-Demand" of
+  //      the DASH-IF IOP v4.3 for live contents transitionning to on-demand.
   const isLastPeriodKnown =
     !isDynamic ||
     (mpdIR.attributes.minimumUpdatePeriod === undefined &&

--- a/src/parsers/manifest/dash/parse_mpd.ts
+++ b/src/parsers/manifest/dash/parse_mpd.ts
@@ -320,11 +320,18 @@ function parseCompleteIntermediateRepresentation(
     }
   }
 
+  const isLastPeriodKnown =
+    !isDynamic ||
+    (mpdIR.attributes.minimumUpdatePeriod === undefined &&
+     (parsedPeriods[parsedPeriods.length - 1]?.end !== undefined ||
+      mpdIR.attributes.duration !== undefined));
+
   const parsedMPD : IParsedManifest = {
     availabilityStartTime,
     clockOffset: args.externalClockOffset,
     isDynamic,
     isLive: isDynamic,
+    isLastPeriodKnown,
     periods: parsedPeriods,
     publishTime: rootAttributes.publishTime,
     suggestedPresentationDelay: rootAttributes.suggestedPresentationDelay,

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -53,10 +53,12 @@ export default function parseLocalManifest(
   const parsedPeriods = localManifest.periods
     .map(period => parsePeriod(period, { periodIdGenerator,
                                          isFinished }));
+
   return { availabilityStartTime: 0,
            expired: localManifest.expired,
            transportType: "local",
-           isDynamic: !localManifest.isFinished,
+           isDynamic: !isFinished,
+           isLastPeriodKnown: isFinished,
            isLive: false,
            uris: [],
            timeBounds: { absoluteMinimumTime: minimumPosition ?? 0,

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -296,7 +296,7 @@ function createManifest(
   const isLastPeriodKnown = !isDynamic ||
                             mplData.pollInterval === undefined &&
                             (manifests.length <= 0 ||
-                             manifests[manifests.length - 1].isLastPeriodKnown === true);
+                             manifests[manifests.length - 1].isLastPeriodKnown);
   const manifest = { availabilityStartTime: 0,
                      clockOffset,
                      suggestedPresentationDelay: 10,

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -293,6 +293,10 @@ function createManifest(
   }
 
   const time = performance.now();
+  const isLastPeriodKnown = !isDynamic ||
+                            mplData.pollInterval === undefined &&
+                            (manifests.length <= 0 ||
+                             manifests[manifests.length - 1].isLastPeriodKnown === true);
   const manifest = { availabilityStartTime: 0,
                      clockOffset,
                      suggestedPresentationDelay: 10,
@@ -300,6 +304,7 @@ function createManifest(
                      transportType: "metaplaylist",
                      isLive: isDynamic,
                      isDynamic,
+                     isLastPeriodKnown,
                      uris: url == null ? [] :
                                          [url],
                      timeBounds: { minimumTime,

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -628,6 +628,7 @@ function createSmoothStreamingParser(
       clockOffset: serverTimeOffset,
       isLive,
       isDynamic: isLive,
+      isLastPeriodKnown: true,
       timeBounds: { absoluteMinimumTime: minimumTime,
                     timeshiftDepth,
                     maximumTimeData },

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -210,10 +210,11 @@ export interface IParsedManifest {
    */
   isLive : boolean;
   /**
-   * If true, no more periods will be added after the last manifest period.
-   * The attribute is undefined if there is no way to know if the last period is known.
+   * If `true`, no more periods will be added after the current last manifest's
+   * Period.
+   * `false` if we know that more Period is coming or if we don't know.
    */
-  isLastPeriodKnown? : boolean;
+  isLastPeriodKnown : boolean;
   /** Periods contained in this manifest. */
   periods: IParsedPeriod[];
   /**

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -209,6 +209,11 @@ export interface IParsedManifest {
    * its "live edge".
    */
   isLive : boolean;
+  /**
+   * If true, no more periods will be added after the last manifest period.
+   * The attribute is undefined if there is no way to know if the last period is known.
+   */
+  isLastPeriodKnown? : boolean;
   /** Periods contained in this manifest. */
   periods: IParsedPeriod[];
   /**


### PR DESCRIPTION
It happens that some live contents have temporarely a last period whose end if defined, and whose manifest are dynamics and need to be updated.
In that case, if we buffer until the end of the period, we would trigger the end of stream. If the RxPlayer plays until the end, then its state will change to ENDED.

It is not what we want, as it should probably be BUFFERING, as the content may be updated with new content, we can't consider it to be ENDED.
Moreover, passing to the ENDED state, and then returning to the PAUSED state without any user action is not a behavior that we want.