### PR TITLE
doc: fix typo about representationFilter

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -856,7 +856,7 @@ considered stable:
     rxPlayer.loadVideo({
       // ...
       transportOptions: {
-        representationFilter(representations, infos) {
+        representationFilter(representation, infos) {
           // ...
         }
       }


### PR DESCRIPTION
There is a minor typo in the documentation about representationFilter which can lead to some confusion.