### PR TITLE
Only rely on pinkie's Promise when necessary

### DIFF
--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import {
   Observable,
 } from "rxjs";
@@ -31,6 +30,7 @@ import {
   ITransportPipelines,
 } from "../../../transports";
 import assert from "../../../utils/assert";
+import PPromise from "../../../utils/promise";
 import TaskCanceller from "../../../utils/task_canceller";
 import errorSelector from "../utils/error_selector";
 import {

--- a/src/core/fetchers/utils/try_urls_with_backoff.ts
+++ b/src/core/fetchers/utils/try_urls_with_backoff.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { isOffline } from "../../../compat";
 import {
   CustomLoaderError,
@@ -25,6 +24,7 @@ import {
 import log from "../../../log";
 import cancellableSleep from "../../../utils/cancellable_sleep";
 import getFuzzedDelay from "../../../utils/get_fuzzed_delay";
+import PPromise from "../../../utils/promise";
 import TaskCanceller, {
   CancellationSignal,
 } from "../../../utils/task_canceller";

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import pinkie from "pinkie";
 import {
   catchError,
   combineLatest,
@@ -36,6 +35,7 @@ import createSegmentFetcher, {
 import log from "../../../log";
 import { ISegment } from "../../../manifest";
 import objectAssign from "../../../utils/object_assign";
+import PPromise from "../../../utils/promise";
 import { freeRequest } from "./create_request";
 import getCompleteSegmentId from "./get_complete_segment_id";
 import getContentInfos from "./get_content_infos";
@@ -51,9 +51,6 @@ import {
   ILoaders,
 } from "./types";
 import VideoThumbnailLoaderError from "./video_thumbnail_loader_error";
-
-const PPromise = typeof Promise === "function" ? Promise :
-                                                 pinkie;
 
 const MIN_NEEDED_DATA_AFTER_TIME = 2;
 

--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import log from "../../../../../log";
 import assertUnreachable from "../../../../../utils/assert_unreachable";
 import noop from "../../../../../utils/noop";
+import PPromise from "../../../../../utils/promise";
 import parseMpdIr, {
   IIrParserResponse,
   ILoadedXlinkData,

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import PPromise from "../../utils/promise";
 import TaskCanceller, {
   CancellationError,
 } from "../../utils/task_canceller";
@@ -32,8 +33,7 @@ export default function addSegmentIntegrityChecks<T>(
   segmentLoader : ISegmentLoader<T>
 ) : ISegmentLoader<T> {
   return (url, content, initialCancelSignal, callbacks) => {
-    return new Promise((res, rej) => {
-
+    return new PPromise((res, rej) => {
       const canceller = new TaskCanceller();
       const unregisterCancelLstnr = initialCancelSignal
         .register(function onCheckCancellation(err : CancellationError) {

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import features from "../../features";
+import PPromise from "../../utils/promise";
 import request from "../../utils/request";
 import takeFirstSet from "../../utils/take_first_set";
 import { CancellationSignal } from "../../utils/task_canceller";

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { ISegment } from "../../manifest";
 import { concat } from "../../utils/byte_parsing";
+import PPromise from "../../utils/promise";
 import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { formatError } from "../../errors";
 import features from "../../features";
 import log from "../../log";
@@ -24,6 +23,7 @@ import {
   ILoadedResource,
 } from "../../parsers/manifest/dash/parsers_types";
 import objectAssign from "../../utils/object_assign";
+import PPromise from "../../utils/promise";
 import request from "../../utils/request";
 import {
   strToUtf8,

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { CustomLoaderError } from "../../errors";
+import PPromise from "../../utils/promise";
 import request, {
   fetchIsSupported,
 } from "../../utils/request";
@@ -130,7 +130,7 @@ export default function generateSegmentLoader(
                    transport: "dash",
                    url };
 
-    return new Promise((res, rej) => {
+    return new PPromise((res, rej) => {
       /** `true` when the custom segmentLoader should not be active anymore. */
       let hasFinished = false;
 

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
+import PPromise from "../../utils/promise";
 import request, {
   fetchIsSupported,
 } from "../../utils/request";

--- a/src/transports/local/segment_loader.ts
+++ b/src/transports/local/segment_loader.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { CustomLoaderError } from "../../errors";
 import {
   ILocalManifestInitSegmentLoader,
   ILocalManifestSegmentLoader,
 } from "../../parsers/manifest/local";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
+import PPromise from "../../utils/promise";
 import {
   CancellationError,
   CancellationSignal,
@@ -39,7 +39,7 @@ import {
 function loadInitSegment(
   customSegmentLoader : ILocalManifestInitSegmentLoader,
   cancelSignal : CancellationSignal
-) : PPromise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
+) : Promise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
   return new PPromise((res, rej) => {
     /** `true` when the custom segmentLoader should not be active anymore. */
     let hasFinished = false;
@@ -107,7 +107,7 @@ function loadSegment(
   segment : { time : number; duration : number; timestampOffset? : number },
   customSegmentLoader : ILocalManifestSegmentLoader,
   cancelSignal : CancellationSignal
-) : PPromise< ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
+) : Promise< ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
   return new PPromise((res, rej) => {
     /** `true` when the custom segmentLoader should not be active anymore. */
     let hasFinished = false;
@@ -191,7 +191,7 @@ export default function segmentLoader(
   content : ISegmentContext,
   cancelSignal : CancellationSignal,
   _callbacks : ISegmentLoaderCallbacks<ArrayBuffer | null>
-) : PPromise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
+) : Promise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {
   const { segment } = content;
   const privateInfos = segment.privateInfos;
   if (segment.isInit) {

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import features from "../../features";
 import Manifest, {
   Adaptation,
@@ -29,6 +28,7 @@ import parseMetaPlaylist, {
 import { IParsedManifest } from "../../parsers/manifest/types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
+import PPromise from "../../utils/promise";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
   IChunkTimeInfo,

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import features from "../../features";
 import log from "../../log";
 import Manifest, {
@@ -25,6 +24,7 @@ import { getMDAT } from "../../parsers/containers/isobmff";
 import createSmoothManifestParser, {
   SmoothRepresentationIndex,
 } from "../../parsers/manifest/smooth";
+import PPromise from "../../utils/promise";
 import request from "../../utils/request";
 import {
   strToUtf8,
@@ -178,8 +178,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       content : ISegmentContext,
       cancelSignal : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
-    ) : PPromise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
-                 ISegmentLoaderResultSegmentCreated<ILoadedAudioVideoSegmentFormat>>
+    ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
+                ISegmentLoaderResultSegmentCreated<ILoadedAudioVideoSegmentFormat>>
     {
       return segmentLoader(url, content, cancelSignal, callbacks);
     },
@@ -255,8 +255,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       content : ISegmentContext,
       cancelSignal : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedTextSegmentFormat>
-    ) : PPromise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
-                 ISegmentLoaderResultSegmentCreated<ILoadedTextSegmentFormat>> {
+    ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
+                ISegmentLoaderResultSegmentCreated<ILoadedTextSegmentFormat>> {
       const { segment, representation } = content;
       if (segment.isInit || url === null) {
         return PPromise.resolve({ resultType: "segment-created",
@@ -436,8 +436,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
       content : ISegmentContext,
       cancelSignal : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedImageSegmentFormat>
-    ) : PPromise<ISegmentLoaderResultSegmentLoaded<ILoadedImageSegmentFormat> |
-                 ISegmentLoaderResultSegmentCreated<ILoadedImageSegmentFormat>> {
+    ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedImageSegmentFormat> |
+                ISegmentLoaderResultSegmentCreated<ILoadedImageSegmentFormat>> {
       if (content.segment.isInit || url === null) {
         // image do not need an init segment. Passthrough directly to the parser
         return PPromise.resolve({ resultType: "segment-created" as const,

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { CustomLoaderError } from "../../errors";
 import assert from "../../utils/assert";
+import PPromise from "../../utils/promise";
 import request from "../../utils/request";
 import {
   CancellationError,
@@ -165,7 +165,7 @@ const generateSegmentLoader = ({
                                   checkMediaSegmentIntegrity);
     }
 
-    return new Promise((res, rej) => {
+    return new PPromise((res, rej) => {
       /** `true` when the custom segmentLoader should not be active anymore. */
       let hasFinished = false;
 

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { CustomLoaderError } from "../../errors";
+import PPromise from "../../utils/promise";
 import {
   CancellationError,
   CancellationSignal,

--- a/src/utils/cancellable_sleep.ts
+++ b/src/utils/cancellable_sleep.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
+import PPromise from "./promise";
 import {
   CancellationError,
   CancellationSignal,

--- a/src/utils/cast_to_observable.ts
+++ b/src/utils/cast_to_observable.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import {
   from as observableFrom,
   Observable,
   of as observableOf,
 } from "rxjs";
 import isNullOrUndefined from "./is_null_or_undefined";
+import PPromise from "./promise";
 
 /**
  * Try to cast the given value into an observable.
@@ -30,7 +30,6 @@ import isNullOrUndefined from "./is_null_or_undefined";
  */
 function castToObservable<T>(value : Observable<T> |
                                      Promise<T> |
-                                     PPromise<T> |
                                      Exclude<T, Observable<T>>) : Observable<T> {
   if (value instanceof Observable) {
     return value;

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import config from "../../config";
 import {
   NetworkErrorTypes,
@@ -112,7 +111,7 @@ const _AbortController : IAbortControllerConstructor|null =
 
 export default function fetchRequest(
   options : IFetchOptions
-) : PPromise<IFetchedStreamComplete> {
+) : Promise<IFetchedStreamComplete> {
   let headers : Headers | { [key : string ] : string } | undefined;
   if (!isNullOrUndefined(options.headers)) {
     if (isNullOrUndefined(_Headers)) {
@@ -170,7 +169,7 @@ export default function fetchRequest(
   return fetch(
     options.url,
     fetchOpts
-  ).then((response : Response) : PPromise<IFetchedStreamComplete> => {
+  ).then((response : Response) : Promise<IFetchedStreamComplete> => {
     if (!isNullOrUndefined(timeout)) {
       clearTimeout(timeout);
     }
@@ -196,7 +195,7 @@ export default function fetchRequest(
 
     return readBufferAndSendEvents();
 
-    async function readBufferAndSendEvents() : PPromise<IFetchedStreamComplete> {
+    async function readBufferAndSendEvents() : Promise<IFetchedStreamComplete> {
       const data = await reader.read();
 
       if (!data.done && !isNullOrUndefined(data.value)) {

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -18,6 +18,7 @@ import config from "../../config";
 import { RequestError } from "../../errors";
 import isNonEmptyString from "../is_non_empty_string";
 import isNullOrUndefined from "../is_null_or_undefined";
+import PPromise from "../promise";
 import {
   CancellationError,
   CancellationSignal,
@@ -138,7 +139,7 @@ export default function request<T>(
                                                   options.timeout,
   };
 
-  return new Promise((resolve, reject) => {
+  return new PPromise((resolve, reject) => {
     const { onProgress, cancelSignal } = options;
     const { url,
             headers,

--- a/src/utils/rx-from_cancellable_promise.ts
+++ b/src/utils/rx-from_cancellable_promise.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import PPromise from "pinkie";
 import { Observable } from "rxjs";
 import TaskCanceller from "./task_canceller";
 
@@ -41,7 +40,7 @@ import TaskCanceller from "./task_canceller";
  */
 export default function fromCancellablePromise<T>(
   canceller : TaskCanceller,
-  fn : () => PPromise<T>
+  fn : () => Promise<T>
 ) : Observable<T> {
   return new Observable((obs) => {
     let isUnsubscribedFrom = false;


### PR DESCRIPTION
While debugging an unrelated issue, I noticed that pinkie's Promise implementation was being used even on a recent browser with a native Promise implementation.

This is due to mix-ups in the code, where we're including directly this implementation (`import PPromise from "pinkie";`) instead of importing the file selecting one or the other depending on browser support (`import PPromise from "../../utils/promise"`).

This is not a big issue at all, and I would guess most places still relied on the native implementation, but it's probably better for performance reason to use the native one when available.

I was also wondering if it made sense to use pinkie at all. Originally, it was just imported so the player can be used on IE11.
Yet it seems that RxJS, one of our other dependencies, does not actually work out-of-the box on IE11 without a Promise polyfill already declared by the application.

I didn't remove the pinkie dependency for now, but I would be very ready to do so if we can prove that this is completely unnecessary.