### PR TITLE
Support UTCTiming element with the http-xsdate scheme

### DIFF
--- a/src/parsers/manifest/dash/common/get_http_utc-timing_url.ts
+++ b/src/parsers/manifest/dash/common/get_http_utc-timing_url.ts
@@ -16,6 +16,16 @@
 
 import { IMPDIntermediateRepresentation } from "../node_parser_types";
 
+type ISupportedHttpUtcTimingScheme =
+  {
+    schemeIdUri : "urn:mpeg:dash:utc:http-iso:2014";
+    value : string;
+  } |
+  {
+    schemeIdUri : "urn:mpeg:dash:utc:http-xsdate:2014";
+    value : string;
+  };
+
 /**
  * @param {Object} mpdIR
  * @returns {string|undefined}
@@ -24,12 +34,11 @@ export default function getHTTPUTCTimingURL(
   mpdIR : IMPDIntermediateRepresentation
 ) : string|undefined {
   const UTCTimingHTTP = mpdIR.children.utcTimings
-    .filter((utcTiming) : utcTiming is {
-      schemeIdUri : "urn:mpeg:dash:utc:http-iso:2014";
-      value : string;
-    } =>
-      utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-iso:2014" &&
-      utcTiming.value !== undefined
+    .filter((utcTiming) : utcTiming is ISupportedHttpUtcTimingScheme =>
+      (
+        utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-iso:2014" ||
+        utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-xsdate:2014"
+      ) && utcTiming.value !== undefined
     );
 
   return UTCTimingHTTP.length > 0 ? UTCTimingHTTP[0].value :


### PR DESCRIPTION
While both doing the inventory of what MPD attributes handle the RxPlayer and working on low-latency contents, I noted that the RxPlayer did not support `UTCTiming` element with the `urn:mpeg:dash:utc:http-xsdate:2014` scheme value

Yet it is very simple to implement - at least in JavaScript - as we already handle the `http-iso` format and that both are valid ISO8601 dates. As we use the `Date` builtin to transform such strings to a JS `Number`, we can thus use the exact same parsing logic for both.