### PR TITLE
Reduce coupling between fetchers and ABR by using callbacks in the former

### DIFF
--- a/src/core/abr/index.ts
+++ b/src/core/abr/index.ts
@@ -20,13 +20,17 @@ import ABRManager, {
 } from "./abr_manager";
 export {
   IABRAddedSegmentEvent,
-  IABRStreamEvents,
   IABREstimate,
   IABRMetricsEvent,
+  IABRMetricsEventValue,
   IABRRepresentationChangeEvent,
   IABRRequestBeginEvent,
+  IABRRequestBeginEventValue,
   IABRRequestEndEvent,
+  IABRRequestEndEventValue,
   IABRRequestProgressEvent,
+  IABRRequestProgressEventValue,
+  IABRStreamEvents,
 } from "./representation_estimator";
 
 export default ABRManager;

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -131,7 +131,7 @@ export interface IRepresentationEstimatorPlaybackObservation {
 }
 
 /** Content of the `IABRMetricsEvent` event's payload. */
-interface IABRMetricsEventValue {
+export interface IABRMetricsEventValue {
   /** Time the request took to perform the request, in milliseconds. */
   duration: number;
   /** Amount of bytes downloaded with this request. */
@@ -174,19 +174,22 @@ export interface IABRRepresentationChangeEvent {
  */
 export interface IABRRequestBeginEvent {
   type: "requestBegin";
-  value: {
-    /**
-     * String identifying this request.
-     *
-     * Only one request communicated to the current `RepresentationEstimator`
-     * should have this `id` at the same time.
-     */
-    id: string;
-    /** Metadata on the requested segment. */
-    segment: ISegment;
-    /** Value of `performance.now` at the time the request began.  */
-    requestTimestamp: number;
-  };
+  value: IABRRequestBeginEventValue;
+}
+
+/** Value associated with a `IABRRequestBeginEvent`. */
+export interface IABRRequestBeginEventValue {
+  /**
+   * String identifying this request.
+   *
+   * Only one request communicated to the current `RepresentationEstimator`
+   * should have this `id` at the same time.
+   */
+  id: string;
+  /** Metadata on the requested segment. */
+  segment: ISegment;
+  /** Value of `performance.now` at the time the request began.  */
+  requestTimestamp: number;
 }
 
 /**
@@ -197,24 +200,27 @@ export interface IABRRequestBeginEvent {
  */
 export interface IABRRequestProgressEvent {
   type: "progress";
-  value: {
-    /** Amount of time since the request has started, in seconds. */
-    duration : number;
-    /**
-     * Same `id` value used to identify that request at the time the corresponding
-     * `IABRRequestBeginEvent` event was sent.
-     */
-    id: string;
-    /** Current downloaded size, in bytes. */
-    size : number;
-    /** Value of `performance.now` at the time this progression report was available. */
-    timestamp : number;
-    /**
-     * Total size of the segment to download (including already-loaded data),
-     * in bytes.
-     */
-    totalSize : number;
-  };
+  value: IABRRequestProgressEventValue;
+}
+
+/** Value associated with a `IABRRequestProgressEvent`. */
+export interface IABRRequestProgressEventValue {
+  /** Amount of time since the request has started, in seconds. */
+  duration : number;
+  /**
+   * Same `id` value used to identify that request at the time the corresponding
+   * `IABRRequestBeginEvent` event was sent.
+   */
+  id: string;
+  /** Current downloaded size, in bytes. */
+  size : number;
+  /** Value of `performance.now` at the time this progression report was available. */
+  timestamp : number;
+  /**
+   * Total size of the segment to download (including already-loaded data),
+   * in bytes.
+   */
+  totalSize : number;
 }
 
 /**
@@ -225,13 +231,16 @@ export interface IABRRequestProgressEvent {
  */
 export interface IABRRequestEndEvent {
   type: "requestEnd";
-  value: {
-    /**
-     * Same `id` value used to identify that request at the time the corresponding
-     * `IABRRequestBeginEvent` event was sent.
-     */
-    id: string;
-  };
+  value: IABRRequestEndEventValue;
+}
+
+/** Value associated with a `IABRRequestProgressEvent`. */
+export interface IABRRequestEndEventValue {
+  /**
+   * Same `id` value used to identify that request at the time the corresponding
+   * `IABRRequestBeginEvent` event was sent.
+   */
+  id: string;
 }
 
 /** Object allowing to filter some Representations out based on different attributes. */

--- a/src/core/fetchers/index.ts
+++ b/src/core/fetchers/index.ts
@@ -26,7 +26,7 @@ import SegmentFetcherCreator, {
   ISegmentFetcherChunkEvent,
   ISegmentFetcherCreatorBackoffOptions,
   ISegmentFetcherEvent,
-  ISegmentFetcherWarning,
+  ISegmentFetcherRetry,
 } from "./segment";
 
 export {
@@ -46,5 +46,5 @@ export {
 
   ISegmentFetcherChunkEvent,
   ISegmentFetcherChunkCompleteEvent,
-  ISegmentFetcherWarning,
+  ISegmentFetcherRetry,
 };

--- a/src/core/fetchers/segment/index.ts
+++ b/src/core/fetchers/segment/index.ts
@@ -22,7 +22,7 @@ import {
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherEvent,
-  ISegmentFetcherWarning,
+  ISegmentFetcherRetry,
 } from "./segment_fetcher";
 import SegmentFetcherCreator, {
   ISegmentFetcherCreatorBackoffOptions,
@@ -35,6 +35,6 @@ export {
   ISegmentFetcherChunkCompleteEvent,
   ISegmentFetcherChunkEvent,
   ISegmentFetcherEvent,
-  ISegmentFetcherWarning,
+  ISegmentFetcherRetry,
   ISegmentFetcherCreatorBackoffOptions,
 };

--- a/src/core/fetchers/segment/prioritizer.ts
+++ b/src/core/fetchers/segment/prioritizer.ts
@@ -23,88 +23,6 @@ import log from "../../../log";
 import arrayFindIndex from "../../../utils/array_find_index";
 
 /**
- * Event sent when the corresponding task is a low-priority task that has just
- * been temporarly interrupted due to another task with a high priority.
- * The task will restart (from scratch) when tasks with more priority are
- * finished.
- */
-export interface IInterruptedTaskEvent { type : "interrupted" }
-
-/** Event sent when the corresponding task emit an event. */
-export interface ITaskDataEvent<T> { type : "data";
-                                     value : T; }
-
-/**
- * Event sent when the corresponding task has ended (it will then complete).
- * You can use this event to schedule another task you wanted to perform after
- * that one.
- */
-export interface IEndedTaskEvent { type : "ended" }
-
-/** Events sent when a task has been created through the `create` method. */
-export type ITaskEvent<T> = IInterruptedTaskEvent |
-                            ITaskDataEvent<T> |
-                            IEndedTaskEvent;
-
-/** Stored object representing a single task. */
-interface IPrioritizerTask<T> {
-  /**
-   * Observable created by the ObservablePrioritizer allowing to identify
-   * the task.
-   * This is another Observable wrapping the underlying Observable that the
-   * ObservablePrioritizer is asked to run.
-   */
-  observable : Observable<ITaskEvent<T>>;
-  /**
-   * Function used to start and interrupt a task:
-   *   - when `true` is emitted the task should be started. If it was already
-   *     started, it will be interrupted first.
-   *   - when `false` is emitted, the task should just be interrupted if running
-   */
-  trigger : (shouldRun : boolean) => void;
-  /**
-   * Subscription of the underlying, wrapped, Observable.
-   * Only defined when the task has been started, `null` otherwise.
-   */
-  subscription : Subscription | null;
-  /** Priority of the task. Lower that number is, higher is the priority. */
-  priority : number;
-  /** `true` if the underlying wrapped Observable either errored of completed. */
-  finished : boolean;
-}
-
-/** Options to give to the ObservablePrioritizer. */
-export interface IPrioritizerOptions {
-  /** @see IPrioritizerPrioritySteps */
-  prioritySteps : IPrioritizerPrioritySteps;
-}
-
-/**
- * Define both the `low` and `high` priority steps:
- *
- *   - Any Observable with a priority number that is lower or equal to the
- *     `high` value will be an Observable with high priority.
- *
- *     When Observables with high priorities are scheduled, they immediately
- *     abort pending Observables with low priorities (which will have then to
- *     wait until all higher-priority Observable have ended before re-starting).
- *
- *   - Any Observable with a priority number that is higher or equal to the
- *     `low` value will be an Observable with low priority.
- *
- *     Pending Observables with low priorities have the added particularity*
- *     of being aborted as soon as a high priority Observable is scheduled.
- *
- *     * Other pending Observables are not aborted when a higher-priority
- *     Observable is scheduled, as their priorities only affect them before
- *     they are started (to know when to start them).
- */
-export interface IPrioritizerPrioritySteps {
-  low : number;
-  high : number;
-}
-
-/**
  * Create Observables which can be priorized between one another.
  *
  * With this class, you can link an Observables to a priority number.
@@ -555,4 +473,86 @@ export default class ObservablePrioritizer<T> {
     return this._minPendingPriority !== null &&
            this._minPendingPriority <= this._prioritySteps.high;
   }
+}
+
+/**
+ * Event sent when the corresponding task is a low-priority task that has just
+ * been temporarly interrupted due to another task with a high priority.
+ * The task will restart (from scratch) when tasks with more priority are
+ * finished.
+ */
+export interface IInterruptedTaskEvent { type : "interrupted" }
+
+/** Event sent when the corresponding task emit an event. */
+export interface ITaskDataEvent<T> { type : "data";
+                                     value : T; }
+
+/**
+ * Event sent when the corresponding task has ended (it will then complete).
+ * You can use this event to schedule another task you wanted to perform after
+ * that one.
+ */
+export interface IEndedTaskEvent { type : "ended" }
+
+/** Events sent when a task has been created through the `create` method. */
+export type ITaskEvent<T> = IInterruptedTaskEvent |
+                            ITaskDataEvent<T> |
+                            IEndedTaskEvent;
+
+/** Stored object representing a single task. */
+interface IPrioritizerTask<T> {
+  /**
+   * Observable created by the ObservablePrioritizer allowing to identify
+   * the task.
+   * This is another Observable wrapping the underlying Observable that the
+   * ObservablePrioritizer is asked to run.
+   */
+  observable : Observable<ITaskEvent<T>>;
+  /**
+   * Function used to start and interrupt a task:
+   *   - when `true` is emitted the task should be started. If it was already
+   *     started, it will be interrupted first.
+   *   - when `false` is emitted, the task should just be interrupted if running
+   */
+  trigger : (shouldRun : boolean) => void;
+  /**
+   * Subscription of the underlying, wrapped, Observable.
+   * Only defined when the task has been started, `null` otherwise.
+   */
+  subscription : Subscription | null;
+  /** Priority of the task. Lower that number is, higher is the priority. */
+  priority : number;
+  /** `true` if the underlying wrapped Observable either errored of completed. */
+  finished : boolean;
+}
+
+/** Options to give to the ObservablePrioritizer. */
+export interface IPrioritizerOptions {
+  /** @see IPrioritizerPrioritySteps */
+  prioritySteps : IPrioritizerPrioritySteps;
+}
+
+/**
+ * Define both the `low` and `high` priority steps:
+ *
+ *   - Any Observable with a priority number that is lower or equal to the
+ *     `high` value will be an Observable with high priority.
+ *
+ *     When Observables with high priorities are scheduled, they immediately
+ *     abort pending Observables with low priorities (which will have then to
+ *     wait until all higher-priority Observable have ended before re-starting).
+ *
+ *   - Any Observable with a priority number that is higher or equal to the
+ *     `low` value will be an Observable with low priority.
+ *
+ *     Pending Observables with low priorities have the added particularity*
+ *     of being aborted as soon as a high priority Observable is scheduled.
+ *
+ *     * Other pending Observables are not aborted when a higher-priority
+ *     Observable is scheduled, as their priorities only affect them before
+ *     they are started (to know when to start them).
+ */
+export interface IPrioritizerPrioritySteps {
+  low : number;
+  high : number;
 }

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  Observable,
-  Subject,
-} from "rxjs";
+import { Observable } from "rxjs";
 import config from "../../../config";
-import { formatError, ICustomError } from "../../../errors";
+import {
+  formatError,
+  ICustomError,
+} from "../../../errors";
 import Manifest, {
   Adaptation,
   ISegment,
@@ -40,10 +40,10 @@ import TaskCanceller, {
   CancellationSignal,
 } from "../../../utils/task_canceller";
 import {
-  IABRMetricsEvent,
-  IABRRequestBeginEvent,
-  IABRRequestEndEvent,
-  IABRRequestProgressEvent,
+  IABRMetricsEventValue,
+  IABRRequestBeginEventValue,
+  IABRRequestEndEventValue,
+  IABRRequestProgressEventValue,
 } from "../../abr";
 import { IBufferType } from "../../segment_buffers";
 import errorSelector from "../utils/error_selector";
@@ -57,33 +57,30 @@ const { DEFAULT_MAX_REQUESTS_RETRY_ON_ERROR,
 const generateRequestID = idGenerator();
 
 /**
- * Create a function which will fetch and parse segments.
+ * Create an `ISegmentFetcher` object which will allow to easily fetch and parse
+ * segments.
+ * An `ISegmentFetcher` also implements a retry mechanism, based on the given
+ * `options` argument, which may retry a segment request when it fails.
+ *
  * @param {string} bufferType
  * @param {Object} transport
- * @param {Subject} requests$
+ * @param {Object} callbacks
  * @param {Object} options
  * @returns {Function}
  */
-export default function createSegmentFetcher<
-  LoadedFormat,
-  TSegmentDataType,
->(
+export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
   bufferType : IBufferType,
-  pipeline : ISegmentPipeline<LoadedFormat, TSegmentDataType>,
-  requests$ : Subject<IABRMetricsEvent |
-                      IABRRequestBeginEvent |
-                      IABRRequestProgressEvent |
-                      IABRRequestEndEvent>,
+  pipeline : ISegmentPipeline<TLoadedFormat, TSegmentDataType>,
+  callbacks : ISegmentFetcherCreatorCallbacks,
   options : ISegmentFetcherOptions
 ) : ISegmentFetcher<TSegmentDataType> {
-
   /**
    * Cache audio and video initialization segments.
    * This allows to avoid doing too many requests for what are usually very
    * small files.
    */
   const cache = arrayIncludes(["audio", "video"], bufferType) ?
-    new InitializationSegmentCache<LoadedFormat>() :
+    new InitializationSegmentCache<TLoadedFormat>() :
     undefined;
 
   const { loadSegment, parseSegment } = pipeline;
@@ -91,11 +88,13 @@ export default function createSegmentFetcher<
   /**
    * Fetch a specific segment.
    *
-   * This function returns an Observable which will fetch the segment on
+   * This function returns an Observable which will fetch segments on
    * subscription.
+   * If the corresponding request fails, it may retry it based on the given
+   * options.
+   *
    * This Observable will emit various events during that request lifecycle and
    * throw if the segment request(s) (including potential retries) fail.
-   *
    * The Observable will automatically complete once no events are left to be
    * sent.
    * @param {Object} content
@@ -118,11 +117,9 @@ export default function createSegmentFetcher<
       }
 
       const id = generateRequestID();
-      requests$.next({ type: "requestBegin",
-                       value: { segment,
-                                requestTimestamp: performance.now(),
-                                id } });
-
+      callbacks.onRequestBegin?.({ segment,
+                                   requestTimestamp: performance.now(),
+                                   id });
       const canceller = new TaskCanceller();
       let hasRequestEnded = false;
 
@@ -134,12 +131,11 @@ export default function createSegmentFetcher<
          */
         onProgress(info : ISegmentLoadingProgressInformation) : void {
           if (info.totalSize !== undefined && info.size < info.totalSize) {
-            requests$.next({ type: "progress",
-                             value: { duration: info.duration,
-                                      size: info.size,
-                                      totalSize: info.totalSize,
-                                      timestamp: performance.now(),
-                                      id } });
+            callbacks.onProgress?.({ duration: info.duration,
+                                     size: info.size,
+                                     totalSize: info.totalSize,
+                                     timestamp: performance.now(),
+                                     id });
           }
         },
 
@@ -149,7 +145,7 @@ export default function createSegmentFetcher<
          * argument.
          * @param {*} chunkData
          */
-        onNewChunk(chunkData : LoadedFormat) : void {
+        onNewChunk(chunkData : TLoadedFormat) : void {
           obs.next({ type: "chunk" as const,
                      parse: generateParserFunction(chunkData, true) });
         },
@@ -181,10 +177,9 @@ export default function createSegmentFetcher<
                res.resultData.size !== undefined &&
                res.resultData.requestDuration !== undefined)
           {
-            requests$.next({ type: "metrics",
-                             value: { size: res.resultData.size,
-                                      duration: res.resultData.requestDuration,
-                                      content } });
+            callbacks.onMetrics?.({ size: res.resultData.size,
+                                    duration: res.resultData.requestDuration,
+                                    content });
           }
 
           if (!canceller.isUsed) {
@@ -192,11 +187,11 @@ export default function createSegmentFetcher<
             // of the previous `next` calls. In that case, we don't want to send
             // a "requestEnd" again as it has already been sent on cancellation.
             //
-            // Note that we only perform this check for `"requestEnd"` on
+            // Note that we only perform this check for `onRequestEnd` on
             // purpose. Observable's events should have been ignored by RxJS if
             // the Observable has already been canceled and we don't care if
             // `"metrics"` is sent there.
-            requests$.next({ type: "requestEnd", value: { id } });
+            callbacks.onRequestEnd?.({ id });
           }
           obs.complete();
         })
@@ -208,7 +203,7 @@ export default function createSegmentFetcher<
       return () => {
         if (!hasRequestEnded) {
           canceller.cancel();
-          requests$.next({ type: "requestEnd", value: { id } });
+          callbacks.onRequestEnd?.({ id });
         }
       };
 
@@ -231,7 +226,7 @@ export default function createSegmentFetcher<
        * @param {Boolean} isChunked
        * @returns {Function}
        */
-      function generateParserFunction(data : LoadedFormat, isChunked : boolean)  {
+      function generateParserFunction(data : TLoadedFormat, isChunked : boolean)  {
         return function parse(initTimescale? : number) :
           ISegmentParserParsedInitSegment<TSegmentDataType> |
           ISegmentParserParsedSegment<TSegmentDataType>
@@ -252,7 +247,7 @@ export default function createSegmentFetcher<
        * @param {*} err
        */
       function onRetry(err: unknown) : void {
-        obs.next({ type: "warning" as const,
+        obs.next({ type: "retry" as const,
                    value: errorSelector(err) });
       }
     });
@@ -264,10 +259,9 @@ export type ISegmentFetcher<TSegmentDataType> = (content : ISegmentLoaderContent
 
 /** Event sent by the SegmentFetcher when fetching a segment. */
 export type ISegmentFetcherEvent<TSegmentDataType> =
-  ISegmentFetcherChunkCompleteEvent |
   ISegmentFetcherChunkEvent<TSegmentDataType> |
-  ISegmentFetcherWarning;
-
+  ISegmentFetcherChunkCompleteEvent |
+  ISegmentFetcherRetry;
 
 /**
  * Event sent when a new "chunk" of the segment is available.
@@ -304,10 +298,38 @@ export interface ISegmentLoaderContent { manifest : Manifest;
                                          representation : Representation;
                                          segment : ISegment; }
 
-/** An Error happened while loading (usually a request error). */
-export interface ISegmentFetcherWarning { type : "warning";
-                                          value : ICustomError; }
+/**
+ * An Error happened while loading which led to a retry.
+ * The request is retried from scratch.
+ */
+export interface ISegmentFetcherRetry { type : "retry";
+                                        value : ICustomError; }
 
+/**
+ * Callbacks that can be bound when creating an `ISegmentFetcher`.
+ * Those allows to be notified of an `ISegmentFetcher` various lifecycles and of
+ * network information.
+ */
+export interface ISegmentFetcherCreatorCallbacks {
+  /** Called when a segment request begins. */
+  onRequestBegin? : (arg : IABRRequestBeginEventValue) => void;
+  /** Called when progress information is available on a pending segment request. */
+  onProgress? : (arg : IABRRequestProgressEventValue) => void;
+  /**
+   * Called when a segment request ends (either because it completed, it failed
+   * or was canceled).
+   */
+  onRequestEnd? : (arg : IABRRequestEndEventValue) => void;
+  /**
+   * Called when network metrics linked to a segment request are available,
+   * once the request has terminated.
+   * This callback may be called before or after the corresponding
+   * `onRequestEnd` callback, you should not rely on the order between the two.
+   */
+  onMetrics? : (arg : IABRMetricsEventValue) => void;
+}
+
+/** Options allowing to configure an `ISegmentFetcher`'s behavior. */
 export interface ISegmentFetcherOptions {
   /**
    * Initial delay to wait if a request fails before making a new request, in

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -14,18 +14,11 @@
  * limitations under the License.
  */
 
-import { Subject } from "rxjs";
 import config from "../../../config";
 import {
   ISegmentPipeline,
   ITransportPipelines,
 } from "../../../transports";
-import {
-  IABRMetricsEvent,
-  IABRRequestBeginEvent,
-  IABRRequestEndEvent,
-  IABRRequestProgressEvent,
-} from "../../abr";
 import { IBufferType } from "../../segment_buffers";
 import applyPrioritizerToSegmentFetcher, {
   IPrioritizedSegmentFetcher,
@@ -33,24 +26,12 @@ import applyPrioritizerToSegmentFetcher, {
 import ObservablePrioritizer from "./prioritizer";
 import createSegmentFetcher, {
   getSegmentFetcherOptions,
+  ISegmentFetcherCreatorCallbacks,
   ISegmentFetcherEvent,
 } from "./segment_fetcher";
 
 const { MIN_CANCELABLE_PRIORITY,
         MAX_HIGH_PRIORITY_LEVEL } = config;
-
-/** Options used by the `SegmentFetcherCreator`. */
-export interface ISegmentFetcherCreatorBackoffOptions {
-  /**
-   * Whether the content is played in a low-latency mode.
-   * This has an impact on default backoff delays.
-   */
-  lowLatencyMode : boolean;
-  /** Maximum number of time a request on error will be retried. */
-  maxRetryRegular : number | undefined;
-  /** Maximum number of time a request be retried when the user is offline. */
-  maxRetryOffline : number | undefined;
-}
 
 /**
  * Interact with the transport pipelines to download segments with the right
@@ -60,12 +41,15 @@ export interface ISegmentFetcherCreatorBackoffOptions {
  *
  * @example
  * ```js
- * const creator = new SegmentFetcherCreator(transport);
+ * const creator = new SegmentFetcherCreator(transport, {
+ *   lowLatencyMode: false,
+ *   maxRetryRegular: Infinity,
+ *   maxRetryOffline: Infinity,
+ * });
  *
  * // 2 - create a new fetcher with its backoff options
  * const fetcher = creator.createSegmentFetcher("audio", {
- *   maxRetryRegular: Infinity,
- *   maxRetryOffline: Infinity,
+ *   // ... (lifecycle callbacks if wanted)
  * });
  *
  * // 3 - load a segment with a given priority
@@ -119,28 +103,36 @@ export default class SegmentFetcherCreator {
    * Create a segment fetcher, allowing to easily perform segment requests.
    * @param {string} bufferType - The type of buffer concerned (e.g. "audio",
    * "video", etc.)
-   * @param {Subject} requests$ - Subject through which request-related events
-   * (such as those needed by the ABRManager) will be sent.
+   * @param {Object} callbacks
    * @returns {Object}
    */
   createSegmentFetcher(
     bufferType : IBufferType,
-    requests$ : Subject<IABRRequestBeginEvent |
-                        IABRRequestProgressEvent |
-                        IABRRequestEndEvent |
-                        IABRMetricsEvent>
+    callbacks : ISegmentFetcherCreatorCallbacks
   ) : IPrioritizedSegmentFetcher<unknown> {
     const backoffOptions = getSegmentFetcherOptions(bufferType, this._backoffOptions);
     const pipelines = this._transport[bufferType];
 
     // Types are very complicated here as they are per-type of buffer.
-    // This is the reason why `any` is used instead.
     const segmentFetcher = createSegmentFetcher<unknown, unknown>(
       bufferType,
       pipelines as ISegmentPipeline<unknown, unknown>,
-      requests$,
+      callbacks,
       backoffOptions
     );
     return applyPrioritizerToSegmentFetcher(this._prioritizer, segmentFetcher);
   }
+}
+
+/** Options used by the `SegmentFetcherCreator`. */
+export interface ISegmentFetcherCreatorBackoffOptions {
+  /**
+   * Whether the content is played in a low-latency mode.
+   * This has an impact on default backoff delays.
+   */
+  lowLatencyMode : boolean;
+  /** Maximum number of time a request on error will be retried. */
+  maxRetryRegular : number | undefined;
+  /** Maximum number of time a request be retried when the user is offline. */
+  maxRetryOffline : number | undefined;
 }

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -260,7 +260,7 @@ export default class DownloadingQueue<T> {
       return request$
         .pipe(mergeMap((evt) => {
           switch (evt.type) {
-            case "warning":
+            case "retry":
               return observableOf({ type: "retry" as const,
                                     value: { segment, error: evt.value } });
             case "interrupted":
@@ -336,7 +336,7 @@ export default class DownloadingQueue<T> {
                                         IEndOfSegmentEvent> =>
       {
         switch (evt.type) {
-          case "warning":
+          case "retry":
             return observableOf({ type: "retry" as const,
                                   value: { segment, error: evt.value } });
           case "interrupted":

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -52,10 +52,7 @@ import assertUnreachable from "../../../utils/assert_unreachable";
 import objectAssign from "../../../utils/object_assign";
 import { createSharedReference } from "../../../utils/reference";
 import { IReadOnlyPlaybackObserver } from "../../api";
-import {
-  IPrioritizedSegmentFetcher,
-  ISegmentFetcherWarning,
-} from "../../fetchers";
+import { IPrioritizedSegmentFetcher } from "../../fetchers";
 import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
 import {
@@ -68,6 +65,7 @@ import {
   IStreamStatusEvent,
   IStreamTerminatingEvent,
   IInbandEventsEvent,
+  IStreamWarningEvent,
 } from "../types";
 import DownloadingQueue, {
   IDownloadingQueueEvent,
@@ -386,7 +384,7 @@ export default function RepresentationStream<TSegmentDataType>({
   function onQueueEvent(
     evt : IDownloadingQueueEvent<TSegmentDataType>
   ) : Observable<IStreamEventAddedSegment<TSegmentDataType> |
-                 ISegmentFetcherWarning |
+                 IStreamWarningEvent |
                  IEncryptionDataEncounteredEvent |
                  IInbandEventsEvent |
                  IStreamNeedsManifestRefresh |

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -209,7 +209,8 @@ export default class VideoThumbnailLoader {
     const segmentFetcher = createSegmentFetcher(
       "video",
       loader.video,
-      new Subject(),
+      // We don't care about the SegmentFetcher's lifecycle events
+      {},
       { baseDelay: 0,
         maxDelay: 0,
         maxRetryOffline: 0,

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -586,6 +586,7 @@ export interface ISegmentLoaderCallbacks<T> {
   onNewChunk : (data : T) => void;
 }
 
+/** Information related to a pending Segment request progressing. */
 export interface ISegmentLoadingProgressInformation {
   /** Time since the beginning of the request so far, in seconds. */
   duration : number;


### PR DESCRIPTION
This commit tries to reduce the strong implicit link between the `fetchers` (in `src/core/fetchers`) and the ABR logic (in `src/core/abr`).

Why
===

In the previous code, the `SegmentFetcher` (deep inside the fetchers code) directly used an RxJS Subject to send various network lifecycle events which was listened to by the `RepresentationEstimator` (deep inside the ABR code). The `stream` (in `src/core/stream`) was the one linking both by creating the Subject and passing it to both modules.

I wasn't happy with that link, even more considering that new cases (the `VideoThumbnailLoader` and the future `ContentDownloader`) may want to use the `fetchers` code to load and parse segments without needing any adaptive logic from the ABR. In that case, they needed to provide a mute Subject, which didn't make much sense.

What
====

That's the reason why I decided to switch to a more generic callback-based solution instead. Instead of a Subject on which various `fetchers` lifecycle events (such as: `requestBegin` or `requestEnd`) will be sent, the caller can now provide callbacks to be notified on those various events.

This way of doing it is more usual in JS-land and also goes toward our long term goal of phasing out the hard-to-grasp RxJS to more usual patterns, to improve the RxPlayer code readability and debuggability.
It also improve the code of the `AdaptationStream`, which had to perform some tricks to perform the link between the abr and fetchers code.

I also profited from the modification here to continue our recent style change of putting TypeScript interface definitions after the main export to improve readability for newcomers. A huge part of the diff may be due to that.
I also profited to rename the `warning` fetcher event to `retry` to make it more explicit that this event triggers a complete retry of the segment retry (and we might thus re-download chunks from scratch).

This is still not perfect though as data communicated through the callbacks still respect an interface coming from the ABR. I chose this for simplicity reasons.