### PR TITLE
API: Fix unknown active Period happening when switching rapidly between Representation

### DIFF
--- a/src/core/stream/orchestrator/active_period_emitter.ts
+++ b/src/core/stream/orchestrator/active_period_emitter.ts
@@ -109,12 +109,12 @@ export default function ActivePeriodEmitter(
         case "representationChange": {
           const { period, type } = evt.value;
           const currentInfos = acc[period.id];
-          if (currentInfos !== undefined && !currentInfos.buffers.has(type)) {
-            currentInfos.buffers.add(type);
-          } else {
+          if (currentInfos === undefined) {
             const bufferSet = new Set<IBufferType>();
             bufferSet.add(type);
             acc[period.id] = { period, buffers: bufferSet };
+          } else if (!currentInfos.buffers.has(type)) {
+            currentInfos.buffers.add(type);
           }
         }
           break;


### PR DESCRIPTION
One of the application using the RxPlayer at Canal+ experienced recently a new strange bug:
Some methods, like `getAvailableVideoBitrates`, would always return an empty array, even when it is evident that there are multiple video bitrates available.

After some quick checks, it turned out that multiple RxPlayer API were in the same case and that this was due to the RxPlayer `API` module not knowing which `Period` (subpart of the current content with its own tracks and bitrates characteristics) was being played.

---

The `API` module relies on the `Stream` module's `ActivePeriodEmitter` to know which `Period` is being played.

This last part (the `ActivePeriodEmitter`) knows which Period is the "active Period" by exploiting a side-effect of the current `Stream` behavior:

The "active Period" is the first chronological Period for which each type of buffer ("audio", "video", "text") has a corresponding active `RepresentationStream`.
Why this weird rule is used (instead of simpler solutions like relying on the current position) is out of the scope of this message.

Anyway, turns out there was a pretty big bug in that `ActivePeriodEmitter`:
If multiple `RepresentationStream` were created for a single buffer type (audio, video, text) before other buffer types had their first one for a given `Period`, it would be possible to never be able to emit this `Period` as "active".

The source of the error seems to be due to a very evident logical error.
What was written as:
```js
if (A && B) {
  // Do thing
} else {
  // Do other thing
}
```
Should have been written:
```js
if (A && B) {
  // Do thing
} else if (!B) {
  // Do other thing
}
```
or more succintly (and simply):
```js
if (!A) {
  // Do other thing
} else if (B) {
  // Do thing
}
```

I like to talk about this type of error as "logical typos" because it makes no sense when you read it, yet was most likely written with well-thought logic in mind, it's just that the execution was poorly done.

---

Now the biggest question is why are we seeing this more than 2-years-old bug only now and not before?

I think it may be because we've been lucky (though I prefer to consider us to be unlucky here, I generally prefer immediately-catched errors):

  1. Most contents have only one Period, and in those we usually will create synchronously a single `RepresentationStream` per type at the beginning.
     In this case, no error happens.

  2. Even for multi-Period contents, chances are that text and audio `RepresentationStream`, which generally are much less heavy and thus are pre-loaded faster, will be created before the video one, and we very rarely switch between audio or text Representations.

     Thus we rarely switch between audio or text `RepresentationStream` before the first video `RepresentationStream` is anounced and thus don't see any bug.

There might be other causes. I'm very surprised that we never either catched this bug or seen some weird related behavior on multi-Period contents due to this bug.
