### PR TITLE
Avoid requesting in a loop segments the browser crops for some reasons

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1157,4 +1157,26 @@ export default {
    * and not significant from the media loss perspective.
    */
   DEFAULT_MAXIMUM_TIME_ROUNDING_ERROR: 1 / 1000,
+
+  /**
+   * RxPlayer's media buffers have a linked history registering recent events
+   * that happened on those.
+   * The reason is to implement various heuristics in case of weird browser
+   * behavior.
+   *
+   * The `BUFFERED_HISTORY_RETENTION_TIME` is the minimum age an entry of
+   * that history can have before being removed from the history.
+   */
+  BUFFERED_HISTORY_RETENTION_TIME: 60000,
+
+  /**
+   * RxPlayer's media buffers have a linked history registering recent events
+   * that happened on those.
+   * The reason is to implement various heuristics in case of weird browser
+   * behavior.
+   *
+   * The `BUFFERED_HISTORY_RETENTION_TIME` is the maximum number of entries
+   * there can be in that history.
+   */
+  BUFFERED_HISTORY_MAXIMUM_ENTRIES: 200,
 };

--- a/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
@@ -36,7 +36,7 @@ import assertUnreachable from "../../../../utils/assert_unreachable";
 import { toUint8Array } from "../../../../utils/byte_parsing";
 import hashBuffer from "../../../../utils/hash_buffer";
 import objectAssign from "../../../../utils/object_assign";
-import { IInsertedChunkInfos } from "../../segment_inventory";
+import { IInsertedChunkInfos } from "../../inventory";
 import {
   IEndOfSegmentInfos,
   IEndOfSegmentOperation,
@@ -399,7 +399,7 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
             }
             break;
           case SegmentBufferOperation.EndOfSegment:
-            this._segmentInventory.completeSegment(task.value);
+            this._segmentInventory.completeSegment(task.value, this.getBufferedRanges());
             break;
           case SegmentBufferOperation.Remove:
             this.synchronizeInventory();

