### PR TITLE
Fix/ttml parsing

### DIFF
--- a/src/parsers/texttracks/ttml/nodes.ts
+++ b/src/parsers/texttracks/ttml/nodes.ts
@@ -19,7 +19,8 @@
  * @returns {Element}
  */
 function getBodyNode(tt : Element) : Element|null {
-  return tt.getElementsByTagName("body")[0];
+  const bodyNodes = tt.getElementsByTagName("body");
+  return bodyNodes.length ? bodyNodes[0] : null;
 }
 
 /**

--- a/src/parsers/texttracks/ttml/nodes.ts
+++ b/src/parsers/texttracks/ttml/nodes.ts
@@ -20,7 +20,7 @@
  */
 function getBodyNode(tt : Element) : Element|null {
   const bodyNodes = tt.getElementsByTagName("body");
-  return bodyNodes.length ? bodyNodes[0] : null;
+  return bodyNodes.length > 0 ? bodyNodes[0] : null;
 }
 
 /**


### PR DESCRIPTION
The ttml/nodes `getBodyNode` function is defined to return an HTMLElement or null but would returns undefined in case no body element.
Makes the function returns null. This will fix a BUFFER_APPEND_ERROR in appendSegmentToBuffer