### PR TITLE
scripts: add `s` script (as a faster `start` option), allowing very fast demo building when developing

### DIFF
--- a/demo/full/scripts/controllers/Main.jsx
+++ b/demo/full/scripts/controllers/Main.jsx
@@ -1,4 +1,4 @@
-import RxPlayer from "rx-player";
+import RxPlayer from "../../../../src/index.ts";
 import React from "react";
 import Player from "./Player.jsx";
 

--- a/demo/full/scripts/modules/player/index.js
+++ b/demo/full/scripts/modules/player/index.js
@@ -10,7 +10,7 @@ import {
   Subject,
   takeUntil,
 } from "rxjs";
-import RxPlayer from "rx-player";
+import RxPlayer from "../../../../../src/index.ts";
 import { linkPlayerEventsToState } from "./events.js";
 import $handleCatchUpMode from "./catchUp";
 import VideoThumbnailLoader, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "chai": "4.3.4",
         "cheerio": "1.0.0-rc.10",
         "core-js": "3.17.3",
+        "esbuild": "0.12.25",
         "eslint": "7.32.0",
         "eslint-plugin-import": "2.24.2",
         "eslint-plugin-jsdoc": "36.1.0",
@@ -5112,6 +5113,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
       }
     },
     "node_modules/escalade": {
@@ -17375,6 +17386,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "esbuild": {
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
+      "dev": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prepublishOnly": "npm run build:modular",
     "standalone": "node ./scripts/run_standalone_demo.js",
     "start": "node ./scripts/start_demo_web_server.js",
-    "start:fast": "node ./scripts/start_demo_web_server.js --fast",
+    "s": "node ./scripts/start_demo_web_server.js --fast",
     "wasm-strip": "node scripts/wasm-strip.js dist/mpd-parser.wasm",
     "test:appveyor": "npm run test:unit && npm run test:memory",
     "test:integration": "node tests/integration/run.js --bchromehl --bfirefoxhl",
@@ -141,7 +141,7 @@
   "scripts-list": {
     "Build a demo page (e.g. to test a code change)": {
       "start": "Build the \"full\" demo (with a UI) with the non-minified RxPlayer and serve it on a local server. Re-build on file updates.",
-      "start:fast": "Very fast version of `start` which does not perform type-checking. This script can be useful for very quick checks of modifications on a demo page",
+      "s": "Very fast version of `start` which does not perform type-checking. This script can be useful for quick testing",
       "demo": "Build the demo in demo/bundle.js",
       "demo:min": "Build the demo and minify it in demo/bundle.js",
       "demo:watch": "Build the demo in demo/bundle.js each times the files update.",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepublishOnly": "npm run build:modular",
     "standalone": "node ./scripts/run_standalone_demo.js",
     "start": "node ./scripts/start_demo_web_server.js",
+    "start:fast": "node ./scripts/start_demo_web_server.js --fast",
     "wasm-strip": "node scripts/wasm-strip.js dist/mpd-parser.wasm",
     "test:appveyor": "npm run test:unit && npm run test:memory",
     "test:integration": "node tests/integration/run.js --bchromehl --bfirefoxhl",
@@ -99,6 +100,7 @@
     "chai": "4.3.4",
     "cheerio": "1.0.0-rc.10",
     "core-js": "3.17.3",
+    "esbuild": "0.12.25",
     "eslint": "7.32.0",
     "eslint-plugin-import": "2.24.2",
     "eslint-plugin-jsdoc": "36.1.0",
@@ -139,6 +141,7 @@
   "scripts-list": {
     "Build a demo page (e.g. to test a code change)": {
       "start": "Build the \"full\" demo (with a UI) with the non-minified RxPlayer and serve it on a local server. Re-build on file updates.",
+      "start:fast": "Very fast version of `start` which does not perform type-checking. This script can be useful for very quick checks of modifications on a demo page",
       "demo": "Build the demo in demo/bundle.js",
       "demo:min": "Build the demo and minify it in demo/bundle.js",
       "demo:watch": "Build the demo in demo/bundle.js each times the files update.",

--- a/scripts/fast_demo_build.js
+++ b/scripts/fast_demo_build.js
@@ -1,0 +1,153 @@
+/**
+ * # fast_demo_build.js
+ *
+ * This file allows to perform a "fast" build of the RxPlayer's demo, by using
+ * esbuild.
+ *
+ * You can either run it directly as a script (run `node fast_demo_build.js -h`
+ * to see the different options) or by requiring it as a node module.
+ * If doing the latter you will obtain a function you will have to run with the
+ * right options.
+ */
+
+const path = require("path");
+const esbuild = require("esbuild");
+const getHumanReadableHours = require("./utils/get_human_readable_hours");
+
+// If true, this script is called directly
+if (require.main === module) {
+  const { argv } = process;
+  if (argv.includes("-h") || argv.includes("--help")) {
+    displayHelp();
+    process.exit(0);
+  }
+  const shouldWatch = argv.includes("-w") || argv.includes("--watch");
+  const shouldMinify = argv.includes("-m") || argv.includes("--minify");
+  const production = argv.includes("-p") || argv.includes("--production-mode");
+  fastDemoBuild({
+    watch: shouldWatch,
+    minify: shouldMinify,
+    production,
+  });
+} else {
+  // This script is loaded as a module
+  module.exports = fastDemoBuild;
+}
+
+/**
+ * Build the demo with the given options.
+ * @param {Object} options
+ * @param {boolean} [options.minify] - If `true`, the output will be minified.
+ * @param {boolean} [options.production] - If `false`, the code will be compiled
+ * in "development" mode, which has supplementary assertions.
+ * @param {boolean} [options.watch] - If `true`, the RxPlayer's files involve
+ * will be watched and the code re-built each time one of them changes.
+ */
+function fastDemoBuild(options) {
+  const minify = !!options.minify;
+  const watch = !!options.watch;
+  const isDevMode = !options.production;
+  let beforeTime = performance.now();
+
+  esbuild.build({
+    entryPoints: [path.join(__dirname, "../demo/full/scripts/index.jsx")],
+    bundle: true,
+    minify,
+    outfile: path.join(__dirname, "../demo/full/bundle.js"),
+    watch: !watch ? undefined : {
+      onRebuild(error, result) {
+        if (error) {
+          console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Demo re-build failed:`,
+                        err);
+        } else {
+          if (result.errors > 0 || result.warnings > 0) {
+            const { errors, warnings } = result;
+            console.log(`\x1b[33m[${getHumanReadableHours()}]\x1b[0m ` +
+                        `Demo re-built with ${errors.length} error(s) and ` +
+                        ` ${warnings.length} warning(s) ` +
+                        `(in ${stats.endTime - stats.startTime} ms).`);
+          }
+          console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m ` +
+                      "Demo re-built!");
+        }
+      },
+    },
+    define: {
+      "__DEV__": isDevMode,
+      "__LOGGER_LEVEL__": "\"INFO\"",
+      "process.env.NODE_ENV": JSON.stringify(isDevMode ? "development" : "production"),
+      "__FEATURES__.BIF_PARSER": true,
+      "__FEATURES__.DASH": true,
+      "__FEATURES__.DIRECTFILE": true,
+      "__FEATURES__.EME": true,
+      "__FEATURES__.HTML_SAMI": true,
+      "__FEATURES__.HTML_SRT": true,
+      "__FEATURES__.HTML_TTML": true,
+      "__FEATURES__.HTML_VTT": true,
+      "__FEATURES__.LOCAL_MANIFEST": true,
+      "__FEATURES__.METAPLAYLIST": true,
+      "__FEATURES__.NATIVE_SAMI": true,
+      "__FEATURES__.NATIVE_SRT": true,
+      "__FEATURES__.NATIVE_TTML": true,
+      "__FEATURES__.NATIVE_VTT": true,
+      "__FEATURES__.SMOOTH": true,
+
+      // Path relative to src/features where optional features are implemented
+      "__RELATIVE_PATH__.BIF_PARSER": JSON.stringify("../parsers/images/bif.ts"),
+      "__RELATIVE_PATH__.DASH": JSON.stringify("../transports/dash/index.ts"),
+      "__RELATIVE_PATH__.DASH_JS_PARSER": JSON.stringify("../parsers/manifest/dash/js-parser/index.ts"),
+      "__RELATIVE_PATH__.DIRECTFILE": JSON.stringify("../core/init/initialize_directfile.ts"),
+      "__RELATIVE_PATH__.EME_MANAGER": JSON.stringify("../core/eme/index.ts"),
+      "__RELATIVE_PATH__.HTML_SAMI": JSON.stringify("../parsers/texttracks/sami/html.ts"),
+      "__RELATIVE_PATH__.HTML_SRT": JSON.stringify("../parsers/texttracks/srt/html.ts"),
+      "__RELATIVE_PATH__.HTML_TEXT_BUFFER": JSON.stringify("../core/segment_buffers/implementations/text/html/index.ts"),
+      "__RELATIVE_PATH__.HTML_TTML": JSON.stringify("../parsers/texttracks/ttml/html/index.ts"),
+      "__RELATIVE_PATH__.HTML_VTT": JSON.stringify("../parsers/texttracks/webvtt/html/index.ts"),
+      "__RELATIVE_PATH__.IMAGE_BUFFER": JSON.stringify("../core/segment_buffers/implementations/image/index.ts"),
+      "__RELATIVE_PATH__.LOCAL_MANIFEST": JSON.stringify("../transports/local/index.ts"),
+      "__RELATIVE_PATH__.MEDIA_ELEMENT_TRACK_CHOICE_MANAGER": JSON.stringify("../core/api/media_element_track_choice_manager.ts"),
+      "__RELATIVE_PATH__.METAPLAYLIST": JSON.stringify("../transports/metaplaylist/index.ts"),
+      "__RELATIVE_PATH__.NATIVE_SAMI": JSON.stringify("../parsers/texttracks/sami/native.ts"),
+      "__RELATIVE_PATH__.NATIVE_SRT": JSON.stringify("../parsers/texttracks/srt/native.ts"),
+      "__RELATIVE_PATH__.NATIVE_TEXT_BUFFER": JSON.stringify("../core/segment_buffers/implementations/text/native/index.ts"),
+      "__RELATIVE_PATH__.NATIVE_TTML": JSON.stringify("../parsers/texttracks/ttml/native/index.ts"),
+      "__RELATIVE_PATH__.NATIVE_VTT": JSON.stringify("../parsers/texttracks/webvtt/native/index.ts"),
+      "__RELATIVE_PATH__.SMOOTH": JSON.stringify("../transports/smooth/index.ts"),
+    }
+  }).then(
+  (result) => {
+    if (result.errors > 0 || result.warnings > 0) {
+      const { errors, warnings } = result;
+      console.log(`\x1b[33m[${getHumanReadableHours()}]\x1b[0m ` +
+                  `Demo built with ${errors.length} error(s) and ` +
+                  ` ${warnings.length} warning(s) ` +
+                  `(in ${stats.endTime - stats.startTime} ms).`);
+    }
+    console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m ` +
+                `Build done in ${(performance.now() - beforeTime).toFixed(2)}ms`);
+  },
+  (err) => {
+    console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Demo build failed:`,
+                  err);
+    process.exit(1);
+  });
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  /* eslint-disable no-console */
+  console.log(
+  /* eslint-disable indent */
+`Usage: node generate_full_demo.js [options]
+Options:
+  -h, --help             Display this help
+  -m, --minify           Minify the built demo
+  -p, --production-mode  Build all files in production mode (less runtime checks, mostly).
+  -w, --watch            Re-build each time either the demo or library files change`,
+  /* eslint-enable indent */
+  );
+  /* eslint-enable no-console */
+}

--- a/scripts/fast_demo_build.js
+++ b/scripts/fast_demo_build.js
@@ -47,7 +47,7 @@ function fastDemoBuild(options) {
   const minify = !!options.minify;
   const watch = !!options.watch;
   const isDevMode = !options.production;
-  let beforeTime = performance.now();
+  let beforeTime = process.hrtime.bigint();
 
   esbuild.build({
     entryPoints: [path.join(__dirname, "../demo/full/scripts/index.jsx")],
@@ -123,8 +123,9 @@ function fastDemoBuild(options) {
                   ` ${warnings.length} warning(s) ` +
                   `(in ${stats.endTime - stats.startTime} ms).`);
     }
+    const fullTime = (process.hrtime.bigint() - beforeTime) / 1000000n;
     console.log(`\x1b[32m[${getHumanReadableHours()}]\x1b[0m ` +
-                `Build done in ${(performance.now() - beforeTime).toFixed(2)}ms`);
+                `Build done in ${fullTime}ms`);
   },
   (err) => {
     console.error(`\x1b[31m[${getHumanReadableHours()}]\x1b[0m Demo build failed:`,

--- a/scripts/generate_full_demo.js
+++ b/scripts/generate_full_demo.js
@@ -5,7 +5,7 @@
  * Build the full demo
  * ===================
  *
- * This script allows to build the full demo locally.
+ * This script allows to build the full demo locally, by using Webpack's bundler.
  *
  * You can either run it directly as a script (run `node
  * generate_full_demo.js -h` to see the different options) or by requiring it as
@@ -58,11 +58,6 @@ function generateFullDemo(options) {
     entry: path.join(__dirname, "../demo/full/scripts/index.jsx"),
     resolve: {
       extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
-      alias: {
-        ["rx-player$"]: path.resolve(__dirname, "../src/index.ts"),
-        ["rx-player/tools$"]: path.resolve(__dirname, "../src/tools/index.ts"),
-        ["rx-player/experimental/tools$"]: path.resolve(__dirname, "../src/experimental/tools/index.ts"),
-      },
     },
     output: {
       path: path.join(__dirname, "../demo/full"),

--- a/scripts/start_demo_web_server.js
+++ b/scripts/start_demo_web_server.js
@@ -15,12 +15,22 @@
  */
 
 const path = require("path");
-const generateFullDemo = require("./generate_full_demo");
+const fastBuild = require("./fast_demo_build");
+const slowBuild = require("./generate_full_demo");
 const launchStaticServer = require("./launch_static_server");
 
-generateFullDemo({ watch: true,
-                   minify: false,
-                   production: false });
+const shouldRunFastVersion = process.argv.includes("--fast") ||
+                             process.argv.includes("-f");
+
+if (shouldRunFastVersion) {
+  fastBuild({ watch: true,
+              minify: false,
+              production: false });
+} else {
+  slowBuild({ watch: true,
+              minify: false,
+              production: false });
+}
 
 launchStaticServer(path.join(__dirname, "../demo/full/"),
                    { certificatePath: path.join(__dirname, "../localhost.crt"),


### PR DESCRIPTION
## What this PR does

This PR tries to improve demo building time by using the notoriously faster [esbuild](https://esbuild.github.io/) bundler instead of the Webpack bundler we use by default.

I also profited from this PR to improve on the current webpack config scripts by making them configurable through command line arguments instead of environment variables. This should be easier to understand and follow. That part can (and most probably should!) be added in a separate PR.

By switching from webpack to esbuild when starting a demo, we go on my laptop from 15s-16s to 100-200ms to build the demo page.
16 seconds was not much, but it was enough that it could lead me to switching to another task, waiting for the demo to be built - and thus usually costed much more than that. I would not be surprised if I was the only one in that situation.
With sub-second results, a code modification can be tested instantly.

By making demo bundling close-to costless, it could also improve the time of the `bisect` operations we sometimes  (arguably very rarely) perform and it allows nice new usages like testing multiple demo versions easily.

_We could go even further by using something like [open](https://github.com/sindresorhus/open) to open the developer's default browser on the demo page directly (of course more advanced testing will need to test on multiple browsers, but we're talking about fast checks here)._

Because I did not want to take the bet - and because there are some disadvantages in using esbuild - I still left Webpack by default when running the `npm run start` script. esbuild is only used when using the `npm run s`.

Webpack is also still used when generating the demos for production, the tests and the legacy builds (`dist/rx-player.js` and `dist/rx-player.min.js`). Switching to esbuild for those could be possible in the future, but Webpack is not a pain point in those cases for now (considering tests are long anyway and the others are rare occurrences).

## Disadvantages

### No type-checking performed by esbuild

Among the disadvantages in using `esbuild`, the main one I found is that unlike Webpack, esbuild cannot be used to type-check the files while they are bundled.

At first, I tried to write a script performing both in parallel (bundling and type-checking) to emulate the current `npm run start` behavior, but as it turns out TypeScript did multiple things that made this experiment a pain:
  1. TypeScript's JavaScript API is both unstable and incomplete, so I could not just write a simple Node.js script handling its output in a simple and straightforward way like we do for webpack
  2. tsc binary's `watch` option - which I wanted to use here - clears the screen and adds many line breaks by default, making it harder to making it cohabit with a second script displaying on the same output.

So for now, I only added a supplementary npm script, `npm run check:types:watch` which performs type-checking while watching the files it type-checks (something we might need anyway).

### It is a supplementary dependency

Another thing I do not like is that it is a supplementary dependency which moreover is totally optional.
Thus it adds maintenance cost and also 7MB to the project which leads to approximately a 3% size increase of the `node_modules` directory.

This is not much at all but I still tried to make that dependency "opt-outable" when `npm install`ing by e.g. making it an optional dependency.
However, turns out only `optionalDependencies` exist, and not `optionalDevDependencies` like we would want.

_An old issue seems to have been created about that on npm's issue tracker, https://github.com/npm/npm/issues/3870, but the conclusion seems to be that this is both complicated to write for them and not an important enough feature._

But in truth, I recognize that this is kind of an overengineering need.
3% increase of the node_modules directory is nothing and this dependency only has an impact on locally built demo.

---

What do you think?

Do you think reducing demo building time is even a real need (I won't be angry if you don't :D)?