### PR TITLE
Feat/provides representations for filtering

### DIFF
--- a/doc/api/loadVideo_options.md
+++ b/doc/api/loadVideo_options.md
@@ -856,7 +856,7 @@ considered stable:
     rxPlayer.loadVideo({
       // ...
       transportOptions: {
-        representationFilter(representations, infos) {
+        representationFilter(representation, infos) {
           // ...
         }
       }

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -55,7 +55,8 @@ export interface IRepresentationInfos { bufferType: IAdaptationType;
                                         isClosedCaption? : boolean;
                                         isDub? : boolean;
                                         isSignInterpreted?: boolean;
-                                        normalizedLanguage? : string; }
+                                        normalizedLanguage? : string;
+                                        rawRepresentations: Representation[]; }
 
 /** Type for the `representationFilter` API. */
 export type IRepresentationFilter = (representation: Representation,
@@ -174,26 +175,29 @@ export default class Adaptation {
     const argsRepresentations = parsedAdaptation.representations;
     const representations : Representation[] = [];
     let isSupported : boolean = false;
-    for (let i = 0; i < argsRepresentations.length; i++) {
-      const representation = new Representation(argsRepresentations[i],
-                                                { type: this.type });
+    const rawRepresentations = argsRepresentations.map(
+      r => new Representation(r, { type: this.type })
+    );
+    rawRepresentations.forEach(representation => {
       const shouldAdd =
         isNullOrUndefined(representationFilter) ||
         representationFilter(representation,
-                             { bufferType: this.type,
-                               language: this.language,
-                               normalizedLanguage: this.normalizedLanguage,
-                               isClosedCaption: this.isClosedCaption,
-                               isDub: this.isDub,
-                               isAudioDescription: this.isAudioDescription,
-                               isSignInterpreted: this.isSignInterpreted });
+          { bufferType: this.type,
+            language: this.language,
+            normalizedLanguage: this.normalizedLanguage,
+            isClosedCaption: this.isClosedCaption,
+            isDub: this.isDub,
+            isAudioDescription: this.isAudioDescription,
+            isSignInterpreted: this.isSignInterpreted,
+            rawRepresentations });
       if (shouldAdd) {
         representations.push(representation);
         if (!isSupported && representation.isSupported) {
           isSupported = true;
         }
       }
-    }
+    });
+
     representations.sort((a, b) => a.bitrate - b.bitrate);
     this.representations = representations;
 


### PR DESCRIPTION
I have added the list of representations to the IRepresentationInfos in representationFilter to allow more filtering possibilities.

In my case avoiding AVC streams if there are HEVC streams.
I am not fully happy with this since I have to scan all representations on every representationFilter call.

Here an example
```
    function isHevc(representation) {
        return representation.isSupported && representation.codec.startsWith('hvc');
    }

    function representationFilter(representation, infos) {
        const { rawRepresentations } = infos;
        if (infos.bufferType === 'video') {
            const hasHevcStreams = rawRepresentations.find(isHevc);
            const isHevcStream = isHevc(representation);
            return !hasHevcStreams || isHevcStream;
        }
        return true;
    }
```
