### PR TITLE
buffers: fix clean-up of the SegmentBuffers history

### DIFF
--- a/src/core/segment_buffers/inventory/buffered_history.ts
+++ b/src/core/segment_buffers/inventory/buffered_history.ts
@@ -116,12 +116,12 @@ export default class BufferedHistory {
       }
     }
     if (firstKeptIndex > 0) {
-      this._history.splice(firstKeptIndex);
+      this._history = this._history.splice(firstKeptIndex);
     }
 
     if (this._history.length > this._maxHistoryLength) {
       const toRemove = this._history.length - this._maxHistoryLength;
-      this._history.splice(toRemove);
+      this._history = this._history.splice(toRemove);
     }
   }
 }


### PR DESCRIPTION
We introduced in the `v3.26.1` a new logic in the RxPlayer allowing to notice when the browser crops segment for unknown reasons.
Without it, the RxPlayer would believe that this segment was garbage collected (presumably for memory-related reasons) and retry to download it each time, while staying in an infinite buffering loop.

This cropping-detection feature is based on a short-lived history attached to what we call `SegmentBuffer`s (which represents the actual browser's SourceBuffers). When a segment appears garbage collected immediately after being pushed, we check if it already happened in the past and if it did, if the cropping pattern was similar. If it also was, we conclude that the browser weirdly want to crop that segment, skip the resulting discontinuity and go on with the stream.

However we (I!) made a mistake on how this history was cleaned-up.
Now that I re-dived into the code, I think that I confused how the `splice` method on arrays worked:
instead of removing older entries from that history, we were actually keeping them and removing the rest!

This commit fixes that mistake.

I noticed something was off while debugging a strange issue on one of our content on the Chrome browser, which had exactly the same behavior than the one seen on Safari for which we had to add that feature.
This exact same history fix, once with this fix, works also in this case.