### PR TITLE
wasm/dash: handle Event namespaces

### DIFF
--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -255,7 +255,8 @@ function parseCompleteIntermediateRepresentation(
                           receivedTime: args.manifestReceivedTime,
                           timeShiftBufferDepth,
                           unsafelyBaseOnPreviousManifest,
-                          xlinkInfos };
+                          xlinkInfos,
+                          xmlNamespaces: mpdIR.attributes.namespaces };
   const parsedPeriods = parsePeriods(rootChildren.periods, manifestInfos);
   const mediaPresentationDuration = rootAttributes.duration;
 

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -92,6 +92,16 @@ export interface IMPDAttributes {
   suggestedPresentationDelay? : number;
   maxSegmentDuration? : number;
   maxSubsegmentDuration? : number;
+
+  /**
+   * XML namespaces linked to the `<MPD>` element.
+   *
+   * This property is only needed when the EventStream's `<Event>` elements are
+   * not parsed through the browser's DOMParser API, and thus might depend on
+   * parent namespaces to be parsed correctly.
+   */
+  namespaces? : Array<{ key: string;
+                        value: string; }>;
 }
 
 /** Intermediate representation of an encountered Period node. */
@@ -153,6 +163,16 @@ export interface IPeriodAttributes {
   bitstreamSwitching? : boolean;
   xlinkHref? : string;
   xlinkActuate? : string;
+
+  /**
+   * XML namespaces linked to the `<Period>` element.
+   *
+   * This property is only needed when the EventStream's `<Event>` elements are
+   * not parsed through the browser's DOMParser API, and thus might depend on
+   * parent namespaces to be parsed correctly.
+   */
+  namespaces? : Array<{ key: string;
+                        value: string; }>;
 }
 
 /** AdaptationSet once parsed into its intermediate representation. */
