### PR TITLE
DASH: always consider that the non-last Period is finished in SegmentTimeline contexts

### DIFF
--- a/src/parsers/manifest/dash/common/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/common/parse_representation_index.ts
@@ -37,21 +37,126 @@ import resolveBaseURLs, {
   IResolvedBaseUrl,
 } from "./resolve_base_urls";
 
+/**
+ * Parse the specific segment indexing information found in a representation
+ * into a IRepresentationIndex implementation.
+ * @param {Array.<Object>} representation
+ * @param {Object} context
+ * @returns {Array.<Object>}
+ */
+export default function parseRepresentationIndex(
+  representation : IRepresentationIntermediateRepresentation,
+  context : IRepresentationIndexContext
+) : IRepresentationIndex {
+  const representationBaseURLs = resolveBaseURLs(context.baseURLs,
+                                                 representation.children.baseURLs);
+  const { aggressiveMode,
+          availabilityTimeOffset,
+          manifestBoundsCalculator,
+          isDynamic,
+          end: periodEnd,
+          start: periodStart,
+          receivedTime,
+          timeShiftBufferDepth,
+          unsafelyBaseOnPreviousRepresentation,
+          inbandEventStreams,
+          isLastPeriod } = context;
+
+  const isEMSGWhitelisted = (inbandEvent: IEMSG): boolean => {
+    if (inbandEventStreams === undefined) {
+      return false;
+    }
+    return inbandEventStreams
+      .some(({ schemeIdUri }) => schemeIdUri === inbandEvent.schemeIdUri);
+  };
+  const reprIndexCtxt = { aggressiveMode,
+                          availabilityTimeComplete: true,
+                          availabilityTimeOffset,
+                          unsafelyBaseOnPreviousRepresentation,
+                          isEMSGWhitelisted,
+                          isLastPeriod,
+                          manifestBoundsCalculator,
+                          isDynamic,
+                          periodEnd,
+                          periodStart,
+                          receivedTime,
+                          representationBaseURLs,
+                          representationBitrate: representation.attributes.bitrate,
+                          representationId: representation.attributes.id,
+                          timeShiftBufferDepth };
+  let representationIndex : IRepresentationIndex;
+  if (representation.children.segmentBase !== undefined) {
+    const { segmentBase } = representation.children;
+    representationIndex = new BaseRepresentationIndex(segmentBase, reprIndexCtxt);
+  } else if (representation.children.segmentList !== undefined) {
+    const { segmentList } = representation.children;
+    representationIndex = new ListRepresentationIndex(segmentList, reprIndexCtxt);
+  } else if (representation.children.segmentTemplate !== undefined ||
+             context.parentSegmentTemplates.length > 0)
+  {
+    const segmentTemplates = context.parentSegmentTemplates.slice();
+    const childSegmentTemplate = representation.children.segmentTemplate;
+    if (childSegmentTemplate !== undefined) {
+      segmentTemplates.push(childSegmentTemplate);
+    }
+    const segmentTemplate =
+      objectAssign({},
+                   ...segmentTemplates as [
+                     ISegmentTemplateIntermediateRepresentation
+                   ] /* Ugly TS Hack */);
+    reprIndexCtxt.availabilityTimeComplete =
+      segmentTemplate.availabilityTimeComplete ??
+      context.availabilityTimeComplete;
+    reprIndexCtxt.availabilityTimeOffset =
+      (segmentTemplate.availabilityTimeOffset ?? 0) +
+      context.availabilityTimeOffset;
+    representationIndex = TimelineRepresentationIndex
+      .isTimelineIndexArgument(segmentTemplate) ?
+        new TimelineRepresentationIndex(segmentTemplate, reprIndexCtxt) :
+        new TemplateRepresentationIndex(segmentTemplate, reprIndexCtxt);
+  } else {
+    const adaptationChildren = context.adaptation.children;
+    if (adaptationChildren.segmentBase !== undefined) {
+      const { segmentBase } = adaptationChildren;
+      representationIndex = new BaseRepresentationIndex(segmentBase, reprIndexCtxt);
+    } else if (adaptationChildren.segmentList !== undefined) {
+      const { segmentList } = adaptationChildren;
+      representationIndex = new ListRepresentationIndex(segmentList, reprIndexCtxt);
+    } else {
+      representationIndex = new TemplateRepresentationIndex({
+        duration: Number.MAX_VALUE,
+        timescale: 1,
+        startNumber: 0,
+        media: "",
+      }, reprIndexCtxt);
+    }
+  }
+  return representationIndex;
+}
+
 /** Supplementary context needed to parse a RepresentationIndex. */
