### PR TITLE
Add eslint "no-explicit-any" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -159,7 +159,7 @@ module.exports = {
     ],
     "@typescript-eslint/no-empty-function": "error",
     "@typescript-eslint/no-empty-interface": "error",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-extraneous-class": "error",
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-for-in-array": "error",

--- a/src/compat/__tests__/add_text_track.test.ts
+++ b/src/compat/__tests__/add_text_track.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+// Needed for calling require (which itself is needed to mock properly) because
+// it is not type-checked:
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 describe("compat - addTextTrack", () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe("compat - addTextTrack", () => {
       id: "textTrack1",
       HIDDEN: "hidden",
       SHOWING: "showing",
-    };
+    } as unknown as TextTrack;
     const mockAddTextTrack = jest.fn(() => null);
     const fakeMediaElement = {
       textTracks: [ fakeTextTrack ],
@@ -56,8 +56,8 @@ describe("compat - addTextTrack", () => {
       id: "textTrack1",
       HIDDEN: "hidden",
       SHOWING: "showing",
-    };
-    const fakeTextTracks: any[] = [];
+    } as unknown as TextTrack;
+    const fakeTextTracks: TextTrack[] = [];
     const mockAddTextTrack = jest.fn(() => {
       fakeTextTracks.push(fakeTextTrack);
       return fakeTextTrack;
@@ -99,8 +99,8 @@ describe("compat - addTextTrack", () => {
       kind: undefined,
     };
 
-    const fakeTextTracks: any[] = [];
-    const fakeChildNodes: any[] = [];
+    const fakeTextTracks: TextTrack[] = [];
+    const fakeChildNodes: ChildNode[] = [];
 
     const mockAppendChild = jest.fn((_trackElement) => {
       fakeChildNodes.push(_trackElement);
@@ -138,14 +138,14 @@ describe("compat - addTextTrack", () => {
       id: "textTrack1",
       HIDDEN: "hidden",
       SHOWING: "showing",
-    };
+    } as unknown as TextTrack;
     const fakeTextTrackElement = {
       track: fakeTextTrack,
       kind: undefined,
-    };
+    } as unknown as HTMLTrackElement;
 
-    const fakeTextTracks: any[] = [];
-    const fakeChildNodes: any[] = [];
+    const fakeTextTracks: TextTrack[] = [];
+    const fakeChildNodes: HTMLTrackElement[] = [];
 
     const mockAppendChild = jest.fn((_trackElement) => {
       fakeChildNodes.push(_trackElement);

--- a/src/compat/__tests__/browser_compatibility_types.test.ts
+++ b/src/compat/__tests__/browser_compatibility_types.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Needed for calling require (which itself is needed to mock properly) because
+// it is not type-checked:
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -22,6 +24,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
 describe("compat - browser compatibility types", () => {
+  interface IFakeWindow {
+    MediaSource? : unknown;
+    MozMediaSource? : unknown;
+    WebKitMediaSource? : unknown;
+    MSMediaSource? : unknown;
+  }
+  const win = window as IFakeWindow;
   beforeEach(() => {
     jest.resetModules();
   });
@@ -30,114 +39,114 @@ describe("compat - browser compatibility types", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: true }));
 
-    const origMediaSource = (window as any).MediaSource;
-    const origMozMediaSource = (window as any).MozMediaSource;
-    const origWebKitMediaSource = (window as any).WebKitMediaSource;
-    const origMSMediaSource = (window as any).MSMediaSource;
+    const origMediaSource = win.MediaSource;
+    const origMozMediaSource = win.MozMediaSource;
+    const origWebKitMediaSource = win.WebKitMediaSource;
+    const origMSMediaSource = win.MSMediaSource;
 
-    (window as any).MediaSource = { a: 1 };
-    (window as any).MozMediaSource = { a: 2 };
-    (window as any).WebKitMediaSource = { a: 3 };
-    (window as any).MSMediaSource = { a: 4 };
+    win.MediaSource = { a: 1 };
+    win.MozMediaSource = { a: 2 };
+    win.WebKitMediaSource = { a: 3 };
+    win.MSMediaSource = { a: 4 };
 
     const { MediaSource_ } = require("../browser_compatibility_types");
     expect(MediaSource_).toEqual(undefined);
 
-    (window as any).MediaSource = origMediaSource;
-    (window as any).MozMediaSource = origMozMediaSource;
-    (window as any).WebKitMediaSource = origWebKitMediaSource;
-    (window as any).MSMediaSource = origMSMediaSource;
+    win.MediaSource = origMediaSource;
+    win.MozMediaSource = origMozMediaSource;
+    win.WebKitMediaSource = origWebKitMediaSource;
+    win.MSMediaSource = origMSMediaSource;
   });
 
   it("should use the native MediaSource if defined", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = (window as any).MediaSource;
-    const origMozMediaSource = (window as any).MozMediaSource;
-    const origWebKitMediaSource = (window as any).WebKitMediaSource;
-    const origMSMediaSource = (window as any).MSMediaSource;
+    const origMediaSource = win.MediaSource;
+    const origMozMediaSource = win.MozMediaSource;
+    const origWebKitMediaSource = win.WebKitMediaSource;
+    const origMSMediaSource = win.MSMediaSource;
 
-    (window as any).MediaSource = { a: 1 };
-    (window as any).MozMediaSource = { a: 2 };
-    (window as any).WebKitMediaSource = { a: 3 };
-    (window as any).MSMediaSource = { a: 4 };
+    win.MediaSource = { a: 1 };
+    win.MozMediaSource = { a: 2 };
+    win.WebKitMediaSource = { a: 3 };
+    win.MSMediaSource = { a: 4 };
 
     const { MediaSource_ } = require("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 1 });
 
-    (window as any).MediaSource = origMediaSource;
-    (window as any).MozMediaSource = origMozMediaSource;
-    (window as any).WebKitMediaSource = origWebKitMediaSource;
-    (window as any).MSMediaSource = origMSMediaSource;
+    win.MediaSource = origMediaSource;
+    win.MozMediaSource = origMozMediaSource;
+    win.WebKitMediaSource = origWebKitMediaSource;
+    win.MSMediaSource = origMSMediaSource;
   });
 
   it("should use MozMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = (window as any).MediaSource;
-    const origMozMediaSource = (window as any).MozMediaSource;
-    const origWebKitMediaSource = (window as any).WebKitMediaSource;
-    const origMSMediaSource = (window as any).MSMediaSource;
+    const origMediaSource = win.MediaSource;
+    const origMozMediaSource = win.MozMediaSource;
+    const origWebKitMediaSource = win.WebKitMediaSource;
+    const origMSMediaSource = win.MSMediaSource;
 
-    (window as any).MediaSource = undefined;
-    (window as any).MozMediaSource = { a: 2 };
-    (window as any).WebKitMediaSource = undefined;
-    (window as any).MSMediaSource = undefined;
+    win.MediaSource = undefined;
+    win.MozMediaSource = { a: 2 };
+    win.WebKitMediaSource = undefined;
+    win.MSMediaSource = undefined;
 
     const { MediaSource_ } = require("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 2 });
 
-    (window as any).MediaSource = origMediaSource;
-    (window as any).MozMediaSource = origMozMediaSource;
-    (window as any).WebKitMediaSource = origWebKitMediaSource;
-    (window as any).MSMediaSource = origMSMediaSource;
+    win.MediaSource = origMediaSource;
+    win.MozMediaSource = origMozMediaSource;
+    win.WebKitMediaSource = origWebKitMediaSource;
+    win.MSMediaSource = origMSMediaSource;
   });
 
   it("should use WebKitMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = (window as any).MediaSource;
-    const origMozMediaSource = (window as any).MozMediaSource;
-    const origWebKitMediaSource = (window as any).WebKitMediaSource;
-    const origMSMediaSource = (window as any).MSMediaSource;
+    const origMediaSource = win.MediaSource;
+    const origMozMediaSource = win.MozMediaSource;
+    const origWebKitMediaSource = win.WebKitMediaSource;
+    const origMSMediaSource = win.MSMediaSource;
 
-    (window as any).MediaSource = undefined;
-    (window as any).MozMediaSource = undefined;
-    (window as any).WebKitMediaSource = { a: 3 };
-    (window as any).MSMediaSource = undefined;
+    win.MediaSource = undefined;
+    win.MozMediaSource = undefined;
+    win.WebKitMediaSource = { a: 3 };
+    win.MSMediaSource = undefined;
 
     const { MediaSource_ } = require("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 3 });
 
-    (window as any).MediaSource = origMediaSource;
-    (window as any).MozMediaSource = origMozMediaSource;
-    (window as any).WebKitMediaSource = origWebKitMediaSource;
-    (window as any).MSMediaSource = origMSMediaSource;
+    win.MediaSource = origMediaSource;
+    win.MozMediaSource = origMozMediaSource;
+    win.WebKitMediaSource = origWebKitMediaSource;
+    win.MSMediaSource = origMSMediaSource;
   });
 
   it("should use MSMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = (window as any).MediaSource;
-    const origMozMediaSource = (window as any).MozMediaSource;
-    const origWebKitMediaSource = (window as any).WebKitMediaSource;
-    const origMSMediaSource = (window as any).MSMediaSource;
+    const origMediaSource = win.MediaSource;
+    const origMozMediaSource = win.MozMediaSource;
+    const origWebKitMediaSource = win.WebKitMediaSource;
+    const origMSMediaSource = win.MSMediaSource;
 
-    (window as any).MediaSource = undefined;
-    (window as any).MozMediaSource = undefined;
-    (window as any).WebKitMediaSource = undefined;
-    (window as any).MSMediaSource = { a: 4 };
+    win.MediaSource = undefined;
+    win.MozMediaSource = undefined;
+    win.WebKitMediaSource = undefined;
+    win.MSMediaSource = { a: 4 };
 
     const { MediaSource_ } = require("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 4 });
 
-    (window as any).MediaSource = origMediaSource;
-    (window as any).MozMediaSource = origMozMediaSource;
-    (window as any).WebKitMediaSource = origWebKitMediaSource;
-    (window as any).MSMediaSource = origMSMediaSource;
+    win.MediaSource = origMediaSource;
+    win.MozMediaSource = origMozMediaSource;
+    win.WebKitMediaSource = origWebKitMediaSource;
+    win.MSMediaSource = origMSMediaSource;
   });
 });

--- a/src/compat/__tests__/browser_version.test.ts
+++ b/src/compat/__tests__/browser_version.test.ts
@@ -30,7 +30,9 @@ describe("Compat - Browser version", () => {
                           /* eslint-enable no-param-reassign */
                         }))(navigator.userAgent));
 
-  const nav: any = navigator;
+  const nav = navigator as {
+    userAgent: string;
+  };
 
   afterEach(() => {
     nav.userAgent = origUserAgent;

--- a/src/compat/__tests__/change_source_buffer_type.test.ts
+++ b/src/compat/__tests__/change_source_buffer_type.test.ts
@@ -23,7 +23,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
   /* eslint-enable max-len */
 
     const spy = jest.spyOn(log, "warn");
-    const fakeSourceBuffer : any = {};
+    const fakeSourceBuffer : SourceBuffer = {} as unknown as SourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto"))
       .toBe(false);
     expect(spy).not.toHaveBeenCalled();
@@ -35,7 +35,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
 
     const spy = jest.spyOn(log, "warn");
     const changeTypeFn = jest.fn();
-    const fakeSourceBuffer : any = { changeType: changeTypeFn };
+    const fakeSourceBuffer = { changeType: changeTypeFn } as unknown as SourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto"))
       .toBe(true);
     expect(spy).not.toHaveBeenCalled();
@@ -48,7 +48,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
     const spy = jest.spyOn(log, "warn");
     const err = new Error("bar");
     const changeTypeFn = jest.fn(() => { throw err; });
-    const fakeSourceBuffer : any = { changeType: changeTypeFn };
+    const fakeSourceBuffer = { changeType: changeTypeFn } as unknown as SourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto"))
       .toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);

--- a/src/compat/__tests__/clear_element_src.test.ts
+++ b/src/compat/__tests__/clear_element_src.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
@@ -29,7 +28,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should empty the src and remove the Attribute for a given Element", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
     };
@@ -47,7 +46,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should throw if failed to remove the Attribute for a given Element", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { throw new Error("Oups, can't remove attribute."); },
     };
@@ -65,7 +64,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should disable text tracks and remove childs if on firefox", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
       textTracks: [
@@ -80,7 +79,7 @@ describe("Compat - clearElementSrc", () => {
       hasChildNodes: () => true,
       removeChild: (node: { nodeName: string }) => {
         const { childNodes } = fakeElement;
-        const idx = arrayFindIndex(childNodes, (n: any) => n.nodeName === node.nodeName);
+        const idx = arrayFindIndex(childNodes, (n) => n.nodeName === node.nodeName);
         childNodes.splice(idx, 1);
       },
     };
@@ -109,7 +108,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should log when failed to remove text track child node if on firefox", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
       textTracks: [
@@ -163,7 +162,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should not remove audio child node if on firefox and no text tracks", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
       textTracks: [],
@@ -195,7 +194,7 @@ describe("Compat - clearElementSrc", () => {
   });
 
   it("should not handle text tracks nodes is has no child nodes if on firefox", () => {
-    const fakeElement : any = {
+    const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
       textTracks: [],

--- a/src/compat/__tests__/fullscreen.test.ts
+++ b/src/compat/__tests__/fullscreen.test.ts
@@ -21,251 +21,266 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
+interface IFakeDocument {
+  createElement(eltType: string) : HTMLElement;
+  fullscreenElement? : Element | null;
+  mozCancelFullScreen? : () => void;
+  mozFullScreenElement? : HTMLElement;
+  msExitFullscreen? : () => void;
+  exitFullscreen? : () => void;
+  msFullscreenElement? : Element | null;
+  webkitExitFullscreen : () => void;
+  webkitFullscreenElement : Element | null | undefined;
+  webkitHidden? : boolean;
+}
+
+const doc = document as unknown as IFakeDocument;
+
 describe("compat - isFullScreen", () => {
   beforeEach(() => {
     jest.resetModules();
   });
 
   it("should return false when is not fullscreen", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
-    const origWebkitFullscreenElement = (document as any).webkitFullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
+    const origWebkitFullscreenElement = doc.webkitFullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).mozFullScreenElement = undefined;
-    (document as any).webkitFullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
+    doc.fullscreenElement = undefined;
+    doc.mozFullScreenElement = undefined;
+    doc.webkitFullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
 
     const { isFullscreen } = require("../fullscreen");
     expect(isFullscreen()).toBe(false);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
-    (document as any).webkitFullscreenElement = origWebkitFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
+    doc.webkitFullscreenElement = origWebkitFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
   });
 
   it("should return true when is fullscreen", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
-    const origWebkitFullscreenElement = (document as any).webkitFullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
+    const origWebkitFullscreenElement = doc.webkitFullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
 
-    (document as any).fullscreenElement = document.createElement("video");
-    (document as any).mozFullScreenElement = undefined;
-    (document as any).webkitFullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
+    doc.fullscreenElement = doc.createElement("video");
+    doc.mozFullScreenElement = undefined;
+    doc.webkitFullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
 
     const { isFullscreen } = require("../fullscreen");
     expect(isFullscreen()).toBe(true);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
-    (document as any).webkitFullscreenElement = origWebkitFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
+    doc.webkitFullscreenElement = origWebkitFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
   });
 });
 
 describe("compat - requestFullscreen", () => {
   it("should request full screen with requestFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    (document as any).fullscreenElement = undefined;
+    const origFullscreenElement = doc.fullscreenElement;
+    doc.fullscreenElement = undefined;
 
     const { requestFullscreen } = require("../fullscreen");
-    const videoElt = document.createElement("video");
+    const videoElt = doc.createElement("video");
     const mockRequestFullscreen = jest.fn(() =>
-      (document as any).fullscreenElement = videoElt);
+      doc.fullscreenElement = videoElt);
     const fakeElement = {
       requestFullscreen: mockRequestFullscreen,
     };
 
     requestFullscreen(fakeElement);
-    expect((document as any).fullscreenElement).toBe(videoElt);
+    expect(doc.fullscreenElement).toBe(videoElt);
 
-    (document as any).fullscreenElement = origFullscreenElement;
+    doc.fullscreenElement = origFullscreenElement;
   });
 
   it("should request full screen with msRequestFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
 
     const { requestFullscreen } = require("../fullscreen");
-    const videoElt = document.createElement("video");
+    const videoElt = doc.createElement("video");
     const mockRequestFullscreen =
-      jest.fn(() => (document as any).msFullscreenElement = videoElt);
+      jest.fn(() => doc.msFullscreenElement = videoElt);
     const fakeElement = {
       msRequestFullscreen: mockRequestFullscreen,
     };
 
     requestFullscreen(fakeElement);
-    expect((document as any).msFullscreenElement).toBe(videoElt);
+    expect(doc.msFullscreenElement).toBe(videoElt);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
   });
 
   it("should request full screen with mozRequestFullScreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
-    (document as any).mozFullScreenElement = undefined;
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
+    doc.mozFullScreenElement = undefined;
 
     const { requestFullscreen } = require("../fullscreen");
-    const videoElt = document.createElement("video");
+    const videoElt = doc.createElement("video");
     const mockRequestFullscreen =
-      jest.fn(() => (document as any).mozFullScreenElement = videoElt);
+      jest.fn(() => doc.mozFullScreenElement = videoElt);
     const fakeElement = {
       mozRequestFullScreen: mockRequestFullscreen,
     };
 
     requestFullscreen(fakeElement);
-    expect((document as any).mozFullScreenElement).toBe(videoElt);
+    expect(doc.mozFullScreenElement).toBe(videoElt);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
   });
 
   it("should request full screen with webkitRequestFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
-    const origWebkitFullscreenElement = (document as any).webkitFullscreenElement;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
+    const origWebkitFullscreenElement = doc.webkitFullscreenElement;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
-    (document as any).mozFullScreenElement = undefined;
-    (document as any).webkitFullscreenElement = undefined;
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
+    doc.mozFullScreenElement = undefined;
+    doc.webkitFullscreenElement = undefined;
 
     const { requestFullscreen } = require("../fullscreen");
-    const videoElt = document.createElement("video");
+    const videoElt = doc.createElement("video");
     const mockRequestFullscreen =
-      jest.fn(() => (document as any).webkitFullscreenElement = videoElt);
+      jest.fn(() => doc.webkitFullscreenElement = videoElt);
     const fakeElement = {
       webkitRequestFullscreen: mockRequestFullscreen,
     };
 
     requestFullscreen(fakeElement);
-    expect((document as any).webkitFullscreenElement).toBe(videoElt);
+    expect(doc.webkitFullscreenElement).toBe(videoElt);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
-    (document as any).webkitFullscreenElement = origWebkitFullscreenElement;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
+    doc.webkitFullscreenElement = origWebkitFullscreenElement;
   });
 });
 
 describe("compat - exitFullScreen", () => {
   it("should exit full screen with exitFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origExitFullscreen = (document as any).exitFullscreen;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origExitFullscreen = doc.exitFullscreen;
 
-    (document as any).fullscreenElement = document.createElement("video");
-    (document as any).exitFullscreen = jest.fn(() => {
-      (document as any).fullscreenElement = undefined;
+    doc.fullscreenElement = doc.createElement("video");
+    doc.exitFullscreen = jest.fn(() => {
+      doc.fullscreenElement = undefined;
     });
 
     const { exitFullscreen } = require("../fullscreen");
 
     exitFullscreen();
-    expect((document as any).fullscreenElement).toBe(undefined);
+    expect(doc.fullscreenElement).toBe(undefined);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).exitFullscreen = origExitFullscreen;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.exitFullscreen = origExitFullscreen;
   });
 
   it("should exit full screen with msExitFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
-    const origExitFullscreen = (document as any).exitFullscreen;
-    const origMsExitFullscreen = (document as any).msExitFullscreen;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
+    const origExitFullscreen = doc.exitFullscreen;
+    const origMsExitFullscreen = doc.msExitFullscreen;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = document.createElement("video");
-    (document as any).exitFullscreen = undefined;
-    (document as any).msExitFullscreen = jest.fn(() => {
-      (document as any).msFullscreenElement = undefined;
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = doc.createElement("video");
+    doc.exitFullscreen = undefined;
+    doc.msExitFullscreen = jest.fn(() => {
+      doc.msFullscreenElement = undefined;
     });
 
     const { exitFullscreen } = require("../fullscreen");
 
     exitFullscreen();
-    expect((document as any).msFullscreenElement).toBe(undefined);
+    expect(doc.msFullscreenElement).toBe(undefined);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
-    (document as any).exitFullscreen = origExitFullscreen;
-    (document as any).msExitFullscreen = origMsExitFullscreen;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
+    doc.exitFullscreen = origExitFullscreen;
+    doc.msExitFullscreen = origMsExitFullscreen;
   });
 
   it("should exit full screen with mozCancelFullScreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
-    const origExitFullscreen = (document as any).exitFullscreen;
-    const origMsExitFullscreen = (document as any).msExitFullscreen;
-    const origmozCancelFullScreen = (document as any).mozCancelFullScreen;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
+    const origExitFullscreen = doc.exitFullscreen;
+    const origMsExitFullscreen = doc.msExitFullscreen;
+    const origmozCancelFullScreen = doc.mozCancelFullScreen;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
-    (document as any).mozFullScreenElement = document.createElement("video");
-    (document as any).exitFullscreen = undefined;
-    (document as any).msExitFullscreen = undefined;
-    (document as any).mozCancelFullScreen = jest.fn(() =>
-      (document as any).mozFullScreenElement = undefined);
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
+    doc.mozFullScreenElement = doc.createElement("video");
+    doc.exitFullscreen = undefined;
+    doc.msExitFullscreen = undefined;
+    doc.mozCancelFullScreen = jest.fn(() =>
+      doc.mozFullScreenElement = undefined);
 
     const { exitFullscreen } = require("../fullscreen");
 
     exitFullscreen();
-    expect((document as any).mozFullScreenElement).toBe(undefined);
+    expect(doc.mozFullScreenElement).toBe(undefined);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
-    (document as any).exitFullscreen = origExitFullscreen;
-    (document as any).msExitFullscreen = origMsExitFullscreen;
-    (document as any).mozCancelFullScreen = origmozCancelFullScreen;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
+    doc.exitFullscreen = origExitFullscreen;
+    doc.msExitFullscreen = origMsExitFullscreen;
+    doc.mozCancelFullScreen = origmozCancelFullScreen;
   });
 
   it("should exit full screen with webkitExitFullscreen API", () => {
-    const origFullscreenElement = (document as any).fullscreenElement;
-    const origMsFullscreenElement = (document as any).msFullscreenElement;
-    const origmozFullScreenElement = (document as any).mozFullScreenElement;
-    const origWebkitFullscreenElement = (document as any).webkitFullscreenElement;
-    const origExitFullscreen = (document as any).exitFullscreen;
-    const origMsExitFullscreen = (document as any).msExitFullscreen;
-    const origmozCancelFullScreen = (document as any).mozCancelFullScreen;
-    const origwebkitExitFullscreen = (document as any).webkitExitFullscreen;
+    const origFullscreenElement = doc.fullscreenElement;
+    const origMsFullscreenElement = doc.msFullscreenElement;
+    const origmozFullScreenElement = doc.mozFullScreenElement;
+    const origWebkitFullscreenElement = doc.webkitFullscreenElement;
+    const origExitFullscreen = doc.exitFullscreen;
+    const origMsExitFullscreen = doc.msExitFullscreen;
+    const origmozCancelFullScreen = doc.mozCancelFullScreen;
+    const origwebkitExitFullscreen = doc.webkitExitFullscreen;
 
-    (document as any).fullscreenElement = undefined;
-    (document as any).msFullscreenElement = undefined;
-    (document as any).mozFullScreenElement = undefined;
-    (document as any).webkitFullscreenElement = document.createElement("video");
-    (document as any).exitFullscreen = undefined;
-    (document as any).msExitFullscreen = undefined;
-    (document as any).mozCancelFullScreen = undefined;
-    (document as any).webkitExitFullscreen = jest.fn(() =>
-      (document as any).webkitFullscreenElement = undefined);
+    doc.fullscreenElement = undefined;
+    doc.msFullscreenElement = undefined;
+    doc.mozFullScreenElement = undefined;
+    doc.webkitFullscreenElement = doc.createElement("video");
+    doc.exitFullscreen = undefined;
+    doc.msExitFullscreen = undefined;
+    doc.mozCancelFullScreen = undefined;
+    doc.webkitExitFullscreen = jest.fn(() =>
+      doc.webkitFullscreenElement = undefined);
 
     const { exitFullscreen } = require("../fullscreen");
 
     exitFullscreen();
-    expect((document as any).webkitFullscreenElement).toBe(undefined);
+    expect(doc.webkitFullscreenElement).toBe(undefined);
 
-    (document as any).fullscreenElement = origFullscreenElement;
-    (document as any).msFullscreenElement = origMsFullscreenElement;
-    (document as any).mozFullScreenElement = origmozFullScreenElement;
-    (document as any).webkitFullscreenElement = origWebkitFullscreenElement;
-    (document as any).exitFullscreen = origExitFullscreen;
-    (document as any).msExitFullscreen = origMsExitFullscreen;
-    (document as any).mozCancelFullScreen = origmozCancelFullScreen;
-    (document as any).webkitExitFullscreen = origwebkitExitFullscreen;
+    doc.fullscreenElement = origFullscreenElement;
+    doc.msFullscreenElement = origMsFullscreenElement;
+    doc.mozFullScreenElement = origmozFullScreenElement;
+    doc.webkitFullscreenElement = origWebkitFullscreenElement;
+    doc.exitFullscreen = origExitFullscreen;
+    doc.msExitFullscreen = origMsExitFullscreen;
+    doc.mozCancelFullScreen = origmozCancelFullScreen;
+    doc.webkitExitFullscreen = origwebkitExitFullscreen;
   });
 });