--- a/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
@@ -107,7 +107,7 @@ export default class ImageSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos);
+      this._segmentInventory.completeSegment(_infos, this._buffered);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -234,7 +234,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos);
+      this._segmentInventory.completeSegment(_infos, this._buffered);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
@@ -206,7 +206,7 @@ export default class NativeTextSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos);
+      this._segmentInventory.completeSegment(_infos, this._buffered);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -23,8 +23,10 @@ import {
 } from "../../../manifest";
 import SegmentInventory, {
   IBufferedChunk,
+  IBufferedHistoryEntry,
+  IChunkContext,
   IInsertedChunkInfos,
-} from "../segment_inventory";
+} from "../inventory";
 
 /**
  * Class allowing to push segments and remove data to a buffer to be able
@@ -174,6 +176,23 @@ export abstract class SegmentBuffer {
   public getPendingOperations() : Array<ISBOperation<unknown>> {
     // Return no pending operation by default (for synchronous SegmentBuffers)
     return [];
+  }
+
+  /**
+   * Returns a recent history of registered operations performed and event
+   * received linked to the segment given in argument.
+   *
+   * Not all operations and events are registered in the returned history.
+   * Please check the return type for more information on what is available.
+   *
+   * Note that history is short-lived for memory usage and performance reasons.
+   * You may not receive any information on operations that happened too long
+   * ago.
+   * @param {Object} context
+   * @returns {Array.<Object>}
+   */
+  public getSegmentHistory(context : IChunkContext) : IBufferedHistoryEntry[] {
+    return this._segmentInventory.getHistoryFor(context);
   }
 
   /**

--- a/src/core/segment_buffers/index.ts
+++ b/src/core/segment_buffers/index.ts
@@ -27,11 +27,14 @@ import {
   SegmentBuffer,
   SegmentBufferOperation,
 } from "./implementations";
+import {
+  IBufferedChunk,
+  IChunkContext,
+} from "./inventory";
 import SegmentBuffersStore, {
   ISegmentBufferOptions,
   ITextTrackSegmentBufferOptions,
 } from "./segment_buffers_store";
-import { IBufferedChunk } from "./segment_inventory";
 
 export default SegmentBuffersStore;
 export {
@@ -43,7 +46,9 @@ export {
   SegmentBuffer,
 
   IBufferType,
+
   IBufferedChunk,
+  IChunkContext,
 
   IPushChunkInfos,
   IPushedChunkData,

--- a/src/core/segment_buffers/inventory/buffered_history.ts
+++ b/src/core/segment_buffers/inventory/buffered_history.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { areSameContent } from "../../../manifest";
+import { IChunkContext } from "./types";
+
+/**
+ * Entry of a `BufferedHistory`, added when the initial buffered range of a
+ * **full segment** (and not just of a sub-chunk of a segment like in some
+ * low-latency streaming usages) in the buffer becomes known.
+ */
+export interface IBufferedHistoryEntry {
+  /** `performance.now()` when the event happened. */
+  date : number;
+  /** Start time at which we observed that segment/chunk starts at, in seconds. */
+  bufferedStart : number;
+  /** *End time at which we observed that segment/chunk ends at, in seconds. */
+  bufferedEnd : number;
+  /** Content metadata linked to the segment, allowing to recognize it. */
+  context : IChunkContext;
+
+}
+
+/**
+ * Register a short-lived history of buffer information.
+ *
+ * This class can be useful to develop heuristics based on short-term buffer
+ * history, such as knowing the real start and end of a buffered segment once
+ * it has been pushed in a buffer.
+ *
+ * By storing in a history important recent actions and events, the
+ * `BufferedHistory` can help other RxPlayer modules detect and work-around
+ * unusual behavior.
+ *
+ * @class BufferedHistory
+ */
+export default class BufferedHistory {
+  /** Complete recent history in chronological order (from oldest to newest) */
+  private _history : IBufferedHistoryEntry[];
+  /** Maximum time a history entry should be retained. */
+  private _lifetime : number;
+  /** Maximum number of entries the `BufferedHistory`'s history should have. */
+  private _maxHistoryLength : number;
+
+  /**
+   * @param {number} lifetime - Maximum time a history entry should be retained.
+   * @param {number} maxHistoryLength - Maximum number of entries the history
+   * should have.
+   */
+  constructor(lifetime : number, maxHistoryLength : number) {
+    this._history = [];
+    this._lifetime = lifetime;
+    this._maxHistoryLength = maxHistoryLength;
+  }
+
+  /**
+   * Add an entry to the `BufferedHistory`'s history indicating the buffered
+   * range of a pushed segment.
+   *
+   * To call when the full range of a given segment becomes known.
+   *
+   * @param {Object} context
+   * @param {number} bufferedStart
+   * @param {number} bufferedEnd
+   */
+  public addBufferedSegment(
+    context : IChunkContext,
+    bufferedStart : number,
+    bufferedEnd : number
+  ) : void {
+    const now = performance.now();
+    this._history.push({ date: now,
+                         bufferedStart,
+                         bufferedEnd,
+                         context });
+    this._cleanHistory(now);
+
+  }
+  /**
+   * Returns all entries linked to the given segment.
+   * @param {Object} context
+   * @returns {Array.<Object>}
+   */
+  public getHistoryFor(
+    context : IChunkContext
+  ) : IBufferedHistoryEntry[] {
+    return this._history.filter(el => areSameContent(el.context, context));
+  }
+
+  /**
+   * If the current history does not satisfy `_lifetime` or `_maxHistoryLength`,
+   * clear older entries until it does.
+   * @param {number} now - Current `performance.now()` result.
+   */
+  private _cleanHistory(now : number) {
+    const historyEarliestLimit = now - this._lifetime;
+    let firstKeptIndex = 0;
+    for (const event of this._history) {
+      if (event.date < historyEarliestLimit) {
+        firstKeptIndex++;
+      } else {
+        break;
+      }
+    }
+    if (firstKeptIndex > 0) {
+      this._history.splice(firstKeptIndex);
+    }
+
+    if (this._history.length > this._maxHistoryLength) {
+      const toRemove = this._history.length - this._maxHistoryLength;
+      this._history.splice(toRemove);
+    }
+  }
+}

--- a/src/core/segment_buffers/inventory/index.ts
+++ b/src/core/segment_buffers/inventory/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import SegmentInventory, {
+  IBufferedChunk,
+  IInsertedChunkInfos,
+} from "./segment_inventory";
+
+export default SegmentInventory;
+export {
+  IBufferedChunk,
+  IInsertedChunkInfos,
+};
+export { IBufferedHistoryEntry } from "./buffered_history";
+export { IChunkContext } from "./types";

--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -14,32 +14,26 @@
  * limitations under the License.
  */
 
-import config from "../../config";
-import log from "../../log";
+import config from "../../../config";
+import log from "../../../log";
 import {
   Adaptation,
   areSameContent,
   ISegment,
   Period,
   Representation,
-} from "../../manifest";
-import takeFirstSet from "../../utils/take_first_set";
+} from "../../../manifest";
+import takeFirstSet from "../../../utils/take_first_set";
+import BufferedHistory, {
+  IBufferedHistoryEntry,
+} from "./buffered_history";
+import { IChunkContext } from "./types";
 
