### PR TITLE
Resilience when retrieving external ressources related clock

### DIFF
--- a/src/parsers/manifest/dash/common/get_clock_offset.ts
+++ b/src/parsers/manifest/dash/common/get_clock_offset.ts
@@ -30,11 +30,11 @@ import log from "../../../../log";
  * @returns {number|undefined}
  */
 export default function getClockOffset(
-  serverClock : string
-) : number|undefined {
+  serverClock: string
+): number | undefined {
   const httpOffset = Date.parse(serverClock) - performance.now();
   if (isNaN(httpOffset)) {
-    log.warn("DASH Parser: Invalid clock received: ",  serverClock);
+    log.warn("DASH Parser: Invalid clock received: ", serverClock);
     return undefined;
   }
   return httpOffset;

--- a/src/parsers/manifest/dash/js-parser/parse_from_document.ts
+++ b/src/parsers/manifest/dash/js-parser/parse_from_document.ts
@@ -88,11 +88,14 @@ export default function parseFromDocument(
           ) : IDashParserResponse<string> {
             const resourceInfos : ILoadedXlinkData[] = [];
             for (let i = 0; i < loadedXlinks.length; i++) {
-              const { responseData: xlinkData,
+              const { responseData: xlinkResp,
                       receivedTime,
                       sendingTime,
                       url } = loadedXlinks[i];
-              const wrappedData = "<root>" + xlinkData + "</root>";
+              if (!xlinkResp.success) {
+                throw xlinkResp.error;
+              }
+              const wrappedData = "<root>" + xlinkResp.data + "</root>";
               const dataAsXML = new DOMParser().parseFromString(wrappedData, "text/xml");
               if (dataAsXML == null || dataAsXML.children.length === 0) {
                 throw new Error("DASH parser: Invalid external ressources");

--- a/src/parsers/manifest/dash/parsers_types.ts
+++ b/src/parsers/manifest/dash/parsers_types.ts
@@ -61,6 +61,10 @@ export interface IDashParserNeedsResources<T extends string | ArrayBuffer> {
   };
 }
 
+export type IResponseData<T> =
+  { success: true; data: T } |
+  { success: false; error: Error };
+
 /** Format a loaded resource should take. */
 export interface ILoadedResource<T extends string | ArrayBuffer> {
   /**
@@ -80,6 +84,8 @@ export interface ILoadedResource<T extends string | ArrayBuffer> {
    * `undefined` if unknown or not applicable.
    */
   receivedTime? : number;
-  /** The loaded resource itself, under the right format. */
-  responseData : T;
+  /** The loaded resource itself, under the right format.
+   * Or an error, when fetching ressources.
+   */
+  responseData : IResponseData<T>;
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -441,12 +441,15 @@ export default class DashWasmParser {
       ) : IDashParserResponse<string> | IDashParserResponse<ArrayBuffer> => {
         const resourceInfos : ILoadedXlinkData[] = [];
         for (let i = 0; i < loadedXlinks.length; i++) {
-          const { responseData: xlinkData,
+          const { responseData: xlinkResp,
                   receivedTime,
                   sendingTime,
                   url } = loadedXlinks[i];
+          if (!xlinkResp.success) {
+            throw xlinkResp.error;
+          }
           const [periodsIr,
-                 periodsIRWarnings] = this._parseXlink(xlinkData);
+                 periodsIRWarnings] = this._parseXlink(xlinkResp.data);
           resourceInfos.push({ url,
                                receivedTime,
                                sendingTime,

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -15,10 +15,14 @@
  */
 
 import PPromise from "pinkie";
+import { formatError } from "../../errors";
 import features from "../../features";
 import log from "../../log";
 import Manifest from "../../manifest";
-import { IDashParserResponse } from "../../parsers/manifest/dash/parsers_types";
+import {
+  IDashParserResponse,
+  ILoadedResource,
+} from "../../parsers/manifest/dash/parsers_types";
 import objectAssign from "../../utils/object_assign";
 import request from "../../utils/request";
 import {
@@ -154,32 +158,103 @@ export default function generateManifestParser(
                       responseType: "arraybuffer" as const,
                       cancelSignal });
           return req;
+        }).then((res) => {
+          if (value.format === "string") {
+            if (typeof res.responseData !== "string") {
+              throw new Error("External DASH resources should have been a string");
+            }
+            return objectAssign(res, {
+              responseData: {
+                success: true as const,
+                data: res.responseData },
+            });
+          } else {
+            if (!(res.responseData instanceof ArrayBuffer)) {
+              throw new Error("External DASH resources should have been ArrayBuffers");
+            }
+            return objectAssign(res, {
+              responseData: {
+                success: true as const,
+                data: res.responseData },
+            });
+          }
+        }, (err) => {
+          const error = formatError(err, {
+            defaultCode: "PIPELINE_PARSE_ERROR",
+            defaultReason: "An unknown error occured when parsing ressources.",
+          });
+          return objectAssign({}, {
+            size: undefined,
+            requestDuration: undefined,
+            responseData: {
+              success: false as const,
+              error },
+          });
         });
       });
 
       return PPromise.all(externalResources).then(loadedResources => {
         if (value.format === "string") {
-          const resources = loadedResources.map(resource => {
-            if (typeof resource.responseData !== "string") {
-              throw new Error("External DASH resources should have been a string");
-            }
-            // Normally not needed but TypeScript is just dumb here
-            return objectAssign(resource, { responseData: resource.responseData });
-          });
-          return processMpdParserResponse(value.continue(resources));
+          assertLoadedResourcesFormatString(loadedResources);
+          return processMpdParserResponse(value.continue(loadedResources));
         } else {
-          const resources = loadedResources.map(resource => {
-            if (!(resource.responseData instanceof ArrayBuffer)) {
-              throw new Error("External DASH resources should have been ArrayBuffers");
-            }
-            // Normally not needed but TypeScript is just dumb here
-            return objectAssign(resource, { responseData: resource.responseData });
-          });
-          return processMpdParserResponse(value.continue(resources));
+          assertLoadedResourcesFormatArrayBuffer(loadedResources);
+          return processMpdParserResponse(value.continue(loadedResources));
         }
       });
     }
   };
+}
+
+/**
+ * Throw if the given input is not in the expected format.
+ * Allows to enforce runtime type-checking as compile-time type-checking here is
+ * difficult to enforce.
+ *
+ * @param loadedResource
+ * @returns
+ */
+function assertLoadedResourcesFormatString(
+  loadedResources : Array<ILoadedResource<string | ArrayBuffer>>
+) : asserts loadedResources is Array<ILoadedResource<string>> {
+  if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.PRODUCTION as number) {
+    return;
+  }
+  loadedResources.forEach((loadedResource) => {
+    const { responseData } = loadedResource;
+    if (responseData.success && typeof responseData.data === "string") {
+      return;
+    } else if (!responseData.success) {
+      return;
+    }
+    throw new Error("Invalid data given to the LoadedRessource");
+  });
+}
+
+/**
+ * Throw if the given input is not in the expected format.
+ * Allows to enforce runtime type-checking as compile-time type-checking here is
+ * difficult to enforce.
+ *
+ * @param loadedResource
+ * @returns
+ */
+function assertLoadedResourcesFormatArrayBuffer(
+  loadedResources : Array<ILoadedResource<string | ArrayBuffer>>
+) : asserts loadedResources is Array<ILoadedResource<ArrayBuffer>> {
+  if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.PRODUCTION as number) {
+    return;
+  }
+
+  loadedResources.forEach((loadedResource) => {
+    const { responseData } = loadedResource;
+    if (responseData.success && responseData.data instanceof ArrayBuffer) {
+      return;
+    } else if (!responseData.success) {
+      return;
+    }
+    throw new Error("Invalid data given to the LoadedRessource");
+  });
 }
 
 /**

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -27,7 +27,7 @@ export default function assert(
   assertion : boolean,
   message? : string
 ) : asserts assertion {
-  if (__ENVIRONMENT__.DEV === __ENVIRONMENT__.CURRENT_ENV && !assertion) {
+  if (__ENVIRONMENT__.DEV === __ENVIRONMENT__.CURRENT_ENV as number && !assertion) {
     throw new AssertionError(message === undefined ? "invalid assertion" :
                                                      message);
   }


### PR DESCRIPTION
The low latency manifests are generally filled with a tag `<UTCTiming/>`, this allows the player to download external resources to be able to synchronize the clock with real date.

However, sometimes in those manifests, the resources are using the non-encrypted protocol HTTP instead of HTTPS, the browser is preventing to doing that to not break the security, so the player crashed.

We now are more resilient to that kind of behavior by using a default behavior.