### PR TITLE
add exactOptionalPropertyTypes typescript option

### DIFF
--- a/src/compat/__tests__/fullscreen.test.ts
+++ b/src/compat/__tests__/fullscreen.test.ts
@@ -23,15 +23,15 @@
 
 interface IFakeDocument {
   createElement(eltType: string) : HTMLElement;
-  fullscreenElement? : Element | null;
-  mozCancelFullScreen? : () => void;
-  mozFullScreenElement? : HTMLElement;
-  msExitFullscreen? : () => void;
-  exitFullscreen? : () => void;
-  msFullscreenElement? : Element | null;
+  fullscreenElement? : Element | null | undefined;
+  mozCancelFullScreen? : (() => void) | undefined;
+  mozFullScreenElement? : HTMLElement | undefined;
+  msExitFullscreen? : (() => void) | undefined;
+  exitFullscreen? : (() => void) | undefined;
+  msFullscreenElement? : Element | null | undefined;
   webkitExitFullscreen : () => void;
   webkitFullscreenElement : Element | null | undefined;
-  webkitHidden? : boolean;
+  webkitHidden? : boolean | undefined;
 }
 
 const doc = document as unknown as IFakeDocument;

--- a/src/compat/__tests__/is_vtt_cue.test.ts
+++ b/src/compat/__tests__/is_vtt_cue.test.ts
@@ -63,7 +63,7 @@ describe("Compat - isVTTCue", () => {
     const originalVTTCue = window.VTTCue;
     win.VTTCue = MockVTTCue;
     const cue = new VTTCue(0, 10, "");
-    win.VTTCue = undefined;
+    delete win.VTTCue;
     const isVTTCue = require("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(false);
     window.VTTCue = originalVTTCue;

--- a/src/compat/eme/custom_media_keys/ie11_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/ie11_media_keys.ts
@@ -45,7 +45,7 @@ class IE11MediaKeySession
   public keyStatuses: ICustomMediaKeyStatusMap;
   private readonly _mk: MSMediaKeys;
   private readonly _closeSession$: Subject<void>;
-  private _ss?: MSMediaKeySession;
+  private _ss: MSMediaKeySession | undefined;
   constructor(mk: MSMediaKeys) {
     super();
     this.expiration = NaN;

--- a/src/compat/eme/custom_media_keys/index.ts
+++ b/src/compat/eme/custom_media_keys/index.ts
@@ -173,14 +173,18 @@ if (isNode ||
       supported = supported && (distinctiveIdentifier !== "required");
 
       if (supported) {
-        const keySystemConfigurationResponse = {
-          videoCapabilities,
-          audioCapabilities,
+        const keySystemConfigurationResponse : MediaKeySystemConfiguration = {
           initDataTypes: ["cenc"],
           distinctiveIdentifier: "not-allowed" as const,
           persistentState: "required" as const,
           sessionTypes: ["temporary", "persistent-license"],
         };
+        if (videoCapabilities !== undefined) {
+          keySystemConfigurationResponse.videoCapabilities = videoCapabilities;
+        }
+        if (audioCapabilities !== undefined) {
+          keySystemConfigurationResponse.audioCapabilities = audioCapabilities;
+        }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const customMediaKeys = createCustomMediaKeys(keyType);

--- a/src/core/abr/buffer_based_chooser.ts
+++ b/src/core/abr/buffer_based_chooser.ts
@@ -109,9 +109,9 @@ export interface IBufferBasedChooserPlaybackObservation {
    */
   bufferGap : number;
   /** The bitrate of the currently downloaded segments, in bps. */
-  currentBitrate? : number;
+  currentBitrate? : number | undefined;
   /** The "maintainability score" of the currently downloaded segments. */
-  currentScore? : number;
+  currentScore? : number | undefined;
   /** Playback rate wanted */
   speed : number;
 }

--- a/src/core/abr/network_analyzer.ts
+++ b/src/core/abr/network_analyzer.ts
@@ -327,7 +327,7 @@ export default class NetworkAnalyzer {
     currentRepresentation : Representation | null,
     currentRequests : IRequestInfo[],
     lastEstimatedBitrate: number|undefined
-  ) : { bandwidthEstimate? : number; bitrateChosen : number } {
+  ) : { bandwidthEstimate? : number | undefined; bitrateChosen : number } {
     let newBitrateCeil : number | undefined; // bitrate ceil for the chosen Representation
     let bandwidthEstimate;
     const localConf = this._config;

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -119,7 +119,7 @@ export interface IABREstimate {
    * have, you will most likely only want to do it when the Representation is
    * known to be maintaninable.
    */
-  knownStableBitrate?: number;
+  knownStableBitrate?: number | undefined;
 }
 
 /** Media properties the `RepresentationEstimator` will need to keep track of. */

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -163,13 +163,13 @@ interface IPositionUpdateItem {
   /** Amount of buffer available for now in front of the current position, in seconds. */
   bufferGap : number;
   /** Current maximum seekable position. */
-  maximumBufferTime? : number;
-  wallClockTime? : number;
+  maximumBufferTime? : number | undefined;
+  wallClockTime? : number | undefined;
   /**
    * Only for live contents. Difference between the "live edge" and the current
    * position, in seconds.
    */
-  liveGap? : number;
+  liveGap? : number | undefined;
 }
 
 /** Payload emitted with a `bitrateEstimationChange` event. */
@@ -321,7 +321,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      * URL of the Manifest (or just of the content for DirectFile contents)
      * currently being played.
      */
-    url? : string;
+    url : string | undefined;
 
     /** Subject allowing to stop playing that content. */
     stop$ : Subject<void>;

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -63,7 +63,7 @@ interface IVideoTrackPreferenceObject {
  */
 interface ITMAudioRepresentation { id : string|number;
                                    bitrate : number;
-                                   codec? : string; }
+                                   codec? : string | undefined; }
 
 /** Audio track returned by the TrackChoiceManager. */
 export interface ITMAudioTrack { language : string;
@@ -85,11 +85,11 @@ export interface ITMTextTrack { language : string;
  */
 interface ITMVideoRepresentation { id : string|number;
                                    bitrate : number;
-                                   width? : number;
-                                   height? : number;
-                                   codec? : string;
-                                   frameRate? : string;
-                                   hdrInfo?: IHDRInformation; }
+                                   width? : number | undefined;
+                                   height? : number | undefined;
+                                   codec? : string | undefined;
+                                   frameRate? : string | undefined;
+                                   hdrInfo?: IHDRInformation | undefined; }
 
 /** Video track returned by the TrackChoiceManager. */
 export interface ITMVideoTrack { id : number|string;
@@ -134,10 +134,11 @@ type INormalizedPreferredAudioTrack = null |
 
 /** Audio track preference when it is not set to `null`. */
 interface INormalizedPreferredAudioTrackObject {
-  normalized? : string;
-  audioDescription? : boolean;
+  normalized? : string | undefined;
+  audioDescription? : boolean | undefined;
   codec? : { all: boolean;
-             test: RegExp; };
+             test: RegExp; } |
+           undefined;
 }
 
 /** Text track preference once normalized by the TrackChoiceManager. */

--- a/src/core/eme/__tests__/__global__/utils.ts
+++ b/src/core/eme/__tests__/__global__/utils.ts
@@ -44,20 +44,15 @@ import {
 
 /** Default MediaKeySystemAccess configuration used by the RxPlayer. */
 export const defaultKSConfig = [{
-  audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
-                         robustness: undefined },
-                       { contentType: "audio/webm;codecs=opus",
-                         robustness: undefined } ],
+  audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                       { contentType: "audio/webm;codecs=opus" } ],
   distinctiveIdentifier: "optional" as const,
   initDataTypes: ["cenc"] as const,
   persistentState: "optional" as const,
   sessionTypes: ["temporary"] as const,
-  videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"",
-                         robustness: undefined },
-                       { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
-                         robustness: undefined },
-                       { contentType: "video/webm;codecs=\"vp8\"",
-                         robustness: undefined } ],
+  videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                       { contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                       { contentType: "video/webm;codecs=\"vp8\"" } ],
 }];
 
 /** Default Widevine MediaKeySystemAccess configuration used by the RxPlayer. */

--- a/src/core/eme/find_key_system.ts
+++ b/src/core/eme/find_key_system.ts
@@ -192,21 +192,23 @@ function buildKeySystemConfigurations(
   // More details here:
   // https://storage.googleapis.com/wvdocs/Chrome_EME_Changes_and_Best_Practices.pdf
   // https://www.w3.org/TR/encrypted-media/#get-supported-configuration-and-consent
+
   const videoCapabilities: IMediaCapability[] =
-    flatMap(videoRobustnesses,
-            robustness => [{ contentType: "video/mp4;codecs=\"avc1.4d401e\"",
-                             robustness },
-                           { contentType: "video/mp4;codecs=\"avc1.42e01e\"",
-                             robustness },
-                           { contentType: "video/webm;codecs=\"vp8\"",
-                             robustness } ]);
+    flatMap(audioRobustnesses, (robustness) =>
+      ["video/mp4;codecs=\"avc1.4d401e\"",
+       "video/mp4;codecs=\"avc1.42e01e\"",
+       "video/webm;codecs=\"vp8\""].map(contentType => {
+        return robustness !== undefined ? { contentType, robustness } :
+                                          { contentType };
+      }));
 
   const audioCapabilities: IMediaCapability[] =
-    flatMap(audioRobustnesses,
-            robustness => [{ contentType: "audio/mp4;codecs=\"mp4a.40.2\"",
-                             robustness },
-                           { contentType: "audio/webm;codecs=opus",
-                             robustness } ]);
+    flatMap(audioRobustnesses, (robustness) =>
+      ["audio/mp4;codecs=\"mp4a.40.2\"",
+       "audio/webm;codecs=opus"].map(contentType => {
+        return robustness !== undefined ? { contentType, robustness } :
+                                          { contentType };
+      }));
 
   // TODO Re-test with a set contentType but an undefined robustness on the
   // STBs on which this problem was found.

--- a/src/core/eme/types.ts
+++ b/src/core/eme/types.ts
@@ -40,7 +40,7 @@ export interface IInitializationDataInfo {
    * `undefined` when not known (different from an empty array - which would
    * just mean that there's no key id involved).
    */
-  keyIds? : Uint8Array[];
+  keyIds? : Uint8Array[] | undefined;
   /** Every initialization data for that type. */
   values: Array<{
     /**
@@ -298,7 +298,7 @@ export interface IContentProtection {
    * `undefined` when not known (different from an empty array - which would
    * just mean that there's no key id involved).
    */
-  keyIds? : Uint8Array[];
+  keyIds? : Uint8Array[] | undefined;
   /** Every initialization data for that type. */
   values: Array<{
     /**

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -54,11 +54,11 @@ export interface IManifestFetcherParsedResult {
    * The time (`performance.now()`) at which the request was started (at which
    * the JavaScript call was done).
    */
-  sendingTime? : number;
+  sendingTime? : number | undefined;
   /** The time (`performance.now()`) at which the request was fully received. */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /* The time taken to parse the Manifest through the corresponding parse function. */
-  parsingTime? : number;
+  parsingTime? : number | undefined;
 }
 
 /** Emitted when a fetching or parsing minor error happened. */
@@ -86,7 +86,7 @@ export interface IManifestFetcherParserOptions {
    * If set, offset to add to `performance.now()` to obtain the current
    * server's time.
    */
-  externalClockOffset? : number;
+  externalClockOffset? : number | undefined;
   /** The previous value of the Manifest (when updating). */
   previousManifest : Manifest | null;
   /**

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -442,8 +442,8 @@ export function getSegmentFetcherOptions(
   bufferType : string,
   { maxRetryRegular,
     maxRetryOffline,
-    lowLatencyMode } : { maxRetryRegular? : number;
-                         maxRetryOffline? : number;
+    lowLatencyMode } : { maxRetryRegular? : number | undefined;
+                         maxRetryOffline? : number | undefined;
                          lowLatencyMode : boolean; }
 ) : ISegmentFetcherOptions {
   return { maxRetryRegular: bufferType === "image" ? 0 :

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -100,8 +100,8 @@ export interface IDirectFileOptions { autoPlay : boolean;
                                       mediaElement : HTMLMediaElement;
                                       playbackObserver : PlaybackObserver;
                                       speed : IReadOnlySharedReference<number>;
-                                      startAt? : IInitialTimeOptions;
-                                      url? : string; }
+                                      startAt? : IInitialTimeOptions | undefined;
+                                      url? : string | undefined; }
 
 /**
  * Launch a content in "Directfile mode".

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -127,7 +127,7 @@ export interface IInitializeArguments {
   /** Emit the playback rate (speed) set by the user. */
   speed : IReadOnlySharedReference<number>;
   /** The configured starting position. */
-  startAt? : IInitialTimeOptions;
+  startAt? : IInitialTimeOptions | undefined;
   /** Configuration specific to the text track. */
   textTrackOptions : ITextTrackSegmentBufferOptions;
 }
@@ -237,7 +237,7 @@ export default function InitializeOnMediaSource(
          * ID identifying the current MediaKeys' system ID. Can be used to only
          * send initialization data linked to that ID as an optimization measure.
          */
-        drmSystemId? : string;
+        drmSystemId? : string | undefined;
       },
       evt : IEMEManagerEvent | IEMEDisabledEvent
     ) => {

--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -48,9 +48,9 @@ export interface IManifestUpdateSchedulerArguments {
   manifestFetcher : ManifestFetcher;
   /** Information about the initial load of the manifest */
   initialManifest : { manifest : Manifest;
-                      sendingTime? : number;
-                      receivedTime? : number;
-                      parsingTime? : number; };
+                      sendingTime? : number | undefined;
+                      receivedTime? : number | undefined;
+                      parsingTime? : number | undefined; };
   /** Minimum interval to keep between Manifest updates */
   minimumManifestUpdateInterval : number;
   /** Allows the rest of the code to ask for a Manifest refresh */
@@ -74,7 +74,7 @@ export interface IManifestRefreshSchedulerEvent {
    * Optional wanted refresh delay, which is the minimum time you want to wait
    * before updating the Manifest
    */
-  delay? : number;
+  delay? : number | undefined;
   /**
    * Whether the parsing can be done in the more efficient "unsafeMode".
    * This mode is extremely fast but can lead to de-synchronisation with the
@@ -127,9 +127,9 @@ export default function manifestUpdateScheduler({
    * encountered.
    */
   function handleManifestRefresh$(
-    { sendingTime, parsingTime, updatingTime } : { sendingTime?: number;
-                                                   parsingTime? : number;
-                                                   updatingTime? : number; }
+    { sendingTime, parsingTime, updatingTime } : { sendingTime?: number | undefined;
+                                                   parsingTime? : number | undefined;
+                                                   updatingTime? : number | undefined; }
   ) : Observable<IWarningEvent> {
     /**
      * Total time taken to fully update the last Manifest, in milliseconds.

--- a/src/core/init/stream_events_emitter/are_same_stream_events.ts
+++ b/src/core/init/stream_events_emitter/are_same_stream_events.ts
@@ -28,12 +28,12 @@
  * @param {Object} evt2
  * @returns {Boolean}
  */
-function areSameStreamEvents(evt1: { id?: string;
+function areSameStreamEvents(evt1: { id?: string | undefined;
                                      start: number;
-                                     end?: number; },
-                             evt2: { id?: string;
+                                     end?: number | undefined; },
+                             evt2: { id?: string | undefined;
                                      start: number;
-                                     end?: number; }): boolean {
+                                     end?: number | undefined; }): boolean {
   return evt1.id === evt2.id &&
          evt1.start === evt2.start &&
          evt1.end === evt2.end;

--- a/src/core/init/stream_events_emitter/types.ts
+++ b/src/core/init/stream_events_emitter/types.ts
@@ -22,7 +22,7 @@ export interface IStreamEventData {
 }
 
 export interface IStreamEventPayload {
-  id?: string;
+  id?: string | undefined;
   start: number;
   end: number;
   data: IStreamEventData;
@@ -30,7 +30,7 @@ export interface IStreamEventPayload {
 }
 
 export interface INonFiniteStreamEventPayload {
-  id?: string;
+  id?: string | undefined;
   start: number;
   data: IStreamEventData;
   publicEvent: IPublicNonFiniteStreamEvent;

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -445,11 +445,11 @@ export interface INativeTextTracksBufferSegmentData {
    * This is mostly needed for "sami" subtitles, to know which cues can / should
    * be parsed.
    */
-  language? : string;
+  language? : string | undefined;
   /** start time from which the segment apply, in seconds. */
-  start? : number;
+  start? : number | undefined;
   /** end time until which the segment apply, in seconds. */
-  end? : number;
+  end? : number | undefined;
 }
 
 /**

--- a/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
@@ -45,7 +45,7 @@ export default class NativeTextSegmentBuffer extends SegmentBuffer {
 
   private readonly _videoElement : HTMLMediaElement;
   private readonly _track : ICompatTextTrack;
-  private readonly _trackElement? : HTMLTrackElement;
+  private readonly _trackElement : HTMLTrackElement | undefined;
 
   private _buffered : ManualTimeRanges;
 
@@ -268,11 +268,11 @@ export interface INativeTextTracksBufferSegmentData {
    * This is mostly needed for "sami" subtitles, to know which cues can / should
    * be parsed.
    */
-  language? : string;
+  language? : string | undefined;
   /** start time from which the segment apply, in seconds. */
-  start? : number;
+  start? : number | undefined;
   /** end time until which the segment apply, in seconds. */
-  end? : number;
+  end? : number | undefined;
 }
 
 /**

--- a/src/errors/request_error.ts
+++ b/src/errors/request_error.ts
@@ -50,7 +50,10 @@ export default class RequestError extends Error {
 
     this.name = "RequestError";
     this.url = url;
-    this.xhr = xhr;
+
+    if (xhr !== undefined) {
+      this.xhr = xhr;
+    }
     this.status = status;
     this.type = type;
     this.message = type;

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -75,8 +75,8 @@ export default class VideoThumbnailLoader {
   private readonly _videoElement: HTMLVideoElement;
 
   private _player: Player;
-  private _currentTask?: ITimeSettingTask;
-  private _nextTaskSegmentsCompleteIds?: string[];
+  private _currentTask : ITimeSettingTask | undefined;
+  private _nextTaskSegmentsCompleteIds : string[] | undefined;
   constructor(videoElement: HTMLVideoElement,
               player: Player) {
     this._videoElement = videoElement;

--- a/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
@@ -127,7 +127,7 @@ const mediaCapabilitiesProber = {
     }>
   ) : Promise<ICompatibleKeySystem[]> {
     const promises: Array<Promise<{ globalStatus: ProberStatus;
-                                    result? : ICompatibleKeySystem; }>> = [];
+                                    result? : ICompatibleKeySystem | undefined; }>> = [];
     configurations.forEach((configuration) => {
       const globalConfig = {
         keySystem: configuration,

--- a/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/probeMediaConfiguration.ts
@@ -36,7 +36,7 @@ export interface IProbedMediaConfiguration {
   globalStatus: ProberStatus;
   resultsFromAPIS: Array<{
     APIName: ICapabilitiesTypes;
-    result?: IResultsFromAPI;
+    result?: IResultsFromAPI | undefined;
   }>;
 }
 
@@ -63,7 +63,7 @@ function probeMediaConfiguration(
   let globalStatus : ProberStatus|undefined;
   const resultsFromAPIS: Array<{
     APIName: ICapabilitiesTypes;
-    result?: IResultsFromAPI;
+    result: IResultsFromAPI | undefined;
   }> = [];
   const promises = [];
   for (const browserAPI of browserAPIS) {
@@ -103,7 +103,7 @@ function probeMediaConfiguration(
   }
 
   return PPromise.all(promises).then(() => {
-    if (globalStatus == null) {
+    if (globalStatus === undefined) {
       globalStatus = ProberStatus.Unknown;
     }
 

--- a/src/experimental/tools/mediaCapabilitiesProber/types.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/types.ts
@@ -52,9 +52,9 @@ export interface IDisplayConfiguration {
 }
 
 export interface IMediaConfiguration {
-  type?: "media-source"|"file";
-  video?: IVideoConfiguration;
-  audio?: IAudioConfiguration;
+  type?: "media-source" | "file" | undefined;
+  video?: IVideoConfiguration | undefined;
+  audio?: IAudioConfiguration | undefined;
   keySystem?: IKeySystem;
   hdcp?: string;
   display?: IDisplayConfiguration;

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -109,15 +109,17 @@ export default class Adaptation {
    * @param {Object|undefined} [options]
    */
   constructor(parsedAdaptation : IParsedAdaptation, options : {
-    representationFilter? : IRepresentationFilter;
-    isManuallyAdded? : boolean;
+    representationFilter? : IRepresentationFilter | undefined;
+    isManuallyAdded? : boolean | undefined;
   } = {}) {
     const { trickModeTracks } = parsedAdaptation;
     const { representationFilter, isManuallyAdded } = options;
     this.id = parsedAdaptation.id;
-    this.isTrickModeTrack = parsedAdaptation.isTrickModeTrack;
-
     this.type = parsedAdaptation.type;
+
+    if  (parsedAdaptation.isTrickModeTrack !== undefined) {
+      this.isTrickModeTrack = parsedAdaptation.isTrickModeTrack;
+    }
 
     if (parsedAdaptation.language !== undefined) {
       this.language = parsedAdaptation.language;

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -83,18 +83,18 @@ interface ISupplementaryTextTrack {
 interface IManifestParsingOptions {
   /* eslint-disable import/no-deprecated */
   /** Text tracks to add manually to the Manifest instance. */
-  supplementaryTextTracks? : ISupplementaryTextTrack[];
+  supplementaryTextTracks? : ISupplementaryTextTrack[] | undefined;
   /** Image tracks to add manually to the Manifest instance. */
-  supplementaryImageTracks? : ISupplementaryImageTrack[];
+  supplementaryImageTracks? : ISupplementaryImageTrack[] | undefined;
   /* eslint-enable import/no-deprecated */
   /** External callback peforming an automatic filtering of wanted Representations. */
-  representationFilter? : IRepresentationFilter;
+  representationFilter? : IRepresentationFilter | undefined;
   /** Optional URL that points to a shorter version of the Manifest used
    * for updates only. When using this URL for refresh, the manifest will be
    * updated with the partial update type. If this URL is undefined, then the
    * manifest will be updated fully when it needs to be refreshed, and it will
    * fetched through the original URL. */
-  manifestUpdateUrl? : string;
+  manifestUpdateUrl? : string | undefined;
 }
 
 /** Representation affected by a `decipherabilityUpdate` event. */
@@ -197,7 +197,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
 
   /** Optional URL that points to a shorter version of the Manifest used
    * for updates only. */
-  public updateUrl?: string;
+  public updateUrl : string | undefined;
 
   /**
    * Suggested delay from the "live edge" (i.e. the position corresponding to
@@ -205,7 +205,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * from.
    * This only applies to live contents.
    */
-  public suggestedPresentationDelay? : number;
+  public suggestedPresentationDelay : number | undefined;
 
   /**
    * Amount of time, in seconds, this Manifest is valid from the time when it
@@ -213,7 +213,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * If no lifetime is set, this Manifest does not become invalid after an
    * amount of time.
    */
-  public lifetime? : number;
+  public lifetime : number | undefined;
 
   /**
    * Minimum time, in seconds, at which a segment defined in the Manifest
@@ -221,14 +221,14 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * This is also used as an offset for live content to apply to a segment's
    * time.
    */
-  public availabilityStartTime? : number;
+  public availabilityStartTime : number | undefined;
 
   /**
    * It specifies the wall-clock time when the manifest was generated and published
    * at the origin server. It is present in order to identify different versions
    * of manifest instances.
    */
-  public publishTime?: number;
+  public publishTime: number | undefined;
 
   /**
    * Array containing every minor errors that happened when the Manifest has
@@ -271,7 +271,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
      *      segment, and `timeshiftDepth` would be the whole depth that will
      *      become available once enough segments have been generated.
      */
-    absoluteMinimumTime? : number;
+    absoluteMinimumTime? : number | undefined;
     /**
      * Some dynamic contents have the concept of a "window depth" (or "buffer
      * depth") which allows to set a minimum position for all reachable

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -50,13 +50,13 @@ export default class Period {
    * Duration of this Period, in seconds.
    * `undefined` for still-running Periods.
    */
-  public duration? : number;
+  public duration : number | undefined;
 
   /**
    * Absolute end time of the Period, in seconds.
    * `undefined` for still-running Periods.
    */
-  public end? : number;
+  public end : number | undefined;
 
   /**
    * Array containing every errors that happened when the Period has been
@@ -74,7 +74,7 @@ export default class Period {
    */
   constructor(
     args : IParsedPeriod,
-    representationFilter? : IRepresentationFilter
+    representationFilter? : IRepresentationFilter | undefined
   ) {
     this.contentWarnings = [];
     this.id = args.id;

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -55,7 +55,7 @@ class Representation {
    * A string describing the codec used for this Representation.
    * undefined if we do not know.
    */
-  public codec? : string;
+  public codec : string | undefined;
 
   /**
    * A string describing the mime-type for this Representation.
@@ -93,7 +93,7 @@ class Representation {
    *     Representation
    *   - if `undefined` there is no certainty on this matter
    */
-  public decipherable? : boolean;
+  public decipherable? : boolean  | undefined;
 
   /** `true` if the Representation is in a supported codec, false otherwise. */
   public isSupported : boolean;

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -38,12 +38,12 @@ export interface ISmoothInitSegmentPrivateInfos {
    * as found in the Manifest.
    */
   timescale : number;
-  codecPrivateData? : string;
-  bitsPerSample? : number;
-  channels? : number;
-  packetSize? : number;
-  samplingRate? : number;
-  protection? : { keyId : Uint8Array };
+  codecPrivateData? : string | undefined;
+  bitsPerSample? : number | undefined;
+  channels? : number | undefined;
+  packetSize? : number | undefined;
+  samplingRate? : number | undefined;
+  protection? : { keyId : Uint8Array } | undefined;
 }
 
 /**
@@ -78,7 +78,7 @@ export interface IMetaPlaylistPrivateInfos {
   /** The segment originally created by this transport's RepresentationIndex. */
   originalSegment : ISegment;
   contentStart : number;
-  contentEnd? : number;
+  contentEnd? : number | undefined;
 }
 
 /**
@@ -112,12 +112,12 @@ export interface ILocalManifestSegmentPrivateInfos {
  * exploited by the corresponding transport logic.
  */
 export interface IPrivateInfos {
-  smoothInitSegment? : ISmoothInitSegmentPrivateInfos;
-  smoothMediaSegment? : ISmoothSegmentPrivateInfos;
-  metaplaylistInfos? : IMetaPlaylistPrivateInfos;
-  localManifestInitSegment? : ILocalManifestInitSegmentPrivateInfos;
-  localManifestSegment? : ILocalManifestSegmentPrivateInfos;
-  isEMSGWhitelisted? : (evt: IEMSG) => boolean;
+  smoothInitSegment? : ISmoothInitSegmentPrivateInfos | undefined;
+  smoothMediaSegment? : ISmoothSegmentPrivateInfos | undefined;
+  metaplaylistInfos? : IMetaPlaylistPrivateInfos | undefined;
+  localManifestInitSegment? : ILocalManifestInitSegmentPrivateInfos | undefined;
+  localManifestSegment? : ILocalManifestSegmentPrivateInfos | undefined;
+  isEMSGWhitelisted? : ((evt: IEMSG) => boolean) | undefined;
 }
 
 /** Represent a single Segment from a Representation. */
@@ -149,24 +149,24 @@ export interface ISegment {
    * contain an index describing other Segments
    * TODO put in privateInfos?
    */
-  indexRange? : [number, number];
+  indexRange? : [number, number] | undefined;
   /**
    * Optional number of the Segment
    * TODO put in privateInfos?
    */
-  number? : number;
+  number? : number | undefined;
   /**
    * Allows to store supplementary information on a segment that can be later
    * exploited by the transport logic.
    */
-  privateInfos? : IPrivateInfos;
+  privateInfos? : IPrivateInfos | undefined;
   /** Optional byte range to retrieve the Segment from its URL(s) */
-  range? : [number, number];
+  range? : [number, number] | undefined;
   /**
    * Estimated time, in seconds, at which the concerned segment should be
    * offseted when decoded.
    */
-  timestampOffset? : number;
+  timestampOffset? : number | undefined;
   /**
    * Estimated start time for the segment, in seconds.
    * Note that some rounding errors and some differences between what the

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -39,7 +39,7 @@ export interface IHDRInformation {
    * It is used to ask to the user agent if the color depth is supported by the
    * output device.
    */
-  colorDepth?: number;
+  colorDepth? : number | undefined;
   /**
    * It is the HDR eotf. It is the transfer function having the video signal as
    * input and converting it into the linear light output of the display. The
@@ -47,14 +47,14 @@ export interface IHDRInformation {
    *
    * It may be used here to ask the MediaSource if it supported.
    */
-  eotf?: string;
+  eotf? : string | undefined;
   /**
    * It is the video color space used for encoding. An HDR content may not have
    * a wide color gamut.
    *
    * It may be used to ask about output device color space support.
    */
-  colorSpace?: string;
+  colorSpace? : string | undefined;
 }
 
 /** Manifest, as documented in the API documentation. */

--- a/src/parsers/manifest/dash/common/__tests__/manifest_bounds_calculator.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/manifest_bounds_calculator.test.ts
@@ -46,6 +46,7 @@ describe("DASH parsers - ManifestBoundsCalculator", () => {
   /* eslint-enable max-len */
     const manifestBoundsCalculator = new ManifestBoundsCalculator({
       isDynamic: false,
+      timeShiftBufferDepth: undefined,
     });
     expect(manifestBoundsCalculator.estimateMinimumBound()).toEqual(0);
     expect(manifestBoundsCalculator.estimateMinimumBound()).toEqual(0);

--- a/src/parsers/manifest/dash/common/get_hdr_information.ts
+++ b/src/parsers/manifest/dash/common/get_hdr_information.ts
@@ -39,7 +39,7 @@ export interface IParsedWEBMHDRInformation {
    *
    * It may be used to ask about output device color space support.
    */
-  colorSpace?: "rec2020";
+  colorSpace: "rec2020" | undefined;
 }
 
 /**

--- a/src/parsers/manifest/dash/common/get_periods_time_infos.ts
+++ b/src/parsers/manifest/dash/common/get_periods_time_infos.ts
@@ -21,9 +21,9 @@ interface IPeriodTimeInformation {
   /** Time in seconds at which the Period starts. */
   periodStart: number;
   /** Difference in seconds between the Period's end and its start. */
-  periodDuration?: number;
+  periodDuration?: number | undefined;
   /** Time in seconds at which the Period ends. */
-  periodEnd?: number;
+  periodEnd?: number | undefined;
 }
 
 /** Additionnal context needed to retrieve the period time information. */
@@ -31,7 +31,7 @@ export interface IParsedPeriodsContext {
   /** Value of MPD@availabilityStartTime. */
   availabilityStartTime : number;
   /** Value of MPD@mediaPresentationDuration. */
-  duration? : number;
+  duration? : number | undefined;
   /** `true` if MPD@type is equal to "dynamic". */
   isDynamic : boolean;
 }

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -38,7 +38,7 @@ import { createIndexURLs } from "./tokens";
  */
 export interface IBaseIndex {
   /** Byte range for a possible index of segments in the server. */
-  indexRange?: [number, number];
+  indexRange?: [number, number] | undefined;
   /**
    * Temporal offset, in the current timescale (see timescale), to add to the
    * presentation time (time a segment has at decoding time) to obtain the
@@ -57,15 +57,15 @@ export interface IBaseIndex {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
-    range?: [number, number];
-  };
+    range?: [number, number] | undefined;
+  } | undefined;
   /**
    * Base URL(s) to access any segment. Can contain tokens to replace to convert
    * it to real URLs.
    */
   mediaURLs : string[] | null;
   /** Number from which the first segments in this index starts with. */
-  startNumber? : number;
+  startNumber? : number | undefined;
   /** Every segments defined in this index. */
   timeline : IIndexSegment[];
   /**
@@ -113,9 +113,9 @@ export interface IBaseIndexContextArgument {
   /** Base URL for the Representation concerned. */
   representationBaseURLs : IResolvedBaseUrl[];
   /** ID of the Representation concerned. */
-  representationId? : string;
+  representationId? : string | undefined;
   /** Bitrate of the Representation concerned. */
-  representationBitrate? : number;
+  representationBitrate? : number | undefined;
   /* Function that tells if an EMSG is whitelisted by the manifest */
   isEMSGWhitelisted: (inbandEvent: IEMSG) => boolean;
 }

--- a/src/parsers/manifest/dash/common/indexes/get_init_segment.ts
+++ b/src/parsers/manifest/dash/common/indexes/get_init_segment.ts
@@ -25,8 +25,10 @@ import { IEMSG } from "../../../../containers/isobmff";
  */
 export default function getInitSegment(
   index: { timescale: number;
-           initialization?: { mediaURLs: string[] | null; range?: [number, number] };
-           indexRange?: [number, number];
+           initialization?: { mediaURLs: string[] | null;
+                              range?: [number, number] | undefined; } |
+                            undefined;
+           indexRange?: [number, number] | undefined;
            indexTimeOffset : number; },
   isEMSGWhitelisted?: (inbandEvent: IEMSG) => boolean
 ) : ISegment {

--- a/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
@@ -52,9 +52,9 @@ function getWantedRepeatIndex(
  * @returns {Array.<Object>}
  */
 export default function getSegmentsFromTimeline(
-  index : { availabilityTimeComplete? : boolean;
+  index : { availabilityTimeComplete? : boolean | undefined;
             mediaURLs : string[] | null;
-            startNumber? : number;
+            startNumber? : number | undefined;
             timeline : IIndexSegment[];
             timescale : number;
             indexTimeOffset : number; },

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -37,7 +37,7 @@ export interface IListIndex {
    */
   duration : number;
   /** Byte range for a possible index of segments in the server. */
-  indexRange?: [number, number];
+  indexRange?: [number, number] | undefined;
   /**
    * Temporal offset, in the current timescale (see timescale), to add to the
    * presentation time (time a segment has at decoding time) to obtain the
@@ -56,14 +56,14 @@ export interface IListIndex {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
-    range?: [number, number];
-  };
+    range?: [number, number] | undefined;
+  } | undefined;
   /** Information on the list of segments for this index. */
   list: Array<{
     /** URLs of the segment. */
     mediaURLs : string[] | null;
     /** Possible byte-range of the segment. */
-    mediaRange? : [number, number];
+    mediaRange? : [number, number] | undefined;
   }>;
   /**
    * Timescale to convert a time given here into seconds.
@@ -78,12 +78,12 @@ export interface IListIndex {
  * Most of the properties here are already defined in IListIndex.
  */
 export interface IListIndexIndexArgument {
-  duration? : number;
-  indexRange?: [number, number];
-  initialization?: { media? : string;
-                     range? : [number, number]; };
-  list: Array<{ media? : string;
-                mediaRange? : [number, number]; }>;
+  duration? : number | undefined;
+  indexRange?: [number, number] | undefined;
+  initialization?: { media? : string | undefined;
+                     range? : [number, number] | undefined; };
+  list: Array<{ media? : string | undefined;
+                mediaRange? : [number, number] | undefined; }>;
   /**
    * Offset present in the index to convert from the mediaTime (time declared in
    * the media segments and in this index) to the presentationTime (time wanted
@@ -98,8 +98,8 @@ export interface IListIndexIndexArgument {
    * The time given here is in the current
    * timescale (see timescale)
    */
-  presentationTimeOffset? : number;
-  timescale? : number;
+  presentationTimeOffset? : number | undefined;
+  timescale? : number | undefined;
 }
 
 /** Aditional context needed by a SegmentList RepresentationIndex. */
@@ -109,9 +109,9 @@ export interface IListIndexContextArgument {
   /** Base URL for the Representation concerned. */
   representationBaseURLs : IResolvedBaseUrl[];
   /** ID of the Representation concerned. */
-  representationId? : string;
+  representationId? : string | undefined;
   /** Bitrate of the Representation concerned. */
-  representationBitrate? : number;
+  representationBitrate? : number | undefined;
   /* Function that tells if an EMSG is whitelisted by the manifest */
   isEMSGWhitelisted: (inbandEvent: IEMSG) => boolean;
 }

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -49,14 +49,14 @@ export interface ITemplateIndex {
    */
   timescale : number;
   /** Byte range for a possible index of segments in the server. */
-  indexRange?: [number, number];
+  indexRange?: [number, number] | undefined;
   /** Information on the initialization segment. */
   initialization? : {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
-    range?: [number, number];
-  };
+    range?: [number, number] | undefined;
+  } | undefined;
   /**
    * URL base to access any segment.
    * Can contain token to replace to convert it to real URLs.
@@ -91,7 +91,7 @@ export interface ITemplateIndex {
    */
   presentationTimeOffset : number;
   /** Number from which the first segments in this index starts with. */
-  startNumber? : number;
+  startNumber? : number | undefined;
 }
 
 /**
@@ -99,14 +99,15 @@ export interface ITemplateIndex {
  * Most of the properties here are already defined in ITemplateIndex.
  */
 export interface ITemplateIndexIndexArgument {
-  duration? : number;
-  indexRange?: [number, number];
-  initialization?: { media? : string;
-                     range? : [number, number]; };
-  media? : string;
-  presentationTimeOffset? : number;
-  startNumber? : number;
-  timescale? : number;
+  duration? : number | undefined;
+  indexRange?: [number, number] | undefined;
+  initialization?: { media? : string | undefined;
+                     range? : [number, number] | undefined; } |
+                   undefined;
+  media? : string | undefined;
+  presentationTimeOffset? : number | undefined;
+  startNumber? : number | undefined;
+  timescale? : number | undefined;
 }
 
 /** Aditional context needed by a SegmentTemplate RepresentationIndex. */
@@ -125,9 +126,9 @@ export interface ITemplateIndexContextArgument {
   /** Base URL for the Representation concerned. */
   representationBaseURLs : IResolvedBaseUrl[];
   /** ID of the Representation concerned. */
-  representationId? : string;
+  representationId? : string | undefined;
   /** Bitrate of the Representation concerned. */
-  representationBitrate? : number;
+  representationBitrate? : number | undefined;
   /* Function that tells if an EMSG is whitelisted by the manifest */
   isEMSGWhitelisted: (inbandEvent: IEMSG) => boolean;
 }
@@ -150,9 +151,9 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
   /** Absolute start of the Period, in seconds. */
   private _periodStart : number;
   /** Difference between the end time of the Period and its start time, in timescale. */
-  private _scaledPeriodEnd? : number;
+  private _scaledPeriodEnd : number | undefined;
   /** Minimum availabilityTimeOffset concerning the segments of this Representation. */
-  private _availabilityTimeOffset? : number;
+  private _availabilityTimeOffset : number | undefined;
   /** Whether the corresponding Manifest can be updated and changed. */
   private _isDynamic : boolean;
   /* Function that tells if an EMSG is whitelisted by the manifest */

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -58,7 +58,7 @@ export interface ITimelineIndex {
   /** If `false`, the last segment anounced might be still incomplete. */
   availabilityTimeComplete : boolean;
   /** Byte range for a possible index of segments in the server. */
-  indexRange?: [number, number];
+  indexRange?: [number, number] | undefined;
   /**
    * Temporal offset, in the current timescale (see timescale), to add to the
    * presentation time (time a segment has at decoding time) to obtain the
@@ -77,15 +77,15 @@ export interface ITimelineIndex {
     /** URLs to access the initialization segment. */
     mediaURLs: string[] | null;
     /** possible byte range to request it. */
-    range?: [number, number];
-  };
+    range?: [number, number] | undefined;
+  } | undefined;
   /**
    * Base URL(s) to access any segment. Can contain tokens to replace to convert
    * it to real URLs.
    */
   mediaURLs : string[] | null ;
   /** Number from which the first segments in this index starts with. */
-  startNumber? : number;
+  startNumber? : number | undefined;
   /**
    * Every segments defined in this index.
    * `null` at the beginning as this property is parsed lazily (only when first
@@ -117,11 +117,13 @@ export interface ITimelineIndex {
  * Most of the properties here are already defined in ITimelineIndex.
  */
 export interface ITimelineIndexIndexArgument {
-  indexRange?: [number, number];
-  initialization? : { media? : string; range?: [number, number] };
-  media? : string;
-  startNumber? : number;
-  timescale? : number;
+  indexRange?: [number, number] | undefined;
+  initialization? : { media? : string | undefined;
+                      range?: [number, number] | undefined; } |
+                    undefined;
+  media? : string | undefined;
+  startNumber? : number | undefined;
+  timescale? : number | undefined;
   /**
    * Offset present in the index to convert from the mediaTime (time declared in
    * the media segments and in this index) to the presentationTime (time wanted
@@ -136,10 +138,10 @@ export interface ITimelineIndexIndexArgument {
    * The time given here is in the current
    * timescale (see timescale)
    */
-  presentationTimeOffset? : number;
+  presentationTimeOffset? : number | undefined;
 
-  timelineParser? : () => HTMLCollection;
-  timeline? : ISegmentTimelineElement[];
+  timelineParser? : (() => HTMLCollection) | undefined;
+  timeline? : ISegmentTimelineElement[] | undefined;
 }
 
 /** Aditional context needed by a SegmentTimeline RepresentationIndex. */
@@ -158,13 +160,13 @@ export interface ITimelineIndexContextArgument {
    * Time (in terms of `performance.now`) at which the XML file containing this
    * index was received
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Base URL for the Representation concerned. */
   representationBaseURLs : IResolvedBaseUrl[];
   /** ID of the Representation concerned. */
-  representationId? : string;
+  representationId? : string | undefined;
   /** Bitrate of the Representation concerned. */
-  representationBitrate? : number;
+  representationBitrate? : number | undefined;
   /**
    * The parser should take this previous version of the
    * `TimelineRepresentationIndex` - which was from the same Representation
@@ -180,7 +182,7 @@ export interface ITimelineIndexContextArgument {
 
 export interface ILastSegmentInformation {
   /** End of the timeline on `time`, timescaled. */
-  lastPosition? : number;
+  lastPosition? : number | undefined;
 
   /** Defines the time at which `lastPosition` was last calculated. */
   time : number;

--- a/src/parsers/manifest/dash/common/infer_adaptation_type.ts
+++ b/src/parsers/manifest/dash/common/infer_adaptation_type.ts
@@ -30,8 +30,8 @@ const SUPPORTED_TEXT_TYPES = ["subtitle", "caption"];
 
 /** Structure of a parsed "scheme-like" element in the MPD. */
 interface IScheme {
-  schemeIdUri? : string;
-  value? : string;
+  schemeIdUri? : string | undefined;
+  value? : string | undefined;
 }
 
 /**

--- a/src/parsers/manifest/dash/common/manifest_bounds_calculator.ts
+++ b/src/parsers/manifest/dash/common/manifest_bounds_calculator.ts
@@ -47,7 +47,7 @@ export default class ManifestBoundsCalculator {
   /**
    * @param {Object} args
    */
-  constructor(args : { timeShiftBufferDepth? : number;
+  constructor(args : { timeShiftBufferDepth : number | undefined;
                        isDynamic : boolean; }
   ) {
     this._isDynamic = args.isDynamic;

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -51,22 +51,22 @@ export interface IAdaptationSetsContextInfos {
   /** Allows to obtain the first available position of a content. */
   manifestBoundsCalculator : ManifestBoundsCalculator;
   /* End time of the current period, in seconds. */
-  end? : number;
+  end? : number | undefined;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
   /** Manifest DASH profiles used for signaling some features */
-  manifestProfiles?: string;
+  manifestProfiles?: string | undefined;
   /**
    * Time (in terms of `performance.now`) at which the XML file containing
    * this AdaptationSet was received.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** SegmentTemplate parsed in the Period, if found. */
-  segmentTemplate? : ISegmentTemplateIntermediateRepresentation;
+  segmentTemplate? : ISegmentTemplateIntermediateRepresentation | undefined;
   /** Start time of the current period, in seconds. */
   start : number;
   /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number;
+  timeShiftBufferDepth? : number | undefined;
   /**
    * The parser should take this Period - which is from a previously parsed
    * Manifest for the same dynamic content - as a base to speed-up the parsing
@@ -121,9 +121,11 @@ interface IAdaptationSwitchingInfos  {
  * @returns {Boolean}
  */
 function isVisuallyImpaired(
-  accessibility? : { schemeIdUri? : string; value? : string }
+  accessibility : { schemeIdUri? : string | undefined;
+                    value? : string | undefined; } |
+                  undefined
 ) : boolean {
-  if (accessibility == null) {
+  if (accessibility === undefined) {
     return false;
   }
 
@@ -148,9 +150,11 @@ function isVisuallyImpaired(
  * @returns {Boolean}
  */
 function isHardOfHearing(
-  accessibility? : { schemeIdUri? : string; value? : string }
+  accessibility : { schemeIdUri? : string | undefined;
+                    value? : string | undefined; } |
+                  undefined
 ) : boolean {
-  if (accessibility == null) {
+  if (accessibility === undefined) {
     return false;
   }
 
@@ -166,9 +170,11 @@ function isHardOfHearing(
  * @returns {Boolean}
  */
 function hasSignLanguageInterpretation(
-  accessibility? : { schemeIdUri? : string; value? : string }
+  accessibility : { schemeIdUri? : string | undefined;
+                    value? : string | undefined; } |
+                  undefined
 ) : boolean {
-  if (accessibility == null) {
+  if (accessibility === undefined) {
     return false;
   }
 

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -47,11 +47,11 @@ export interface IMPDParserArguments {
    * If set, offset to add to `performance.now()` to obtain the current server's
    * time.
    */
-  externalClockOffset? : number;
+  externalClockOffset? : number | undefined;
   /** Time, in terms of `performance.now` at which this MPD was received. */
-  manifestReceivedTime? : number;
+  manifestReceivedTime? : number | undefined;
   /** Default base time, in seconds. */
-  referenceDateTime? : number;
+  referenceDateTime? : number | undefined;
   /**
    * The parser should take this Manifest - which is a previously parsed
    * Manifest for the same dynamic content - as a base to speed-up the parsing
@@ -62,13 +62,13 @@ export interface IMPDParserArguments {
    */
   unsafelyBaseOnPreviousManifest : Manifest | null;
   /** URL of the manifest (post-redirection if one). */
-  url? : string;
+  url? : string | undefined;
 }
 
 export interface ILoadedXlinkData {
-  url? : string;
-  sendingTime? : number;
-  receivedTime? : number;
+  url? : string | undefined;
+  sendingTime? : number | undefined;
+  receivedTime? : number | undefined;
   parsed : IPeriodIntermediateRepresentation[];
   warnings : Error[];
 }
@@ -127,7 +127,7 @@ export default function parseMpdIr(
   mpdIR : IMPDIntermediateRepresentation,
   args : IMPDParserArguments,
   warnings : Error[],
-  hasLoadedClock? : boolean,
+  hasLoadedClock? : boolean | undefined,
   xlinkInfos : IXLinkInfos = new WeakMap()
 ) : IIrParserResponse {
   const { children: rootChildren,

--- a/src/parsers/manifest/dash/common/parse_periods.ts
+++ b/src/parsers/manifest/dash/common/parse_periods.ts
@@ -44,11 +44,11 @@ const generatePeriodID = idGenerator();
 /** Information about each linked Xlink. */
 export type IXLinkInfos = WeakMap<IPeriodIntermediateRepresentation, {
   /** Real URL (post-redirection) used to download this xlink. */
-  url? : string;
+  url? : string | undefined;
   /** Time at which the request was sent (since the time origin), in ms. */
-  sendingTime? : number;
+  sendingTime? : number | undefined;
   /** Time at which the request was received (since the time origin), in ms. */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
 }>;
 
 /** Context needed when calling `parsePeriods`. */
@@ -57,17 +57,17 @@ export interface IPeriodsContextInfos {
   aggressiveMode : boolean;
   availabilityStartTime : number;
   baseURLs : IResolvedBaseUrl[];
-  clockOffset? : number;
-  duration? : number;
+  clockOffset? : number | undefined;
+  duration? : number | undefined;
   isDynamic : boolean;
-  manifestProfiles?: string;
+  manifestProfiles?: string | undefined;
   /**
    * Time (in terms of `performance.now`) at which the XML file containing this
    * Period was received.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number;
+  timeShiftBufferDepth? : number | undefined;
   /**
    * The parser should take this Manifest - which is a previously parsed
    * Manifest for the same dynamic content - as a base to speed-up the parsing
@@ -85,7 +85,7 @@ export interface IPeriodsContextInfos {
    * Document form.
    */
   xmlNamespaces? : Array<{ key : string;
-                           value : string; }>;
+                           value : string; }> | undefined;
 }
 
 /**

--- a/src/parsers/manifest/dash/common/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/common/parse_representation_index.ts
@@ -51,7 +51,7 @@ export interface IRepresentationInfos {
   /** Allows to obtain the first/last available position of a dynamic content. */
   manifestBoundsCalculator : ManifestBoundsCalculator;
   /** End time of the current period, in seconds. */
-  end? : number;
+  end? : number | undefined;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
   /**
@@ -64,11 +64,11 @@ export interface IRepresentationInfos {
    * Time (in terms of `performance.now`) at which the XML file containing this
    * Representation was received.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Start time of the current period, in seconds. */
   start : number;
   /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number;
+  timeShiftBufferDepth? : number | undefined;
   /**
    * The parser should take this Representation - which is the same as this one
    * parsed at an earlier time - as a base to speed-up the parsing process.

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -71,11 +71,11 @@ export interface IAdaptationInfos {
   /** Allows to obtain the first/last available position of a dynamic content. */
   manifestBoundsCalculator : ManifestBoundsCalculator;
   /** End time of the current period, in seconds. */
-  end? : number;
+  end? : number | undefined;
   /** Whether the Manifest can evolve with time. */
   isDynamic : boolean;
   /** Manifest DASH profiles used for signalling some features */
-  manifestProfiles?: string;
+  manifestProfiles?: string | undefined;
   /**
    * Parent parsed SegmentTemplate elements.
    * Sorted by provenance from higher level (e.g. Period) to lower-lever (e.g.
@@ -86,11 +86,11 @@ export interface IAdaptationInfos {
    * Time (in terms of `performance.now`) at which the XML file containing this
    * Representation was received.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Start time of the current period, in seconds. */
   start : number;
   /** Depth of the buffer for the whole content, in seconds. */
-  timeShiftBufferDepth? : number;
+  timeShiftBufferDepth? : number | undefined;
   /**
    * The parser should take this Adaptation - which is from a previously parsed
    * Manifest for the same dynamic content - as a base to speed-up the parsing
@@ -111,9 +111,9 @@ function getHDRInformation(
   { adaptationProfiles,
     manifestProfiles,
     codecs,
-  }: { adaptationProfiles?: string;
-       manifestProfiles?: string;
-       codecs?: string; }
+  }: { adaptationProfiles?: string | undefined;
+       manifestProfiles?: string | undefined;
+       codecs?: string | undefined; }
 ): undefined | IHDRInformation {
   const profiles = (adaptationProfiles ?? "") + (manifestProfiles ?? "");
   if (codecs === undefined) {

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -131,7 +131,7 @@ export interface IPeriodChildren {
   /**
    * Provide a template with which we will be able to request segments.
    */
-  segmentTemplate? : ISegmentTemplateIntermediateRepresentation;
+  segmentTemplate? : ISegmentTemplateIntermediateRepresentation | undefined;
   /**
    * Allows to signal events linked to this Period.
    *
@@ -189,17 +189,17 @@ export interface IAdaptationSetChildren {
   representations : IRepresentationIntermediateRepresentation[];
 
   // optional
-  accessibilities? : IScheme[];
-  contentComponent? : IContentComponentAttributes;
-  contentProtections? : IContentProtectionIntermediateRepresentation[];
-  essentialProperties? : IScheme[];
-  inbandEventStreams? : IScheme[];
+  accessibilities? : IScheme[] | undefined;
+  contentComponent? : IContentComponentAttributes | undefined;
+  contentProtections? : IContentProtectionIntermediateRepresentation[] | undefined;
+  essentialProperties? : IScheme[] | undefined;
+  inbandEventStreams? : IScheme[] | undefined;
   roles? : IScheme[];
-  supplementalProperties? : IScheme[];
+  supplementalProperties? : IScheme[] | undefined;
 
-  segmentBase? : ISegmentBaseIntermediateRepresentation;
-  segmentList? : ISegmentListIntermediateRepresentation;
-  segmentTemplate? : ISegmentTemplateIntermediateRepresentation;
+  segmentBase? : ISegmentBaseIntermediateRepresentation | undefined;
+  segmentList? : ISegmentListIntermediateRepresentation | undefined;
+  segmentTemplate? : ISegmentTemplateIntermediateRepresentation | undefined;
 }
 
 /* Intermediate representation for An AdaptationSet node's attributes. */
@@ -336,20 +336,20 @@ export interface IContentProtectionAttributes {
 }
 
 export interface ISegmentTemplateIntermediateRepresentation {
-  availabilityTimeComplete? : boolean;
-  availabilityTimeOffset?: number;
-  bitstreamSwitching? : boolean;
-  duration? : number;
-  index? : string;
-  indexRange?: [number, number];
-  indexRangeExact? : boolean;
-  media? : string;
-  presentationTimeOffset? : number;
-  startNumber? : number;
-  timescale? : number;
-  initialization? : { media?: string };
-  timeline? : ISegmentTimelineElement[];
-  timelineParser? : ITimelineParser;
+  availabilityTimeComplete? : boolean | undefined;
+  availabilityTimeOffset? : number | undefined;
+  bitstreamSwitching? : boolean | undefined;
+  duration? : number | undefined;
+  index? : string | undefined;
+  indexRange?: [number, number] | undefined;
+  indexRangeExact? : boolean | undefined;
+  media? : string | undefined;
+  presentationTimeOffset? : number | undefined;
+  startNumber? : number | undefined;
+  timescale? : number | undefined;
+  initialization? : { media?: string } | undefined;
+  timeline? : ISegmentTimelineElement[] | undefined;
+  timelineParser? : ITimelineParser | undefined;
 }
 
 export interface ISegmentTimelineElement {
@@ -382,9 +382,9 @@ export interface IScheme {
    *
    * `undefined` if no `schemeIdUri` attribute has been found.
    */
-  schemeIdUri? : string;
+  schemeIdUri? : string | undefined;
   /** Inner content of that scheme. */
-  value? : string;
+  value? : string | undefined;
 }
 
 export interface IEventStreamIntermediateRepresentation {
@@ -395,9 +395,9 @@ export interface IEventStreamIntermediateRepresentation {
 }
 
 export interface IEventStreamAttributes {
-  schemeIdUri? : string;
-  timescale? : number;
-  value? : string;
+  schemeIdUri? : string | undefined;
+  timescale? : number | undefined;
+  value? : string | undefined;
 
   /**
    * XML namespaces linked to the `<EventStream>` element.
@@ -406,7 +406,7 @@ export interface IEventStreamAttributes {
    * not parsed through the browser's DOMParser API, and thus might depend on
    * parent namespaces to be parsed correctly.
    */
-  namespaces? : Array<{ key: string; value: string }>;
+  namespaces? : Array<{ key: string; value: string }> | undefined;
 }
 
 export interface IEventStreamChildren {

--- a/src/parsers/manifest/dash/parsers_types.ts
+++ b/src/parsers/manifest/dash/parsers_types.ts
@@ -71,19 +71,19 @@ export interface ILoadedResource<T extends string | ArrayBuffer> {
    * The URL of the loaded resource (post-redirection if one).
    * `undefined` if unknown or inexistant.
    */
-  url? : string;
+  url? : string | undefined;
   /**
    * The time, in terms of `performance.now()`, at which the resource was
    * starting to be fetched.
    * `undefined` if unknown or not applicable.
    */
-  sendingTime? : number;
+  sendingTime? : number | undefined;
   /**
    * The time, in terms of `performance.now()`, at which the resource was
    * fully-fetched.
    * `undefined` if unknown or not applicable.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** The loaded resource itself, under the right format.
    * Or an error, when fetching ressources.
    */

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -69,11 +69,11 @@ export interface IMetaPlaylist {
 export default function parseMetaPlaylist(
   data : unknown,
   parserOptions : {
-    url?: string;
+    url?: string | undefined;
     serverSyncInfos?: {
       serverTimestamp: number;
       clientTime: number;
-    };
+    } | undefined;
   }
 ): IParserResponse<IParsedManifest> {
   let parsedData;
@@ -147,9 +147,9 @@ export default function parseMetaPlaylist(
 function createManifest(
   mplData : IMetaPlaylist,
   manifests : Manifest[],
-  parserOptions:  { url?: string;
+  parserOptions:  { url?: string | undefined;
                     serverSyncInfos?: { serverTimestamp: number;
-                                        clientTime: number; }; }
+                                        clientTime: number; } | undefined; }
 ): IParsedManifest {
   const { url, serverSyncInfos } = parserOptions;
   const clockOffset = serverSyncInfos !== undefined ?

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -64,8 +64,8 @@ interface IAdaptationParserArguments { root : Element;
                                        timescale : number;
                                        protections : IContentProtectionSmooth[];
                                        isLive : boolean;
-                                       timeShiftBufferDepth? : number;
-                                       manifestReceivedTime? : number; }
+                                       timeShiftBufferDepth? : number | undefined;
+                                       manifestReceivedTime? : number | undefined; }
 
 type IAdaptationType = "audio" |
                        "video" |
@@ -86,15 +86,15 @@ const MIME_TYPES : Partial<Record<string, string>> = {
 };
 
 export interface IHSSParserConfiguration {
-  aggressiveMode? : boolean;
-  suggestedPresentationDelay? : number;
-  referenceDateTime? : number;
-  minRepresentationBitrate? : number;
-  keySystems? : (hex? : Uint8Array) => IKeySystem[];
+  aggressiveMode? : boolean | undefined;
+  suggestedPresentationDelay? : number | undefined;
+  referenceDateTime? : number | undefined;
+  minRepresentationBitrate? : number | undefined;
+  keySystems? : ((hex : Uint8Array | undefined) => IKeySystem[]) | undefined;
   serverSyncInfos? : {
     serverTimestamp: number;
     clientTime: number;
-  };
+  } | undefined;
 }
 
 interface ISmoothParsedQualityLevel {
@@ -104,16 +104,16 @@ interface ISmoothParsedQualityLevel {
   customAttributes : string[];
 
   // optional
-  audiotag? : number;
-  bitsPerSample? : number;
-  channels? : number;
-  codecs? : string;
-  height? : number;
-  id? : string;
-  mimeType? : string;
-  packetSize? : number;
-  samplingRate? : number;
-  width? : number;
+  audiotag? : number | undefined;
+  bitsPerSample? : number | undefined;
+  channels? : number | undefined;
+  codecs? : string | undefined;
+  height? : number | undefined;
+  id? : string | undefined;
+  mimeType? : string | undefined;
+  packetSize? : number | undefined;
+  samplingRate? : number | undefined;
+  width? : number | undefined;
 }
 
 /**
@@ -122,9 +122,11 @@ interface ISmoothParsedQualityLevel {
  */
 function createSmoothStreamingParser(
   parserOptions : IHSSParserConfiguration = {}
-) : (manifest : Document, url? : string, manifestReceivedTime? : number)
-  => IParsedManifest
-{
+) : (
+    manifest : Document,
+    url? : string | undefined,
+    manifestReceivedTime? : number | undefined
+  ) => IParsedManifest {
   const referenceDateTime = parserOptions.referenceDateTime === undefined ?
     Date.UTC(1970, 0, 1, 0, 0, 0, 0) / 1000 :
     parserOptions.referenceDateTime;

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -178,12 +178,12 @@ export interface ISmoothRepresentationIndexContextInformation {
 
 /** Information allowing to generate a Smooth initialization segment. */
 interface ISmoothInitSegmentPrivateInfos {
-  bitsPerSample? : number;
-  channels? : number;
-  codecPrivateData? : string;
-  packetSize? : number;
-  samplingRate? : number;
-  protection? : { keyId : Uint8Array };
+  bitsPerSample? : number | undefined;
+  channels? : number | undefined;
+  codecPrivateData? : string | undefined;
+  packetSize? : number | undefined;
+  samplingRate? : number | undefined;
+  protection? : { keyId : Uint8Array } | undefined;
 }
 
 /**
@@ -198,13 +198,13 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * Information needed to generate an initialization segment.
    * Taken from the Manifest.
    */
-  private _initSegmentInfos : { codecPrivateData? : string;
-                                bitsPerSample? : number;
-                                channels? : number;
-                                packetSize? : number;
-                                samplingRate? : number;
+  private _initSegmentInfos : { codecPrivateData? : string | undefined;
+                                bitsPerSample? : number | undefined;
+                                channels? : number | undefined;
+                                packetSize? : number | undefined;
+                                samplingRate? : number | undefined;
                                 timescale : number;
-                                protection? : { keyId : Uint8Array }; };
+                                protection? : { keyId : Uint8Array } | undefined; };
 
   /**
    * if `true`, this class will return segments even if we're not sure they had
@@ -225,13 +225,13 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
    * Useful to know if a segment present in the timeline has actually been
    * generated on the server-side
    */
-  private _scaledLiveGap? : number;
+  private _scaledLiveGap : number | undefined;
 
   /**
    * Defines the end of the latest available segment when this index was known to
    * be valid, in the index's timescale.
    */
-  private _initialScaledLastPosition? : number;
+  private _initialScaledLastPosition : number | undefined;
 
   /**
    * Defines the earliest time when this index was known to be valid (that is, when

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -18,8 +18,8 @@ import { IRepresentationIndex } from "../../manifest";
 import { IHDRInformation } from "../../manifest/types";
 
 export interface IManifestStreamEvent { start: number;
-                                        end?: number;
-                                        id?: string;
+                                        end?: number | undefined;
+                                        id?: string | undefined;
                                         data: IParsedStreamEventData; }
 
 export interface IParsedStreamEventData {
@@ -33,7 +33,7 @@ export interface IParsedStreamEventData {
 
 /** Describes information about an encryption Key ID of a given media. */
 export interface IContentProtectionKID { keyId : Uint8Array;
-                                         systemId?: string; }
+                                         systemId?: string | undefined; }
 
 /**
  * Encryption initialization data.
@@ -92,37 +92,37 @@ export interface IParsedRepresentation {
   id: string;
 
   /** Codec(s) associated with this Representation. */
-  codecs?: string;
+  codecs?: string | undefined;
   /**
    * Information about the encryption associated with this Representation.
    * Not set if unknown or if the content is not encrypted.
    */
-  contentProtections? : IContentProtections;
+  contentProtections? : IContentProtections | undefined;
   /**
    * Frame rate (images per seconds) associated with this Representation.
    * Not set if unknown or if it makes no sense (e.g. for subtitles).
    */
-  frameRate?: string;
+  frameRate?: string | undefined;
   /**
    * Height (top to bottom) in pixels this Representation has.
    * Not set if unknown or if it makes no sense (e.g. for audio).
    */
-  height?: number;
+  height?: number | undefined;
   /**
    * Defines the mime-type of the content.
    * This allows to deduce the media container but most of the time, the
    * `codecs` will also be needed to know how to decode that media.
    */
-  mimeType?: string;
+  mimeType?: string | undefined;
   /**
    * Width (left to right) in pixels this Representation has.
    * Not set if unknown or if it makes no sense (e.g. for audio).
    */
-  width?: number;
+  width?: number | undefined;
   /**
    * Information about the HDR characteristic of a content.
    */
-  hdrInfo?: IHDRInformation;
+  hdrInfo?: IHDRInformation | undefined;
 }
 
 /** Every possible types an Adaptation can have. */
@@ -155,34 +155,34 @@ export interface IParsedAdaptation {
    * Not set if unknown or if it makes no sense for the current track (e.g. for
    * a video track).
    */
-  audioDescription? : boolean;
+  audioDescription? : boolean | undefined;
   /**
    * Whether this Adaptation are closed captions for the hard of hearing.
    * Not set if unknown or if it makes no sense for the current track (e.g. for
    * a video track).
    */
-  closedCaption? : boolean;
+  closedCaption? : boolean | undefined;
   /**
    * If true this Adaptation is in a dub: it was recorded in another language
    * than the original(s) one(s).
    */
-  isDub? : boolean;
+  isDub? : boolean | undefined;
   /**
    * If true this Adaptation is in a sign interpreted: which is a variant of the
    * video with sign language.
    */
-  isSignInterpreted? : boolean;
+  isSignInterpreted? : boolean | undefined;
   /** Tells if the track is a trick mode track. */
-  isTrickModeTrack? : boolean;
+  isTrickModeTrack? : boolean | undefined;
   /**
    * Language the `Adaptation` is in.
    * Not set if unknown or if it makes no sense for the current track.
    */
-  language?: string;
+  language?: string | undefined;
   /**
    * TrickMode tracks attached to the adaptation.
    */
-  trickModeTracks?: IParsedAdaptation[];
+  trickModeTracks?: IParsedAdaptation[] | undefined;
 }
 
 /** Information on a given period of time in the Manifest */
@@ -205,18 +205,18 @@ export interface IParsedPeriod {
    * Duration of the Period (from the start to the end), in seconds.
    * `undefined` if the Period is the last one and is still being updated.
    */
-  duration? : number;
+  duration? : number | undefined;
   /**
    * Time at which the Period ends, in seconds.
    * `undefined` if the Period is the last one and is still
    * being updated.
    */
-  end? : number;
+  end? : number | undefined;
   /**
    * Array containing every stream event from period in manifest.
    * `undefined` if no parsed stream event in manifest.
    */
-  streamEvents?: IManifestStreamEvent[];
+  streamEvents?: IManifestStreamEvent[] | undefined;
 }
 
 /** Information on the whole content */
@@ -240,23 +240,23 @@ export interface IParsedManifest {
    * The wall-clock time when the manifest was generated and published at the
    * origin server
    */
-  publishTime?: number;
+  publishTime? : number | undefined;
   /** Underlying transport protocol: "smooth", "dash", "metaplaylist" etc. */
   transportType: string;
   /** Base time from which the segments are generated. */
-  availabilityStartTime? : number;
+  availabilityStartTime? : number | undefined;
   /**
    * Offset, in milliseconds, the client's clock (in terms of `performance.now`)
    * has relatively to the server's
    */
-  clockOffset?: number;
+  clockOffset? : number | undefined;
   /** If set, the Manifest needs to be updated when that Promise resolves. */
-  expired? : Promise<void>;
+  expired? : Promise<void> | undefined;
   /**
    * Duration of the validity of this Manifest from its download time.
    * After that time has elapsed, the Manifest should be refreshed.
    */
-  lifetime?: number;
+  lifetime? : number | undefined;
   /**
    * Data allowing to calculate the minimum and maximum seekable positions at
    * any given time.
@@ -266,7 +266,7 @@ export interface IParsedManifest {
      * The minimum time, in seconds, available in this Manifest.
      * `undefined` if that value is unknown.
      */
-    absoluteMinimumTime? : number;
+    absoluteMinimumTime? : number | undefined;
     /**
      * Some dynamic contents have the concept of a "window depth" (or "buffer
      * depth") which allows to set a minimum position for all reachable
@@ -311,8 +311,8 @@ export interface IParsedManifest {
    * Suggested delay from the last position the player should start from by
    * default.
    */
-  suggestedPresentationDelay? : number;
+  suggestedPresentationDelay? : number | undefined;
   /** URIs where the manifest can be refreshed by order of importance. */
-  uris?: string[];
+  uris? : string[] | undefined;
 }
 

--- a/src/parsers/manifest/utils/index_helpers.ts
+++ b/src/parsers/manifest/utils/index_helpers.ts
@@ -28,7 +28,7 @@ export interface IIndexSegment {
    */
   repeatCount: number;
   /** Optional byte-range the segment is available at when requested. */
-  range?: [number, number];
+  range?: [number, number] | undefined;
 }
 
 /**
@@ -42,7 +42,7 @@ export interface IIndexSegment {
 export function calculateRepeat(
   element : IIndexSegment,
   nextElement? : IIndexSegment | null | undefined,
-  maxPosition? : number
+  maxPosition? : number | undefined
 ) : number {
   const { repeatCount } = element;
 

--- a/src/parsers/texttracks/webvtt/html/to_html.ts
+++ b/src/parsers/texttracks/webvtt/html/to_html.ts
@@ -39,10 +39,10 @@ export default function toHTML(
   cueObj : { start : number;
              end : number;
              settings: Partial<Record<string, string>>;
-             header? : string;
+             header? : string | undefined;
              payload : string[]; },
   styling : { classes : IStyleElements;
-              global? : string; }
+              global? : string | undefined; }
 ) : IVTTHTMLCue {
   const { start, end, settings, header, payload } = cueObj;
 

--- a/src/parsers/texttracks/webvtt/parse_cue_block.ts
+++ b/src/parsers/texttracks/webvtt/parse_cue_block.ts
@@ -78,7 +78,7 @@ function parseTimeAndSettings(
 
 export interface IVTTCueObject { start : number;
                                  end : number;
-                                 header? : string;
+                                 header : string | undefined;
                                  settings: Partial<Record<string, string>>;
                                  payload : string[]; }
 

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -94,8 +94,8 @@ export default function generateSegmentLoader(
   { lowLatencyMode,
     segmentLoader: customSegmentLoader,
     checkMediaSegmentIntegrity } : { lowLatencyMode: boolean;
-                                     segmentLoader? : ICustomSegmentLoader;
-                                     checkMediaSegmentIntegrity? : boolean; }
+                                     segmentLoader? : ICustomSegmentLoader | undefined;
+                                     checkMediaSegmentIntegrity? : boolean | undefined; }
 ) : ISegmentLoader<Uint8Array | ArrayBuffer | null> {
   return checkMediaSegmentIntegrity !== true ? segmentLoader :
                                                addSegmentIntegrityChecks(segmentLoader);
@@ -140,8 +140,8 @@ export default function generateSegmentLoader(
        */
       const resolve = (
         _args : { data : ArrayBuffer|Uint8Array;
-                  size? : number;
-                  duration? : number; }
+                  size? : number | undefined;
+                  duration? : number | undefined; }
       ) => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;
@@ -183,7 +183,7 @@ export default function generateSegmentLoader(
       const progress = (
         _args : { duration : number;
                   size : number;
-                  totalSize? : number; }
+                  totalSize? : number | undefined; }
       ) => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -42,7 +42,9 @@ import getEventsOutOfEMSGs from "./get_events_out_of_emsgs";
  * @returns {Function}
  */
 export default function generateAudioVideoSegmentParser(
-  { __priv_patchLastSegmentInSidx } : { __priv_patchLastSegmentInSidx? : boolean }
+  { __priv_patchLastSegmentInSidx } : {
+    __priv_patchLastSegmentInSidx? : boolean | undefined;
+  }
 ) : ISegmentParser<
   ArrayBuffer | Uint8Array | null,
   ArrayBuffer | Uint8Array | null

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -43,7 +43,7 @@ import lowLatencySegmentLoader from "./low_latency_segment_loader";
 export default function generateTextTrackLoader(
   { lowLatencyMode,
     checkMediaSegmentIntegrity } : { lowLatencyMode: boolean;
-                                     checkMediaSegmentIntegrity? : boolean; }
+                                     checkMediaSegmentIntegrity? : boolean | undefined; }
 ) : ISegmentLoader<Uint8Array | ArrayBuffer | string | null> {
   return checkMediaSegmentIntegrity !== true ? textTrackLoader :
                                                addSegmentIntegrityChecks(textTrackLoader);

--- a/src/transports/dash/text_parser.ts
+++ b/src/transports/dash/text_parser.ts
@@ -172,7 +172,9 @@ function parsePlainTextTrack(
  * @returns {Function}
  */
 export default function generateTextTrackParser(
-  { __priv_patchLastSegmentInSidx } : { __priv_patchLastSegmentInSidx? : boolean }
+  { __priv_patchLastSegmentInSidx } : {
+    __priv_patchLastSegmentInSidx? : boolean | undefined;
+  }
 ) : ISegmentParser< ArrayBuffer | Uint8Array | string | null,
                     ITextTrackSegmentData | null > {
   /**

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -43,7 +43,7 @@ function regularManifestLoader(
  * @returns {Function}
  */
 export default function generateManifestLoader(
-  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader }
+  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader | undefined }
 ) : (
     url : string | undefined,
     cancelSignal : CancellationSignal

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -51,7 +51,7 @@ function regularSegmentLoader(
   content : ISegmentContext,
   callbacks : ISegmentLoaderCallbacks<Uint8Array | ArrayBuffer | null>,
   cancelSignal : CancellationSignal,
-  checkMediaSegmentIntegrity? : boolean
+  checkMediaSegmentIntegrity? : boolean | undefined
 ) : Promise<ISegmentLoaderResultSegmentLoaded<Uint8Array | ArrayBuffer | null>> {
   let headers;
   const range = content.segment.range;
@@ -85,8 +85,8 @@ const generateSegmentLoader = ({
   checkMediaSegmentIntegrity,
   customSegmentLoader,
 } : {
-  checkMediaSegmentIntegrity? : boolean;
-  customSegmentLoader? : ICustomSegmentLoader;
+  checkMediaSegmentIntegrity? : boolean | undefined;
+  customSegmentLoader? : ICustomSegmentLoader | undefined;
 }) => (
   url : string | null,
   content : ISegmentContext,
@@ -176,8 +176,8 @@ const generateSegmentLoader = ({
        */
       const resolve = (_args : {
         data : ArrayBuffer|Uint8Array;
-        size? : number;
-        duration? : number;
+        size? : number | undefined;
+        duration? : number | undefined;
       }) => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;
@@ -231,7 +231,7 @@ const generateSegmentLoader = ({
       const progress = (
         _args : { duration : number;
                   size : number;
-                  totalSize? : number; }
+                  totalSize? : number | undefined; }
       ) => {
         if (hasFinished || cancelSignal.isCancelled) {
           return;

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -373,7 +373,7 @@ export interface IManifestParserResult {
    * This property should only be set when a unique URL is sufficient to
    * retrieve the whole data.
    */
-  url? : string;
+  url? : string | undefined;
 }
 
 /**
@@ -416,11 +416,11 @@ export interface ITextTrackSegmentData {
    * This is mostly needed for "sami" subtitles, to know which cues can / should
    * be parsed.
    */
-  language? : string;
+  language? : string | undefined;
   /** start time from which the segment apply, in seconds. */
-  start? : number;
+  start? : number | undefined;
   /** end time until which the segment apply, in seconds. */
-  end? : number;
+  end? : number | undefined;
 }
 
 /** Format under which image data is decodable by the RxPlayer. */
@@ -487,21 +487,21 @@ interface IServerSyncInfos { serverTimestamp : number;
                              clientTime : number; }
 
 export interface ITransportOptions {
-  aggressiveMode? : boolean;
-  checkMediaSegmentIntegrity? : boolean;
+  aggressiveMode? : boolean | undefined;
+  checkMediaSegmentIntegrity? : boolean | undefined;
   lowLatencyMode : boolean;
-  manifestLoader?: ICustomManifestLoader;
-  manifestUpdateUrl? : string;
-  referenceDateTime? : number;
-  representationFilter? : IRepresentationFilter;
-  segmentLoader? : ICustomSegmentLoader;
-  serverSyncInfos? : IServerSyncInfos;
+  manifestLoader?: ICustomManifestLoader | undefined;
+  manifestUpdateUrl? : string | undefined;
+  referenceDateTime? : number | undefined;
+  representationFilter? : IRepresentationFilter | undefined;
+  segmentLoader? : ICustomSegmentLoader | undefined;
+  serverSyncInfos? : IServerSyncInfos | undefined;
   /* eslint-disable import/no-deprecated */
-  supplementaryImageTracks? : ISupplementaryImageTrack[];
-  supplementaryTextTracks? : ISupplementaryTextTrack[];
+  supplementaryImageTracks? : ISupplementaryImageTrack[] | undefined;
+  supplementaryTextTracks? : ISupplementaryTextTrack[] | undefined;
   /* eslint-enable import/no-deprecated */
 
-  __priv_patchLastSegmentInSidx? : boolean;
+  __priv_patchLastSegmentInSidx? : boolean | undefined;
 }
 
 export type ICustomSegmentLoader = (
@@ -532,10 +532,10 @@ export type ICustomManifestLoader = (
 
   // second argument: callbacks
   callbacks : { resolve : (args : { data : ILoadedManifestFormat;
-                                    sendingTime? : number;
-                                    receivingTime? : number;
-                                    size? : number;
-                                    duration? : number; })
+                                    sendingTime? : number | undefined;
+                                    receivingTime? : number | undefined;
+                                    size? : number | undefined;
+                                    duration? : number | undefined; })
                           => void;
 
                  reject : (err? : Error) => void;
@@ -597,7 +597,7 @@ export interface ISegmentLoadingProgressInformation {
   /** Size of the data already downloaded, in bytes. */
   size : number;
   /** Size of whole data to download (data already-loaded included), in bytes. */
-  totalSize? : number;
+  totalSize? : number | undefined;
 }
 
 /**
@@ -646,19 +646,19 @@ export interface IChunkCompleteInformation {
    * This property should only be set when a unique URL is sufficient to
    * retrieve the whole data.
    */
-  url? : string;
+  url? : string | undefined;
   /**
    * Time at which the request began in terms of `performance.now`.
    * If fetching the corresponding data necessitated to perform multiple
    * requests, this time corresponds to the first request made.
    */
-  sendingTime? : number;
+  sendingTime? : number | undefined;
   /**
    * Time at which the request ended in terms of `performance.now`.
    * If fetching the corresponding data necessitated to perform multiple
    * requests, this time corresponds to the last request to end.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Size in bytes of the loaded data.  `undefined` if we don't know.  */
   size : number | undefined;
 }
@@ -702,7 +702,7 @@ export interface ISegmentParserParsedInitChunk<DataType> {
    * Timescale metadata found inside this initialization segment.
    * That timescale might be useful when parsing further merdia segments.
    */
-  initTimescale? : number;
+  initTimescale? : number | undefined;
   /**
    * If set to `true`, some protection information has been found in this
    * initialization segment and lead the corresponding `Representation`
@@ -757,7 +757,7 @@ export interface ISegmentParserParsedMediaChunk<DataType> {
    * If set and not empty, then "events" have been encountered in this parsed
    * chunks.
    */
-  inbandEvents? : IInbandEvent[];
+  inbandEvents? : IInbandEvent[] | undefined;
   /**
    * If set to `true`, then parsing this chunk revealed that the current
    * Manifest instance needs to be refreshed.
@@ -791,19 +791,19 @@ export interface IRequestedData<T> {
    * This property should only be set when a unique URL is sufficient to
    * retrieve the whole data.
    */
-  url? : string;
+  url? : string | undefined;
   /**
    * Time at which the request began in terms of `performance.now`.
    * If fetching the corresponding data necessitated to perform multiple
    * requests, this time corresponds to the first request made.
    */
-  sendingTime? : number;
+  sendingTime? : number | undefined;
   /**
    * Time at which the request ended in terms of `performance.now`.
    * If fetching the corresponding data necessitated to perform multiple
    * requests, this time corresponds to the last request to end.
    */
-  receivedTime? : number;
+  receivedTime? : number | undefined;
   /** Size in bytes of the loaded data.  `undefined` if we don't know.  */
   size : number | undefined;
 }

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -51,11 +51,11 @@ export default function callCustomManifestLoader(
        * @param {Object} args
        */
       const resolve = (_args : { data : ILoadedManifestFormat;
-                                 size? : number;
-                                 duration? : number;
-                                 url? : string;
-                                 receivingTime? : number;
-                                 sendingTime? : number; }) =>
+                                 size? : number | undefined;
+                                 duration? : number | undefined;
+                                 url? : string | undefined;
+                                 receivingTime? : number | undefined;
+                                 sendingTime? : number | undefined; }) =>
       {
         if (hasFinished || cancelSignal.isCancelled) {
           return;

--- a/src/transports/utils/generate_manifest_loader.ts
+++ b/src/transports/utils/generate_manifest_loader.ts
@@ -66,7 +66,7 @@ function generateRegularManifestLoader(
  * @returns {Function}
  */
 export default function generateManifestLoader(
-  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader },
+  { customManifestLoader } : { customManifestLoader?: ICustomManifestLoader | undefined },
   preferredType: "arraybuffer" | "text" | "document"
 ) : (
     url : string | undefined,

--- a/src/utils/__tests__/flat_map.test.ts
+++ b/src/utils/__tests__/flat_map.test.ts
@@ -19,12 +19,15 @@
 
 import flatMap from "../flat_map";
 
-const proto = Array.prototype as unknown as {
-  flatMap?<U, This = undefined>(
+interface IProtoWithFlatMap {
+  flatMap? : (<U, This = undefined>(
     callback: (this: This, value: unknown, index: number, array: unknown[]) => U | U[],
-    thisArg?: This
-  ): U[];
-};
+    thisArg?: This | undefined
+  ) => U[]) | undefined;
+}
+
+
+const proto = Array.prototype as unknown as IProtoWithFlatMap;
 
 /* eslint-disable @typescript-eslint/unbound-method */
 const initialFlatMap = proto.flatMap;
@@ -32,7 +35,7 @@ const initialFlatMap = proto.flatMap;
 
 describe("utils - starts-with", () => {
   beforeEach(() => {
-    proto.flatMap = undefined;
+    delete proto.flatMap;
   });
 
   afterEach(() => {
@@ -49,7 +52,9 @@ describe("utils - starts-with", () => {
   if (typeof initialFlatMap === "function") {
     it("should call the original flatMap function if available", () => {
       proto.flatMap = initialFlatMap;
-      const flatMapSpy = jest.spyOn(proto, "flatMap");
+      // TODO find what bother typescript here instead of adding "as any"
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      const flatMapSpy = jest.spyOn(proto as any, "flatMap");
       const func1 = (x : number) : number[] => [x, x + 1, x - 1];
       const func2 = (x : number) : string => String(x) + "a";
       expect(flatMap([1, 2, 3], func1))

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -61,14 +61,14 @@ export interface IFetchedDataObject {
    * Value of the "Content-Length" header, which should (yet also might not be)
    * the size of the complete data that will be fetched.
    */
-  totalSize? : number;
+  totalSize : number | undefined;
   /**
    * Current available chunk, which might only be a sub-part of the whole
    * data.
    * To retrieve the whole data, all `chunk` received from `fetchRequest` can be
    * concatenated.
    */
-  chunk: ArrayBuffer;
+  chunk : ArrayBuffer;
 }
 
 /** Options for the `fetchRequest` utils function. */
@@ -88,13 +88,13 @@ export interface IFetchOptions {
    */
   cancelSignal : CancellationSignal;
   /** Optional headers for the HTTP GET request perfomed by `fetchRequest`. */
-  headers? : { [ header: string ] : string }|null;
+  headers? : { [ header: string ] : string } | undefined | null;
   /**
    * Optional timeout for the HTTP GET request perfomed by `fetchRequest`.
    * This timeout is just enabled until the HTTP response from the server, even
    * if not all data has been received yet.
    */
-  timeout? : number;
+  timeout? : number | undefined;
 }
 
 const { DEFAULT_REQUEST_TIMEOUT } = config;
@@ -161,11 +161,15 @@ export default function fetchRequest(
       abortFetch();
     });
 
-  return fetch(options.url,
-               { headers,
-                 method: "GET",
-                 signal: !isNullOrUndefined(abortController) ? abortController.signal :
-                                                               undefined }
+  const fetchOpts : RequestInit = { method: "GET" };
+  if (headers !== undefined) {
+    fetchOpts.headers = headers;
+  }
+  fetchOpts.signal = !isNullOrUndefined(abortController) ? abortController.signal :
+                                                           null;
+  return fetch(
+    options.url,
+    fetchOpts
   ).then((response : Response) : PPromise<IFetchedStreamComplete> => {
     if (!isNullOrUndefined(timeout)) {
       clearTimeout(timeout);

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -279,25 +279,26 @@ export interface IRequestOptions<ResponseType> {
   url : string;
   /** Dictionary of headers you want to set. `null` or `undefined` for no header. */
   headers? : { [ header: string ] : string } |
-             null;
+             null |
+             undefined;
   /** Wanted format for the response */
-  responseType? : ResponseType;
+  responseType? : ResponseType | undefined;
   /**
    * Optional timeout, in milliseconds, after which we will cancel a request.
    * Set to DEFAULT_REQUEST_TIMEOUT by default.
    */
-  timeout? : number;
+  timeout? : number | undefined;
   /**
    * "Cancelation token" used to be able to cancel the request.
    * When this token is "cancelled", the request will be aborted and the Promise
    * returned by `request` will be rejected.
    */
-  cancelSignal? : CancellationSignal;
+  cancelSignal? : CancellationSignal | undefined;
   /**
    * When defined, this callback will be called on each XHR "progress" event
    * with data related to this request's progress.
    */
-  onProgress? : (info : IProgressInfo) => void;
+  onProgress? : ((info : IProgressInfo) => void) | undefined;
 }
 
 /** Data emitted by `request`'s Promise when the request succeeded. */
@@ -330,5 +331,5 @@ export interface IProgressInfo {
   size : number;
   sendingTime : number;
   url : string;
-  totalSize? : number;
+  totalSize? : number | undefined;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
     "allowJs": true,
     "target": "es2017",
     "lib": ["es2017", "dom"],
-    // TODO
-    // "exactOptionalPropertyTypes": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
     "noImplicitAny": true,

--- a/tsconfig.modules.json
+++ b/tsconfig.modules.json
@@ -4,8 +4,7 @@
     "declaration": true,
     "target": "es5",
     "lib": ["es2017", "dom"],
-    // TODO
-    // "exactOptionalPropertyTypes": true,
+    "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": false,
     "noImplicitAny": true,


### PR DESCRIPTION
This PR adds the `exactOptionalPropertyTypes` typescript option which adds a semantic difference in property types and arguments between the question mark (for optional parameters) and an union with `undefined` (`| undefined`).

exactOptionalPropertyTypes documentation: https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes

---

Both are generally equivalent without the option but with it, the question mark only means that the property / argument may or may not be present and `| undefined` will mean that the property / argument is always present but may be set to `undefined`.

In most cases, those are equivalent yet in some real cases, such as when using the `for ... in` operator, checking a function's arity or using methods like `hasOwnProperty`, there is a difference of behavior between those two possibilities. Here, not having a distinction between the two could potentially lead to issues.

Moreover, the RxPlayer being a library used by several applications we do not control, I prefer adding that supplementary distinction to limit even more the possibility of type issues or regressions when they update the RxPlayer's version.

---

For now, I mainly added in most places a `| undefined` when optional property/arguments were defined with a question mark.
Of course, this is not optimal as it adds a lot of clutter in the code.

We may want to write stricter code in the future to clearly chose one between the two, and even update the current code so only one of both is actually possible.
In types exposed to the API, I prefer however keeping the two possibilities in most places for now as it simplifies the RxPlayer maintainance.