### PR TITLE
stream: fix logic for range eviction on QuotaExceededError

### DIFF
--- a/src/core/stream/representation/force_garbage_collection.ts
+++ b/src/core/stream/representation/force_garbage_collection.ts
@@ -84,19 +84,17 @@ function selectGCedRanges(
 
   // start by trying to remove all ranges that do not contain the
   // current time and respect the gcGap
-  // respect the gcGap? FIXME?
   for (let i = 0; i < outerRanges.length; i++) {
     const outerRange = outerRanges[i];
-    if (position - gcGap < outerRange.end) {
+    if (position - gcGap > outerRange.end) {
       cleanedupRanges.push(outerRange);
-    }
-    else if (position + gcGap > outerRange.start) {
+    } else if (position + gcGap < outerRange.start) {
       cleanedupRanges.push(outerRange);
     }
   }
 
   // try to clean up some space in the current range
-  if (innerRange != null) {
+  if (innerRange !== null) {
     log.debug("Stream: GC removing part of inner range", cleanedupRanges);
     if (position - gcGap > innerRange.start) {
       cleanedupRanges.push({ start: innerRange.start,


### PR DESCRIPTION
This is a very minor fix on what appeared to be an inefective strategy when receiving a QuotaExceededError, which is an error which may appear when a pushed segment overloads the memory.

The previous strategy was to try to clean-up ranges of data - that are far away from the current position - from the buffer (a strategy generally already performed by the browser).

However, and at least to me, the condition appeared to be the reverse of what we should check for. We were not clearing far away ranges, but ranges that were close (yet thankfully not the one containing the current position).
Still, I welcome any reviewer to re-check, as this type of range-related logic is notoriously hard to reason about.

We did not observe any bug or weird behavior linked to this problem and this logic should very rarely be useful, so this is not a huge fix.