### PR TITLE
add supplementary exported types to the API

### DIFF
--- a/doc/api/exported_types.md
+++ b/doc/api/exported_types.md
@@ -71,7 +71,7 @@ RxPlayer's method ``loadVideo``.
 Example:
 
 ```ts
-// the type(s) wanted
+// the type wanted
 import { ILoadVideoOptions } from "rx-player/types";
 
 // hypothetical file exporting an RxPlayer instance
@@ -95,14 +95,31 @@ rxPlayer.loadVideo(loadVideoOpts);
 Speaking of ``loadVideo``, some subparts of ``ILoadVideoOptions`` are also
 exported:
 
-  - ``ITransportOptions``: type for the ``transportOptions`` property
-    optionally given to ``loadVideo``.
-
   - ``IKeySystemOption``: type for an element of the ``keySystems`` array,
     which is an optional property given to ``loadVideo``.
 
     To clarify, the ``keySystems`` property in a ``loadVideo`` call is an
     optional array of one or multiple ``IKeySystemOption``.
+
+  - `IPersistentSessionStorage`: type of the `licenseStorage` property of the
+    `keySystems` option given to `loadVideo`.
+
+  - `IPersistentSessionInfo`: type used by an `IPersistentSessionStorage`.
+
+  - ``ITransportOptions``: type for the ``transportOptions`` property
+    optionally given to ``loadVideo``.
+
+  - `IManifestLoader`: type for the `manifestLoader` function optionally set
+    on the `transportOptions` option of `loadVideo`.
+
+  - `IRepresentationFilter`: type for the `representationFilter` function
+    optionally set on the `transportOptions` option of `loadVideo`.
+
+  - `IRepresentationInfos`: type for the second argument of the
+    `representationFilter` function (defined by `IRepresentationFilter`.)
+
+  - `ISegmentLoader`: type for the `segmentLoader` function optionally set on
+    the `transportOptions` option of `loadVideo`.
 
   - ``ISupplementaryTextTrackOption``: type for an element of the
     ``supplementaryTextTracks`` array, which is an optional property given to
@@ -123,6 +140,16 @@ exported:
 
   - ``IStartAtOption``: type for the ``startAt`` property optionally given to
     ``loadVideo``.
+
+
+### Manifest structure #########################################################
+
+Several `RxPlayer` methods rely on a `Manifest` structure and one of its
+"children": the `Period`, the `Adaptation`, the `Representation` or the
+`Segment`.
+
+All of those can be imported from `"rx-player/types"` respectively as
+`IManifest`, `IPeriod`, `IAdaptation`, `IRepresentation` and `ISegment`
 
 
 ### getAvailableAudioTracks method / availableAudioTracksChange event ##########
@@ -299,4 +326,30 @@ function processEventData(eventData : IStreamEventData) {
 rxPlayer.addEventListener("streamEvent", (evt : IStreamEvent) {
   processEventData(evt.data);
 });
+```
+
+
+### RxPlayer errors and warnings ###############################################
+
+RxPlayer errors and warnings may for now be either a plain `Error` instance or
+a special RxPlayer-defined error (which extends the `Error` Object).
+
+All RxPlayer-defined error are compatible with the exported `IPlayerError` type.
+
+Which means that you could write the following:
+```ts
+// the type wanted
+import { IPlayerError } from "rx-player/types";
+
+// hypothetical file exporting an RxPlayer instance
+import rxPlayer from "./player";
+
+rxPlayer.addEventListener("error", (err : Error | IPlayerError) => {
+  // ...
+});
+
+rxPlayer.addEventListener("warning", (err : Error | IPlayerError) => {
+  // ...
+});
+
 ```

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -23,8 +23,8 @@ import config from "../../config";
 import log from "../../log";
 import { IRepresentationFilter } from "../../manifest";
 import {
-  CustomManifestLoader,
-  CustomSegmentLoader,
+  ICustomManifestLoader,
+  ICustomSegmentLoader,
   ILoadedManifestFormat,
   ITransportOptions as IParsedTransportOptions,
 } from "../../transports";
