### PR TITLE
Cast License in Uint8Array

### DIFF
--- a/src/compat/eme/custom_media_keys/webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys.ts
@@ -113,7 +113,7 @@ class WebkitMediaKeySession
     this.keyStatuses = new Map();
     this.expiration = NaN;
 
-    this.update = (license: Uint8Array) => {
+    this.update = (license: BufferSource) => {
       return new PPromise((resolve, reject) => {
         /* eslint-disable @typescript-eslint/no-unsafe-member-access */
         if (this._nativeSession === undefined ||
@@ -122,9 +122,17 @@ class WebkitMediaKeySession
           return reject("Unavailable WebKit key session.");
         }
         try {
+          let uInt8Arraylicense: Uint8Array;
+          if (license instanceof ArrayBuffer) {
+            uInt8Arraylicense = new Uint8Array(license);
+          } else if (license instanceof Uint8Array) {
+            uInt8Arraylicense = license;
+          } else {
+            uInt8Arraylicense = new Uint8Array(license.buffer);
+          }
           /* eslint-disable @typescript-eslint/no-unsafe-member-access */
           // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-          resolve(this._nativeSession.update(license));
+          resolve(this._nativeSession.update(uInt8Arraylicense));
           /* eslint-enable @typescript-eslint/no-unsafe-member-access */
         } catch (err) {
           reject(err);


### PR DESCRIPTION
We noticed a bug inside the RxPlayer on the FairPlay DRM environment where the [`update()` EME method](https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySession/update) was expecting a strict `Uint8Array` type but sometimes it happens that the application for some reasons provides an [`ArrayBuffer`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).

For most of the CDM, it's not a problem, but for FairPlay on Safari, it waits for a strict `UInt8Array`.

In this PR, we are still allowing the `ArrayBuffer` as the rx-player doc was explicit about it:

> In any case, if a license is provided by this function it should be under a BufferSource type (example: an Uint8Array or an ArrayBuffer). [Link](https://developers.canal-plus.com/rx-player/doc/pages/api/loadVideo_options.html#subchapter-keySystems)

But internally, we cast whatever we receive except null in an **Uint8Array**.