### PR TITLE
 Avoid warning logs when "creating" segments

### DIFF
--- a/src/core/abr/pending_requests_store.ts
+++ b/src/core/abr/pending_requests_store.ts
@@ -70,11 +70,9 @@ export default class PendingRequestsStore {
    */
   public remove(id : string) : void {
     if (this._currentRequests[id] == null) {
-      // TODO This breaks github actions.
-      // Find why
-      // if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
-      //   throw new Error("ABR: can't remove unknown request");
-      // }
+      if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
+        throw new Error("ABR: can't remove unknown request");
+      }
       log.warn("ABR: can't remove unknown request");
     }
     delete this._currentRequests[id];

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -119,7 +119,8 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
       /**
        * If the request succeeded, set to the corresponding
        * `IChunkCompleteInformation` object.
-       * If the request failed or was cancelled, set to `null`.
+       * For any other completion cases: if the request either failed, was
+       * cancelled or just if no request was needed, set to `null`.
        *
        * Stays to `undefined` when the request is still pending.
        */
@@ -216,6 +217,8 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
           if (res.resultType !== "segment-created") {
             requestInfo = res.resultData;
             sendNetworkMetricsIfAvailable();
+          } else {
+            requestInfo = null;
           }
 
           if (!canceller.isUsed) {


### PR DESCRIPTION
A small oversight led to the RxPlayer potentially logging a warning each time a segment is either created directly from the Manifest's information - which as far as I remember - only happens in Smooth contents or when no initialization segment exist (such as for subtitles).

Aside from this unnecessary warning, there should be no other real issue.

This warning was due to the fact that we're announcing the end of those segment's "requests" (between quotes as there there is in fact no request happening) two times in a row, breaking an assertion later in the code that ended request should be pending in the first place.

It's annoying that I saw that just after finalizing the release, but thankfully this is a very minor issue that will probably not bother
anyone, and should appear relatively rarely for DASH contents (maybe once when switching to a track with subtitles? Even this is unsure).