-export interface IRepresentationInfos {
+export interface IRepresentationIndexContext {
   /** Parsed AdaptationSet which contains the Representation. */
   adaptation : IAdaptationSetIntermediateRepresentation;
   /** Whether we should request new segments even if they are not yet finished. */
   aggressiveMode : boolean;
+  /** If false, declared segments in the MPD might still be not completely generated. */
   availabilityTimeComplete : boolean;
   /** availability time offset of the concerned Adaptation. */
   availabilityTimeOffset : number;
   /** Eventual URLs from which every relative URL will be based on. */
   baseURLs : IResolvedBaseUrl[];
+  /** End time of the current Period, in seconds. */
+  end? : number | undefined;
+  /** List of inband event streams that are present on the representation */
+  inbandEventStreams: IScheme[] | undefined;
+  /**
+   * Set to `true` if the linked Period is the chronologically last one in the
+   * Manifest.
+   */
+  isLastPeriod : boolean;
   /** Allows to obtain the first/last available position of a dynamic content. */
   manifestBoundsCalculator : ManifestBoundsCalculator;
-  /** End time of the current period, in seconds. */
-  end? : number | undefined;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
   /**
@@ -76,101 +181,4 @@ export interface IRepresentationInfos {
    * de-synchronization with what is actually on the server.
    */
   unsafelyBaseOnPreviousRepresentation : Representation | null;
-  /** List of inband event streams that are present on the representation */
-  inbandEventStreams: IScheme[] | undefined;
-}
-
-/**
- * Parse the specific segment indexing information found in a representation
- * into a IRepresentationIndex implementation.
- * @param {Array.<Object>} representation
- * @param {Object} representationInfos
- * @returns {Array.<Object>}
- */
-export default function parseRepresentationIndex(
-  representation : IRepresentationIntermediateRepresentation,
-  representationInfos : IRepresentationInfos
-) : IRepresentationIndex {
-  const representationBaseURLs = resolveBaseURLs(representationInfos.baseURLs,
-                                                 representation.children.baseURLs);
-  const { aggressiveMode,
-          availabilityTimeOffset,
-          manifestBoundsCalculator,
-          isDynamic,
-          end: periodEnd,
-          start: periodStart,
-          receivedTime,
-          timeShiftBufferDepth,
-          unsafelyBaseOnPreviousRepresentation,
-          inbandEventStreams } = representationInfos;
-
-  const isEMSGWhitelisted = (inbandEvent: IEMSG): boolean => {
-    if (inbandEventStreams === undefined) {
-      return false;
-    }
-    return inbandEventStreams
-      .some(({ schemeIdUri }) => schemeIdUri === inbandEvent.schemeIdUri);
-  };
-  const context = { aggressiveMode,
-                    availabilityTimeComplete: true,
-                    availabilityTimeOffset,
-                    unsafelyBaseOnPreviousRepresentation,
-                    isEMSGWhitelisted,
-                    manifestBoundsCalculator,
-                    isDynamic,
-                    periodEnd,
-                    periodStart,
-                    receivedTime,
-                    representationBaseURLs,
-                    representationBitrate: representation.attributes.bitrate,
-                    representationId: representation.attributes.id,
-                    timeShiftBufferDepth };
-  let representationIndex : IRepresentationIndex;
-  if (representation.children.segmentBase !== undefined) {
-    const { segmentBase } = representation.children;
-    representationIndex = new BaseRepresentationIndex(segmentBase, context);
-  } else if (representation.children.segmentList !== undefined) {
-    const { segmentList } = representation.children;
-    representationIndex = new ListRepresentationIndex(segmentList, context);
-  } else if (representation.children.segmentTemplate !== undefined ||
-             representationInfos.parentSegmentTemplates.length > 0)
-  {
-    const segmentTemplates = representationInfos.parentSegmentTemplates.slice();
-    const childSegmentTemplate = representation.children.segmentTemplate;
-    if (childSegmentTemplate !== undefined) {
-      segmentTemplates.push(childSegmentTemplate);
-    }
-    const segmentTemplate =
-      objectAssign({},
-                   ...segmentTemplates as [
-                     ISegmentTemplateIntermediateRepresentation
-                   ] /* Ugly TS Hack */);
-    context.availabilityTimeComplete =
-      segmentTemplate.availabilityTimeComplete ??
-      representationInfos.availabilityTimeComplete;
-    context.availabilityTimeOffset =
-      (segmentTemplate.availabilityTimeOffset ?? 0) +
-      representationInfos.availabilityTimeOffset;
-    representationIndex = TimelineRepresentationIndex
-      .isTimelineIndexArgument(segmentTemplate) ?
-        new TimelineRepresentationIndex(segmentTemplate, context) :
-        new TemplateRepresentationIndex(segmentTemplate, context);
-  } else {
-    const adaptationChildren = representationInfos.adaptation.children;
-    if (adaptationChildren.segmentBase !== undefined) {
-      const { segmentBase } = adaptationChildren;
-      representationIndex = new BaseRepresentationIndex(segmentBase, context);
-    } else if (adaptationChildren.segmentList !== undefined) {
-      const { segmentList } = adaptationChildren;
-      representationIndex = new ListRepresentationIndex(segmentList, context);
-    } else {
-      representationIndex = new TemplateRepresentationIndex({
-        duration: Number.MAX_VALUE,
-        timescale: 1,
-        startNumber: 0,
-        media: "",
-      }, context);
-    }
-  }
-  return representationIndex;
 }

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -26,14 +26,13 @@ import {
 import {
   IAdaptationSetIntermediateRepresentation,
   IRepresentationIntermediateRepresentation,
-  ISegmentTemplateIntermediateRepresentation,
   IScheme,
   IContentProtectionIntermediateRepresentation,
 } from "../node_parser_types";
 import { getWEBMHDRInformation } from "./get_hdr_information";
-import ManifestBoundsCalculator from "./manifest_bounds_calculator";
-import parseRepresentationIndex from "./parse_representation_index";
-import { IResolvedBaseUrl } from "./resolve_base_urls";
+import parseRepresentationIndex, {
+  IRepresentationIndexContext,
+} from "./parse_representation_index";
 
 /**
  * Combine inband event streams from representation and
@@ -57,49 +56,6 @@ function combineInbandEventStreams(
     return undefined;
   }
   return newSchemeId;
-}
-
-/** Supplementary context needed to parse a Representation. */
-export interface IAdaptationInfos {
-  /** Whether we should request new segments even if they are not yet finished. */
-  aggressiveMode : boolean;
-  availabilityTimeComplete: boolean;
-  /** availability time offset of the concerned Adaptation. */
-  availabilityTimeOffset: number;
-  /** Eventual URLs from which every relative URL will be based on. */
-  baseURLs : IResolvedBaseUrl[];
-  /** Allows to obtain the first/last available position of a dynamic content. */
-  manifestBoundsCalculator : ManifestBoundsCalculator;
-  /** End time of the current period, in seconds. */
-  end? : number | undefined;
-  /** Whether the Manifest can evolve with time. */
-  isDynamic : boolean;
-  /** Manifest DASH profiles used for signalling some features */
-  manifestProfiles?: string | undefined;
-  /**
-   * Parent parsed SegmentTemplate elements.
-   * Sorted by provenance from higher level (e.g. Period) to lower-lever (e.g.
-   * AdaptationSet).
-   */
-  parentSegmentTemplates : ISegmentTemplateIntermediateRepresentation[];
-  /**
-   * Time (in terms of `performance.now`) at which the XML file containing this
-   * Representation was received.
-   */
-  receivedTime? : number | undefined;
-  /** Start time of the current period, in seconds. */
-  start : number;
-  /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number | undefined;
-  /**
-   * The parser should take this Adaptation - which is from a previously parsed
-   * Manifest for the same dynamic content - as a base to speed-up the parsing
-   * process.
-   * /!\ If unexpected differences exist between both, there is a risk of
-   * de-synchronization with what is actually on the server,
-   * Use with moderation.
-   */
-  unsafelyBaseOnPreviousAdaptation : Adaptation | null;
 }
 
 /**
@@ -138,13 +94,13 @@ function getHDRInformation(
 /**
  * Process intermediate representations to create final parsed representations.
  * @param {Array.<Object>} representationsIR
- * @param {Object} adaptationInfos
+ * @param {Object} context
  * @returns {Array.<Object>}
  */
 export default function parseRepresentations(
   representationsIR : IRepresentationIntermediateRepresentation[],
   adaptation : IAdaptationSetIntermediateRepresentation,
-  adaptationInfos : IAdaptationInfos
+  context : IRepresentationContext
 ): IParsedRepresentation[] {
   const parsedRepresentations : IParsedRepresentation[] = [];
   for (const representation of representationsIR) {
@@ -171,7 +127,7 @@ export default function parseRepresentations(
     }
 
     // Retrieve previous version of the Representation, if one.
-    const unsafelyBaseOnPreviousRepresentation = adaptationInfos
+    const unsafelyBaseOnPreviousRepresentation = context
       .unsafelyBaseOnPreviousAdaptation?.getRepresentation(representationID) ??
       null;
 
@@ -180,18 +136,19 @@ export default function parseRepresentations(
 
     const availabilityTimeComplete =
       representation.attributes.availabilityTimeComplete ??
-      adaptationInfos.availabilityTimeComplete;
+      context.availabilityTimeComplete;
     const availabilityTimeOffset =
       (representation.attributes.availabilityTimeOffset ?? 0) +
-      adaptationInfos.availabilityTimeOffset;
-    const representationInfos = objectAssign({}, adaptationInfos,
-                                             { availabilityTimeOffset,
-                                               availabilityTimeComplete,
-                                               unsafelyBaseOnPreviousRepresentation,
-                                               adaptation,
-                                               inbandEventStreams });
+      context.availabilityTimeOffset;
+    const reprIndexCtxt = objectAssign({},
+                                       context,
+                                       { availabilityTimeOffset,
+                                         availabilityTimeComplete,
+                                         unsafelyBaseOnPreviousRepresentation,
+                                         adaptation,
+                                         inbandEventStreams });
     const representationIndex = parseRepresentationIndex(representation,
-                                                         representationInfos);
+                                                         reprIndexCtxt);
 
     // Find bitrate
     let representationBitrate : number;
@@ -297,10 +254,34 @@ export default function parseRepresentations(
 
     parsedRepresentation.hdrInfo =
       getHDRInformation({ adaptationProfiles: adaptation.attributes.profiles,
-                          manifestProfiles: adaptationInfos.manifestProfiles,
+                          manifestProfiles: context.manifestProfiles,
                           codecs });
 
     parsedRepresentations.push(parsedRepresentation);
   }
   return parsedRepresentations;
 }
+
+/** Supplementary context needed to parse a Representation. */
+export interface IRepresentationContext extends IInheritedRepresentationIndexContext {
+  /** Manifest DASH profiles used for signalling some features */
+  manifestProfiles?: string | undefined;
+  /**
+   * The parser should take this Adaptation - which is from a previously parsed
+   * Manifest for the same dynamic content - as a base to speed-up the parsing
+   * process.
+   * /!\ If unexpected differences exist between both, there is a risk of
+   * de-synchronization with what is actually on the server,
+   * Use with moderation.
+   */
+  unsafelyBaseOnPreviousAdaptation : Adaptation | null;
+}
+
+/**
+ * Supplementary context needed to parse a Representation common with
+ * `IRepresentationIndexContext`.
+ */
+type IInheritedRepresentationIndexContext = Omit<IRepresentationIndexContext,
+                                                 "adaptation" |
+                                                 "unsafelyBaseOnPreviousRepresentation" |
+                                                 "inbandEventStreams">;


### PR DESCRIPTION
This PR fixes an issue we recently had at Canal+ linked to ambiguous DASH Period boundaries:

An infinite rebuffering issue could arise when playing a live multi-Period DASH content where the audio and video tracks had different ending timestamp (even in the order of some milliseconds) AND the duration of the Period (either taken from the `Period@duration` attribute or inferred from the `Period@start` of the next Period if one) was set to be the maximum time between them (which very oddly is the DASH-IF recommendation).

In that condition, the RxPlayer could be waiting indefinitely at the end of the corresponding Period for what it thinks to be the last - but is actually inexistent - audio or video segment (respectively depending on if the audio track or the video track is shorter)  to be generated and that even as new Periods are defined in the MPD.

We already were aware of this possibility but thought that for multiple reasons it made more sense to always set the Period's duration to the minimum between all tracks, as it leads to less ambiguity especially when we're dealing with `<SegmentTemplate>` indexing without a `<SegmentTimeline>`, in which case there would be no way to know which segment is the last one for each track.

In a case with a `<SegmentTimeline>` though, this issue is theoretically resolvable.
If we consider that as long the corresponding Period is not the last one in the MPD, it means that its segments have been fully generated.

We were for a long time unsure of if it was the case, so we were very reticent to do that development.
What changed things very recently however, is that we just encountered the case - and the concerned people don't seem to want to remove that ambiguity on the packaging side for various reasons - and that the `dash.js` player seems to have taken the decision [to do exactly the fix we're speaking of](https://github.com/Dash-Industry-Forum/dash.js/blob/01b27851514e6a3dcd9c23743f789c601de6fde7/src/dash/DashHandler.js#L225-L228) (_trigger warning (for the link): veeery long lines!_).

I'm however still afraid of breaking things for (arguably extremely rare) use cases where, e.g., the penultimate Period would still be in a process of being generated (in which case, we will skip it as soon as we reach its current end).

---

As this PR's commits add yet another property in the context objects communicated in the DASH MPD parser functions (more specifically, in the common part between the JS and WASM parser), most of the diff of that PR is actually linked to DRYing the linked type definitions - with the help of TypeScript builtin `Omit` type, so that they are only documented once in the code.
And as it is the new way of doing things, I also moved type definitions that I updated at the end of the corresponding files (so that what a new dev sees first is the actual code, not types).