### PR TITLE
[Proposal] DASH: Handle ContentProtection Element present at the Representation level

### DIFF
--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -28,6 +28,7 @@ import {
   IRepresentationIntermediateRepresentation,
   ISegmentTemplateIntermediateRepresentation,
   IScheme,
+  IContentProtectionIntermediateRepresentation,
 } from "../node_parser_types";
 import { getWEBMHDRInformation } from "./get_hdr_information";
 import ManifestBoundsCalculator from "./manifest_bounds_calculator";
@@ -237,8 +238,16 @@ export default function parseRepresentations(
         adaptation.attributes.width;
     }
 
-    if (adaptation.children.contentProtections != null) {
-      const contentProtections = adaptation.children.contentProtections
+    const contentProtectionsIr : IContentProtectionIntermediateRepresentation[] =
+      adaptation.children.contentProtections !== undefined ?
+        adaptation.children.contentProtections :
+        [];
+    if (representation.children.contentProtections !== undefined) {
+      contentProtectionsIr.push(...representation.children.contentProtections);
+    }
+
+    if (contentProtectionsIr.length > 0) {
+      const contentProtections = contentProtectionsIr
         .reduce<IContentProtections>((acc, cp) => {
           let systemId : string|undefined;
           if (cp.attributes.schemeIdUri !== undefined &&

--- a/src/parsers/manifest/dash/js-parser/node_parsers/Representation.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/Representation.ts
@@ -20,6 +20,7 @@ import {
   IRepresentationIntermediateRepresentation,
 } from "../../node_parser_types";
 import parseBaseURL from "./BaseURL";
+import parseContentProtection from "./ContentProtection";
 import parseSegmentBase from "./SegmentBase";
 import parseSegmentList from "./SegmentList";
 import parseSegmentTemplate from "./SegmentTemplate";
@@ -42,6 +43,7 @@ function parseRepresentationChildren(
   const children : IRepresentationChildren = {
     baseURLs: [],
   };
+  const contentProtections = [];
 
   let warnings : Error[] = [];
   for (let i = 0; i < representationChildren.length; i++) {
@@ -80,8 +82,22 @@ function parseRepresentationChildren(
           warnings = warnings.concat(segmentTemplateWarnings);
           children.segmentTemplate = segmentTemplate;
           break;
+
+        case "ContentProtection":
+          const [ contentProtection,
+                  contentProtectionWarnings ] = parseContentProtection(currentElement);
+          if (contentProtectionWarnings.length > 0) {
+            warnings = warnings.concat(contentProtectionWarnings);
+          }
+          if (contentProtection !== undefined) {
+            contentProtections.push(contentProtection);
+          }
+          break;
       }
     }
+  }
+  if (contentProtections.length > 0) {
+    children.contentProtections = contentProtections;
   }
   return [children, warnings];
 }

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -242,6 +242,7 @@ export interface IRepresentationChildren {
   baseURLs : IBaseUrlIntermediateRepresentation[];
 
   // optional
+  contentProtections? : IContentProtectionIntermediateRepresentation[];
   inbandEventStreams? : IScheme[];
   segmentBase? : ISegmentBaseIntermediateRepresentation;
   segmentList? : ISegmentListIntermediateRepresentation;

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Representation.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Representation.ts
@@ -30,6 +30,7 @@ import {
 } from "../types";
 import { parseString } from "../utils";
 import { generateBaseUrlAttrParser } from "./BaseURL";
+import { generateContentProtectionAttrParser } from "./ContentProtection";
 import { generateSchemeAttrParser } from "./Scheme";
 import { generateSegmentBaseAttrParser } from "./SegmentBase";
 import { generateSegmentListChildrenParser } from "./SegmentList";
@@ -56,6 +57,19 @@ export function generateRepresentationChildrenParser(
         parsersStack.pushParsers(nodeId,
                                  noop,
                                  generateBaseUrlAttrParser(baseUrl, linearMemory));
+        break;
+      }
+
+      case TagName.ContentProtection: {
+        const contentProtection = { children: { cencPssh: [] },
+                                    attributes: {} };
+        if (childrenObj.contentProtections === undefined) {
+          childrenObj.contentProtections = [];
+        }
+        childrenObj.contentProtections.push(contentProtection);
+        const contentProtAttrParser =
+          generateContentProtectionAttrParser(contentProtection, linearMemory);
+        parsersStack.pushParsers(nodeId, noop, contentProtAttrParser);
         break;
       }
 


### PR DESCRIPTION
The RxPlayer always considered the DASH-IF IOP specification first when implementing DASH features.

DASH-IF IOP v4.3 indicates that a `ContentProtection` element should always be in an `<AdaptationSet>` element and should apply to all `<Representation>` it contains (DASH-IF IOP v4.3 chapter 7.7.2).

However, we encountered multiple MPD who put their `ContentProtection` at the `<Representation>` level and some highly-used media players seems to handle that case:
  - The ExoPlayer: https://github.com/google/ExoPlayer/blob/029a2b27cbdc27cf9d51d4a73ebeb503968849f6/library/dash/src/main/java/com/google/android/exoplayer2/source/dash/manifest/DashManifestParser.java#L712
  - The ShakaPlayer:
    https://github.com/google/shaka-player/blob/c993fca5793200a7d4ba556d6ef150db52365f68/lib/dash/dash_parser.js#L1168-L1173

(another library I looked at, dash.js, seems to only handle it at AdaptationSet-level)

Also, the DASH specification (not the DASH-IF IOP) seems to authorize this way of doing it.

Handling it at Representation-level both could make sense and is very easy to handle in the RxPlayer (the parsed result is already part of our internal `Representation` structure).

So this is only a proposal.

This commit just merge ContentProtection encountered at the `<AdaptationSet>` level with the ones encountered at the `<Representation> level.