@@ -86,13 +86,13 @@ export interface ITransportOptions {
   /** Manifest object that will be used initially. */
   initialManifest? : ILoadedManifestFormat;
   /** Custom implementation for performing Manifest requests. */
-  manifestLoader? : CustomManifestLoader;
+  manifestLoader? : ICustomManifestLoader;
   /** Possible custom URL pointing to a shorter form of the Manifest. */
   manifestUpdateUrl? : string;
   /** Minimum bound for Manifest updates, in milliseconds. */
   minimumManifestUpdateInterval? : number;
   /** Custom implementation for performing segment requests. */
-  segmentLoader? : CustomSegmentLoader;
+  segmentLoader? : ICustomSegmentLoader;
   /** Custom logic to filter out unwanted qualities. */
   representationFilter? : IRepresentationFilter;
   /** Base time for the segments in case it is not found in the Manifest. */

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -23,10 +23,10 @@ import { Subject } from "rxjs";
 import log from "../../log";
 import {
   Adaptation,
+  IHDRInformation,
   Period,
   Representation,
 } from "../../manifest";
-import { IHDRInformation } from "../../manifest/types";
 import arrayFind from "../../utils/array_find";
 import arrayIncludes from "../../utils/array_includes";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -20,7 +20,10 @@ import isNullOrUndefined from "../utils/is_null_or_undefined";
 import normalizeLanguage from "../utils/languages";
 import uniq from "../utils/uniq";
 import Representation from "./representation";
-import { IAdaptationType } from "./types";
+import {
+  IAdaptationType,
+  IExposedRepresentation,
+} from "./types";
 
 /** List in an array every possible value for the Adaptation's `type` property. */
 export const SUPPORTED_ADAPTATIONS_TYPE: IAdaptationType[] = [ "audio",
@@ -33,15 +36,15 @@ export const SUPPORTED_ADAPTATIONS_TYPE: IAdaptationType[] = [ "audio",
  * in the `representationFilter` API.
  */
 export interface IRepresentationInfos { bufferType: IAdaptationType;
-                                        language?: string;
-                                        isAudioDescription? : boolean;
-                                        isClosedCaption? : boolean;
-                                        isDub? : boolean;
-                                        isSignInterpreted?: boolean;
-                                        normalizedLanguage? : string; }
+                                        language?: string | undefined;
+                                        isAudioDescription? : boolean | undefined;
+                                        isClosedCaption? : boolean | undefined;
+                                        isDub? : boolean | undefined;
+                                        isSignInterpreted?: boolean | undefined;
+                                        normalizedLanguage? : string | undefined; }
 
 /** Type for the `representationFilter` API. */
-export type IRepresentationFilter = (representation: Representation,
+export type IRepresentationFilter = (representation: IExposedRepresentation,
                                      adaptationInfos: IRepresentationInfos) => boolean;
 
 /**

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -16,6 +16,7 @@
 
 import Adaptation, {
   IRepresentationFilter,
+  IRepresentationInfos,
   SUPPORTED_ADAPTATIONS_TYPE,
 } from "./adaptation";
 import areSameContent from "./are_same_content";
@@ -33,9 +34,13 @@ import {
   ISegment,
   StaticRepresentationIndex,
 } from "./representation_index";
-import { IAdaptationType } from "./types";
+import {
+  IAdaptationType,
+  IHDRInformation,
+} from "./types";
 
 export default Manifest;
+export * from "./types";
 export {
   // utils
   areSameContent,
@@ -48,9 +53,11 @@ export {
   // types
   IAdaptationType,
   IBaseContentInfos,
+  IHDRInformation,
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,
   IRepresentationFilter,
+  IRepresentationInfos,
   IRepresentationIndex,
   ISegment,
   ISupplementaryImageTrack,

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -34,7 +34,7 @@ import {
  */
 class Representation {
   /** ID uniquely identifying the Representation in the Adaptation. */
-  public readonly id : string|number;
+  public readonly id : string;
 
   /**
    * Interface allowing to get information about segments available for this

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -56,3 +56,97 @@ export interface IHDRInformation {
    */
   colorSpace?: string;
 }
+
+/** Manifest, as documented in the API documentation. */
+export interface IExposedManifest {
+  periods : IExposedPeriod[];
+  /**
+   * @deprecated
+   */
+  adaptations : { audio? : IExposedAdaptation[];
+                  video? : IExposedAdaptation[];
+                  text? : IExposedAdaptation[];
+                  image? : IExposedAdaptation[]; };
+  isLive : boolean;
+  transport : string;
+}
+
+/** Period, as documented in the API documentation. */
+export interface IExposedPeriod {
+  id : string;
+  start : number;
+  end? : number | undefined;
+  adaptations : { audio? : IExposedAdaptation[];
+                  video? : IExposedAdaptation[];
+                  text? : IExposedAdaptation[];
+                  image? : IExposedAdaptation[]; };
+}
+
+/** Adaptation (represents a track), as documented in the API documentation. */
+export interface IExposedAdaptation {
+  /** String identifying the Adaptation, unique per Period. */
+  id : string;
+  type : "video" | "audio" | "text" | "image";
+  language? : string | undefined;
+  normalizedLanguage? : string | undefined;
+  isAudioDescription? : boolean | undefined;
+  isClosedCaption? : boolean | undefined;
+  isTrickModeTrack? : boolean | undefined;
+  representations : IExposedRepresentation[];
+
+  getAvailableBitrates() : number[];
+}
+
+/** Representation (represents a quality), as documented in the API documentation. */
+export interface IExposedRepresentation {
+  /** String identifying the Representation, unique per Adaptation. */
+  id : string;
+  bitrate : number;
+  /** Codec used by the segment in that Representation. */
+  codec? : string | undefined;
+  /**
+   * Whether we are able to decrypt this Representation / unable to decrypt it or
+   * if we don't know yet:
+   *   - if `true`, it means that we know we were able to decrypt this
+   *     Representation in the current content.
+   *   - if `false`, it means that we know we were unable to decrypt this
+   *     Representation
+   *   - if `undefined` there is no certainty on this matter
+   */
+  decipherable? : boolean | undefined;
+  /**
+   * This property makes the most sense for video Representations.
+   * It defines the height of the video, in pixels.
+   */
+  height? : number | undefined;
+  /**
+   * This property makes the most sense for video Representations.
+   * It defines the height of the video, in pixels.
+   */
+  width? : number | undefined;
+  /**
+   * The represesentation frame rate for this Representation. It defines either
+   * the number of frames per second as an integer (24), or as a ratio
+   * (24000 / 1000).
+   */
+  frameRate? : string | undefined;
+  /** If the track is HDR, gives the HDR characteristics of the content */
+  hdrInfo? : IHDRInformation;
+  index : IExposedRepresentationIndex;
+}
+
+interface IExposedRepresentationIndex {
+  getSegments(up : number, duration : number) : IExposedSegment[];
+}
+
+/** Segment, as documented in the API documentation. */
+export interface IExposedSegment {
+  id : string;
+  timescale : number;
+  duration? : number | undefined;
+  time : number;
+  isInit? : boolean | undefined;
+  range? : number[] | null | undefined;
+  indexRange? : number[] | null | undefined;
+  number? : number | undefined;
+}

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -89,7 +89,7 @@ export interface IParsedRepresentation {
    * Representation but which should be different than any other Representation
    * in the same Adaptation.
    */
-  id: string | number;
+  id: string;
 
   /** Codec(s) associated with this Representation. */
   codecs?: string;

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -48,3 +48,21 @@ export {
   IStreamEvent,
   IStreamEventData,
 } from "./core/api";
+export {
+  IPersistentSessionInfo,
+  IPersistentSessionStorage,
+} from "./core/eme";
+export { ICustomError as IPlayerError } from "./errors";
+export {
+  IExposedAdaptation as IAdaptation,
+  IExposedManifest as IManifest,
+  IExposedPeriod as IPeriod,
+  IExposedRepresentation as IRepresentation,
+  IExposedSegment as ISegment,
+  IRepresentationFilter,
+  IRepresentationInfos,
+} from "./manifest";
+export {
+  ICustomSegmentLoader as ISegmentLoader,
+  ICustomManifestLoader as IManifestLoader,
+} from "./transports";

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -25,7 +25,7 @@ import {
 } from "../../utils/task_canceller";
 import warnOnce from "../../utils/warn_once";
 import {
-  CustomSegmentLoader,
+  ICustomSegmentLoader,
   ILoadedAudioVideoSegmentFormat,
   ISegmentContext,
   ISegmentLoader,
@@ -94,7 +94,7 @@ export default function generateSegmentLoader(
   { lowLatencyMode,
     segmentLoader: customSegmentLoader,
     checkMediaSegmentIntegrity } : { lowLatencyMode: boolean;
-                                     segmentLoader? : CustomSegmentLoader;
+                                     segmentLoader? : ICustomSegmentLoader;
                                      checkMediaSegmentIntegrity? : boolean; }
 ) : ISegmentLoader<Uint8Array | ArrayBuffer | null> {
   return checkMediaSegmentIntegrity !== true ? segmentLoader :
@@ -158,7 +158,7 @@ export default function generateSegmentLoader(
        * Callback triggered when the custom segment loader fails
        * @param {*} err - The corresponding error encountered
        */
-      const reject = (err = {}) : void => {
+      const reject = (err : unknown) : void => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;
         }

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -17,7 +17,7 @@
 import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
-  CustomManifestLoader,
+  ICustomManifestLoader,
   ILoadedManifestFormat,
   IRequestedData,
 } from "../types";
@@ -43,7 +43,7 @@ function regularManifestLoader(
  * @returns {Function}
  */
 export default function generateManifestLoader(
-  { customManifestLoader } : { customManifestLoader?: CustomManifestLoader }
+  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader }
 ) : (
     url : string | undefined,
     cancelSignal : CancellationSignal

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -23,7 +23,7 @@ import {
   CancellationSignal,
 } from "../../utils/task_canceller";
 import {
-  CustomSegmentLoader,
+  ICustomSegmentLoader,
   ISegmentContext,
   ISegmentLoaderCallbacks,
   ISegmentLoaderResultSegmentCreated,
@@ -86,7 +86,7 @@ const generateSegmentLoader = ({
   customSegmentLoader,
 } : {
   checkMediaSegmentIntegrity? : boolean;
-  customSegmentLoader? : CustomSegmentLoader;
+  customSegmentLoader? : ICustomSegmentLoader;
 }) => (
   url : string | null,
   content : ISegmentContext,
@@ -206,7 +206,7 @@ const generateSegmentLoader = ({
        * Callback triggered when the custom segment loader fails
        * @param {*} err - The corresponding error encountered
        */
-      const reject = (err = {}) => {
+      const reject = (err : unknown) => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;
         }

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -17,6 +17,11 @@
 import { IInbandEvent } from "../core/stream";
 import Manifest, {
   Adaptation,
+  IExposedAdaptation,
+  IExposedManifest,
+  IExposedPeriod,
+  IExposedRepresentation,
+  IExposedSegment,
   IRepresentationFilter,
   ISegment,
   ISupplementaryImageTrack,
@@ -481,11 +486,11 @@ export interface ITransportOptions {
   aggressiveMode? : boolean;
   checkMediaSegmentIntegrity? : boolean;
   lowLatencyMode : boolean;
-  manifestLoader?: CustomManifestLoader;
+  manifestLoader?: ICustomManifestLoader;
   manifestUpdateUrl? : string;
   referenceDateTime? : number;
   representationFilter? : IRepresentationFilter;
-  segmentLoader? : CustomSegmentLoader;
+  segmentLoader? : ICustomSegmentLoader;
   serverSyncInfos? : IServerSyncInfos;
   /* eslint-disable import/no-deprecated */
   supplementaryImageTracks? : ISupplementaryImageTrack[];
@@ -495,34 +500,29 @@ export interface ITransportOptions {
   __priv_patchLastSegmentInSidx? : boolean;
 }
 
-export type CustomSegmentLoader = (
+export type ICustomSegmentLoader = (
   // first argument: infos on the segment
-  args : { adaptation : Adaptation;
-           representation : Representation;
-           segment : ISegment;
-           transport : string;
-           url : string;
-           manifest : Manifest; },
+  infos : { url : string;
+            manifest : IExposedManifest;
+            period : IExposedPeriod;
+            adaptation : IExposedAdaptation;
+            representation : IExposedRepresentation;
+            segment : IExposedSegment; },
 
   // second argument: callbacks
   callbacks : { resolve : (rArgs : { data : ArrayBuffer | Uint8Array;
-                                     sendingTime? : number;
-                                     receivingTime? : number;
-                                     size? : number;
-                                     duration? : number; })
-                          => void;
+                                     sendingTime? : number | undefined;
+                                     receivingTime? : number | undefined;
+                                     size? : number | undefined;
+                                     duration? : number | undefined; }) => void;
 
-                progress : (pArgs : { duration : number;
-                                      size : number;
-                                      totalSize? : number; })
-                           => void;
-                reject : (err? : Error) => void;
-                fallback? : () => void; }
+                 reject : (err? : unknown) => void;
+                 fallback? : (() => void) | undefined; }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;
 
-export type CustomManifestLoader = (
+export type ICustomManifestLoader = (
   // first argument: url of the manifest
   url : string | undefined,
 

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -21,13 +21,13 @@ import {
   CancellationSignal,
 } from "../../utils/task_canceller";
 import {
-  CustomManifestLoader,
+  ICustomManifestLoader,
   ILoadedManifestFormat,
   IRequestedData,
 } from "../types";
 
 export default function callCustomManifestLoader(
-  customManifestLoader : CustomManifestLoader,
+  customManifestLoader : ICustomManifestLoader,
   fallbackManifestLoader : (
     url : string | undefined,
     cancelSignal : CancellationSignal

--- a/src/transports/utils/generate_manifest_loader.ts
+++ b/src/transports/utils/generate_manifest_loader.ts
@@ -18,7 +18,7 @@ import assertUnreachable from "../../utils/assert_unreachable";
 import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
-  CustomManifestLoader,
+  ICustomManifestLoader,
   ILoadedManifestFormat,
   IRequestedData,
 } from "../types";
@@ -66,7 +66,7 @@ function generateRegularManifestLoader(
  * @returns {Function}
  */
 export default function generateManifestLoader(
-  { customManifestLoader } : { customManifestLoader?: CustomManifestLoader },
+  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader },
   preferredType: "arraybuffer" | "text" | "document"
 ) : (
     url : string | undefined,

--- a/tests/integration/scenarios/dash_multi_periods.js
+++ b/tests/integration/scenarios/dash_multi_periods.js
@@ -312,7 +312,7 @@ describe("DASH multi-Period with different choices", function () {
   });
 });
 
-describe.only("DASH multi-Period with same choices", function () {
+describe("DASH multi-Period with same choices", function () {
   let player;
 
   async function loadContent() {


### PR DESCRIPTION
Fixes #972

Add the following TypeScript types to the `rx-player/types` path, and document them:
  - `IPersistentSessionInfo`
  - `IPersistentSessionStorage`
  - `ICustomError` (as `IPlayerError`)
  - `IRepresentationFilter`
  - `IRepresentationInfos` (the second argument of the `representationFilter` function)
  -  `ICustomSegmentLoader` as (`ISegmentLoader`)
  -  `ICustomManifestLoader` as (`IManifestLoader`)

Those are all types that may be encountered in the API.

I also added those newly defined types:
  - `IManifest`
  - `IPeriod`
  - `IAdaptation`
  - `IRepresentation`
  - `ISegment`

Which are sub-types of the corresponding RxPlayer's structure with only the properties and methods we defined in the API documentation.

I profited from this commit to do some clean-up:
  - The `CustomManifestLoader` and `CustomSegmentLoader` types have been renamed to `ICustomManifestLoader` and `ICustomSegmentLoader` to unify type naming
  - A Representation's `id` could be `string | number` for I don't know what legacy reasons. As this does not appear necessary anymore (and as it's just an internal type anyway), I chose to just type it as `string`.

---

There's still a last thing to check. Some of the methods and properties in the API depend on a type named differently and imported from a different place than the renamed one that will be exported from `"rx-player/types"`.

I don't know if `tsserver`, for example, is smart enough to auto-import the renamed (through a `export { internal_name_type as api_name_type }` construct) type that is exported from `"rx-player/types"` and not the original type definition which is exported from a deeper internal directory - as I guess most application developpers will just rely on tsserver and not look for the types in the API themselves.