### PR TITLE
dash: do not trigger refresh from a ListRepresentationIndex

### DIFF
--- a/src/parsers/manifest/dash/indexes/list.ts
+++ b/src/parsers/manifest/dash/indexes/list.ts
@@ -212,17 +212,18 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
   }
 
   /**
-   * Returns true if, based on the arguments, the index should be refreshed.
-   * (If we should re-fetch the manifest)
+   * Returns whether the Manifest should be refreshed based on the
+   * `ListRepresentationIndex`'s state and the time range the player is
+   * currently considering.
    * @param {Number} _fromTime
-   * @param {Number} toTime
+   * @param {Number} _toTime
    * @returns {Boolean}
    */
-  shouldRefresh(_fromTime : number, toTime : number) : boolean {
-    const { timescale, duration, list } = this._index;
-    const scaledTo = toTime * timescale;
-    const i = Math.floor(scaledTo / duration);
-    return i < 0 || i >= list.length;
+  shouldRefresh(_fromTime : number, _toTime : number) : boolean {
+    // DASH Manifests are usually refreshed through other means, i.e. thanks to
+    // the `minimumUpdatePeriod` attribute.
+    // Moreover, SegmentList are usually only found in static MPDs.
+    return false;
   }
 
   /**


### PR DESCRIPTION
`RepresentationIndex`es, which are basically interfaces to get information about segment regardless of the current streaming protocol, have a function called `shouldRefresh`.

This function takes in argument the time range currently considered for download by the player and returns `true` if the `RepresentationIndex` estimates that a new Manifest has more information on the wanted segments and therefore that it should be refreshed.

Used for both DASH and Smooth at first (years ago?), it finally was considered only useful for Smooth contents, as DASH also provide other mechanisms for recurrent MPD updates that we now prefer (most notably the `minimumUpdatePeriod` attribute) over this.

However a logic was still present for `ListRepresentationIndex` - used when a `<SegmentList>` element is encountered in a MPD - despite the fact that they're (almost?) always for static contents.

There `shouldRefresh` would return `true` if the wanted time range went over the end of the last segment in the SegmentList. This seems fine, yet it can return false positives in cases of not-perfectly formed MPDs and rounding errors.

The result would be unnecessary new MPD requests.

I thus chose to always return `false` for that method, like for any other `shouldRefresh` implementation beside the smooth one.

This bug was seen as part of the investigation for the #960 issue.