### PR TITLE
directfile: use getStartDate in getWallClockTime when available

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1338,7 +1338,16 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     const { isDirectFile, manifest } = this._priv_contentInfos;
     if (isDirectFile) {
-      return this.videoElement.currentTime;
+      const mediaElement : HTMLMediaElement & {
+        getStartDate? : () => number | null | undefined;
+      } = this.videoElement;
+      if (typeof mediaElement.getStartDate === "function") {
+        const startDate = mediaElement.getStartDate();
+        if (typeof startDate === "number" && !isNaN(startDate)) {
+          return startDate + mediaElement.currentTime;
+        }
+      }
+      return mediaElement.currentTime;
     }
     if (manifest !== null) {
       const currentTime = this.videoElement.currentTime;

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1338,6 +1338,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     const { isDirectFile, manifest } = this._priv_contentInfos;
     if (isDirectFile) {
+      // Calculating the "wall-clock time" necessitate to obtain first an offset,
+      // and then adding that offset to the HTMLMediaElement's current position.
+      // That offset is in most case present inside the Manifest file, yet in
+      // directfile mode, the RxPlayer won't parse that file, the browser does it.
+      //
+      // Thankfully Safari declares a `getStartDate` method allowing to obtain
+      // that offset when available. This logic is thus mainly useful when
+      // playing HLS contents in directfile mode on Safari.
       const mediaElement : HTMLMediaElement & {
         getStartDate? : () => number | null | undefined;
       } = this.videoElement;


### PR DESCRIPTION
Fixes #1055

This PR add the usage of the `HTMLMediaElement.prototype.getStartDate` method when available (for now just seen on Safari when playing HLS contents) to provide a real "wall-clock time" (which is in our case, the offseted position to correspond to the air time) when playing directfile contents.

Previously, all directfile contents just returned the real non-offseted position when calling `getWallClockTime`.

More information [on the corresponding issue](https://github.com/canalplus/rx-player/issues/1055)