### PR TITLE
dash: provide default startNumber for number-based SegmentTimeline

### DIFF
--- a/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
@@ -66,9 +66,7 @@ export default function getSegmentsFromTimeline(
   const scaledTo = toIndexTime(from + durationWanted, index);
   const { timeline, timescale, mediaURLs, startNumber } = index;
 
-  let currentNumber = startNumber != null ? startNumber :
-                                            undefined;
-
+  let currentNumber = startNumber ?? 1;
   const segments : ISegment[] = [];
 
   const timelineLength = timeline.length;
@@ -88,8 +86,7 @@ export default function getSegmentsFromTimeline(
     let segmentNumberInCurrentRange = getWantedRepeatIndex(start, duration, scaledUp);
     let segmentTime = start + segmentNumberInCurrentRange * duration;
     while (segmentTime < scaledTo && segmentNumberInCurrentRange <= repeat) {
-      const segmentNumber = currentNumber != null ?
-        currentNumber + segmentNumberInCurrentRange : undefined;
+      const segmentNumber = currentNumber + segmentNumberInCurrentRange;
 
       const detokenizedURLs = mediaURLs === null ?
         null :
@@ -119,9 +116,7 @@ export default function getSegmentsFromTimeline(
       return segments;
     }
 
-    if (currentNumber != null) {
-      currentNumber += repeat + 1;
-    }
+    currentNumber += repeat + 1;
   }
 
   return segments;

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -257,8 +257,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     const segments : ISegment[] = [];
 
     // number corresponding to the Period's start
-    const numberOffset = startNumber == null ? 1 :
-                                               startNumber;
+    const numberOffset = startNumber ?? 1;
 
     // calcul initial time from Period start, where the first segment would have
     // the `0` number

--- a/tests/contents/DASH_static_number_based_SegmentTimeline/index.js
+++ b/tests/contents/DASH_static_number_based_SegmentTimeline/index.js
@@ -1,0 +1,4 @@
+import manifestInfos from "./infos.js";
+
+export { manifestInfos };
+

--- a/tests/contents/DASH_static_number_based_SegmentTimeline/infos.js
+++ b/tests/contents/DASH_static_number_based_SegmentTimeline/infos.js
@@ -1,0 +1,27 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_number_based_SegmentTimeline/media/";
+
+export default {
+  url: BASE_URL + "manifest.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 100.760,
+  minimumPosition: 0,
+  maximumPosition: 100.760,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 100.760,
+
+      // TODO?
+      adaptations: {},
+    },
+  ],
+};
+

