### PR TITLE
directfile: disable all audio tracks before enabling one to work-around Safari issue on MacOS Monterey

### DIFF
--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -28,6 +28,7 @@ import {
   ICompatVideoTrackList,
 } from "../../compat/browser_compatibility_types";
 import { Representation } from "../../manifest";
+import assert from "../../utils/assert";
 import EventEmitter from "../../utils/event_emitter";
 import normalizeLanguage from "../../utils/languages";
 import {
@@ -338,7 +339,7 @@ export default class MediaElementTrackChoiceManager
     for (let i = 0; i < this._audioTracks.length; i++) {
       const { track, nativeTrack } = this._audioTracks[i];
       if (track.id === id) {
-        nativeTrack.enabled = true;
+        this._enableAudioTrackFromIndex(i);
         this._audioTrackLockedOn = nativeTrack;
         return;
       }
@@ -589,7 +590,7 @@ export default class MediaElementTrackChoiceManager
       for (let i = 0; i < this._audioTracks.length; i++) {
         const { nativeTrack } = this._audioTracks[i];
         if (nativeTrack === this._audioTrackLockedOn) {
-          nativeTrack.enabled = true;
+          this._enableAudioTrackFromIndex(i);
           return;
         }
       }
@@ -616,7 +617,7 @@ export default class MediaElementTrackChoiceManager
           if (audioTrack.track.normalized === normalized &&
             audioTrack.track.audioDescription === track.audioDescription
           ) {
-            audioTrack.nativeTrack.enabled = true;
+            this._enableAudioTrackFromIndex(j);
             return;
           }
         }
@@ -901,6 +902,23 @@ export default class MediaElementTrackChoiceManager
         return;
       };
     }
+  }
+
+  /**
+   * Enable an audio track (and disable all others), based on its index in the
+   * `this._audioTracks` array.
+   * @param {number} index}
+   */
+  private _enableAudioTrackFromIndex(index : number) : void {
+    assert(index < this._audioTracks.length);
+    for (let i = 0; i < this._audioTracks.length; i++) {
+      if (i !== index) {
+        this._audioTracks[i].nativeTrack.enabled = false;
+      }
+    }
+
+    this._audioTracks[index].nativeTrack.enabled = true;
+    return;
   }
 }
 

--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -911,10 +911,11 @@ export default class MediaElementTrackChoiceManager
    */
   private _enableAudioTrackFromIndex(index : number) : void {
     assert(index < this._audioTracks.length);
-    for (let i = 0; i < this._audioTracks.length; i++) {
-      if (i !== index) {
-        this._audioTracks[i].nativeTrack.enabled = false;
-      }
+
+    // Seen on Safari MacOS only (2022-02-14), not disabling ALL audio tracks
+    // first (even the wanted one), can lead to the media not playing.
+    for (const audioTrack of this._audioTracks) {
+      audioTrack.nativeTrack.enabled = false;
     }
 
     this._audioTracks[index].nativeTrack.enabled = true;


### PR DESCRIPTION
We recently observed an issue on Safari where enabling an audio track in directfile mode without disabling the others led to the new audio track not being audible (but the previous one still being audible).

To our knowledge, Safari had no problem with this previously but by checking the HTML5 living standard recently, we saw that at least now, enabling an audio track does not mean that the others are disabled and could even mean hearing multiple audio tracks at once.

This PR thus disables all other audio tracks when enabling a new one, which should not be problematic in any case.

It has been tested on Safari with success.