### PR TITLE
stream: add the concept of a "locked" stream

### DIFF
--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -170,6 +170,7 @@ export default function initializeDirectfileContent({
                                      mediaElement,
                                      null,
                                      EMPTY,
+                                     EMPTY,
                                      setCurrentTime);
 
   /**

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -46,6 +46,7 @@ import { maintainEndOfStream } from "./end_of_stream";
 import initialSeekAndPlay from "./initial_seek_and_play";
 import StallAvoider, {
   IDiscontinuityEvent,
+  ILockedStreamEvent,
 } from "./stall_avoider";
 import streamEventsEmitter from "./stream_events_emitter";
 import {
@@ -145,6 +146,9 @@ export default function createMediaSourceLoader(
     /** Emits discontinuities detected by the StreamOrchestrator. */
     const discontinuityUpdate$ = new Subject<IDiscontinuityEvent>();
 
+    /** Emits event when streams are "locked", meaning they cannot load segments. */
+    const lockedStream$ = new Subject<ILockedStreamEvent>();
+
     // Creates Observable which will manage every Stream for the given Content.
     const streams$ = StreamOrchestrator({ manifest, initialPeriod },
                                         streamClock$,
@@ -171,6 +175,9 @@ export default function createMediaSourceLoader(
                                         discontinuity: imminentDiscontinuity,
                                         position });
             return EMPTY;
+          case "locked-stream":
+            lockedStream$.next(evt.value);
+            return EMPTY;
           default:
             return observableOf(evt);
         }
