### PR TITLE
ttml: Reinterpret percentages in fontSize attribute as relative to the Computed Cell Size

### DIFF
--- a/src/parsers/texttracks/ttml/html/apply_font_size.ts
+++ b/src/parsers/texttracks/ttml/html/apply_font_size.ts
@@ -38,7 +38,6 @@ export default function applyFontSize(
   }
 
   if (firstFontSize[2] === "px" ||
-      firstFontSize[2] === "%" ||
       firstFontSize[2] === "em")
   {
     element.style.fontSize = firstFontSize[1] + firstFontSize[2];
@@ -46,6 +45,17 @@ export default function applyFontSize(
     element.style.position = "relative";
     addClassName(element, "proportional-style");
     element.setAttribute("data-proportional-font-size", firstFontSize[1]);
+  } else if (firstFontSize[2] === "%") {
+    const toNum = Number(firstFontSize[1]);
+    if (isNaN(toNum)) {
+      log.warn("TTML Parser: could not parse fontSize value \"" +
+               firstFontSize[1] +
+               "\" into a number");
+    } else {
+      element.style.position = "relative";
+      addClassName(element, "proportional-style");
+      element.setAttribute("data-proportional-font-size", String(toNum / 100));
+    }
   } else {
     log.warn("TTML Parser: unhandled fontSize unit:", firstFontSize[2]);
   }


### PR DESCRIPTION
This PR fixes an issue we recently encountered with TTML subtitles with `fontSize` values indicated in percentages led to very small subtitles.

Before:
![wrong_000](https://user-images.githubusercontent.com/8694124/136211945-2a6d0466-2c5f-453a-bc17-56d83d604025.png)

Now:
![right](https://user-images.githubusercontent.com/8694124/136211991-213114f5-c318-42bc-863c-3341facd86b6.png)

---

The reason was that previously, when the TTML fontSize styling attribute was parsed, the RxPlayer made as if percentages keep the same semantics between TTML and CSS.

However this isn't the case at all:
  - [In CSS](https://drafts.csswg.org/css-fonts/#valdef-font-size-length-percentage), a percentage indicates the font-size relative to the one of its parent.
  - [In TTML](https://www.w3.org/TR/2018/REC-ttml1-20181108/#style-attribute-fontSize), it seems to be in most cases the percentage relative to the Computed Cell Size (a TTML concept).

So if I understood correctly all this, it is basically the equivalent of the `c` unit, multiplied by 100.
This also seems to be how other player are interpreting it:
  - Shaka-player: https://github.com/google/shaka-player/blob/7c81b0b3f779bcec90b58afce332935d2f2670cf/lib/text/ui_text_displayer.js#L534-L541

  - dash.js: https://github.com/Dash-Industry-Forum/dash.js/blob/a2b96237861154434dcb8bb572d8563c1437a1f4/src/streaming/text/TextTracks.js#L319-L323

Though there is another part to the TTML specification I do not fully understand yet:
`if not region element, then relative to the parent element's computed font size`

Does this mean that if the cue has no linked `region` element, it is the same definition than for CSS? I don't know, but if that's the case, it is not properly handled now.