@@ -370,6 +390,15 @@ export interface IEventStreamAttributes {
   schemeIdUri? : string;
   timescale? : number;
   value? : string;
+
+  /**
+   * XML namespaces linked to the `<EventStream>` element.
+   *
+   * This property is only needed when the EventStream's `<Event>` elements are
+   * not parsed through the browser's DOMParser API, and thus might depend on
+   * parent namespaces to be parsed correctly.
+   */
+  namespaces? : Array<{ key: string; value: string }>;
 }
 
 export interface IEventStreamChildren {

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
@@ -25,7 +25,11 @@ pub fn report_mpd_attrs(e : &quick_xml::events::BytesStart) {
                     MaxSegmentDuration.try_report_as_iso_8601_duration(&attr),
                 b"maxSubsegmentDuration" =>
                     MaxSubsegmentDuration.try_report_as_iso_8601_duration(&attr),
-                _ => {},
+                x => {
+                    if x.len() > 6 && &x[..6] == b"xmlns:" {
+                        Namespace.try_report_as_key_value(&x[6..], &attr);
+                    }
+                }
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
@@ -42,7 +46,11 @@ pub fn report_period_attrs(tag_bs : &quick_xml::events::BytesStart) {
                 b"bitstreamSwitching" => BitstreamSwitching.try_report_as_bool(&attr),
                 b"xlink:href" => XLinkHref.try_report_as_string(&attr),
                 b"xlink:actuate" => XLinkActuate.try_report_as_string(&attr),
-                _ => {},
+                x => {
+                    if x.len() > 6 && &x[..6] == b"xmlns:" {
+                        Namespace.try_report_as_key_value(&x[6..], &attr);
+                    }
+                }
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
@@ -272,7 +280,11 @@ pub fn report_event_stream_attrs(tag_bs : &quick_xml::events::BytesStart) {
                 b"schemeIdUri" => SchemeIdUri.try_report_as_string(&attr),
                 b"value" => SchemeValue.try_report_as_string(&attr),
                 b"timescale" => TimeScale.try_report_as_u64(&attr),
-                _ => {},
+                x => {
+                    if x.len() > 6 && &x[..6] == b"xmlns:" {
+                        Namespace.try_report_as_key_value(&x[6..], &attr);
+                    }
+                }
             },
             Err(err) => ParsingError::from(err).report_err(),
         };

--- a/src/parsers/manifest/dash/wasm-parser/rs/utils.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/utils.rs
@@ -180,6 +180,14 @@ fn read_next_float(
     Ok((val_f64, i))
 }
 
+pub fn u32_to_u8_slice_be(x:u32) -> [u8;4] {
+    let b1 : u8 = ((x >> 24) & 0xff) as u8;
+    let b2 : u8 = ((x >> 16) & 0xff) as u8;
+    let b3 : u8 = ((x >> 8) & 0xff) as u8;
+    let b4 : u8 = (x & 0xff) as u8;
+    return [b1, b2, b3, b4]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/EventStream.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/EventStream.ts
@@ -81,6 +81,25 @@ export function generateEventStreamAttrParser(
       case AttributeName.TimeScale:
         esAttrs.timescale = dataView.getFloat64(ptr, true);
         break;
+      case AttributeName.Namespace:
+        const xmlNs = { key: "", value: "" };
+        let offset = ptr;
+        const keySize = dataView.getUint32(offset);
+        offset += 4;
+
+        xmlNs.key = parseString(textDecoder, linearMemory.buffer, offset, keySize);
+        offset += keySize;
+
+        const valSize = dataView.getUint32(offset);
+        offset += 4;
+        xmlNs.value = parseString(textDecoder, linearMemory.buffer, offset, valSize);
+
+        if (esAttrs.namespaces === undefined) {
+          esAttrs.namespaces = [xmlNs];
+        } else {
+          esAttrs.namespaces.push(xmlNs);
+        }
+        break;
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
@@ -152,6 +152,26 @@ export function generateMPDAttrParser(
         const location = parseString(textDecoder, linearMemory.buffer, ptr, len);
         mpdChildren.locations.push(location);
         break;
+      case AttributeName.Namespace:
+        const xmlNs = { key: "", value: "" };
+        dataView = new DataView(linearMemory.buffer);
+        let offset = ptr;
+        const keySize = dataView.getUint32(offset);
+        offset += 4;
+
+        xmlNs.key = parseString(textDecoder, linearMemory.buffer, offset, keySize);
+        offset += keySize;
+
+        const valSize = dataView.getUint32(offset);
+        offset += 4;
+        xmlNs.value = parseString(textDecoder, linearMemory.buffer, offset, valSize);
+
+        if (mpdAttrs.namespaces === undefined) {
+          mpdAttrs.namespaces = [xmlNs];
+        } else {
+          mpdAttrs.namespaces.push(xmlNs);
+        }
+        break;
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Period.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Period.ts
@@ -141,6 +141,26 @@ export function generatePeriodAttrParser(
                                                ptr,
                                                len);
         break;
+      case AttributeName.Namespace:
+        const xmlNs = { key: "", value: "" };
+        const dataView = new DataView(linearMemory.buffer);
+        let offset = ptr;
+        const keySize = dataView.getUint32(offset);
+        offset += 4;
+
+        xmlNs.key = parseString(textDecoder, linearMemory.buffer, offset, keySize);
+        offset += keySize;
+
+        const valSize = dataView.getUint32(offset);
+        offset += 4;
+        xmlNs.value = parseString(textDecoder, linearMemory.buffer, offset, valSize);
+
+        if (periodAttrs.namespaces === undefined) {
+          periodAttrs.namespaces = [xmlNs];
+        } else {
+          periodAttrs.namespaces.push(xmlNs);
+        }
+        break;
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/types.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/types.ts
@@ -250,4 +250,34 @@ export const enum AttributeName {
   /// The first number indicating the starting range (included).
   /// The second indicating the ending range (non-included).
   EventStreamEltRange = 69,
+
+  /// Describes an XML namespace coming from either a `<MPD>` element, a
+  /// `<Period> element or a `<EventStream>` elements, as those are the three
+  /// parent tags of potential `<Event>` elements.
+  ///
+  /// It is reported as the concatenation of four values:
+  ///
+  ///   - In the four first bytes: The length of the namespace's name (the
+  ///     part in the XML attribute just after "xmlns:"), as a big endian
+  ///     unsigned 32 bit integer
+  ///
+  ///   - The namespace's name (the part coming after "xmlns:" in the
+  ///     attribute's name), as an UTF-8 encoded string.
+  ///     The length of this attribute is indicated by the preceding four
+  ///     bytes.
+  ///
+  ///   - As the next four bytes: The length of the namespace's value (the
+  ///     corresponding XML attribute's value), as a big endian
+  ///     unsigned 32 bit integer
+  ///
+  ///   - The namespace's value (the value of the corresponding XML
+  ///     attribute), as an UTF-8 encoded string.
+  ///     The length of this attribute is indicated by the preceding four
+  ///     bytes.
+  ///
+  /// This special Attribute was needed because we need those namespaces to be
+  /// able to communicate `<Event>` property under a JavaScript's Element
+  /// format: the browser's `DOMParser` API needs to know all potential
+  /// namespaces that will appear in it.
+  Namespace = 70,
 }


### PR DESCRIPTION
There was a subtle issue with the WebAssembly DASH parser, which could lead to inexploitable `streamEvent` events (emit when an `<Event>` element encountered in the MPD begin to be "active").

As per the RxPlayer API documentation, `<Event>` elements are sent as an `Element` JavaScript type through the `streamEvent` event, meaning that we have to use the the DOM-related JavaScript APIs (to be able to create that `Element` type).

However, the main API we used, DOMParser, performed validity checks on the given XML.
We initially though that just feeding it the `<Event>` element was OK, it was valid XML after all, but we forgot about XML namespaces!

Namespaces are special attributes and Element names. They are recognized by the inclusion of the ":" character after them. They have to be declared thanks to an `xmns:<NAMESPACE_NAME>` attribute in one of its parent element.

As only the `<Event>` tag subset is given to it, not the full MPD (for performance reasons as that API was one of the main reasons for us switching to WASM). This means that namespaces declared elsewhere in the MPD was not available to the DOMParser.

When the DOMParser API encounter an unknown namespace, it sadly fails.
This is the source of the issue I'm trying to fix.

---

After iterating through multiple other uglier but simpler solutions (whose goal were mostly to work-around JavaScript validity checks), I did not find any way of handling that properly (and surely).

As a last stretch, I tried to implement it more "cleanly", by:

  - registering all namespaces declaed in all `<Event>` element's parents (which are in order: the `<MPD>` element, the `<Period>` element and the `<EventStream>` element).

  - temporarily creating a parent element named `<toremove>` to that `<Event>`, just before feeding it to the DOMParser. This element will contain all declared namespaces in all three of its parents.

  - removing the `<toremove>` element just after the DOMParser API has been called.

This commit is the result of that experimentation. It seems to work well with all tested contents.

Thoughts?