@@ -194,6 +201,7 @@ export default function createMediaSourceLoader(
                                        mediaElement,
                                        manifest,
                                        discontinuityUpdate$,
+                                       lockedStream$,
                                        setCurrentTime);
 
     /**

--- a/src/core/init/stall_avoider.ts
+++ b/src/core/init/stall_avoider.ts
@@ -202,13 +202,13 @@ export default function StallAvoider(
       }
       const currPos = tick.position;
       const rebufferingPos = tick.rebuffering.position ?? currPos;
-      const lckdPeriodStart = lockedStreamEvt.period.start;
-      if (currPos < lckdPeriodStart &&
-          Math.abs(rebufferingPos - lckdPeriodStart) < 1)
+      const lockedPeriodStart = lockedStreamEvt.period.start;
+      if (currPos < lockedPeriodStart &&
+          Math.abs(rebufferingPos - lockedPeriodStart) < 1)
       {
         log.warn("Init: rebuffering because of a future locked stream.\n" +
                  "Trying to unlock by seeking to the next Period");
-        setCurrentTime(lckdPeriodStart + 0.001);
+        setCurrentTime(lockedPeriodStart + 0.001);
       }
     }),
     ignoreElements()

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -259,7 +259,10 @@ export default function AdaptationStream({
         fromEstimate.manual &&
         !isFirstEstimate)
     {
-      return reloadAfterSwitch(period, clock$, DELTA_POSITION_AFTER_RELOAD.bitrateSwitch);
+      return reloadAfterSwitch(period,
+                               adaptation.type,
+                               clock$,
+                               DELTA_POSITION_AFTER_RELOAD.bitrateSwitch);
     }
 
     /**

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -44,6 +44,7 @@ import {
   IStreamNeedsManifestRefresh,
   IStreamTerminatingEvent,
   IStreamWarningEvent,
+  IWaitingMediaSourceReloadInternalEvent,
 } from "./types";
 
 const EVENTS = {
@@ -195,6 +196,16 @@ const EVENTS = {
 
   warning(value : ICustomError) : IStreamWarningEvent {
     return { type: "warning", value };
+  },
+
+  waitingMediaSourceReload(
+    bufferType : IBufferType,
+    period : Period,
+    position : number,
+    autoPlay : boolean
+  ) : IWaitingMediaSourceReloadInternalEvent {
+    return { type: "waiting-media-source-reload",
+             value: { bufferType, period, position, autoPlay } };
   },
 };
 

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -31,6 +31,7 @@ import {
   ICompletedStreamEvent,
   IEncryptionDataEncounteredEvent,
   IEndOfStreamEvent,
+  ILockedStreamEvent,
   INeedsBufferFlushEvent,
   INeedsDecipherabilityFlush,
   INeedsMediaSourceReload,
@@ -106,22 +107,34 @@ const EVENTS = {
   },
 
   /**
-   * @param {Object} period - The Period to which the stream logic asking for a
-   * media source reload is linked.
    * @param {number} reloadAt - Position at which we should reload
    * @param {boolean} reloadOnPause - If `false`, stay on pause after reloading.
    * if `true`, automatically play once reloaded.
    * @returns {Object}
    */
   needsMediaSourceReload(
-    period : Period,
     reloadAt : number,
     reloadOnPause : boolean
   ) : INeedsMediaSourceReload {
     return { type: "needs-media-source-reload",
              value: { position : reloadAt,
-                      autoPlay : reloadOnPause,
-                      period } };
+                      autoPlay : reloadOnPause } };
+  },
+
+  /**
+   * @param {string} bufferType - The buffer type for which the stream cannot
+   * currently load segments.
+   * @param {Object} period - The Period for which the stream cannot
+   * currently load segments.
+   * media source reload is linked.
+   * @returns {Object}
+   */
+  lockedStream(
+    bufferType : IBufferType,
+    period : Period
+  ) : ILockedStreamEvent {
+    return { type: "locked-stream",
+             value: { bufferType, period } };
   },
 
   needsBufferFlush(): INeedsBufferFlushEvent {

--- a/src/core/stream/orchestrator/active_period_emitter.ts
+++ b/src/core/stream/orchestrator/active_period_emitter.ts
@@ -26,7 +26,7 @@ import {
 } from "rxjs/operators";
 import { Period } from "../../../manifest";
 import { IBufferType } from "../../segment_buffers";
-import { IMultiplePeriodStreamsEvent } from "../types";
+import { IStreamOrchestratorEvent } from "../types";
 
 interface IPeriodObject { period : Period;
                           buffers: Set<IBufferType>; }
@@ -72,7 +72,7 @@ type IPeriodsList = Partial<Record<string, IPeriodObject>>;
  * @returns {Observable}
  */
 export default function ActivePeriodEmitter(
-  buffers$: Array<Observable<IMultiplePeriodStreamsEvent>>
+  buffers$: Array<Observable<IStreamOrchestratorEvent>>
 ) : Observable<Period|null> {
   const numberOfStreams = buffers$.length;
   return observableMerge(...buffers$).pipe(
@@ -80,7 +80,7 @@ export default function ActivePeriodEmitter(
     filter(({ type }) => type === "periodStreamCleared" ||
                          type === "adaptationChange" ||
                          type === "representationChange"),
-    scan<IMultiplePeriodStreamsEvent, IPeriodsList>((acc, evt) => {
+    scan<IStreamOrchestratorEvent, IPeriodsList>((acc, evt) => {
       switch (evt.type) {
         case "periodStreamCleared": {
           const { period, type } = evt.value;

--- a/src/core/stream/orchestrator/are_streams_complete.ts
+++ b/src/core/stream/orchestrator/are_streams_complete.ts
@@ -24,7 +24,7 @@ import {
   map,
   startWith,
 } from "rxjs/operators";
-import { IMultiplePeriodStreamsEvent } from "../types";
+import { IStreamOrchestratorEvent } from "../types";
 
 /**
  * Returns an Observable which emits ``true`` when all PeriodStreams given are
@@ -44,7 +44,7 @@ import { IMultiplePeriodStreamsEvent } from "../types";
  * @returns {Observable}
  */
 export default function areStreamsComplete(
-  ...streams : Array<Observable<IMultiplePeriodStreamsEvent>>
+  ...streams : Array<Observable<IStreamOrchestratorEvent>>
 ) : Observable<boolean> {
   /**
    * Array of Observables linked to the Array of Streams which emit:

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -237,16 +237,6 @@ export default function StreamOrchestrator(
           null
         >((message) => {
           switch (message.type) {
-            case "needs-media-source-reload":
-              // Only reload the MediaSource when the more immediately required
-              // Period is the one asking for it
-              const firstPeriod = periodList.head();
-              if (firstPeriod === undefined ||
-                  firstPeriod.id !== message.value.period.id)
-              {
-                return null;
-              }
-              break;
             case "periodStreamReady":
               enableOutOfBoundsCheck = true;
               periodList.add(message.value.period);

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -165,7 +165,7 @@ export default function PeriodStream({
         if (segmentBufferStatus.type === "initialized") {
           log.info(`Stream: Clearing previous ${bufferType} SegmentBuffer`);
           if (SegmentBuffersStore.isNative(bufferType)) {
-            return reloadAfterSwitch(period, clock$, 0);
+            return reloadAfterSwitch(period, bufferType, clock$, 0);
           }
           cleanBuffer$ = segmentBufferStatus.value
             .removeBuffer(period.start,
@@ -187,7 +187,7 @@ export default function PeriodStream({
       if (SegmentBuffersStore.isNative(bufferType) &&
           segmentBuffersStore.getStatus(bufferType).type === "disabled")
       {
-        return reloadAfterSwitch(period, clock$, relativePosAfterSwitch);
+        return reloadAfterSwitch(period, bufferType, clock$, relativePosAfterSwitch);
       }
 
       log.info(`Stream: Updating ${bufferType} adaptation`, adaptation, period);
@@ -207,7 +207,7 @@ export default function PeriodStream({
                                                        playbackInfos,
                                                        options);
           if (strategy.type === "needs-reload") {
-            return reloadAfterSwitch(period, clock$, relativePosAfterSwitch);
+            return reloadAfterSwitch(period, bufferType, clock$, relativePosAfterSwitch);
           }
 
           const needsBufferFlush$ = strategy.type === "flush-buffer"

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -348,6 +348,36 @@ export interface INeedsMediaSourceReload {
 }
 
 /**
+ * A stream cannot go forward loading segments because it needs the
+ * `MediaSource` to be reloaded first.
+ *
+ * This is a Stream internal event before being translated into either an
+ * `INeedsMediaSourceReload` event or an `ILockedStreamEvent` depending on if
+ * the reloading action has to be taken now or when the corresponding Period
+ * becomes active.
+ */
+export interface IWaitingMediaSourceReloadInternalEvent {
+  type: "waiting-media-source-reload";
+  value: {
+    /** Period concerned. */
+    period : Period;
+    /** Buffer type concerned. */
+    bufferType : IBufferType;
+    /**
+     * The position in seconds and the time at which the MediaSource should be
+     * reset once it has been reloaded.
+     */
+    position : number;
+    /**
+     * If `true`, we want the HTMLMediaElement to play right after the reload is
+     * done.
+     * If `false`, we want to stay in a paused state at that point.
+     */
+    autoPlay : boolean;
+  };
+}
+
+/**
  * The stream is unable to load segments for a particular Period and buffer
  * type until that Period becomes the currently-played Period.
  *
@@ -427,11 +457,10 @@ export type IRepresentationStreamEvent = IStreamStatusEvent |
 
 /** Event sent by an `AdaptationStream`. */
 export type IAdaptationStreamEvent = IBitrateEstimationChangeEvent |
-                                     INeedsMediaSourceReload |
                                      INeedsDecipherabilityFlush |
                                      IRepresentationChangeEvent |
                                      INeedsBufferFlushEvent |
-                                     ILockedStreamEvent |
+                                     IWaitingMediaSourceReloadInternalEvent |
 
                                      // From a RepresentationStream
 
@@ -445,9 +474,8 @@ export type IAdaptationStreamEvent = IBitrateEstimationChangeEvent |
 
 /** Event sent by a `PeriodStream`. */
 export type IPeriodStreamEvent = IPeriodStreamReadyEvent |
-                                 INeedsMediaSourceReload |
                                  IAdaptationChangeEvent |
-                                 ILockedStreamEvent |
+                                 IWaitingMediaSourceReloadInternalEvent |
 
                                  // From an AdaptationStream
 
@@ -474,10 +502,9 @@ export type IMultiplePeriodStreamsEvent = IPeriodStreamClearedEvent |
                                           // From a PeriodStream
 
                                           IPeriodStreamReadyEvent |
-                                          INeedsMediaSourceReload |
                                           INeedsBufferFlushEvent |
                                           IAdaptationChangeEvent |
-                                          ILockedStreamEvent |
+                                          IWaitingMediaSourceReloadInternalEvent |
 
                                           // From an AdaptationStream
 


### PR DESCRIPTION
## Overview

This commit fixes a rare infinite rebuffering issue occuring when playing close - but before - the next Period's start, when one of its associated audio and/or video PeriodStream or AdaptationStream requires a reloading of the MediaSource before having the chance to load any segment.

For example this can happen when disabling the video track of the next Period, before it had the chance to load any segment. In that case, when playing close to that Period, the clock will anounce that we should rebuffer because there is not enough data ahead in the video buffer to guarantee a smooth playback.

Yet the future video stream does not want to download any video segments - because video tracks have been disabled - yet the `StreamOrchestrator` refuses to ask for the removal of the video SourceBuffer - because we're still playing the previous Period which needs a video SourceBuffer.


https://user-images.githubusercontent.com/8694124/131698584-9a1ff103-f9a6-493d-b6e8-c27c715bd093.mp4

_Here, we can see a rebuffering because we're missing video content (look at the buffer content chart below the video). However, that video content will never come because the next Period's video track is disabled._


So this is kind of a fancy deadlock:
  - The init is putting the player in REBUFFERING mode while playing the previous Period, waiting for the next Period to load segments before playing it.
  - The stream awaits the time when the next Period is the active one to be able to remove the video SourceBuffer (which would quit the current rebuffering situation)

Here I'm specifically talking about video SourceBuffer removal, but this situation can ultimately happen anytime some stream refuse to load a segment until it is the current one (which for the moment only includes MediaSource reloading requests).

## Solution implemented here

The current solution is sadly not perfect, yet it is simple enough and should work in all possible cases.

First it introduces the concept of a "locked stream", which is sent by a Stream when it refuses to download a segment until the Period is the current one.

When a PeriodStream or AdaptationStream is left in such situation, it looks if it seems to be the currently played Period:
  - if it is, it ask to reload the MediaSource instead
  - if it isn't, it instead sends a new "locked-stream" event

The `StallAvoider`, which is the part in the `Init` avoiding any stalling possibilities, will then listen to those "locked-stream" events.
If it is rebuffering waiting on data at least very close to that next Period, it will automatically perform a seek to that Period's beginning.


https://user-images.githubusercontent.com/8694124/131698949-17dc7dde-3b03-4b86-b784-5cccbcfea511.mp4

_Here, we're still short on video content, yet as soon as we're both rebuffering and receiving the "locked-stream" event, the `StallAvoider` seeks to the next Period's start._


## Limitations with this solution

There are still multiple issues with this solution.

First, this moves the responsibility of checking which Period is the current one from the `StreamOrchestrator` to the concerned `PeriodStream` or `AdaptationStream`, which is arguably less apropriate.

Moving back the logic the `StreamOrchestrator` should be possible but I did not look too much into it for now.

Also, due to how the RxPlayer is currently architectured, there isn't any event to indicate that a stream has "unlocked".

This is very problematic because it means that the `StallAvoider` isn't just able to store the last state for each Period and buffer type combination (a simpler solution).
Any handling of locked stream needs thus to be done immediately after the event is received. After, it won't know if it hasn't unlocked since then.

The previous issue is also the reason why we have to seek at the beginning of the next Period, instead of just temporarily disabling RxPlayer's rebuffering logic to let regular playback reach the end of the current buffer (which may already lead to the second Period) by itself.

This means that some frames will be unnecessarily skipped, which is also a little sad :/.