--- a/src/compat/__tests__/is_offline.test.ts
+++ b/src/compat/__tests__/is_offline.test.ts
@@ -21,37 +21,45 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
+interface IFakeNavigator {
+  onLine? : boolean | null;
+}
+interface IFakeWindow {
+  navigator : IFakeNavigator;
+}
+const win = window as IFakeWindow;
+
 // FIXME We cannot mock navigator.onLine easily, sadly
 xdescribe("Compat - isOffline", () => {
   it("should return true if navigator.onLine is `false`", () => {
-    const oldNavigator = window.navigator;
-    (window as any).navigator = { onLine: false };
+    const oldNavigator = win.navigator;
+    win.navigator = { onLine: false };
     const isOffline = require("../is_offline").default;
     expect(isOffline()).toEqual(true);
-    (window as any).navigator = oldNavigator;
+    win.navigator = oldNavigator;
   });
 
   it("should return false if navigator.onLine is `true`", () => {
-    const oldNavigator = window.navigator;
-    (window as any).navigator = { onLine: true };
+    const oldNavigator = win.navigator;
+    win.navigator = { onLine: true };
     const isOffline = require("../is_offline").default;
     expect(isOffline()).toEqual(false);
-    (window as any).navigator = oldNavigator;
+    win.navigator = oldNavigator;
   });
 
   it("should return false if navigator.onLine is `undefined`", () => {
-    const oldNavigator = window.navigator;
-    (window as any).navigator = {};
+    const oldNavigator = win.navigator;
+    win.navigator = {};
     const isOffline = require("../is_offline").default;
     expect(isOffline()).toEqual(false);
-    (window as any).navigator = oldNavigator;
+    win.navigator = oldNavigator;
   });
 
   it("should return false if navigator.onLine is `null`", () => {
-    const oldNavigator = window.navigator;
-    (window as any).navigator = { onLine: null };
+    const oldNavigator = win.navigator;
+    win.navigator = { onLine: null };
     const isOffline = require("../is_offline").default;
     expect(isOffline()).toEqual(false);
-    (window as any).navigator = oldNavigator;
+    win.navigator = oldNavigator;
   });
 });