--- a/tests/contents/DASH_static_number_based_SegmentTimeline/media/manifest.mpd
+++ b/tests/contents/DASH_static_number_based_SegmentTimeline/media/manifest.mpd
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" mediaPresentationDuration="PT0H1M40.760S" minBufferTime="PT0H0M4.000S" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemalocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd">
+   <Period duration="PT0H1M40.760S" start="PT0S">
+      <AdaptationSet contentType="video" frameRate="25" maxFrameRate="25" maxHeight="540" maxWidth="960" mimeType="video/mp4" par="16:9" sar="1:1" scanType="progressive" subsegmentAlignment="true" subsegmentStartsWithSAP="2">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <Representation bandwidth="1502584" codecs="avc1.4D401F" height="540" id="Video4.1.1.1" width="960">
+            <SegmentTemplate initialization="video_1500_avc-init.mp4" media="video_1500_avc-$Number$.mp4"  timescale="90000"><SegmentTimeline><S d="360000" r="24" t="0" /><S d="68400" /></SegmentTimeline></SegmentTemplate></Representation>
+         <Representation bandwidth="1102584" codecs="avc1.4D401F" height="540" id="Video5.1.1.1" width="960">
+            <SegmentTemplate initialization="video_1100_avc-init.mp4" media="video_1100_avc-$Number$.mp4"  timescale="90000"><SegmentTimeline><S d="360000" r="24" t="0" /><S d="68400" /></SegmentTimeline></SegmentTemplate></Representation>
+         <Representation bandwidth="752568" codecs="avc1.4D401E" height="432" id="Video3.1.1.1" width="768">
+            <SegmentTemplate initialization="video_750_avc-init.mp4" media="video_750_avc-$Number$.mp4"  timescale="90000"><SegmentTimeline><S d="360000" r="24" t="0" /><S d="68400" /></SegmentTimeline></SegmentTemplate></Representation>
+         <Representation bandwidth="302584" codecs="avc1.4D401E" height="360" id="Video2.1.1.1" width="640">
+            <SegmentTemplate initialization="video_300_avc-init.mp4" media="video_300_avc-$Number$.mp4"  timescale="90000"><SegmentTimeline><S d="360000" r="24" t="0" /><S d="68400" /></SegmentTimeline></SegmentTemplate></Representation>
+         <Representation bandwidth="192568" codecs="avc1.4D401E" height="234" id="Video1.1.1.1" width="416">
+            <SegmentTemplate initialization="video_190_avc-init.mp4" media="video_190_avc-$Number$.mp4"  timescale="90000"><SegmentTimeline><S d="360000" r="24" t="0" /><S d="68400" /></SegmentTimeline></SegmentTemplate></Representation>
+      </AdaptationSet>
+      <AdaptationSet audioSamplingRate="48000" codecs="mp4a.40.2" contentType="audio" lang="fr" mimeType="audio/mp4" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+         <AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" value="2" />
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <Representation bandwidth="68700" id="Audio1.1.1">
+            <SegmentTemplate initialization="audio_64_aaclc_fra-init.ts" media="audio_64_aaclc_fra-$Number$.ts"  timescale="90000"><SegmentTimeline><S d="360960" t="0" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="359040" /><S d="360960" /><S d="67200" /></SegmentTimeline></SegmentTemplate></Representation>
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/tests/contents/DASH_static_number_based_SegmentTimeline/urls.js
+++ b/tests/contents/DASH_static_number_based_SegmentTimeline/urls.js
@@ -1,0 +1,22 @@
+/* eslint-env node */
+
+const path = require("path");
+
+/**
+ * Data worth a little more than 15s of playback audio+video
+ *
+ * Note: the same actual low-bitrate segments are used for every video tracks to
+ * avoid being too heavy.
+ */
+
+const baseURL = "/DASH_static_number_based_SegmentTimeline/media/";
+
+module.exports = [
+  // Manifest
+  {
+    url: baseURL + "manifest.mpd",
+    path: path.join(__dirname, "./media/manifest.mpd"),
+    contentType: "application/dash+xml",
+  },
+];
+

--- a/tests/contents/urls.js
+++ b/tests/contents/urls.js
@@ -12,6 +12,7 @@ const urls7 = require("./DASH_static_SegmentTemplate_Multi_Periods/urls");
 const urls8 = require("./directfile_webm/urls");
 const urls9 = require("./DASH_dynamic_SegmentTemplate_Multi_Periods/urls");
 const urls10 = require("./DASH_static_broken_cenc_in_MPD/urls");
+const urls11 = require("./DASH_static_number_based_SegmentTimeline/urls");
 
 module.exports = [
   ...urls1,
@@ -24,4 +25,5 @@ module.exports = [
   ...urls8,
   ...urls9,
   ...urls10,
+  ...urls11,
 ];


### PR DESCRIPTION
DASH indexes of segments which rely on a `<SegmentTemplate>` element can either declare segment URLs based on the corresponding segment's timestamp or on a number incrementing with each segment from a given base, the `startNumber`.

Usually, time-based SegmentTemplates contains a `<SegmentTimeline>` element, listing all segments and their corresponding timestamps whereas number-based don't.

But this is not always the case, for example a number-based indexing scheme can be linked to a `<SegmentTimeline>` in the MPD (we might even in many case prefer it because a SegmentTimeline facilitates live-edge detection on the player-side).

As per the DASH-IF IOP the `startNumber` attribute is totally optional and should be set to `1` by default.
This is something we considered when no SegmentTimeline was present yet not when it was.

This is because the logic inside the RxPlayer is different in both situations:
  - in the presence of a SegmentTimeline the RxPlayer's `SegmentTimelineRepresentationIndex` structure is used to retrieve segment URLs
  - in a SegmentTemplate without any SegmentTimeline, the RxPlayer use a `SegmentTemplateRepresentationIndex`, which has a whole other logic

The implementation of a default value for `startNumber` was only implemented for the latter. Consequently, any number-based index with a SegmentTimeline but without a `startNumber` attribute would lead to an error when obtaining the URL for the first needed segments.

This PR fixes that.

Note that the majority of the code here is to add integration tests which tests that parsing a MPD with a SegmentTimeline and number-based works well.