-const { MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE,
+const { BUFFERED_HISTORY_RETENTION_TIME,
+        BUFFERED_HISTORY_MAXIMUM_ENTRIES,
+        MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE,
         MAX_MANIFEST_BUFFERED_DURATION_DIFFERENCE,
         MINIMUM_SEGMENT_SIZE } = config;
-
-/** Content information for a single buffered chunk */
-interface IBufferedChunkInfos {
-  /** Adaptation this chunk is related to. */
-  adaptation : Adaptation;
-  /** Period this chunk is related to. */
-  period : Period;
-  /** Representation this chunk is related to. */
-  representation : Representation;
-  /** Segment this chunk is related to. */
-  segment : ISegment;
-}
 
 /** Information stored on a single chunk by the SegmentInventory. */
 export interface IBufferedChunk {
@@ -60,14 +54,12 @@ export interface IBufferedChunk {
   /**
    * Supposed end, in seconds, the chunk is expected to end at.
    *
-   * It can correspond either to the end of the chunk or to the end of the whole
-   * segment the chunk is linked to. This should not matter as chunks linked to
-   * the same segment will all be merged once all chunks have been pushed and
-   * the `completeSegment` API call is done. Until then, this property should
-   * not be relied on.
-   *
-   * You can know whether the `completeSegment` API has been called by checking
-   * the `partiallyPushed` property.
+   * If the current `chunk` is part of a "partially pushed" segment (see
+   * `partiallyPushed`), the definition of this property is flexible in the way
+   * that it can correspond either to the end of the chunk or to the end of the
+   * whole segment the chunk is linked to.
+   * As such, this property should not be relied on until the segment has been
+   * fully-pushed.
    */
   end : number;
   /**
@@ -89,11 +81,11 @@ export interface IBufferedChunk {
    */
   precizeStart : boolean;
   /** Information on what that chunk actually contains. */
-  infos : IBufferedChunkInfos;
+  infos : IChunkContext;
   /**
    * If `true`, this chunk is only a partial chunk of a whole segment.
-   * In this condition, `start` and `end` may be ignored, as they may either
-   * refer to the chunk or to the whole segment.
+   * In this condition, the `start` and `end` properties may be ignored, as it
+   * is unclear if they refer to the chunk or to the whole segment.
    *
    * Inversely, if `false`, this chunk is a whole segment whose inner chunks
    * have all been fully pushed.
@@ -102,16 +94,23 @@ export interface IBufferedChunk {
    */
   partiallyPushed : boolean;
   /**
+   * If `true`, the segment as a whole is divided into multiple parts in the
+   * buffer, with other segment(s) between them.
+   * If `false`, it is contiguous.
+   *
+   * Splitted segments are a rare occurence that is more complicated to handle
+   * than contiguous ones.
+   */
+  splitted : boolean;
+  /**
    * Supposed start, in seconds, the chunk is expected to start at.
    *
-   * It can correspond either to the start of the chunk or to the start of the
-   * whole segment the chunk is linked to. This should not matter as chunks
-   * linked to the same segment will all be merged once all chunks have been
-   * pushed and the `completeSegment` API call is done. Until then, this
-   * property should not be relied on.
-   *
-   * You can know whether the `completeSegment` API has been called by checking
-   * the `partiallyPushed` property.
+   * If the current `chunk` is part of a "partially pushed" segment (see
+   * `partiallyPushed`), the definition of this property is flexible in the way
+   * that it can correspond either to the start of the chunk or to the start of
+   * the whole segment the chunk is linked to.
+   * As such, this property should not be relied on until the segment has been
+   * fully-pushed.
    */
   start : number; // Supposed start the segment should start from, in seconds
 }
@@ -161,8 +160,12 @@ export default class SegmentInventory {
    */
   private _inventory : IBufferedChunk[];
 
+  private _bufferedHistory : BufferedHistory;
+
   constructor() {
     this._inventory = [];
+    this._bufferedHistory = new BufferedHistory(BUFFERED_HISTORY_RETENTION_TIME,
+                                                BUFFERED_HISTORY_MAXIMUM_ENTRIES);
   }
 
   /**
@@ -173,8 +176,8 @@ export default class SegmentInventory {
   }
 
   /**
-   * Infer each segment's bufferedStart and bufferedEnd from the TimeRanges
-   * given.
+   * Infer each segment's `bufferedStart` and `bufferedEnd` properties from the
+   * TimeRanges given.
    *
    * The TimeRanges object given should come from the media buffer linked to
    * that SegmentInventory.
@@ -227,7 +230,7 @@ export default class SegmentInventory {
                                     null = null;
 
       // remove garbage-collected segments
-      // (not in that TimeRange nor in the previous one)
+      // (Those not in that TimeRange nor in the previous one)
       const numberOfSegmentToDelete = inventoryIndex - indexBefore;
       if (numberOfSegmentToDelete > 0) {
         const lastDeletedSegment = // last garbage-collected segment
@@ -259,6 +262,8 @@ export default class SegmentInventory {
                                          bufferType);
 
         if (inventoryIndex === inventory.length - 1) {
+          // This is the last segment in the inventory.
+          // We can directly update the end as the end of the current range.
           guessBufferedEndFromRangeEnd(thisSegment, rangeEnd, bufferType);
           return;
         }
@@ -347,6 +352,7 @@ export default class SegmentInventory {
 
     const inventory = this._inventory;
     const newSegment = { partiallyPushed: true,
+                         splitted: false,
                          start,
                          end,
                          precizeStart: false,
@@ -553,6 +559,7 @@ export default class SegmentInventory {
               log.debug("SI: Segment pushed is contained in a previous one",
                         bufferType, start, end, segmentI.start, segmentI.end);
               const nextSegment = { partiallyPushed: segmentI.partiallyPushed,
+                                    splitted: true,
                                     start: newSegment.end,
                                     end: segmentI.end,
                                     precizeStart: segmentI.precizeStart &&
@@ -563,6 +570,7 @@ export default class SegmentInventory {
                                     bufferedEnd: segmentI.end,
                                     infos: segmentI.infos };
               segmentI.end = newSegment.start;
+              segmentI.splitted = true;
               segmentI.bufferedEnd = undefined;
               segmentI.precizeEnd = segmentI.precizeEnd &&
                                     newSegment.precizeStart;
@@ -676,20 +684,27 @@ export default class SegmentInventory {
     content : { period: Period;
                 adaptation: Adaptation;
                 representation: Representation;
-                segment: ISegment; }
+                segment: ISegment; },
+    newBuffered : TimeRanges
   ) : void {
     if (content.segment.isInit) {
       return;
     }
     const inventory = this._inventory;
 
-    let foundIt = false;
+
+    const resSegments : IBufferedChunk[] = [];
+
     for (let i = 0; i < inventory.length; i++) {
       if (areSameContent(inventory[i].infos, content)) {
-        if (foundIt) {
-          log.warn("SI: Completed Segment is splitted.", content);
+        let splitted = false;
+        if (resSegments.length > 0) {
+          splitted = true;
+          if (resSegments.length === 1) {
+            log.warn("SI: Completed Segment is splitted.", content);
+            resSegments[0].splitted = true;
+          }
         }
-        foundIt = true;
 
         const firstI = i;
         i += 1;
@@ -710,11 +725,25 @@ export default class SegmentInventory {
         this._inventory[firstI].partiallyPushed = false;
         this._inventory[firstI].end = lastEnd;
         this._inventory[firstI].bufferedEnd = lastBufferedEnd;
+        this._inventory[firstI].splitted = splitted;
+        resSegments.push(this._inventory[firstI]);
       }
     }
 
-    if (!foundIt) {
+    if (resSegments.length === 0) {
       log.warn("SI: Completed Segment not found", content);
+    } else {
+      this.synchronizeBuffered(newBuffered);
+      for (const seg of resSegments) {
+        if (seg.bufferedStart !== undefined && seg.bufferedEnd !== undefined) {
+          this._bufferedHistory.addBufferedSegment(seg.infos,
+                                                   seg.bufferedStart,
+                                                   seg.bufferedEnd);
+        } else {
+          log.debug("SI: buffered range not known after sync. Skipping history.",
+                    seg);
+        }
+      }
     }
   }
 
@@ -727,6 +756,23 @@ export default class SegmentInventory {
    */
   public getInventory() : IBufferedChunk[] {
     return this._inventory;
+  }
+
+  /**
+   * Returns a recent history of registered operations performed and event
+   * received linked to the segment given in argument.
+   *
+   * Not all operations and events are registered in the returned history.
+   * Please check the return type for more information on what is available.
+   *
+   * Note that history is short-lived for memory usage and performance reasons.
+   * You may not receive any information on operations that happened too long
+   * ago.
+   * @param {Object} context
+   * @returns {Array.<Object>}
+   */
+  public getHistoryFor(context : IChunkContext) : IBufferedHistoryEntry[] {
+    return this._bufferedHistory.getHistoryFor(context);
   }
 }
 
@@ -792,7 +838,7 @@ function guessBufferedStartFromRangeStart(
   rangeStart : number,
   lastDeletedSegmentInfos : { end : number; precizeEnd : boolean } |
                             null,
-  bufferType? : string
+  bufferType : string
 ) : void {
   if (firstSegmentInRange.bufferedStart !== undefined) {
     if (firstSegmentInRange.bufferedStart < rangeStart) {
@@ -941,7 +987,7 @@ function prettyPrintInventory(inventory : IBufferedChunk[]) : string {
   let lastChunk : IBufferedChunk | null = null;
   let lastLetter : string | null = null;
 
-  function generateNewLetter(infos : IBufferedChunkInfos) : string {
+  function generateNewLetter(infos : IChunkContext) : string {
     const currentLetter = String.fromCharCode(letters.length + 65);
     letters.push({ letter: currentLetter,
                    periodId: infos.period.id,

--- a/src/core/segment_buffers/inventory/types.ts
+++ b/src/core/segment_buffers/inventory/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Adaptation,
+  ISegment,
+  Period,
+  Representation,
+} from "../../../manifest";
+
+/** Content information for a single buffered chunk */
+export interface IChunkContext {
+  /** Adaptation this chunk is related to. */
+  adaptation : Adaptation;
+  /** Period this chunk is related to. */
+  period : Period;
+  /** Representation this chunk is related to. */
+  representation : Representation;
+  /** Segment this chunk is related to. */
+  segment : ISegment;
+}
+

--- a/src/core/stream/representation/get_buffer_status.ts
+++ b/src/core/stream/representation/get_buffer_status.ts
@@ -116,12 +116,16 @@ export default function getBufferStatus(
                                   end: neededRange.end + 0.5 },
                                 segmentBuffer.getInventory());
 
+  /** Callback allowing to retrieve a segment's history in the buffer. */
+  const getBufferedHistory = segmentBuffer.getSegmentHistory.bind(segmentBuffer);
+
   /** List of segments we will need to download. */
   const neededSegments = getNeededSegments({ content,
+                                             bufferedSegments,
                                              currentPlaybackTime: tick.getCurrentTime(),
                                              fastSwitchThreshold,
+                                             getBufferedHistory,
                                              neededRange,
-                                             bufferedSegments,
                                              segmentsBeingPushed })
     .map((segment) => ({ priority: getSegmentPriority(segment.time, tick),
                          segment }));

--- a/src/core/stream/representation/get_needed_segments.ts
+++ b/src/core/stream/representation/get_needed_segments.ts
@@ -415,39 +415,36 @@ function shouldReloadSegmentGCedAtTheStart(
   segmentEntries : IBufferedHistoryEntry[],
   currentBufferedStart : number | undefined
 ) : boolean {
-  let prevSegEntry : IBufferedHistoryEntry | null = null;
-  for (let entryIdx = segmentEntries.length - 1; entryIdx >= 0; entryIdx--) {
-    const entry = segmentEntries[entryIdx];
-
-    if (prevSegEntry !== null) {
-      // Compare `bufferedStart` from the last time this segment was pushed
-      // (`entry.bufferedStart`) to the previous time it was pushed
-      // (`prevSegEntry.bufferedStart`).
-      //
-      // If in both cases, we notice that their initial `bufferedStart` are close,
-      // it means that in recent history the same segment has been accused to be
-      // garbage collected two times at roughly the same positions just after being
-      // pushed.
-      // This is very unlikely and might be linked to either a content or browser
-      // issue. In that case, don't try to reload.
-      const prevBufferedStart = prevSegEntry.bufferedStart;
-      if (Math.abs(prevBufferedStart - entry.bufferedStart) <= 0.01) {
-        return false;
-      }
-    } else {
-      prevSegEntry = entry;
-
-      // If the current segment's buffered start is much higher than what it
-      // initially was when we pushed it, the segment has a very high chance of
-      // having been truly garbage-collected.
-      if (currentBufferedStart !== undefined &&
-          currentBufferedStart - entry.bufferedStart > 0.05)
-      {
-        return true;
-      }
-    }
+  if (segmentEntries.length < 2) {
+    return true;
   }
-  return true;
+
+  const lastEntry = segmentEntries[segmentEntries.length - 1];
+  const lastBufferedStart = lastEntry.bufferedStart;
+
+  // If the current segment's buffered start is much higher than what it
+  // initially was when we pushed it, the segment has a very high chance of
+  // having been truly garbage-collected.
+  if (currentBufferedStart !== undefined &&
+      currentBufferedStart - lastBufferedStart > 0.05)
+  {
+    return true;
+  }
+
+  const prevEntry = segmentEntries[segmentEntries.length - 2];
+  const prevBufferedStart = prevEntry.bufferedStart;
+
+  // Compare `bufferedStart` from the last time this segment was pushed
+  // (`entry.bufferedStart`) to the previous time it was pushed
+  // (`prevSegEntry.bufferedStart`).
+  //
+  // If in both cases, we notice that their initial `bufferedStart` are close,
+  // it means that in recent history the same segment has been accused to be
+  // garbage collected two times at roughly the same positions just after being
+  // pushed.
+  // This is very unlikely and might be linked to either a content or browser
+  // issue. In that case, don't try to reload.
+  return Math.abs(prevBufferedStart - lastBufferedStart) > 0.01;
 }
 
 /**
@@ -471,36 +468,33 @@ function shouldReloadSegmentGCedAtTheEnd(
   segmentEntries : IBufferedHistoryEntry[],
   currentBufferedEnd : number | undefined
 ) : boolean {
-  let prevSegmentBufferEnd : IBufferedHistoryEntry | null = null;
-  for (let entryIdx = segmentEntries.length - 1; entryIdx >= 0; entryIdx--) {
-    // Compare `bufferedEnd` from the last time this segment was pushed
-    // (`entry.bufferedEnd`) to the previous time it was pushed
-    // (`prevSegEntry.bufferedEnd`).
-    //
-    // If in both cases, we notice that their initial `bufferedEnd` are close,
-    // it means that in recent history the same segment has been accused to be
-    // garbage collected two times at roughly the same positions just after being
-    // pushed.
-    // This is very unlikely and might be linked to either a content or browser
-    // issue. In that case, don't try to reload.
-    const entry = segmentEntries[entryIdx];
-    if (prevSegmentBufferEnd !== null) {
-      const prevBufferedEnd = prevSegmentBufferEnd.bufferedEnd;
-      if (Math.abs(prevBufferedEnd - entry.bufferedEnd) <= 0.01) {
-        return false;
-      }
-    } else {
-      prevSegmentBufferEnd = entry;
-
-      // If the current segment's buffered end is much lower than what it
-      // initially was when we pushed it, the segment has a very high chance of
-      // having been truly garbage-collected.
-      if (currentBufferedEnd !== undefined &&
-          entry.bufferedEnd - currentBufferedEnd > 0.05)
-      {
-        return true;
-      }
-    }
+  if (segmentEntries.length < 2) {
+    return true;
   }
-  return true;
+  const lastEntry = segmentEntries[segmentEntries.length - 1];
+  const lastBufferedEnd = lastEntry.bufferedEnd;
+
+  // If the current segment's buffered end is much lower than what it
+  // initially was when we pushed it, the segment has a very high chance of
+  // having been truly garbage-collected.
+  if (currentBufferedEnd !== undefined &&
+      lastBufferedEnd - currentBufferedEnd > 0.05)
+  {
+    return true;
+  }
+
+  const prevEntry = segmentEntries[segmentEntries.length - 2];
+  const prevBufferedEnd = prevEntry.bufferedEnd;
+
+  // Compare `bufferedEnd` from the last time this segment was pushed
+  // (`entry.bufferedEnd`) to the previous time it was pushed
+  // (`prevSegEntry.bufferedEnd`).
+  //
+  // If in both cases, we notice that their initial `bufferedEnd` are close,
+  // it means that in recent history the same segment has been accused to be
+  // garbage collected two times at roughly the same positions just after being
+  // pushed.
+  // This is very unlikely and might be linked to either a content or browser
+  // issue. In that case, don't try to reload.
+  return Math.abs(prevBufferedEnd - lastBufferedEnd) > 0.01;
 }

--- a/src/core/stream/representation/get_needed_segments.ts
+++ b/src/core/stream/representation/get_needed_segments.ts
@@ -124,16 +124,18 @@ export default function getNeededSegments({
                                                            consideredSegments[i + 1];
 
       let lazySegmentHistory : IBufferedHistoryEntry[] | null = null;
-      if (isStartGarbageCollected(currentSeg, prevSeg, neededRange.start)) {
+      if (doesStartSeemGarbageCollected(currentSeg, prevSeg, neededRange.start)) {
         lazySegmentHistory = getBufferedHistory(currentSeg.infos);
-        if (shouldReloadSegmentGCedAtTheStart(lazySegmentHistory)) {
+        if (shouldReloadSegmentGCedAtTheStart(lazySegmentHistory,
+                                              currentSeg.bufferedStart)) {
           return false;
         }
         log.debug("Stream: skipping segment gc-ed at the start", currentSeg);
       }
-      if (isEndGarbageCollected(currentSeg, nextSeg, neededRange.start)) {
+      if (doesEndSeemGarbageCollected(currentSeg, nextSeg, neededRange.start)) {
         lazySegmentHistory = lazySegmentHistory ?? getBufferedHistory(currentSeg.infos);
-        if (shouldReloadSegmentGCedAtTheEnd(lazySegmentHistory)) {
+        if (shouldReloadSegmentGCedAtTheEnd(lazySegmentHistory,
+                                            currentSeg.bufferedEnd)) {
           return false;
         }
         log.debug("Stream: skipping segment gc-ed at the end", currentSeg);
@@ -321,7 +323,7 @@ function canFastSwitch(
  * If `currentSeg` has only been garbage collected for some data which is before
  * that time, we will return `false`.
  */
-function isStartGarbageCollected(
+function doesStartSeemGarbageCollected(
   currentSeg : IBufferedChunk,
   prevSeg : IBufferedChunk | null,
   maximumStartTime : number
@@ -363,7 +365,7 @@ function isStartGarbageCollected(
  * If `currentSeg` has only been garbage collected for some data which is after
  * that time, we will return `false`.
  */
-function isEndGarbageCollected(
+function doesEndSeemGarbageCollected(
   currentSeg : IBufferedChunk,
   nextSeg : IBufferedChunk | null,
   minimumEndTime : number
@@ -393,60 +395,94 @@ function isEndGarbageCollected(
 }
 
 /**
- * Returns `true` if a segment that has been garbage-coolected at the start
+ * Returns `true` if a segment that has been garbage-collected at the start
  * might profit from being re-loaded.
  *
  * Returns `false` if we have a high chance of staying in the same situation
  * after re-loading the segment.
  *
  * This function takes in argument the entries of a SegmentBuffer's history
- * related to the corresponding asegment and check if the segment appeared
+ * related to the corresponding segment and check if the segment appeared
  * garbage-collected at the start directly after the last few times it was
  * pushed, indicating that the issue might be sourced at a browser issue instead
  * of classical garbage collection.
  *
  * @param {Array.<Object>} segmentEntries
+ * @param {number|undefined} currentBufferedStart
  * @returns {boolean}
  */
 function shouldReloadSegmentGCedAtTheStart(
-  segmentEntries : IBufferedHistoryEntry[]
+  segmentEntries : IBufferedHistoryEntry[],
+  currentBufferedStart : number | undefined
 ) : boolean {
-  let prevSegmentBufferStart : IBufferedHistoryEntry | null = null;
+  let prevSegEntry : IBufferedHistoryEntry | null = null;
   for (let entryIdx = segmentEntries.length - 1; entryIdx >= 0; entryIdx--) {
     const entry = segmentEntries[entryIdx];
-    if (prevSegmentBufferStart !== null) {
-      const prevBufferedStart = prevSegmentBufferStart.bufferedStart;
+
+    if (prevSegEntry !== null) {
+      // Compare `bufferedStart` from the last time this segment was pushed
+      // (`entry.bufferedStart`) to the previous time it was pushed
+      // (`prevSegEntry.bufferedStart`).
+      //
+      // If in both cases, we notice that their initial `bufferedStart` are close,
+      // it means that in recent history the same segment has been accused to be
+      // garbage collected two times at roughly the same positions just after being
+      // pushed.
+      // This is very unlikely and might be linked to either a content or browser
+      // issue. In that case, don't try to reload.
+      const prevBufferedStart = prevSegEntry.bufferedStart;
       if (Math.abs(prevBufferedStart - entry.bufferedStart) <= 0.01) {
         return false;
       }
     } else {
-      prevSegmentBufferStart = entry;
+      prevSegEntry = entry;
+
+      // If the current segment's buffered start is much higher than what it
+      // initially was when we pushed it, the segment has a very high chance of
+      // having been truly garbage-collected.
+      if (currentBufferedStart !== undefined &&
+          currentBufferedStart - entry.bufferedStart > 0.05)
+      {
+        return true;
+      }
     }
   }
   return true;
 }
 
 /**
- * Returns `true` if a segment that has been garbage-coolected at the end
+ * Returns `true` if a segment that has been garbage-collected at the end
  * might profit from being re-loaded.
  *
  * Returns `false` if we have a high chance of staying in the same situation
  * after re-loading the segment.
  *
  * This function takes in argument the entries of a SegmentBuffer's history
- * related to the corresponding asegment and check if the segment appeared
+ * related to the corresponding segment and check if the segment appeared
  * garbage-collected at the end directly after the last few times it was
  * pushed, indicating that the issue might be sourced at a browser issue instead
  * of classical garbage collection.
  *
  * @param {Array.<Object>} segmentEntries
+ * @param {number|undefined} currentBufferedStart
  * @returns {boolean}
  */
 function shouldReloadSegmentGCedAtTheEnd(
-  segmentEntries : IBufferedHistoryEntry[]
+  segmentEntries : IBufferedHistoryEntry[],
+  currentBufferedEnd : number | undefined
 ) : boolean {
   let prevSegmentBufferEnd : IBufferedHistoryEntry | null = null;
   for (let entryIdx = segmentEntries.length - 1; entryIdx >= 0; entryIdx--) {
+    // Compare `bufferedEnd` from the last time this segment was pushed
+    // (`entry.bufferedEnd`) to the previous time it was pushed
+    // (`prevSegEntry.bufferedEnd`).
+    //
+    // If in both cases, we notice that their initial `bufferedEnd` are close,
+    // it means that in recent history the same segment has been accused to be
+    // garbage collected two times at roughly the same positions just after being
+    // pushed.
+    // This is very unlikely and might be linked to either a content or browser
+    // issue. In that case, don't try to reload.
     const entry = segmentEntries[entryIdx];
     if (prevSegmentBufferEnd !== null) {
       const prevBufferedEnd = prevSegmentBufferEnd.bufferedEnd;
@@ -455,6 +491,15 @@ function shouldReloadSegmentGCedAtTheEnd(
       }
     } else {
       prevSegmentBufferEnd = entry;
+
+      // If the current segment's buffered end is much lower than what it
+      // initially was when we pushed it, the segment has a very high chance of
+      // having been truly garbage-collected.
+      if (currentBufferedEnd !== undefined &&
+          entry.bufferedEnd - currentBufferedEnd > 0.05)
+      {
+        return true;
+      }
     }
   }
   return true;


### PR DESCRIPTION
This tries to fix #987.

In that issue, Safari advertised that the first pushed audio segment started at 0.450+ where the RxPlayer previously thought it started at exactly 0 second (based on MPD information and container metadata, such as the `tfdt` box of ISOBMFF segments).

The behavior of the player when encountering such a big difference, is to re-download the corresponding segment, because it thinks that the pushed segment has been partly garbage-collected by the browser.

In the Safari issue, re-pushing the same segments led to the same result and as such we end up requesting the same segment in a loop while rebuffering endlessly.

In that situation, it appears obvious that we should just ignore the issue and just seek over that gap and continue. However having agarbage-collected segment (even just after being pushed) could be a legitimate case which might resolve itself by re-downloading the segment.

So it's not too clear what the logic should be.

---

In this commit, I implement the following logic:

  1. I added an "history" abstraction on top of the SegmentInventory, which will record important information observed on buffered segments over time.

     For the moment, it only stores the initially observed buffered start time and end time of every pushed segments relatively to the expected start and end, even if those segments have since been replaced / removed.

     Because just storing an infinite history of pushed segments could lead to a consequent memory usage after long sessions, I put a maximal size (for the moment, 200 elements, which seems a lot more than enough here) and a maximum lifetime (every recorded events which are older than a minute are automatically removed).

  2. In the RepresentationStream, when it notices that an already buffered segment has been partially garbage collected at the start and/or end, the player checks thanks to the history if this garbage collection happened right when pushing it. If it was, it checks if this same segment has already been pushed before and in that case, if we were in this same situation at that time.

     If that's the case, the player does not re-ask for the segment to be loaded.

   3. Because the newer discontinuity-handling logic is well-designed (:p), the player is then able to automatically skip over the corresponding gap it knows will not be filled.

This is basically an heuristic which could be simplified as:
Don't retry to load segment which appears to be twice in a row incomplete just after pushing it.

---

The history solution might appear weird and over-engineered when compared to other more ad-hoc and minimal ones (for example, we could have added some kind of tag to a re-downloaded segment instead and use that tag to know that we can stop retrying it), but I still prefer it for several reasons:

  - it seems easier to comprehend and maintain: the notion of an history is simple, prevalent and logical enough for it to find its place in both the SegmentBuffers module and the RepresentationStream one.

  - it allows to answer several other linked issues, such as segment partially GCed or even removed when on the border of other Period (which we don't much have anymore usually, due to other improvements, but which can still technically happen).

  - it also can help a lot during debugging sessions of those kind of issues.
    Knowing what happened in the buffers not only now but also in the past is a very nice tool to have.

    Today, when we debug those issues, we usually dive deep in debug logs and put breakpoints in specific loops iteration.
    Being able to just easily rely on an history of what happened chronologically is much better.

---

The code is still rough but it should work well.