### PR TITLE
api: add retry configuration to `segmentLoader`/`manifestLoader` APIs

### DIFF
--- a/doc/api/plugins.md
+++ b/doc/api/plugins.md
@@ -13,59 +13,26 @@ Those plugins are often under the form of functions passed as an argument to the
 <a name="segmentLoader"></a>
 ## segmentLoader ###############################################################
 
-The segmentLoader is a function that can be included in the ``transportOptions``
-of the ``loadVideo`` API call.
+The `segmentLoader` is a function that can be included in the `transportOptions`
+of the `loadVideo` API call.
 
-A segmentLoader allows to define a custom audio/video segment loader (it might
+A `segmentLoader` allows to define a custom audio/video segment loader (it might
 on the future work for other types of segments, so always check the type if you
 only want those two).
-
 The segment loader is the part performing the segment request. One usecase where
 you might want to set your own segment loader is to integrate Peer-to-Peer
 segment downloading through the player.
 
-To give a complete example, here is a segment loader which uses an XHR (it has
-no use, as our implementation does the same thing and more):
+Before the complete documentation, let's write an example which will just use
+an XMLHttpRequest (it has no use, as our implementation does the same thing and
+more):
 ```js
 /**
  * @param {Object} infos - infos about the segment to download
- * @param {string} infos.url - the url the segment request should normally be on
- * @param {Object} infos.adaptation - the Adaptation containing the segment.
- * More information on its structure can be found on the documentation linked
- * below [1]
- * @param {Object} infos.representation - the Representation containing the
- * segment.
- * More information on its structure can be found on the documentation linked
- * below [2]
- * @param {Object} infos.segment - the segment itself
- * More information on its structure can be found on the documentation linked
- * below [3]
-
- * @param {Object} callbacks
- * @param {Function} callbacks.resolve - Callback to call when the request is
- * finished with success. It should be called with an object with at least 3
- * properties:
- *   - data {ArrayBuffer} - the segment data
- *   - duration {Number|undefined} - the duration of the request, in
- *     milliseconds.
- *   - size {Number|undefined} - size, in bytes, of the total downloaded
- *     response.
- * @param {Function} callbacks.progress - Callback to call when progress
- * information is available on the current request. This callback allows to
- * improve our adaptive streaming logic by better predicting the bandwidth
- * before the request is finished.
- * This function should be called with the following properties:
- *   - duration {Number} - the duration since the beginning of the request
- *   - size {Number} - the current size, in bytes, downloaded
- *   - totalSize {Number|undefined} - the whole size of the wanted data, in
- *     bytes. Can be let to undefined when not known.
- * our default implementation instead for this segment. No argument is needed.
- * @param {Function} callbacks.reject - Callback to call when an error is
- * encountered. If you relied on an XHR, it is recommended to include it as an
- * object property named "xhr" in the argument.
- * @param {Function} callbacks.fallback - Callback to call if you want to call
- * our default implementation instead for this segment. No argument is needed.
-
+ * @param {Object} callbacks - Object containing several callbacks to indicate
+ * that the segment has been loaded, the loading operation has failed or to
+ * fallback to our default implementation. More information on this object below
+ * this code example.
  * @returns {Function|undefined} - If a function is defined in the return value,
  * it will be called if and when the request is canceled.
  */
@@ -127,28 +94,137 @@ const customSegmentLoader = (infos, callbacks) => {
 };
 ```
 
-[1] [Adaptation structure](./manifest.md#adaptation)
+As you can see, this function takes two arguments:
 
-[2] [Representation structure](./manifest.md#representation)
+  1. **infos**: An Object giving information about the wanted segments.
+     This object contains the following properties:
 
-[3] [Segment structure](./manifest.md#segment)
+       - *url* (`string`): The URL the segment request should normally be
+         performed at.
+
+       - *manifest* (`Object`) - the Manifest object containing the segment.
+         More information on its structure can be found on the documentation
+         linked below [1].
+
+       - *period* (`Object`) - the Period object containing the segment.
+         More information on its structure can be found on the documentation
+         linked below [2].
+
+       - *adaptation* (`Object`) - the Adaptation object containing the segment.
+         More information on its structure can be found on the documentation
+         linked below [3].
+
+       - *representation* (`Object`) - the Representation object containing the
+         segment.
+         More information on its structure can be found on the documentation
+         linked below [4].
+
+       - *segment* (`Object`) - the segment object related to this segment.
+         More information on its structure can be found on the documentation
+         linked below [5].
+
+     [1] [Manifest structure](./manifest.md#manifest)
+
+     [2] [Period structure](./manifest.md#period)
+
+     [3] [Adaptation structure](./manifest.md#adaptation)
+
+     [4] [Representation structure](./manifest.md#representation)
+
+     [5] [Segment structure](./manifest.md#segment)
+
+  2. **callbacks**: An object containing multiple callbacks to allow this
+     `segmentLoader` to communicate various events to the RxPlayer.
+
+     This Object contains the following functions:
+
+       - **resolve**: To call after the segment is loaded, to communicate it to
+         the RxPlayer.
+
+         When called, it should be given an object with the following
+         properties:
+           - *data* (`ArrayBuffer`|`Uint8Array`) - the segment data.
+
+           - *duration* (`Number|undefined`) - the duration the request took, in
+             milliseconds.
+
+             This value may be used to estimate the ideal user bandwidth.
+
+
+           - *size* (`Number|undefined`) size, in bytes, of the total downloaded
+             response.
+
+       - **progress** - Callback to call when progress information is available
+         on the current request. This callback allows to improve our adaptive
+         streaming logic by better predicting the bandwidth before the request
+         is finished and whether a request is stalling.
+
+         When called, it should be given an object with the following
+         properties:
+
+           - *duration* (`Number`) - The duration since the beginning of the
+             request, in milliseconds.
+
+           - *size* (`Number`) - the current size loaded, in bytes.
+
+           - *totalSize* (`Number|undefined`) - the whole size of the wanted
+             data, in bytes. Can be let to undefined when not known.
+
+       - **reject**: Callback to call when an error is encountered which made
+         loading the segment impossible.
+
+         It is recommended (but not enforced) to give it an Object or error
+         instance with the following properties:
+            - *canRetry* (`boolean|undefined`): If set to `true`, the RxPlayer
+              may retry the request (depending on the configuration set by the
+              application).
+
+              If set to `false`, the RxPlayer will never try to retry this
+              request and will probably just stop the current content.
+
+              If not set or set to `undefined`, the RxPlayer might retry or fail
+              depending on other factors.
+
+            - *xhr* (`XMLHttpRequest|undefined`): If an `XMLHttpRequest` was
+              used to perform this request, this should be the corresponding
+              instance.
+
+              This can be used for example by the RxPlayer to know whether
+              retrying should be done when the `canRetry` property is not set.
+
+            - *isOfflineError* (`boolean|undefined`): If set to `true`, this
+              indicates that this error is due to the user being offline
+              (disconnected from the needed network).
+
+              If set to `false`, this indicates that it wasn't.
+
+              If not known or not applicable, you can just set it to undefined
+              or not define it at all.
+
+              The RxPlayer might retry a segment request due to the user being
+              offline a different amount of time than when the error is due to
+              another issue, depending on its configuration.
+
+       - **fallback**: Callback to call if you want to call our default
+         implementation instead for loading this segment. No argument is needed.
+
+The `segmentLoader` can also return a function, which will be called if/when
+the request is aborted. You can define one to clean-up or dispose all resources.
 
 
 
 <a name="manifestLoader"></a>
 ## manifestLoader ##############################################################
 
-The manifestLoader is a function that can be included in the
+The `manifestLoader` is a function that can be included in the
 ``transportOptions`` of the ``loadVideo`` API call.
 
-A manifestLoader allows to define a custom [Manifest](../terms.md#manifest)
-loader.
+A `manifestLoader` allows to define a custom [Manifest](../terms.md#manifest)
+loader. The Manifest loader is the part performing the Manifest request.
 
-The Manifest loader is the part performing the Manifest request.
-
-Here is a Manifest loader which uses an XHR (it has no use, as our
-implementation does the same thing and more):
-
+Before the complete documentation, let's write an example which will just use
+an XMLHttpRequest (it has no use, as our implementation does the same thing and
+more):
 ```js
 /**
  * @param {string|undefined} url - the url the Manifest request should normally
@@ -156,26 +232,10 @@ implementation does the same thing and more):
  * Can be undefined in very specific conditions, like in cases when the
  * `loadVideo` call had no defined URL (e.g. "local" manifest, playing a locally
  * crafted "Metaplaylist" content).
- * @param {Object} callbacks
- * @param {Function} callbacks.resolve - Callback to call when the request is
- * finished with success. It should be called with an object with at least 3
- * properties:
- *   - data {*} - the Manifest data
- *   - duration {Number|undefined} - the duration of the request, in
- *     milliseconds.
- *   - size {Number|undefined} - size, in bytes, of the total downloaded
- *     response.
- *   - url {string|undefined} - url of the Manifest (post redirection if one).
- *   - sendingTime {number|undefined} - Time at which the manifest request was
- *     done as a unix timestamp in milliseconds.
- *   - receivingTime {number|undefined} - Time at which the manifest request was
- *     finished as a unix timestamp in milliseconds.
- * @param {Function} callbacks.reject - Callback to call when an error is
- * encountered. If you relied on an XHR, it is recommended to include it as an
- * object property named "xhr" in the argument.
- * @param {Function} callbacks.fallback - Callback to call if you want to call
- * our default implementation instead for this segment. No argument is needed.
-
+ * @param {Object} callbacks - Object containing several callbacks to indicate
+ * that the manifest has been loaded, the loading operation has failed or to
+ * fallback to our default implementation. More information on this object below
+ * this code example.
  * @returns {Function|undefined} - If a function is defined in the return value,
  * it will be called if and when the request is canceled.
  */
@@ -188,7 +248,7 @@ const customManifestLoader = (url, callbacks) => {
       const duration = performance.now() - baseTime;
 
       const now = Date.now();
-      const receivingTime = now
+      const receivingTime = now;
 
       // Note: We could have calculated `sendingTime` before the request, but
       // that date would be wrong if the user updated the clock while the
@@ -236,6 +296,86 @@ const customManifestLoader = (url, callbacks) => {
   };
 };
 ```
+
+As you can see, this function takes two arguments:
+
+  1. **url**: The URL the Manifest request should normally be performed at.
+
+     This argument can be `undefined` in very rare and specific conditions where
+     the Manifest URL doesn't exist or has not been communicated by the
+     application.
+
+  2. **callbacks**: An object containing multiple callbacks to allow this
+     `manifestLoader` to communicate the loaded Manifest or an encountered error
+     to the RxPlayer.
+
+     This Object contains the following functions:
+
+       - **resolve**: To call after the Manifest is loaded, to communicate it to
+         the RxPlayer.
+
+         When called, it should be given an object with the following
+         properties:
+           - *data* - the Manifest data.
+             Many formats are accepted depending on what makes sense in the
+             current transport: string, Document, ArrayBuffer, Uint8Array,
+             object.
+
+           - *duration* (`Number|undefined`) - the duration of the request, in
+             milliseconds.
+
+           - *size* (`Number|undefined`) size, in bytes, of the total downloaded
+             response.
+
+           - *url* (`string|undefined`) - url of the Manifest (after any
+             potential redirection if one).
+
+           - *sendingTime* (`number|undefined`) - Time at which the manifest
+             request was done as a unix timestamp in milliseconds.
+
+           - *receivingTime* (`number|undefined`) - Time at which the manifest
+             request was finished as a unix timestamp in milliseconds.
+
+       - **reject**: Callback to call when an error is encountered which made
+         loading the Manifest impossible.
+
+         It is recommended (but not enforced) to give it an Object or error
+         instance with the following properties:
+            - *canRetry* (`boolean|undefined`): If set to `true`, the RxPlayer
+              may retry the request (depending on the configuration set by the
+              application).
+
+              If set to `false`, the RxPlayer will never try to retry this
+              request and will probably just stop the current content.
+
+              If not set or set to `undefined`, the RxPlayer might retry or fail
+              depending on other factors.
+
+            - *xhr* (`XMLHttpRequest|undefined`): If an `XMLHttpRequest` was
+              used to perform this request, this should be the corresponding
+              instance.
+
+              This can be used for example by the RxPlayer to know whether
+              retrying should be done when the `canRetry` property is not set.
+
+            - *isOfflineError* (`boolean|undefined`): If set to `true`, this
+              indicates that this error is due to the user being offline
+              (disconnected from the needed network).
+
+              If set to `false`, this indicates that it wasn't.
+
+              If not known or not applicable, you can just set it to undefined
+              or not define it at all.
+
+              The RxPlayer might retry a Manifest request due to the user being
+              offline a different amount of time than when the error is due to
+              another issue, depending on its configuration.
+
+       - **fallback**: Callback to call if you want to call our default
+         implementation instead for this Manifest. No argument is needed.
+
+The `manifestLoader` can also return a function, which will be called if/when
+the request is aborted. You can define one to clean-up or dispose all resources.
 
 
 <a name="representationFilter"></a>

--- a/src/errors/__tests__/network_error.test.ts
+++ b/src/errors/__tests__/network_error.test.ts
@@ -35,27 +35,6 @@ describe("errors - NetworkError", () => {
       .toBe("NetworkError (PIPELINE_LOAD_ERROR) TIMEOUT");
   });
 
-  it("should be able to use an object instead", () => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", "http://www.example.com");
-    const networkError = new NetworkError("PIPELINE_LOAD_ERROR",
-                                          { xhr,
-                                            url: "foo://www.example.com",
-                                            status: 12,
-                                            type: "TIMEOUT",
-                                            message: "TIMEOUT" });
-    expect(networkError).toBeInstanceOf(Error);
-    expect(networkError.name).toBe("NetworkError");
-    expect(networkError.type).toBe("NETWORK_ERROR");
-    expect(networkError.xhr).toBe(xhr);
-    expect(networkError.status).toBe(12);
-    expect(networkError.errorType).toBe("TIMEOUT");
-    expect(networkError.code).toBe("PIPELINE_LOAD_ERROR");
-    expect(networkError.fatal).toBe(false);
-    expect(networkError.message)
-      .toBe("NetworkError (PIPELINE_LOAD_ERROR) TIMEOUT");
-  });
-
   it("should filter in a valid error code", () => {
     const xhr = new XMLHttpRequest();
     xhr.open("GET", "http://www.example.com");

--- a/src/errors/assertion_error.ts
+++ b/src/errors/assertion_error.ts
@@ -17,6 +17,8 @@
 /**
  * Error due to an abnormal assertion fails.
  *
+ * This should be an internal error which is later transformed into a documented
+ * (as part of the API) Error instance before being emitted to the application.
  * @class AssertionError
  * @extends Error
  */

--- a/src/errors/custom_loader_error.ts
+++ b/src/errors/custom_loader_error.ts
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 
-import { INetworkErrorType } from "./error_codes";
-
 /**
- * Internal Error used when doing requests through fetch / XHRs.
+ * Internal error used to better handle errors happening when a custom
+ * `segmentLoader` or `manifestLoader` has been used.
  *
  * It is not part of the API, as such it is only a temporary error which is
  * later converted to another Error instance (e.g. NETWORK_ERROR).
- *
- * @class RequestError
+ * @class CustomLoaderError
  * @extends Error
  */
-export default class RequestError extends Error {
-  public readonly name : "RequestError";
-  public readonly type : INetworkErrorType;
+export default class CustomLoaderError extends Error {
+  public readonly name : "CustomLoaderError";
   public readonly message : string;
-  public readonly xhr? : XMLHttpRequest;
-  public readonly url : string;
-  public readonly status : number;
+  public readonly canRetry : boolean;
+  public readonly isOfflineError : boolean;
+  public readonly xhr : XMLHttpRequest | undefined;
 
   /**
    * @param {XMLHttpRequest} xhr
@@ -39,20 +36,21 @@ export default class RequestError extends Error {
    * @param {string} type
    */
   constructor(
-    url : string,
-    status : number,
-    type : INetworkErrorType,
-    xhr? : XMLHttpRequest
+    message : string,
+    canRetry : boolean,
+    isOfflineError : boolean,
+    xhr : XMLHttpRequest | undefined
   ) {
     super();
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
-    Object.setPrototypeOf(this, RequestError.prototype);
+    Object.setPrototypeOf(this, CustomLoaderError.prototype);
 
-    this.name = "RequestError";
-    this.url = url;
+    this.name = "CustomLoaderError";
+
+    this.message = message;
+    this.canRetry = canRetry;
+    this.isOfflineError = isOfflineError;
     this.xhr = xhr;
-    this.status = status;
-    this.type = type;
-    this.message = type;
   }
 }
+

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -15,6 +15,7 @@
  */
 
 import AssertionError from "./assertion_error";
+import CustomLoaderError from "./custom_loader_error";
 import EncryptedMediaError from "./encrypted_media_error";
 import {
   ErrorCodes,
@@ -34,6 +35,7 @@ import RequestError from "./request_error";
 
 export {
   AssertionError,
+  CustomLoaderError,
   EncryptedMediaError,
   ErrorCodes,
   ErrorTypes,

--- a/src/errors/network_error.ts
+++ b/src/errors/network_error.ts
@@ -21,14 +21,7 @@ import {
   NetworkErrorTypes,
 } from "./error_codes";
 import errorMessage from "./error_message";
-
-export interface INetworkErrorOptions {
-  xhr? : XMLHttpRequest; // possible linked XHR to the error
-  url : string; // URL the request was on
-  status : number; // HTTP code of the response. 0 if not known.
-  type : INetworkErrorType; // Type of the error
-  message : string; // Message to display to the user
-}
+import RequestError from "./request_error";
 
 /**
  * Error linked to network interactions (requests).
@@ -49,10 +42,10 @@ export default class NetworkError extends Error {
 
   /**
    * @param {string} code
-   * @param {Error} options
+   * @param {Error} baseError
    * @param {Boolean} fatal
    */
-  constructor(code : INetworkErrorCode, options : INetworkErrorOptions) {
+  constructor(code : INetworkErrorCode, baseError : RequestError) {
     super();
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, NetworkError.prototype);
@@ -60,13 +53,13 @@ export default class NetworkError extends Error {
     this.name = "NetworkError";
     this.type = ErrorTypes.NETWORK_ERROR;
 
-    this.xhr = options.xhr === undefined ? null : options.xhr;
-    this.url = options.url;
-    this.status = options.status;
-    this.errorType = options.type;
+    this.xhr = baseError.xhr === undefined ? null : baseError.xhr;
+    this.url = baseError.url;
+    this.status = baseError.status;
+    this.errorType = baseError.type;
 
     this.code = code;
-    this.message = errorMessage(this.name, this.code, options.message);
+    this.message = errorMessage(this.name, this.code, baseError.message);
     this.fatal = false;
   }
 


### PR DESCRIPTION
Before this commit, it was not possible to indicate that a Manifest or segment request could be retried when using a custom `manifestLoader` or `segmentLoader` (respectively for Manifest requests and segment requests performed through a separate logic).

Consequently, the RxPlayer would always throw on the first error encountered in either two of these APIs.

This was not too bad, as custom loaders could "fallback" to our implementation when it couldn't perform the request, and our implementation does have a more advanced retry management.

Still, those APIs could be more powerful for specific cases where a request can/should be retried through the custom logic.

Consequently, I added two optional properties that can be set on a rejected error (kind of like the `keySystems[].getLicense` API):

  - `canRetry`: indicate whether the RxPlayer __CAN__ retry the request. Even if `true`, the RxPlayer might decide no to based on its configuration.

  - `isOfflineError`: indicate whether the error is due to the user being offline (from the corresponding network).

    I added this one because the RxPlayer uses different retry counter depending on whether the error is due to an "offline error" or a ""regular"" error.

Those are both optional properties and it shouldn't change anything to the previous behavior when they are not set.
As such, this commit shouldn't break the API.

I also rewrote much of the documentation for both APIs (`manifestLoader` and `segmentLoader`) because it became too complex for just writing an example code.