### PR TITLE
eme: add `formatInitializationData` keySystems option

### DIFF
--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -267,12 +267,17 @@ export default function EMEManager(
           // `generateKeyRequest` awaits a single Uint8Array containing all
           // initialization data.
           const concatInitData = concat(...initializationData.values.map(i => i.data));
+          const formattedInitData =
+            typeof options.formatInitializationData === "function" ?
+              options.formatInitializationData(concatInitData,
+                                               initializationData.type) :
+              concatInitData;
 
           const generateRequest$ = sessionEvt.type !== "created-session" ?
               EMPTY :
               generateKeyRequest(mediaKeySession,
                                  initializationData.type,
-                                 concatInitData).pipe(
+                                 formattedInitData).pipe(
                 catchError((error: unknown) => {
                   throw new EncryptedMediaError(
                     "KEY_GENERATE_REQUEST_ERROR",

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -601,4 +601,8 @@ export interface IKeySystemOption {
      */
     keyOutputRestricted? : boolean;
   };
+  formatInitializationData? : (
+    initData : Uint8Array,
+    initDataType : string | undefined
+  ) => Uint8Array;
 }


### PR DESCRIPTION
This is a very very simple implementation of #1017, which basically adds a `formatInitializationData` callback to the `keySystems` loadVideo option.

This callback will allow an application to generate its own encrytion initialization data, for when the right one is not in the content.

I'm still unsure if this is the right way to do it though:

  1. By putting its logic only in the `EMEManager` (for simplicity reason), the new initialization data will not be known from any other module.

     This may be dangerous for future evolutions if we're not careful.
     E.g., another module could presume that the wanted keySystem's data is unavailable and thus bypass completely the EMEManager logic.

  2. `formatInitializationData` takes an `Uint8Array` as argument and outputs an `Uint8Array`.

     This makes sense in the current code, yet we may also prefer a more generic `ArrayBuffer` type here.

  3. It takes as argument every initialization data concatenated and return what should be fed to `MediaKeySession.generateRequest`.
     As such, it is kind-of a low-level very specialized callback, without the notion of a "pssh" nor of a "key system".

     This can both be good or bad.