### PR TITLE
Future-proof the transport code for a v4.0.0

### DIFF
--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -221,11 +221,7 @@ an XMLHttpRequest (it has no use, as our implementation does the same thing and
 more):
 ```js
 /**
- * @param {string|undefined} url - the url the Manifest request should normally
- * be on.
- * Can be undefined in very specific conditions, like in cases when the
- * `loadVideo` call had no defined URL (e.g. "local" manifest, playing a locally
- * crafted "Metaplaylist" content).
+ * @param {Object} manifestInfo - Information about the Manifest to download
  * @param {Object} callbacks - Object containing several callbacks to indicate
  * that the manifest has been loaded, the loading operation has failed or to
  * fallback to our default implementation. More information on this object below
@@ -233,7 +229,8 @@ more):
  * @returns {Function|undefined} - If a function is defined in the return value,
  * it will be called if and when the request is canceled.
  */
-const customManifestLoader = (url, callbacks) => {
+const customManifestLoader = (manifestInfo, callbacks) => {
+  const { url } = manifestInfo;
   const xhr = new XMLHttpRequest();
   const baseTime = performance.now();
 
@@ -293,11 +290,14 @@ const customManifestLoader = (url, callbacks) => {
 
 As you can see, this function takes two arguments:
 
-  1. **url**: The URL the Manifest request should normally be performed at.
+  1. **manifestInfo** (`object`): An Object giving information about the wanted
+     Manifest. This object contains the following properties:
 
-     This argument can be `undefined` in very rare and specific conditions where
-     the Manifest URL doesn't exist or has not been communicated by the
-     application.
+     - **url**: The URL the Manifest request should normally be performed at.
+
+       This argument can be `undefined` in very rare and specific conditions
+       where the Manifest URL doesn't exist or has not been communicated by the
+       application.
 
   2. **callbacks**: An object containing multiple callbacks to allow this
      `manifestLoader` to communicate the loaded Manifest or an encountered error

--- a/src/core/eme/__tests__/__global__/get_license.test.ts
+++ b/src/core/eme/__tests__/__global__/get_license.test.ts
@@ -156,7 +156,7 @@ describe("core - eme - global tests - getLicense", () => {
                       ignoreLicenseRequests: false }, done);
   });
 
-  it("should be able to retry two times and succeed after a time with a resolved null", (done) => {
+  it("should be able to retry one time and succeed after a time with a resolved null", (done) => {
     checkGetLicense({ isGetLicensePromiseBased: true,
                       configuredRetries: undefined,
                       configuredTimeout: undefined,
@@ -165,7 +165,7 @@ describe("core - eme - global tests - getLicense", () => {
                       ignoreLicenseRequests: true }, done);
   });
 
-  it("should be able to retry two times and succeed after a time with a returned null", (done) => {
+  it("should be able to retry one time and succeed after a time with a returned null", (done) => {
     checkGetLicense({ isGetLicensePromiseBased: false,
                       configuredRetries: undefined,
                       configuredTimeout: undefined,

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -478,7 +478,11 @@ export default function RepresentationStream<TSegmentDataType>({
       return observableMerge(segmentEncryptionEvent$, pushEvent$);
     } else {
       const { inbandEvents,
+              predictedSegments,
               needsManifestRefresh } = evt;
+      if (predictedSegments !== undefined) {
+        representation.index.addPredictedSegments(predictedSegments, evt.segment);
+      }
 
       const manifestRefresh$ =  needsManifestRefresh === true ?
         observableOf(EVENTS.needsManifestRefresh()) :

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -444,40 +444,41 @@ export default function RepresentationStream<TSegmentDataType>({
                  IStreamNeedsManifestRefresh |
                  IStreamManifestMightBeOutOfSync>
   {
+    // Supplementary encryption information might have been parsed.
+    for (const protInfo of evt.protectionData) {
+      // TODO better handle use cases like key rotation by not always grouping
+      // every protection data together? To check.
+      representation.addProtectionData(protInfo.initDataType, protInfo.initData);
+    }
+
+    let segmentEncryptionEvent$ : Observable<IEncryptionDataEncounteredEvent> = EMPTY;
+    if (!hasSentEncryptionData) {
+      const protData = representation.getAllEncryptionData().map(p =>
+        EVENTS.encryptionDataEncountered(p));
+      if (protData.length > 0) {
+        segmentEncryptionEvent$ = observableOf(...protData);
+        hasSentEncryptionData = true;
+      }
+    }
+
     if (evt.segmentType === "init") {
-      nextTick(() => {
-        reCheckNeededSegments$.next();
-      });
+      if (!representation.index.isInitialized() &&
+          evt.segmentList !== undefined)
+      {
+        representation.index.initialize(evt.segmentList);
+        nextTick(() => { reCheckNeededSegments$.next(); });
+      }
       initSegmentState.segmentData = evt.initializationData;
       initSegmentState.isLoaded = true;
-
-      // Now that the initialization segment has been parsed - which may have
-      // included encryption information - take care of the encryption event
-      // if not already done.
-      const allEncryptionData = representation.getAllEncryptionData();
-      const initEncEvt$ = !hasSentEncryptionData &&
-                          allEncryptionData.length > 0 ?
-        observableOf(...allEncryptionData.map(p =>
-          EVENTS.encryptionDataEncountered(p))) :
-        EMPTY;
       const pushEvent$ = pushInitSegment({ playbackObserver,
                                            content,
                                            segment: evt.segment,
                                            segmentData: evt.initializationData,
                                            segmentBuffer });
-      return observableMerge(initEncEvt$, pushEvent$);
+      return observableMerge(segmentEncryptionEvent$, pushEvent$);
     } else {
       const { inbandEvents,
-              needsManifestRefresh,
-              protectionDataUpdate } = evt;
-
-      // TODO better handle use cases like key rotation by not always grouping
-      // every protection data together? To check.
-      const segmentEncryptionEvent$ = protectionDataUpdate &&
-                                     !hasSentEncryptionData ?
-        observableOf(...representation.getAllEncryptionData().map(p =>
-          EVENTS.encryptionDataEncountered(p))) :
-        EMPTY;
+              needsManifestRefresh } = evt;
 
       const manifestRefresh$ =  needsManifestRefresh === true ?
         observableOf(EVENTS.needsManifestRefresh()) :

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -25,7 +25,6 @@ import Manifest, {
 import Period from "./period";
 import Representation from "./representation";
 import {
-  IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
   IRepresentationIndex,
   ISegment,
@@ -56,7 +55,6 @@ export {
 
   // types
   IAdaptationType,
-  IBaseContentInfos,
   IHDRInformation,
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -246,7 +246,7 @@ class Representation {
    * @param {Uint8Array} data
    * @returns {boolean}
    */
-  public _addProtectionData(
+  public addProtectionData(
     initDataType : string,
     data : Array<{
       systemId : string;

--- a/src/manifest/representation_index/index.ts
+++ b/src/manifest/representation_index/index.ts
@@ -16,14 +16,12 @@
 
 import StaticRepresentationIndex from "./static";
 import {
-  IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
   IRepresentationIndex,
   ISegment,
 } from "./types";
 
 export {
-  IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
   IRepresentationIndex,
   ISegment,

--- a/src/manifest/representation_index/static.ts
+++ b/src/manifest/representation_index/static.ts
@@ -129,6 +129,10 @@ export default class StaticRepresentationIndex implements IRepresentationIndex {
     return true;
   }
 
+  initialize() : void {
+    log.error("A `StaticRepresentationIndex` does not need to be initialized");
+  }
+
   _replace() : void {
     log.warn("Tried to replace a static RepresentationIndex");
   }

--- a/src/manifest/representation_index/static.ts
+++ b/src/manifest/representation_index/static.ts
@@ -133,6 +133,10 @@ export default class StaticRepresentationIndex implements IRepresentationIndex {
     log.error("A `StaticRepresentationIndex` does not need to be initialized");
   }
 
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `StaticRepresentationIndex`");
+  }
+
   _replace() : void {
     log.warn("Tried to replace a static RepresentationIndex");
   }

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -21,7 +21,7 @@ import {
   ILocalManifestInitSegmentLoader,
   ILocalManifestSegmentLoader,
 } from "../../parsers/manifest/local";
-import { IIndexSegmentListItem } from "../../transports";
+import { ISegmentInformation } from "../../transports";
 
 /**
  * Supplementary information specific to Smooth Initialization segments.
@@ -388,7 +388,19 @@ export interface IRepresentationIndex {
    * this `initialize` method.
    * @param {Array.<Object>} segmentList
    */
-  initialize(segmentList : IIndexSegmentListItem[]) : void;
+  initialize(segmentList : ISegmentInformation[]) : void;
+
+  /**
+   * Add segments to a RepresentationIndex that were predicted after parsing the
+   * segment linked to `currentSegment`.
+   * @param {Array.<Object>} nextSegments - The segment information parsed.
+   * @param {Object} segment - Information on the segment which contained that
+   * new segment information.
+   */
+  addPredictedSegments(
+    nextSegments : ISegmentInformation[],
+    currentSegment : ISegment
+  ) : void;
 
   /**
    * Replace the index with another one, such as after a Manifest update.

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -15,17 +15,13 @@
  */
 
 import { ICustomError } from "../../errors";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
-} from "../../manifest";
 import { IEMSG } from "../../parsers/containers/isobmff";
 import {
   ILocalIndexSegment,
   ILocalManifestInitSegmentLoader,
   ILocalManifestSegmentLoader,
 } from "../../parsers/manifest/local";
+import { IIndexSegmentListItem } from "../../transports";
 
 /**
  * Supplementary information specific to Smooth Initialization segments.
@@ -44,6 +40,8 @@ export interface ISmoothInitSegmentPrivateInfos {
   packetSize? : number;
   samplingRate? : number;
   protection? : { keyId : Uint8Array };
+  height? : number;
+  width? : number;
 }
 
 /**
@@ -63,22 +61,20 @@ export interface ISmoothSegmentPrivateInfos {
   duration : number;
 }
 
-/** Describes a given "real" Manifest for MetaPlaylist's segments. */
-export interface IBaseContentInfos { manifest: Manifest;
-                                     period: Period;
-                                     adaptation: Adaptation;
-                                     representation: Representation; }
-
 /** Supplementary information needed for segments in the "metaplaylist" transport. */
 export interface IMetaPlaylistPrivateInfos {
   /** The original transport protocol (e.g. "dash", "smooth" etc.) */
   transportType : string;
-  /** The context this segment is in. */
-  baseContent : IBaseContentInfos;
-  /** The segment originally created by this transport's RepresentationIndex. */
-  originalSegment : ISegment;
   contentStart : number;
   contentEnd? : number;
+
+  /** The segment originally created by this transport's RepresentationIndex. */
+  originalSegment : ISegment;
+
+  isLive : boolean;
+  manifestPublishTime? : number;
+  periodEnd? : number;
+  periodStart : number;
 }
 
 /**
@@ -109,7 +105,8 @@ export interface ILocalManifestSegmentPrivateInfos {
  * tranport logic used.
  * Called "private" as it won't be read or exploited by any code in the core
  * logic of the player. That information is only here to be retrieved and
- * exploited by the corresponding transport logic.
+ * exploited by the corresponding transport logic when loading or parsing the
+ * corresponding segment.
  */
 export interface IPrivateInfos {
   smoothInitSegment? : ISmoothInitSegmentPrivateInfos;
@@ -364,18 +361,34 @@ export interface IRepresentationIndex {
    *
    * Most index don't rely on the initialization segment to give an index and
    * as such, this method should return `true` directly.
-   * However in some index, the segment lists might only be known after the
-   * initialization has been loaded. In those case, it should return `false`
-   * until the corresponding segment list is known, at which point it can return
-   * `true`.
    *
-   * You can use any ad-hoc mean you want to "initialize" an index.
-   * This is usually done by adding supplementary methods (like one named
-   * `initialize`) to that `RepresentationIndex` and calling it directly in the
-   * segment parsing code.
+   * However in some index, the segment list might only be known after the
+   * initialization has been loaded and parsed. In those case, it should return
+   * `false` until the corresponding segment list is known, at which point you
+   * can call the `initialize` method with that list so the `isInitialized` can
+   * return `true`.
    * @returns {boolean}
    */
   isInitialized() : boolean;
+
+  /**
+   * Some `RepresentationIndex` do not have the list of media segments known in
+   * advance.
+   * Instead, those are only known once the initialization segment is loaded and
+   * parsed.
+   *
+   * Such `RepresentationIndex` whose list of media segments is still unknown
+   * are called "uninitialized". You can know if a `RepresentationIndex` is
+   * uninitialized by checking if its `isInitialized` method returns `false`.
+   *
+   * To initialize those `RepresentationIndex` and thus be able to obtain the
+   * list of its linked media segments through its corresponding methods, you
+   * have to initialize it with the list of segments once it is known
+   * (presumably, after parsing the initialization segment) by giving them to
+   * this `initialize` method.
+   * @param {Array.<Object>} segmentList
+   */
+  initialize(segmentList : IIndexSegmentListItem[]) : void;
 
   /**
    * Replace the index with another one, such as after a Manifest update.

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -19,6 +19,7 @@ import {
   IRepresentationIndex,
   ISegment,
 } from "../../../../../manifest";
+import { IIndexSegmentListItem } from "../../../../../transports";
 import { IEMSG } from "../../../../containers/isobmff";
 import {
   fromIndexTime,
@@ -320,26 +321,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   }
 
   /**
-   * No segment in a `BaseRepresentationIndex` are known initially.
-   * It is only defined generally in an "index segment" that will thus need to
-   * be first loaded and parsed.
-   * Until then, this `BaseRepresentationIndex` is considered as `uninitialized`
-   * (@see isInitialized).
-   *
-   * Once that those information are available, the present
-   * `BaseRepresentationIndex` can be "initialized" by adding that parsed
-   * segment information through this method.
-   * @param {Array.<Object>} indexSegments
-   * @returns {Array.<Object>}
-   */
-  initializeIndex(indexSegments : IAddedIndexSegment[]) : void {
-    for (let i = 0; i < indexSegments.length; i++) {
-      _addSegmentInfos(this._index, indexSegments[i]);
-    }
-    this._isInitialized = true;
-  }
-
-  /**
    * Returns `false` as a `BaseRepresentationIndex` should not be dynamic and as
    * such segments should never fall out-of-sync.
    * @returns {Boolean}
@@ -375,6 +356,30 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   }
 
   /**
+   * No segment in a `BaseRepresentationIndex` are known initially.
+   *
+   * It is only defined generally in an "index segment" that will thus need to
+   * be first loaded and parsed.
+   * Until then, this `BaseRepresentationIndex` is considered as `uninitialized`
+   * (@see isInitialized).
+   *
+   * Once that those information are available, the present
+   * `BaseRepresentationIndex` can be "initialized" by adding that parsed
+   * segment information through this method.
+   * @param {Array.<Object>} indexSegments
+   * @returns {Array.<Object>}
+   */
+  initialize(indexSegments : IIndexSegmentListItem[]) : void {
+    if (this._isInitialized) {
+      return ;
+    }
+    for (let i = 0; i < indexSegments.length; i++) {
+      _addSegmentInfos(this._index, indexSegments[i]);
+    }
+    this._isInitialized = true;
+  }
+
+  /**
    * Replace in-place this `BaseRepresentationIndex` information by the
    * information from another one.
    * @param {Object} newIndex
@@ -389,22 +394,4 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   _update() : void {
     log.error("Base RepresentationIndex: Cannot update a SegmentList");
   }
-}
-
-/**
- * Format of a segment received through the `initialize` method, allowing  to
- * add segments to a BaseRepresentationIndex.
- */
-export interface IAddedIndexSegment {
-  /** This segment start time, timescaled. */
-  time : number;
-  /** This segment difference between its end and start time, timescaled. */
-  duration : number;
-  /** Dividing `time` or `duration` with this value allows to obtain seconds. */
-  timescale : number;
-  /**
-   * Start and ending bytes (included) for the segment in the whole ISOBMFF
-   * buffer.
-   */
-  range : [number, number];
 }

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -19,7 +19,7 @@ import {
   IRepresentationIndex,
   ISegment,
 } from "../../../../../manifest";
-import { IIndexSegmentListItem } from "../../../../../transports";
+import { ISegmentInformation } from "../../../../../transports";
 import { IEMSG } from "../../../../containers/isobmff";
 import {
   fromIndexTime,
@@ -369,7 +369,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
    * @param {Array.<Object>} indexSegments
    * @returns {Array.<Object>}
    */
-  initialize(indexSegments : IIndexSegmentListItem[]) : void {
+  initialize(indexSegments : ISegmentInformation[]) : void {
     if (this._isInitialized) {
       return ;
     }
@@ -377,6 +377,10 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       _addSegmentInfos(this._index, indexSegments[i]);
     }
     this._isInitialized = true;
+  }
+
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `BaseRepresentationIndex`");
   }
 
   /**

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -303,6 +303,10 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
     log.error("A `ListRepresentationIndex` does not need to be initialized");
   }
 
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `ListRepresentationIndex`");
+  }
+
   /**
    * @param {Object} newIndex
    */

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -299,6 +299,10 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
     return true;
   }
 
+  initialize() : void {
+    log.error("A `ListRepresentationIndex` does not need to be initialized");
+  }
+
   /**
    * @param {Object} newIndex
    */
@@ -306,10 +310,7 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
     this._index = newIndex._index;
   }
 
-  /**
-   * @param {Object} newIndex
-   */
   _update() : void {
-    log.error("List RepresentationIndex: Cannot update a SegmentList");
+    log.error("A `ListRepresentationIndex` cannot be updated");
   }
 }

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -426,6 +426,10 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     log.error("A `TemplateRepresentationIndex` does not need to be initialized");
   }
 
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `TemplateRepresentationIndex`");
+  }
+
   /**
    * @param {Object} newIndex
    */

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -15,6 +15,7 @@
  */
 
 import config from "../../../../../config";
+import log from "../../../../../log";
 import {
   IRepresentationIndex,
   ISegment,
@@ -419,6 +420,10 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
    */
   isInitialized() : true {
     return true;
+  }
+
+  initialize() : void {
+    log.error("A `TemplateRepresentationIndex` does not need to be initialized");
   }
 
   /**

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -507,6 +507,10 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     return true;
   }
 
+  initialize() : void {
+    log.error("A `TimelineRepresentationIndex` does not need to be initialized");
+  }
+
   /**
    * Returns `true` if the given object can be used as an "index" argument to
    * create a new `TimelineRepresentationIndex`.

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -511,6 +511,10 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     log.error("A `TimelineRepresentationIndex` does not need to be initialized");
   }
 
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `TimelineRepresentationIndex`");
+  }
+
   /**
    * Returns `true` if the given object can be used as an "index" argument to
    * create a new `TimelineRepresentationIndex`.

--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -165,6 +165,10 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
     log.error("A `LocalRepresentationIndex` does not need to be initialized");
   }
 
+  addPredictedSegments() : void {
+    log.warn("Cannot add predicted segments to a `LocalRepresentationIndex`");
+  }
+
   _replace(newIndex : LocalRepresentationIndex) : void {
     this._isFinished = newIndex._isFinished;
     this._index.segments = newIndex._index.segments;

--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -161,6 +161,10 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
     return true;
   }
 
+  initialize() : void {
+    log.error("A `LocalRepresentationIndex` does not need to be initialized");
+  }
+
   _replace(newIndex : LocalRepresentationIndex) : void {
     this._isFinished = newIndex._isFinished;
     this._index.segments = newIndex._index.segments;

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -199,17 +199,17 @@ function createManifest(
             for (let iRep = 0; iRep < currentAdaptation.representations.length; iRep++) {
               const currentRepresentation = currentAdaptation.representations[iRep];
 
-              const contentInfos = {
-                manifest: currentManifest,
-                period: currentPeriod,
-                adaptation: currentAdaptation,
-                representation: currentRepresentation,
+              const baseContentMetadata = {
+                isLive: currentManifest.isLive,
+                manifestPublishTime: currentManifest.publishTime,
+                periodStart: currentPeriod.start,
+                periodEnd: currentPeriod.end,
               };
 
               const newIndex = new MetaRepresentationIndex(currentRepresentation.index,
                                                            [contentOffset, contentEnd],
                                                            content.transport,
-                                                           contentInfos);
+                                                           baseContentMetadata);
               representations.push({
                 bitrate: currentRepresentation.bitrate,
                 index: newIndex,

--- a/src/parsers/manifest/metaplaylist/representation_index.ts
+++ b/src/parsers/manifest/metaplaylist/representation_index.ts
@@ -16,11 +16,18 @@
 
 import { ICustomError } from "../../../errors";
 import {
-  IBaseContentInfos,
   IRepresentationIndex,
   ISegment,
 } from "../../../manifest";
+import { IIndexSegmentListItem } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
+
+export interface IBaseContentMetadata {
+  isLive : boolean;
+  manifestPublishTime? : number;
+  periodEnd? : number;
+  periodStart : number;
+}
 
 /**
  * The MetaRepresentationIndex is wrapper for all kind of RepresentationIndex (from
@@ -44,7 +51,7 @@ export default class MetaRepresentationIndex implements IRepresentationIndex {
   /** Underlying transport for the Representation (e.g. "dash" or "smooth"). */
   private _transport : string;
   /** Various information about the real underlying Representation. */
-  private _baseContentInfos : IBaseContentInfos;
+  private _baseContentMetadata : IBaseContentMetadata;
 
   /**
    * Create a new `MetaRepresentationIndex`.
@@ -61,13 +68,13 @@ export default class MetaRepresentationIndex implements IRepresentationIndex {
     wrappedIndex: IRepresentationIndex,
     contentBounds: [number, number|undefined],
     transport: string,
-    baseContentInfos: IBaseContentInfos
+    baseContentInfos: IBaseContentMetadata
   ) {
     this._wrappedIndex = wrappedIndex;
     this._timeOffset = contentBounds[0];
     this._contentEnd = contentBounds[1];
     this._transport = transport;
-    this._baseContentInfos = baseContentInfos;
+    this._baseContentMetadata = baseContentInfos;
   }
 
   /**
@@ -187,6 +194,10 @@ export default class MetaRepresentationIndex implements IRepresentationIndex {
     return this._wrappedIndex.isInitialized();
   }
 
+  public initialize(indexSegments : IIndexSegmentListItem[]) : void {
+    return this._wrappedIndex.initialize(indexSegments);
+  }
+
   /**
    * @param {Object} newIndex
    */
@@ -221,10 +232,13 @@ export default class MetaRepresentationIndex implements IRepresentationIndex {
     }
     clonedSegment.privateInfos.metaplaylistInfos = {
       transportType: this._transport,
-      baseContent: this._baseContentInfos,
       contentStart: this._timeOffset,
       contentEnd: this._contentEnd,
       originalSegment: segment,
+      isLive: this._baseContentMetadata.isLive,
+      manifestPublishTime: this._baseContentMetadata.manifestPublishTime,
+      periodStart: this._baseContentMetadata.periodStart,
+      periodEnd: this._baseContentMetadata.periodEnd,
     };
     return clonedSegment;
   }

--- a/src/parsers/manifest/metaplaylist/representation_index.ts
+++ b/src/parsers/manifest/metaplaylist/representation_index.ts
@@ -19,7 +19,7 @@ import {
   IRepresentationIndex,
   ISegment,
 } from "../../../manifest";
-import { IIndexSegmentListItem } from "../../../transports";
+import { ISegmentInformation } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
 
 export interface IBaseContentMetadata {
@@ -194,8 +194,15 @@ export default class MetaRepresentationIndex implements IRepresentationIndex {
     return this._wrappedIndex.isInitialized();
   }
 
-  public initialize(indexSegments : IIndexSegmentListItem[]) : void {
+  public initialize(indexSegments : ISegmentInformation[]) : void {
     return this._wrappedIndex.initialize(indexSegments);
+  }
+
+  public addPredictedSegments(
+    nextSegments : ISegmentInformation[],
+    currentSegment : ISegment
+  ) : void {
+    return this._wrappedIndex.addPredictedSegments(nextSegments, currentSegment);
   }
 
   /**

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -48,6 +48,7 @@ import parseProtectionNode, {
   IKeySystem,
 } from "./parse_protection_node";
 import RepresentationIndex from "./representation_index";
+import SharedSmoothSegmentTimeline from "./shared_smooth_segment_timeline";
 import parseBoolean from "./utils/parseBoolean";
 import reduceChildren from "./utils/reduceChildren";
 import { replaceRepresentationSmoothTokens } from "./utils/tokens";
@@ -330,8 +331,12 @@ function createSmoothStreamingParser(
         return res;
       }, { qualityLevels: [], cNodes: [] });
 
-    const index = { timeline: parseCNodes(cNodes),
-                    timescale: _timescale };
+    const sharedSmoothTimeline = new SharedSmoothSegmentTimeline({
+      timeline: parseCNodes(cNodes),
+      timescale: _timescale,
+      timeShiftBufferDepth,
+      manifestReceivedTime,
+    });
 
     // we assume that all qualityLevels have the same
     // codec and mimeType
@@ -344,13 +349,9 @@ function createSmoothStreamingParser(
 
     const representations = qualityLevels.map((qualityLevel) => {
       const path = resolveURL(rootURL, baseURL);
-      const repIndex = {
-        timeline: index.timeline,
-        timescale: index.timescale,
-        media: replaceRepresentationSmoothTokens(path,
-                                                 qualityLevel.bitrate,
-                                                 qualityLevel.customAttributes),
-      };
+      const media = replaceRepresentationSmoothTokens(path,
+                                                      qualityLevel.bitrate,
+                                                      qualityLevel.customAttributes);
       const mimeType = isNonEmptyString(qualityLevel.mimeType) ?
         qualityLevel.mimeType :
         DEFAULT_MIME_TYPES[adaptationType];
@@ -394,11 +395,11 @@ function createSmoothStreamingParser(
       const aggressiveMode = parserOptions.aggressiveMode == null ?
         DEFAULT_AGGRESSIVE_MODE :
         parserOptions.aggressiveMode;
-      const reprIndex = new RepresentationIndex(repIndex, { aggressiveMode,
-                                                            isLive,
-                                                            manifestReceivedTime,
-                                                            segmentPrivateInfos,
-                                                            timeShiftBufferDepth });
+      const reprIndex = new RepresentationIndex({ aggressiveMode,
+                                                  isLive,
+                                                  sharedSmoothTimeline,
+                                                  media,
+                                                  segmentPrivateInfos });
       const representation : IParsedRepresentation = objectAssign({},
                                                                   qualityLevel,
                                                                   { index: reprIndex,

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -382,6 +382,8 @@ function createSmoothStreamingParser(
                                     codecPrivateData: qualityLevel.codecPrivateData,
                                     packetSize: qualityLevel.packetSize,
                                     samplingRate: qualityLevel.samplingRate,
+                                    height: qualityLevel.height,
+                                    width: qualityLevel.width,
 
                                     // TODO set multiple protections here
                                     // instead of the first one

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -23,61 +23,15 @@ import {
   IRepresentationIndex,
   ISegment,
 } from "../../../manifest";
-import clearTimelineFromPosition from "../utils/clear_timeline_from_position";
 import {
   checkDiscontinuity,
   getIndexSegmentEnd,
 } from "../utils/index_helpers";
 import isSegmentStillAvailable from "../utils/is_segment_still_available";
-import updateSegmentTimeline from "../utils/update_segment_timeline";
-import addSegmentInfos from "./utils/add_segment_infos";
+import SharedSmoothSegmentTimeline, {
+  IIndexSegment,
+} from "./shared_smooth_segment_timeline";
 import { replaceSegmentSmoothTokens } from "./utils/tokens";
-
-/**
- * Object describing information about one segment or several consecutive
- * segments.
- */
-export interface IIndexSegment {
-  /** Time (timescaled) at which the segment starts. */
-  start : number;
-  /** Duration (timescaled) of the segment. */
-  duration : number;
-  /**
-   * Amount of consecutive segments with that duration.
-   *
-   * For example let's consider the following IIndexSegment:
-   * ```
-   * { start: 10, duration: 2, repeatCount: 2 }
-   * ```
-   * Here, because `repeatCount` is set to `2`, this object actually defines 3
-   * segments:
-   *   1. one starting at `10` and ending at `12` (10 + 2)
-   *   2. another one starting at `12` (the previous one's end) and ending at
-   *      `14` (12 + 2)
-   *   3. another one starting at `14` (the previous one's end) and ending at
-   *      `16` (14 +2)
-   */
-  repeatCount: number;
-}
-
-/**
- * Object containing information about the segments available in a
- * `SmoothRepresentationIndex`.
- */
-interface ITimelineIndex {
-  /**
-   * "Timescale" used here allowing to convert the time in this object into
-   * seconds (by doing `time / timescale`).
-   */
-  timescale : number;
-  /**
-   * Generic tokenized (e.g. with placeholders for time information) URL for
-   * every segments anounced here.
-   */
-  media : string;
-  /** Contains information about all segments available here. */
-  timeline : IIndexSegment[];
-}
 
 /**
  * @param {Number} start
@@ -106,17 +60,17 @@ function getSegmentNumber(
  *   - to {Number}: timescaled timestamp of the end time (start time + duration)
  */
 function normalizeRange(
-  index: { timescale?: number },
-  start: number,
-  duration: number
+  timescale : number | undefined,
+  start : number,
+  duration : number
 ) : { up: number;
       to: number; }
 {
-  const timescale = index.timescale === undefined ||
-                    index.timescale === 0 ? 1 :
-                                            index.timescale;
-  return { up: start * timescale,
-           to: (start + duration) * timescale };
+  const ts = timescale === undefined ||
+             timescale === 0 ? 1 :
+                               timescale;
+  return { up: start * ts,
+           to: (start + duration) * ts };
 }
 
 /**
@@ -136,7 +90,7 @@ function calculateRepeat(
   // start of the next S element, the end of the Period or until the
   // next MPD update.
   // TODO Also for SMOOTH????
-  if (segment.duration != null && repeatCount < 0) {
+  if (segment.duration !== undefined && repeatCount < 0) {
     const repeatEnd = nextSegment !== undefined ? nextSegment.start :
                                                   Infinity;
     repeatCount = Math.ceil((repeatEnd - segment.start) / segment.duration) - 1;
@@ -165,15 +119,18 @@ export interface ISmoothRepresentationIndexContextInformation {
    * `false` otherwise.
    */
   isLive : boolean;
-  /** Value of `performance.now()` when the Manifest request was finished. */
-  manifestReceivedTime : number | undefined;
+  /**
+   * Generic tokenized (e.g. with placeholders for time information) URL for
+   * every segments anounced here.
+   */
+  media : string;
   /**
    * Contains information allowing to generate the corresponding initialization
    * segment.
    */
   segmentPrivateInfos : ISmoothInitSegmentPrivateInfos;
-  /** Depth of the DVR window, in seconds. */
-  timeShiftBufferDepth : number | undefined;
+
+  sharedSmoothTimeline : SharedSmoothSegmentTimeline;
 }
 
 /** Information allowing to generate a Smooth initialization segment. */
@@ -238,14 +195,6 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
   private _initialScaledLastPosition? : number;
 
   /**
-   * Defines the earliest time when this index was known to be valid (that is, when
-   * all segments declared in it are available). This means either:
-   *   - the manifest downloading time, if known
-   *   - else, the time of creation of this RepresentationIndex, as the best guess
-   */
-  private _indexValidityTime : number;
-
-  /**
    * If `true` the corresponding Smooth Manifest was announced as a live
    * content.
    * `false` otherwise.
@@ -256,10 +205,13 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * Contains information on the list of segments available in this
    * SmoothRepresentationIndex.
    */
-  private _index : ITimelineIndex;
+  private _sharedSmoothTimeline : SharedSmoothSegmentTimeline;
 
-  /** Depth of the DVR window anounced in the Manifest, in seconds. */
-  private _timeShiftBufferDepth : number | undefined;
+  /**
+   * Generic tokenized (e.g. with placeholders for time information) URL for
+   * every segments anounced here.
+   */
+  private _media : string;
 
   /**
    * Creates a new `SmoothRepresentationIndex`.
@@ -267,42 +219,36 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * @param {Object} options
    */
   constructor(
-    index : ITimelineIndex,
     options : ISmoothRepresentationIndexContextInformation
   ) {
     const { aggressiveMode,
             isLive,
             segmentPrivateInfos,
-            timeShiftBufferDepth } = options;
-    const estimatedReceivedTime = options.manifestReceivedTime == null ?
-      performance.now() :
-      options.manifestReceivedTime;
-    this._index = index;
-    this._indexValidityTime = estimatedReceivedTime;
-    this._timeShiftBufferDepth = timeShiftBufferDepth;
+            media,
+            sharedSmoothTimeline } = options;
+    this._sharedSmoothTimeline = sharedSmoothTimeline;
 
     this._initSegmentInfos = { bitsPerSample: segmentPrivateInfos.bitsPerSample,
                                channels: segmentPrivateInfos.channels,
                                codecPrivateData: segmentPrivateInfos.codecPrivateData,
                                packetSize: segmentPrivateInfos.packetSize,
                                samplingRate: segmentPrivateInfos.samplingRate,
-                               timescale: index.timescale,
+                               timescale: sharedSmoothTimeline.timescale,
                                height: segmentPrivateInfos.height,
                                width: segmentPrivateInfos.width,
                                protection: segmentPrivateInfos.protection };
 
     this._isAggressiveMode = aggressiveMode;
     this._isLive = isLive;
+    this._media = media;
 
-    if (index.timeline.length !== 0) {
-      const lastItem = index.timeline[index.timeline.length - 1];
+    if (sharedSmoothTimeline.timeline.length !== 0 && isLive) {
+      const { timeline, validityTime } = sharedSmoothTimeline;
+      const lastItem = timeline[timeline.length - 1];
       const scaledEnd = getIndexSegmentEnd(lastItem, null);
-      this._initialScaledLastPosition = scaledEnd;
-
-      if (isLive) {
-        const scaledReceivedTime = (estimatedReceivedTime / 1000) * index.timescale;
-        this._scaledLiveGap = scaledReceivedTime - scaledEnd;
-      }
+      const scaledTimelineValidityTime = (validityTime / 1000) *
+        sharedSmoothTimeline.timescale;
+      this._scaledLiveGap = scaledTimelineValidityTime - scaledEnd;
     }
   }
 
@@ -331,8 +277,9 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    */
   getSegments(from : number, dur : number) : ISegment[] {
     this._refreshTimeline();
-    const { up, to } = normalizeRange(this._index, from, dur);
-    const { timeline, timescale, media } = this._index;
+    const { timescale, timeline } = this._sharedSmoothTimeline;
+    const { up, to } = normalizeRange(timescale, from, dur);
+    const media = this._media;
     const isAggressive = this._isAggressiveMode;
 
     let currentNumber : number|undefined;
@@ -340,7 +287,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
 
     const timelineLength = timeline.length;
 
-    const maxPosition = this._scaledLiveGap == null ?
+    const maxPosition = this._scaledLiveGap === undefined ?
       undefined :
       ((performance.now() / 1000) * timescale) - this._scaledLiveGap;
 
@@ -354,11 +301,11 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
                                                          duration;
       while (segmentTime < to &&
              segmentNumberInCurrentRange <= repeat &&
-             (maxPosition == null ||
+             (maxPosition === undefined ||
              (segmentTime + timeToAddToCheckMaxPosition) <= maxPosition))
       {
         const time = segmentTime;
-        const number = currentNumber != null ?
+        const number = currentNumber !== undefined ?
           currentNumber + segmentNumberInCurrentRange :
           undefined;
         const segment = { id: String(segmentTime),
@@ -384,7 +331,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
         return segments;
       }
 
-      if (currentNumber != null) {
+      if (currentNumber !== undefined) {
         currentNumber += repeat + 1;
       }
     }
@@ -404,7 +351,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
     if (!this._isLive) {
       return false;
     }
-    const { timeline, timescale } = this._index;
+    const { timeline, timescale } = this._sharedSmoothTimeline;
 
     const lastSegmentInCurrentTimeline = timeline[timeline.length - 1];
     if (lastSegmentInCurrentTimeline === undefined) {
@@ -441,11 +388,11 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    */
   getFirstPosition() : number|null {
     this._refreshTimeline();
-    const index = this._index;
-    if (index.timeline.length === 0) {
+    const { timeline, timescale } = this._sharedSmoothTimeline;
+    if (timeline.length === 0) {
       return null;
     }
-    return index.timeline[0].start / index.timescale;
+    return timeline[0].start / timescale;
   }
 
   /**
@@ -455,23 +402,23 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    */
   getLastPosition() : number|undefined {
     this._refreshTimeline();
-    const index = this._index;
+    const { timeline, timescale } = this._sharedSmoothTimeline;
 
-    if (this._scaledLiveGap == null) {
-      const lastTimelineElement = index.timeline[index.timeline.length - 1];
-      return getIndexSegmentEnd(lastTimelineElement, null) / index.timescale;
+    if (this._scaledLiveGap === undefined) {
+      const lastTimelineElement = timeline[timeline.length - 1];
+      return getIndexSegmentEnd(lastTimelineElement, null) / timescale;
     }
 
-    for (let i = index.timeline.length - 1; i >= 0; i--) {
-      const timelineElt = index.timeline[i];
-      const timescaledNow = (performance.now() / 1000) * index.timescale;
+    for (let i = timeline.length - 1; i >= 0; i--) {
+      const timelineElt = timeline[i];
+      const timescaledNow = (performance.now() / 1000) * timescale;
       const { start, duration, repeatCount } = timelineElt;
       for (let j = repeatCount; j >= 0; j--) {
         const end = start + (duration * (j + 1));
         const positionToReach = this._isAggressiveMode ? end - duration :
                                                          end;
         if (positionToReach <= timescaledNow - this._scaledLiveGap) {
-          return end / index.timescale;
+          return end / timescale;
         }
       }
     }
@@ -489,7 +436,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    */
   checkDiscontinuity(timeSec : number) : number | null {
     this._refreshTimeline();
-    return checkDiscontinuity(this._index, timeSec, undefined);
+    return checkDiscontinuity(this._sharedSmoothTimeline, timeSec, undefined);
   }
 
   /**
@@ -514,7 +461,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
       return true;
     }
     this._refreshTimeline();
-    const { timeline, timescale } = this._index;
+    const { timeline, timescale } = this._sharedSmoothTimeline;
     return isSegmentStillAvailable(segment, timeline, timescale, 0);
   }
 
@@ -537,65 +484,9 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * @param {Object} newIndex
    */
   _replace(newIndex : SmoothRepresentationIndex) : void {
-    const oldTimeline = this._index.timeline;
-    const newTimeline = newIndex._index.timeline;
-    const oldTimescale = this._index.timescale;
-    const newTimescale = newIndex._index.timescale;
-
-    this._index = newIndex._index;
     this._initialScaledLastPosition = newIndex._initialScaledLastPosition;
-    this._indexValidityTime = newIndex._indexValidityTime;
     this._scaledLiveGap = newIndex._scaledLiveGap;
-
-    if (oldTimeline.length === 0 ||
-        newTimeline.length === 0 ||
-        oldTimescale !== newTimescale)
-    {
-      return; // don't take risk, if something is off, take the new one
-    }
-
-    const lastOldTimelineElement = oldTimeline[oldTimeline.length - 1];
-    const lastNewTimelineElement = newTimeline[newTimeline.length - 1];
-    const newEnd = getIndexSegmentEnd(lastNewTimelineElement, null);
-    if (getIndexSegmentEnd(lastOldTimelineElement, null) <= newEnd) {
-      return;
-    }
-
-    for (let i = 0; i < oldTimeline.length; i++) {
-      const oldTimelineRange = oldTimeline[i];
-      const oldEnd = getIndexSegmentEnd(oldTimelineRange, null);
-      if (oldEnd === newEnd) { // just add the supplementary segments
-        this._index.timeline = this._index.timeline.concat(oldTimeline.slice(i + 1));
-        return;
-      }
-
-      if (oldEnd > newEnd) { // adjust repeatCount + add supplementary segments
-        if (oldTimelineRange.duration !== lastNewTimelineElement.duration) {
-          return;
-        }
-
-        const rangeDuration = newEnd - oldTimelineRange.start;
-        if (rangeDuration === 0) {
-          log.warn("Smooth Parser: a discontinuity detected in the previous manifest" +
-            " has been resolved.");
-          this._index.timeline = this._index.timeline.concat(oldTimeline.slice(i));
-          return;
-        }
-        if (rangeDuration < 0 || rangeDuration % oldTimelineRange.duration !== 0) {
-          return;
-        }
-
-        const repeatWithOld = (rangeDuration / oldTimelineRange.duration) - 1;
-        const relativeRepeat = oldTimelineRange.repeatCount - repeatWithOld;
-        if (relativeRepeat < 0) {
-          return;
-        }
-        lastNewTimelineElement.repeatCount += relativeRepeat;
-        const supplementarySegments = oldTimeline.slice(i + 1);
-        this._index.timeline = this._index.timeline.concat(supplementarySegments);
-        return;
-      }
-    }
+    this._sharedSmoothTimeline.replace(newIndex._sharedSmoothTimeline);
   }
 
   /**
@@ -604,10 +495,8 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * @param {Object} newIndex
    */
   _update(newIndex : SmoothRepresentationIndex) : void {
-    updateSegmentTimeline(this._index.timeline, newIndex._index.timeline);
-    this._initialScaledLastPosition = newIndex._initialScaledLastPosition;
-    this._indexValidityTime = newIndex._indexValidityTime;
     this._scaledLiveGap = newIndex._scaledLiveGap;
+    this._sharedSmoothTimeline.update(newIndex._sharedSmoothTimeline);
   }
 
   /**
@@ -637,19 +526,17 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
   }
 
   /**
-   * Add new segments to a `SmoothRepresentationIndex`.
+   * Add segments to a `SharedSmoothSegmentTimeline` that were predicted to come
+   * after `currentSegment`.
    * @param {Array.<Object>} nextSegments - The segment information parsed.
    * @param {Object} segment - Information on the segment which contained that
    * new segment information.
    */
-  addNewSegments(
+  addPredictedSegments(
     nextSegments : Array<{ duration : number; time : number; timescale : number }>,
-    currentSegment : { duration : number; time : number }
+    currentSegment : ISegment
   ) : void {
-    this._refreshTimeline();
-    for (let i = 0; i < nextSegments.length; i++) {
-      addSegmentInfos(this._index, nextSegments[i], currentSegment);
-    }
+    this._sharedSmoothTimeline.addPredictedSegments(nextSegments, currentSegment);
   }
 
   /**
@@ -657,21 +544,6 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * available due to the timeshift window
    */
   private _refreshTimeline() : void {
-    // clean segments before time shift buffer depth
-    if (this._initialScaledLastPosition == null) {
-      return;
-    }
-    const index = this._index;
-    const timeShiftBufferDepth = this._timeShiftBufferDepth;
-    const timeSinceLastRealUpdate = (performance.now() -
-                                     this._indexValidityTime) / 1000;
-    const lastPositionEstimate = timeSinceLastRealUpdate +
-                                 this._initialScaledLastPosition / index.timescale;
-
-    if (timeShiftBufferDepth != null) {
-      const minimumPosition = (lastPositionEstimate - timeShiftBufferDepth) *
-                              index.timescale;
-      clearTimelineFromPosition(index.timeline, minimumPosition);
-    }
+    this._sharedSmoothTimeline.refresh();
   }
 }

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -184,6 +184,8 @@ interface ISmoothInitSegmentPrivateInfos {
   packetSize? : number;
   samplingRate? : number;
   protection? : { keyId : Uint8Array };
+  height? : number;
+  width? : number;
 }
 
 /**
@@ -204,6 +206,8 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
                                 packetSize? : number;
                                 samplingRate? : number;
                                 timescale : number;
+                                height? : number;
+                                width? : number;
                                 protection? : { keyId : Uint8Array }; };
 
   /**
@@ -283,6 +287,8 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
                                packetSize: segmentPrivateInfos.packetSize,
                                samplingRate: segmentPrivateInfos.samplingRate,
                                timescale: index.timescale,
+                               height: segmentPrivateInfos.height,
+                               width: segmentPrivateInfos.width,
                                protection: segmentPrivateInfos.protection };
 
     this._isAggressiveMode = aggressiveMode;
@@ -624,6 +630,10 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    */
   isInitialized() : true {
     return true;
+  }
+
+  initialize() : void {
+    log.error("A `SmoothRepresentationIndex` does not need to be initialized");
   }
 
   /**

--- a/src/parsers/manifest/smooth/shared_smooth_segment_timeline.ts
+++ b/src/parsers/manifest/smooth/shared_smooth_segment_timeline.ts
@@ -1,0 +1,241 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../../../log";
+import { ISegment } from "../../../manifest";
+import clearTimelineFromPosition from "../utils/clear_timeline_from_position";
+import { getIndexSegmentEnd } from "../utils/index_helpers";
+import updateSegmentTimeline from "../utils/update_segment_timeline";
+import addSegmentInfos from "./utils/add_segment_infos";
+
+/**
+ * Smooth contents provide the index of segments under a "StreamIndex", the
+ * smooth equivalent of an AdaptationSet.
+ *
+ * This means that multiple "QualityLevel" (smooth's Representation) are going
+ * to rely on the exact same list of segments. This also means that all
+ * mutations on that timeline (whether it is to evict old segments or to add
+ * new ones) should presumably happen for all of them at the same time.
+ *
+ * The `SharedSmoothSegmentTimeline` is an abstraction over that index of
+ * segments whose goal is to explicitely provide a data structure that can be
+ * shared to every `RepresentationIndex` linked to Representations being part
+ * of the same smooth Adaptation, thus allowing to mutualize any side-effect
+ * done to it automatically.
+ *
+ * @class SharedSmoothSegmentTimeline
+ */
+export default class SharedSmoothSegmentTimeline {
+  /**
+   * Array describing the list of segments available.
+   * Note that this same list might be shared by multiple `RepresentationIndex`
+   * (as they link to the same timeline in the Manifest).
+   */
+  public timeline : IIndexSegment[];
+
+  /** Timescale allowing to convert time values in `timeline` into seconds. */
+  public timescale : number;
+
+  /**
+   * Defines the earliest time - in terms of `performance.now()` - when the
+   * timeline was known to be valid (that is, when all segments declared in it
+   * are available).
+   *
+   * This is either:
+   *   - the Manifest downloading time, if known
+   *   - else, the time of creation of this SharedSmoothSegmentTimeline, as a
+   *     guess
+   */
+  public validityTime : number;
+
+  private _timeShiftBufferDepth : number | undefined;
+  private _initialScaledLastPosition : number | undefined;
+
+
+  constructor(args : ISharedSmoothSegmentTimelineArguments) {
+    const { timeline, timescale, timeShiftBufferDepth, manifestReceivedTime } = args;
+    this.timeline = timeline;
+    this.timescale = timescale;
+    const estimatedReceivedTime = manifestReceivedTime ?? performance.now();
+    this.validityTime = estimatedReceivedTime;
+    this._timeShiftBufferDepth = timeShiftBufferDepth;
+
+    if (timeline.length !== 0) {
+      const lastItem = timeline[timeline.length - 1];
+      const scaledEnd = getIndexSegmentEnd(lastItem, null);
+      this._initialScaledLastPosition = scaledEnd;
+    }
+  }
+
+
+  /**
+   * Clean-up timeline to remove segment information which should not be
+   * available due to the timeshift window
+   */
+  public refresh() : void {
+    // clean segments before time shift buffer depth
+    if (this._initialScaledLastPosition === undefined) {
+      return;
+    }
+    const timeShiftBufferDepth = this._timeShiftBufferDepth;
+    const timeSinceLastRealUpdate = (performance.now() -
+                                     this.validityTime) / 1000;
+    const lastPositionEstimate = timeSinceLastRealUpdate +
+                                 this._initialScaledLastPosition / this.timescale;
+
+    if (timeShiftBufferDepth !== undefined) {
+      const minimumPosition = (lastPositionEstimate - timeShiftBufferDepth) *
+                              this.timescale;
+      clearTimelineFromPosition(this.timeline, minimumPosition);
+    }
+  }
+
+  /**
+   * Replace this SharedSmoothSegmentTimeline by a newly downloaded one.
+   * Check if the old timeline had more information about new segments and re-add
+   * them if that's the case.
+   * @param {Object} newSmoothTimeline
+   */
+  public replace(newSmoothTimeline : SharedSmoothSegmentTimeline) : void {
+    const oldTimeline = this.timeline;
+    const newTimeline = newSmoothTimeline.timeline;
+    const oldTimescale = this.timescale;
+    const newTimescale = newSmoothTimeline.timescale;
+
+    this._initialScaledLastPosition = newSmoothTimeline._initialScaledLastPosition;
+    this.validityTime = newSmoothTimeline.validityTime;
+
+    if (oldTimeline.length === 0 ||
+        newTimeline.length === 0 ||
+        oldTimescale !== newTimescale)
+    {
+      return; // don't take risk, if something is off, take the new one
+    }
+
+    const lastOldTimelineElement = oldTimeline[oldTimeline.length - 1];
+    const lastNewTimelineElement = newTimeline[newTimeline.length - 1];
+    const newEnd = getIndexSegmentEnd(lastNewTimelineElement, null);
+    if (getIndexSegmentEnd(lastOldTimelineElement, null) <= newEnd) {
+      return;
+    }
+
+    for (let i = 0; i < oldTimeline.length; i++) {
+      const oldTimelineRange = oldTimeline[i];
+      const oldEnd = getIndexSegmentEnd(oldTimelineRange, null);
+      if (oldEnd === newEnd) { // just add the supplementary segments
+        this.timeline = this.timeline.concat(oldTimeline.slice(i + 1));
+        return;
+      }
+
+      if (oldEnd > newEnd) { // adjust repeatCount + add supplementary segments
+        if (oldTimelineRange.duration !== lastNewTimelineElement.duration) {
+          return;
+        }
+
+        const rangeDuration = newEnd - oldTimelineRange.start;
+        if (rangeDuration === 0) {
+          log.warn("Smooth Parser: a discontinuity detected in the previous manifest" +
+            " has been resolved.");
+          this.timeline = this.timeline.concat(oldTimeline.slice(i));
+          return;
+        }
+        if (rangeDuration < 0 || rangeDuration % oldTimelineRange.duration !== 0) {
+          return;
+        }
+
+        const repeatWithOld = (rangeDuration / oldTimelineRange.duration) - 1;
+        const relativeRepeat = oldTimelineRange.repeatCount - repeatWithOld;
+        if (relativeRepeat < 0) {
+          return;
+        }
+        lastNewTimelineElement.repeatCount += relativeRepeat;
+        const supplementarySegments = oldTimeline.slice(i + 1);
+        this.timeline = this.timeline.concat(supplementarySegments);
+        return;
+      }
+    }
+  }
+
+  /**
+   * Update the current SharedSmoothSegmentTimeline with a new, partial, version.
+   * This method might be use to only add information about new segments.
+   * @param {Object} newSmoothTimeline
+   */
+  public update(newSmoothTimeline : SharedSmoothSegmentTimeline) : void {
+    updateSegmentTimeline(this.timeline, newSmoothTimeline.timeline);
+    this._initialScaledLastPosition = newSmoothTimeline._initialScaledLastPosition;
+    this.validityTime = newSmoothTimeline.validityTime;
+  }
+
+  /**
+   * Add segments to a `SharedSmoothSegmentTimeline` that were predicted to come
+   * after `currentSegment`.
+   * @param {Array.<Object>} nextSegments - The segment information parsed.
+   * @param {Object} segment - Information on the segment which contained that
+   * new segment information.
+   */
+  public addPredictedSegments(
+    nextSegments : Array<{ duration : number; time : number; timescale : number }>,
+    currentSegment : ISegment
+  ) : void {
+    if (currentSegment.privateInfos?.smoothMediaSegment === undefined) {
+      log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
+      return;
+    }
+
+    this.refresh();
+    for (let i = 0; i < nextSegments.length; i++) {
+      addSegmentInfos(this.timeline,
+                      this.timescale,
+                      nextSegments[i],
+                      currentSegment.privateInfos.smoothMediaSegment);
+    }
+  }
+}
+
+export interface ISharedSmoothSegmentTimelineArguments {
+  timeline : IIndexSegment[];
+  timescale : number;
+  timeShiftBufferDepth : number | undefined;
+  manifestReceivedTime : number | undefined;
+}
+
+/**
+ * Object describing information about one segment or several consecutive
+ * segments.
+ */
+export interface IIndexSegment {
+  /** Time (timescaled) at which the segment starts. */
+  start : number;
+  /** Duration (timescaled) of the segment. */
+  duration : number;
+  /**
+   * Amount of consecutive segments with that duration.
+   *
+   * For example let's consider the following IIndexSegment:
+   * ```
+   * { start: 10, duration: 2, repeatCount: 2 }
+   * ```
+   * Here, because `repeatCount` is set to `2`, this object actually defines 3
+   * segments:
+   *   1. one starting at `10` and ending at `12` (10 + 2)
+   *   2. another one starting at `12` (the previous one's end) and ending at
+   *      `14` (12 + 2)
+   *   3. another one starting at `14` (the previous one's end) and ending at
+   *      `16` (14 +2)
+   */
+  repeatCount: number;
+}

--- a/src/parsers/manifest/smooth/utils/add_segment_infos.ts
+++ b/src/parsers/manifest/smooth/utils/add_segment_infos.ts
@@ -20,27 +20,25 @@ export interface IIndexSegment { start : number;
                                  duration : number;
                                  repeatCount: number; }
 
-export interface ITimelineIndex { timescale : number;
-                                  timeline : IIndexSegment[]; }
-
 /**
  * Add a new segment to the index.
  *
  * /!\ Mutate the given index
- * @param {Object} index
+ * @param {Array.<Object>} timeline
+ * @param {number} timescale
  * @param {Object} newSegment
  * @param {Object} currentSegment
  * @returns {Boolean} - true if the segment has been added
  */
 export default function _addSegmentInfos(
-  index : ITimelineIndex,
+  timeline : IIndexSegment[],
+  timescale : number,
   newSegment : { time : number;
                  duration : number;
                  timescale : number; },
   currentSegment : { time : number;
                      duration : number; }
 ) : boolean {
-  const { timeline, timescale } = index;
   const timelineLength = timeline.length;
   const last = timeline[timelineLength - 1];
 
@@ -66,9 +64,9 @@ export default function _addSegmentInfos(
     if (last.duration === scaledNewSegment.duration) {
       last.repeatCount++;
     } else {
-      index.timeline.push({ duration: scaledNewSegment.duration,
-                            start: scaledNewSegment.time,
-                            repeatCount: 0 });
+      timeline.push({ duration: scaledNewSegment.duration,
+                      start: scaledNewSegment.time,
+                      repeatCount: 0 });
     }
     return true;
   }

--- a/src/parsers/manifest/utils/__tests__/get_first_time_from_adaptations.test.ts
+++ b/src/parsers/manifest/utils/__tests__/get_first_time_from_adaptations.test.ts
@@ -33,6 +33,7 @@ function generateRepresentationIndex(
     canBeOutOfSyncError() : true { return true; },
     isInitialized() : true { return true; },
     initialize() : void { return ; },
+    addPredictedSegments() : void { return ; },
     _replace() { /* noop */ },
     _update() { /* noop */ },
   };

--- a/src/parsers/manifest/utils/__tests__/get_first_time_from_adaptations.test.ts
+++ b/src/parsers/manifest/utils/__tests__/get_first_time_from_adaptations.test.ts
@@ -32,6 +32,7 @@ function generateRepresentationIndex(
     isFinished() { return false; },
     canBeOutOfSyncError() : true { return true; },
     isInitialized() : true { return true; },
+    initialize() : void { return ; },
     _replace() { /* noop */ },
     _update() { /* noop */ },
   };

--- a/src/parsers/manifest/utils/__tests__/get_last_time_from_adaptation.test.ts
+++ b/src/parsers/manifest/utils/__tests__/get_last_time_from_adaptation.test.ts
@@ -32,6 +32,7 @@ function generateRepresentationIndex(
     isFinished() { return false; },
     isInitialized() : true { return true; },
     initialize() : void { return ; },
+    addPredictedSegments() : void { return ; },
     canBeOutOfSyncError() : true { return true; },
     _replace() { /* noop */ },
     _update() { /* noop */ },

--- a/src/parsers/manifest/utils/__tests__/get_last_time_from_adaptation.test.ts
+++ b/src/parsers/manifest/utils/__tests__/get_last_time_from_adaptation.test.ts
@@ -31,6 +31,7 @@ function generateRepresentationIndex(
     isSegmentStillAvailable() : undefined { return ; },
     isFinished() { return false; },
     isInitialized() : true { return true; },
+    initialize() : void { return ; },
     canBeOutOfSyncError() : true { return true; },
     _replace() { /* noop */ },
     _update() { /* noop */ },

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -31,7 +31,7 @@ import inferSegmentContainer from "../utils/infer_segment_container";
 export default function addSegmentIntegrityChecks<T>(
   segmentLoader : ISegmentLoader<T>
 ) : ISegmentLoader<T> {
-  return (url, content, initialCancelSignal, callbacks) => {
+  return (url, context, initialCancelSignal, callbacks) => {
     return new Promise((res, rej) => {
 
       const canceller = new TaskCanceller();
@@ -48,13 +48,12 @@ export default function addSegmentIntegrityChecks<T>(
        */
       function cancelAndRejectOnBadIntegrity(data : T) : void {
         if (!(data instanceof Array) && !(data instanceof Uint8Array) ||
-            inferSegmentContainer(content.adaptation.type,
-                                  content.representation) !== "mp4")
+            inferSegmentContainer(context.type, context.mimeType) !== "mp4")
         {
           return;
         }
         try {
-          checkISOBMFFIntegrity(new Uint8Array(data), content.segment.isInit);
+          checkISOBMFFIntegrity(new Uint8Array(data), context.segment.isInit);
         } catch (err) {
           unregisterCancelLstnr();
           canceller.cancel();
@@ -62,7 +61,7 @@ export default function addSegmentIntegrityChecks<T>(
         }
       }
 
-      segmentLoader(url, content, canceller.signal, {
+      segmentLoader(url, context, canceller.signal, {
         ...callbacks,
         onNewChunk(data) {
           cancelAndRejectOnBadIntegrity(data);

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -200,9 +200,10 @@ export default function generateSegmentLoader(
 
       const customCallbacks = { reject, resolve, progress, fallback };
 
-      const args = { context: { segment: context.segment,
-                                type: context.type },
-                     transport: "dash",
+      const args = { isInit: context.segment.isInit,
+                     range: context.segment.range,
+                     indexRange: context.segment.indexRange,
+                     type: context.type,
                      url };
       const abort = customSegmentLoader(args, customCallbacks);
 

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -24,10 +24,10 @@ import {
   getSegmentsFromCues,
   getTimeCodeScale,
 } from "../../parsers/containers/matroska";
-import { BaseRepresentationIndex } from "../../parsers/manifest/dash";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import takeFirstSet from "../../utils/take_first_set";
 import {
+  IProtectionDataInfo,
   ISegmentContext,
   ISegmentParser,
   ISegmentParserParsedInitChunk,
@@ -50,42 +50,42 @@ export default function generateAudioVideoSegmentParser(
   return function audioVideoSegmentParser(
     loadedSegment : { data : ArrayBuffer | Uint8Array | null;
                       isChunked : boolean; },
-    content : ISegmentContext,
+    context : ISegmentContext,
     initTimescale : number | undefined
   ) : ISegmentParserParsedMediaChunk< Uint8Array | ArrayBuffer | null > |
       ISegmentParserParsedInitChunk< Uint8Array | ArrayBuffer | null > {
-    const { period, adaptation, representation, segment, manifest } = content;
+    const { segment, periodStart, periodEnd } = context;
     const { data, isChunked } = loadedSegment;
-    const appendWindow : [number, number | undefined] = [ period.start, period.end ];
+    const appendWindow : [number, number | undefined] = [ periodStart, periodEnd ];
 
     if (data === null) {
       if (segment.isInit) {
         return { segmentType: "init",
                  initializationData: null,
-                 protectionDataUpdate: false,
+                 protectionData: [],
                  initTimescale: undefined };
       }
       return { segmentType: "media",
                chunkData: null,
                chunkInfos: null,
                chunkOffset: 0,
-               protectionDataUpdate: false,
+               protectionData: [],
                appendWindow };
     }
 
     const chunkData = data instanceof Uint8Array ? data :
                                                    new Uint8Array(data);
 
-    const containerType = inferSegmentContainer(adaptation.type, representation);
+    const containerType = inferSegmentContainer(context.type, context.mimeType);
 
     // TODO take a look to check if this is an ISOBMFF/webm?
     const seemsToBeMP4 = containerType === "mp4" || containerType === undefined;
 
-    let protectionDataUpdate = false;
+    const protectionData : IProtectionDataInfo[] = [];
     if (seemsToBeMP4) {
       const psshInfo = takePSSHOut(chunkData);
       if (psshInfo.length > 0) {
-        protectionDataUpdate = representation._addProtectionData("cenc", psshInfo);
+        protectionData.push({ initDataType: "cenc", initData: psshInfo });
       }
     }
 
@@ -108,7 +108,7 @@ export default function generateAudioVideoSegmentParser(
             return segment.privateInfos.isEMSGWhitelisted(evt);
           });
           const events = getEventsOutOfEMSGs(whitelistedEMSGs,
-                                             manifest.publishTime);
+                                             context.manifestPublishTime);
           if (events !== undefined) {
             const { needsManifestRefresh, inbandEvents } = events;
             return { segmentType: "media",
@@ -117,7 +117,7 @@ export default function generateAudioVideoSegmentParser(
                      chunkOffset,
                      appendWindow,
                      inbandEvents,
-                     protectionDataUpdate,
+                     protectionData,
                      needsManifestRefresh };
           }
         }
@@ -127,17 +127,17 @@ export default function generateAudioVideoSegmentParser(
                chunkData,
                chunkInfos,
                chunkOffset,
-               protectionDataUpdate,
+               protectionData,
                appendWindow };
     }
     // we're handling an initialization segment
     const { indexRange } = segment;
 
-    let nextSegments = null;
+    let segmentList;
     if (containerType === "webm") {
-      nextSegments = getSegmentsFromCues(chunkData, 0);
+      segmentList = getSegmentsFromCues(chunkData, 0);
     } else if (seemsToBeMP4) {
-      nextSegments = getSegmentsFromSidx(chunkData, Array.isArray(indexRange) ?
+      segmentList = getSegmentsFromSidx(chunkData, Array.isArray(indexRange) ?
                                                       indexRange[0] :
                                                       0);
 
@@ -149,21 +149,14 @@ export default function generateAudioVideoSegmentParser(
       // TODO Cleaner way? I tried to always check the obtained segment after
       // a byte-range request but it leads to a lot of code.
       if (__priv_patchLastSegmentInSidx === true &&
-          nextSegments !== null &&
-          nextSegments.length > 0)
+          segmentList !== null &&
+          segmentList.length > 0)
       {
-        const lastSegment = nextSegments[ nextSegments.length - 1 ];
+        const lastSegment = segmentList[ segmentList.length - 1 ];
         if (Array.isArray(lastSegment.range)) {
           lastSegment.range[1] = Infinity;
         }
       }
-    }
-
-    if (representation.index instanceof BaseRepresentationIndex &&
-        nextSegments !== null &&
-        nextSegments.length > 0)
-    {
-      representation.index.initializeIndex(nextSegments);
     }
 
     const timescale = seemsToBeMP4             ? getMDHDTimescale(chunkData) :
@@ -175,7 +168,8 @@ export default function generateAudioVideoSegmentParser(
 
     return { segmentType: "init",
              initializationData: chunkData,
-             protectionDataUpdate,
-             initTimescale: parsedTimescale };
+             protectionData,
+             initTimescale: parsedTimescale,
+             segmentList: segmentList ?? undefined };
   };
 }

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -57,14 +57,14 @@ export default function generateTextTrackLoader(
    */
   function textTrackLoader(
     url : string | null,
-    content : ISegmentContext,
+    context : ISegmentContext,
     cancelSignal : CancellationSignal,
     callbacks : ISegmentLoaderCallbacks<ILoadedTextSegmentFormat>
   ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
               ISegmentLoaderResultSegmentCreated<ILoadedTextSegmentFormat> |
               ISegmentLoaderResultChunkedComplete>
   {
-    const { adaptation, representation, segment } = content;
+    const { segment } = context;
     const { range } = segment;
 
     if (url === null) {
@@ -76,11 +76,11 @@ export default function generateTextTrackLoader(
       return initSegmentLoader(url, segment, cancelSignal, callbacks);
     }
 
-    const containerType = inferSegmentContainer(adaptation.type, representation);
+    const containerType = inferSegmentContainer(context.type, context.mimeType);
     const seemsToBeMP4 = containerType === "mp4" || containerType === undefined;
     if (lowLatencyMode && seemsToBeMP4) {
       if (fetchIsSupported()) {
-        return lowLatencySegmentLoader(url, content, callbacks, cancelSignal);
+        return lowLatencySegmentLoader(url, context, callbacks, cancelSignal);
       } else {
         warnOnce("DASH: Your browser does not have the fetch API. You will have " +
                  "a higher chance of rebuffering when playing close to the live edge");

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -18,7 +18,6 @@ import {
   getMDHDTimescale,
   getSegmentsFromSidx,
 } from "../../parsers/containers/isobmff";
-import { BaseRepresentationIndex } from "../../parsers/manifest/dash";
 import {
   strToUtf8,
   utf8ToStr,
@@ -44,7 +43,7 @@ import {
  * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
  * @param {boolean} isChunked - If `true`, the `data` may contain only a
  * decodable subpart of the full data in the linked segment.
- * @param {Object} content - Object describing the context of the given
+ * @param {Object} context - Object describing the context of the given
  * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
  * `Manifest` it is a part of etc.
  * @param {number|undefined} initTimescale - `timescale` value - encountered
@@ -60,19 +59,19 @@ import {
 function parseISOBMFFEmbeddedTextTrack(
   data : ArrayBuffer | Uint8Array | string,
   isChunked : boolean,
-  content : ISegmentContext,
+  context : ISegmentContext,
   initTimescale : number | undefined,
   __priv_patchLastSegmentInSidx? : boolean
 ) : ISegmentParserParsedMediaChunk< ITextTrackSegmentData | null > |
     ISegmentParserParsedInitChunk< null > {
-  const { period, representation, segment } = content;
+  const { segment } = context;
   const { isInit, indexRange } = segment;
 
   const chunkBytes = typeof data === "string"   ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
                                                   new Uint8Array(data);
   if (isInit) {
-    const sidxSegments =
+    const segmentList =
       getSegmentsFromSidx(chunkBytes, Array.isArray(indexRange) ? indexRange[0] :
                                                                   0);
 
@@ -84,32 +83,27 @@ function parseISOBMFFEmbeddedTextTrack(
     // TODO Cleaner way? I tried to always check the obtained segment after
     // a byte-range request but it leads to a lot of code.
     if (__priv_patchLastSegmentInSidx === true &&
-        sidxSegments !== null &&
-        sidxSegments.length > 0)
+        segmentList !== null &&
+        segmentList.length > 0)
     {
-      const lastSegment = sidxSegments[ sidxSegments.length - 1 ];
+      const lastSegment = segmentList[ segmentList.length - 1 ];
       if (Array.isArray(lastSegment.range)) {
         lastSegment.range[1] = Infinity;
       }
     }
 
     const mdhdTimescale = getMDHDTimescale(chunkBytes);
-    if (representation.index instanceof BaseRepresentationIndex &&
-        sidxSegments !== null &&
-        sidxSegments.length > 0)
-    {
-      representation.index.initializeIndex(sidxSegments);
-    }
     return { segmentType: "init",
              initializationData: null,
-             protectionDataUpdate: false,
-             initTimescale: mdhdTimescale };
+             protectionData: [],
+             initTimescale: mdhdTimescale,
+             segmentList: segmentList ?? undefined };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
                                            segment,
                                            initTimescale);
-  const chunkData = getISOBMFFEmbeddedTextTrackData(content,
+  const chunkData = getISOBMFFEmbeddedTextTrackData(context,
                                                     chunkBytes,
                                                     chunkInfos,
                                                     isChunked);
@@ -118,8 +112,8 @@ function parseISOBMFFEmbeddedTextTrack(
            chunkData,
            chunkInfos,
            chunkOffset,
-           protectionDataUpdate: false,
-           appendWindow: [period.start, period.end] };
+           protectionData: [],
+           appendWindow: [context.periodStart, context.periodEnd] };
 }
 
 /**
@@ -128,7 +122,7 @@ function parseISOBMFFEmbeddedTextTrack(
  * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
  * @param {boolean} isChunked - If `true`, the `data` may contain only a
  * decodable subpart of the full data in the linked segment.
- * @param {Object} content - Object describing the context of the given
+ * @param {Object} context - Object describing the context of the given
  * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
  * `Manifest` it is a part of etc.
  * @returns {Observable.<Object>}
@@ -136,15 +130,15 @@ function parseISOBMFFEmbeddedTextTrack(
 function parsePlainTextTrack(
   data : ArrayBuffer | Uint8Array | string,
   isChunked : boolean,
-  content : ISegmentContext
+  context : ISegmentContext
 ) : ISegmentParserParsedMediaChunk< ITextTrackSegmentData | null > |
     ISegmentParserParsedInitChunk< null > {
-  const { period, segment } = content;
+  const { periodStart, periodEnd, segment } = context;
   const { timestampOffset = 0 } = segment;
   if (segment.isInit) {
     return { segmentType: "init",
              initializationData: null,
-             protectionDataUpdate: false,
+             protectionData: [],
              initTimescale: undefined };
   }
 
@@ -156,13 +150,13 @@ function parsePlainTextTrack(
   } else {
     textTrackData = data;
   }
-  const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
+  const chunkData = getPlainTextTrackData(context, textTrackData, isChunked);
   return { segmentType: "media",
            chunkData,
            chunkInfos: null,
            chunkOffset: timestampOffset,
-           protectionDataUpdate: false,
-           appendWindow: [period.start, period.end] };
+           protectionData: [],
+           appendWindow: [periodStart, periodEnd] };
 }
 
 /**
@@ -183,29 +177,29 @@ export default function generateTextTrackParser(
   return function textTrackParser(
     loadedSegment : { data : ArrayBuffer | Uint8Array | string | null;
                       isChunked : boolean; },
-    content : ISegmentContext,
+    context : ISegmentContext,
     initTimescale : number | undefined
   ) : ISegmentParserParsedMediaChunk< ITextTrackSegmentData | null > |
       ISegmentParserParsedInitChunk< null > {
-    const { period, adaptation, representation, segment } = content;
+    const { periodStart, periodEnd, segment } = context;
     const { data, isChunked } = loadedSegment;
 
     if (data === null) {
       // No data, just return an empty placeholder object
       return segment.isInit ? { segmentType: "init",
                                 initializationData: null,
-                                protectionDataUpdate: false,
+                                protectionData: [],
                                 initTimescale: undefined } :
 
                               { segmentType: "media",
                                 chunkData: null,
                                 chunkInfos: null,
                                 chunkOffset: segment.timestampOffset ?? 0,
-                                protectionDataUpdate: false,
-                                appendWindow: [period.start, period.end] };
+                                protectionData: [],
+                                appendWindow: [periodStart, periodEnd] };
     }
 
-    const containerType = inferSegmentContainer(adaptation.type, representation);
+    const containerType = inferSegmentContainer(context.type, context.mimeType);
 
     // TODO take a look to check if this is an ISOBMFF/webm when undefined?
     if (containerType === "webm") {
@@ -214,10 +208,10 @@ export default function generateTextTrackParser(
     } else if (containerType === "mp4") {
       return parseISOBMFFEmbeddedTextTrack(data,
                                            isChunked,
-                                           content,
+                                           context,
                                            initTimescale, __priv_patchLastSegmentInSidx);
     } else {
-      return parsePlainTextTrack(data, isChunked, content);
+      return parsePlainTextTrack(data, isChunked, context);
     }
   };
 }

--- a/src/transports/local/text_parser.ts
+++ b/src/transports/local/text_parser.ts
@@ -39,7 +39,7 @@ import {
  * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
  * @param {boolean} isChunked - If `true`, the `data` may contain only a
  * decodable subpart of the full data in the linked segment.
- * @param {Object} content - Object describing the context of the given
+ * @param {Object} context - Object describing the context of the given
  * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
  * `Manifest` it is a part of etc.
  * @param {number|undefined} initTimescale - `timescale` value - encountered
@@ -52,12 +52,12 @@ import {
 function parseISOBMFFEmbeddedTextTrack(
   data : string | Uint8Array | ArrayBuffer,
   isChunked : boolean,
-  content : ISegmentContext,
+  context : ISegmentContext,
   initTimescale : number | undefined
 ) : ISegmentParserParsedInitChunk<null> |
     ISegmentParserParsedMediaChunk<ITextTrackSegmentData | null>
 {
-  const { period, segment } = content;
+  const { periodStart, periodEnd, segment } = context;
 
   const chunkBytes = typeof data === "string" ? strToUtf8(data) :
                      data instanceof Uint8Array ? data :
@@ -67,13 +67,13 @@ function parseISOBMFFEmbeddedTextTrack(
     return { segmentType: "init",
              initializationData: null,
              initTimescale: mdhdTimescale,
-             protectionDataUpdate: false };
+             protectionData: [] };
   }
   const chunkInfos = getISOBMFFTimingInfos(chunkBytes,
                                            isChunked,
                                            segment,
                                            initTimescale);
-  const chunkData = getISOBMFFEmbeddedTextTrackData(content,
+  const chunkData = getISOBMFFEmbeddedTextTrackData(context,
                                                     chunkBytes,
                                                     chunkInfos,
                                                     isChunked);
@@ -82,8 +82,8 @@ function parseISOBMFFEmbeddedTextTrack(
            chunkData,
            chunkInfos,
            chunkOffset,
-           protectionDataUpdate: false,
-           appendWindow: [period.start, period.end] };
+           protectionData: [],
+           appendWindow: [periodStart, periodEnd] };
 }
 
 /**
@@ -91,7 +91,7 @@ function parseISOBMFFEmbeddedTextTrack(
  * @param {ArrayBuffer|Uint8Array|string} data - The segment data.
  * @param {boolean} isChunked - If `true`, the `data` may contain only a
  * decodable subpart of the full data in the linked segment.
- * @param {Object} content - Object describing the context of the given
+ * @param {Object} context - Object describing the context of the given
  * segment's data: of which segment, `Representation`, `Adaptation`, `Period`,
  * `Manifest` it is a part of etc.
  * @returns {Object}
@@ -99,16 +99,16 @@ function parseISOBMFFEmbeddedTextTrack(
 function parsePlainTextTrack(
   data : string | Uint8Array | ArrayBuffer,
   isChunked : boolean,
-  content : ISegmentContext
+  context : ISegmentContext
 ) : ISegmentParserParsedInitChunk<null> |
     ISegmentParserParsedMediaChunk<ITextTrackSegmentData | null>
 {
-  const { period, segment } = content;
+  const { segment, periodStart, periodEnd } = context;
   if (segment.isInit) {
     return { segmentType: "init",
              initializationData: null,
              initTimescale: undefined,
-             protectionDataUpdate: false };
+             protectionData: [] };
   }
 
   let textTrackData : string;
@@ -119,32 +119,32 @@ function parsePlainTextTrack(
   } else {
     textTrackData = data;
   }
-  const chunkData = getPlainTextTrackData(content, textTrackData, isChunked);
+  const chunkData = getPlainTextTrackData(context, textTrackData, isChunked);
   const chunkOffset = takeFirstSet<number>(segment.timestampOffset, 0);
   return { segmentType: "media",
            chunkData,
            chunkInfos: null,
            chunkOffset,
-           protectionDataUpdate: false,
-           appendWindow: [period.start, period.end] };
+           protectionData: [],
+           appendWindow: [periodStart, periodEnd] };
 }
 
 /**
  * Parse TextTrack data.
  * @param {Object} loadedSegment
- * @param {Object} content
+ * @param {Object} context
  * @param {number | undefined} initTimescale
  * @returns {Object}
  */
 export default function textTrackParser(
   loadedSegment : { data : ILoadedTextSegmentFormat;
                     isChunked : boolean; },
-  content : ISegmentContext,
+  context : ISegmentContext,
   initTimescale : number | undefined
 ) : ISegmentParserParsedInitChunk<null> |
     ISegmentParserParsedMediaChunk<ITextTrackSegmentData | null>
 {
-  const { period, adaptation, representation, segment } = content;
+  const { segment, periodStart, periodEnd } = context;
   const { data, isChunked } = loadedSegment;
 
   if (data === null) {
@@ -152,7 +152,7 @@ export default function textTrackParser(
     if (segment.isInit) {
       return { segmentType: "init",
                initializationData: null,
-               protectionDataUpdate: false,
+               protectionData: [],
                initTimescale: undefined };
     }
     const chunkOffset = segment.timestampOffset ?? 0;
@@ -160,19 +160,19 @@ export default function textTrackParser(
              chunkData: null,
              chunkInfos: null,
              chunkOffset,
-             protectionDataUpdate: false,
-             appendWindow: [period.start, period.end] };
+             protectionData: [],
+             appendWindow: [periodStart, periodEnd] };
   }
 
-  const containerType = inferSegmentContainer(adaptation.type, representation);
+  const containerType = inferSegmentContainer(context.type, context.mimeType);
 
   // TODO take a look to check if this is an ISOBMFF/webm when undefined?
   if (containerType === "webm") {
     // TODO Handle webm containers
     throw new Error("Text tracks with a WEBM container are not yet handled.");
   } else if (containerType === "mp4") {
-    return parseISOBMFFEmbeddedTextTrack(data, isChunked, content, initTimescale);
+    return parseISOBMFFEmbeddedTextTrack(data, isChunked, context, initTimescale);
   } else {
-    return parsePlainTextTrack(data, isChunked, content);
+    return parsePlainTextTrack(data, isChunked, context);
   }
 }

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -17,11 +17,8 @@
 import PPromise from "pinkie";
 import features from "../../features";
 import Manifest, {
-  Adaptation,
   IMetaPlaylistPrivateInfos,
   ISegment,
-  Period,
-  Representation,
 } from "../../manifest";
 import parseMetaPlaylist, {
   IParserResponse as IMPLParserResponse,
@@ -57,25 +54,27 @@ import generateManifestLoader from "./manifest_loader";
  * @param {number} offset
  * @returns {Object}
  */
-function getOriginalContent(segment : ISegment) : { manifest : Manifest;
-                                                    period : Period;
-                                                    adaptation : Adaptation;
-                                                    representation : Representation;
-                                                    segment : ISegment; }
-{
+function getOriginalContext(
+  mplContext : ISegmentContext
+) : ISegmentContext {
+  const { segment } = mplContext;
   if (segment.privateInfos?.metaplaylistInfos === undefined) {
     throw new Error("MetaPlaylist: missing private infos");
   }
-  const { manifest,
-          period,
-          adaptation,
-          representation } = segment.privateInfos.metaplaylistInfos.baseContent;
+  const { isLive,
+          periodStart,
+          periodEnd,
+          manifestPublishTime } = segment.privateInfos.metaplaylistInfos;
   const { originalSegment } = segment.privateInfos.metaplaylistInfos;
-  return  { manifest,
-            period,
-            adaptation,
-            representation,
-            segment: originalSegment };
+  return  { segment: originalSegment,
+            type: mplContext.type,
+            language: mplContext.language,
+            mimeType: mplContext.mimeType,
+            codecs: mplContext.codecs,
+            isLive,
+            periodStart,
+            periodEnd,
+            manifestPublishTime };
 }
 
 /**
@@ -242,32 +241,33 @@ export default function(options : ITransportOptions): ITransportPipelines {
   const audioPipeline = {
     loadSegment(
       url : string | null,
-      content : ISegmentContext,
+      context : ISegmentContext,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
                 ISegmentLoaderResultSegmentCreated<ILoadedAudioVideoSegmentFormat> |
                 ISegmentLoaderResultChunkedComplete>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { audio } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
-      return audio.loadSegment(url, ogContent, cancelToken, callbacks);
+
+      const ogContext = getOriginalContext(context);
+      return audio.loadSegment(url, ogContext, cancelToken, callbacks);
     },
 
     parseSegment(
       loadedSegment : { data : ILoadedAudioVideoSegmentFormat; isChunked : boolean },
-      content : ISegmentContext,
+      context : ISegmentContext,
       initTimescale : number | undefined
     ) : ISegmentParserParsedInitChunk<ArrayBuffer | Uint8Array | null> |
         ISegmentParserParsedMediaChunk<ArrayBuffer | Uint8Array | null>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { audio } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
 
-      const parsed = audio.parseSegment(loadedSegment, ogContent, initTimescale);
+      const ogContext = getOriginalContext(context);
+      const parsed = audio.parseSegment(loadedSegment, ogContext, initTimescale);
       if (parsed.segmentType === "init") {
         return parsed;
       }
@@ -279,32 +279,31 @@ export default function(options : ITransportOptions): ITransportPipelines {
   const videoPipeline = {
     loadSegment(
       url : string | null,
-      content : ISegmentContext,
+      context : ISegmentContext,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
                 ISegmentLoaderResultSegmentCreated<ILoadedAudioVideoSegmentFormat> |
                 ISegmentLoaderResultChunkedComplete>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { video } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
-      return video.loadSegment(url, ogContent, cancelToken, callbacks);
+      const ogContext = getOriginalContext(context);
+      return video.loadSegment(url, ogContext, cancelToken, callbacks);
     },
 
     parseSegment(
       loadedSegment : { data : ILoadedAudioVideoSegmentFormat; isChunked : boolean },
-      content : ISegmentContext,
+      context : ISegmentContext,
       initTimescale : number | undefined
     ) : ISegmentParserParsedInitChunk<ArrayBuffer | Uint8Array | null> |
         ISegmentParserParsedMediaChunk<ArrayBuffer | Uint8Array | null>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { video } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
-
-      const parsed = video.parseSegment(loadedSegment, ogContent, initTimescale);
+      const ogContext = getOriginalContext(context);
+      const parsed = video.parseSegment(loadedSegment, ogContext, initTimescale);
       if (parsed.segmentType === "init") {
         return parsed;
       }
@@ -316,32 +315,33 @@ export default function(options : ITransportOptions): ITransportPipelines {
   const textTrackPipeline = {
     loadSegment(
       url : string | null,
-      content : ISegmentContext,
+      context : ISegmentContext,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedTextSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
                 ISegmentLoaderResultSegmentCreated<ILoadedTextSegmentFormat> |
                 ISegmentLoaderResultChunkedComplete>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { text } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
-      return text.loadSegment(url, ogContent, cancelToken, callbacks);
+
+      const ogContext = getOriginalContext(context);
+      return text.loadSegment(url, ogContext, cancelToken, callbacks);
     },
 
     parseSegment(
       loadedSegment : { data : ILoadedTextSegmentFormat; isChunked : boolean },
-      content : ISegmentContext,
+      context : ISegmentContext,
       initTimescale : number | undefined
     ) : ISegmentParserParsedInitChunk<ITextTrackSegmentData | null> |
         ISegmentParserParsedMediaChunk<ITextTrackSegmentData>
     {
-      const { segment } = content;
+      const { segment } = context;
       const { contentStart, contentEnd } = getMetaPlaylistPrivateInfos(segment);
       const { text } = getTransportPipelinesFromSegment(segment);
-      const ogContent = getOriginalContent(segment);
 
-      const parsed = text.parseSegment(loadedSegment, ogContent, initTimescale);
+      const ogContext = getOriginalContext(context);
+      const parsed = text.parseSegment(loadedSegment, ogContext, initTimescale);
       if (parsed.segmentType === "init") {
         return parsed;
       }

--- a/src/transports/smooth/is_mp4_embedded_track.ts
+++ b/src/transports/smooth/is_mp4_embedded_track.ts
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../manifest";
-
 /**
  * Returns `true` if the given Representation refers to segments in an MP4
  * container
  * @param {Representation} representation
  * @returns {Boolean}
  */
-export default function isMP4EmbeddedTrack(
-  representation : Representation
-) : boolean {
-  return typeof representation.mimeType === "string" &&
-         representation.mimeType.indexOf("mp4") >= 0;
+export default function isMP4EmbeddedTrack(mimeType : string | undefined) : boolean {
+  return typeof mimeType === "string" && mimeType.indexOf("mp4") >= 0;
 }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -49,32 +49,6 @@ import isMP4EmbeddedTrack from "./is_mp4_embedded_track";
 import { patchSegment } from "./isobmff";
 import generateSegmentLoader from "./segment_loader";
 
-// XXX TODO
-// /**
-//  * @param {Object} adaptation
-//  * @param {Object} dlSegment
-//  * @param {Object} nextSegments
-//  */
-// function addNextSegments(
-//   adaptation : Adaptation,
-//   nextSegments : INextSegmentsInfos[],
-//   dlSegment : ISegment
-// ) : void {
-//   log.debug("Smooth Parser: update segments information.");
-//   const representations = adaptation.representations;
-//   for (let i = 0; i < representations.length; i++) {
-//     const representation = representations[i];
-//     if (representation.index instanceof SmoothRepresentationIndex &&
-//         dlSegment?.privateInfos?.smoothMediaSegment !== undefined)
-//     {
-//       representation.index.addNewSegments(nextSegments,
-//                                           dlSegment.privateInfos.smoothMediaSegment);
-//     } else {
-//       log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
-//     }
-//   }
-// }
-
 export default function(options : ITransportOptions) : ITransportPipelines {
   const smoothManifestParser = createSmoothManifestParser(options);
   const segmentLoader = generateSegmentLoader(options);
@@ -185,15 +159,14 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       }
       const { nextSegments, chunkInfos, scaledSegmentTime } = timingInfos;
       const chunkData = patchSegment(responseBuffer, scaledSegmentTime);
-      if (nextSegments.length > 0) {
-        // XXX TODO
-        // addNextSegments(adaptation, nextSegments, segment);
-      }
+      const predictedSegments = nextSegments.length > 0 ? nextSegments :
+                                                          undefined;
       return { segmentType: "media",
                chunkData,
                chunkInfos,
                chunkOffset: 0,
                protectionData: [],
+               predictedSegments,
                appendWindow: [undefined, undefined] };
     },
   };
@@ -357,13 +330,9 @@ export default function(options : ITransportOptions) : ITransportPipelines {
         _sdData = chunkString;
       }
 
-      if (chunkInfos !== null &&
-          Array.isArray(nextSegments) && nextSegments.length > 0)
-      {
-        // XXX TODO
-        // addNextSegments(adaptation, nextSegments, segment);
-      }
-
+      const predictedSegments = Array.isArray(nextSegments) &&
+                                nextSegments.length > 0 ? nextSegments :
+                                                          undefined;
       const chunkOffset = segmentStart ?? 0;
       return { segmentType: "media",
                chunkData: { type: _sdType,
@@ -374,6 +343,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                chunkInfos,
                chunkOffset,
                protectionData: [],
+               predictedSegments,
                appendWindow: [undefined, undefined] };
     },
   };

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -16,14 +16,9 @@
 
 import PPromise from "pinkie";
 import log from "../../log";
-import Manifest, {
-  Adaptation,
-  ISegment,
-} from "../../manifest";
+import Manifest from "../../manifest";
 import { getMDAT } from "../../parsers/containers/isobmff";
-import createSmoothManifestParser, {
-  SmoothRepresentationIndex,
-} from "../../parsers/manifest/smooth";
+import createSmoothManifestParser from "../../parsers/manifest/smooth";
 import request from "../../utils/request";
 import {
   strToUtf8,
@@ -49,37 +44,36 @@ import {
 } from "../types";
 import checkISOBMFFIntegrity from "../utils/check_isobmff_integrity";
 import generateManifestLoader from "../utils/generate_manifest_loader";
-import extractTimingsInfos, {
-  INextSegmentsInfos,
-} from "./extract_timings_infos";
+import extractTimingsInfos from "./extract_timings_infos";
 import isMP4EmbeddedTrack from "./is_mp4_embedded_track";
 import { patchSegment } from "./isobmff";
 import generateSegmentLoader from "./segment_loader";
 
-/**
- * @param {Object} adaptation
- * @param {Object} dlSegment
- * @param {Object} nextSegments
- */
-function addNextSegments(
-  adaptation : Adaptation,
-  nextSegments : INextSegmentsInfos[],
-  dlSegment : ISegment
-) : void {
-  log.debug("Smooth Parser: update segments information.");
-  const representations = adaptation.representations;
-  for (let i = 0; i < representations.length; i++) {
-    const representation = representations[i];
-    if (representation.index instanceof SmoothRepresentationIndex &&
-        dlSegment?.privateInfos?.smoothMediaSegment !== undefined)
-    {
-      representation.index.addNewSegments(nextSegments,
-                                          dlSegment.privateInfos.smoothMediaSegment);
-    } else {
-      log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
-    }
-  }
-}
+// XXX TODO
+// /**
+//  * @param {Object} adaptation
+//  * @param {Object} dlSegment
+//  * @param {Object} nextSegments
+//  */
+// function addNextSegments(
+//   adaptation : Adaptation,
+//   nextSegments : INextSegmentsInfos[],
+//   dlSegment : ISegment
+// ) : void {
+//   log.debug("Smooth Parser: update segments information.");
+//   const representations = adaptation.representations;
+//   for (let i = 0; i < representations.length; i++) {
+//     const representation = representations[i];
+//     if (representation.index instanceof SmoothRepresentationIndex &&
+//         dlSegment?.privateInfos?.smoothMediaSegment !== undefined)
+//     {
+//       representation.index.addNewSegments(nextSegments,
+//                                           dlSegment.privateInfos.smoothMediaSegment);
+//     } else {
+//       log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
+//     }
+//   }
+// }
 
 export default function(options : ITransportOptions) : ITransportPipelines {
   const smoothManifestParser = createSmoothManifestParser(options);
@@ -122,44 +116,44 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     /**
      * Load a Smooth audio/video segment.
      * @param {string|null} url
-     * @param {Object} content
+     * @param {Object} context
      * @param {Object} cancelSignal
      * @param {Object} callbacks
      * @returns {Promise}
      */
     loadSegment(
       url : string | null,
-      content : ISegmentContext,
+      context : ISegmentContext,
       cancelSignal : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
     ) : PPromise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
                  ISegmentLoaderResultSegmentCreated<ILoadedAudioVideoSegmentFormat>>
     {
-      return segmentLoader(url, content, cancelSignal, callbacks);
+      return segmentLoader(url, context, cancelSignal, callbacks);
     },
 
     parseSegment(
       loadedSegment : { data : ArrayBuffer | Uint8Array | null;
                         isChunked : boolean; },
-      content : ISegmentContext,
+      context : ISegmentContext,
       initTimescale : number | undefined
     ) : ISegmentParserParsedInitChunk< ArrayBuffer | Uint8Array | null> |
         ISegmentParserParsedMediaChunk< ArrayBuffer | Uint8Array | null >
     {
-      const { segment, adaptation, manifest } = content;
+      const { segment } = context;
       const { data, isChunked } = loadedSegment;
       if (data === null) {
         if (segment.isInit) {
           return { segmentType: "init",
                    initializationData: null,
-                   protectionDataUpdate: false,
+                   protectionData: [],
                    initTimescale: undefined };
         }
         return { segmentType: "media",
                  chunkData: null,
                  chunkInfos: null,
                  chunkOffset: 0,
-                 protectionDataUpdate: false,
+                 protectionData: [],
                  appendWindow: [undefined, undefined] };
       }
 
@@ -173,7 +167,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                  // smooth init segments are crafted by hand.
                  // Their timescale is the one from the manifest.
                  initTimescale: timescale,
-                 protectionDataUpdate: false };
+                 protectionData: [] };
       }
 
       const timingInfos = initTimescale !== undefined ?
@@ -181,7 +175,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                             isChunked,
                             initTimescale,
                             segment,
-                            manifest.isLive) :
+                            context.isLive) :
         null;
       if (timingInfos === null ||
           timingInfos.chunkInfos === null ||
@@ -192,13 +186,14 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       const { nextSegments, chunkInfos, scaledSegmentTime } = timingInfos;
       const chunkData = patchSegment(responseBuffer, scaledSegmentTime);
       if (nextSegments.length > 0) {
-        addNextSegments(adaptation, nextSegments, segment);
+        // XXX TODO
+        // addNextSegments(adaptation, nextSegments, segment);
       }
       return { segmentType: "media",
                chunkData,
                chunkInfos,
                chunkOffset: 0,
-               protectionDataUpdate: false,
+               protectionData: [],
                appendWindow: [undefined, undefined] };
     },
   };
@@ -206,18 +201,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
   const textTrackPipeline = {
     loadSegment(
       url : string | null,
-      content : ISegmentContext,
+      context : ISegmentContext,
       cancelSignal : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedTextSegmentFormat>
     ) : PPromise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
                  ISegmentLoaderResultSegmentCreated<ILoadedTextSegmentFormat>> {
-      const { segment, representation } = content;
+      const { segment } = context;
       if (segment.isInit || url === null) {
         return PPromise.resolve({ resultType: "segment-created",
                                   resultData: null });
       }
 
-      const isMP4 = isMP4EmbeddedTrack(representation);
+      const isMP4 = isMP4EmbeddedTrack(context.mimeType);
       if (!isMP4) {
         return request({ url,
                          responseType: "text",
@@ -236,7 +231,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                        resultData: data };
             }
             const dataU8 = new Uint8Array(data.responseData);
-            checkISOBMFFIntegrity(dataU8, content.segment.isInit);
+            checkISOBMFFIntegrity(dataU8, context.segment.isInit);
             return { resultType: "segment-loaded" as const,
                      resultData: { ...data, responseData: dataU8 } };
           });
@@ -246,20 +241,18 @@ export default function(options : ITransportOptions) : ITransportPipelines {
     parseSegment(
       loadedSegment : { data : ArrayBuffer | Uint8Array | string | null;
                         isChunked : boolean; },
-      content : ISegmentContext,
+      context : ISegmentContext,
       initTimescale : number | undefined
     ) : ISegmentParserParsedInitChunk< null > |
         ISegmentParserParsedMediaChunk< ITextTrackSegmentData | null >
     {
-      const { manifest, adaptation, representation, segment } = content;
-      const { language } = adaptation;
-      const isMP4 = isMP4EmbeddedTrack(representation);
-      const { mimeType = "", codec = "" } = representation;
+      const { segment, language, mimeType = "", codecs = "" } = context;
+      const isMP4 = isMP4EmbeddedTrack(context.mimeType);
       const { data, isChunked } = loadedSegment;
       if (segment.isInit) { // text init segment has no use in HSS
         return { segmentType: "init",
                  initializationData: null,
-                 protectionDataUpdate: false,
+                 protectionData: [],
                  initTimescale: undefined };
       }
       if (data === null) {
@@ -267,7 +260,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                  chunkData: null,
                  chunkInfos: null,
                  chunkOffset: 0,
-                 protectionDataUpdate: false,
+                 protectionData: [],
                  appendWindow: [undefined, undefined] };
       }
 
@@ -292,7 +285,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                               isChunked,
                               initTimescale,
                               segment,
-                              manifest.isLive) :
+                              context.isLive) :
           null;
 
         nextSegments = timingInfos?.nextSegments;
@@ -311,7 +304,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
             segment.end;
         }
 
-        const lcCodec = codec.toLowerCase();
+        const lcCodec = codecs.toLowerCase();
         if (mimeType === "application/ttml+xml+mp4" ||
             lcCodec === "stpp" ||
             lcCodec === "stpp.ttml.im1t"
@@ -353,7 +346,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
         }
 
         if (_sdType === undefined) {
-          const lcCodec = codec.toLowerCase();
+          const lcCodec = codecs.toLowerCase();
           if (lcCodec === "srt") {
             _sdType = "srt";
           } else {
@@ -367,7 +360,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       if (chunkInfos !== null &&
           Array.isArray(nextSegments) && nextSegments.length > 0)
       {
-        addNextSegments(adaptation, nextSegments, segment);
+        // XXX TODO
+        // addNextSegments(adaptation, nextSegments, segment);
       }
 
       const chunkOffset = segmentStart ?? 0;
@@ -379,7 +373,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                             language },
                chunkInfos,
                chunkOffset,
-               protectionDataUpdate: false,
+               protectionData: [],
                appendWindow: [undefined, undefined] };
     },
   };

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -249,10 +249,11 @@ const generateSegmentLoader = ({
       };
 
       const customCallbacks = { reject, resolve, fallback, progress };
-      const args = { context,
-                     transport: "smooth",
+      const args = { isInit: context.segment.isInit,
+                     range: context.segment.range,
+                     indexRange: context.segment.indexRange,
+                     type: context.type,
                      url };
-
       const abort = customSegmentLoader(args, customCallbacks);
 
       cancelSignal.register(abortCustomLoader);

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -1,4 +1,5 @@
 /**
+>>>>>>> 9b1338c6a (smooth: move the addition of predicted segments from the segment parser to the RepresentationStream)
  * Copyright 2015 CANAL+ Group
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -438,7 +439,7 @@ export interface ITransportOptions {
 }
 
 export type ICustomSegmentLoader = (
-  // first argument: infos on the segment
+  // first argument: information on the segment
   args : ICustomSegmentLoaderSegmentContext,
 
   // second argument: callbacks
@@ -491,8 +492,8 @@ export interface ICustomSegmentLoaderSegmentContext {
 }
 
 export type ICustomManifestLoader = (
-  // first argument: url of the manifest
-  url : string | undefined,
+  // first argument: information on the Manifest
+  args : ICustomManifestLoaderContextInfo,
 
   // second argument: callbacks
   callbacks : { resolve : (args : { data : ILoadedManifestFormat;
@@ -507,6 +508,10 @@ export type ICustomManifestLoader = (
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;
+
+export interface ICustomManifestLoaderContextInfo {
+  url : string | undefined;
+}
 
 /** Context given to a segment loader and parser. */
 export interface ISegmentContext {

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -698,7 +698,7 @@ export interface ISegmentParserParsedInitChunk<DataType> {
    * This might then be used to communicate it to the corresponding
    * `RepresentationIndex`.
    */
-  segmentList? : IIndexSegmentListItem[];
+  segmentList? : ISegmentInformation[];
 }
 
 /**
@@ -752,6 +752,14 @@ export interface ISegmentParserParsedMediaChunk<DataType> {
    * Empty array if no such information was found.
    */
   protectionData : IProtectionDataInfo[];
+  /**
+   * Some segments might contain information about segments coming after them.
+   * Those are called "predicted segments".
+   *
+   * If set, this array will contain the list of segment predicted to come just
+   * after this segment.
+   */
+  predictedSegments? : ISegmentInformation[];
 }
 
 /** Format of protection data found in a segment/chunk. */
@@ -780,7 +788,7 @@ export interface IProtectionDataInfo {
  * This type describes the information obtained on a single segment when the
  * initialization segment has been parsed.
  */
-export interface IIndexSegmentListItem {
+export interface ISegmentInformation {
   /** This segment start time, timescaled. */
   time : number;
   /** This segment difference between its end and start time, timescaled. */

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -439,9 +439,7 @@ export interface ITransportOptions {
 
 export type ICustomSegmentLoader = (
   // first argument: infos on the segment
-  args : { context : ICustomSegmentLoaderSegmentContext;
-           transport : string;
-           url : string; },
+  args : ICustomSegmentLoaderSegmentContext,
 
   // second argument: callbacks
   callbacks : { resolve : (rArgs : { data : ArrayBuffer | Uint8Array;
@@ -458,42 +456,36 @@ export type ICustomSegmentLoader = (
 
 /** Context given to a segment loader and parser. */
 export interface ICustomSegmentLoaderSegmentContext {
-  /** Metadata about the wanted segment. */
-  segment : {
-    /**
-     * If true, this segment is an initialization segment with no decodable data.
-     *
-     * Those types of segment contain no decodable data and are only there for
-     * initialization purposes, such as giving initial infos to the decoder on
-     * subsequent media segments that will be pushed.
-     *
-     * Note that if `isInit` is false, it only means that the segment contains
-     * decodable media, it can also contain important initialization information.
-     *
-     * Also, a segment which would contain both all initialization data and the
-     * decodable data would have `isInit` set to `false` as it is not purely an
-     * initialization segment.
-     *
-     * Segments which are not purely an initialization segments are called "media
-     * segments" in the code.
-     */
-    isInit : boolean;
-    /**
-     * URLs where this segment is available. From the most to least prioritary.
-     * `null` if the concept of URL does not apply here.
-     */
-    mediaURLs : string[]|null;
-    /**
-     * If set, the corresponding byte-range in the downloaded segment will
-     * contain an index describing other Segments.
-     */
-    indexRange? : [number, number];
-    /**
-     * If set, the corresponding byte-range is the subset in bytes of the loaded
-     * data where the segment actually is.
-     */
-    range? : [number, number];
-  };
+  /** URL where the segment should be loaded. */
+  url : string | undefined;
+  /**
+   * If true, this segment is an initialization segment with no decodable data.
+   *
+   * Those types of segment contain no decodable data and are only there for
+   * initialization purposes, such as giving initial infos to the decoder on
+   * subsequent media segments that will be pushed.
+   *
+   * Note that if `isInit` is false, it only means that the segment contains
+   * decodable media, it can also contain important initialization information.
+   *
+   * Also, a segment which would contain both all initialization data and the
+   * decodable data would have `isInit` set to `false` as it is not purely an
+   * initialization segment.
+   *
+   * Segments which are not purely an initialization segments are called "media
+   * segments" in the code.
+   */
+  isInit : boolean | undefined;
+  /**
+   * If set, the corresponding byte-range in the downloaded segment will
+   * contain an index describing other Segments.
+   */
+  indexRange? : [number, number];
+  /**
+   * If set, the corresponding byte-range is the subset in bytes of the loaded
+   * data where the segment actually is.
+   */
+  range? : [number, number];
   /** Type of the corresponding track. */
   type : IAdaptationType;
 }

--- a/src/transports/utils/__tests__/infer_segment_container.test.ts
+++ b/src/transports/utils/__tests__/infer_segment_container.test.ts
@@ -14,190 +14,67 @@
  * limitations under the License.
  */
 
-import type { Representation } from "../../../manifest";
 import inferSegmentContainer from "../infer_segment_container";
 
 describe("Transport utils - inferSegmentContainer", () => {
   it("should return \"mp4\" for audio and video tracks with a specific mime-type", () => {
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/mp4" } as Representation))
-      .toEqual("mp4");
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/mp4" } as Representation))
-      .toEqual("mp4");
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/mp4" } as Representation))
-      .toEqual("mp4");
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/mp4" } as Representation))
-      .toEqual("mp4");
+    expect(inferSegmentContainer("audio", "audio/mp4")).toEqual("mp4");
+    expect(inferSegmentContainer("video", "video/mp4")).toEqual("mp4");
+    expect(inferSegmentContainer("audio", "video/mp4")).toEqual("mp4");
+    expect(inferSegmentContainer("video", "audio/mp4")).toEqual("mp4");
   });
 
   /* eslint-disable max-len */
   it("should return undefined for non-audio nor video tracks with a mime-type indicating mp4 audio or video", () => {
   /* eslint-enable max-len */
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/mp4" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/mp4" } as Representation))
-      .toEqual(undefined);
+    expect(inferSegmentContainer("text", "audio/mp4")).toEqual(undefined);
+    expect(inferSegmentContainer("text", "video/mp4")).toEqual(undefined);
   });
 
   /* eslint-disable max-len */
   it("should return \"webm\" for audio and video tracks with a specific mime-type", () => {
   /* eslint-enable max-len */
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/webm" } as Representation))
-      .toEqual("webm");
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/webm" } as Representation))
-      .toEqual("webm");
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/webm" } as Representation))
-      .toEqual("webm");
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/webm" } as Representation))
-      .toEqual("webm");
+    expect(inferSegmentContainer("audio", "audio/webm")).toEqual("webm");
+    expect(inferSegmentContainer("video", "video/webm")).toEqual("webm");
+    expect(inferSegmentContainer("audio", "video/webm")).toEqual("webm");
+    expect(inferSegmentContainer("video", "audio/webm")).toEqual("webm");
   });
 
   /* eslint-disable max-len */
   it("should return undefined for non-audio nor video tracks with a mime-type indicating webm audio or video", () => {
   /* eslint-enable max-len */
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "audio/webm" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "video/webm" } as Representation))
-      .toEqual(undefined);
+    expect(inferSegmentContainer("text", "audio/webm")).toEqual(undefined);
+    expect(inferSegmentContainer("text", "video/webm")).toEqual(undefined);
   });
 
   /* eslint-disable max-len */
   it("should return undefined for audio and video tracks with any other mime-type", () => {
   /* eslint-enable max-len */
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "application/mp4" } as Representation))
+    expect(inferSegmentContainer("audio", "application/mp4"))
       .toEqual(undefined);
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "application/mp4" } as Representation))
+    expect(inferSegmentContainer("video", "application/mp4"))
       .toEqual(undefined);
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "" } as Representation))
+    expect(inferSegmentContainer("audio", ""))
       .toEqual(undefined);
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "" } as Representation))
+    expect(inferSegmentContainer("video", ""))
       .toEqual(undefined);
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "foo" } as Representation))
+    expect(inferSegmentContainer("audio", "foo"))
       .toEqual(undefined);
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "bar" } as Representation))
+    expect(inferSegmentContainer("video", "bar"))
       .toEqual(undefined);
-    expect(inferSegmentContainer("audio",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {} } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("video",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {} } as Representation))
-      .toEqual(undefined);
+    expect(inferSegmentContainer("audio", undefined)).toEqual(undefined);
   });
 
   it("should return \"mp4\" for a text track with a specific mime-type", () => {
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "application/mp4" } as Representation))
-      .toEqual("mp4");
+    expect(inferSegmentContainer("text", "application/mp4")).toEqual("mp4");
   });
 
 
   it("should return undefined for text tracks with any other mime-type", () => {
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "text/mp4" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "text/plain" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {},
-                                   mimeType: "foo" } as Representation))
-      .toEqual(undefined);
-    expect(inferSegmentContainer("text",
-                                 { bitrate: 0,
-                                   id: "1",
-                                   index: {} } as Representation))
-      .toEqual(undefined);
+    expect(inferSegmentContainer("text", "text/mp4")).toEqual(undefined);
+    expect(inferSegmentContainer("text", "text/plain")).toEqual(undefined);
+    expect(inferSegmentContainer("text", "")).toEqual(undefined);
+    expect(inferSegmentContainer("text", "foo")).toEqual(undefined);
+    expect(inferSegmentContainer("text", undefined)).toEqual(undefined);
   });
 });

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -117,7 +117,7 @@ export default function callCustomManifestLoader(
       };
 
       const callbacks = { reject, resolve, fallback };
-      const abort = customManifestLoader(url, callbacks);
+      const abort = customManifestLoader({ url }, callbacks);
 
       cancelSignal.register(abortCustomLoader);
 

--- a/src/transports/utils/infer_segment_container.ts
+++ b/src/transports/utils/infer_segment_container.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  IAdaptationType,
-  Representation,
-} from "../../manifest";
+import { IAdaptationType } from "../../manifest";
 
 /**
  * Guess the type of container a segment is in based on Manifest information.
@@ -33,22 +30,19 @@ import {
  */
 export default function inferSegmentContainer(
   adaptationType : IAdaptationType,
-  representation : Representation
+  mimeType : string | undefined
 ) : "webm" | "mp4" | undefined {
   if (adaptationType === "audio" || adaptationType === "video") {
-    if (representation.mimeType === "video/mp4" ||
-        representation.mimeType === "audio/mp4")
-    {
+    if (mimeType === "video/mp4" || mimeType === "audio/mp4") {
       return "mp4";
     }
-    if (representation.mimeType === "video/webm" ||
-        representation.mimeType === "audio/webm")
+    if (mimeType === "video/webm" || mimeType === "audio/webm")
     {
       return "webm";
     }
     return undefined;
   } else if (adaptationType === "text") {
-    return representation.mimeType === "application/mp4" ?
+    return mimeType === "application/mp4" ?
       "mp4" :
       undefined;
   }

--- a/src/transports/utils/parse_text_track.ts
+++ b/src/transports/utils/parse_text_track.ts
@@ -15,15 +15,12 @@
  */
 
 import log from "../../log";
-import {
-  Adaptation,
-  ISegment,
-  Representation,
-} from "../../manifest";
+import { ISegment } from "../../manifest";
 import { getMDAT } from "../../parsers/containers/isobmff";
 import { utf8ToStr } from "../../utils/string_parsing";
 import {
   IChunkTimeInfo,
+  ISegmentContext,
   ITextTrackSegmentData,
 } from "../types";
 
@@ -45,13 +42,12 @@ export function extractTextTrackFromISOBMFF(chunkBytes : Uint8Array) : string {
  * @returns {string}
  */
 export function getISOBMFFTextTrackFormat(
-  representation : Representation
+  codecs : string | undefined
 ) : "ttml" | "vtt" {
-  const codec = representation.codec;
-  if (codec === undefined) {
+  if (codecs === undefined) {
     throw new Error("Cannot parse subtitles: unknown format");
   }
-  switch (codec.toLowerCase()) {
+  switch (codecs.toLowerCase()) {
     case "stpp": // stpp === TTML in MP4
     case "stpp.ttml.im1t":
       return "ttml";
@@ -59,7 +55,7 @@ export function getISOBMFFTextTrackFormat(
       return "vtt";
   }
   throw new Error("The codec used for the subtitles " +
-                  `"${codec}" is not managed yet.`);
+                  `"${codecs}" is not managed yet.`);
 }
 
 /**
@@ -68,10 +64,10 @@ export function getISOBMFFTextTrackFormat(
  * @returns {string}
  */
 export function getPlainTextTrackFormat(
-  representation : Representation
+  codecs : string | undefined,
+  mimeType : string | undefined
 ) : "ttml" | "sami" | "vtt" | "srt" {
-  const { mimeType = "" } = representation;
-  switch (representation.mimeType) {
+  switch (mimeType) {
     case "application/ttml+xml":
       return "ttml";
     case "application/x-sami":
@@ -81,12 +77,13 @@ export function getPlainTextTrackFormat(
       return "vtt";
   }
 
-  const { codec = "" } = representation;
-  const codeLC = codec.toLowerCase();
-  if (codeLC === "srt") {
-    return "srt";
+  if (codecs !== undefined) {
+    const codeLC = codecs.toLowerCase();
+    if (codeLC === "srt") {
+      return "srt";
+    }
   }
-  throw new Error(`could not find a text-track parser for the type ${mimeType}`);
+  throw new Error(`could not find a text-track parser for the type ${mimeType ?? ""}`);
 }
 
 /**
@@ -98,10 +95,10 @@ export function getPlainTextTrackFormat(
  */
 export function getISOBMFFEmbeddedTextTrackData(
   { segment,
-    adaptation,
-    representation } : { segment : ISegment;
-                         adaptation : Adaptation;
-                         representation : Representation; },
+    language,
+    codecs } : { segment : ISegment;
+                 codecs? : string;
+                 language? : string; },
   chunkBytes : Uint8Array,
   chunkInfos : IChunkTimeInfo | null,
   isChunked : boolean
@@ -127,11 +124,11 @@ export function getISOBMFFEmbeddedTextTrackData(
     }
   }
 
-  const type = getISOBMFFTextTrackFormat(representation);
+  const type = getISOBMFFTextTrackFormat(codecs);
   const textData = extractTextTrackFromISOBMFF(chunkBytes);
   return { data: textData,
            type,
-           language: adaptation.language,
+           language,
            start: startTime,
            end: endTime } ;
 }
@@ -144,14 +141,11 @@ export function getISOBMFFEmbeddedTextTrackData(
  * @returns {Object|null}
  */
 export function getPlainTextTrackData(
-  { segment,
-    adaptation,
-    representation } : { segment : ISegment;
-                         adaptation : Adaptation;
-                         representation : Representation; },
+  context : ISegmentContext,
   textTrackData : string,
   isChunked : boolean
 ) : ITextTrackSegmentData | null {
+  const { segment } = context;
   if (segment.isInit) {
     return null;
   }
@@ -167,10 +161,10 @@ export function getPlainTextTrackData(
     }
   }
 
-  const type = getPlainTextTrackFormat(representation);
+  const type = getPlainTextTrackFormat(context.codecs, context.mimeType);
   return { data: textTrackData,
            type,
-           language: adaptation.language,
+           language: context.language,
            start,
            end };
 }

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -335,11 +335,11 @@ describe("loadVideo Options", () => {
         numberOfTimeCustomSegmentLoaderWentThrough = 0;
       });
 
-      const customSegmentLoader = (infos, callbacks) => {
+      const customSegmentLoader = (info, callbacks) => {
         numberOfTimeCustomSegmentLoaderWasCalled++;
 
         // we will only use this custom loader for videos segments.
-        if (infos.context.type !== "video") {
+        if (info.type !== "video") {
           callbacks.fallback();
           return;
         }
@@ -367,10 +367,10 @@ describe("loadVideo Options", () => {
           callbacks.reject(err);
         };
 
-        xhr.open("GET", infos.url);
+        xhr.open("GET", info.url);
         xhr.responseType = "arraybuffer";
 
-        const range = infos.context.segment.range;
+        const range = info.range;
         if (range) {
           if (range[1] && range[1] !== Infinity) {
             xhr.setRequestHeader("Range", `bytes=${range[0]}-${range[1]}`);

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -339,7 +339,7 @@ describe("loadVideo Options", () => {
         numberOfTimeCustomSegmentLoaderWasCalled++;
 
         // we will only use this custom loader for videos segments.
-        if (infos.adaptation.type !== "video") {
+        if (infos.context.type !== "video") {
           callbacks.fallback();
           return;
         }
@@ -370,7 +370,7 @@ describe("loadVideo Options", () => {
         xhr.open("GET", infos.url);
         xhr.responseType = "arraybuffer";
 
-        const range = infos.segment.range;
+        const range = infos.context.segment.range;
         if (range) {
           if (range[1] && range[1] !== Infinity) {
             xhr.setRequestHeader("Range", `bytes=${range[0]}-${range[1]}`);
@@ -457,7 +457,7 @@ describe("loadVideo Options", () => {
         };
       };
 
-      it("should pass through the custom segmentLoader for segment requests", async () => {
+      it("should pass through the custom manifestLoader for manifest requests", async () => {
         player.loadVideo({
           transport: manifestInfos.transport,
           url: manifestInfos.url,

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -423,7 +423,7 @@ describe("loadVideo Options", () => {
         numberOfTimeCustomManifestLoaderWasCalled = 0;
       });
 
-      const customManifestLoader = (url, callbacks) => {
+      const customManifestLoader = ({ url }, callbacks) => {
         numberOfTimeCustomManifestLoaderWasCalled++;
         const xhr = new XMLHttpRequest();
         const sendingTime = Date.now();


### PR DESCRIPTION
## Overview

This branch is a WIP to [minimally] refactor the segment pipeline code (again, though this is more of a continuation!) so we can agree on a future-proof high-level architecture for the incoming v4.0.0.

I started working on after realizing that developing complex features like #975 was very hard to do with the current `transport` code (in `src/transports`).

The reason behind that complexity is linked to the fact that the transport code already contains other complex features relying on precize behavior, limiting the code's flexibility.
I'm thinking here especially about the "MetaPlaylist" transport and the `segmentLoader` API.

This PR tries to raise the flexibility of the transport code by:

  - limiting the number of arguments given to a RxPlayer loader and parser to the strict minimum that should be currently needed.
    This is because adding new arguments seems much easier than removing ones, which might even be passed to APIs (and thus un-removable).

  - clarifying semantically what those arguments mean.
    This makes sense especially for features like #975, where for example the `Adaptation` a `Representation` is linked to in the Manifest is different from the `Adaptation` it is linked to currently in the RxPlayer core (this is also technically a possibility today).

  - avoiding most side-effects (excepted requests done by loaders of course).

    For example, segment parsers could previously add encryption information to a `Representation` after finding encryption information in a segment.
    Removing this kind of global mutation from the transport code to move it to a more central place should simplify how we think about the code.

## The problem with existing APIs

The problem with the aforementioned APIs (MetaPlaylist transport + `segmentLoader`) was mostly the same: they relied on the complete `Manifest`, `Period`, `Adaptation` and `Representation` structures linked to a segment.

Giving all this information through the public API (as the `segmentLoader` is part of it) is problematic for two reasons:
  - mainly, we cannot change any of it without introduce a breaking change
  - it was also not clear semantically: were those the structures currently linked to the segment in the RxPlayer's `Manifest` global structure or were those the structures linked to the segment according to the Manifest document initially parsed?
    This question only makes sense because of features such as #975 and how we treat the `urn:mpeg:dash:adaptation-set-switching:2016` DASH's `SupplementalProperty`, which can bring a difference between the two.

## What has been done

The current PR:

  - reduces drastically the properties given to the `loadSegment` and `parseSegment` functions of a transport pipeline to just what should theoretically be needed to properly load and parse information from segments.

  - likewise heavily reduces even more the number of properties given to a `segmentLoader` which is part of the API.
    To load a segment, very few arguments should be needed (mostly an URL and a byte range).

  - Move out most side-effects performed by segment parsers.
    For now, they are all moved to the `RepresentationStream`.

    This means that what is sometimes transport-specific code is moved to the transport-agnostic logic.
    This could seem like a problem, however those differences had to already be taken into account under another form in the core logic, what is done here is more about providing a complete interface which can handle every possibility in a transport-agnostic way.

    For example a transport-agnostic `RepresentationIndex` structure could previously be considered "uninitialized", to properly handle some specificities about DASH's SegmentBase elements.
    This PR moves the task of initializing it from the transport-specific segment parser to the transport-agnostic `RepresentationStream`, the same core logic that checks whether initialization is done.
    "Initializing" any other kind of index will be a no-op and log an error, as it is unnecessary (the core logic is able to detect whether this action is necessary by checking the already-existing `isInitialized` method first).