--- a/src/compat/__tests__/is_vtt_cue.test.ts
+++ b/src/compat/__tests__/is_vtt_cue.test.ts
@@ -22,6 +22,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
 describe("Compat - isVTTCue", () => {
+  interface IFakeWindow {
+    VTTCue? : VTTCue | typeof MockVTTCue;
+  }
   class MockVTTCue {
     public startTime : number;
     public endTime : number;
@@ -32,19 +35,20 @@ describe("Compat - isVTTCue", () => {
       this.text = text;
     }
   }
+  const win = window as IFakeWindow;
 
   it("should return true if the given cue is an instance of a vtt cue", () => {
-    const originalVTTCue = (window as any).VTTCue;
-    (window as any).VTTCue = MockVTTCue;
+    const originalVTTCue = window.VTTCue;
+    win.VTTCue = MockVTTCue;
     const cue = new VTTCue(0, 10, "");
     const isVTTCue = require("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(true);
-    (window as any).VTTCue = originalVTTCue;
+    window.VTTCue = originalVTTCue;
   });
 
   it("should return false if the given cue is not an instance of a vtt cue", () => {
-    const originalVTTCue = (window as any).VTTCue;
-    (window as any).VTTCue = MockVTTCue;
+    const originalVTTCue = window.VTTCue;
+    win.VTTCue = MockVTTCue;
     const cue = {
       startTime: 0,
       endTime: 10,
@@ -52,16 +56,16 @@ describe("Compat - isVTTCue", () => {
     };
     const isVTTCue = require("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(false);
-    (window as any).VTTCue = originalVTTCue;
+    window.VTTCue = originalVTTCue;
   });
 
   it("should return false in any case if window does not define a VTTCue", () => {
-    const originalVTTCue = (window as any).VTTCue;
-    (window as any).VTTCue = MockVTTCue;
+    const originalVTTCue = window.VTTCue;
+    win.VTTCue = MockVTTCue;
     const cue = new VTTCue(0, 10, "");
-    (window as any).VTTCue = undefined;
+    win.VTTCue = undefined;
     const isVTTCue = require("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(false);
-    (window as any).VTTCue = originalVTTCue;
+    window.VTTCue = originalVTTCue;
   });
 });

--- a/src/compat/__tests__/make_vtt_cue.test.ts
+++ b/src/compat/__tests__/make_vtt_cue.test.ts
@@ -33,16 +33,23 @@ describe("Compat - makeVTTCue", () => {
     }
   }
 
+  const win = window as {
+    VTTCue? : unknown;
+    TextTrackCue? : unknown;
+  };
+
+  const ogVTTuCue = win.VTTCue;
+  const ogTextTrackCue = win.TextTrackCue;
   beforeEach(() => {
     jest.resetModules();
+    win.VTTCue = ogVTTuCue;
+    win.TextTrackCue = ogTextTrackCue;
   });
 
-  it("should throw if VTTCue are not available", () => {
+  it("should throw if nor VTTCue nor TextTrackCue is available", () => {
     const logSpy = { warn: jest.fn() };
-    jest.mock("../browser_compatibility_types", () => ({
-      __esModule: true as const,
-      VTTCue_: undefined,
-    }));
+    win.VTTCue = undefined;
+    win.TextTrackCue = undefined;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: logSpy,
@@ -63,10 +70,7 @@ describe("Compat - makeVTTCue", () => {
 
   it("should warn and not create anything if start time is after end time", () => {
     const logSpy = { warn: jest.fn() };
-    jest.mock("../browser_compatibility_types", () => ({
-      __esModule: true as const,
-      VTTCue_: MockVTTCue,
-    }));
+    win.VTTCue = MockVTTCue;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: logSpy,
@@ -80,10 +84,7 @@ describe("Compat - makeVTTCue", () => {
 
   it("should create a new VTT Cue in other cases", () => {
     const logSpy = { warn: jest.fn() };
-    jest.mock("../browser_compatibility_types", () => ({
-      __esModule: true as const,
-      VTTCue_: MockVTTCue,
-    }));
+    win.VTTCue = MockVTTCue;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: logSpy,

--- a/src/compat/__tests__/play.test.ts
+++ b/src/compat/__tests__/play.test.ts
@@ -53,7 +53,7 @@ describe("compat - play", () => {
     const fakeMediaElement = { play: mockPlay };
 
     const play$ = require("../play").default;
-    play$(fakeMediaElement).subscribe(() => null, (err: any) => {
+    play$(fakeMediaElement).subscribe(() => null, (err: unknown) => {
       expect(err).toBe(notAllowedError);
       done();
     });
@@ -67,7 +67,7 @@ describe("compat - play", () => {
     const fakeMediaElement = { play: mockPlay };
 
     const play$ = require("../play").default;
-    play$(fakeMediaElement).subscribe(() => null, (err: any) => {
+    play$(fakeMediaElement).subscribe(() => null, (err: unknown) => {
       expect(err).toBe(notAllowedError);
       done();
     });

--- a/src/compat/__tests__/remove_cue.test.ts
+++ b/src/compat/__tests__/remove_cue.test.ts
@@ -56,7 +56,7 @@ describe("compat - removeCue", () => {
     }));
 
     const removeCue = require("../remove_cue").default;
-    removeCue(fakeTrack as any, { id: "1" } as any);
+    removeCue(fakeTrack, { id: "1" });
 
     expect(fakeTrack.cues.length).toBe(0);
     expect(mockRemoveCue).toHaveBeenCalledTimes(1);
@@ -100,7 +100,7 @@ describe("compat - removeCue", () => {
     }));
 
     const removeCue = require("../remove_cue").default;
-    removeCue(fakeTrack as any, fakeCue as any);
+    removeCue(fakeTrack, fakeCue);
 
     expect(fakeTrack.cues.length).toBe(0);
     expect(mockRemoveCue).toHaveBeenCalledTimes(1);
@@ -144,7 +144,7 @@ describe("compat - removeCue", () => {
     }));
 
     const removeCue = require("../remove_cue").default;
-    removeCue(fakeTrack as any, fakeCue as any);
+    removeCue(fakeTrack, fakeCue);
 
     expect(fakeTrack.cues.length).toBe(0);
     expect(mockRemoveCue).toHaveBeenCalledTimes(1);
@@ -181,7 +181,7 @@ describe("compat - removeCue", () => {
     };
 
     const removeCue = require("../remove_cue").default;
-    removeCue(fakeTrack as any, fakeCue as any);
+    removeCue(fakeTrack, fakeCue);
 
     expect(fakeTrack.cues.length).toBe(1);
     expect(fakeTrack.mode).toBe("showing");
@@ -217,7 +217,7 @@ describe("compat - removeCue", () => {
     };
 
     const removeCue = require("../remove_cue").default;
-    removeCue(fakeTrack as any, { id: "1" } as any);
+    removeCue(fakeTrack, { id: "1" });
 
     expect(fakeTrack.cues.length).toBe(1);
     expect(fakeTrack.mode).toBe("showing");

--- a/src/compat/__tests__/set_element_src.test.ts
+++ b/src/compat/__tests__/set_element_src.test.ts
@@ -29,7 +29,7 @@ describe("compat - setElementSrc", () => {
   });
 
   it("should set element src and clear it when unsubscribe", (done) => {
-    const fakeMediaElement: any = {
+    const fakeMediaElement = {
       src: "",
       removeAttribute: () => null,
     };

--- a/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
+++ b/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
@@ -21,15 +21,20 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-const originalWebKitMediaKeys = (window as any).WebKitMediaKeys;
-
 describe("compat - shouldFavourSafariMediaKeys", () => {
+  const win = window as unknown as Window & {
+    WebKitMediaKeys? : unknown;
+    HTMLMediaElement : typeof HTMLMediaElement;
+  };
+
+  const originalWebKitMediaKeys = win.WebKitMediaKeys;
+
   beforeEach(() => {
     jest.resetModules();
   });
 
   afterEach(() => {
-    (window as any).WebKitMediaKeys = originalWebKitMediaKeys;
+    win.WebKitMediaKeys = originalWebKitMediaKeys;
   });
 
   it("should return false if we are not on Safari", () => {
@@ -45,7 +50,7 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return false if we are on Safari but WekitMediaKeys is not available", () => {
   /* eslint-enable max-len */
 
-    (window as any).WebKitMediaKeys = undefined;
+    win.WebKitMediaKeys = undefined;
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isSafari: true };
@@ -58,13 +63,16 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return true if we are on Safari and a WebKitMediaKeys implementation is available", () => {
   /* eslint-enable max-len */
 
-    (window as any).WebKitMediaKeys = {
+    win.WebKitMediaKeys = {
       isTypeSupported: () => ({}),
       prototype: {
         createSession: () => ({}),
       },
     };
-    (window as any).HTMLMediaElement.prototype.webkitSetMediaKeys = () => ({});
+    const proto = win.HTMLMediaElement.prototype as unknown as {
+      webkitSetMediaKeys : () => Record<string, never>;
+    };
+    proto.webkitSetMediaKeys = () => ({});
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isSafari: true };

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -59,16 +59,19 @@ interface ICompatTextTrack extends TextTrack {
  * Browser implementation of the `document` object with added optional vendored
  * functions for some "old" browsers.
  */
-interface ICompatDocument extends Document { mozCancelFullScreen? : () => void;
-                                             mozFullScreenElement? : HTMLElement;
-                                             mozHidden? : boolean;
-                                             msExitFullscreen? : () => void;
-                                             webkitExitFullscreen : () => void;
-                                             fullscreenElement : Element | null;
-                                             msFullscreenElement? : Element | null;
-                                             webkitFullscreenElement : Element | null;
-                                             msHidden? : boolean;
-                                             webkitHidden? : boolean; }
+interface ICompatDocument extends Document {
+  fullscreenElement : Element | null;
+  mozCancelFullScreen? : () => void;
+  mozFullScreenElement? : HTMLElement;
+  mozHidden? : boolean;
+  msExitFullscreen? : () => void;
+  msFullscreenElement? : Element | null;
+  msHidden? : boolean;
+  pictureInPictureElement? : HTMLElement | null | undefined;
+  webkitExitFullscreen : () => void;
+  webkitFullscreenElement : Element | null;
+  webkitHidden? : boolean;
+}
 
 /**
  * HTMLMediaElement with added optional vendored functions used by "old"
@@ -84,7 +87,19 @@ interface ICompatDocument extends Document { mozCancelFullScreen? : () => void;
 interface ICompatHTMLMediaElement extends HTMLMediaElement {
   mozRequestFullScreen? : () => void;
   msRequestFullscreen? : () => void;
-  webkitRequestFullscreen : () => void;
+  webkitRequestFullscreen? : () => void;
+  webkitSupportsPresentationMode? : boolean;
+  webkitSetPresentationMode? : () => void;
+  webkitPresentationMode? : string;
+  mozSetMediaKeys? : (mediaKeys: unknown) => void;
+  msSetMediaKeys? : (mediaKeys: unknown) => void;
+  webkitSetMediaKeys? : (mediaKeys: unknown) => void;
+  webkitKeys? : {
+    createSession? : (
+      mimeType : string,
+      initData : BufferSource
+    ) => MediaKeySession;
+  };
   readonly audioTracks? : ICompatAudioTrackList;
   readonly videoTracks? : ICompatVideoTrackList;
 }
@@ -157,33 +172,23 @@ export interface ICompatPictureInPictureWindow
   extends EventTarget { width: number;
                         height: number; }
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+interface WindowsWithMediaSourceImplems extends Window {
+  MediaSource? : typeof MediaSource;
+  MozMediaSource? : typeof MediaSource;
+  WebKitMediaSource? : typeof MediaSource;
+  MSMediaSource? : typeof MediaSource;
+}
 
-/**
- * Shortcut to the global browser object `window`. Set to an empty object in
- * non-browser platforms
- */
-const win = isNode ? {} :
-                     window as any;
-
-/** Browser implementation of an HTMLElement. */
-const HTMLElement_ : typeof HTMLElement = win.HTMLElement;
-
-/** TextTrack cue constructor, as implemented by the browser. */
-const VTTCue_ : ICompatVTTCueConstructor | undefined =
-  !isNullOrUndefined(win.VTTCue) ? win.VTTCue :
-                                   win.TextTrackCue;
+const win : WindowsWithMediaSourceImplems | undefined = isNode ? undefined :
+                                                                 window;
 
 /** MediaSource implementation, including vendored implementations. */
 const MediaSource_ : typeof MediaSource | undefined =
-  !isNullOrUndefined(win.MediaSource)       ? win.MediaSource :
-  !isNullOrUndefined(win.MozMediaSource)    ? win.MozMediaSource :
-  !isNullOrUndefined(win.WebKitMediaSource) ? win.WebKitMediaSource :
-                                              win.MSMediaSource;
-
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  win === undefined                            ? undefined :
+  !isNullOrUndefined(win.MediaSource)          ? win.MediaSource :
+  !isNullOrUndefined(win.MozMediaSource)       ? win.MozMediaSource :
+  !isNullOrUndefined(win.WebKitMediaSource)    ? win.WebKitMediaSource :
+                                                 win.MSMediaSource;
 
 /** List an HTMLMediaElement's possible values for its readyState property. */
 const READY_STATES = { HAVE_NOTHING: 0,
@@ -203,7 +208,6 @@ export interface ICompatTextTrackList extends TextTrackList {
 }
 
 export {
-  HTMLElement_,
   ICompatDocument,
   ICompatHTMLMediaElement,
   ICompatAudioTrackList,
@@ -216,5 +220,4 @@ export {
   ICompatVTTCueConstructor,
   MediaSource_,
   READY_STATES,
-  VTTCue_,
 };

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -16,15 +16,20 @@
 
 import isNode from "./is_node";
 
+interface IIE11WindowObject extends Window {
+  MSInputMethodContext? : unknown;
+}
+
+interface IIE11Document extends Document {
+  documentMode? : unknown;
+}
+
 // true on IE11
 // false on Edge and other IEs/browsers.
-/* eslint-disable @typescript-eslint/strict-boolean-expressions */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-const isIE11 : boolean = !isNode &&
-                         !!(window as any).MSInputMethodContext &&
-                         !!(document as any).documentMode;
-/* eslint-enable @typescript-eslint/strict-boolean-expressions */
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
+const isIE11 : boolean =
+  !isNode &&
+  typeof (window as IIE11WindowObject).MSInputMethodContext !== "undefined" &&
+  typeof (document as IIE11Document).documentMode !== "undefined";
 
 // true for IE / Edge
 const isIEOrEdge : boolean = isNode ?
@@ -45,16 +50,16 @@ const isSamsungBrowser : boolean = !isNode &&
 const isTizen : boolean = !isNode &&
                           /Tizen/.test(navigator.userAgent);
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
+interface ISafariWindowObject extends Window {
+  safari? : { pushNotification? : { toString() : string } };
+}
+
 const isSafari : boolean =
   !isNode && (
     Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") >= 0 ||
-    (window as any).safari?.pushNotification.toString() ===
+    (window as ISafariWindowObject).safari?.pushNotification?.toString() ===
       "[object SafariRemoteNotification]"
   );
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
-/* eslint-enable @typescript-eslint/no-unsafe-call */
 
 const isSafariMobile : boolean = !isNode &&
                                  typeof navigator.platform === "string" &&

--- a/src/compat/can_rely_on_video_visibility_and_size.ts
+++ b/src/compat/can_rely_on_video_visibility_and_size.ts
@@ -39,7 +39,6 @@ import { getFirefoxVersion } from "./browser_version";
  * @returns {boolean}
  */
 export default function canRelyOnVideoVisibilityAndSize(): boolean {
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
   if (!isFirefox) {
     return true;
   }
@@ -47,6 +46,7 @@ export default function canRelyOnVideoVisibilityAndSize(): boolean {
   if (firefoxVersion === null || firefoxVersion < 67) {
     return true;
   }
-  return (HTMLVideoElement as any)?.prototype?.requirePictureInPicture !== undefined;
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  const proto : (HTMLVideoElement & { requirePictureInPicture? : () => void }) |
+                undefined = HTMLVideoElement?.prototype;
+  return proto?.requirePictureInPicture !== undefined;
 }

--- a/src/compat/eme/custom_media_keys/ms_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/ms_media_keys_constructor.ts
@@ -24,16 +24,18 @@ interface IMSMediaKeysConstructor {
 
 let MSMediaKeysConstructor: IMSMediaKeysConstructor|undefined;
 if (!isNode) {
-  /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  const { MSMediaKeys } = (window as any);
-  if (MSMediaKeys !== undefined &&
-      MSMediaKeys.prototype !== undefined &&
-      typeof MSMediaKeys.isTypeSupported === "function" &&
-      typeof MSMediaKeys.prototype.createSession === "function") {
+  const { MSMediaKeys } = (window as Window & {
+    MSMediaKeys? : IMSMediaKeysConstructor;
+  });
+  if (
+    MSMediaKeys !== undefined &&
+    MSMediaKeys.prototype !== undefined &&
+    typeof MSMediaKeys.isTypeSupported === "function" &&
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    typeof MSMediaKeys.prototype.createSession === "function"
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  ) {
     MSMediaKeysConstructor = MSMediaKeys;
   }
-  /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }
 export { MSMediaKeysConstructor };

--- a/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
@@ -177,16 +177,11 @@ export default function getOldWebKitMediaKeysCallbacks() : {
     if (videoElement == null) {
       videoElement = document.createElement("video");
     }
-    /* eslint-disable @typescript-eslint/unbound-method */
     if (videoElement != null && typeof videoElement.canPlayType === "function") {
-      /* eslint-enable @typescript-eslint/unbound-method */
-      /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-      /* eslint-disable @typescript-eslint/strict-boolean-expressions */
-      /* eslint-disable @typescript-eslint/no-unsafe-call */
-      return !!(videoElement as any).canPlayType("video/mp4", keyType);
-      /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-      /* eslint-enable @typescript-eslint/strict-boolean-expressions */
-      /* eslint-enable @typescript-eslint/no-unsafe-call */
+      return !!(videoElement.canPlayType as unknown as (
+        mimeType : string,
+        keyType? : string
+      ) => boolean)("video/mp4", keyType);
     } else {
       return false;
     }

--- a/src/compat/eme/custom_media_keys/types.ts
+++ b/src/compat/eme/custom_media_keys/types.ts
@@ -47,7 +47,7 @@ export interface ICustomMediaKeys {
 
 export interface ICustomMediaKeyStatusMap {
   readonly size: number;
-  forEach(callback: (status : MediaKeyStatus) => void, thisArg?: any): void;
+  forEach(callback: (status : MediaKeyStatus) => void, thisArg?: unknown): void;
   get(
     keyId: BufferSource |
            null

--- a/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
 import isNode from "../../is_node";
 
 type IWebKitMediaKeys = unknown;
@@ -28,12 +29,15 @@ let WebKitMediaKeysConstructor: undefined|IWebKitMediaKeysConstructor;
 if (!isNode) {
   /* eslint-disable @typescript-eslint/no-unsafe-assignment */
   /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  const { WebKitMediaKeys } = (window as any);
+  const { WebKitMediaKeys } = (window as Window & {
+    WebKitMediaKeys? : IWebKitMediaKeysConstructor;
+  });
 
   if (WebKitMediaKeys !== undefined &&
       typeof WebKitMediaKeys.isTypeSupported === "function" &&
       typeof WebKitMediaKeys.prototype.createSession === "function" &&
-      typeof (HTMLMediaElement.prototype as any).webkitSetMediaKeys === "function") {
+      typeof (HTMLMediaElement.prototype as ICompatHTMLMediaElement)
+        .webkitSetMediaKeys === "function") {
     WebKitMediaKeysConstructor = WebKitMediaKeys;
   }
   /* eslint-enable @typescript-eslint/no-unsafe-assignment */

--- a/src/compat/fullscreen.ts
+++ b/src/compat/fullscreen.ts
@@ -38,10 +38,8 @@ function requestFullscreen(element : HTMLMediaElement) : void {
       elt.mozRequestFullScreen();
     } else if (typeof elt.webkitRequestFullscreen === "function") {
       (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        elt.webkitRequestFullscreen as any
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      )((Element as any).ALLOW_KEYBOARD_INPUT);
+        elt.webkitRequestFullscreen as (allowKeybordInput? : boolean) => void
+      )((Element as { ALLOW_KEYBOARD_INPUT? : boolean }).ALLOW_KEYBOARD_INPUT);
     }
   }
 }

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -20,7 +20,6 @@ import {
   ICompatTextTrack,
   ICompatVTTCue,
   MediaSource_,
-  VTTCue_,
 } from "./browser_compatibility_types";
 import canPatchISOBMFFSegment from "./can_patch_isobmff";
 import tryToChangeSourceBufferType, {
@@ -109,7 +108,6 @@ export {
   shouldValidateMetadata,
   shouldWaitForDataBeforeLoaded,
   tryToChangeSourceBufferType,
-  VTTCue_,
   whenLoadedMetadata$,
   whenMediaSourceOpen$,
 };

--- a/src/compat/is_vtt_cue.ts
+++ b/src/compat/is_vtt_cue.ts
@@ -25,7 +25,6 @@ export default function isVTTCue(
   cue : ICompatVTTCue|TextTrackCue
 ) : cue is ICompatVTTCue {
   /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  return typeof (window as any).VTTCue === "function" &&
-         cue instanceof (window as any).VTTCue;
+  return typeof window.VTTCue === "function" && cue instanceof window.VTTCue;
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }

--- a/src/compat/make_vtt_cue.ts
+++ b/src/compat/make_vtt_cue.ts
@@ -15,10 +15,8 @@
  */
 
 import log from "../log";
-import {
-  ICompatVTTCue,
-  VTTCue_,
-} from "./browser_compatibility_types";
+import isNullOrUndefined from "../utils/is_null_or_undefined";
+import { ICompatVTTCue } from "./browser_compatibility_types";
 
 /**
  * Creates a cue using the best platform-specific interface available.
@@ -34,9 +32,6 @@ export default function makeCue(
   endTime : number,
   payload : string
 ) : ICompatVTTCue|TextTrackCue|null {
-  if (VTTCue_ == null) {
-    throw new Error("VTT cues not supported in your target");
-  }
   if (startTime >= endTime) {
 
     // IE/Edge will throw in this case.
@@ -45,5 +40,12 @@ export default function makeCue(
     return null;
   }
 
-  return new VTTCue_(startTime, endTime, payload);
+  if (isNullOrUndefined(window.VTTCue)) {
+    if (isNullOrUndefined(window.TextTrackCue)) {
+      throw new Error("VTT cues not supported in your target");
+    }
+    return new (TextTrackCue as unknown as typeof VTTCue)(startTime, endTime, payload);
+  } else {
+    return new VTTCue(startTime, endTime, payload);
+  }
 }

--- a/src/compat/on_height_width_change.ts
+++ b/src/compat/on_height_width_change.ts
@@ -60,7 +60,7 @@ interface IDOMRectReadOnly { readonly x: number;
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 const _ResizeObserver : IResizeObserverConstructor |
                         undefined = isNode ? undefined :
-                                            (window as any).ResizeObserver;
+                                             window.ResizeObserver;
 /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 

--- a/src/core/api/__tests__/media_element_track_choice_manager.test.ts
+++ b/src/core/api/__tests__/media_element_track_choice_manager.test.ts
@@ -32,13 +32,11 @@ const fakeMediaElement = {
   videoTracks: [
     { language: "", selected: true },
   ],
-};
+} as unknown as HTMLVideoElement;
 
 describe("API - MediaElementTrackChoiceManager", () => {
   it("should returns correct results for getter", () => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
     const audioTracks = trackManager.getAvailableAudioTracks();
     const textTracks = trackManager.getAvailableTextTracks();
     const videoTracks = trackManager.getAvailableVideoTracks();
@@ -71,13 +69,14 @@ describe("API - MediaElementTrackChoiceManager", () => {
     });
   });
   it("should returns correct results for setters", () => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
 
     trackManager.setAudioTrackById("gen_audio_en_1");
     // unset enabled attribute of other track, as browser is supported to do this
-    fakeMediaElement.audioTracks[1].enabled = false;
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (fakeMediaElement as any).audioTracks[1].enabled = false;
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
     expect(trackManager.getChosenAudioTrack()).toEqual({
       id: "gen_audio_en_1",
       language: "en",
@@ -97,9 +96,7 @@ describe("API - MediaElementTrackChoiceManager", () => {
     });
   });
   it("should emit available tracks change when changing text contents", (done) => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
 
     trackManager
       .addEventListener("availableTextTracksChange", (tracks) => {
@@ -113,15 +110,13 @@ describe("API - MediaElementTrackChoiceManager", () => {
       });
 
     // Fake browser behavior
-    fakeMediaElement.textTracks.unshift({ language: "es", mode: "hidden" });
-    /* eslint-disable-next-line */
-    (fakeMediaElement.textTracks as any).onaddtrack();
+    (fakeMediaElement.textTracks as unknown as TextTrack[])
+      .unshift({ language: "es", mode: "hidden" } as TextTrack);
+    fakeMediaElement.textTracks.onaddtrack?.({} as TrackEvent);
   });
 
   it("should emit available tracks change when changing video contents", (done) => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
 
     trackManager
       .addEventListener("availableVideoTracksChange", (tracks) => {
@@ -132,15 +127,20 @@ describe("API - MediaElementTrackChoiceManager", () => {
       });
 
     // Fake browser behavior
-    fakeMediaElement.videoTracks.unshift({ language: "en", selected: false });
-    /* eslint-disable-next-line */
-    (fakeMediaElement.videoTracks as any).onaddtrack();
+    /* eslint-disable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _elt = fakeMediaElement as any;
+    _elt.videoTracks.unshift({ language: "en", selected: false });
+    _elt.videoTracks.onaddtrack?.({} as TrackEvent);
+    /* eslint-enable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
   });
 
   it("should emit available tracks change when changing audio contents", (done) => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
 
     trackManager
       .addEventListener("availableAudioTracksChange", (tracks) => {
@@ -154,15 +154,20 @@ describe("API - MediaElementTrackChoiceManager", () => {
       });
 
     // Fake browser behavior
-    fakeMediaElement.audioTracks.unshift({ language: "en", enabled: false });
-    /* eslint-disable-next-line */
-    (fakeMediaElement.audioTracks as any).onaddtrack();
+    /* eslint-disable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _elt = fakeMediaElement as any;
+    _elt.audioTracks.unshift({ language: "en", selected: false });
+    _elt.audioTracks.onaddtrack?.({} as TrackEvent);
+    /* eslint-enable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
   });
 
   it("should emit chosen track when changing text content", (done) => {
-    const trackManager = new MediaElementTrackChoiceManager(
-      fakeMediaElement as any
-    );
+    const trackManager = new MediaElementTrackChoiceManager(fakeMediaElement);
 
     trackManager
       .addEventListener("textTrackChange", (chosenTrack) => {
@@ -174,7 +179,6 @@ describe("API - MediaElementTrackChoiceManager", () => {
 
     // Fake browser behavior
     fakeMediaElement.textTracks[0].mode = "hidden";
-    /* eslint-disable-next-line */
-    (fakeMediaElement.textTracks as any).onchange();
+    fakeMediaElement.textTracks?.onchange?.(undefined as unknown as Event);
   });
 });

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import config from "../../../config";
 import log from "../../../log";

--- a/src/core/eme/__tests__/__global__/init_data.test.ts
+++ b/src/core/eme/__tests__/__global__/init_data.test.ts
@@ -21,6 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
   EMPTY,

--- a/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/core/eme/__tests__/__global__/media_key_system_access.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import {
   EMPTY,

--- a/src/core/eme/__tests__/__global__/media_keys.test.ts
+++ b/src/core/eme/__tests__/__global__/media_keys.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-restricted-properties */
 
 import {

--- a/src/core/eme/__tests__/__global__/server_certificate.test.ts
+++ b/src/core/eme/__tests__/__global__/server_certificate.test.ts
@@ -23,7 +23,6 @@
 /* eslint-disable no-restricted-properties */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 
-
 import { Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
 import { IContentProtection } from "../../types";
@@ -79,7 +78,8 @@ describe("core - eme - global tests - server certificate", () => {
     const EMEManager = require("../../eme_manager").default;
     EMEManager(videoElt, ksConfigCert, initDataSubject)
       .pipe(takeUntil(kill$))
-      .subscribe((evt : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((evt : { type : string; value : any }) => {
 
         switch (++eventsReceived) {
           case 1:
@@ -148,7 +148,8 @@ describe("core - eme - global tests - server certificate", () => {
     const EMEManager = require("../../eme_manager").default;
     EMEManager(videoElt, ksConfigCert, initDataSubject)
       .pipe(takeUntil(kill$))
-      .subscribe((evt : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((evt : { type : string; value : any }) => {
         switch (++eventsReceived) {
           case 1:
             expect(evt.type).toEqual("created-media-keys");
@@ -228,7 +229,8 @@ describe("core - eme - global tests - server certificate", () => {
     const EMEManager = require("../../eme_manager").default;
     EMEManager(videoElt, ksConfigCert, initDataSubject)
       .pipe(takeUntil(kill$))
-      .subscribe((evt : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((evt : { type : string; value : any }) => {
         switch (++eventsReceived) {
           case 1:
             expect(evt.type).toEqual("created-media-keys");
@@ -293,7 +295,8 @@ describe("core - eme - global tests - server certificate", () => {
     jest.spyOn(MediaKeySystemAccessImpl.prototype, "createMediaKeys")
       .mockImplementation(() => {
         const mediaKeys = new MediaKeysImpl();
-        (mediaKeys as any).setServerCertificate = undefined;
+        (mediaKeys as { setServerCertificate? : unknown })
+          .setServerCertificate = undefined;
         return Promise.resolve(mediaKeys);
       });
     const serverCertificateSpy =
@@ -313,7 +316,8 @@ describe("core - eme - global tests - server certificate", () => {
     const EMEManager = require("../../eme_manager").default;
     EMEManager(videoElt, ksConfigCert, initDataSubject)
       .pipe(takeUntil(kill$))
-      .subscribe((evt : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((evt : { type : string; value : any }) => {
         switch (++eventsReceived) {
           case 1:
             expect(evt.type).toEqual("created-media-keys");

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -118,7 +118,7 @@ export class MediaKeyStatusMapImpl {
       parent: MediaKeyStatusMapImpl
     ) => void,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    thisArg?: any
+    thisArg?: unknown
   ): void {
     this._map.forEach((value, key) => callbackfn.bind(thisArg, value, key, this));
   }
@@ -138,13 +138,15 @@ export class MediaKeyStatusMapImpl {
  * Custom implementation of an EME-compliant MediaKeySession.
  * @class MediaKeySessionImpl
  */
-export class MediaKeySessionImpl extends EventEmitter<any> {
+export class MediaKeySessionImpl extends EventEmitter<Record<string, unknown>> {
   public readonly closed : Promise<void>;
   public readonly expiration: number;
   public readonly keyStatuses : MediaKeyStatusMapImpl;
   public readonly sessionId: string;
-  public onkeystatuseschange: ((this: MediaKeySessionImpl, ev: Event) => any) | null;
-  public onmessage: ((this: MediaKeySessionImpl, ev: MediaKeyMessageEvent) => any) | null;
+  public onkeystatuseschange: ((this: MediaKeySessionImpl, ev: Event) => unknown) | null;
+  public onmessage: (
+    (this: MediaKeySessionImpl, ev: MediaKeyMessageEvent) => unknown
+  ) | null;
 
   private _currentKeyId : number;
   private _close? : () => void;
@@ -317,8 +319,10 @@ export function mockCompat(exportedFunctions = {}) {
  */
 export function testEMEManagerImmediateError(
   /* eslint-disable @typescript-eslint/naming-convention */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   EMEManager : any,
+  /* eslint-enable @typescript-eslint/no-explicit-any */
   /* eslint-enable @typescript-eslint/naming-convention */
   mediaElement : HTMLMediaElement,
   keySystemsConfigs : unknown[],
@@ -328,6 +332,7 @@ export function testEMEManagerImmediateError(
     EMEManager(mediaElement, keySystemsConfigs, contentProtections$)
       .subscribe(
         (evt : unknown) => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const eventStr = JSON.stringify(evt as any);
           rej(new Error("Received an EMEManager event: " + eventStr));
         },
@@ -344,7 +349,8 @@ export function testEMEManagerImmediateError(
  * @param {Object} initDataVal
  */
 export function expectLicenseRequestMessage(
-  evt : { type : string; value : any},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  evt : { type : string; value : any },
   initDataVal : { type : string | undefined;
                   values : Array<{ systemId : string | unknown;
                                    data : Uint8Array; }>; }
@@ -360,7 +366,8 @@ export function expectLicenseRequestMessage(
  * @param {string|undefined} initDataType
  */
 export function expectInitDataIgnored(
-  evt : { type : string; value : any},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  evt : { type : string; value : any },
   initDataVal : { type : string | undefined;
                   values : Array<{ systemId : string | undefined;
                                    data : Uint8Array; }>; }
@@ -375,7 +382,8 @@ export function expectInitDataIgnored(
  * @param {string|undefined} initDataType
  */
 export function expectEncryptedEventReceived(
-  evt : { type : string; value : any},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  evt : { type : string; value : any },
   initData : IEncryptedEventData
 ) : void {
   expect(evt.type).toEqual("encrypted-event-received");

--- a/src/core/eme/__tests__/clean_old_loaded_sessions.test.ts
+++ b/src/core/eme/__tests__/clean_old_loaded_sessions.test.ts
@@ -52,14 +52,14 @@ function createLoadedSessionsStore() : LoadedSessionsStore {
     closeSession() {
       return timer(Math.random() * 50);
     },
-  } as any;
+  } as unknown as LoadedSessionsStore;
 }
 
 const emptyLoadedSessionsStore = {
   getLength() { return 0; },
   getAll() { return []; },
   closeSession() { throw new Error("closeSession should not have been called"); },
-} as any as LoadedSessionsStore;
+} as unknown as LoadedSessionsStore;
 
 /**
  * Call `cleanOldLoadedSessions` with the given loadedSessionsStore and
@@ -108,12 +108,12 @@ function checkNothingHappen(
 function checkEntriesCleaned(
   loadedSessionsStore : LoadedSessionsStore,
   limit : number,
-  entries : any[],
+  entries : Array<{ initializationData: unknown }>,
   done : () => void
 ) {
   const closeSessionSpy = jest.spyOn(loadedSessionsStore, "closeSession");
   let itemNb = 0;
-  const pendingEntries : any[] = [];
+  const pendingEntries : unknown[] = [];
   cleanOldLoadedSessions(loadedSessionsStore, limit).subscribe({
     next: (evt) => {
       if (evt.type === "cleaning-old-session") {

--- a/src/core/eme/__tests__/clean_old_stored_persistent_info.test.ts
+++ b/src/core/eme/__tests__/clean_old_stored_persistent_info.test.ts
@@ -21,7 +21,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-
 function createPersistentSessionsStore() {
   return {
     getLength() : number {
@@ -30,7 +29,7 @@ function createPersistentSessionsStore() {
     deleteOldSessions() : void {
       return ;
     },
-  } as any;
+  };
 }
 
 const emptyPersistentSessionsStore = {
@@ -45,6 +44,7 @@ const emptyPersistentSessionsStore = {
  * @param {Object} persistentSessionsStore
  * @param {number} limit
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function checkNothingHappen(persistentSessionsStore : any, limit : number) {
   const deleteLastSpy = jest.spyOn(persistentSessionsStore, "deleteOldSessions");
   const logInfoSpy = jest.fn();
@@ -66,6 +66,7 @@ function checkNothingHappen(persistentSessionsStore : any, limit : number) {
  * @param {number} numberToRemove
  */
 function checkRemoved(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   persistentSessionsStore : any,
   limit : number,
   numberToRemove : number

--- a/src/core/eme/__tests__/init_media_keys.test.ts
+++ b/src/core/eme/__tests__/init_media_keys.test.ts
@@ -63,7 +63,8 @@ describe("core - eme - initMediaKeys", () => {
     const keySystemsConfigs = [{ l: 4 }, { d: 12 }];
     initMediaKeys(mediaElement, keySystemsConfigs)
       .pipe(take(1))
-      .subscribe((result : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((result : { type : string; value : any }) => {
         expect(result.type).toEqual("created-media-keys");
         expect(result.value.mediaKeys).toEqual(fakeResult.mediaKeys);
         expect(result.value.mediaKeySystemAccess)
@@ -112,7 +113,8 @@ describe("core - eme - initMediaKeys", () => {
     const keySystemsConfigs = [{ l: 4 }, { d: 12 }];
     initMediaKeys(mediaElement, keySystemsConfigs)
       .pipe(
-        tap((evt: any) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        tap((evt: { type : string; value : any }) => {
           if (evt.type === "created-media-keys") {
             evt.value.attachMediaKeys$.next();
           }
@@ -206,7 +208,8 @@ describe("core - eme - initMediaKeys", () => {
 
     let eventReceived = false;
     initMediaKeys(mediaElement, keySystemsConfigs)
-      .subscribe((evt : any) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .subscribe((evt : { type : string; value : any }) => {
         expect(evt.type).toEqual("created-media-keys");
         expect(evt.value.mediaKeys).toEqual(fakeResult.mediaKeys);
         expect(evt.value.mediaKeySystemAccess).toEqual(fakeResult.mediaKeySystemAccess);

--- a/src/core/eme/check_key_statuses.ts
+++ b/src/core/eme/check_key_statuses.ts
@@ -47,6 +47,17 @@ export interface IKeyStatusesCheckingOptions {
 }
 
 /**
+ * MediaKeyStatusMap's iterator seems to be quite peculiar and wrongly defined
+ * by TypeScript.
+ */
+type IKeyStatusesForEach = (
+  callback: (
+    ((arg1 : MediaKeyStatus, arg2 : ArrayBuffer) => void) |
+    ((arg1 : ArrayBuffer, arg2 : MediaKeyStatus) => void)
+  )
+) => void;
+
+/**
  * Look at the current key statuses in the sessions and construct the
  * appropriate warnings, whitelisted and blacklisted key ids.
  *
@@ -70,11 +81,9 @@ export default function checkKeyStatuses(
   const whitelistedKeyIds : Uint8Array[] = [];
   const { fallbackOn = {}, throwOnLicenseExpiration } = options;
 
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  /* eslint-disable @typescript-eslint/no-unsafe-call */
-  (session.keyStatuses as any).forEach((_arg1 : unknown, _arg2 : unknown) => {
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  /* eslint-enable @typescript-eslint/no-unsafe-call */
+  (session.keyStatuses.forEach as IKeyStatusesForEach)((
+    _arg1 : unknown,
+    _arg2 : unknown) => {
     // Hack present because the order of the arguments has changed in spec
     // and is not the same between some versions of Edge and Chrome.
     const [keyStatus, keyStatusKeyId] = (() => {

--- a/src/core/eme/session_events_listener.ts
+++ b/src/core/eme/session_events_listener.ts
@@ -138,7 +138,7 @@ export default function SessionEventsListener(
         const getLicenseTimeout = isNullOrUndefined(getLicenseConfig.timeout) ?
           10 * 1000 :
           getLicenseConfig.timeout;
-        return (castToObservable(getLicense) as Observable<BufferSource|null>)
+        return castToObservable(getLicense)
           .pipe(getLicenseTimeout >= 0 ? timeout(getLicenseTimeout) :
                                          identity /* noop */);
       });
@@ -310,7 +310,7 @@ function handleKeyStatusesChangeEvent(
       }
       return castToObservable(keySystemOptions.onKeyStatusesChange(keyStatusesEvent,
                                                                    session));
-    }, undefined) as Observable< BufferSource | null >;
+    }, undefined);
   }).pipe(
     map(licenseObject => ({ type: "key-status-change-handled" as const,
                             value : { session, license: licenseObject } })),

--- a/src/core/fetchers/segment/__tests__/prioritizer.test.ts
+++ b/src/core/fetchers/segment/__tests__/prioritizer.test.ts
@@ -33,7 +33,7 @@ import Prioritizer, {
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 /* eslint-disable no-restricted-properties */
 
-function assert(condition: any, msg?: string): asserts condition {
+function assert(condition: boolean, msg?: string): asserts condition {
   if (!condition) {
     throw new Error(msg ?? "The asserted condition turned out to be false.");
   }

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -16,7 +16,10 @@
 
 import { Subject } from "rxjs";
 import config from "../../../config";
-import { ITransportPipelines } from "../../../transports";
+import {
+  ISegmentPipeline,
+  ITransportPipelines,
+} from "../../../transports";
 import {
   IABRMetricsEvent,
   IABRRequestBeginEvent,
@@ -90,7 +93,7 @@ export default class SegmentFetcherCreator {
    * about it, but typing as any just in select places, like here, looks like
    * a good compromise.
    */
-  private readonly _prioritizer : ObservablePrioritizer<ISegmentFetcherEvent<any>>;
+  private readonly _prioritizer : ObservablePrioritizer<ISegmentFetcherEvent<unknown>>;
   /**
    * Options used by the SegmentFetcherCreator, e.g. to allow configuration on
    * segment retries (number of retries maximum, default delay and so on).
@@ -126,16 +129,18 @@ export default class SegmentFetcherCreator {
                         IABRRequestProgressEvent |
                         IABRRequestEndEvent |
                         IABRMetricsEvent>
-  ) : IPrioritizedSegmentFetcher<any> {
+  ) : IPrioritizedSegmentFetcher<unknown> {
     const backoffOptions = getSegmentFetcherOptions(bufferType, this._backoffOptions);
     const pipelines = this._transport[bufferType];
 
     // Types are very complicated here as they are per-type of buffer.
     // This is the reason why `any` is used instead.
-    const segmentFetcher = createSegmentFetcher<any, any>(bufferType,
-                                                          pipelines,
-                                                          requests$,
-                                                          backoffOptions);
+    const segmentFetcher = createSegmentFetcher<unknown, unknown>(
+      bufferType,
+      pipelines as ISegmentPipeline<unknown, unknown>,
+      requests$,
+      backoffOptions
+    );
     return applyPrioritizerToSegmentFetcher(this._prioritizer, segmentFetcher);
   }
 }

--- a/src/core/init/__tests__/refresh_scheduled_events_list.test.ts
+++ b/src/core/init/__tests__/refresh_scheduled_events_list.test.ts
@@ -36,7 +36,7 @@ describe("core - init - refreshScheduledEventsList", () => {
                                                    { start: 13,
                                                      end: 13.1,
                                                      id: "4" }] } ] };
-    const oldScheduledEvents: any[] = [
+    const oldScheduledEvents = [
       { start: 1000,
         end: 1000000,
         id: "must-disapear",

--- a/src/core/segment_buffers/garbage_collector.ts
+++ b/src/core/segment_buffers/garbage_collector.ts
@@ -31,7 +31,7 @@ import { SegmentBuffer } from "./implementations";
 
 export interface IGarbageCollectorArgument {
   /** SegmentBuffer implementation */
-  segmentBuffer : SegmentBuffer<unknown>;
+  segmentBuffer : SegmentBuffer;
   /** Emit current position in seconds regularly */
   clock$ : Observable<number>;
   /** Maximum time to keep behind current time position, in seconds */
@@ -80,7 +80,7 @@ export default function BufferGarbageCollector({
  * @returns {Observable}
  */
 function clearBuffer(
-  segmentBuffer : SegmentBuffer<unknown>,
+  segmentBuffer : SegmentBuffer,
   position : number,
   maxBufferBehind : number,
   maxBufferAhead : number

--- a/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
@@ -28,25 +28,11 @@ import {
 } from "../types";
 import ManualTimeRanges from "../utils/manual_time_ranges";
 
-/** Format of the data pushed to the `ImageSegmentBuffer`. */
-export interface IImageTrackSegmentData {
-  /** Image track data, in the given type */
-  data : IBifThumbnail[];
-  /** The type of the data (example: "bif") */
-  type : string;
-  /** End time until which the segment apply */
-  end : number;
-  /** Start time from which the segment apply */
-  start : number;
-  /** Timescale to convert the start and end into seconds */
-  timescale : number;
-}
-
 /**
  * Image SegmentBuffer implementation.
  * @class ImageSegmentBuffer
  */
-export default class ImageSegmentBuffer extends SegmentBuffer<IImageTrackSegmentData> {
+export default class ImageSegmentBuffer extends SegmentBuffer {
   public readonly bufferType : "image";
   private _buffered : ManualTimeRanges;
 
@@ -61,7 +47,7 @@ export default class ImageSegmentBuffer extends SegmentBuffer<IImageTrackSegment
    * @param {Object} data
    */
   public pushChunk(
-    infos : IPushChunkInfos<IImageTrackSegmentData>
+    infos : IPushChunkInfos<unknown>
   ) : Observable<void> {
     return observableDefer(() => {
       log.debug("ISB: appending new data.");
@@ -70,7 +56,10 @@ export default class ImageSegmentBuffer extends SegmentBuffer<IImageTrackSegment
       }
       const { appendWindow,
               chunk } = infos.data;
-      const { start, end, timescale } = chunk;
+
+      // The following check is ugly. I don't care, the image buffer is there
+      // due to an ugly deprecated API that will soon disappear
+      const { start, end, timescale } = chunk as IImageTrackSegmentData;
       const appendWindowStart = appendWindow[0] ?? 0;
       const appendWindowEnd = appendWindow[1] ?? Infinity;
 
@@ -135,4 +124,18 @@ export default class ImageSegmentBuffer extends SegmentBuffer<IImageTrackSegment
     log.debug("ISB: disposing image SegmentBuffer");
     this._buffered.remove(0, Infinity);
   }
+}
+
+/** Format of the data pushed to the `ImageSegmentBuffer`. */
+export interface IImageTrackSegmentData {
+  /** Image track data, in the given type */
+  data : IBifThumbnail[];
+  /** The type of the data (example: "bif") */
+  type : string;
+  /** End time until which the segment apply */
+  end : number;
+  /** Start time from which the segment apply */
+  start : number;
+  /** Timescale to convert the start and end into seconds */
+  timescale : number;
 }

--- a/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
@@ -40,9 +40,7 @@ import parseTextTrackToCues from "./parsers";
  * expected behavior to display subtitles synchronized to the video.
  * @class NativeTextSegmentBuffer
  */
-export default class NativeTextSegmentBuffer
-  extends SegmentBuffer<ITextTrackSegmentData>
-{
+export default class NativeTextSegmentBuffer extends SegmentBuffer {
   public readonly bufferType : "text";
 
   private readonly _videoElement : HTMLMediaElement;
@@ -77,7 +75,7 @@ export default class NativeTextSegmentBuffer
    * @param {Object} infos
    * @returns {Observable}
    */
-  public pushChunk(infos : IPushChunkInfos<ITextTrackSegmentData>) : Observable<void> {
+  public pushChunk(infos : IPushChunkInfos<unknown>) : Observable<void> {
     return observableDefer(() => {
       log.debug("NTSB: Appending new native text tracks");
       if (infos.data.chunk === null) {
@@ -86,6 +84,7 @@ export default class NativeTextSegmentBuffer
       const { timestampOffset,
               appendWindow,
               chunk } = infos.data;
+      assertChunkIsTextTrackSegmentData(chunk);
       const { start: startTime,
               end: endTime,
               data: dataString,
@@ -256,4 +255,81 @@ export default class NativeTextSegmentBuffer
     }
     this._buffered.remove(start, end);
   }
+}
+
+/** Data of chunks that should be pushed to the NativeTextSegmentBuffer. */
+export interface INativeTextTracksBufferSegmentData {
+  /** The text track data, in the format indicated in `type`. */
+  data : string;
+  /** The format of `data` (examples: "ttml", "srt" or "vtt") */
+  type : string;
+  /**
+   * Language in which the text track is, as a language code.
+   * This is mostly needed for "sami" subtitles, to know which cues can / should
+   * be parsed.
+   */
+  language? : string;
+  /** start time from which the segment apply, in seconds. */
+  start? : number;
+  /** end time until which the segment apply, in seconds. */
+  end? : number;
+}
+
+/**
+ * Throw if the given input is not in the expected format.
+ * Allows to enforce runtime type-checking as compile-time type-checking here is
+ * difficult to enforce.
+ * @param {Object} chunk
+ */
+function assertChunkIsTextTrackSegmentData(
+  chunk : unknown
+) : asserts chunk is INativeTextTracksBufferSegmentData {
+  if (!__DEV__) {
+    return;
+  }
+  if (
+    typeof chunk !== "object" ||
+    chunk === null ||
+    typeof (chunk as INativeTextTracksBufferSegmentData).data !== "string" ||
+    typeof (chunk as INativeTextTracksBufferSegmentData).type !== "string" ||
+    (
+      (chunk as INativeTextTracksBufferSegmentData).language !== undefined &&
+      typeof (chunk as INativeTextTracksBufferSegmentData).language !== "string"
+    ) ||
+    (
+      (chunk as INativeTextTracksBufferSegmentData).start !== undefined &&
+      typeof (chunk as INativeTextTracksBufferSegmentData).start !== "string"
+    ) ||
+    (
+      (chunk as INativeTextTracksBufferSegmentData).end !== undefined &&
+      typeof (chunk as INativeTextTracksBufferSegmentData).end !== "string"
+    )
+  ) {
+    throw new Error("Invalid format given to a NativeTextSegmentBuffer");
+  }
+}
+
+/*
+ * The following ugly code is here to provide a compile-time check that an
+ * `INativeTextTracksBufferSegmentData` (type of data pushed to a
+ * `NativeTextSegmentBuffer`) can be derived from a `ITextTrackSegmentData`
+ * (text track data parsed from a segment).
+ *
+ * It doesn't correspond at all to real code that will be called. This is just
+ * a hack to tell TypeScript to perform that check.
+ */
+if (__DEV__) {
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  /* eslint-disable @typescript-eslint/ban-ts-comment */
+  // @ts-ignore
+  function _checkType(
+    input : ITextTrackSegmentData
+  ) : void {
+    function checkEqual(_arg : INativeTextTracksBufferSegmentData) : void {
+      /* nothing */
+    }
+    checkEqual(input);
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+  /* eslint-enable @typescript-eslint/ban-ts-comment */
 }

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -63,7 +63,7 @@ import SegmentInventory, {
  * If operations happens synchronously, this method will just return an empty
  * array.
  */
-export abstract class SegmentBuffer<T> {
+export abstract class SegmentBuffer {
   /** "Type" of the buffer (e.g. "audio", "video", "text", "image"). */
   public readonly abstract bufferType : IBufferType;
 
@@ -112,7 +112,7 @@ export abstract class SegmentBuffer<T> {
    * @param {Object} infos
    * @returns {Observable}
    */
-  public abstract pushChunk(infos : IPushChunkInfos<T>) : Observable<void>;
+  public abstract pushChunk(infos : IPushChunkInfos<unknown>) : Observable<void>;
 
   /**
    * Remove buffered data (added to the same FIFO queue than `pushChunk`).
@@ -171,7 +171,7 @@ export abstract class SegmentBuffer<T> {
    * processed)
    * @returns {Array.<Object>}
    */
-  public getPendingOperations() : Array<ISBOperation<T>> {
+  public getPendingOperations() : Array<ISBOperation<unknown>> {
     // Return no pending operation by default (for synchronous SegmentBuffers)
     return [];
   }

--- a/src/core/segment_buffers/segment_buffers_store.ts
+++ b/src/core/segment_buffers/segment_buffers_store.ts
@@ -91,16 +91,7 @@ export default class SegmentBuffersStore {
    * disabled. This means that the corresponding type (e.g. audio, video etc.)
    * won't be needed when playing the current content.
    */
-  private _initializedSegmentBuffers : {
-    audio? : SegmentBuffer<BufferSource | null> |
-             null;
-    video? : SegmentBuffer<BufferSource | null> |
-              null;
-    text? : SegmentBuffer<unknown> |
-            null;
-    image? : SegmentBuffer<unknown> |
-             null;
-  };
+  private _initializedSegmentBuffers : Partial<Record<IBufferType, SegmentBuffer | null>>;
 
   /**
    * Callbacks called after a SourceBuffer is either created or disabled.
@@ -172,7 +163,7 @@ export default class SegmentBuffersStore {
    * @returns {Object|null}
    */
   public getStatus(bufferType : IBufferType) : { type : "initialized";
-                                                 value : SegmentBuffer<any>; } |
+                                                 value : SegmentBuffer; } |
                                                { type : "uninitialized" } |
                                                { type : "disabled" }
   {
@@ -251,7 +242,7 @@ export default class SegmentBuffersStore {
     bufferType : IBufferType,
     codec : string,
     options : ISegmentBufferOptions = {}
-  ) : SegmentBuffer<any> {
+  ) : SegmentBuffer {
     const memorizedSegmentBuffer = this._initializedSegmentBuffers[bufferType];
     if (shouldHaveNativeBuffer(bufferType)) {
       if (memorizedSegmentBuffer != null) {
@@ -279,7 +270,7 @@ export default class SegmentBuffersStore {
       return memorizedSegmentBuffer;
     }
 
-    let segmentBuffer : SegmentBuffer<unknown>;
+    let segmentBuffer : SegmentBuffer;
     if (bufferType === "text") {
       log.info("SB: Creating a new text SegmentBuffer");
 

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -90,7 +90,7 @@ export interface IAdaptationStreamClockTick extends IRepresentationStreamClockTi
 }
 
 /** Arguments given when creating a new `AdaptationStream`. */
-export interface IAdaptationStreamArguments<T> {
+export interface IAdaptationStreamArguments {
   /**
    * Module allowing to find the best Representation depending on the current
    * conditions like the current network bandwidth.
@@ -107,7 +107,7 @@ export interface IAdaptationStreamArguments<T> {
               adaptation : Adaptation; };
   options: IAdaptationStreamOptions;
   /** SourceBuffer wrapper - needed to push media segments. */
-  segmentBuffer : SegmentBuffer<T>;
+  segmentBuffer : SegmentBuffer;
   /** Module used to fetch the wanted media segments. */
   segmentFetcherCreator : SegmentFetcherCreator;
   /**
@@ -174,7 +174,7 @@ export interface IAdaptationStreamOptions {
  * @param {Object} args
  * @returns {Observable}
  */
-export default function AdaptationStream<T>({
+export default function AdaptationStream({
   abrManager,
   clock$,
   content,
@@ -182,7 +182,7 @@ export default function AdaptationStream<T>({
   segmentBuffer,
   segmentFetcherCreator,
   wantedBufferAhead$,
-} : IAdaptationStreamArguments<T>) : Observable<IAdaptationStreamEvent<T>> {
+} : IAdaptationStreamArguments) : Observable<IAdaptationStreamEvent> {
   const directManualBitrateSwitching = options.manualBitrateSwitchingMode === "direct";
   const { manifest, period, adaptation } = content;
 
@@ -229,7 +229,7 @@ export default function AdaptationStream<T>({
 
   /** Recursively create `RepresentationStream`s according to the last estimate. */
   const representationStreams$ = abrEstimate$
-    .pipe(exhaustMap((estimate, i) : Observable<IAdaptationStreamEvent<T>> => {
+    .pipe(exhaustMap((estimate, i) : Observable<IAdaptationStreamEvent> => {
       return recursivelyCreateRepresentationStreams(estimate, i === 0);
     }));
 
@@ -250,7 +250,7 @@ export default function AdaptationStream<T>({
   function recursivelyCreateRepresentationStreams(
     fromEstimate : IABREstimate,
     isFirstEstimate : boolean
-  ) : Observable<IAdaptationStreamEvent<T>> {
+  ) : Observable<IAdaptationStreamEvent> {
     const { representation } = fromEstimate;
 
     // A manual bitrate switch might need an immediate feedback.
@@ -341,7 +341,7 @@ export default function AdaptationStream<T>({
     representation : Representation,
     terminateCurrentStream$ : Observable<ITerminationOrder>,
     fastSwitchThreshold$ : Observable<number | undefined>
-  ) : Observable<IRepresentationStreamEvent<T>> {
+  ) : Observable<IRepresentationStreamEvent> {
     return observableDefer(() => {
       const oldBufferGoalRatio = bufferGoalRatioMap[representation.id];
       const bufferGoalRatio = oldBufferGoalRatio != null ? oldBufferGoalRatio :

--- a/src/core/stream/orchestrator/get_blacklisted_ranges.ts
+++ b/src/core/stream/orchestrator/get_blacklisted_ranges.ts
@@ -31,7 +31,7 @@ import { SegmentBuffer } from "../../segment_buffers";
  * @returns {Array.<Object>}
  */
 export default function getBlacklistedRanges(
-  segmentBuffer : SegmentBuffer<unknown>,
+  segmentBuffer : SegmentBuffer,
   contents : Array<{ adaptation : Adaptation;
                      period : Period;
                      representation : Representation; }>

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -123,7 +123,7 @@ export default function StreamOrchestrator(
   // Keep track of a unique BufferGarbageCollector created per
   // SegmentBuffer.
   const garbageCollectors =
-    new WeakMapMemory((segmentBuffer : SegmentBuffer<unknown>) => {
+    new WeakMapMemory((segmentBuffer : SegmentBuffer) => {
       const { bufferType } = segmentBuffer;
       const defaultMaxBehind = MAXIMUM_MAX_BUFFER_BEHIND[bufferType] != null ?
                                  MAXIMUM_MAX_BUFFER_BEHIND[bufferType] as number :

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -68,7 +68,7 @@ export interface IAdaptationSwitchOptions {
  * @returns {Object}
  */
 export default function getAdaptationSwitchStrategy(
-  segmentBuffer : SegmentBuffer<unknown>,
+  segmentBuffer : SegmentBuffer,
   period : Period,
   adaptation : Adaptation,
   playbackInfo : { currentTime : number; readyState : number },

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -86,7 +86,7 @@ export interface IPeriodStreamArguments {
   clock$ : Observable<IPeriodStreamClockTick>;
   content : { manifest : Manifest;
               period : Period; };
-  garbageCollectors : WeakMapMemory<SegmentBuffer<unknown>, Observable<never>>;
+  garbageCollectors : WeakMapMemory<SegmentBuffer, Observable<never>>;
   segmentFetcherCreator : SegmentFetcherCreator;
   segmentBuffersStore : SegmentBuffersStore;
   options: IPeriodStreamOptions;
@@ -246,10 +246,10 @@ export default function PeriodStream({
    * @param {Object} segmentBuffer
    * @returns {Observable}
    */
-  function createAdaptationStream<T>(
+  function createAdaptationStream(
     adaptation : Adaptation,
-    segmentBuffer : SegmentBuffer<T>
-  ) : Observable<IAdaptationStreamEvent<T>|IStreamWarningEvent> {
+    segmentBuffer : SegmentBuffer
+  ) : Observable<IAdaptationStreamEvent|IStreamWarningEvent> {
     const { manifest } = content;
     const adaptationStreamClock$ = clock$.pipe(map(tick => {
       const buffered = segmentBuffer.getBufferedRanges();
@@ -293,12 +293,12 @@ export default function PeriodStream({
  * @param {Object} adaptation
  * @returns {Object}
  */
-function createOrReuseSegmentBuffer<T>(
+function createOrReuseSegmentBuffer(
   segmentBuffersStore : SegmentBuffersStore,
   bufferType : IBufferType,
   adaptation : Adaptation,
   options: { textTrackOptions? : ITextTrackSegmentBufferOptions }
-) : SegmentBuffer<T> {
+) : SegmentBuffer {
   const segmentBufferStatus = segmentBuffersStore.getStatus(bufferType);
   if (segmentBufferStatus.type === "initialized") {
     log.info("Stream: Reusing a previous SegmentBuffer for the type", bufferType);

--- a/src/core/stream/representation/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/append_segment_to_buffer.ts
@@ -45,7 +45,7 @@ import forceGarbageCollection from "./force_garbage_collection";
  */
 export default function appendSegmentToBuffer<T>(
   clock$ : Observable<{ position : number }>,
-  segmentBuffer : SegmentBuffer<T>,
+  segmentBuffer : SegmentBuffer,
   dataInfos : IPushChunkInfos<T>
 ) : Observable<unknown> {
   const append$ = segmentBuffer.pushChunk(dataInfos);

--- a/src/core/stream/representation/force_garbage_collection.ts
+++ b/src/core/stream/representation/force_garbage_collection.ts
@@ -43,7 +43,7 @@ const GC_GAP_BEEFY = config.BUFFER_GC_GAPS.BEEFY;
  */
 export default function forceGarbageCollection(
   timings$ : Observable<{ position : number }>,
-  bufferingQueue : SegmentBuffer<unknown>
+  bufferingQueue : SegmentBuffer
 ) : Observable<unknown> {
   // wait for next timing event
   return timings$.pipe(

--- a/src/core/stream/representation/get_buffer_status.ts
+++ b/src/core/stream/representation/get_buffer_status.ts
@@ -88,7 +88,7 @@ export default function getBufferStatus(
            getCurrentTime() : number; },
   fastSwitchThreshold : number | undefined,
   bufferGoal : number,
-  segmentBuffer : SegmentBuffer<unknown>
+  segmentBuffer : SegmentBuffer
 ) : IBufferStatus {
   const { period, representation } = content;
   segmentBuffer.synchronizeInventory();

--- a/src/core/stream/representation/push_init_segment.ts
+++ b/src/core/stream/representation/push_init_segment.ts
@@ -54,7 +54,7 @@ export default function pushInitSegment<T>(
                                    representation : Representation; };
                         segmentData : T | null;
                         segment : ISegment;
-                        segmentBuffer : SegmentBuffer<T>; }
+                        segmentBuffer : SegmentBuffer; }
 ) : Observable< IStreamEventAddedSegment<T> > {
   return observableDefer(() => {
     if (segmentData === null) {

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -58,7 +58,7 @@ export default function pushMediaSegment<T>(
                         initSegmentData : T | null;
                         parsedSegment : ISegmentParserParsedSegment<T>;
                         segment : ISegment;
-                        segmentBuffer : SegmentBuffer<T>; }
+                        segmentBuffer : SegmentBuffer; }
 ) : Observable< IStreamEventAddedSegment<T> > {
   return observableDefer(() => {
     if (parsedSegment.chunkData === null) {

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -128,7 +128,7 @@ export interface IRepresentationStreamArguments<TSegmentDataType> {
              period : Period;
              representation : Representation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
-  segmentBuffer : SegmentBuffer<TSegmentDataType>;
+  segmentBuffer : SegmentBuffer;
   /** Interface used to load new segments. */
   segmentFetcher : IPrioritizedSegmentFetcher<TSegmentDataType>;
   /**
@@ -209,7 +209,7 @@ export default function RepresentationStream<TSegmentDataType>({
   terminate$,
   options,
 } : IRepresentationStreamArguments<TSegmentDataType>
-) : Observable<IRepresentationStreamEvent<TSegmentDataType>> {
+) : Observable<IRepresentationStreamEvent> {
   const { manifest, period, adaptation, representation } = content;
   const { bufferGoal$, drmSystemId, fastSwitchThreshold$ } = options;
   const bufferType = adaptation.type;

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -396,30 +396,30 @@ export interface INeedsDecipherabilityFlush {
 }
 
 /** Event sent by a `RepresentationStream`. */
-export type IRepresentationStreamEvent<T> = IStreamStatusEvent |
-                                            IStreamEventAddedSegment<T> |
-                                            IEncryptionDataEncounteredEvent |
-                                            IStreamManifestMightBeOutOfSync |
-                                            IStreamTerminatingEvent |
-                                            IStreamNeedsManifestRefresh |
-                                            IStreamWarningEvent |
-                                            IInbandEventsEvent;
+export type IRepresentationStreamEvent = IStreamStatusEvent |
+                                         IStreamEventAddedSegment<unknown> |
+                                         IEncryptionDataEncounteredEvent |
+                                         IStreamManifestMightBeOutOfSync |
+                                         IStreamTerminatingEvent |
+                                         IStreamNeedsManifestRefresh |
+                                         IStreamWarningEvent |
+                                         IInbandEventsEvent;
 
 /** Event sent by an `AdaptationStream`. */
-export type IAdaptationStreamEvent<T> = IBitrateEstimationChangeEvent |
-                                        INeedsMediaSourceReload |
-                                        INeedsDecipherabilityFlush |
-                                        IRepresentationChangeEvent |
+export type IAdaptationStreamEvent = IBitrateEstimationChangeEvent |
+                                     INeedsMediaSourceReload |
+                                     INeedsDecipherabilityFlush |
+                                     IRepresentationChangeEvent |
 
-                                        // From a RepresentationStream
+                                     // From a RepresentationStream
 
-                                        IStreamStatusEvent |
-                                        IStreamEventAddedSegment<T> |
-                                        IEncryptionDataEncounteredEvent |
-                                        IStreamManifestMightBeOutOfSync |
-                                        IStreamNeedsManifestRefresh |
-                                        IStreamWarningEvent |
-                                        IInbandEventsEvent;
+                                     IStreamStatusEvent |
+                                     IStreamEventAddedSegment<unknown> |
+                                     IEncryptionDataEncounteredEvent |
+                                     IStreamManifestMightBeOutOfSync |
+                                     IStreamNeedsManifestRefresh |
+                                     IStreamWarningEvent |
+                                     IInbandEventsEvent;
 
 /** Event sent by a `PeriodStream`. */
 export type IPeriodStreamEvent = IPeriodStreamReadyEvent |

--- a/src/experimental/features/__tests__/dash_wasm.test.ts
+++ b/src/experimental/features/__tests__/dash_wasm.test.ts
@@ -39,6 +39,7 @@ describe("Features list - DASH WASM Parser", () => {
 
     expect(initializeSpy).toHaveBeenCalledTimes(1);
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { transports: {},
                                   dashParsers: { js: null,
                                                  wasm: null } };

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -264,16 +264,8 @@ export default class VideoThumbnailLoader {
         }),
         catchError((err: unknown) => {
           let message = "Unknown error.";
-          if ((err as { message?: string; toString(): string }).message !== undefined ||
-            /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-            /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-            /* eslint-disable @typescript-eslint/no-unsafe-call */
-              typeof (err as { message?: string;
-                               toString(): string; }).toString === "function") {
-            message = (err as any).message ?? (err as any).toString();
-            /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-            /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-            /* eslint-enable @typescript-eslint/no-unsafe-call */
+          if (err instanceof Error) {
+            message = err.message ?? err.toString();
           }
           throw new VideoThumbnailLoaderError("LOADING_ERROR", message);
         })

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/DRMInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/DRMInfos.test.ts
@@ -89,7 +89,7 @@ describe("MediaCapabilitiesProber probers - DRMInfos", () => {
     const probeDRMInfos = require("../../probers/DRMInfos").default;
     expect.assertions(2);
     probeDRMInfos(configuration)
-      .then((res: any) => {
+      .then((res: unknown) => {
         expect(res).toEqual(
           [
             ProberStatus.Supported,
@@ -126,7 +126,7 @@ describe("MediaCapabilitiesProber probers - DRMInfos", () => {
     const probeDRMInfos = require("../../probers/DRMInfos").default;
     expect.assertions(2);
     probeDRMInfos(configuration)
-      .then((res: any) => {
+      .then((res: unknown) => {
         expect(res).toEqual(
           [
             ProberStatus.NotSupported,

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/HDCPPolicy.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/HDCPPolicy.test.ts
@@ -72,7 +72,7 @@ describe("MediaCapabilitiesProber probers - HDCPPolicy", () => {
 
     expect.assertions(3);
     probeHDCPPolicy({ hdcp: "1.1" })
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.Unknown);
         expect(mockCreateMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockRequestMediaKeySystemAcces).toHaveBeenCalledTimes(1);
@@ -102,7 +102,7 @@ describe("MediaCapabilitiesProber probers - HDCPPolicy", () => {
 
     expect.assertions(3);
     probeHDCPPolicy({ hdcp: "1.1" })
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.Supported);
         expect(mockCreateMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockRequestMediaKeySystemAcces).toHaveBeenCalledTimes(1);
@@ -132,7 +132,7 @@ describe("MediaCapabilitiesProber probers - HDCPPolicy", () => {
 
     expect.assertions(3);
     probeHDCPPolicy({ hdcp: "1.1" })
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockCreateMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockRequestMediaKeySystemAcces).toHaveBeenCalledTimes(1);

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/decodingInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/decodingInfos.test.ts
@@ -21,6 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import PPromise from "../../../../../utils/promise";
 
@@ -31,6 +32,7 @@ import {
 } from "../../types";
 
 const origDecodingInfo = (navigator as any).mediaCapabilities;
+const origMediaCapabilities = (navigator as any).mediaCapabilities;
 
 /**
  * Stub decodingInfo API to resolve.
@@ -66,6 +68,9 @@ function resetDecodingInfos(): void {
 describe("MediaCapabilitiesProber probers - decodingInfo", () => {
   beforeEach(() => {
     jest.resetModules();
+  });
+  afterEach(() => {
+    (navigator as any).mediaCapabilities = origMediaCapabilities;
   });
 
   it("should throw if no video and audio config", (done) => {
@@ -179,14 +184,12 @@ describe("MediaCapabilitiesProber probers - decodingInfo", () => {
   });
 
   it("should throw if API mediaCapabilities not available", () => {
-    const origMediaCapabilities = (navigator as any).mediaCapabilities;
     delete (navigator as any).mediaCapabilities;
     /* eslint-disable @typescript-eslint/no-floating-promises */
     expect(probeDecodingInfos({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: MediaCapabilities API not available"
     );
     /* eslint-enable @typescript-eslint/no-floating-promises */
-    (navigator as any).mediaCapabilities = origMediaCapabilities;
   });
 
   it("should throw if API decodingInfo not available", () => {
@@ -200,11 +203,6 @@ describe("MediaCapabilitiesProber probers - decodingInfo", () => {
       "MediaCapabilitiesProber >>> API_CALL: Decoding Info not available"
     );
     /* eslint-enable @typescript-eslint/no-floating-promises */
-    if ((navigator as any).mediaCapabilities) {
-      (navigator as any).mediaCapabilities.decodingInfo = origDecodingInfo;
-    } else {
-      (navigator as any).mediaCapabilities = undefined;
-    }
   });
 
   it("should resolve with `Supported` if decodingInfo supports (video only)", (done) => {

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaContentType.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaContentType.test.ts
@@ -98,7 +98,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.Supported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -125,7 +125,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.Supported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -155,7 +155,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.Supported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -182,7 +182,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -209,7 +209,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -239,7 +239,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();
@@ -271,7 +271,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
 
     expect.assertions(2);
     probeMediaContentType(config)
-      .then(([res]: [any]) => {
+      .then(([res]: [unknown]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockIsTypeSupported).toHaveBeenCalledTimes(1);
         done();

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 
 import { ProberStatus } from "../../types";

--- a/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
@@ -115,7 +115,7 @@ const mediaCapabilitiesProber = {
   },
 
   /**
-   * From an array of given configurations (type  and key system configuration), return
+   * From an array of given configurations (type and key system configuration), return
    * supported ones.
    * @param {Array.<Object>} configurations
    * @returns {Promise}
@@ -126,7 +126,8 @@ const mediaCapabilitiesProber = {
       configuration: IMediaKeySystemConfiguration;
     }>
   ) : Promise<ICompatibleKeySystem[]> {
-    const promises: Array<Promise<any>> = [];
+    const promises: Array<Promise<{ globalStatus: ProberStatus;
+                                    result? : ICompatibleKeySystem; }>> = [];
     configurations.forEach((configuration) => {
       const globalConfig = {
         keySystem: configuration,
@@ -152,8 +153,15 @@ const mediaCapabilitiesProber = {
       );
     });
     return PPromise.all(promises)
-      .then((supportedConfigs) => {
-        return supportedConfigs
+      .then((configs) => {
+        // TODO I added those lines to work-around a type issue but does it
+        // really correspond to the original intent? I find it hard to
+        // understand and shouldn't we also rely on things like `globalStatus`
+        // here?
+        return configs
+          .filter((x) : x is { globalStatus : ProberStatus;
+                               result : ICompatibleKeySystem; } =>
+            x.result !== undefined)
           .map(({ result }: { result: ICompatibleKeySystem }) => result);
       });
   },

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/decodingInfo.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/decodingInfo.ts
@@ -36,8 +36,11 @@ function isMediaCapabilitiesAPIAvailable(): Promise<void> {
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "MediaCapabilities API not available");
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     if (!("decodingInfo" in (navigator as any).mediaCapabilities)) {
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "Decoding Info not available");
     }
@@ -78,8 +81,15 @@ export default function probeDecodingInfos(
       "Not enough arguments for calling mediaCapabilites.");
     }
 
-    // eslint-disable-next-line
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    /* eslint-disable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-disable @typescript-eslint/no-unsafe-return */
     return (navigator as any).mediaCapabilities.decodingInfo(config)
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    /* eslint-enable @typescript-eslint/no-unsafe-call */
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+    /* eslint-enable @typescript-eslint/no-unsafe-return */
       .then((result: IDecodingInfos) => {
         return [
           result.supported ? ProberStatus.Supported : ProberStatus.NotSupported,

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/mediaContentTypeWithFeatures/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/mediaContentTypeWithFeatures/index.ts
@@ -38,8 +38,11 @@ function isTypeSupportedWithFeaturesAPIAvailable(): Promise<void> {
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "MSMediaKeys API not available");
     }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     if (!("isTypeSupportedWithFeatures" in (window as any).MSMediaKeys)) {
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "isTypeSupportedWithFeatures not available");
     }
@@ -72,8 +75,10 @@ export default function probeTypeWithFeatures(
     /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
     /* eslint-disable @typescript-eslint/no-unsafe-call */
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     const result: ISupportWithFeatures =
       (window as any).MSMediaKeys.isTypeSupportedWithFeatures(type, features);
+    /* eslint-enable @typescript-eslint/no-explicit-any */
     /* eslint-enable @typescript-eslint/no-unsafe-assignment */
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
     /* eslint-enable @typescript-eslint/no-unsafe-call */

--- a/src/features/__tests__/initialize_features.test.ts
+++ b/src/features/__tests__/initialize_features.test.ts
@@ -27,8 +27,15 @@ describe("Features - initializeFeaturesObject", () => {
     jest.resetModules();
   });
 
+  /* eslint-disable @typescript-eslint/naming-convention */
+  const win = window as unknown as {
+    __FEATURES__: unknown;
+    __RELATIVE_PATH__ : unknown;
+  };
+  /* eslint-enable @typescript-eslint/naming-convention */
+
   it("should set no feature if nothing is enabled", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get() { return false; },
     });
     const feat = {};
@@ -37,14 +44,14 @@ describe("Features - initializeFeaturesObject", () => {
     const initializeFeaturesObject = require("../initialize_features").default;
     initializeFeaturesObject();
     expect<unknown>(feat).toEqual({});
-    delete (window as any).__FEATURES__;
+    delete win.__FEATURES__;
   });
 
   it("should set the right features when everything is enabled", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get() { return true; },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       EME_MANAGER: "../core/eme/index.ts",
       IMAGE_BUFFER: "../core/segment_buffers/implementations/image/index.ts",
       BIF_PARSER: "../parsers/images/bif.ts",
@@ -123,17 +130,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the html text buffer if the html vtt parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "HTML_VTT";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       HTML_TEXT_BUFFER: "../core/segment_buffers/implementations/text/html/index.ts",
       HTML_VTT: "../parsers/texttracks/webvtt/html/index.ts",
     };
@@ -155,17 +162,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the html text buffer if the html sami parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "HTML_SAMI";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       HTML_TEXT_BUFFER: "../core/segment_buffers/implementations/text/html/index.ts",
       HTML_SAMI: "../parsers/texttracks/sami/html",
     };
@@ -187,17 +194,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the html text buffer if the html ttml parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "HTML_TTML";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       HTML_TEXT_BUFFER: "../core/segment_buffers/implementations/text/html/index.ts",
       HTML_TTML: "../parsers/texttracks/ttml/html/index",
     };
@@ -219,17 +226,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the html text buffer if the html srt parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "HTML_SRT";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       HTML_TEXT_BUFFER: "../core/segment_buffers/implementations/text/html/index.ts",
       HTML_SRT: "../parsers/texttracks/srt/html",
     };
@@ -251,17 +258,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the native text buffer if the native vtt parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "NATIVE_VTT";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       NATIVE_TEXT_BUFFER: "../core/segment_buffers/implementations/text/native/index",
       NATIVE_VTT: "../parsers/texttracks/webvtt/native/index",
     };
@@ -283,17 +290,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the native text buffer if the native sami parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "NATIVE_SAMI";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       NATIVE_TEXT_BUFFER: "../core/segment_buffers/implementations/text/native/index.ts",
       NATIVE_SAMI: "../parsers/texttracks/sami/native",
     };
@@ -315,17 +322,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the native text buffer if the native ttml parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "NATIVE_TTML";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       NATIVE_TEXT_BUFFER: "../core/segment_buffers/implementations/text/native/index.ts",
       NATIVE_TTML: "../parsers/texttracks/ttml/native/index",
     };
@@ -347,17 +354,17 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 
   it("should add the native text buffer if the native srt parser is added", () => {
-    (window as any).__FEATURES__ = new Proxy({}, {
+    win.__FEATURES__ = new Proxy({}, {
       get(_target, prop) {
         return prop === "NATIVE_SRT";
       },
     });
-    (window as any).__RELATIVE_PATH__ = {
+    win.__RELATIVE_PATH__ = {
       NATIVE_TEXT_BUFFER: "../core/segment_buffers/implementations/text/native/index.ts",
       NATIVE_SRT: "../parsers/texttracks/srt/native",
     };
@@ -379,7 +386,7 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete (window as any).__FEATURES__;
-    delete (window as any).__RELATIVE_PATH__;
+    delete win.__FEATURES__;
+    delete win.__RELATIVE_PATH__;
   });
 });

--- a/src/features/list/__tests__/bif_parser.test.ts
+++ b/src/features/list/__tests__/bif_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/images/bif", () => ({
 
 describe("Features list - BIF Parser", () => {
   it("should add the BIF Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addBIFParserFeature(featureObject);
     expect(featureObject).toEqual({ imageParser: bifParser });

--- a/src/features/list/__tests__/dash.test.ts
+++ b/src/features/list/__tests__/dash.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../../transports/dash", () => ({
 
 describe("Features list - DASH", () => {
   it("should add DASH in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { transports: {},
                                   dashParsers: { js: null,
                                                  wasm: null } };

--- a/src/features/list/__tests__/directfile.test.ts
+++ b/src/features/list/__tests__/directfile.test.ts
@@ -28,6 +28,7 @@ jest.mock("../../../core/init/initialize_directfile", () => ({
 
 describe("Features list - Directfile", () => {
   it("should add Directfile in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addDirectfileFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/eme.test.ts
+++ b/src/features/list/__tests__/eme.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../core/eme", () => ({
 
 describe("Features list - EME", () => {
   it("should add EME in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addEMEFeature(featureObject);
     expect(featureObject).toEqual({ emeManager });

--- a/src/features/list/__tests__/html_sami_parser.test.ts
+++ b/src/features/list/__tests__/html_sami_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/sami/html", () => ({
 
 describe("Features list - HTML SAMI Parser", () => {
   it("should add an HTML SAMI Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { htmlTextTracksParsers: {} };
     addHTMLSAMIFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/html_srt_parser.test.ts
+++ b/src/features/list/__tests__/html_srt_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/srt/html", () => ({
 
 describe("Features list - HTML srt Parser", () => {
   it("should add an HTML srt Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { htmlTextTracksParsers: {} };
     addHTMLsrtFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/html_text_buffer.test.ts
+++ b/src/features/list/__tests__/html_text_buffer.test.ts
@@ -28,6 +28,7 @@ jest.mock("../../../core/segment_buffers/implementations/text/html", () => ({
 
 describe("Features list - HTML Text Buffer", () => {
   it("should add an HTML Text Buffer in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addHTMLTextBuffer(featureObject);
     expect(featureObject).toEqual({ htmlTextTracksBuffer });

--- a/src/features/list/__tests__/html_ttml_parser.test.ts
+++ b/src/features/list/__tests__/html_ttml_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/ttml/html", () => ({
 
 describe("Features list - HTML ttml Parser", () => {
   it("should add an HTML ttml Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { htmlTextTracksParsers: {} };
     addHTMLttmlFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/html_vtt_parser.test.ts
+++ b/src/features/list/__tests__/html_vtt_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/webvtt/html", () => ({
 
 describe("Features list - HTML VTT Parser", () => {
   it("should add an HTML VTT Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { htmlTextTracksParsers: {} };
     addHTMLVTTFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/image_buffer.test.ts
+++ b/src/features/list/__tests__/image_buffer.test.ts
@@ -25,6 +25,7 @@ describe("Features list - HTML Text Buffer", () => {
   });
 
   it("should add an Image Buffer in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addImageBufferFeature(featureObject);
     expect(featureObject).toEqual({ imageBuffer });

--- a/src/features/list/__tests__/native_sami_parser.test.ts
+++ b/src/features/list/__tests__/native_sami_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/sami/native", () => ({
 
 describe("Features list - native SAMI Parser", () => {
   it("should add an native SAMI Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { nativeTextTracksParsers: {} };
     addNativeSAMIFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/native_srt_parser.test.ts
+++ b/src/features/list/__tests__/native_srt_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/srt/native", () => ({
 
 describe("Features list - native srt Parser", () => {
   it("should add an native srt Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { nativeTextTracksParsers: {} };
     addNativesrtFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/native_text_buffer.test.ts
+++ b/src/features/list/__tests__/native_text_buffer.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../../core/segment_buffers/implementations/text/native", () => ({
 
 describe("Features list - native Text Buffer", () => {
   it("should add an native Text Buffer in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = {};
     addNativeTextBuffer(featureObject);
     expect(featureObject).toEqual({ nativeTextTracksBuffer });

--- a/src/features/list/__tests__/native_ttml_parser.test.ts
+++ b/src/features/list/__tests__/native_ttml_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/ttml/native", () => ({
 
 describe("Features list - native ttml Parser", () => {
   it("should add an native ttml Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { nativeTextTracksParsers: {} };
     addNativettmlFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/native_vtt_parser.test.ts
+++ b/src/features/list/__tests__/native_vtt_parser.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../parsers/texttracks/webvtt/native", () => ({
 
 describe("Features list - native vtt Parser", () => {
   it("should add an native vtt Parser in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { nativeTextTracksParsers: {} };
     addNativevttFeature(featureObject);
     expect(featureObject).toEqual({

--- a/src/features/list/__tests__/smooth.test.ts
+++ b/src/features/list/__tests__/smooth.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../../transports/smooth", () => ({
 
 describe("Features list - Smooth", () => {
   it("should add Smooth in the current features", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const featureObject : any = { transports: {} };
     addSmoothFeature(featureObject);
     expect(featureObject).toEqual({ transports: { smooth: SmoothFeature } });

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -48,11 +48,11 @@ export type IEMEManager = (mediaElement : HTMLMediaElement,
 
 export type IHTMLTextTracksBuffer =
   new(mediaElement : HTMLMediaElement,
-      textTrackElement : HTMLElement) => SegmentBuffer<unknown>;
+      textTrackElement : HTMLElement) => SegmentBuffer;
 
 export type INativeTextTracksBuffer =
   new(mediaElement : HTMLMediaElement,
-      hideNativeSubtitle : boolean) => SegmentBuffer<unknown>;
+      hideNativeSubtitle : boolean) => SegmentBuffer;
 
 export type IMediaElementTrackChoiceManager = typeof MediaElementTrackChoiceManager;
 
@@ -60,14 +60,6 @@ interface IBifThumbnail { index : number;
                           duration : number;
                           ts : number;
                           data : Uint8Array; }
-
-interface IImageTrackSegmentData {
-  data : IBifThumbnail[]; // image track data, in the given type
-  end : number; // end time time until which the segment apply
-  start : number; // start time from which the segment apply
-  timescale : number; // timescale to convert the start and end into seconds
-  type : string; // the type of the data (example: "bif")
-}
 
 interface IBifObject { fileFormat : string;
                        version : string;
@@ -81,7 +73,7 @@ interface IBifObject { fileFormat : string;
                        thumbs : IBifThumbnail[]; }
 
 export type IImageBuffer =
-  new() => SegmentBuffer<IImageTrackSegmentData>;
+  new() => SegmentBuffer;
 
 export type IImageParser =
   ((buffer : Uint8Array) => IBifObject);

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -379,22 +379,22 @@ describe("Manifest - Manifest", () => {
     const newAdaptations = {};
     const newPeriod1 = { id: "foo0", start: 4, adaptations: {} };
     const newPeriod2 = { id: "foo1", start: 12, adaptations: {} };
-    const newManifest : any = { adaptations: newAdaptations,
-                                availabilityStartTime: 6,
-                                id: "man2",
-                                isDynamic: true,
-                                isLive: true,
-                                lifetime: 14,
-                                contentWarnings: [new Error("c"), new Error("d")],
-                                suggestedPresentationDelay: 100,
-                                timeShiftBufferDepth: 3,
-                                _timeBounds: { absoluteMinimumTime: 7,
-                                               timeshiftDepth: 5,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 40,
-                                                                  time: 30000 } },
-                                periods: [newPeriod1, newPeriod2],
-                                uris: ["url3", "url4"] };
+    const newManifest = { adaptations: newAdaptations,
+                          availabilityStartTime: 6,
+                          id: "man2",
+                          isDynamic: true,
+                          isLive: true,
+                          lifetime: 14,
+                          contentWarnings: [new Error("c"), new Error("d")],
+                          suggestedPresentationDelay: 100,
+                          timeShiftBufferDepth: 3,
+                          _timeBounds: { absoluteMinimumTime: 7,
+                                         timeshiftDepth: 5,
+                                         maximumTimeData: { isLinear: false,
+                                                            value: 40,
+                                                            time: 30000 } },
+                          periods: [newPeriod1, newPeriod2],
+                          uris: ["url3", "url4"] };
 
     manifest.replace(newManifest);
     expect(manifest.adaptations).toEqual(newAdaptations);
@@ -499,7 +499,7 @@ describe("Manifest - Manifest", () => {
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
-    manifest.replace(newManifest as any);
+    manifest.replace(newManifest);
 
     expect(manifest.periods).toEqual([newPeriod1, newPeriod2, newPeriod3]);
 
@@ -552,7 +552,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const Manifest = require("../manifest").default;
-    const manifest = new Manifest(oldManifestArgs as any, {});
+    const manifest = new Manifest(oldManifestArgs, {});
     const [oldPeriod1] = manifest.periods;
 
     const eeSpy = jest.spyOn(manifest, "trigger").mockImplementation(jest.fn());
@@ -576,7 +576,7 @@ describe("Manifest - Manifest", () => {
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
-    manifest.replace(newManifest as any);
+    manifest.replace(newManifest);
 
     expect(manifest.periods).toEqual([newPeriod1, newPeriod2, newPeriod3]);
 
@@ -627,7 +627,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const Manifest = require("../manifest").default;
-    const manifest = new Manifest(oldManifestArgs as any, {});
+    const manifest = new Manifest(oldManifestArgs, {});
 
     const eeSpy = jest.spyOn(manifest, "trigger").mockImplementation(jest.fn());
 
@@ -650,7 +650,7 @@ describe("Manifest - Manifest", () => {
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
-    manifest.replace(newManifest as any);
+    manifest.replace(newManifest);
 
     expect(manifest.periods).toEqual([newPeriod1, newPeriod2, newPeriod3]);
 
@@ -701,7 +701,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const Manifest = require("../manifest").default;
-    const manifest = new Manifest(oldManifestArgs as any, {});
+    const manifest = new Manifest(oldManifestArgs, {});
     const [oldPeriod1, oldPeriod2] = manifest.periods;
 
     const eeSpy = jest.spyOn(manifest, "trigger").mockImplementation(jest.fn());
@@ -731,7 +731,7 @@ describe("Manifest - Manifest", () => {
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
-    manifest.replace(newManifest as any);
+    manifest.replace(newManifest);
 
     expect(manifest.periods).toEqual([ newPeriod1,
                                        newPeriod2,

--- a/src/manifest/__tests__/period.test.ts
+++ b/src/manifest/__tests__/period.test.ts
@@ -74,7 +74,7 @@ describe("Manifest - Period", () => {
     let period = null;
     let errorReceived = null;
     try {
-      period = new Period(args as any);
+      period = new Period(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -155,7 +155,7 @@ describe("Manifest - Period", () => {
     let period = null;
     let errorReceived = null;
     try {
-      period = new Period(args as any);
+      period = new Period(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -204,7 +204,7 @@ describe("Manifest - Period", () => {
     let period = null;
     let errorReceived = null;
     try {
-      period = new Period(args as any);
+      period = new Period(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -253,7 +253,7 @@ describe("Manifest - Period", () => {
     let period = null;
     let errorReceived = null;
     try {
-      period = new Period(args as any);
+      period = new Period(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -302,7 +302,7 @@ describe("Manifest - Period", () => {
     let period = null;
     let errorReceived = null;
     try {
-      period = new Period(args as any);
+      period = new Period(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -338,7 +338,7 @@ describe("Manifest - Period", () => {
                         representations: [{}] };
     const video2 = [videoAda2];
     const args = { id: "12", adaptations: { video, video2 }, start: 0 };
-    const period = new Period(args as any);
+    const period = new Period(args);
     expect(period.contentWarnings).toHaveLength(1);
 
     expect(adaptationSpy).toHaveBeenCalledTimes(2);
@@ -370,7 +370,7 @@ describe("Manifest - Period", () => {
     const video = [videoAda1];
     const bar = undefined;
     const args = { id: "12", adaptations: { bar, video }, start: 0 };
-    const period = new Period(args as any);
+    const period = new Period(args);
     expect(period.adaptations).toEqual({
       video: video.map(v => ({ ...v, contentWarnings: [] })),
     });
@@ -400,7 +400,7 @@ describe("Manifest - Period", () => {
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0 };
-    const period = new Period(args as any, representationFilter);
+    const period = new Period(args, representationFilter);
 
     expect(period.contentWarnings).toHaveLength(0);
     expect(period.adaptations.video).toHaveLength(2);
@@ -435,7 +435,7 @@ describe("Manifest - Period", () => {
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args as any);
+    const period = new Period(args);
 
     expect(period.contentWarnings).toHaveLength(2);
     const error = period.contentWarnings[0];
@@ -471,7 +471,7 @@ describe("Manifest - Period", () => {
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args as any);
+    const period = new Period(args);
 
     expect(period.contentWarnings).toHaveLength(0);
   });
@@ -495,7 +495,7 @@ describe("Manifest - Period", () => {
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 72 };
-    const period = new Period(args as any);
+    const period = new Period(args);
     expect(period.start).toEqual(72);
     expect(period.duration).toEqual(undefined);
     expect(period.end).toEqual(undefined);
@@ -520,7 +520,7 @@ describe("Manifest - Period", () => {
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0, duration: 12 };
-    const period = new Period(args as any);
+    const period = new Period(args);
     expect(period.start).toEqual(0);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(12);
@@ -545,7 +545,7 @@ describe("Manifest - Period", () => {
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 50, duration: 12 };
-    const period = new Period(args as any);
+    const period = new Period(args);
     expect(period.start).toEqual(50);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(62);
@@ -577,7 +577,7 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args as any);
+    const period = new Period(args);
 
     expect(period.getAdaptations()).toHaveLength(3);
     expect(period.getAdaptations()).toContain(period.adaptations.video[0]);
@@ -613,7 +613,7 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args as any);
+    const period = new Period(args);
 
     expect(period.getAdaptationsForType("video")).toHaveLength(2);
     expect(period.getAdaptationsForType("video"))
@@ -660,7 +660,7 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args as any);
+    const period = new Period(args);
 
     expect(period.getAdaptation("54")).toEqual(period.adaptations.video[0]);
     expect(period.getAdaptation("55")).toEqual(period.adaptations.video[1]);

--- a/src/manifest/__tests__/update_period_in_place.test.ts
+++ b/src/manifest/__tests__/update_period_in_place.test.ts
@@ -15,8 +15,11 @@
  */
 
 import log from "../../log";
+import type Period from "../period";
 import { MANIFEST_UPDATE_TYPE } from "../types";
 import updatePeriodInPlace from "../update_period_in_place";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const oldVideoRepresentation1 = { contentWarnings: [],
                                   id: "rep-video-1",
@@ -206,7 +209,9 @@ describe("Manifest - updatePeriodInPlace", () => {
     const newPeriodAdaptationsSpy = jest.spyOn(newPeriod, "getAdaptations");
     const logSpy = jest.spyOn(log, "warn");
 
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Full);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Full);
 
     expect(oldPeriod.start).toEqual(500);
     expect(oldPeriod.end).toEqual(520);
@@ -317,7 +322,9 @@ describe("Manifest - updatePeriodInPlace", () => {
     const newPeriodAdaptationsSpy = jest.spyOn(newPeriod, "getAdaptations");
     const logSpy = jest.spyOn(log, "warn");
 
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Partial);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Partial);
 
     expect(oldPeriod.start).toEqual(500);
     expect(oldPeriod.end).toEqual(520);
@@ -417,10 +424,14 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Full);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldPeriod.adaptations.video).toHaveLength(1);
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Partial);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldPeriod.adaptations.video).toHaveLength(1);
     logSpy.mockRestore();
@@ -472,14 +483,18 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Full);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
       "Manifest: Adaptation \"ada-video-2\" not found when merging."
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     logSpy.mockClear();
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Partial);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
       "Manifest: Adaptation \"ada-video-2\" not found when merging."
@@ -524,10 +539,14 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Full);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Partial);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
     logSpy.mockRestore();
@@ -568,14 +587,18 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Full);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
       "Manifest: Representation \"rep-video-2\" not found when merging."
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(2);
     logSpy.mockClear();
-    updatePeriodInPlace(oldPeriod as any, newPeriod as any, MANIFEST_UPDATE_TYPE.Partial);
+    updatePeriodInPlace(oldPeriod as unknown as Period,
+                        newPeriod as unknown as Period,
+                        MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
       "Manifest: Representation \"rep-video-2\" not found when merging."

--- a/src/manifest/__tests__/update_periods.test.ts
+++ b/src/manifest/__tests__/update_periods.test.ts
@@ -20,6 +20,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 const MANIFEST_UPDATE_TYPE = {
   Full: 0,

--- a/src/parsers/manifest/dash/common/__tests__/attach_trickmode_track.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/attach_trickmode_track.test.ts
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
+import type {
+  IParsedAdaptations,
+  IParsedAdaptation,
+} from "../../../types";
 import attachTrickModeTrack from "../attach_trickmode_track";
 
 describe("attachTrickModeTrack", () => {
   it("should correclty attach trickmode tracks", () => {
-    /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     const trickModeTracks = [
       { adaptation: { type: "video" }, trickModeAttachedAdaptationIds: ["1", "3"] },
       { adaptation: { type: "audio" }, trickModeAttachedAdaptationIds: ["1"] },
-    ] as any;
+    ] as Array<{ adaptation : IParsedAdaptation;
+                 trickModeAttachedAdaptationIds : string[]; }>;
 
     const adaptations = {
       video: [
@@ -36,8 +40,7 @@ describe("attachTrickModeTrack", () => {
         { id: "2", trickModeTracks: undefined },
         { id: "3", trickModeTracks: undefined },
       ],
-    } as any;
-    /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+    } as unknown as IParsedAdaptations;
 
     attachTrickModeTrack(adaptations, trickModeTracks);
 

--- a/src/parsers/manifest/dash/common/__tests__/get_periods_time_infos.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/get_periods_time_infos.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+import type { IPeriodIntermediateRepresentation } from "../../node_parser_types";
+import type { IParsedPeriodsContext } from "../get_periods_time_infos";
+// https://github.com/typescript-eslint/typescript-eslint/issues/2315
+/* eslint-disable no-duplicate-imports */
 import getPeriodsTimeInformation from "../get_periods_time_infos";
+/* eslint-enable no-duplicate-imports */
 
 describe("DASH Parser - getPeriodsTimeInformation", () => {
   it("should guess duration and end from next period.", () => {
@@ -22,7 +27,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       { attributes: { start: 0 } },
       { attributes: { start: 10 } },
     ];
-    const timeInfos = getPeriodsTimeInformation(periodsInfos as any, {} as any);
+    const timeInfos = getPeriodsTimeInformation(
+      periodsInfos as IPeriodIntermediateRepresentation[],
+      {} as IParsedPeriodsContext
+    );
     expect(timeInfos[0].periodDuration).toBe(10);
     expect(timeInfos[0].periodEnd).toBe(10);
     expect(timeInfos[1].periodDuration).toBe(undefined);
@@ -34,7 +42,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       { attributes: { start: 0, duration: 10 } },
       { attributes: { duration: 10 } },
     ];
-    const timeInfos = getPeriodsTimeInformation(periodsInfos as any, {} as any);
+    const timeInfos = getPeriodsTimeInformation(
+      periodsInfos as IPeriodIntermediateRepresentation[],
+      {} as IParsedPeriodsContext
+    );
     expect(timeInfos[0].periodEnd).toBe(10);
     expect(timeInfos[1].periodStart).toBe(10);
     expect(timeInfos[1].periodEnd).toBe(20);
@@ -45,7 +56,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       { attributes: { start: 0, duration: 5 } },
       { attributes: { start: 5, duration: 10 } },
     ];
-    const timeInfos = getPeriodsTimeInformation(periodsInfos as any, {} as any);
+    const timeInfos = getPeriodsTimeInformation(
+      periodsInfos as IPeriodIntermediateRepresentation[],
+      {} as IParsedPeriodsContext
+    );
     expect(timeInfos[0].periodStart).toEqual(periodsInfos[0].attributes.start);
     expect(timeInfos[0].periodDuration).toEqual(periodsInfos[0].attributes.duration);
     expect(timeInfos[1].periodStart).toEqual(periodsInfos[1].attributes.start);
@@ -60,7 +74,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       duration: 20,
     };
     const timeInfos =
-      getPeriodsTimeInformation(periodsInfos as any, manifestInfos as any);
+      getPeriodsTimeInformation(
+        periodsInfos as IPeriodIntermediateRepresentation[],
+        manifestInfos as IParsedPeriodsContext
+      );
     expect(timeInfos[0].periodDuration).toEqual(manifestInfos.duration);
   });
 
@@ -73,7 +90,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       availabilityStartTime: 500,
     };
     const timeInfos =
-      getPeriodsTimeInformation(periodsInfos as any, manifestInfos as any);
+      getPeriodsTimeInformation(
+        periodsInfos as IPeriodIntermediateRepresentation[],
+        manifestInfos as IParsedPeriodsContext
+      );
     expect(timeInfos[0].periodStart).toBe(500);
     expect(timeInfos[0].periodDuration).toBe(10);
     expect(timeInfos[0].periodEnd).toBe(510);
@@ -87,7 +107,10 @@ describe("DASH Parser - getPeriodsTimeInformation", () => {
       isDynamic: false,
     };
     const timeInfos =
-      getPeriodsTimeInformation(periodsInfos as any, manifestInfos as any);
+      getPeriodsTimeInformation(
+        periodsInfos as IPeriodIntermediateRepresentation[],
+        manifestInfos as IParsedPeriodsContext
+      );
     expect(timeInfos[0].periodStart).toBe(0);
     expect(timeInfos[0].periodDuration).toBe(10);
     expect(timeInfos[0].periodEnd).toBe(10);

--- a/src/parsers/manifest/dash/js-parser/__tests__/parse_from_document.test.ts
+++ b/src/parsers/manifest/dash/js-parser/__tests__/parse_from_document.test.ts
@@ -34,7 +34,7 @@ describe("parseFromDocument", () => {
       });
     }).toThrow("document root should be MPD");
     expect(function() {
-      const prevManifest = {} as any as Manifest;
+      const prevManifest = {} as unknown as Manifest;
       parseFromDocument(doc, {
         url: "",
         aggressiveMode: false,

--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -191,11 +191,7 @@ export default class DashWasmParser {
         this._instance = instanceWasm;
 
         // TODO better types?
-        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-        /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-        this._linearMemory = (this._instance.instance.exports as any).memory;
-        /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+        this._linearMemory = this._instance.instance.exports.memory as WebAssembly.Memory;
 
         this.status = "initialized";
       }).catch((err : Error) => {
@@ -350,11 +346,7 @@ export default class DashWasmParser {
 
     try {
       // TODO better type this
-      /* eslint-disable @typescript-eslint/no-unsafe-call */
-      /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-      (this._instance.instance.exports as any).parse();
-      /* eslint-enable @typescript-eslint/no-unsafe-call */
-      /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+      (this._instance.instance.exports.parse as () => void)();
     } catch (err) {
       this._parsersStack.reset();
       this._warnings = [];
@@ -399,11 +391,7 @@ export default class DashWasmParser {
 
     try {
       // TODO better type this
-      /* eslint-disable @typescript-eslint/no-unsafe-call */
-      /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-      (this._instance.instance.exports as any).parse_xlink();
-      /* eslint-enable @typescript-eslint/no-unsafe-call */
-      /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+      (this._instance.instance.exports.parse_xlink as () => void)();
     } catch (err) {
       this._parsersStack.reset();
       this._warnings = [];

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -25,6 +25,7 @@ import {
   IParsedAdaptations,
   IParsedManifest,
   IParsedPeriod,
+  IParsedRepresentation,
 } from "../types";
 import MetaRepresentationIndex from "./representation_index";
 
@@ -194,7 +195,7 @@ function createManifest(
           for (let iAda = 0; iAda < currentAdaptations.length; iAda++) {
             const currentAdaptation = currentAdaptations[iAda];
 
-            const representations : any[] = [];
+            const representations : IParsedRepresentation[] = [];
             for (let iRep = 0; iRep < currentAdaptation.representations.length; iRep++) {
               const currentRepresentation = currentAdaptation.representations[iRep];
 

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -89,7 +89,7 @@ export interface IParsedRepresentation {
    * Representation but which should be different than any other Representation
    * in the same Adaptation.
    */
-  id: string;
+  id: string | number;
 
   /** Codec(s) associated with this Representation. */
   codecs?: string;

--- a/src/parsers/manifest/utils/check_manifest_ids.ts
+++ b/src/parsers/manifest/utils/check_manifest_ids.ts
@@ -63,13 +63,13 @@ export default function checkManifestIDs(
         } else {
           adaptationIDs.push(adaptationID);
         }
-        const representationIDs : string[] = [];
+        const representationIDs : Array<number|string> = [];
         adaptation.representations.forEach(representation => {
           const representationID = representation.id;
           if (arrayIncludes(representationIDs, representationID)) {
             log.warn("Two representations with the same ID found. Updating.",
                      representationID);
-            const newID =  representationID + "-dup";
+            const newID = `${representationID}-dup`;
             representation.id = newID;
             checkManifestIDs(manifest);
             representationIDs.push(newID);

--- a/src/parsers/texttracks/srt/html.ts
+++ b/src/parsers/texttracks/srt/html.ts
@@ -151,18 +151,12 @@ function generateSpansFromSRTText(text : string) : HTMLElement {
         const spanChild = _loop(currentNode);
         spanChild.style.textDecoration = "underline";
         span.appendChild(spanChild);
-      } else if (
-        currentNode.nodeName === "FONT" &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        (currentNode as any).color != null
-      ) {
+      } else if (isNodeFontWithColorProp(currentNode) &&
+                 typeof currentNode.color === "string")
+      {
         // TODO loop through attributes to find color?
-        /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-        /* eslint-disable @typescript-eslint/no-unsafe-member-access */
         const spanChild = _loop(currentNode);
-        spanChild.style.color = (currentNode as any).color;
-        /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-        /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+        spanChild.style.color = currentNode.color;
         span.appendChild(spanChild);
       } else {
         const spanChild = _loop(currentNode);
@@ -173,4 +167,16 @@ function generateSpansFromSRTText(text : string) : HTMLElement {
   };
 
   return _loop(secureDiv);
+}
+
+/**
+ * Returns `true` if the given node is a `<font>` element which contains a
+ * `color` attribute.
+ * @param {Node} node
+ * @returns {boolean}
+ */
+function isNodeFontWithColorProp(
+  node : Node
+) : node is Node & { color : unknown } {
+  return node.nodeName === "FONT" && "color" in node;
 }

--- a/src/parsers/texttracks/webvtt/html/__tests__/convert_payload_to_html.test.ts
+++ b/src/parsers/texttracks/webvtt/html/__tests__/convert_payload_to_html.test.ts
@@ -26,6 +26,9 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     jest.resetModules();
   });
 
+  const win = window as {
+    DOMParser : unknown;
+  };
   it("should return empty payload when input text is empty", () => {
     const spyParseFromString = jest.fn(() => {
       return {
@@ -35,8 +38,8 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
       };
     });
 
-    const origDOMParser = (window as any).DOMParser;
-    (window as any).DOMParser = class MockDOMParser {
+    const origDOMParser = win.DOMParser;
+    win.DOMParser = class MockDOMParser {
       constructor() {
         // Useless constructor in mock
       }
@@ -55,7 +58,7 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     expect(convertPayloadToHTML("", {})).toEqual([]);
     expect(spyParseFromString).toHaveBeenCalledTimes(1);
     expect(spy).not.toHaveBeenCalled();
-    (window as any).DOMParser = origDOMParser;
+    win.DOMParser = origDOMParser;
   });
 
   it("should convert normal input text with no style", () => {
@@ -84,8 +87,8 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
       default: spyCreateStyledElement,
     }));
 
-    const origDOMParser = (window as any).DOMParser;
-    (window as any).DOMParser = class MockDOMParser {
+    const origDOMParser = win.DOMParser;
+    win.DOMParser = class MockDOMParser {
       constructor() {
         // Useless constructor in mock
       }
@@ -98,6 +101,6 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     expect(convertPayloadToHTML(innerText, {})).toEqual([bNode, span]);
     expect(spyParseFromString).toHaveBeenCalledTimes(1);
     expect(spyCreateStyledElement).toHaveBeenCalledTimes(2);
-    (window as any).DOMParser = origDOMParser;
+    win.DOMParser = origDOMParser;
   });
 });

--- a/src/transports/utils/__tests__/check_isobmff_integrity.test.ts
+++ b/src/transports/utils/__tests__/check_isobmff_integrity.test.ts
@@ -64,10 +64,10 @@ describe("transports utils - checkISOBMFFIntegrity", () => {
       error = e;
     }
     expect(error).toBeInstanceOf(OtherError);
-    expect((error as any).name).toEqual("OtherError");
-    expect((error as any).type).toEqual("OTHER_ERROR");
-    expect((error as any).code).toEqual("INTEGRITY_ERROR");
-    expect((error as any).message)
+    expect((error as typeof OtherError).name).toEqual("OtherError");
+    expect((error as typeof OtherError).type).toEqual("OTHER_ERROR");
+    expect((error as typeof OtherError).code).toEqual("INTEGRITY_ERROR");
+    expect((error as typeof OtherError).message)
       .toEqual("OtherError (INTEGRITY_ERROR) Incomplete `ftyp` box");
   });
 
@@ -85,10 +85,10 @@ describe("transports utils - checkISOBMFFIntegrity", () => {
       error = e;
     }
     expect(error).toBeInstanceOf(OtherError);
-    expect((error as any).name).toEqual("OtherError");
-    expect((error as any).type).toEqual("OTHER_ERROR");
-    expect((error as any).code).toEqual("INTEGRITY_ERROR");
-    expect((error as any).message)
+    expect((error as typeof OtherError).name).toEqual("OtherError");
+    expect((error as typeof OtherError).type).toEqual("OTHER_ERROR");
+    expect((error as typeof OtherError).code).toEqual("INTEGRITY_ERROR");
+    expect((error as typeof OtherError).message)
       .toEqual("OtherError (INTEGRITY_ERROR) Incomplete `moov` box");
   });
 
@@ -108,10 +108,10 @@ describe("transports utils - checkISOBMFFIntegrity", () => {
       error = e;
     }
     expect(error).toBeInstanceOf(OtherError);
-    expect((error as any).name).toEqual("OtherError");
-    expect((error as any).type).toEqual("OTHER_ERROR");
-    expect((error as any).code).toEqual("INTEGRITY_ERROR");
-    expect((error as any).message)
+    expect((error as typeof OtherError).name).toEqual("OtherError");
+    expect((error as typeof OtherError).type).toEqual("OTHER_ERROR");
+    expect((error as typeof OtherError).code).toEqual("INTEGRITY_ERROR");
+    expect((error as typeof OtherError).message)
       .toEqual("OtherError (INTEGRITY_ERROR) Incomplete `moof` box");
   });
 
@@ -131,10 +131,10 @@ describe("transports utils - checkISOBMFFIntegrity", () => {
       error = e;
     }
     expect(error).toBeInstanceOf(OtherError);
-    expect((error as any).name).toEqual("OtherError");
-    expect((error as any).type).toEqual("OTHER_ERROR");
-    expect((error as any).code).toEqual("INTEGRITY_ERROR");
-    expect((error as any).message)
+    expect((error as typeof OtherError).name).toEqual("OtherError");
+    expect((error as typeof OtherError).type).toEqual("OTHER_ERROR");
+    expect((error as typeof OtherError).code).toEqual("INTEGRITY_ERROR");
+    expect((error as typeof OtherError).message)
       .toEqual("OtherError (INTEGRITY_ERROR) Incomplete `mdat` box");
   });
 });

--- a/src/transports/utils/__tests__/infer_segment_container.test.ts
+++ b/src/transports/utils/__tests__/infer_segment_container.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { Representation } from "../../../manifest";
 import inferSegmentContainer from "../infer_segment_container";
 
 describe("Transport utils - inferSegmentContainer", () => {
@@ -22,25 +23,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as any))
+                                   mimeType: "audio/mp4" } as Representation))
       .toEqual("mp4");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as any))
+                                   mimeType: "video/mp4" } as Representation))
       .toEqual("mp4");
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as any))
+                                   mimeType: "video/mp4" } as Representation))
       .toEqual("mp4");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as any))
+                                   mimeType: "audio/mp4" } as Representation))
       .toEqual("mp4");
   });
 
@@ -51,25 +52,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as any))
+                                   mimeType: "audio/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as any))
+                                   mimeType: "video/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as any))
+                                   mimeType: "video/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as any))
+                                   mimeType: "audio/mp4" } as Representation))
       .toEqual(undefined);
   });
 
@@ -80,25 +81,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as any))
+                                   mimeType: "audio/webm" } as Representation))
       .toEqual("webm");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as any))
+                                   mimeType: "video/webm" } as Representation))
       .toEqual("webm");
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as any))
+                                   mimeType: "video/webm" } as Representation))
       .toEqual("webm");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as any))
+                                   mimeType: "audio/webm" } as Representation))
       .toEqual("webm");
   });
 
@@ -109,25 +110,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as any))
+                                   mimeType: "audio/webm" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as any))
+                                   mimeType: "video/webm" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as any))
+                                   mimeType: "video/webm" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as any))
+                                   mimeType: "audio/webm" } as Representation))
       .toEqual(undefined);
   });
 
@@ -138,47 +139,47 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as any))
+                                   mimeType: "application/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as any))
+                                   mimeType: "application/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as any))
+                                   mimeType: "" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as any))
+                                   mimeType: "" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "foo" } as any))
+                                   mimeType: "foo" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "bar" } as any))
+                                   mimeType: "bar" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as any))
+                                   index: {} } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as any))
+                                   index: {} } as Representation))
       .toEqual(undefined);
   });
 
@@ -187,7 +188,7 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as any))
+                                   mimeType: "application/mp4" } as Representation))
       .toEqual("mp4");
   });
 
@@ -197,30 +198,30 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "text/mp4" } as any))
+                                   mimeType: "text/mp4" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "text/plain" } as any))
+                                   mimeType: "text/plain" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as any))
+                                   mimeType: "" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "foo" } as any))
+                                   mimeType: "foo" } as Representation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as any))
+                                   index: {} } as Representation))
       .toEqual(undefined);
   });
 });

--- a/src/utils/__tests__/array_find.test.ts
+++ b/src/utils/__tests__/array_find.test.ts
@@ -23,16 +23,16 @@
 import arrayFind from "../array_find";
 
 /* eslint-disable @typescript-eslint/unbound-method */
-const initialArrayFind = (Array.prototype as any).find;
+const initialArrayFind = (Array.prototype as { find : unknown }).find;
 /* eslint-enable @typescript-eslint/unbound-method */
 
 describe("utils - arrayFind", () => {
   beforeEach(() => {
-    (Array.prototype as any).find = undefined;
+    (Array.prototype as { find : unknown }).find = undefined;
   });
 
   afterEach(() => {
-    (Array.prototype as any).find = initialArrayFind;
+    (Array.prototype as { find : unknown }).find = initialArrayFind;
   });
 
   it("should return undefined for an empty array", () => {
@@ -83,12 +83,12 @@ describe("utils - arrayFind", () => {
 
   if (typeof initialArrayFind === "function") {
     it("should call the original array.find function if it exists", () => {
-      (Array.prototype as any).find = initialArrayFind;
+      (Array.prototype as { find : unknown }).find = initialArrayFind;
       const obj1 = {};
       const obj2 = {};
       const context = {};
       const arr = [obj2, obj1, obj2, obj1];
-      const spy = jest.spyOn(arr as any, "find");
+      const spy = jest.spyOn(arr as unknown as { find : () => unknown }, "find");
 
       let currentIndex = 0;
       const predicate = function(

--- a/src/utils/__tests__/array_find_index.test.ts
+++ b/src/utils/__tests__/array_find_index.test.ts
@@ -23,16 +23,16 @@
 import arrayFindIndex from "../array_find_index";
 
 /* eslint-disable @typescript-eslint/unbound-method */
-const initialArrayFindIndex = (Array.prototype as any).findIndex;
+const initialArrayFindIndex = (Array.prototype as { findIndex : unknown }).findIndex;
 /* eslint-enable @typescript-eslint/unbound-method */
 
 describe("utils - arrayFindIndex", () => {
   beforeEach(() => {
-    (Array.prototype as any).findIndex = undefined;
+    (Array.prototype as { findIndex : unknown }).findIndex = undefined;
   });
 
   afterEach(() => {
-    (Array.prototype as any).findIndex = initialArrayFindIndex;
+    (Array.prototype as { findIndex : unknown }).findIndex = initialArrayFindIndex;
   });
 
   it("should return -1 for an empty array", () => {
@@ -83,12 +83,13 @@ describe("utils - arrayFindIndex", () => {
 
   if (typeof initialArrayFindIndex === "function") {
     it("should call the original array.findIndex function if it exists", () => {
-      (Array.prototype as any).findIndex = initialArrayFindIndex;
+      (Array.prototype as { findIndex : unknown }).findIndex = initialArrayFindIndex;
       const obj1 = {};
       const obj2 = {};
       const context = {};
       const arr = [obj2, obj1, obj2, obj1];
-      const spy = jest.spyOn(arr as any, "findIndex");
+      const spy = jest
+        .spyOn(arr as unknown as { findIndex : () => unknown }, "findIndex");
 
       let currentIndex = 0;
       const predicate = function(

--- a/src/utils/__tests__/array_includes.test.ts
+++ b/src/utils/__tests__/array_includes.test.ts
@@ -24,6 +24,7 @@ const initialArrayIncludes = Array.prototype.includes;
 /* eslint-enable @typescript-eslint/unbound-method */
 describe("utils - array-includes", () => {
   beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Array.prototype as any).includes = undefined;
   });
 

--- a/src/utils/__tests__/assert.test.ts
+++ b/src/utils/__tests__/assert.test.ts
@@ -206,6 +206,7 @@ describe("utils - assertInterface", () => {
       e: true,
     };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (Object.prototype as any).f = "number";
 
     const objIface = {

--- a/src/utils/__tests__/flat_map.test.ts
+++ b/src/utils/__tests__/flat_map.test.ts
@@ -19,20 +19,27 @@
 
 import flatMap from "../flat_map";
 
+const proto = Array.prototype as unknown as {
+  flatMap?<U, This = undefined>(
+    callback: (this: This, value: unknown, index: number, array: unknown[]) => U | U[],
+    thisArg?: This
+  ): U[];
+};
+
 /* eslint-disable @typescript-eslint/unbound-method */
-const initialFlatMap = (Array.prototype as any).flatMap;
+const initialFlatMap = proto.flatMap;
 /* eslint-enable @typescript-eslint/unbound-method */
 
 describe("utils - starts-with", () => {
   beforeEach(() => {
-    (Array.prototype as any).flatMap = undefined;
+    proto.flatMap = undefined;
   });
 
   afterEach(() => {
-    (Array.prototype as any).flatMap = initialFlatMap;
+    (proto).flatMap = initialFlatMap;
   });
 
-  it("should mirror Array.prototype.flatMap behavior", () => {
+  it("should mirror prototype.flatMap behavior", () => {
     expect(flatMap([1, 2, 3], x => [x, x + 1, x - 1]))
       .toEqual([ 1, 2, 0, 2, 3, 1, 3, 4, 2 ]);
     expect(flatMap([1, 2, 3], x => `${x}a`))
@@ -41,8 +48,8 @@ describe("utils - starts-with", () => {
 
   if (typeof initialFlatMap === "function") {
     it("should call the original flatMap function if available", () => {
-      (Array.prototype as any).flatMap = initialFlatMap;
-      const flatMapSpy = jest.spyOn((Array.prototype as any), "flatMap");
+      proto.flatMap = initialFlatMap;
+      const flatMapSpy = jest.spyOn(proto, "flatMap");
       const func1 = (x : number) : number[] => [x, x + 1, x - 1];
       const func2 = (x : number) : string => String(x) + "a";
       expect(flatMap([1, 2, 3], func1))

--- a/src/utils/__tests__/id_generator.test.ts
+++ b/src/utils/__tests__/id_generator.test.ts
@@ -23,7 +23,7 @@ const oldNumberDef = window.Number;
 describe("utils - idGenerator", () => {
   afterEach(() => {
     // There's an ugly test in here that changes the Number object
-    (window as any).Number = oldNumberDef;
+    window.Number = oldNumberDef;
   });
 
   it("should increment an ID", () => {
@@ -54,8 +54,8 @@ describe("utils - idGenerator", () => {
   });
   it ("should preprend a 0 after A LOT of ID generation", () => {
     // Ugly but I don't care
-    (window as any).Number = { MAX_SAFE_INTEGER: 3,
-                               isSafeInteger: (x : number) => x <= 3 };
+    window.Number = { MAX_SAFE_INTEGER: 3,
+                      isSafeInteger: (x : number) => x <= 3 } as typeof window.Number;
     const generateNewID1 = idGenerator();
     const generateNewID2 = idGenerator();
     const generateNewID3 = idGenerator();

--- a/src/utils/__tests__/promise.test.ts
+++ b/src/utils/__tests__/promise.test.ts
@@ -18,6 +18,6 @@ import promise from "../promise";
 
 describe("utils - promise", () => {
   it("should export the browser's Promise as a default", () => {
-    expect(promise).toBe(Promise as any);
+    expect(promise).toBe(Promise);
   });
 });

--- a/src/utils/__tests__/starts_with.test.ts
+++ b/src/utils/__tests__/starts_with.test.ts
@@ -24,8 +24,10 @@ const initialStartsWith = String.prototype.startsWith;
 
 describe("utils - starts-with", () => {
   beforeEach(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (String.prototype as any).startsWith = undefined;
+    /* eslint-enable @typescript-eslint/no-explicit-any */
   });
 
   afterEach(() => {

--- a/src/utils/array_find.ts
+++ b/src/utils/array_find.ts
@@ -20,6 +20,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-restricted-properties */
 
+// Ugly transitory type to make duck typing work
+type ArrayWithFind<T> = T[] & {
+  find(predicate: (value: T,
+                   index: number,
+                   obj: T[]) => unknown,
+       thisArg?: unknown): T;
+};
+
 /**
  * Array.prototype.find ponyfill.
  * @param {Array} arr
@@ -30,10 +38,10 @@
 export default function arrayFind<T>(
   arr : T[],
   predicate : (arg: T, index : number, fullArray : T[]) => boolean,
-  thisArg? : any
+  thisArg? : unknown
 ) : T | undefined {
-  if (typeof (Array.prototype as any).find === "function") {
-    return (arr as any).find(predicate, thisArg);
+  if (typeof (Array.prototype as ArrayWithFind<T>).find === "function") {
+    return (arr as ArrayWithFind<T>).find(predicate, thisArg);
   }
 
   const len = arr.length >>> 0;

--- a/src/utils/array_find_index.ts
+++ b/src/utils/array_find_index.ts
@@ -20,6 +20,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable no-restricted-properties */
 
+// Ugly transitory type to make duck typing work
+type ArrayWithFindIndex<T> = T[] & {
+  findIndex(predicate: (value: T,
+                        index: number,
+                        obj: T[]) => unknown,
+            thisArg?: unknown): number;
+};
+
 /**
  * Array.prototype.find ponyfill.
  * @param {Array} arr
@@ -30,10 +38,10 @@
 export default function arrayFindIndex<T>(
   arr : T[],
   predicate : (arg: T, index : number, fullArray : T[]) => boolean,
-  thisArg? : any
+  thisArg? : unknown
 ) : number {
-  if (typeof (Array.prototype as any).findIndex === "function") {
-    return (arr as any).findIndex(predicate, thisArg);
+  if (typeof (Array.prototype as ArrayWithFindIndex<T>).findIndex === "function") {
+    return (arr as ArrayWithFindIndex<T>).findIndex(predicate, thisArg);
   }
 
   const len = arr.length >>> 0;

--- a/src/utils/cast_to_observable.ts
+++ b/src/utils/cast_to_observable.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import PPromise from "pinkie";
 import {
   from as observableFrom,
   Observable,
@@ -27,24 +28,23 @@ import isNullOrUndefined from "./is_null_or_undefined";
  * @param {Observable|Function|*}
  * @returns {Observable}
  */
-function castToObservable<T>(
-  value : Promise<T>) : Observable<T>;
-function castToObservable<T>(value? : T) : Observable<T>;
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-function castToObservable<T>(value? : any) : Observable<T> {
+function castToObservable<T>(value : Observable<T> |
+                                     Promise<T> |
+                                     PPromise<T> |
+                                     Exclude<T, Observable<T>>) : Observable<T> {
   if (value instanceof Observable) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return value;
-  }
-
-  if (!isNullOrUndefined(value) &&
-    /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */
-       (typeof value.subscribe === "function" || typeof value.then === "function"))
+  } else if (
+    value instanceof PPromise ||
+    value instanceof Promise ||
+    (
+      !isNullOrUndefined(value) &&
+      typeof (value as { then? : unknown }).then === "function")
+  )
   {
-    return observableFrom(value) as Observable<T>;
+    return observableFrom(value as Promise<T>);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return observableOf(value);
 }
 

--- a/src/utils/flat_map.ts
+++ b/src/utils/flat_map.ts
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
+// Ugly transitory type to make duck typing work
+type ArrayWithFlatMap<T> = T[] & {
+  flatMap<U, This = undefined>(
+    callback: (this: This, value: T, index: number, array: T[]) => U | U[],
+    thisArg?: This
+  ): U[];
+};
+
 /**
  * Map each element using a mapping function, then flat the result into
  * a new array.
@@ -25,16 +33,10 @@ export default function flatMap<T, U>(
   fn: (arg: T) => U[]|U
 ) : U[] {
   /* eslint-disable @typescript-eslint/unbound-method */
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  /* eslint-disable @typescript-eslint/no-unsafe-return */
-  /* eslint-disable @typescript-eslint/no-unsafe-call */
-  if (typeof (Array.prototype as any).flatMap === "function") {
-    return (originalArray as any).flatMap(fn);
+  if (typeof (Array.prototype as ArrayWithFlatMap<T>).flatMap === "function") {
+    return (originalArray as ArrayWithFlatMap<T>).flatMap(fn);
   }
   /* eslint-enable @typescript-eslint/unbound-method */
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  /* eslint-enable @typescript-eslint/no-unsafe-return */
-  /* eslint-enable @typescript-eslint/no-unsafe-call */
 
   return originalArray.reduce((acc : U[], arg : T) : U[] => {
     const r = fn(arg);

--- a/src/utils/object_assign.ts
+++ b/src/utils/object_assign.ts
@@ -44,7 +44,7 @@ function objectAssign<T, U>(target : T, ...sources : U[]) : T & U {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
         /* eslint-disable @typescript-eslint/no-unsafe-member-access */
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        (to as any)[key] = source[key];
+        to[key] = source[key];
         /* eslint-enable @typescript-eslint/no-unsafe-member-access */
       }
     }

--- a/src/utils/uniq.ts
+++ b/src/utils/uniq.ts
@@ -40,7 +40,7 @@ function uniqFromSet<T>(arr: T[]) : T[] {
  */
 export default  typeof window !== "undefined" &&
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                typeof (window as any).Set === "function" &&
+                typeof window.Set === "function" &&
                 typeof Array.from === "function" ? uniqFromSet :
                                                    uniqFromFilter;
 export {


### PR DESCRIPTION
This commit tries to heavily limit the usage of the `any` TypeScript type, which is a type allowing to avoid type-checking for part of the code where properly-defining / depending on the right type is difficult.

There was already few `any` usage in the RxPlayer's code as we've been pretty careful:

  -  We added the `noImplicitAny` TypeScript compiler option (which forces us to realize when a type is considered any by being explicit about it).

  - We consider variables generally typed as `any`, such as thrown errors, as `unknown` instead.

    Unlike `any`, `unknown` is type-checked and thus needs to be properly infered/duck-typed before being used.

But we still were lazy in some situations, relying on `any` instead.

Those situations were:

  1. In tests, where we sometimes do weird non-type-safe things on purpose (such as when testing the API or browser-exposed code or when doing as if the browser misses or has other features).

  2. In `/compat`, as some browsers have JS-exposed API that either are not known or do not respect the TypeScript one.

  3. When writing in a type-safe matter was too difficult.

     Here I'm thinking mainly about the format of parsed segments, which is different depending on the type of data (text, audio/video, image...).

     At one end of the RxPlayer's logic those segment are loaded and parsed and at another end, they are pushed to the right
     `SegmentBuffer` implementation. In-between, we have type-agnostic code which was too difficult to properly define generically while still guaranteeing through typing that the right segment format went to the right SegmentBuffer.

     So `any` was used in some strategic points instead.

---

As relying on `any` is never ideal and can let bug pass through, I decided to add through this commit, the `@typescript-eslint/no-explicit-any` rule to eslint, the linter that we use.

__This rule allows to forbid any usage of any in the RxPlayer code.__

When `any` was used because guaranteeing type-safety was too difficult in the RxPlayer's code (such as in the `SegmentBuffer`), the now preferred method is to type it as `unknown` instead and essentially perform type-checking at runtime (I still disabled this step in production mode - when `__DEV__` is `false` to ensure we'll not trigger regressions here).

In the vast majority of its usage where we purposely used any because of testing code or of compatibility files, the now preferred solution is to define ad-hoc types containing just what is needed and cast the variable as it.
This is still unsafe, but much more safe than just relying on `any`.

Lastly some places (mostly the testing code and maybe one time in the compatibility files) still rely on `any` because doing any other thing is too difficult/not readable. Here I added the usual lines telling eslint to not consider that rule for those specific parts.

---

I discovered and fixed two minor bugs in this PR, that I detected just by forbidding the `any` type:

  1. In the experimental `MediaCapabilitiesProber` tool, when calling `getCompatibleDRMConfigurations`, we could be left with `undefined` values in the returned array - behavior which does not correspond to the API documentation nor the type.

     For now, I just filter out all `undefined` from that array.
     However, I think that the developer forgot to write something here and I'm not 100% sure of what the original intent was. So there may be a supplementary issue here, to check.

  2. In `src/compat/eme/custom_media_keys/webkit_media_keys.ts`, which defines a custom WebKit implementation for EME APIs, we still called `someSession.close` even when we found out that the corresponding `someSession` was not defined.

     I don't know whether that create a real issue for application user but I doubt it. Still this is technically a bug as it was not at
     all the wanted behavior.