### PR TITLE
update most log so they are more easily exploitable

### DIFF
--- a/src/compat/__tests__/set_element_src.test.ts
+++ b/src/compat/__tests__/set_element_src.test.ts
@@ -57,7 +57,7 @@ describe("compat - setElementSrc", () => {
       map(() => {
         expect(mockLogInfo).toHaveBeenCalledTimes(1);
         expect(mockLogInfo)
-          .toHaveBeenCalledWith("Setting URL to Element", fakeURL, fakeMediaElement);
+          .toHaveBeenCalledWith("Setting URL to HTMLMediaElement", fakeURL);
         expect(fakeMediaElement.src).toBe(fakeURL);
       })
     ).subscribe();

--- a/src/compat/set_element_src.ts
+++ b/src/compat/set_element_src.ts
@@ -35,7 +35,7 @@ export default function setElementSrc$(
   url : string
 ) : Observable<void> {
   return new Observable((observer : Observer<void>) => {
-    log.info("Setting URL to Element", url, mediaElement);
+    log.info("Setting URL to HTMLMediaElement", url);
 
     mediaElement.src = url;
 

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -621,7 +621,8 @@ export default function RepresentationEstimator({
           if (chosenRepFromGuessMode !== null &&
               chosenRepFromGuessMode.bitrate > currentBestBitrate) {
             log.debug("ABR: Choosing representation with guess-based estimation.",
-                      chosenRepFromGuessMode);
+                      chosenRepFromGuessMode.bitrate,
+                      chosenRepFromGuessMode.id);
             prevEstimate.update(chosenRepFromGuessMode,
                                 bandwidthEstimate,
                                 ABRAlgorithmType.GuessBased);
@@ -633,7 +634,8 @@ export default function RepresentationEstimator({
                      knownStableBitrate };
           } else if (chosenRepFromBufferSize !== null) {
             log.debug("ABR: Choosing representation with buffer-based estimation.",
-                      chosenRepFromBufferSize);
+                      chosenRepFromBufferSize.bitrate,
+                      chosenRepFromBufferSize.id);
             prevEstimate.update(chosenRepFromBufferSize,
                                 bandwidthEstimate,
                                 ABRAlgorithmType.BufferBased);
@@ -647,7 +649,8 @@ export default function RepresentationEstimator({
                      knownStableBitrate };
           } else {
             log.debug("ABR: Choosing representation with bandwidth estimation.",
-                      chosenRepFromBandwidth);
+                      chosenRepFromBandwidth.bitrate,
+                      chosenRepFromBandwidth.id);
             prevEstimate.update(chosenRepFromBandwidth,
                                 bandwidthEstimate,
                                 ABRAlgorithmType.BandwidthBased);

--- a/src/core/abr/representation_score_calculator.ts
+++ b/src/core/abr/representation_score_calculator.ts
@@ -94,7 +94,7 @@ export default class RepresentationScoreCalculator {
     if (currentEWMA.getEstimate() > 1 &&
         this._lastRepresentationWithGoodScore !== representation
     ) {
-      log.debug("ABR: New last stable representation", representation);
+      log.debug("ABR: New last stable representation", representation.bitrate);
       this._lastRepresentationWithGoodScore = representation;
     }
   }

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -325,7 +325,8 @@ export default class TrackChoiceManager {
     const adaptations = period.getSupportedAdaptations(bufferType);
     if (periodItem !== undefined) {
       if (periodItem[bufferType] !== undefined) {
-        log.warn(`TrackChoiceManager: ${bufferType} already added for period`, period);
+        log.warn(`TrackChoiceManager: ${bufferType} already added for period`,
+                 period.start);
         return;
       } else {
         periodItem[bufferType] = { adaptations, adaptation$ };
@@ -348,13 +349,15 @@ export default class TrackChoiceManager {
   ) : void {
     const periodIndex = findPeriodIndex(this._periods, period);
     if (periodIndex === undefined) {
-      log.warn(`TrackChoiceManager: ${bufferType} not found for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} not found for period`,
+               period.start);
       return;
     }
 
     const periodItem = this._periods.get(periodIndex);
     if (periodItem[bufferType] === undefined) {
-      log.warn(`TrackChoiceManager: ${bufferType} already removed for period`, period);
+      log.warn(`TrackChoiceManager: ${bufferType} already removed for period`,
+               period.start);
       return;
     }
     delete periodItem[bufferType];

--- a/src/core/eme/eme_manager.ts
+++ b/src/core/eme/eme_manager.ts
@@ -134,8 +134,8 @@ export default function EMEManager(
 
   /** Parsed `encrypted` events coming from the HTMLMediaElement. */
   const mediaEncryptedEvents$ = onEncrypted$(mediaElement).pipe(
-    tap((evt) => {
-      log.debug("EME: Encrypted event received from media element.", evt);
+    tap(() => {
+      log.debug("EME: Encrypted event received from media element.");
     }),
     filterMap<MediaEncryptedEvent, IInitializationDataInfo, null>(
       (evt) => getInitData(evt), null),
@@ -144,7 +144,7 @@ export default function EMEManager(
 
   /** Encryption events coming from the `contentProtections$` argument. */
   const externalEvents$ = contentProtections$.pipe(
-    tap((evt) => { log.debug("EME: Encrypted event received from Player", evt); }));
+    tap(() => { log.debug("EME: Encrypted event received from Player"); }));
 
   /** Emit events signaling that an encryption initialization data is encountered. */
   const initializationData$ = observableMerge(externalEvents$, mediaEncryptedEvents$);

--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -264,7 +264,7 @@ export default function getMediaKeySystemAccess(
                                         currentState.mediaKeySystemAccess,
                                         currentState.keySystemOptions);
       if (cachedKeySystemAccess !== null) {
-        log.info("EME: Found cached compatible keySystem", cachedKeySystemAccess);
+        log.info("EME: Found cached compatible keySystem");
         return observableOf({
           type: "reuse-media-key-system-access" as const,
           value: { mediaKeySystemAccess: cachedKeySystemAccess.keySystemAccess,

--- a/src/core/eme/get_media_keys.ts
+++ b/src/core/eme/get_media_keys.ts
@@ -110,7 +110,7 @@ export default function getMediaKeysInfos(
       }
 
       return createMediaKeys(mediaKeySystemAccess).pipe(map((mediaKeys) => {
-        log.info("EME: MediaKeys created with success", mediaKeys);
+        log.info("EME: MediaKeys created with success");
         const loadedSessionsStore = new LoadedSessionsStore(mediaKeys);
         return { mediaKeys,
                  mediaKeySystemAccess,

--- a/src/core/eme/session_events_listener.ts
+++ b/src/core/eme/session_events_listener.ts
@@ -106,7 +106,7 @@ export default function SessionEventsListener(
                IKeysUpdateEvent |
                ISessionUpdatedEvent>
 {
-  log.info("EME: Binding session events", session);
+  log.info("EME: Binding session events", session.sessionId);
   const sessionWarningSubject$ = new Subject<IEMEWarningEvent>();
   const { getLicenseConfig = {} } = keySystemOptions;
 
@@ -129,7 +129,9 @@ export default function SessionEventsListener(
         messageEvent.messageType :
         "license-request";
 
-      log.info(`EME: Received message event, type ${messageType}`, session, messageEvent);
+      log.info(`EME: Received message event, type ${messageType}`,
+               session.sessionId,
+               messageEvent);
       const getLicense$ = observableDefer(() => {
         const getLicense = keySystemOptions.getLicense(message, messageType);
         const getLicenseTimeout = isNullOrUndefined(getLicenseConfig.timeout) ?
@@ -303,7 +305,7 @@ function handleKeyStatusesChangeEvent(
   keySystem : string,
   keyStatusesEvent : Event
 ) : Observable<IKeyStatusChangeHandledEvent | IKeysUpdateEvent | IEMEWarningEvent> {
-  log.info("EME: keystatuseschange event received", session, keyStatusesEvent);
+  log.info("EME: keystatuseschange event received", session.sessionId);
   const callback$ = observableDefer(() => {
     return tryCatch(() => {
       if (typeof keySystemOptions.onKeyStatusesChange !== "function") {

--- a/src/core/eme/utils/close_session.ts
+++ b/src/core/eme/utils/close_session.ts
@@ -60,7 +60,9 @@ export default function safelyCloseMediaKeySession(
   function recursivelyTryToCloseMediaKeySession(
     retryNb : number
   ) : Observable<unknown> {
-    log.debug("EME: Trying to close a MediaKeySession", mediaKeySession, retryNb);
+    log.debug("EME: Trying to close a MediaKeySession",
+              mediaKeySession.sessionId,
+              retryNb);
     return closeSession(mediaKeySession).pipe(
       tap(() => { log.debug("EME: Succeeded to close MediaKeySession"); }),
       catchError((err : unknown) => {

--- a/src/core/eme/utils/is_session_usable.ts
+++ b/src/core/eme/utils/is_session_usable.ts
@@ -41,7 +41,7 @@ export default function isSessionUsable(
 
   if (keyStatuses.length <= 0) {
     log.debug("EME: isSessionUsable: MediaKeySession given has an empty keyStatuses",
-              loadedSession);
+              loadedSession.sessionId);
     return false;
   }
 

--- a/src/core/eme/utils/loaded_sessions_store.ts
+++ b/src/core/eme/utils/loaded_sessions_store.ts
@@ -167,7 +167,7 @@ export default class LoadedSessionsStore {
         });
     }
 
-    log.debug("EME-LSS: Add MediaKeySession", entry);
+    log.debug("EME-LSS: Add MediaKeySession", entry.sessionType);
     this._storage.store(initializationData, entry);
     return mediaKeySession;
   }

--- a/src/core/eme/utils/persistent_sessions_store.ts
+++ b/src/core/eme/utils/persistent_sessions_store.ts
@@ -183,7 +183,7 @@ export default class PersistentSessionsStore {
       this.delete(initData);
     }
 
-    log.info("EME-PSS: Add new session", sessionId, session);
+    log.info("EME-PSS: Add new session", sessionId);
 
     this._entries.push({ version: 3,
                          sessionId,
@@ -205,7 +205,7 @@ export default class PersistentSessionsStore {
       return;
     }
     const entry = this._entries[index];
-    log.warn("EME-PSS: Delete session from store", entry);
+    log.warn("EME-PSS: Delete session from store", entry.sessionId);
     this._entries.splice(index, 1);
     this._save();
   }

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -23,6 +23,7 @@ import {
 import log from "../../../log";
 import Manifest, {
   Adaptation,
+  getLoggableSegmentId,
   ISegment,
   Period,
   Representation,
@@ -107,7 +108,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
     const { segment } = content;
 
     // used by logs
-    const segmentIdString = getIdString(content);
+    const segmentIdString = getLoggableSegmentId(content);
 
     return new Observable((obs) => {
       // Retrieve from cache if it exists
@@ -164,6 +165,8 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
                          objectAssign({ onRetry }, options),
                          canceller.signal)
         .then((res) => {
+          log.debug("SF: Segment request ended with success", segmentIdString);
+
           if (res.resultType === "segment-loaded") {
             const loadedData = res.resultData.responseData;
             if (cache !== undefined) {
@@ -384,14 +387,4 @@ export function getSegmentFetcherOptions(
                                        INITIAL_BACKOFF_DELAY_BASE.REGULAR,
            maxDelay: lowLatencyMode ? MAX_BACKOFF_DELAY_BASE.LOW_LATENCY :
                                       MAX_BACKOFF_DELAY_BASE.REGULAR };
-}
-
-function getIdString(
-  { period, adaptation, representation, segment } : ISegmentLoaderContent
-) : string {
-  return `${adaptation.type} P: ${period.id} A: ${adaptation.id} ` +
-         `R: ${representation.id} S: ` +
-         (segment.isInit   ? "init" :
-          segment.complete ? `${segment.time}-${segment.duration}` :
-                             `${segment.time}`);
 }

--- a/src/core/init/create_media_source.ts
+++ b/src/core/init/create_media_source.ts
@@ -52,7 +52,7 @@ function resetMediaSource(
       const sourceBuffer = sourceBuffers[i];
       try {
         if (readyState === "open") {
-          log.info("Init: Removing SourceBuffer from mediaSource", sourceBuffer);
+          log.info("Init: Removing SourceBuffer from mediaSource");
           sourceBuffer.abort();
         }
         mediaSource.removeSourceBuffer(sourceBuffer);

--- a/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../../compat";
 import config from "../../../../config";
 import log from "../../../../log";
+import { getLoggableSegmentId } from "../../../../manifest";
 import areArraysOfNumbersEqual from "../../../../utils/are_arrays_of_numbers_equal";
 import assertUnreachable from "../../../../utils/assert_unreachable";
 import { toUint8Array } from "../../../../utils/byte_parsing";
@@ -222,7 +223,7 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
     assertPushedDataIsBufferSource(infos);
     log.debug("AVSB: receiving order to push data to the SourceBuffer",
               this.bufferType,
-              infos);
+              getLoggableSegmentId(infos.inventoryInfos));
     return this._addToQueue({ type: SegmentBufferOperation.Push,
                               value: infos });
   }
@@ -254,7 +255,7 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
   public endOfSegment(infos : IEndOfSegmentInfos) : Observable<void> {
     log.debug("AVSB: receiving order for validating end of segment",
               this.bufferType,
-              infos.segment);
+              getLoggableSegmentId(infos));
     return this._addToQueue({ type: SegmentBufferOperation.EndOfSegment,
                               value: infos });
   }
@@ -447,7 +448,8 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
       switch (this._pendingTask.type) {
         case SegmentBufferOperation.EndOfSegment:
           // nothing to do, we will just acknowledge the segment.
-          log.debug("AVSB: Acknowledging complete segment", this._pendingTask.value);
+          log.debug("AVSB: Acknowledging complete segment",
+                    getLoggableSegmentId(this._pendingTask.value));
           this._flush();
           return;
 
@@ -457,6 +459,9 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
             this._flush();
             return;
           }
+          log.debug("AVSB: pushing segment",
+                    this.bufferType,
+                    getLoggableSegmentId(this._pendingTask.inventoryData));
           this._sourceBuffer.appendBuffer(segmentData);
           break;
 

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -376,7 +376,10 @@ export default function AdaptationStream({
         map((wba) => wba * bufferGoalRatio)
       );
 
-      log.info("Stream: changing representation", adaptation.type, representation);
+      log.info("Stream: changing representation",
+               adaptation.type,
+               representation.id,
+               representation.bitrate);
       return RepresentationStream({ playbackObserver,
                                     content: { representation,
                                                adaptation,

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -180,7 +180,7 @@ export default function StreamOrchestrator(
   const activePeriodChanged$ = ActivePeriodEmitter(streamsArray).pipe(
     filter((period) : period is Period => period !== null),
     map(period => {
-      log.info("Stream: New active period", period);
+      log.info("Stream: New active period", period.start);
       return EVENTS.activePeriodChanged(period);
     }));
 
@@ -403,7 +403,7 @@ export default function StreamOrchestrator(
     basePeriod : Period,
     destroy$ : Observable<void>
   ) : Observable<IMultiplePeriodStreamsEvent> {
-    log.info("SO: Creating new Stream for", bufferType, basePeriod);
+    log.info("SO: Creating new Stream for", bufferType, basePeriod.start);
 
     // Emits the Period of the next Period Stream when it can be created.
     const createNextPeriodStream$ = new Subject<Period>();
@@ -481,7 +481,7 @@ export default function StreamOrchestrator(
         periodStream$.pipe(takeUntil(killCurrentStream$)),
         observableOf(EVENTS.periodStreamCleared(bufferType, basePeriod))
           .pipe(tap(() => {
-            log.info("SO: Destroying Stream for", bufferType, basePeriod);
+            log.info("SO: Destroying Stream for", bufferType, basePeriod.start);
           })));
 
     return observableMerge(currentStream$,

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -168,7 +168,7 @@ export default function PeriodStream({
                                  DELTA_POSITION_AFTER_RELOAD.trackSwitch.other;
 
       if (adaptation === null) { // Current type is disabled for that Period
-        log.info(`Stream: Set no ${bufferType} Adaptation`, period);
+        log.info(`Stream: Set no ${bufferType} Adaptation. P:`, period.start);
         const segmentBufferStatus = segmentBuffersStore.getStatus(bufferType);
         let cleanBuffer$ : Observable<unknown>;
 
@@ -203,7 +203,9 @@ export default function PeriodStream({
                                  relativePosAfterSwitch);
       }
 
-      log.info(`Stream: Updating ${bufferType} adaptation`, adaptation, period);
+      log.info(`Stream: Updating ${bufferType} adaptation`,
+               `A: ${adaptation.id}`,
+               `P: ${period.start}`);
 
       const newStream$ = observableDefer(() => {
         const readyState = playbackObserver.getReadyState();

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -260,7 +260,7 @@ export default class VideoThumbnailLoader {
                                   videoSourceBuffer)
                     .pipe(tap(() => {
                       freeRequest(getCompleteSegmentId(inventoryInfos, segment));
-                      log.debug("VTL: Appended segment.", data);
+                      log.debug("VTL: Appended segment.");
                     }));
                 })
               );

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -19,7 +19,6 @@ import Adaptation, {
   IRepresentationInfos,
   SUPPORTED_ADAPTATIONS_TYPE,
 } from "./adaptation";
-import areSameContent from "./are_same_content";
 import Manifest, {
   IManifestParsingOptions,
   ISupplementaryImageTrack,
@@ -38,12 +37,19 @@ import {
   IAdaptationType,
   IHDRInformation,
 } from "./types";
+import {
+  areSameContent,
+  getLoggableSegmentId,
+  IBufferedChunkInfos,
+} from "./utils";
 
 export default Manifest;
 export * from "./types";
 export {
   // utils
   areSameContent,
+  getLoggableSegmentId,
+  IBufferedChunkInfos,
 
   // classes
   Period,

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
+import isNullOrUndefined from "../utils/is_null_or_undefined";
 import Adaptation from "./adaptation";
 import Period from "./period";
 import Representation from "./representation";
 import { ISegment } from "./representation_index";
 
-/**
- * All information needed for a given chunk to know if it has the same content
- * than another chunk.
- */
-interface IBufferedChunkInfos { adaptation : Adaptation;
-                                period : Period;
-                                representation : Representation;
-                                segment : ISegment; }
+/** All information needed to identify a given segment. */
+export interface IBufferedChunkInfos { adaptation : Adaptation;
+                                       period : Period;
+                                       representation : Representation;
+                                       segment : ISegment; }
 
 /**
  * Check if two contents are the same
@@ -34,7 +32,7 @@ interface IBufferedChunkInfos { adaptation : Adaptation;
  * @param {Object} content2
  * @returns {boolean}
  */
-export default function areSameContent(
+export function areSameContent(
   content1: IBufferedChunkInfos,
   content2: IBufferedChunkInfos
 ): boolean {
@@ -42,4 +40,23 @@ export default function areSameContent(
           content1.representation.id === content2.representation.id &&
           content1.adaptation.id === content2.adaptation.id &&
           content1.period.id === content2.period.id);
+}
+
+/**
+ * Get string describing a given ISegment, useful for log functions.
+ * @param {Object} content
+ * @returns {string|null|undefined}
+ */
+export function getLoggableSegmentId(
+  content : IBufferedChunkInfos | null | undefined
+) : string {
+  if (isNullOrUndefined(content)) {
+    return "";
+  }
+  const { period, adaptation, representation, segment } = content;
+  return `${adaptation.type} P: ${period.id} A: ${adaptation.id} ` +
+         `R: ${representation.id} S: ` +
+         (segment.isInit   ? "init" :
+          segment.complete ? `${segment.time}-${segment.duration}` :
+                             `${segment.time}`);
 }

--- a/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
@@ -49,7 +49,7 @@ describe("flattenOverlappingPeriods", function() {
 
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
-      "DASH: Updating overlapping Periods.", periods[1], periods[2]);
+      "DASH: Updating overlapping Periods.", 60, 60);
     logSpy.mockRestore();
   });
 
@@ -78,7 +78,7 @@ describe("flattenOverlappingPeriods", function() {
 
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
-      "DASH: Updating overlapping Periods.", periods[1], periods[2]);
+      "DASH: Updating overlapping Periods.", 60, 90);
     logSpy.mockRestore();
   });
 
@@ -104,9 +104,9 @@ describe("flattenOverlappingPeriods", function() {
 
     expect(logSpy).toHaveBeenCalledTimes(2);
     expect(logSpy).toHaveBeenCalledWith(
-      "DASH: Updating overlapping Periods.", periods[0], periods[2]);
+      "DASH: Updating overlapping Periods.", 60, 50);
     expect(logSpy).toHaveBeenCalledWith(
-      "DASH: Updating overlapping Periods.", periods[1], periods[2]);
+      "DASH: Updating overlapping Periods.", 0, 50);
     logSpy.mockRestore();
   });
 

--- a/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
+++ b/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
@@ -54,10 +54,12 @@ export default function flattenOverlappingPeriods(
     const parsedPeriod = parsedPeriods[i];
     let lastFlattenedPeriod = flattenedPeriods[flattenedPeriods.length - 1];
     while (
-      lastFlattenedPeriod.duration == null ||
+      lastFlattenedPeriod.duration === undefined ||
       (lastFlattenedPeriod.start + lastFlattenedPeriod.duration) > parsedPeriod.start
     ) {
-      log.warn("DASH: Updating overlapping Periods.", lastFlattenedPeriod, parsedPeriod);
+      log.warn("DASH: Updating overlapping Periods.",
+               lastFlattenedPeriod?.start,
+               parsedPeriod.start);
       lastFlattenedPeriod.duration = parsedPeriod.start - lastFlattenedPeriod.start;
       lastFlattenedPeriod.end = parsedPeriod.start;
       if (lastFlattenedPeriod.duration <= 0) {


### PR DESCRIPTION
This is a smallish yet global log update so they are easily exploitable, that is:

  - there are less heavy objects logged. They are both difficult to exploit and take resources when there are lot of logs displayed (and there is a lot of them in DEBUG mode).

    Instead, key identifying properties of those objects are logged (e.g. A Period's `start`, A Reprentation's `id` or `bitrate` etc..).
    I didn't change anything however for some smallish objects (like segments, array of ranges) and objects containing parsed subtitles, as it may still be very useful

    This task was already begun by Guillaume Renault some time  (year?) ago, but I didn't merge it at the time because I didn't felt it was that much of an issue. I've now changed my mind!

  - add logs for when segment requests begin, end, fail and are cancelled with enough properties to identify which segment we're speaking of

I decided to do this modification today after a debugging session on complicated-to-debug embedded devices.
