### PR TITLE
send available{Audio,Video}BitratesChange event for multi-Period contents

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2940,7 +2940,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     newVal : number[]
   ) : void {
     const prevVal = this._priv_contentEventsMemory[event];
-    if (prevVal === undefined || areArraysOfNumbersEqual(newVal, prevVal)) {
+    if (prevVal === undefined || !areArraysOfNumbersEqual(newVal, prevVal)) {
       this._priv_contentEventsMemory[event] = newVal;
       this.trigger(event, newVal);
     }

--- a/tests/contents/DASH_static_SegmentTimeline/index.js
+++ b/tests/contents/DASH_static_SegmentTimeline/index.js
@@ -1,6 +1,8 @@
 import manifestInfos from "./infos.js";
 import discontinuityInfos from "./discontinuity.js";
 import multiAdaptationSetsInfos from "./multi-AdaptationSets.js";
+import multiPeriodDifferentChoicesInfos from "./multi_period_different_choices";
+import multiPeriodSameChoicesInfos from "./multi_period_same_choices";
 import notStartingAt0ManifestInfos from "./not_starting_at_0.js";
 import streamEventsInfos from "./event-stream";
 import segmentTemplateInheritanceASRep from "./segment_template_inheritance_as_rep";
@@ -10,6 +12,8 @@ export {
   manifestInfos,
   discontinuityInfos,
   multiAdaptationSetsInfos,
+  multiPeriodDifferentChoicesInfos,
+  multiPeriodSameChoicesInfos,
   notStartingAt0ManifestInfos,
   segmentTemplateInheritanceASRep,
   segmentTemplateInheritancePeriodAS,

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi_period_different_choices.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi_period_different_choices.mpd
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  A MPD with two Periods with a lot of audio and video tracks, which have
+  different characteristics depending on the Period.
+-->
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" mediaPresentationDuration="PT3M23S" maxSegmentDuration="PT5S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+
+    <!-- audio fr mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+      <Representation id="audio=256000" bandwidth="256000"></Representation>
+    </AdaptationSet>
+
+    <!-- audio de mp4a.40.2 priority 100 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="100"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+      <Representation id="audio=256000" bandwidth="256000"></Representation>
+    </AdaptationSet>
+
+    <!-- audio de mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+      <Representation id="audio=256000" bandwidth="256000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr hard-of-hearing -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video main avc1.640028 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1.640028 + priority 2 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="2"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+  </Period>
+  <Period id="2" duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+
+    <!-- audio de mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128001"></Representation>
+      <Representation id="audio=256000" bandwidth="256001"></Representation>
+    </AdaptationSet>
+
+    <!-- audio fr mp4a.40.2 priority 10 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="10"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128001"></Representation>
+      <Representation id="audio=256000" bandwidth="256001"></Representation>
+    </AdaptationSet>
+
+    <!-- audio fr mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128001"></Representation>
+      <Representation id="audio=256000" bandwidth="256001"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128001"></Representation>
+      <Representation id="audio=256000" bandwidth="256001"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-audio=128000.dash" media="ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128001"></Representation>
+      <Representation id="audio=256000" bandwidth="256001"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de priority 20 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="20"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+    <!-- text de hard-of-hearing priority 50 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="50"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video avc1 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400001" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795001" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1 + priority 50 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="50"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400001" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795001" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+  </Period>
+</MPD>
+
+

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi_period_same_choices.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi_period_same_choices.mpd
@@ -1,0 +1,636 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  A MPD with two Periods with a lot of audio and video tracks, which have the
+  exact same characteristics (down to even the segments URL) in either Periods.
+-->
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" mediaPresentationDuration="PT3M23S" maxSegmentDuration="PT5S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+
+    <!-- audio fr mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.2 priority 10 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="10"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.2 priority 100 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="100"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de priority 20 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="20"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr hard-of-hearing -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de hard-of-hearing priority 50 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="50"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video avc1 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video main avc1.640028 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1 + priority 50 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="50"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1.640028 + priority 2 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="2"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+  </Period>
+  <Period id="2" duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+
+    <!-- audio fr mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.2 priority 10 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="10"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.5 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.2 priority 100 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      selectionPriority="100"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio fr mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.5 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- audio de mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de priority 20 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="20"
+      subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr hard-of-hearing -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="fr"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de hard-of-hearing priority 50 -->
+    <AdaptationSet
+      id="0"
+      contentType="text"
+      lang="de"
+      selectionPriority="50"
+      subsegmentAlignment="true">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "2" />
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt">
+      </Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video avc1 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video main avc1.640028 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1 + priority 50 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="50"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+
+    <!-- video avc1.640028 + priority 2 + sign interpreted -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="2"
+      startWithSAP="1">
+        <Accessibility schemeIdUri="urn:mpeg:dash:role:2011" value= "sign" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+  </Period>
+</MPD>
+

--- a/tests/contents/DASH_static_SegmentTimeline/multi_period_different_choices.js
+++ b/tests/contents/DASH_static_SegmentTimeline/multi_period_different_choices.js
@@ -1,0 +1,10 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_SegmentTimeline/media/";
+export default {
+  url: BASE_URL + "multi_period_different_choices.mpd",
+  transport: "dash",
+};

--- a/tests/contents/DASH_static_SegmentTimeline/multi_period_same_choices.js
+++ b/tests/contents/DASH_static_SegmentTimeline/multi_period_same_choices.js
@@ -1,0 +1,10 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_SegmentTimeline/media/";
+export default {
+  url: BASE_URL + "multi_period_same_choices.mpd",
+  transport: "dash",
+};

--- a/tests/contents/DASH_static_SegmentTimeline/urls.js
+++ b/tests/contents/DASH_static_SegmentTimeline/urls.js
@@ -106,6 +106,16 @@ module.exports = [
     path: path.join(__dirname, "media/discontinuity.mpd"),
     contentType: "application/dash+xml",
   },
+  {
+    url: BASE_URL + "multi_period_different_choices.mpd",
+    path: path.join(__dirname, "media/multi_period_different_choices.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "multi_period_same_choices.mpd",
+    path: path.join(__dirname, "media/multi_period_same_choices.mpd"),
+    contentType: "application/dash+xml",
+  },
   // Audio initialization segment
   {
     url: BASE_URL + "dash/ateam-audio=128000.dash",

--- a/tests/integration/scenarios/dash_multi_periods.js
+++ b/tests/integration/scenarios/dash_multi_periods.js
@@ -1,9 +1,587 @@
-import launchTestsForContent from "../utils/launch_tests_for_content.js";
-
+import { expect } from "chai";
+import RxPlayer from "../../../src";
 import {
   manifestInfos,
 } from "../../contents/DASH_static_SegmentTemplate_Multi_Periods";
+import {
+  multiPeriodDifferentChoicesInfos,
+  multiPeriodSameChoicesInfos,
+} from "../../contents/DASH_static_SegmentTimeline";
+import launchTestsForContent from "../utils/launch_tests_for_content.js";
+import waitForPlayerState, {
+  waitForLoadedStateAfterLoadVideo,
+} from "../../utils/waitForPlayerState.js";
+import sleep from "../../utils/sleep.js";
 
 describe("DASH non-linear multi-periods content (SegmentTemplate)", function () {
   launchTestsForContent(manifestInfos);
+});
+
+describe("DASH multi-Period with different choices", function () {
+  let player;
+
+  async function loadContent() {
+    player.loadVideo({ url: multiPeriodDifferentChoicesInfos.url,
+                       transport: multiPeriodDifferentChoicesInfos.transport });
+    await waitForLoadedStateAfterLoadVideo(player);
+  }
+
+  async function goToFirstPeriod() {
+    player.seekTo(5);
+    await sleep(500);
+    if (player.getPlayerState() !== "PAUSED") {
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(0, 10);
+  }
+
+  async function goToSecondPeriod() {
+    player.seekTo(120);
+    await sleep(500);
+    if (player.getPlayerState() !== "PAUSED") {
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(118, 122);
+  }
+
+  beforeEach(() => {
+    player = new RxPlayer();
+    player.setWantedBufferAhead(5); // We don't really care
+  });
+
+  afterEach(() => {
+    player.dispose();
+  });
+
+  it("should send the right events when seeking into a new Period", async function () {
+    const availableAudioTracksChange = [];
+    const availableVideoTracksChange = [];
+    const videoTrackChangeEvents = [];
+    const audioTrackChangeEvents = [];
+    const availableAudioBitratesChange = [];
+    const availableVideoBitratesChange = [];
+    const videoBitrateChangeEvents = [];
+    const audioBitrateChangeEvents = [];
+    const periodChangeEvents = [];
+
+    player.addEventListener("availableAudioTracksChange", (payload) => {
+      availableAudioTracksChange.push(payload);
+    });
+    player.addEventListener("availableVideoTracksChange", (payload) => {
+      availableVideoTracksChange.push(payload);
+    });
+    player.addEventListener("audioTrackChange", (payload) => {
+      audioTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("videoTrackChange", (payload) => {
+      videoTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("availableAudioBitratesChange", (payload) => {
+      availableAudioBitratesChange.push(payload);
+    });
+    player.addEventListener("availableVideoBitratesChange", (payload) => {
+      availableVideoBitratesChange.push(payload);
+    });
+    player.addEventListener("audioBitrateChange", (payload) => {
+      audioBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("videoBitrateChange", (payload) => {
+      videoBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("periodChange", (payload) => {
+      periodChangeEvents.push(payload);
+    });
+
+    player.setAudioBitrate(Infinity);
+    player.setVideoBitrate(Infinity);
+
+
+    await loadContent();
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableAudioTracksChange[0]).to.have.length(3);
+
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange[0]).to.have.length(2);
+
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(audioTrackChangeEvents[0].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents[0].id).to.equal("video-video-video/mp4");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableAudioBitratesChange[0]).to.deep.equal([128000, 256000]);
+
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange[0]).to.deep.equal([400000, 1996000]);
+
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(audioBitrateChangeEvents[0]).to.equal(256000);
+
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents[0]).to.equal(1996000);
+
+    expect(periodChangeEvents).to.have.length(1);
+    expect(periodChangeEvents[0].id).to.equal("1");
+
+
+    await goToSecondPeriod();
+
+    expect(availableAudioTracksChange).to.have.length(2);
+    expect(availableAudioTracksChange[1]).to.have.length(5);
+
+    expect(availableVideoTracksChange).to.have.length(2);
+    expect(availableVideoTracksChange[1]).to.have.length(2);
+
+    expect(audioTrackChangeEvents).to.have.length(2);
+    expect(audioTrackChangeEvents[1].id).to.equal("audio-fr-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(2);
+    expect(videoTrackChangeEvents[1].id).to.equal("video-si-video-video/mp4");
+
+    expect(availableAudioBitratesChange).to.have.length(2);
+    expect(availableAudioBitratesChange[1]).to.deep.equal([128001, 256001]);
+
+    expect(availableVideoBitratesChange).to.have.length(2);
+    expect(availableVideoBitratesChange[1]).to.deep.equal([400001, 795001]);
+
+    expect(audioBitrateChangeEvents).to.have.length(2);
+    expect(audioBitrateChangeEvents[1]).to.equal(256001);
+
+    expect(videoBitrateChangeEvents).to.have.length(2);
+    expect(videoBitrateChangeEvents[1]).to.equal(795001);
+
+    expect(periodChangeEvents).to.have.length(2);
+    expect(periodChangeEvents[1].id).to.equal("2");
+
+
+    await goToFirstPeriod();
+
+    expect(availableAudioTracksChange).to.have.length(3);
+    expect(availableAudioTracksChange[2]).to.have.length(3);
+
+    expect(availableVideoTracksChange).to.have.length(3);
+    expect(availableVideoTracksChange[2]).to.have.length(2);
+
+    expect(audioTrackChangeEvents).to.have.length(3);
+    expect(audioTrackChangeEvents[2].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(3);
+    expect(videoTrackChangeEvents[2].id).to.equal("video-video-video/mp4");
+
+    expect(availableAudioBitratesChange).to.have.length(3);
+    expect(availableAudioBitratesChange[2]).to.deep.equal([128000, 256000]);
+
+    expect(availableVideoBitratesChange).to.have.length(3);
+    expect(availableVideoBitratesChange[2]).to.deep.equal([400000, 1996000]);
+
+    expect(audioBitrateChangeEvents).to.have.length(3);
+    expect(audioBitrateChangeEvents[2]).to.equal(256000);
+
+    expect(videoBitrateChangeEvents).to.have.length(3);
+    expect(videoBitrateChangeEvents[2]).to.equal(1996000);
+
+    expect(periodChangeEvents).to.have.length(3);
+    expect(periodChangeEvents[2].id).to.equal("1");
+  });
+
+  it("should send the right events when playing into a new Period", async function () {
+    this.timeout(7000);
+    const availableAudioTracksChange = [];
+    const availableVideoTracksChange = [];
+    const videoTrackChangeEvents = [];
+    const audioTrackChangeEvents = [];
+    const availableAudioBitratesChange = [];
+    const availableVideoBitratesChange = [];
+    const videoBitrateChangeEvents = [];
+    const audioBitrateChangeEvents = [];
+    const periodChangeEvents = [];
+
+    player.addEventListener("availableAudioTracksChange", (payload) => {
+      availableAudioTracksChange.push(payload);
+    });
+    player.addEventListener("availableVideoTracksChange", (payload) => {
+      availableVideoTracksChange.push(payload);
+    });
+    player.addEventListener("audioTrackChange", (payload) => {
+      audioTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("videoTrackChange", (payload) => {
+      videoTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("availableAudioBitratesChange", (payload) => {
+      availableAudioBitratesChange.push(payload);
+    });
+    player.addEventListener("availableVideoBitratesChange", (payload) => {
+      availableVideoBitratesChange.push(payload);
+    });
+    player.addEventListener("audioBitrateChange", (payload) => {
+      audioBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("videoBitrateChange", (payload) => {
+      videoBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("periodChange", (payload) => {
+      periodChangeEvents.push(payload);
+    });
+
+    player.setPlaybackRate(3);
+    player.setAudioBitrate(Infinity);
+    player.setVideoBitrate(Infinity);
+
+
+    await loadContent();
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableAudioTracksChange[0]).to.have.length(3);
+
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange[0]).to.have.length(2);
+
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(audioTrackChangeEvents[0].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents[0].id).to.equal("video-video-video/mp4");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableAudioBitratesChange[0]).to.deep.equal([128000, 256000]);
+
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange[0]).to.deep.equal([400000, 1996000]);
+
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(audioBitrateChangeEvents[0]).to.equal(256000);
+
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents[0]).to.equal(1996000);
+
+    expect(periodChangeEvents).to.have.length(1);
+    expect(periodChangeEvents[0].id).to.equal("1");
+
+
+    // still first Period
+    player.play();
+    player.seekTo(100);
+    await sleep(100);
+    if (player.getPlayerState() !== "PLAYING") {
+      await waitForPlayerState(player, "PLAYING", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(100, 101);
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(periodChangeEvents).to.have.length(1);
+
+    await sleep(4000);
+    expect(player.getPosition()).to.be.at.least(102);
+
+    expect(availableAudioTracksChange).to.have.length(2);
+    expect(availableAudioTracksChange[1]).to.have.length(5);
+
+    expect(availableVideoTracksChange).to.have.length(2);
+    expect(availableVideoTracksChange[1]).to.have.length(2);
+
+    expect(audioTrackChangeEvents).to.have.length(2);
+    expect(audioTrackChangeEvents[1].id).to.equal("audio-fr-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(2);
+    expect(videoTrackChangeEvents[1].id).to.equal("video-si-video-video/mp4");
+
+    expect(availableAudioBitratesChange).to.have.length(2);
+    expect(availableAudioBitratesChange[1]).to.deep.equal([128001, 256001]);
+
+    expect(availableVideoBitratesChange).to.have.length(2);
+    expect(availableVideoBitratesChange[1]).to.deep.equal([400001, 795001]);
+
+    expect(audioBitrateChangeEvents).to.have.length(2);
+    expect(audioBitrateChangeEvents[1]).to.equal(256001);
+
+    expect(videoBitrateChangeEvents).to.have.length(2);
+    expect(videoBitrateChangeEvents[1]).to.equal(795001);
+
+    expect(periodChangeEvents).to.have.length(2);
+    expect(periodChangeEvents[1].id).to.equal("2");
+  });
+});
+
+describe.only("DASH multi-Period with same choices", function () {
+  let player;
+
+  async function loadContent() {
+    player.loadVideo({ url: multiPeriodSameChoicesInfos.url,
+                       transport: multiPeriodSameChoicesInfos.transport });
+    await waitForLoadedStateAfterLoadVideo(player);
+  }
+
+  async function goToFirstPeriod() {
+    player.seekTo(5);
+    await sleep(500);
+    if (player.getPlayerState() !== "PAUSED") {
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(0, 10);
+  }
+
+  async function goToSecondPeriod() {
+    player.seekTo(120);
+    await sleep(500);
+    if (player.getPlayerState() !== "PAUSED") {
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(118, 122);
+  }
+
+  beforeEach(() => {
+    player = new RxPlayer();
+    player.setWantedBufferAhead(5); // We don't really care
+  });
+
+  afterEach(() => {
+    player.dispose();
+  });
+
+  it("should send the right events when seeking into a new Period", async function () {
+    const availableAudioTracksChange = [];
+    const availableVideoTracksChange = [];
+    const videoTrackChangeEvents = [];
+    const audioTrackChangeEvents = [];
+    const availableAudioBitratesChange = [];
+    const availableVideoBitratesChange = [];
+    const videoBitrateChangeEvents = [];
+    const audioBitrateChangeEvents = [];
+    const periodChangeEvents = [];
+
+    player.addEventListener("availableAudioTracksChange", (payload) => {
+      availableAudioTracksChange.push(payload);
+    });
+    player.addEventListener("availableVideoTracksChange", (payload) => {
+      availableVideoTracksChange.push(payload);
+    });
+    player.addEventListener("audioTrackChange", (payload) => {
+      audioTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("videoTrackChange", (payload) => {
+      videoTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("availableAudioBitratesChange", (payload) => {
+      availableAudioBitratesChange.push(payload);
+    });
+    player.addEventListener("availableVideoBitratesChange", (payload) => {
+      availableVideoBitratesChange.push(payload);
+    });
+    player.addEventListener("audioBitrateChange", (payload) => {
+      audioBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("videoBitrateChange", (payload) => {
+      videoBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("periodChange", (payload) => {
+      periodChangeEvents.push(payload);
+    });
+
+    player.setAudioBitrate(Infinity);
+    player.setVideoBitrate(Infinity);
+
+
+    await loadContent();
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableAudioTracksChange[0]).to.have.length(8);
+
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange[0]).to.have.length(4);
+
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(audioTrackChangeEvents[0].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents[0].id).to.equal("video-video-video/mp4-dup");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableAudioBitratesChange[0]).to.deep.equal([128000]);
+
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange[0]).to.deep.equal([400000, 1996000]);
+
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(audioBitrateChangeEvents[0]).to.equal(128000);
+
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents[0]).to.equal(1996000);
+
+    expect(periodChangeEvents).to.have.length(1);
+    expect(periodChangeEvents[0].id).to.equal("1");
+
+
+    await goToSecondPeriod();
+
+    expect(availableAudioTracksChange).to.have.length(2);
+    expect(availableAudioTracksChange[1]).to.have.length(8);
+
+    expect(availableVideoTracksChange).to.have.length(2);
+    expect(availableVideoTracksChange[1]).to.have.length(4);
+
+    expect(audioTrackChangeEvents).to.have.length(2);
+    expect(audioTrackChangeEvents[1].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(2);
+    expect(videoTrackChangeEvents[1].id).to.equal("video-video-video/mp4-dup");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents).to.have.length(1);
+
+    expect(periodChangeEvents).to.have.length(2);
+    expect(periodChangeEvents[1].id).to.equal("2");
+
+
+    await goToFirstPeriod();
+
+    expect(availableAudioTracksChange).to.have.length(3);
+    expect(availableAudioTracksChange[2]).to.have.length(8);
+
+    expect(availableVideoTracksChange).to.have.length(3);
+    expect(availableVideoTracksChange[2]).to.have.length(4);
+
+    expect(audioTrackChangeEvents).to.have.length(3);
+    expect(audioTrackChangeEvents[2].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(3);
+    expect(videoTrackChangeEvents[2].id).to.equal("video-video-video/mp4-dup");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents).to.have.length(1);
+
+    expect(periodChangeEvents).to.have.length(3);
+    expect(periodChangeEvents[2].id).to.equal("1");
+  });
+
+  it("should send the right events when playing into a new Period", async function () {
+    this.timeout(7000);
+    const availableAudioTracksChange = [];
+    const availableVideoTracksChange = [];
+    const videoTrackChangeEvents = [];
+    const audioTrackChangeEvents = [];
+    const availableAudioBitratesChange = [];
+    const availableVideoBitratesChange = [];
+    const videoBitrateChangeEvents = [];
+    const audioBitrateChangeEvents = [];
+    const periodChangeEvents = [];
+
+    player.addEventListener("availableAudioTracksChange", (payload) => {
+      availableAudioTracksChange.push(payload);
+    });
+    player.addEventListener("availableVideoTracksChange", (payload) => {
+      availableVideoTracksChange.push(payload);
+    });
+    player.addEventListener("audioTrackChange", (payload) => {
+      audioTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("videoTrackChange", (payload) => {
+      videoTrackChangeEvents.push(payload);
+    });
+    player.addEventListener("availableAudioBitratesChange", (payload) => {
+      availableAudioBitratesChange.push(payload);
+    });
+    player.addEventListener("availableVideoBitratesChange", (payload) => {
+      availableVideoBitratesChange.push(payload);
+    });
+    player.addEventListener("audioBitrateChange", (payload) => {
+      audioBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("videoBitrateChange", (payload) => {
+      videoBitrateChangeEvents.push(payload);
+    });
+    player.addEventListener("periodChange", (payload) => {
+      periodChangeEvents.push(payload);
+    });
+
+    player.setPlaybackRate(3);
+    player.setAudioBitrate(Infinity);
+    player.setVideoBitrate(Infinity);
+
+
+    await loadContent();
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableAudioTracksChange[0]).to.have.length(8);
+
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange[0]).to.have.length(4);
+
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(audioTrackChangeEvents[0].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents[0].id).to.equal("video-video-video/mp4-dup");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableAudioBitratesChange[0]).to.deep.equal([128000]);
+
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange[0]).to.deep.equal([400000, 1996000]);
+
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(audioBitrateChangeEvents[0]).to.equal(128000);
+
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents[0]).to.equal(1996000);
+
+    expect(periodChangeEvents).to.have.length(1);
+    expect(periodChangeEvents[0].id).to.equal("1");
+
+
+    // still first Period
+    player.play();
+    player.seekTo(100);
+    await sleep(100);
+    if (player.getPlayerState() !== "PLAYING") {
+      await waitForPlayerState(player, "PLAYING", ["SEEKING", "BUFFERING"]);
+    }
+    expect(player.getPosition()).to.be.within(100, 101);
+
+    expect(availableAudioTracksChange).to.have.length(1);
+    expect(availableVideoTracksChange).to.have.length(1);
+    expect(audioTrackChangeEvents).to.have.length(1);
+    expect(videoTrackChangeEvents).to.have.length(1);
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents).to.have.length(1);
+    expect(periodChangeEvents).to.have.length(1);
+
+    await sleep(4000);
+    expect(player.getPosition()).to.be.at.least(102);
+
+    expect(availableAudioTracksChange).to.have.length(2);
+    expect(availableAudioTracksChange[1]).to.have.length(8);
+
+    expect(availableVideoTracksChange).to.have.length(2);
+    expect(availableVideoTracksChange[1]).to.have.length(4);
+
+    expect(audioTrackChangeEvents).to.have.length(2);
+    expect(audioTrackChangeEvents[1].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+
+    expect(videoTrackChangeEvents).to.have.length(2);
+    expect(videoTrackChangeEvents[1].id).to.equal("video-video-video/mp4-dup");
+
+    expect(availableAudioBitratesChange).to.have.length(1);
+    expect(availableVideoBitratesChange).to.have.length(1);
+    expect(audioBitrateChangeEvents).to.have.length(1);
+    expect(videoBitrateChangeEvents).to.have.length(1);
+
+    expect(periodChangeEvents).to.have.length(2);
+    expect(periodChangeEvents[1].id).to.equal("2");
+  });
 });


### PR DESCRIPTION
While browsing the code for a totally unrelated matter, I noticed that a condition in the private `_priv_triggerAvailableBitratesChangeEvent` method in the API module didn't make much sense.

Basically, we were only sending an event linked to a change in bitrate choices if either:

  1. There was no bitrate choice previously (for example, because we just started the content).

  2. There was a bitrate choice previously, but it was the exact same choice that we have now.

The second choice doesn't make sense, but the reverse does (if the list of available bitrates changed emit the event, if not don't).

This, plus the fact that I have the bad habit of mixing-up my `if`s conditions sometimes (programing is hard!) led me to believe that this was an unfortunate typo.

Thankfully, this was not the only way to be notified of the bitrate choices. There was also the `getAvailable{Audio,Video}Bitrates` methods and the `periodChange` event which notifies of ... period change which both had no issue.
  
---

Because this is very easy to test, I added some integration tests to test not only that, but every events that should be linked to Period changes.

Only one line in the code was updated, the huge majority of the diff here are new integration test scenarios.