### PR TITLE
Add forgotten TypeScript types in the exposed segment and manifest loader APIs

### DIFF
--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -521,7 +521,13 @@ export type ICustomSegmentLoader = (
                                      duration? : number | undefined; }) => void;
 
                  reject : (err? : unknown) => void;
-                 fallback? : (() => void) | undefined; }
+                 fallback : () => void;
+                 progress : (
+                   info : { duration : number;
+                            size : number;
+                            totalSize? : number | undefined; }
+                 ) => void;
+  }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;
@@ -532,6 +538,7 @@ export type ICustomManifestLoader = (
 
   // second argument: callbacks
   callbacks : { resolve : (args : { data : ILoadedManifestFormat;
+                                    url? : string | undefined;
                                     sendingTime? : number | undefined;
                                     receivingTime? : number | undefined;
                                     size? : number | undefined;
@@ -539,7 +546,7 @@ export type ICustomManifestLoader = (
                           => void;
 
                  reject : (err? : Error) => void;
-                 fallback? : () => void; }
+                 fallback : () => void; }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;


### PR DESCRIPTION
An application developper recently let me know that the type definitions for the RxPlayer's `transportOptions.segmentLoader` and `transportOptions.manifestLoader` loadVideo option were missing some attributes/arguments:
  - the `url` property that a manifest loader can communicate to the RxPlayer in case of a redirection is not defined (even if setting it worked).
  - the `progress` callback provided to the segment loader to notify about the request was not defined (even if using it worked)

I also noticed a third issue, the `fallback` callback allowing to fallback on the RxPlayer's default loader implementation could be
undefined. I guess it could make sense in some cases, such as cases where the RxPlayer is not able to do requests (for example: a "local-manifest" content) but in that case we would not be aligned with what the API documentation says, as it doesn't say anything about that callback's optionality. And anyway, just throwing in those very rare situations when we cannot fallback should not be that problematic (which is actually what we already do e.g. for "local-manifest" contents).

As a last measure, I also authorized optional attributes to either be not set, or to be set to `undefined`. Previously only the former was accepted.

Note that all those fixes don't change the player's behavior in any way, those are just forgotten typescript types, which will be erased when the application is built for the browser.