### PR TITLE
[Proposal] manualBitrateSwitchingMode doesn't reload anymore

### DIFF
--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -212,7 +212,7 @@ export default function PeriodStream({
             return reloadAfterSwitch(period, clock$, relativePosAfterSwitch);
           }
 
-          const needsBufferFlush$ = strategy.type === "flush-buffer"
+          const optionalBufferFlush$ = strategy.type === "flush-buffer"
             ? observableOf(EVENTS.needsBufferFlush())
             : EMPTY;
 
@@ -227,7 +227,7 @@ export default function PeriodStream({
 
           return segmentBuffersStore.waitForUsableBuffers().pipe(mergeMap(() => {
             return observableConcat(cleanBuffer$,
-                                    needsBufferFlush$,
+                                    optionalBufferFlush$,
                                     observableMerge(adaptationStream$,
                                                     bufferGarbageCollector$));
           }));

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -131,6 +131,17 @@ export default class Period {
   }
 
   /**
+   * Returns `true` if this Period contains the time indicated by `position`, in
+   * seconds.
+   * @param {number}
+   * @returns {boolean}
+   */
+  containsPosition(position : number) : boolean {
+    return position >= this.start &&
+           (this.end === undefined || position < this.end);
+  }
+
+  /**
    * Returns every `Adaptations` (or `tracks`) linked to that Period, in an
    * Array.
    * @returns {Array.<Object>}


### PR DESCRIPTION
This PR is a proposal to implement what I thought initially to be an objectively better `"direct"` `manualBitrateSwitchingMode`, a`loadVideo` option allowing to choose for a direct visual feedback when switching the video quality.

Here's how the direct mode looked before this PR (I throttled my network bandwidth to exacerbate the switching time):

https://user-images.githubusercontent.com/8694124/131108643-aaa964f5-a214-47ac-b675-2b34234f0a2a.mp4


The `"direct"` mode is in opposition with the default `"seamless"` mode, which just uses a segment-replacing logic which might take some time playing the previous video qualities before taking effect (the time to load the new segments plus the time for the decoder to consider them)

The idea behind this PR was to use all the work we did to improve on the closely-related `audioTrckSwitchingMode` (which similarly chooses the behavior when switching to a different audio track), leading us to avoid reloading when switching the video quality in the `"direct"` mode.

Like for `audioTrckSwitchingMode`, this improvement is done by doing the following actions:
  1. cleaning the previous video buffer
  2. performing a very small seek, forcing the lower-level decoder to flush the buffer it reads from
  3. loading and pushing segments of the new chosen quality

After testing the result however, I noticed that video contents are inherently different from audio contents on that matter:
  - With audio, the RxPlayer is usually buffering with no audio playing while the switch is pending.
  - With video however, the previous quality's last decoded frame stay visible while the switch happens

This gives the following aspect:


https://user-images.githubusercontent.com/8694124/131107548-22689961-e133-4862-984c-34b5082a1c6f.mp4



Seeing the previous quality - even while rebuffering the new - can be awkward for a user, which might prefer not seeing anything untl the wanted quality is shown.

Moreover, the API documentation for the `"direct"` `manualBitrateSwitchingMode` states:
  > - there will be a black screen between the previous and new quality

So we could argue that the new behavior would even break the API.

Last but not least, with how the code is currently architectured, we could have another small awkward behavior. In some far-fetched cases where we seek back into already-played (and still buffered) Periods after a recent quality switch, we might even re-observe the behavior:

https://user-images.githubusercontent.com/8694124/131108164-6de29f07-6638-4f19-a19b-c0db0b019fe8.mp4

_Note the helpful "Buffer Content chart" below the player, which gives us a nice peek into what's happening in the buffers_

---

So, should we do it?

We could add another mode to the `manualBitrateSwitchingMode` option (after all, its value is a string because we foresaw potential cases like this).
However by keeping the `"direct"` part doing the reloading I'm afraid that the difference we create with how the `"direct"` `audioTrckSwitchingMode` behaves (which is roughly the same thing that this PR implements) could be a little strange to users or even us.

So I'm also thinking about making this the `"direct"` mode and introducing another, e.g. `"reload"` mode for the previous behavior. Doing this might be an API breaking change so would be more probably scheduled for a v4.

What are your thoughts on this?
