### PR TITLE
WIP: Feat/expose accessibilities and roles

### DIFF
--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -69,6 +69,8 @@ export interface ITMAudioTrack { language : string;
                                  normalized : string;
                                  audioDescription : boolean;
                                  dub? : boolean;
+                                 accessibilities?: string[];
+                                 roles?: string[];
                                  id : number|string;
                                  representations: ITMAudioRepresentation[]; }
 
@@ -76,6 +78,8 @@ export interface ITMAudioTrack { language : string;
 export interface ITMTextTrack { language : string;
                                 normalized : string;
                                 closedCaption : boolean;
+                                accessibilities?: string[];
+                                roles?: string[];
                                 id : number|string; }
 
 /**
@@ -95,6 +99,8 @@ export interface ITMVideoTrack { id : number|string;
                                  signInterpreted?: boolean;
                                  isTrickModeTrack?: boolean;
                                  trickModeTracks?: ITMVideoTrack[];
+                                 accessibilities?: string[];
+                                 roles?: string[];
                                  representations: ITMVideoRepresentation[]; }
 
 /** Audio track from a list of audio tracks returned by the TrackChoiceManager. */
@@ -799,6 +805,8 @@ export default class TrackChoiceManager {
           language: takeFirstSet<string>(adaptation.language, ""),
           normalized: takeFirstSet<string>(adaptation.normalizedLanguage, ""),
           audioDescription: adaptation.isAudioDescription === true,
+          accessibilities: adaptation.accessibilities,
+          roles: adaptation.roles,
           id: adaptation.id,
           active: currentId == null ? false : currentId === adaptation.id,
           representations: adaptation.representations.map(parseAudioRepresentation),
@@ -834,6 +842,8 @@ export default class TrackChoiceManager {
         language: takeFirstSet<string>(adaptation.language, ""),
         normalized: takeFirstSet<string>(adaptation.normalizedLanguage, ""),
         closedCaption: adaptation.isClosedCaption === true,
+        accessibilities: adaptation.accessibilities,
+        roles: adaptation.roles,
         id: adaptation.id,
         active: currentId == null ? false :
                                     currentId === adaptation.id,
@@ -882,6 +892,8 @@ export default class TrackChoiceManager {
           id: adaptation.id,
           active: currentId === null ? false :
                                        currentId === adaptation.id,
+          accessibilities: adaptation.accessibilities,
+          roles: adaptation.roles,
           representations: adaptation.representations.map(parseVideoRepresentation),
         };
         if (adaptation.isSignInterpreted === true) {

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -196,15 +196,15 @@ export default class Adaptation {
       const shouldAdd =
         isNullOrUndefined(representationFilter) ||
         representationFilter(representation,
-          { bufferType: this.type,
-            language: this.language,
-            normalizedLanguage: this.normalizedLanguage,
-            isClosedCaption: this.isClosedCaption,
-            isDub: this.isDub,
-            isAudioDescription: this.isAudioDescription,
-            isSignInterpreted: this.isSignInterpreted,
-            accessibilities: this.accessibilities,
-            roles: this.roles });
+                            { bufferType: this.type,
+                              language: this.language,
+                              normalizedLanguage: this.normalizedLanguage,
+                              isClosedCaption: this.isClosedCaption,
+                              isDub: this.isDub,
+                              isAudioDescription: this.isAudioDescription,
+                              isSignInterpreted: this.isSignInterpreted,
+                              accessibilities: this.accessibilities,
+                              roles: this.roles });
       if (shouldAdd) {
         representations.push(representation);
         if (!isSupported && representation.isSupported) {

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -55,7 +55,9 @@ export interface IRepresentationInfos { bufferType: IAdaptationType;
                                         isClosedCaption? : boolean;
                                         isDub? : boolean;
                                         isSignInterpreted?: boolean;
-                                        normalizedLanguage? : string; }
+                                        normalizedLanguage? : string;
+                                        accessibilities?: string[];
+                                        roles?: string[]; }
 
 /** Type for the `representationFilter` API. */
 export type IRepresentationFilter = (representation: Representation,
@@ -103,6 +105,12 @@ export default class Adaptation {
   /** Language this Adaptation is in, when translated into an ISO639-3 code. */
   public normalizedLanguage? : string;
 
+  /** Adaptation accessibilities as announced in the original Manifest. */
+  public accessibilities?: string[];
+
+  /** Adaptation roles as announced in the original Manifest. */
+  public roles?: string[];
+
   /**
    * `true` if this Adaptation was not present in the original Manifest, but was
    * manually added after through the corresponding APIs.
@@ -137,6 +145,8 @@ export default class Adaptation {
     this.parsingErrors = [];
     this.id = parsedAdaptation.id;
     this.isTrickModeTrack = parsedAdaptation.isTrickModeTrack;
+    this.accessibilities = parsedAdaptation.accessibilities;
+    this.roles = parsedAdaptation.roles;
 
     if (!isSupportedAdaptationType(parsedAdaptation.type)) {
       log.info("Manifest: Not supported adaptation type", parsedAdaptation.type);
@@ -165,6 +175,12 @@ export default class Adaptation {
     if (parsedAdaptation.isSignInterpreted !== undefined) {
       this.isSignInterpreted = parsedAdaptation.isSignInterpreted;
     }
+    if (parsedAdaptation.accessibilities !== undefined) {
+      this.accessibilities = parsedAdaptation.accessibilities;
+    }
+    if (parsedAdaptation.roles !== undefined) {
+      this.roles = parsedAdaptation.roles;
+    }
 
     if (trickModeTracks !== undefined &&
         trickModeTracks.length > 0) {
@@ -180,13 +196,15 @@ export default class Adaptation {
       const shouldAdd =
         isNullOrUndefined(representationFilter) ||
         representationFilter(representation,
-                             { bufferType: this.type,
-                               language: this.language,
-                               normalizedLanguage: this.normalizedLanguage,
-                               isClosedCaption: this.isClosedCaption,
-                               isDub: this.isDub,
-                               isAudioDescription: this.isAudioDescription,
-                               isSignInterpreted: this.isSignInterpreted });
+          { bufferType: this.type,
+            language: this.language,
+            normalizedLanguage: this.normalizedLanguage,
+            isClosedCaption: this.isClosedCaption,
+            isDub: this.isDub,
+            isAudioDescription: this.isAudioDescription,
+            isSignInterpreted: this.isSignInterpreted,
+            accessibilities: this.accessibilities,
+            roles: this.roles });
       if (shouldAdd) {
         representations.push(representation);
         if (!isSupported && representation.isSupported) {

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -174,6 +174,43 @@ function hasSignLanguageInterpretation(
     accessibility.value === "sign");
 }
 
+
+/**
+ * Returns the Accessibility value for schemeIdUri "urn:mpeg:dash:role:2011"
+ * @param {Object} accessibility
+ * @returns {string}
+ */
+function getAccessibilityValue(
+  accessibility? : { schemeIdUri? : string; value? : string }
+) : string|null {
+  if (accessibility == null || accessibility.schemeIdUri !== "urn:mpeg:dash:role:2011") {
+    return null;
+  }
+
+  return (accessibility.value != null)
+    ? accessibility.value
+    : null;
+}
+
+
+/**
+ * Returns the Role value for schemeIdUri "urn:mpeg:dash:role:2011"
+ * @param {Object} role
+ * @returns {string|null}
+ */
+function getRoleValue(
+  role? : { schemeIdUri? : string; value? : string }
+) : string|null {
+  if (role == null || role.schemeIdUri !== "urn:mpeg:dash:role:2011") {
+    return null;
+  }
+
+  return (role.value != null)
+    ? role.value
+    : null;
+}
+
+
 /**
  * Contruct Adaptation ID from the information we have.
  * @param {Object} adaptation
@@ -436,9 +473,27 @@ export default function parseAdaptationSets(
         { id: adaptationID,
           representations,
           type,
-          isTrickModeTrack };
+          isTrickModeTrack,
+          accessibilities: [],
+          roles: [] };
       if (adaptation.attributes.language != null) {
         parsedAdaptationSet.language = adaptation.attributes.language;
+      }
+      if (accessibilities !== undefined) {
+        accessibilities.forEach(accessibility => {
+          const accessibilityValue = getAccessibilityValue(accessibility);
+          if (accessibilityValue !== null && parsedAdaptationSet.accessibilities) {
+            parsedAdaptationSet.accessibilities.push(accessibilityValue);
+          }
+        });
+      }
+      if (roles !== undefined) {
+        roles.forEach(role => {
+          const roleValue = getRoleValue(role);
+          if (roleValue !== null && parsedAdaptationSet.roles) {
+            parsedAdaptationSet.roles.push(roleValue);
+          }
+        });
       }
       if (isClosedCaption != null) {
         parsedAdaptationSet.closedCaption = isClosedCaption;

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -122,6 +122,8 @@ function parseAdaptation(
     audioDescription: adaptation.audioDescription,
     closedCaption: adaptation.closedCaption,
     language: adaptation.language,
+    accessibilities: adaptation.accessibilities,
+    roles: adaptation.roles,
     representations: adaptation.representations.map((representation) =>
       parseRepresentation(representation, { representationIdGenerator,
                                             isFinished })),

--- a/src/parsers/manifest/local/types.ts
+++ b/src/parsers/manifest/local/types.ts
@@ -201,6 +201,10 @@ export interface ILocalAdaptation {
   closedCaption? : boolean;
   /** The ISO 639-3, ISO 639-2 or ISO 639-1 language code for that track. */
   language? : string;
+  /** Contains the accessibilities found for this track */
+  accessibilities? : string[];
+  /** Contains the roles found for this track */
+  roles? : string[];
   /** The different qualities this track is available in. */
   representations: ILocalRepresentation[];
 }

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -42,6 +42,8 @@ export interface IMetaPlaylistTextTrack {
   closedCaption : boolean;
   mimeType : string;
   codecs? : string;
+  accessibilities : string[];
+  roles : string[];
 }
 
 export interface IMetaPlaylist {
@@ -229,6 +231,8 @@ function createManifest(
               closedCaption: currentAdaptation.isClosedCaption,
               isDub: currentAdaptation.isDub,
               language: currentAdaptation.language,
+              accessibilities: currentAdaptation.accessibilities,
+              roles: currentAdaptation.roles,
               isSignInterpreted: currentAdaptation.isSignInterpreted,
             });
             acc[type] = adaptationsForCurrentType;
@@ -248,6 +252,8 @@ function createManifest(
           type: "text",
           language: track.language,
           closedCaption: track.closedCaption,
+          accessibilities: track.accessibilities,
+          roles: track.roles,
           manuallyAdded: true,
           representations: [
             { bitrate: 0,

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -178,11 +178,19 @@ export interface IParsedAdaptation {
    * Language the `Adaptation` is in.
    * Not set if unknown or if it makes no sense for the current track.
    */
-  language?: string;
+  language? : string;
+  /**
+   * Accessibilities defined by Accessibility descriptors in adaptation
+   */
+  accessibilities? : string[];
+  /**
+   * Roles defined by Role descriptors in adaptation
+   */
+  roles? : string[];
   /**
    * TrickMode tracks attached to the adaptation.
    */
-  trickModeTracks?: IParsedAdaptation[];
+  trickModeTracks? : IParsedAdaptation[];
 }
 
 /** Information on a given period of time in the Manifest */


### PR DESCRIPTION
Because we are not always dealing with playlists conforming to standards isDub, isAudioAdaptation and others adaptation properties might not fit our needs.
I am exposing DASH Accessibility and Role descriptors in adaptation objects.

I have also added a `customSelector` property in order to customize our track selection with setPreferredAudioTracks, setPreferredTextTracks and setPreferredVideoTracks 

Here is the code I use as example:
```
if (preferredAudioLanguage === 'qad') {
    player.setPreferredAudioTracks([{
        customSelector: (audioAdaptation) => {
            return (
              audioAdaptation.language === 'und' &&
              audioAdaptation.roles.includes('description')
            );
        }
    }]);
}
```
