### PR TITLE
Better estimate the duration of ISOBMFF segments with multiple moof boxes

### DIFF
--- a/src/parsers/containers/isobmff/read.ts
+++ b/src/parsers/containers/isobmff/read.ts
@@ -14,10 +14,14 @@
  * limitations under the License.
  */
 
-import { getBoxContent } from "./get_box";
+import {
+  getBoxContent,
+  getBoxesContent,
+} from "./get_box";
 
 /**
- * Returns TRAF Box from the whole ISOBMFF File.
+ * Returns the content of the first "traf" box encountered in the given ISOBMFF
+ * data.
  * Returns null if not found.
  * @param {Uint8Array} buffer
  * @returns {Uint8Array|null}
@@ -31,7 +35,27 @@ function getTRAF(buffer : Uint8Array) : Uint8Array|null {
 }
 
 /**
- * Returns MDAT Box from the whole ISOBMFF File.
+ * Returns the content of all "traf" boxes encountered in the given ISOBMFF
+ * data.
+ * Might be preferred to just `getTRAF` if you suspect that your ISOBMFF may
+ * have multiple "moof" boxes.
+ * @param {Uint8Array} buffer
+ * @returns {Array.<Uint8Array>}
+ */
+function getTRAFs(buffer : Uint8Array) : Uint8Array[] {
+  const moofs = getBoxesContent(buffer, 0x6D6F6F66 /* moof */);
+  return moofs.reduce((acc : Uint8Array[], moof : Uint8Array) => {
+    const traf = getBoxContent(moof, 0x74726166 /* traf */);
+    if (traf !== null) {
+      acc.push(traf);
+    }
+    return acc;
+  }, []);
+}
+
+/**
+ * Returns the content of the first "moof" box encountered in the given ISOBMFF
+ * data.
  * Returns null if not found.
  * @param {Uint8Array} buffer
  * @returns {Uint8Array|null}
@@ -41,7 +65,8 @@ function getMDAT(buf : Uint8Array) : Uint8Array|null {
 }
 
 /**
- * Returns MDIA Box from the whole ISOBMFF File.
+ * Returns the content of the first "mdia" box encountered in the given ISOBMFF
+ * data.
  * Returns null if not found.
  * @param {Uint8Array} buffer
  * @returns {Uint8Array|null}
@@ -61,7 +86,8 @@ function getMDIA(buf : Uint8Array) : Uint8Array|null {
 }
 
 /**
- * Returns EMSG Box from the while ISOBMFF File.
+ * Returns the content of the first "emsg" box encountered in the given ISOBMFF
+ * data.
  * Returns null if not found.
  * @param {Uint8Array} buffer
  * @returns {Uint8Array|null}
@@ -72,6 +98,7 @@ function getEMSG(buffer: Uint8Array, offset = 0) : Uint8Array|null {
 
 export {
   getTRAF,
+  getTRAFs,
   getMDAT,
   getMDIA,
   getEMSG,


### PR DESCRIPTION
This is a commit with a smallish improvement to better estimate the duration of segments with multiple "moof" boxes (for example, low-latency segments loaded as a whole instead of per-chunk).

Previously, only the first "trun" box of the first "traf" box of the first "moof" box encountered in an ISOBMFF segment was parsed to obtain the segment's duration.
In most cases, this works. However in some rare situations, media segments might actually contain several subsegments, in which case we would only calculate the first of those subsegments' duration.

Now, we always check if multiple moof boxes are there and, if it is the case, we addition the duration calculated from all found trun boxes.

The previously miscalculted duration never provoked any sensible issue because we have a safeguard preventing huge differences between the duration anounced in the MPD and what has actually been parsed from the segment.
In that case, we used the segment duration as anounced in the MPD, which may be less precise that the segment's metadata (especially if e.g. this is a `$Number$`-based MPD content).

I just tested it with success on some low-latency contents.