### PR TITLE
drm: Use WebkitMediaKeys implementation on Safari Mobile

### DIFF
--- a/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
+++ b/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
@@ -40,27 +40,43 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return false if we are not on Safari", () => {
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
-               isSafari: false };
+               isSafariDesktop: false,
+               isSafariMobile: false };
     });
     const shouldFavourCustomSafariEME = require("../should_favour_custom_safari_EME");
     expect(shouldFavourCustomSafariEME.default()).toBe(false);
   });
 
   /* eslint-disable max-len */
-  it("should return false if we are on Safari but WekitMediaKeys is not available", () => {
+  it("should return false if we are on Safari Desktop but WekitMediaKeys is not available", () => {
   /* eslint-enable max-len */
 
     win.WebKitMediaKeys = undefined;
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
-               isSafari: true };
+               isSafariDesktop: true,
+               isSafariMobile: false };
     });
     const shouldFavourCustomSafariEME = require("../should_favour_custom_safari_EME");
     expect(shouldFavourCustomSafariEME.default()).toBe(false);
   });
 
   /* eslint-disable max-len */
-  it("should return true if we are on Safari and a WebKitMediaKeys implementation is available", () => {
+  it("should return false if we are on Safari Mobile but WekitMediaKeys is not available", () => {
+  /* eslint-enable max-len */
+
+    win.WebKitMediaKeys = undefined;
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isSafariDesktop: false,
+               isSafariMobile: true };
+    });
+    const shouldFavourCustomSafariEME = require("../should_favour_custom_safari_EME");
+    expect(shouldFavourCustomSafariEME.default()).toBe(false);
+  });
+
+  /* eslint-disable max-len */
+  it("should return true if we are on Safari Desktop and a WebKitMediaKeys implementation is available", () => {
   /* eslint-enable max-len */
 
     win.WebKitMediaKeys = {
@@ -75,7 +91,31 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
     proto.webkitSetMediaKeys = () => ({});
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
-               isSafari: true };
+               isSafariDesktop: true,
+               isSafariMobile: false };
+    });
+    const shouldFavourCustomSafariEME = require("../should_favour_custom_safari_EME");
+    expect(shouldFavourCustomSafariEME.default()).toBe(true);
+  });
+
+  /* eslint-disable max-len */
+  it("should return true if we are on Safari Mobile and a WebKitMediaKeys implementation is available", () => {
+  /* eslint-enable max-len */
+
+    win.WebKitMediaKeys = {
+      isTypeSupported: () => ({}),
+      prototype: {
+        createSession: () => ({}),
+      },
+    };
+    const proto = win.HTMLMediaElement.prototype as unknown as {
+      webkitSetMediaKeys : () => Record<string, never>;
+    };
+    proto.webkitSetMediaKeys = () => ({});
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isSafariDesktop: false,
+               isSafariMobile: true };
     });
     const shouldFavourCustomSafariEME = require("../should_favour_custom_safari_EME");
     expect(shouldFavourCustomSafariEME.default()).toBe(true);

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -54,13 +54,15 @@ interface ISafariWindowObject extends Window {
   safari? : { pushNotification? : { toString() : string } };
 }
 
-const isSafari : boolean =
+/** `true` on Safari on a PC platform (i.e. not iPhone / iPad etc.) */
+const isSafariDesktop : boolean =
   !isNode && (
     Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") >= 0 ||
     (window as ISafariWindowObject).safari?.pushNotification?.toString() ===
       "[object SafariRemoteNotification]"
   );
 
+/** `true` on Safari on an iPhone, iPad & iPod platform */
 const isSafariMobile : boolean = !isNode &&
                                  typeof navigator.platform === "string" &&
                                  /iPad|iPhone|iPod/.test(navigator.platform);
@@ -70,7 +72,7 @@ export {
   isIE11,
   isIEOrEdge,
   isFirefox,
-  isSafari,
+  isSafariDesktop,
   isSafariMobile,
   isSamsungBrowser,
   isTizen,

--- a/src/compat/should_favour_custom_safari_EME.ts
+++ b/src/compat/should_favour_custom_safari_EME.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { isSafari } from "./browser_detection";
+import {
+  isSafariDesktop,
+  isSafariMobile,
+} from "./browser_detection";
 import {
   WebKitMediaKeysConstructor,
 } from "./eme/custom_media_keys/webkit_media_keys_constructor";
@@ -27,5 +30,5 @@ import {
  * @returns {boolean}
  */
 export default function shouldFavourCustomSafariEME() : boolean {
-  return isSafari && WebKitMediaKeysConstructor !== undefined;
+  return (isSafariDesktop || isSafariMobile) && WebKitMediaKeysConstructor !== undefined;
 }


### PR DESCRIPTION
After a lot of tests today, we noticed that Safari mobile's standard EME implementation worked in mysterious ways. Despite multiple retries, we never could pass the `generateRequest` step, presumably due to a non-satisfactory `initDataType` argument.

We ended up trying to use the webkit-prefixed APIs in its place, which work differently than the standard but whose behavior is known.

And it worked! We could at last play encrypted directfile contents (including HLS) on Safari IOS.

Note that we already did that for Safari Desktop due to similar issues months (years?) ago, but we might not have tested properly on Safari iOS (in directfile mode) at the time.

---

Because the `isSafari` constant was only `true` for Safari desktop, and because I though making a difference between it and mobile could make sense, I also renamed it into `isSafariDesktop`.