### PR TITLE
Fix native track elements' content not removed in Chrome 96

### DIFF
--- a/src/compat/__tests__/clear_element_src.test.ts
+++ b/src/compat/__tests__/clear_element_src.test.ts
@@ -32,10 +32,6 @@ describe("Compat - clearElementSrc", () => {
       src: "foo",
       removeAttribute() { return null; },
     };
-    jest.mock("../browser_detection.ts", () => ({
-      __esModule: true as const,
-      isFirefox: false,
-    }));
     const clearElementSrc = require("../clear_element_src").default;
 
     const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
@@ -50,10 +46,6 @@ describe("Compat - clearElementSrc", () => {
       src: "foo",
       removeAttribute() { throw new Error("Oups, can't remove attribute."); },
     };
-    jest.mock("../browser_detection.ts", () => ({
-      __esModule: true as const,
-      isFirefox: false,
-    }));
     const clearElementSrc = require("../clear_element_src").default;
     const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
 
@@ -63,7 +55,7 @@ describe("Compat - clearElementSrc", () => {
     expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
   });
 
-  it("should disable text tracks and remove childs if on firefox", () => {
+  it("should disable text tracks and remove childs", () => {
     const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
@@ -84,10 +76,6 @@ describe("Compat - clearElementSrc", () => {
       },
     };
 
-    jest.mock("../browser_detection.ts", () => ({
-      __esModule: true as const,
-      isFirefox: true,
-    }));
     const clearElementSrc = require("../clear_element_src").default;
 
     const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
@@ -107,7 +95,7 @@ describe("Compat - clearElementSrc", () => {
     expect(spyRemoveChild).toHaveBeenCalledWith({ nodeName: "track" });
   });
 
-  it("should log when failed to remove text track child node if on firefox", () => {
+  it("should log when failed to remove text track child node", () => {
     const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
@@ -125,11 +113,6 @@ describe("Compat - clearElementSrc", () => {
         throw new Error();
       },
     };
-
-    jest.mock("../browser_detection", () => ({
-      __esModule: true as const,
-      isFirefox: true,
-    }));
 
     const mockLogWarn = jest.fn((message) => message);
     jest.mock("../../log", () => ({
@@ -173,10 +156,6 @@ describe("Compat - clearElementSrc", () => {
       removeChild: () => null,
     };
 
-    jest.mock("../browser_detection.ts", () => ({
-      __esModule: true as const,
-      isFirefox: true,
-    }));
     const clearElementSrc = require("../clear_element_src").default;
 
     const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
@@ -193,7 +172,7 @@ describe("Compat - clearElementSrc", () => {
     expect(spyRemoveChild).not.toHaveBeenCalled();
   });
 
-  it("should not handle text tracks nodes is has no child nodes if on firefox", () => {
+  it("should not handle text tracks nodes is has no child nodes", () => {
     const fakeElement = {
       src: "foo",
       removeAttribute() { return null; },
@@ -203,10 +182,6 @@ describe("Compat - clearElementSrc", () => {
       removeChild: () => null,
     };
 
-    jest.mock("../browser_detection.ts", () => ({
-      __esModule: true as const,
-      isFirefox: true,
-    }));
     const clearElementSrc = require("../clear_element_src").default;
 
     const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
@@ -220,6 +195,58 @@ describe("Compat - clearElementSrc", () => {
     expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
     expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
     expect(spyHasChildNodes).toHaveBeenCalledTimes(1);
+    expect(spyRemoveChild).not.toHaveBeenCalled();
+  });
+
+  it("should not throw if the textTracks attribute is `null`", () => {
+    const fakeElement = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: null,
+      childNodes: [],
+      hasChildNodes: () => false,
+      removeChild: () => null,
+    };
+
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.childNodes).toEqual([]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(0);
+    expect(spyRemoveChild).not.toHaveBeenCalled();
+  });
+
+  it("should not throw if the textTracks attribute is `undefined`", () => {
+    const fakeElement = {
+      src: "foo",
+      removeAttribute() { return null; },
+      textTracks: undefined,
+      childNodes: [],
+      hasChildNodes: () => false,
+      removeChild: () => null,
+    };
+
+    const clearElementSrc = require("../clear_element_src").default;
+
+    const spyRemoveAttribute = jest.spyOn(fakeElement, "removeAttribute");
+    const spyHasChildNodes = jest.spyOn(fakeElement, "hasChildNodes");
+    const spyRemoveChild = jest.spyOn(fakeElement, "removeChild");
+
+    clearElementSrc(fakeElement);
+
+    expect(fakeElement.src).toBe("");
+    expect(fakeElement.childNodes).toEqual([]);
+    expect(spyRemoveAttribute).toHaveBeenCalledTimes(1);
+    expect(spyRemoveAttribute).toHaveBeenCalledWith("src");
+    expect(spyHasChildNodes).toHaveBeenCalledTimes(0);
     expect(spyRemoveChild).not.toHaveBeenCalled();
   });
 });

--- a/src/compat/clear_element_src.ts
+++ b/src/compat/clear_element_src.ts
@@ -15,19 +15,21 @@
  */
 
 import log from "../log";
-import { isFirefox } from "./browser_detection";
+import isNullOrUndefined from "../utils/is_null_or_undefined";
 
 /**
  * Clear element's src attribute.
  * @param {HTMLMediaElement} element
  */
 export default function clearElementSrc(element : HTMLMediaElement) : void {
-  // On Firefox, we also have to make sure the textTracks elements are both
-  // disabled and removed from the DOM.
+  // On some browsers, we first have to make sure the textTracks elements are
+  // both disabled and removed from the DOM.
   // If we do not do that, we may be left with displayed text tracks on the
-  // screen
-  if (isFirefox) {
-    const { textTracks } = element;
+  // screen, even if the track elements are properly removed, due to browser
+  // issues.
+  // Bug seen on Firefox (I forgot which version) and Chrome 96.
+  const { textTracks } = element;
+  if (!isNullOrUndefined(textTracks)) {
     for (let i = 0; i < textTracks.length; i++) {
       textTracks[i].mode = "disabled";
     }


### PR DESCRIPTION
This commit works around an issue seen recently with Chrome 96 where native text tracks would not be visually removed after stopping a content / reloading another.

First thought to be an RxPlayer issue, we noticed that the corresponding `<track>` element was actually properly removed from the DOM and that the issue only appeared in Chrome, even on Edge Chromium things worked as intented.

After investigation, the issue seems to be linked to Chrome: when the `<track>` element is removed from the DOM synchronously after (or in a microtask after) emptying the src attribute of the linked media element, the `<track>` element disappears from the DOM, but its content stays on it.

Funnily enough, it seems (I forgot about it) that the same issue was present in FireFox some years ago, judging by some firefox-specific code in our `compat` code. Now FireFox doesn't seem to have the issue anymore but Chrome does! `<track>` element handling seems to be a bug-prone area of browsers!

To fix that issue, I chose to generalize what was before a FireFox-specific work-around:
When the `src` attribute of the media element is emptied, we first remove all associated `<track>` elements from it.

This sadly means that an application might not be able to handle `<track>` element by itself (for example, to manually add subtitles), though I still went on with it because:
  1. This should be an extremely rare usecase, even more now that we have more powerful solutions such as the `TextTrackRenderer` tool.
  2. Updating data on the HTMLMediaElement while it is linked to the RxPlayer is already a risky behavior, where multiple things can behave not as intented.