### PR TITLE
[Proposal] Switch from a `Manifest` class to an `IManifest` interface 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -286,7 +286,9 @@ module.exports = {
     "no-console": "error",
     "no-debugger": "error",
     "no-duplicate-case": "error",
-    "no-duplicate-imports": "error",
+    "import/no-duplicates": "error",
+    // replaced by `no-duplicates` which better handle type imports
+    "no-duplicate-imports": "off",
     "no-empty": "error",
     "no-eval": "error",
     "no-fallthrough": "error",

--- a/src/core/abr/abr_manager.ts
+++ b/src/core/abr/abr_manager.ts
@@ -21,7 +21,7 @@ import {
   of as observableOf,
 } from "rxjs";
 import log from "../../log";
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import objectAssign from "../../utils/object_assign";
 import { ISharedReference } from "../../utils/reference";
 import takeFirstSet from "../../utils/take_first_set";
@@ -99,14 +99,14 @@ export default class ABRManager {
    * observable emitting the best representation (given the network/buffer
    * state).
    * @param {string} type
-   * @param {Array.<Representation>} representations
+   * @param {Array.<Object>} representations
    * @param {Observable<Object>} observation$
    * @param {Observable<Object>} streamEvents$
    * @returns {Observable}
    */
   public get$(
     type : IBufferType,
-    representations : Representation[],
+    representations : IRepresentation[],
     observation$ : Observable<IABRManagerPlaybackObservation>,
     streamEvents$ : Observable<IABRStreamEvents>
   ) : Observable<IABREstimate> {

--- a/src/core/abr/guess_based_chooser.ts
+++ b/src/core/abr/guess_based_chooser.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../log";
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import arrayFindIndex from "../../utils/array_find_index";
 import LastEstimateStorage, {
   ABRAlgorithmType,
@@ -81,7 +81,7 @@ export default class GuessBasedChooser {
    * algorithm).
    */
   public getGuess(
-    representations : Representation[],
+    representations : IRepresentation[],
     observation : {
       /**
        * For the concerned media buffer, difference in seconds between the next
@@ -94,10 +94,10 @@ export default class GuessBasedChooser {
        */
       speed: number;
     },
-    currentRepresentation : Representation,
+    currentRepresentation : IRepresentation,
     incomingBestBitrate : number,
     requests : IRequestInfo[]
-  ) : Representation | null {
+  ) : IRepresentation | null {
     const { bufferGap, speed } = observation;
     const lastChosenRep = this._lastAbrEstimate.representation;
     if (lastChosenRep === null) {
@@ -196,7 +196,7 @@ export default class GuessBasedChooser {
    * @returns {boolean}
    */
   private _shouldStopGuess(
-    lastGuess : Representation,
+    lastGuess : IRepresentation,
     scoreData : [number, ScoreConfidenceLevel] | undefined,
     bufferGap : number,
     requests : IRequestInfo[]
@@ -231,7 +231,7 @@ export default class GuessBasedChooser {
   }
 
   private _isLastGuessValidated(
-    lastGuess : Representation,
+    lastGuess : IRepresentation,
     incomingBestBitrate : number,
     scoreData : [number, ScoreConfidenceLevel] | undefined
   ) : boolean {
@@ -261,9 +261,9 @@ export default class GuessBasedChooser {
  * @returns {Object|null}
  */
 function getNextRepresentation(
-  representations : Representation[],
-  currentRepresentation : Representation
-) : Representation | null {
+  representations : IRepresentation[],
+  currentRepresentation : IRepresentation
+) : IRepresentation | null {
   const len = representations.length;
   let index = arrayFindIndex(representations,
                              ({ id }) => id === currentRepresentation.id);
@@ -289,9 +289,9 @@ function getNextRepresentation(
  * @returns {Object|null}
  */
 function getPreviousRepresentation(
-  representations : Representation[],
-  currentRepresentation : Representation
-) : Representation | null {
+  representations : IRepresentation[],
+  currentRepresentation : IRepresentation
+) : IRepresentation | null {
   let index = arrayFindIndex(representations,
                              ({ id }) => id === currentRepresentation.id);
   if (index < 0) {

--- a/src/core/abr/last_estimate_storage.ts
+++ b/src/core/abr/last_estimate_storage.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 
 /** Stores the last estimate made by the `RepresentationEstimator`. */
 export default class LastEstimateStorage {
@@ -28,7 +28,7 @@ export default class LastEstimateStorage {
    * Estimated Representation in the last estimate.
    * `null` if no estimate has been performed yet.
    */
-  public representation : Representation | null;
+  public representation : IRepresentation | null;
 
   /** Algorithm type used to make the last Representation estimate. */
   public algorithmType : ABRAlgorithmType;
@@ -47,7 +47,7 @@ export default class LastEstimateStorage {
    * the `GuessingEstimator`.
    */
   public update(
-    representation : Representation,
+    representation : IRepresentation,
     bandwidth : number | undefined,
     algorithmType : ABRAlgorithmType
   ) : void {

--- a/src/core/abr/network_analyzer.ts
+++ b/src/core/abr/network_analyzer.ts
@@ -16,7 +16,7 @@
 
 import config from "../../config";
 import log from "../../log";
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import arrayFind from "../../utils/array_find";
 import BandwidthEstimator from "./bandwidth_estimator";
 import {
@@ -157,7 +157,7 @@ function estimateRemainingTime(
 function estimateStarvationModeBitrate(
   pendingRequests : IRequestInfo[],
   playbackInfo : IPlaybackConditionsInfo,
-  currentRepresentation : Representation | null,
+  currentRepresentation : IRepresentation | null,
   lowLatencyMode : boolean,
   lastEstimatedBitrate : number|undefined
 ) : number|undefined {
@@ -324,7 +324,7 @@ export default class NetworkAnalyzer {
   public getBandwidthEstimate(
     playbackInfo: IPlaybackConditionsInfo,
     bandwidthEstimator : BandwidthEstimator,
-    currentRepresentation : Representation | null,
+    currentRepresentation : IRepresentation | null,
     currentRequests : IRequestInfo[],
     lastEstimatedBitrate: number|undefined
   ) : { bandwidthEstimate? : number | undefined; bitrateChosen : number } {
@@ -408,7 +408,7 @@ export default class NetworkAnalyzer {
    */
   public isUrgent(
     bitrate: number,
-    currentRepresentation : Representation | null,
+    currentRepresentation : IRepresentation | null,
     currentRequests : IRequestInfo[],
     playbackInfo: IPlaybackConditionsInfo
   ) : boolean {

--- a/src/core/abr/pending_requests_store.ts
+++ b/src/core/abr/pending_requests_store.ts
@@ -15,11 +15,12 @@
  */
 
 import log from "../../log";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../manifest";
 import objectValues from "../../utils/object_values";
 
@@ -140,9 +141,9 @@ export interface IRequestInfo {
 
 /** Content linked to a segment request. */
 export interface IRequestInfoContent {
-  manifest : Manifest;
-  period : Period;
-  adaptation : Adaptation;
-  representation : Representation;
+  manifest : IManifest;
+  period : IPeriod;
+  adaptation : IAdaptation;
+  representation : IRepresentation;
   segment : ISegment;
 }

--- a/src/core/abr/representation_estimator.ts
+++ b/src/core/abr/representation_estimator.ts
@@ -30,9 +30,9 @@ import {
 } from "rxjs";
 import log from "../../log";
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Representation,
+  IRepresentation,
 } from "../../manifest";
 import { getLeftSizeOfRange } from "../../utils/ranges";
 import BandwidthEstimator from "./bandwidth_estimator";
@@ -86,7 +86,7 @@ export interface IABREstimate {
    * The Representation considered as the most adapted to the current network
    * and playback conditions.
    */
-  representation: Representation;
+  representation: IRepresentation;
   /**
    * If `true`, the current `representation` suggested should be switched to as
    * soon as possible. For example, you might want to interrupt all pending
@@ -158,8 +158,8 @@ export interface IABRMetricsEventValue {
   /** Duration of the loaded segment, in seconds. */
   segmentDuration: number | undefined;
   /** Context about the segment downloaded. */
-  content: { representation: Representation;
-             adaptation: Adaptation;
+  content: { representation: IRepresentation;
+             adaptation: IAdaptation;
              segment: ISegment; };
 }
 
@@ -182,7 +182,7 @@ export interface IABRRepresentationChangeEvent {
   type: "representationChange";
   value: {
     /** The new loaded `Representation`. `null` if no Representation is chosen. */
-    representation : Representation |
+    representation : IRepresentation |
                      null;
   };
 }
@@ -272,7 +272,7 @@ export interface IABRAddedSegmentEvent {
      */
     buffered : TimeRanges;
     /** The context for the segment that has been pushed. */
-    content : { representation : Representation }; };
+    content : { representation : IRepresentation }; };
 }
 
 /**
@@ -356,7 +356,7 @@ export interface IRepresentationEstimatorArguments {
    */
   maxAutoBitrate$ : Observable<number>;
   /** The list of Representations the `RepresentationEstimator` can choose from. */
-  representations : Representation[];
+  representations : IRepresentation[];
 }
 
 /**
@@ -366,9 +366,9 @@ export interface IRepresentationEstimatorArguments {
  * @returns {Array.<Representation>}
  */
 function getFilteredRepresentations(
-  representations : Representation[],
+  representations : IRepresentation[],
   filters : IABRFiltersObject
-) : Representation[] {
+) : IRepresentation[] {
   let filteredReps = representations;
 
   if (filters.bitrate != null) {
@@ -584,7 +584,7 @@ export default function RepresentationEstimator({
            * `null` if this buffer size mode is not enabled or if we don't have a
            * choice from it yet.
            */
-          let chosenRepFromBufferSize : Representation | null = null;
+          let chosenRepFromBufferSize : IRepresentation | null = null;
           if (allowBufferBasedEstimates &&
               bufferBasedBitrate !== undefined &&
               bufferBasedBitrate > currentBestBitrate)
@@ -612,7 +612,7 @@ export default function RepresentationEstimator({
            *
            * `null` if not enabled or if there's currently no guess.
            */
-          let chosenRepFromGuessMode : Representation | null = null;
+          let chosenRepFromGuessMode : IRepresentation | null = null;
           if (lowLatencyMode &&
               currentRepresentation !== null &&
               liveGap !== undefined &&

--- a/src/core/abr/representation_score_calculator.ts
+++ b/src/core/abr/representation_score_calculator.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../log";
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import EWMA from "./utils/ewma";
 
 /**
@@ -48,13 +48,13 @@ import EWMA from "./utils/ewma";
  * @class RepresentationScoreCalculator
  */
 export default class RepresentationScoreCalculator {
-  private _currentRepresentationData : { representation : Representation;
+  private _currentRepresentationData : { representation : IRepresentation;
                                          ewma : EWMA;
                                          loadedSegments : number;
                                          loadedDuration : number; } |
                                        null;
 
-  private _lastRepresentationWithGoodScore : Representation | null;
+  private _lastRepresentationWithGoodScore : IRepresentation | null;
 
   constructor() {
     this._currentRepresentationData = null;
@@ -70,7 +70,7 @@ export default class RepresentationScoreCalculator {
    * seconds.
    */
   public addSample(
-    representation : Representation,
+    representation : IRepresentation,
     requestDuration : number,
     segmentDuration : number
   ) : void {
@@ -106,7 +106,7 @@ export default class RepresentationScoreCalculator {
    * @returns {number|undefined}
    */
   public getEstimate(
-    representation : Representation
+    representation : IRepresentation
   ) : [number, ScoreConfidenceLevel] | undefined {
     if (this._currentRepresentationData === null ||
         this._currentRepresentationData.representation.id !== representation.id)
@@ -130,7 +130,7 @@ export default class RepresentationScoreCalculator {
    * `null` if no Representation ever reach that score.
    * @returns {Representation|null}
    */
-  public getLastStableRepresentation() : Representation | null {
+  public getLastStableRepresentation() : IRepresentation | null {
     return this._lastRepresentationWithGoodScore;
   }
 }

--- a/src/core/abr/utils/__tests__/filter_by_bitrate.test.ts
+++ b/src/core/abr/utils/__tests__/filter_by_bitrate.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../../manifest";
+import { IRepresentation } from "../../../../manifest";
 import filterByBitrate from "../filter_by_bitrate";
 
 describe("ABR - filterByBitrate", () => {
@@ -33,14 +33,14 @@ describe("ABR - filterByBitrate", () => {
     });
 
     it("should return all representations when specified bitrate is infinite", () => {
-      expect(filterByBitrate(fakeReps as Representation[], Infinity))
+      expect(filterByBitrate(fakeReps as IRepresentation[], Infinity))
         .toEqual(fakeReps);
     });
 
     it("should return the lowest representation when specified bitrate is 0", () => {
       const expectedFilteredReps = [ { bitrate : 100 },
                                      { bitrate : 100 } ];
-      expect(filterByBitrate(fakeReps as Representation[], 0))
+      expect(filterByBitrate(fakeReps as IRepresentation[], 0))
         .toEqual(expectedFilteredReps);
     });
 
@@ -48,7 +48,7 @@ describe("ABR - filterByBitrate", () => {
       const expectedFilteredReps = [ { bitrate : 100 },
                                      { bitrate : 100 },
                                      { bitrate : 1000 } ];
-      expect(filterByBitrate(fakeReps as Representation[], 1010))
+      expect(filterByBitrate(fakeReps as IRepresentation[], 1010))
         .toEqual(expectedFilteredReps);
     });
   });

--- a/src/core/abr/utils/__tests__/filter_by_width.test.ts
+++ b/src/core/abr/utils/__tests__/filter_by_width.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../../manifest";
+import { IRepresentation } from "../../../../manifest";
 import filterByWidth from "../filter_by_width";
 
 describe("ABR - filterByWidth", () => {
@@ -32,22 +32,22 @@ describe("ABR - filterByWidth", () => {
 
   describe("filterByWidth", () => {
     it("should properly filter representations whose width is < 900", () => {
-      expect(filterByWidth(fakeReps as Representation[], 999))
+      expect(filterByWidth(fakeReps as IRepresentation[], 999))
         .toEqual(expectedWidthReps);
     });
 
     it("should return all representations when specified width is over maxWidth", () => {
-      expect(filterByWidth(fakeReps as Representation[], 1000000))
+      expect(filterByWidth(fakeReps as IRepresentation[], 1000000))
         .toEqual(fakeReps);
     });
 
     it("should return all representations when specified width is infinite", () => {
-      expect(filterByWidth(fakeReps as Representation[], Infinity))
+      expect(filterByWidth(fakeReps as IRepresentation[], Infinity))
         .toEqual(fakeReps);
     });
 
     it("should return first representation when specified width is 0", () => {
-      expect(filterByWidth(fakeReps as Representation[], 0))
+      expect(filterByWidth(fakeReps as IRepresentation[], 0))
         .toEqual([{ width: 100 }]);
     });
 

--- a/src/core/abr/utils/__tests__/select_optimal_representation.test.ts
+++ b/src/core/abr/utils/__tests__/select_optimal_representation.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../../manifest";
+import { IRepresentation } from "../../../../manifest";
 import selectOptimalRepresentation from "../select_optimal_representation";
 
 describe("ABR - selectOptimalRepresentation", () => {
@@ -27,17 +27,17 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return the best representation when the optimal bitrate given is Infinity and no higher limit exists", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        Infinity))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        100,
                                        Infinity))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        Infinity,
                                        Infinity))
@@ -46,22 +46,22 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return the best representation when both the optimal bitrate and the higher limit given are higher or equal than the highest Representation", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        100000,
                                        0,
                                        100000))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        100000,
                                        0,
                                        900000))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        900000,
                                        0,
                                        100000))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        900000,
                                        0,
                                        900000))
@@ -70,32 +70,32 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return one below or equal to the maximum bitrate even if optimal is superior", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        999))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        100))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        1001,
                                        0,
                                        999))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        1001,
                                        0,
                                        1000))
       .toBe(fakeReps[1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        9999))
       .toBe(fakeReps[1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        1001,
                                        0,
                                        1000))
@@ -104,27 +104,27 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should chose the minimum if no Representation is below or equal to the maximum bitrate", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        1,
                                        0,
                                        0))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        101,
                                        0,
                                        0))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        0))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        Infinity,
                                        0,
                                        99))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        0,
                                        99))
@@ -133,17 +133,17 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return the worst representation when the optimal bitrate given is 0 and no lower limit exists", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        0,
                                        Infinity))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        0,
                                        0))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        0,
                                        1000))
@@ -152,22 +152,22 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return the worst representation when both the optimal bitrate and the lower limit given are lower or equal than the lowest Representation", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        4,
                                        0,
                                        Infinity))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        100,
                                        100,
                                        Infinity))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        100,
                                        100000))
       .toBe(fakeReps[0]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        100,
                                        0,
                                        100000))
@@ -176,17 +176,17 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should return one higher or equal to the minimum bitrate even if optimal is inferior", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        1000,
                                        Infinity))
       .toBe(fakeReps[1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        1000,
                                        1000))
       .toBe(fakeReps[1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        1000,
                                        10000,
                                        Infinity))
@@ -195,17 +195,17 @@ describe("ABR - selectOptimalRepresentation", () => {
 
   // eslint-disable-next-line max-len
   it("should chose the maximum if no Representation is higher or equal to the minimum bitrate", () => {
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        10000000,
                                        Infinity))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        0,
                                        Infinity,
                                        Infinity))
       .toBe(fakeReps[fakeReps.length - 1]);
-    expect(selectOptimalRepresentation(fakeReps as Representation[],
+    expect(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                        100,
                                        Infinity,
                                        Infinity))
@@ -215,27 +215,27 @@ describe("ABR - selectOptimalRepresentation", () => {
   // eslint-disable-next-line max-len
   it("should chose one respecting either the minimum or maximum when the minimum is higher than the maximum", () => {
     expect([fakeReps[0], fakeReps[fakeReps.length - 1]])
-      .toContain(selectOptimalRepresentation(fakeReps as Representation[],
+      .toContain(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                              1000,
                                              Infinity,
                                              0));
     expect([fakeReps[0], fakeReps[fakeReps.length - 1]])
-      .toContain(selectOptimalRepresentation(fakeReps as Representation[],
+      .toContain(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                              0,
                                              Infinity,
                                              0));
     expect([fakeReps[0], fakeReps[fakeReps.length - 1]])
-      .toContain(selectOptimalRepresentation(fakeReps as Representation[],
+      .toContain(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                              Infinity,
                                              Infinity,
                                              0));
     expect([fakeReps[1], fakeReps[2]])
-      .toContain(selectOptimalRepresentation(fakeReps as Representation[],
+      .toContain(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                              1000,
                                              10000,
                                              1000));
     expect([fakeReps[1], fakeReps[2]])
-      .toContain(selectOptimalRepresentation(fakeReps as Representation[],
+      .toContain(selectOptimalRepresentation(fakeReps as IRepresentation[],
                                              10000,
                                              10000,
                                              1000));

--- a/src/core/abr/utils/filter_by_bitrate.ts
+++ b/src/core/abr/utils/filter_by_bitrate.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../manifest";
+import { IRepresentation } from "../../../manifest";
 import arrayFindIndex from "../../../utils/array_find_index";
 
 /**
@@ -26,9 +26,9 @@ import arrayFindIndex from "../../../utils/array_find_index";
  * @returns {Array.<Object>}
  */
 export default function filterByBitrate(
-  representations : Representation[],
+  representations : IRepresentation[],
   bitrate : number
-) : Representation[] {
+) : IRepresentation[] {
   if (representations.length === 0) {
     return [];
   }

--- a/src/core/abr/utils/filter_by_width.ts
+++ b/src/core/abr/utils/filter_by_width.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../manifest";
+import { IRepresentation } from "../../../manifest";
 import arrayFind from "../../../utils/array_find";
 import takeFirstSet from "../../../utils/take_first_set";
 
@@ -27,9 +27,9 @@ import takeFirstSet from "../../../utils/take_first_set";
  * @returns {Array.<Object>}
  */
 export default function filterByWidth(
-  representations : Representation[],
+  representations : IRepresentation[],
   width : number
-) : Representation[] {
+) : IRepresentation[] {
   const sortedRepsByWidth = representations
     .slice() // clone
     .sort((a, b) => takeFirstSet<number>(a.width, 0) -

--- a/src/core/abr/utils/select_optimal_representation.ts
+++ b/src/core/abr/utils/select_optimal_representation.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../../manifest";
+import { IRepresentation } from "../../../manifest";
 import arrayFindIndex from "../../../utils/array_find_index";
 
 /**
  * From the given array of Representations (sorted by bitrate order ascending),
  * returns the one corresponding to the given optimal, minimum and maximum
  * bitrates.
- * @param {Array.<Representation>} representations - The representations array,
+ * @param {Array.<Object>} representations - The representations array,
  * sorted in bitrate ascending order.
  * @param {Number} optimalBitrate - The optimal bitrate the Representation
  * should have under the current condition.
@@ -31,14 +31,14 @@ import arrayFindIndex from "../../../utils/array_find_index";
  * @param {Number} maxBitrate - The maximum bitrate the chosen Representation
  * should have. We will take the Representation with the minimum bitrate if none
  * is found.
- * @returns {Representation|undefined}
+ * @returns {Object|undefined}
  */
 export default function selectOptimalRepresentation(
-  representations : Representation[],
+  representations : IRepresentation[],
   optimalBitrate : number,
   minBitrate : number,
   maxBitrate : number
-) : Representation {
+) : IRepresentation {
   const wantedBitrate = optimalBitrate <= minBitrate ? minBitrate :
                         optimalBitrate >= maxBitrate ? maxBitrate :
                                                        optimalBitrate;

--- a/src/core/api/media_element_track_choice_manager.ts
+++ b/src/core/api/media_element_track_choice_manager.ts
@@ -27,7 +27,7 @@ import {
   ICompatVideoTrack,
   ICompatVideoTrackList,
 } from "../../compat/browser_compatibility_types";
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import assert from "../../utils/assert";
 import EventEmitter from "../../utils/event_emitter";
 import normalizeLanguage from "../../utils/languages";
@@ -85,7 +85,7 @@ function createAudioTracks(
                     normalized: string;
                     language: string;
                     audioDescription: boolean;
-                    representations: Representation[]; };
+                    representations: IRepresentation[]; };
            nativeTrack: ICompatAudioTrack; }> {
   const newAudioTracks = [];
   const languagesOccurences: Partial<Record<string, number>> = {};
@@ -103,7 +103,7 @@ function createAudioTracks(
                     id,
                     normalized: normalizeLanguage(audioTrack.language),
                     audioDescription: false,
-                    representations: [] as Representation[] };
+                    representations: [] as IRepresentation[] };
     newAudioTracks.push({ track,
                           nativeTrack: audioTrack });
   }
@@ -152,7 +152,7 @@ function createTextTracks(
 function createVideoTracks(
   videoTracks: ICompatVideoTrackList
 ): Array<{ track: { id: string;
-                    representations: Representation[]; };
+                    representations: IRepresentation[]; };
            nativeTrack: ICompatVideoTrack; }> {
   const newVideoTracks = [];
   const languagesOccurences: Partial<Record<string, number>> = {};
@@ -167,7 +167,7 @@ function createVideoTracks(
                occurences.toString();
     languagesOccurences[language] = occurences + 1;
     newVideoTracks.push({ track: { id,
-                                   representations: [] as Representation[] },
+                                   representations: [] as IRepresentation[] },
                           nativeTrack: videoTrack });
   }
   return newVideoTracks;

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -63,10 +63,11 @@ import {
 } from "../../errors";
 import features from "../../features";
 import log from "../../log";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import { IBifThumbnail } from "../../parsers/images/bif";
 import areArraysOfNumbersEqual from "../../utils/are_arrays_of_numbers_equal";
@@ -203,16 +204,16 @@ interface IPublicAPIEvent {
   error : ICustomError | Error;
   warning : ICustomError | Error;
   nativeTextTracksChange : TextTrack[];
-  periodChange : Period;
+  periodChange : IPeriod;
   availableAudioBitratesChange : number[];
   availableVideoBitratesChange : number[];
   availableAudioTracksChange : ITMAudioTrackListItem[];
   availableTextTracksChange : ITMTextTrackListItem[];
   availableVideoTracksChange : ITMVideoTrackListItem[];
-  decipherabilityUpdate : Array<{ manifest : Manifest;
-                                  period : Period;
-                                  adaptation : Adaptation;
-                                  representation : Representation; }>;
+  decipherabilityUpdate : Array<{ manifest : IManifest;
+                                  period : IPeriod;
+                                  adaptation : IAdaptation;
+                                  representation : IRepresentation; }>;
   seeking : null;
   seeked : null;
   streamEvent : IStreamEvent;
@@ -344,20 +345,20 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      * `null` if the current content loaded has no manifest or if the content is
      * not yet loaded.
      */
-    manifest : Manifest|null;
+    manifest : IManifest | null;
 
     /**
      * Current Period being played.
      * `null` if no Period is being played.
      */
-    currentPeriod : Period|null;
+    currentPeriod : IPeriod|null;
 
     /**
      * Store currently considered adaptations, per active period.
      * `null` if no Adaptation is active
      */
     activeAdaptations : {
-      [periodId : string] : Partial<Record<IBufferType, Adaptation|null>>;
+      [periodId : string] : Partial<Record<IBufferType, IAdaptation|null>>;
     } | null;
 
     /**
@@ -365,7 +366,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      * `null` if no Representation is active
      */
     activeRepresentations : {
-      [periodId : string] : Partial<Record<IBufferType, Representation|null>>;
+      [periodId : string] : Partial<Record<IBufferType, IRepresentation|null>>;
     } | null;
 
     /** Store starting audio track if one. */
@@ -435,7 +436,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
   /** Information about last content being played. */
   private _priv_lastContentPlaybackInfos : { options?: IParsedLoadVideoOptions;
-                                             manifest?: Manifest;
+                                             manifest?: IManifest;
                                              lastPlaybackPosition?: number; };
 
   /** All possible Error types emitted by the RxPlayer. */
@@ -786,12 +787,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       let manifest$ : Observable<IManifestFetcherParsedResult |
                                  IManifestFetcherWarningEvent>;
 
-      if (initialManifest instanceof Manifest) {
-        manifest$ = observableOf({ type: "parsed",
-                                   manifest: initialManifest });
-      } else if (initialManifest !== undefined) {
-        manifest$ = manifestFetcher.parse(initialManifest, { previousManifest: null,
-                                                             unsafeMode: false });
+      if (!isNullOrUndefined(initialManifest)) {
+        // Rudimentary check for if this is an `IManifest`
+        if (typeof (initialManifest as IManifest).getPeriodForTime === "function") {
+          manifest$ = observableOf({ type: "parsed",
+                                     manifest: initialManifest as IManifest });
+        } else {
+          manifest$ = manifestFetcher.parse(initialManifest, { previousManifest: null,
+                                                               unsafeMode: false });
+        }
       } else {
         manifest$ = manifestFetcher.fetch(url).pipe(
           mergeMap((response) => response.type === "warning" ?
@@ -1128,7 +1132,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @deprecated
    * @returns {Manifest|null} - The current Manifest (`null` when not known).
    */
-  getManifest() : Manifest|null {
+  getManifest() : IManifest|null {
     warnOnce("getManifest is deprecated." +
              " Please open an issue if you used this API.");
     if (this._priv_contentInfos === null) {
@@ -1145,7 +1149,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * when none is known for now.
    */
   getCurrentAdaptations(
-  ) : Partial<Record<IBufferType, Adaptation|null>> | null {
+  ) : Partial<Record<IBufferType, IAdaptation|null>> | null {
     warnOnce("getCurrentAdaptations is deprecated." +
              " Please open an issue if you used this API.");
     if (this._priv_contentInfos === null) {
@@ -1169,7 +1173,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * (`null` when none is known for now.
    */
   getCurrentRepresentations(
-  ) : Partial<Record<IBufferType, Representation|null>> | null {
+  ) : Partial<Record<IBufferType, IRepresentation|null>> | null {
     warnOnce("getCurrentRepresentations is deprecated." +
              " Please open an issue if you used this API.");
     return this._priv_getCurrentRepresentations();
@@ -2504,7 +2508,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * Initialize various private properties and emit initial event.
    * @param {Object} value
    */
-  private _priv_onManifestReady({ manifest } : { manifest : Manifest }) : void {
+  private _priv_onManifestReady({ manifest } : { manifest : IManifest }) : void {
     const contentInfos = this._priv_contentInfos;
     if (contentInfos === null) {
       log.error("API: The manifest is loaded but no content is.");
@@ -2547,7 +2551,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    *
    * @param {Object} value
    */
-  private _priv_onActivePeriodChanged({ period } : { period : Period }) : void {
+  private _priv_onActivePeriodChanged({ period } : { period : IPeriod }) : void {
     if (this._priv_contentInfos === null) {
       log.error("API: The active period changed but no content is loaded");
       return;
@@ -2597,8 +2601,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   private _priv_onPeriodStreamReady(value : {
     type : IBufferType;
-    period : Period;
-    adaptation$ : Subject<Adaptation|null>;
+    period : IPeriod;
+    adaptation$ : Subject<IAdaptation|null>;
   }) : void {
     const { type, period, adaptation$ } = value;
 
@@ -2651,7 +2655,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   private _priv_onPeriodStreamCleared(value : {
     type : IBufferType;
-    period : Period;
+    period : IPeriod;
   }) : void {
     const { type, period } = value;
 
@@ -2716,8 +2720,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     period,
   } : {
     type : IBufferType;
-    adaptation : Adaptation|null;
-    period : Period;
+    adaptation : IAdaptation|null;
+    period : IPeriod;
   }) : void {
     if (this._priv_contentInfos === null) {
       log.error("API: The adaptations changed but no content is loaded");
@@ -2782,8 +2786,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     representation,
   }: {
     type : IBufferType;
-    period : Period;
-    representation : Representation|null;
+    period : IPeriod;
+    representation : IRepresentation|null;
   }) : void {
     if (this._priv_contentInfos === null) {
       log.error("API: The representations changed but no content is loaded");
@@ -2961,7 +2965,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   private _priv_getCurrentRepresentations(
-  ) : Partial<Record<IBufferType, Representation|null>> | null {
+  ) : Partial<Record<IBufferType, IRepresentation|null>> | null {
     if (this._priv_contentInfos === null) {
       return null;
     }

--- a/src/core/api/track_choice_manager.ts
+++ b/src/core/api/track_choice_manager.ts
@@ -22,10 +22,10 @@
 import { Subject } from "rxjs";
 import log from "../../log";
 import {
-  Adaptation,
+  IAdaptation,
   IHDRInformation,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import arrayFind from "../../utils/array_find";
 import arrayIncludes from "../../utils/array_includes";
@@ -111,19 +111,19 @@ export interface ITMVideoTrackListItem
   extends ITMVideoTrack { active : boolean }
 
 /** Audio information stored for a single Period. */
-interface ITMPeriodAudioInfos { adaptations : Adaptation[];
-                                adaptation$ : Subject<Adaptation|null>; }
+interface ITMPeriodAudioInfos { adaptations : IAdaptation[];
+                                adaptation$ : Subject<IAdaptation|null>; }
 
 /** Text information stored for a single Period. */
-interface ITMPeriodTextInfos { adaptations : Adaptation[];
-                               adaptation$ : Subject<Adaptation|null>; }
+interface ITMPeriodTextInfos { adaptations : IAdaptation[];
+                               adaptation$ : Subject<IAdaptation|null>; }
 
 /** Video information stored for a single Period. */
-interface ITMPeriodVideoInfos { adaptations : Adaptation[];
-                                adaptation$ : Subject<Adaptation|null>; }
+interface ITMPeriodVideoInfos { adaptations : IAdaptation[];
+                                adaptation$ : Subject<IAdaptation|null>; }
 
 /** Every information stored for a single Period. */
-interface ITMPeriodInfos { period : Period;
+interface ITMPeriodInfos { period : IPeriod;
                            audio? : ITMPeriodAudioInfos;
                            text? : ITMPeriodTextInfos;
                            video? : ITMPeriodVideoInfos; }
@@ -214,28 +214,28 @@ export default class TrackChoiceManager {
   private _preferredVideoTracks : IVideoTrackPreference[];
 
   /** Memorization of the previously-chosen audio Adaptation for each Period. */
-  private _audioChoiceMemory : WeakMap<Period, Adaptation|null>;
+  private _audioChoiceMemory : WeakMap<IPeriod, IAdaptation|null>;
 
   /** Memorization of the previously-chosen text Adaptation for each Period. */
-  private _textChoiceMemory : WeakMap<Period, Adaptation|null>;
+  private _textChoiceMemory : WeakMap<IPeriod, IAdaptation|null>;
 
   /** Memorization of the previously-chosen video Adaptation for each Period. */
   private _videoChoiceMemory : WeakMap<
-    Period,
+    IPeriod,
     {
       /**
        * The "base" Adaptation (if a trickmode track was chosen, this is the
        * Adaptation the trickmode track is linked to, and not the trickmode
        * track itself).
        */
-      baseAdaptation : Adaptation;
+      baseAdaptation : IAdaptation;
       /**
        * The chosen Adaptation itself (may be different from `baseAdaptation`
        * when a trickmode track is chosen, in which case `baseAdaptation` is
        * the Adaptation the trickmode track is linked to and `adaptation` is the
        * trickmode track).
        */
-      adaptation : Adaptation;
+      adaptation : IAdaptation;
     } |
     /** Set to `null` when no video track was chosen. */
     null
@@ -319,8 +319,8 @@ export default class TrackChoiceManager {
    */
   public addPeriod(
     bufferType : "audio" | "text"| "video",
-    period : Period,
-    adaptation$ : Subject<Adaptation|null>
+    period : IPeriod,
+    adaptation$ : Subject<IAdaptation|null>
   ) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const adaptations = period.getSupportedAdaptations(bufferType);
@@ -346,7 +346,7 @@ export default class TrackChoiceManager {
    */
   public removePeriod(
     bufferType : "audio" | "text" | "video",
-    period : Period
+    period : IPeriod
   ) : void {
     const periodIndex = findPeriodIndex(this._periods, period);
     if (periodIndex === undefined) {
@@ -393,7 +393,7 @@ export default class TrackChoiceManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialAudioTrack(period : Period) : void {
+  public setInitialAudioTrack(period : IPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem !== undefined ? periodItem.audio :
                                                   null;
@@ -429,7 +429,7 @@ export default class TrackChoiceManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialTextTrack(period : Period) : void {
+  public setInitialTextTrack(period : IPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem !== undefined ? periodItem.text :
                                                  null;
@@ -463,7 +463,7 @@ export default class TrackChoiceManager {
    *   - the last choice for this period, if one
    * @param {Period} period - The concerned Period.
    */
-  public setInitialVideoTrack(period : Period) : void {
+  public setInitialVideoTrack(period : IPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem !== undefined ? periodItem.video :
                                                  null;
@@ -474,7 +474,7 @@ export default class TrackChoiceManager {
     const videoAdaptations = period.getSupportedAdaptations("video");
 
     const prevVideoAdaptation = this._videoChoiceMemory.get(period);
-    let newBaseAdaptation : Adaptation | null;
+    let newBaseAdaptation : IAdaptation | null;
 
     if (prevVideoAdaptation === null) {
       newBaseAdaptation = null;
@@ -509,7 +509,7 @@ export default class TrackChoiceManager {
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
    */
-  public setAudioTrackByID(period : Period, wantedId : string) : void {
+  public setAudioTrackByID(period : IPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem !== undefined ? periodItem.audio :
                                                   null;
@@ -537,7 +537,7 @@ export default class TrackChoiceManager {
    * @param {Period} period - The concerned Period.
    * @param {string} wantedId - adaptation id of the wanted track
    */
-  public setTextTrackByID(period : Period, wantedId : string) : void {
+  public setTextTrackByID(period : IPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem !== undefined ? periodItem.text :
                                                  null;
@@ -568,7 +568,7 @@ export default class TrackChoiceManager {
    * @throws Error - Throws if the given id is not found in any video adaptation
    * of the given Period.
    */
-  public setVideoTrackByID(period : Period, wantedId : string) : void {
+  public setVideoTrackByID(period : IPeriod, wantedId : string) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem !== undefined ? periodItem.video :
                                                   null;
@@ -597,7 +597,7 @@ export default class TrackChoiceManager {
    *
    * @throws Error - Throws if the period given has not been added
    */
-  public disableTextTrack(period : Period) : void {
+  public disableTextTrack(period : IPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem !== undefined ? periodItem.text :
                                                  null;
@@ -618,7 +618,7 @@ export default class TrackChoiceManager {
    * @param {Object} period
    * @throws Error - Throws if the period given has not been added
    */
-  public disableVideoTrack(period : Period) : void {
+  public disableVideoTrack(period : IPeriod) : void {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem?.video;
     if (videoInfos === undefined) {
@@ -665,7 +665,7 @@ export default class TrackChoiceManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The audio track chosen for this Period
    */
-  public getChosenAudioTrack(period : Period) : ITMAudioTrack|null {
+  public getChosenAudioTrack(period : IPeriod) : ITMAudioTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem !== undefined ? periodItem.audio :
                                                   null;
@@ -701,7 +701,7 @@ export default class TrackChoiceManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The text track chosen for this Period
    */
-  public getChosenTextTrack(period : Period) : ITMTextTrack|null {
+  public getChosenTextTrack(period : IPeriod) : ITMTextTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem !== undefined ? periodItem.text :
                                                  null;
@@ -732,7 +732,7 @@ export default class TrackChoiceManager {
    * @param {Period} period - The concerned Period.
    * @returns {Object|null} - The video track chosen for this Period
    */
-  public getChosenVideoTrack(period : Period) : ITMVideoTrack|null {
+  public getChosenVideoTrack(period : IPeriod) : ITMVideoTrack|null {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem !== undefined ? periodItem.video :
                                                   null;
@@ -782,7 +782,7 @@ export default class TrackChoiceManager {
    *
    * @returns {Array.<Object>}
    */
-  public getAvailableAudioTracks(period : Period) : ITMAudioTrackListItem[] {
+  public getAvailableAudioTracks(period : IPeriod) : ITMAudioTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const audioInfos = periodItem !== undefined ? periodItem.audio :
                                                   null;
@@ -820,7 +820,7 @@ export default class TrackChoiceManager {
    * @param {Period} period
    * @returns {Array.<Object>}
    */
-  public getAvailableTextTracks(period : Period) : ITMTextTrackListItem[] {
+  public getAvailableTextTracks(period : IPeriod) : ITMTextTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const textInfos = periodItem !== undefined ? periodItem.text :
                                                  null;
@@ -850,7 +850,7 @@ export default class TrackChoiceManager {
    *
    * @returns {Array.<Object>}
    */
-  public getAvailableVideoTracks(period : Period) : ITMVideoTrackListItem[] {
+  public getAvailableVideoTracks(period : IPeriod) : ITMVideoTrackListItem[] {
     const periodItem = getPeriodItem(this._periods, period);
     const videoInfos = periodItem !== undefined ? periodItem.video :
                                                   null;
@@ -1128,14 +1128,14 @@ export default class TrackChoiceManager {
  */
 function createAudioPreferenceMatcher(
   preferredAudioTrack : INormalizedPreferredAudioTrackObject
-) : (audioAdaptation : Adaptation) => boolean {
+) : (audioAdaptation : IAdaptation) => boolean {
   /**
    * Compares an audio Adaptation to the given `preferredAudioTrack` preference.
    * Returns `true` if it matches, false otherwise.
    * @param {Object} audioAdaptation
    * @returns {boolean}
    */
-  return function matchAudioPreference(audioAdaptation : Adaptation) : boolean {
+  return function matchAudioPreference(audioAdaptation : IAdaptation) : boolean {
     if (preferredAudioTrack.normalized !== undefined) {
       const language = audioAdaptation.normalizedLanguage ?? "";
       if (language !== preferredAudioTrack.normalized) {
@@ -1155,7 +1155,7 @@ function createAudioPreferenceMatcher(
       return true;
     }
     const regxp = preferredAudioTrack.codec.test;
-    const codecTestingFn = (rep : Representation) =>
+    const codecTestingFn = (rep : IRepresentation) =>
       rep.codec !== undefined && regxp.test(rep.codec);
 
     if (preferredAudioTrack.codec.all) {
@@ -1175,9 +1175,9 @@ function createAudioPreferenceMatcher(
  * @returns {Adaptation|null}
  */
 function findFirstOptimalAudioAdaptation(
-  audioAdaptations : Adaptation[],
+  audioAdaptations : IAdaptation[],
   preferredAudioTracks : INormalizedPreferredAudioTrack[]
-) : Adaptation|null {
+) : IAdaptation|null {
   if (audioAdaptations.length === 0) {
     return null;
   }
@@ -1215,14 +1215,14 @@ function findFirstOptimalAudioAdaptation(
  */
 function createTextPreferenceMatcher(
   preferredTextTrack : INormalizedPreferredTextTrackObject
-) : (textAdaptation : Adaptation) => boolean {
+) : (textAdaptation : IAdaptation) => boolean {
   /**
    * Compares a text Adaptation to the given `preferredTextTrack` preference.
    * Returns `true` if it matches, false otherwise.
    * @param {Object} textAdaptation
    * @returns {boolean}
    */
-  return function matchTextPreference(textAdaptation : Adaptation) : boolean {
+  return function matchTextPreference(textAdaptation : IAdaptation) : boolean {
     return takeFirstSet<string>(textAdaptation.normalizedLanguage,
                                 "") === preferredTextTrack.normalized &&
     (preferredTextTrack.closedCaption ? textAdaptation.isClosedCaption === true :
@@ -1240,9 +1240,9 @@ function createTextPreferenceMatcher(
  * @returns {Adaptation|null}
  */
 function findFirstOptimalTextAdaptation(
-  textAdaptations : Adaptation[],
+  textAdaptations : IAdaptation[],
   preferredTextTracks : INormalizedPreferredTextTrack[]
-) : Adaptation|null {
+) : IAdaptation|null {
   if (textAdaptations.length === 0) {
     return null;
   }
@@ -1280,14 +1280,14 @@ function findFirstOptimalTextAdaptation(
  */
 function createVideoPreferenceMatcher(
   preferredVideoTrack : IVideoTrackPreferenceObject
-) : (videoAdaptation : Adaptation) => boolean {
+) : (videoAdaptation : IAdaptation) => boolean {
   /**
    * Compares a video Adaptation to the given `preferredVideoTrack` preference.
    * Returns `true` if it matches, false otherwise.
    * @param {Object} videoAdaptation
    * @returns {boolean}
    */
-  return function matchVideoPreference(videoAdaptation : Adaptation) : boolean {
+  return function matchVideoPreference(videoAdaptation : IAdaptation) : boolean {
     if (preferredVideoTrack.signInterpreted !== undefined &&
         preferredVideoTrack.signInterpreted !== videoAdaptation.isSignInterpreted)
     {
@@ -1297,7 +1297,7 @@ function createVideoPreferenceMatcher(
       return true;
     }
     const regxp = preferredVideoTrack.codec.test;
-    const codecTestingFn = (rep : Representation) =>
+    const codecTestingFn = (rep : IRepresentation) =>
       rep.codec !== undefined && regxp.test(rep.codec);
 
     if (preferredVideoTrack.codec.all) {
@@ -1317,9 +1317,9 @@ function createVideoPreferenceMatcher(
  * @returns {Adaptation|null}
  */
 function findFirstOptimalVideoAdaptation(
-  videoAdaptations : Adaptation[],
+  videoAdaptations : IAdaptation[],
   preferredVideoTracks : IVideoTrackPreference[]
-) : Adaptation|null {
+) : IAdaptation|null {
   if (videoAdaptations.length === 0) {
     return null;
   }
@@ -1353,7 +1353,7 @@ function findFirstOptimalVideoAdaptation(
  */
 function findPeriodIndex(
   periods : SortedList<ITMPeriodInfos>,
-  period : Period
+  period : IPeriod
 ) : number|undefined {
   for (let i = 0; i < periods.length(); i++) {
     const periodI = periods.get(i);
@@ -1373,7 +1373,7 @@ function findPeriodIndex(
  */
 function getPeriodItem(
   periods : SortedList<ITMPeriodInfos>,
-  period : Period
+  period : IPeriod
 ) : ITMPeriodInfos|undefined {
   for (let i = 0; i < periods.length(); i++) {
     const periodI = periods.get(i);
@@ -1389,7 +1389,7 @@ function getPeriodItem(
  * @returns {Object}
  */
 function parseVideoRepresentation(
-  { id, bitrate, frameRate, width, height, codec, hdrInfo } : Representation
+  { id, bitrate, frameRate, width, height, codec, hdrInfo } : IRepresentation
 ) : ITMVideoRepresentation {
   return { id, bitrate, frameRate, width, height, codec, hdrInfo };
 }
@@ -1400,15 +1400,15 @@ function parseVideoRepresentation(
  * @returns {Object}
  */
 function parseAudioRepresentation(
-  { id, bitrate, codec } : Representation
+  { id, bitrate, codec } : IRepresentation
 )  : ITMAudioRepresentation {
   return { id, bitrate, codec };
 }
 
 function getRightVideoTrack(
-  adaptation : Adaptation,
+  adaptation : IAdaptation,
   isTrickModeEnabled : boolean
-) : Adaptation {
+) : IAdaptation {
   if (isTrickModeEnabled &&
       adaptation.trickModeTracks?.[0] !== undefined)
   {

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -23,7 +23,7 @@ import {
   ICustomError,
 } from "../../../errors";
 import log from "../../../log";
-import Manifest from "../../../manifest";
+import { IManifest } from "../../../manifest";
 import {
   IRequestedData,
   ITransportManifestPipeline,
@@ -49,7 +49,7 @@ export interface IManifestFetcherParsedResult {
   type : "parsed";
 
   /** The resulting Manifest */
-  manifest : Manifest;
+  manifest : IManifest;
   /**
    * The time (`performance.now()`) at which the request was started (at which
    * the JavaScript call was done).
@@ -88,7 +88,7 @@ export interface IManifestFetcherParserOptions {
    */
   externalClockOffset? : number | undefined;
   /** The previous value of the Manifest (when updating). */
-  previousManifest : Manifest | null;
+  previousManifest : IManifest | null;
   /**
    * If set to `true`, the Manifest parser can perform advanced optimizations
    * to speed-up the parsing process. Those optimizations might lead to a
@@ -365,7 +365,7 @@ export default class ManifestFetcher {
        * To call once the Manifest has been parsed.
        * @param {Object} manifest
        */
-      function emitManifestAndComplete(manifest : Manifest) : void {
+      function emitManifestAndComplete(manifest : IManifest) : void {
         onWarnings(manifest.contentWarnings);
         const parsingTime = performance.now() - parsingTimeStart;
         log.info(`MF: Manifest parsed in ${parsingTime}ms`);

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -366,7 +366,6 @@ export default class ManifestFetcher {
        * @param {Object} manifest
        */
       function emitManifestAndComplete(manifest : IManifest) : void {
-        onWarnings(manifest.contentWarnings);
         const parsingTime = performance.now() - parsingTimeStart;
         log.info(`MF: Manifest parsed in ${parsingTime}ms`);
 

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -21,12 +21,13 @@ import {
   ICustomError,
 } from "../../../errors";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
-  getLoggableSegmentId,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
+  getLoggableSegmentId,
 } from "../../../manifest";
 import {
   IChunkCompleteInformation,
@@ -372,10 +373,10 @@ export interface ISegmentFetcherChunkEvent<TSegmentDataType> {
 export interface ISegmentFetcherChunkCompleteEvent { type: "chunk-complete" }
 
 /** Content used by the segment loader as a context to load a new segment. */
-export interface ISegmentLoaderContent { manifest : Manifest;
-                                         period : Period;
-                                         adaptation : Adaptation;
-                                         representation : Representation;
+export interface ISegmentLoaderContent { manifest : IManifest;
+                                         period : IPeriod;
+                                         adaptation : IAdaptation;
+                                         representation : IRepresentation;
                                          segment : ISegment; }
 
 /**

--- a/src/core/init/create_stream_playback_observer.ts
+++ b/src/core/init/create_stream_playback_observer.ts
@@ -19,7 +19,7 @@ import {
   map,
   Observable,
 } from "rxjs";
-import Manifest from "../../manifest";
+import { IManifest } from "../../manifest";
 import { IReadOnlySharedReference } from "../../utils/reference";
 import {
   IPlaybackObservation,
@@ -49,7 +49,7 @@ export interface IStreamPlaybackObserverArguments {
  * @returns {Observable}
  */
 export default function createStreamPlaybackObserver(
-  manifest : Manifest,
+  manifest : IManifest,
   playbackObserver : PlaybackObserver,
   { autoPlay,
     initialPlayPerformed,

--- a/src/core/init/duration_updater.ts
+++ b/src/core/init/duration_updater.ts
@@ -40,7 +40,7 @@ import {
   onSourceEnded$,
 } from "../../compat/event_listeners";
 import log from "../../log";
-import Manifest from "../../manifest";
+import { IManifest } from "../../manifest";
 import { fromEvent } from "../../utils/event_emitter";
 
 /** Number of seconds in a regular year. */
@@ -56,7 +56,7 @@ const YEAR_IN_SECONDS = 365 * 24 * 3600;
  * @returns {Observable}
  */
 export default function DurationUpdater(
-  manifest : Manifest,
+  manifest : IManifest,
   mediaSource : MediaSource
 ) : Observable<never> {
   return observableDefer(() => {
@@ -105,7 +105,7 @@ export default function DurationUpdater(
  */
 function setMediaSourceDuration(
   mediaSource: MediaSource,
-  manifest: Manifest,
+  manifest: IManifest,
   lastSetDuration?: number
 ): Observable<number | null> {
   return isMediaSourceOpened$(mediaSource).pipe(

--- a/src/core/init/events_generators.ts
+++ b/src/core/init/events_generators.ts
@@ -15,10 +15,11 @@
  */
 
 import { ICustomError } from "../../errors";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import SegmentBuffersStore, {
   IBufferType,
@@ -67,10 +68,10 @@ function unstalled() : IUnstalledEvent {
  * @returns {Object}
  */
 function decipherabilityUpdate(
-  arg : Array<{ manifest : Manifest;
-                period : Period;
-                adaptation : Adaptation;
-                representation : Representation; }>
+  arg : Array<{ manifest : IManifest;
+                period : IPeriod;
+                adaptation : IAdaptation;
+                representation : IRepresentation; }>
 ) : IDecipherabilityUpdateEvent {
   return { type: "decipherabilityUpdate", value: arg };
 }
@@ -81,7 +82,7 @@ function decipherabilityUpdate(
  * @returns {Object}
  */
 function manifestReady(
-  manifest : Manifest
+  manifest : IManifest
 ) : IManifestReadyEvent {
   return { type: "manifestReady", value: { manifest } };
 }
@@ -102,7 +103,7 @@ function manifestUpdate() : IManifestUpdateEvent {
  */
 function nullRepresentation(
   type : IBufferType,
-  period : Period
+  period : IPeriod
 ) : IRepresentationChangeEvent {
   return { type: "representationChange",
            value: { type,

--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -16,7 +16,7 @@
 
 import config from "../../config";
 import log from "../../log";
-import Manifest from "../../manifest";
+import { IManifest } from "../../manifest";
 
 const { DEFAULT_LIVE_GAP } = config;
 
@@ -40,7 +40,7 @@ export interface IInitialTimeOptions { position? : number;
  * @returns {Number}
  */
 export default function getInitialTime(
-  manifest : Manifest,
+  manifest : IManifest,
   lowLatencyMode : boolean,
   startAt? : IInitialTimeOptions
 ) : number {

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -30,7 +30,7 @@ import {
 } from "rxjs";
 import { MediaError } from "../../errors";
 import log from "../../log";
-import Manifest from "../../manifest";
+import { IManifest } from "../../manifest";
 import { IReadOnlySharedReference } from "../../utils/reference";
 import ABRManager from "../abr";
 import { PlaybackObserver } from "../api";
@@ -65,7 +65,7 @@ export interface IMediaSourceLoaderArguments {
   /** Various stream-related options. */
   bufferOptions : IStreamOrchestratorOptions;
   /* Manifest of the content we want to play. */
-  manifest : Manifest;
+  manifest : IManifest;
   /** Media Element on which the content will be played. */
   mediaElement : HTMLMediaElement;
   /** Emit playback conditions regularly. */

--- a/src/core/init/manifest_update_scheduler.ts
+++ b/src/core/init/manifest_update_scheduler.ts
@@ -29,7 +29,7 @@ import {
 } from "rxjs";
 import config from "../../config";
 import log from "../../log";
-import Manifest from "../../manifest";
+import { IManifest } from "../../manifest";
 import throttle from "../../utils/rx-throttle";
 import {
   IManifestFetcherParsedResult,
@@ -47,7 +47,7 @@ export interface IManifestUpdateSchedulerArguments {
   /** Interface allowing to refresh the Manifest */
   manifestFetcher : ManifestFetcher;
   /** Information about the initial load of the manifest */
-  initialManifest : { manifest : Manifest;
+  initialManifest : { manifest : IManifest;
                       sendingTime? : number | undefined;
                       receivedTime? : number | undefined;
                       parsingTime? : number | undefined; };

--- a/src/core/init/stall_avoider.ts
+++ b/src/core/init/stall_avoider.ts
@@ -27,8 +27,9 @@ import isSeekingApproximate from "../../compat/is_seeking_approximate";
 import config from "../../config";
 import { MediaError } from "../../errors";
 import log from "../../log";
-import Manifest, {
-  Period,
+import {
+  IManifest,
+  IPeriod,
 } from "../../manifest";
 import { getNextRangeGap } from "../../utils/ranges";
 import {
@@ -60,7 +61,7 @@ export interface ILockedStreamEvent {
   /** Buffer type for which no segment will currently load. */
   bufferType : IBufferType;
   /** Period for which no segment will currently load. */
-  period : Period;
+  period : IPeriod;
 }
 
 /**
@@ -72,7 +73,7 @@ export interface IDiscontinuityEvent {
   /** Buffer type concerned by the discontinuity. */
   bufferType : IBufferType;
   /** Period concerned by the discontinuity. */
-  period : Period;
+  period : IPeriod;
   /**
    * Close discontinuity time information.
    * `null` if no discontinuity has been detected currently for that buffer
@@ -110,7 +111,7 @@ interface IDiscontinuityStoredInfo {
   /** Buffer type concerned by the discontinuity. */
   bufferType : IBufferType;
   /** Period concerned by the discontinuity. */
-  period : Period;
+  period : IPeriod;
   /** Discontinuity time information. */
   discontinuity : IDiscontinuityTimeInfo;
   /**
@@ -133,7 +134,7 @@ interface IDiscontinuityStoredInfo {
  */
 export default function StallAvoider(
   playbackObserver : PlaybackObserver,
-  manifest: Manifest | null,
+  manifest: IManifest | null,
   lockedStream$ : Observable<ILockedStreamEvent>,
   discontinuityUpdate$: Observable<IDiscontinuityEvent>
 ) : Observable<IStalledEvent | IUnstalledEvent | IWarningEvent> {
@@ -369,7 +370,7 @@ export default function StallAvoider(
  */
 function findSeekableDiscontinuity(
   discontinuitiesStore : IDiscontinuityStoredInfo[],
-  manifest : Manifest,
+  manifest : IManifest,
   stalledPosition : number
 ) : number | null {
   if (discontinuitiesStore.length === 0) {

--- a/src/core/init/stream_events_emitter/refresh_scheduled_events_list.ts
+++ b/src/core/init/stream_events_emitter/refresh_scheduled_events_list.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Manifest from "../../../manifest";
+import { IManifest } from "../../../manifest";
 import areSameStreamEvents from "./are_same_stream_events";
 import {
   INonFiniteStreamEventPayload,
@@ -29,7 +29,7 @@ import {
  */
 function refreshScheduledEventsList(
   oldScheduledEvents: Array<IStreamEventPayload|INonFiniteStreamEventPayload>,
-  manifest: Manifest
+  manifest: IManifest
 ): Array<IStreamEventPayload|INonFiniteStreamEventPayload> {
   const scheduledEvents: Array<IStreamEventPayload|INonFiniteStreamEventPayload> = [];
   const { periods } = manifest;

--- a/src/core/init/stream_events_emitter/stream_events_emitter.ts
+++ b/src/core/init/stream_events_emitter/stream_events_emitter.ts
@@ -32,7 +32,7 @@ import {
   of as observableOf,
 } from "rxjs";
 import config from "../../../config";
-import Manifest from "../../../manifest";
+import { IManifest } from "../../../manifest";
 import { fromEvent } from "../../../utils/event_emitter";
 import { IPlaybackObservation } from "../../api";
 import refreshScheduledEventsList from "./refresh_scheduled_events_list";
@@ -62,7 +62,7 @@ function isFiniteStreamEvent(
  * @param {HTMLMediaElement} mediaElement
  * @returns {Observable}
  */
-function streamEventsEmitter(manifest: Manifest,
+function streamEventsEmitter(manifest: IManifest,
                              mediaElement: HTMLMediaElement,
                              observation$: Observable<IPlaybackObservation>
 ): Observable<IStreamEvent> {

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -15,10 +15,11 @@
  */
 
 import { ICustomError } from "../../errors";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import {
   IAttachedMediaKeysEvent,
@@ -60,7 +61,7 @@ export interface IManifestReadyEvent {
   type : "manifestReady";
   value : {
     /** The Manifest we just parsed. */
-    manifest : Manifest;
+    manifest : IManifest;
   };
 }
 
@@ -76,10 +77,10 @@ export interface IManifestUpdateEvent { type: "manifestUpdate";
  */
 export interface IDecipherabilityUpdateEvent {
   type: "decipherabilityUpdate";
-  value: Array<{ manifest : Manifest;
-                 period : Period;
-                 adaptation : Adaptation;
-                 representation : Representation; }>; }
+  value: Array<{ manifest : IManifest;
+                 period : IPeriod;
+                 adaptation : IAdaptation;
+                 representation : IRepresentation; }>; }
 
 /** Event sent when a minor happened. */
 export interface IWarningEvent { type : "warning";

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -16,10 +16,10 @@
 
 import { Observable } from "rxjs";
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import SegmentInventory, {
   IBufferedChunk,
@@ -266,11 +266,11 @@ export interface IPushedChunkData<T> {
  */
 export interface IEndOfSegmentInfos {
   /** Adaptation object linked to the chunk. */
-  adaptation : Adaptation;
+  adaptation : IAdaptation;
   /** Period object linked to the chunk. */
-  period : Period;
+  period : IPeriod;
   /** Representation object linked to the chunk. */
-  representation : Representation;
+  representation : IRepresentation;
   /** The segment object linked to the pushed chunk. */
   segment : ISegment;
 }

--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -17,11 +17,11 @@
 import config from "../../../config";
 import log from "../../../log";
 import {
-  Adaptation,
+  IAdaptation,
   areSameContent,
   ISegment,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import takeFirstSet from "../../../utils/take_first_set";
 import BufferedHistory, {
@@ -107,11 +107,11 @@ export interface IBufferedChunk {
 /** information to provide when "inserting" a new chunk into the SegmentInventory. */
 export interface IInsertedChunkInfos {
   /** The Adaptation that chunk is linked to */
-  adaptation : Adaptation;
+  adaptation : IAdaptation;
   /** The Period that chunk is linked to */
-  period : Period;
+  period : IPeriod;
   /** The Representation that chunk is linked to. */
-  representation : Representation;
+  representation : IRepresentation;
   /** The Segment that chunk is linked to. */
   segment : ISegment;
   /**
@@ -670,9 +670,9 @@ export default class SegmentInventory {
    * @param {Object} content
    */
   public completeSegment(
-    content : { period: Period;
-                adaptation: Adaptation;
-                representation: Representation;
+    content : { period: IPeriod;
+                adaptation: IAdaptation;
+                representation: IRepresentation;
                 segment: ISegment; },
     newBuffered : TimeRanges
   ) : void {

--- a/src/core/segment_buffers/inventory/types.ts
+++ b/src/core/segment_buffers/inventory/types.ts
@@ -15,20 +15,20 @@
  */
 
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 
 /** Content information for a single buffered chunk */
 export interface IChunkContext {
   /** Adaptation this chunk is related to. */
-  adaptation : Adaptation;
+  adaptation : IAdaptation;
   /** Period this chunk is related to. */
-  period : Period;
+  period : IPeriod;
   /** Representation this chunk is related to. */
-  representation : Representation;
+  representation : IRepresentation;
   /** Segment this chunk is related to. */
   segment : ISegment;
 }

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -44,10 +44,11 @@ import {
 import config from "../../../config";
 import { formatError } from "../../../errors";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import deferSubscriptions from "../../../utils/defer_subscriptions";
 import {
@@ -109,9 +110,9 @@ export interface IAdaptationStreamArguments {
   /** Regularly emit playback conditions. */
   playbackObserver : IReadOnlyPlaybackObserver<IAdaptationStreamPlaybackObservation>;
   /** Content you want to create this Stream for. */
-  content : { manifest : Manifest;
-              period : Period;
-              adaptation : Adaptation; };
+  content : { manifest : IManifest;
+              period : IPeriod;
+              adaptation : IAdaptation; };
   options: IAdaptationStreamOptions;
   /** SourceBuffer wrapper - needed to push media segments. */
   segmentBuffer : SegmentBuffer;
@@ -362,7 +363,7 @@ export default function AdaptationStream({
    * @returns {Observable}
    */
   function createRepresentationStream(
-    representation : Representation,
+    representation : IRepresentation,
     terminateCurrentStream$ : Observable<ITerminationOrder>,
     fastSwitchThreshold$ : Observable<number | undefined>
   ) : Observable<IRepresentationStreamEvent> {

--- a/src/core/stream/adaptation/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/create_representation_estimator.ts
@@ -24,9 +24,10 @@ import {
   switchMap,
 } from "rxjs";
 import { MediaError } from "../../../errors";
-import Manifest, {
-  Adaptation,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IRepresentation,
 } from "../../../manifest";
 import { fromEvent } from "../../../utils/event_emitter";
 import ABRManager, {
@@ -53,8 +54,8 @@ import ABRManager, {
  * @returns {Object}
  */
 export default function createRepresentationEstimator(
-  { manifest, adaptation } : { manifest : Manifest;
-                               adaptation : Adaptation; },
+  { manifest, adaptation } : { manifest : IManifest;
+                               adaptation : IAdaptation; },
   abrManager : ABRManager,
   observation$ : Observable<IABRManagerPlaybackObservation>
 ) : { estimator$ : Observable<IABREstimate>;
@@ -67,7 +68,7 @@ export default function createRepresentationEstimator(
     // Emit directly a first time on subscription (after subscribing to event)
     observableOf(null)
   ).pipe(
-    map(() : Representation[] => {
+    map(() : IRepresentation[] => {
       /** Representations for which a `RepresentationStream` can be created. */
       const playableRepresentations = adaptation.getPlayableRepresentations();
       if (playableRepresentations.length <= 0) {

--- a/src/core/stream/events_generators.ts
+++ b/src/core/stream/events_generators.ts
@@ -17,10 +17,10 @@
 import { Subject } from "rxjs";
 import { ICustomError } from "../../errors";
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import { IContentProtection } from "../eme";
 import { IBufferType } from "../segment_buffers";
@@ -48,15 +48,15 @@ import {
 } from "./types";
 
 const EVENTS = {
-  activePeriodChanged(period : Period) : IActivePeriodChangedEvent {
+  activePeriodChanged(period : IPeriod) : IActivePeriodChangedEvent {
     return { type : "activePeriodChanged",
              value : { period } };
   },
 
   adaptationChange(
     bufferType : IBufferType,
-    adaptation : Adaptation|null,
-    period : Period
+    adaptation : IAdaptation|null,
+    period : IPeriod
   ) : IAdaptationChangeEvent {
     return { type: "adaptationChange",
              value : { type: bufferType,
@@ -65,9 +65,9 @@ const EVENTS = {
   },
 
   addedSegment<T>(
-    content : { adaptation : Adaptation;
-                period : Period;
-                representation : Representation; },
+    content : { adaptation : IAdaptation;
+                period : IPeriod;
+                representation : IRepresentation; },
     segment : ISegment,
     buffered : TimeRanges,
     segmentData : T
@@ -132,7 +132,7 @@ const EVENTS = {
    */
   lockedStream(
     bufferType : IBufferType,
-    period : Period
+    period : IPeriod
   ) : ILockedStreamEvent {
     return { type: "locked-stream",
              value: { bufferType, period } };
@@ -153,8 +153,8 @@ const EVENTS = {
 
   periodStreamReady(
     type : IBufferType,
-    period : Period,
-    adaptation$ : Subject<Adaptation|null>
+    period : IPeriod,
+    adaptation$ : Subject<IAdaptation|null>
   ) : IPeriodStreamReadyEvent {
     return { type: "periodStreamReady",
              value: { type, period, adaptation$ } };
@@ -162,7 +162,7 @@ const EVENTS = {
 
   periodStreamCleared(
     type : IBufferType,
-    period : Period
+    period : IPeriod
   ) : IPeriodStreamClearedEvent {
     return { type: "periodStreamCleared",
              value: { type, period } };
@@ -177,8 +177,8 @@ const EVENTS = {
 
   representationChange(
     type : IBufferType,
-    period : Period,
-    representation : Representation
+    period : IPeriod,
+    representation : IRepresentation
   ) : IRepresentationChangeEvent {
     return { type: "representationChange",
              value: { type, period, representation } };
@@ -200,7 +200,7 @@ const EVENTS = {
 
   waitingMediaSourceReload(
     bufferType : IBufferType,
-    period : Period,
+    period : IPeriod,
     position : number,
     autoPlay : boolean
   ) : IWaitingMediaSourceReloadInternalEvent {

--- a/src/core/stream/orchestrator/active_period_emitter.ts
+++ b/src/core/stream/orchestrator/active_period_emitter.ts
@@ -22,11 +22,11 @@ import {
   Observable,
   scan,
 } from "rxjs";
-import { Period } from "../../../manifest";
+import { IPeriod } from "../../../manifest";
 import { IBufferType } from "../../segment_buffers";
 import { IStreamOrchestratorEvent } from "../types";
 
-interface IPeriodObject { period : Period;
+interface IPeriodObject { period : IPeriod;
                           buffers: Set<IBufferType>; }
 
 type IPeriodsList = Partial<Record<string, IPeriodObject>>;
@@ -71,7 +71,7 @@ type IPeriodsList = Partial<Record<string, IPeriodObject>>;
  */
 export default function ActivePeriodEmitter(
   buffers$: Array<Observable<IStreamOrchestratorEvent>>
-) : Observable<Period|null> {
+) : Observable<IPeriod|null> {
   const numberOfStreams = buffers$.length;
   return observableMerge(...buffers$).pipe(
     // not needed to filter, this is an optim
@@ -123,9 +123,9 @@ export default function ActivePeriodEmitter(
       return acc;
     }, {}),
 
-    map((list) : Period | null => {
+    map((list) : IPeriod | null => {
       const activePeriodIDs = Object.keys(list);
-      const completePeriods : Period[] = [];
+      const completePeriods : IPeriod[] = [];
       for (let i = 0; i < activePeriodIDs.length; i++) {
         const periodInfos = list[activePeriodIDs[i]];
         if (periodInfos !== undefined && periodInfos.buffers.size === numberOfStreams) {
@@ -133,7 +133,7 @@ export default function ActivePeriodEmitter(
         }
       }
 
-      return completePeriods.reduce<Period|null>((acc, period) => {
+      return completePeriods.reduce<IPeriod|null>((acc, period) => {
         if (acc === null) {
           return period;
         }

--- a/src/core/stream/orchestrator/get_blacklisted_ranges.ts
+++ b/src/core/stream/orchestrator/get_blacklisted_ranges.ts
@@ -16,9 +16,9 @@
 
 import log from "../../../log";
 import {
-  Adaptation,
-  Period,
-  Representation,
+  IAdaptation,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import { IRange } from "../../../utils/ranges";
 import { SegmentBuffer } from "../../segment_buffers";
@@ -32,9 +32,9 @@ import { SegmentBuffer } from "../../segment_buffers";
  */
 export default function getBlacklistedRanges(
   segmentBuffer : SegmentBuffer,
-  contents : Array<{ adaptation : Adaptation;
-                     period : Period;
-                     representation : Representation; }>
+  contents : Array<{ adaptation : IAdaptation;
+                     period : IPeriod;
+                     representation : IRepresentation; }>
 ) : IRange[] {
   if (contents.length === 0) {
     return [];

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -38,8 +38,9 @@ import {
 import config from "../../../config";
 import { MediaError } from "../../../errors";
 import log from "../../../log";
-import Manifest, {
-  Period,
+import {
+  IManifest,
+  IPeriod,
 } from "../../../manifest";
 import deferSubscriptions from "../../../utils/defer_subscriptions";
 import { fromEvent } from "../../../utils/event_emitter";
@@ -114,8 +115,8 @@ export type IStreamOrchestratorOptions =
  * @returns {Observable}
  */
 export default function StreamOrchestrator(
-  content : { manifest : Manifest;
-              initialPeriod : Period; },
+  content : { manifest : IManifest;
+              initialPeriod : IPeriod; },
   playbackObserver : IReadOnlyPlaybackObserver<IStreamOrchestratorPlaybackObservation>,
   abrManager : ABRManager,
   segmentBuffersStore : SegmentBuffersStore,
@@ -178,7 +179,7 @@ export default function StreamOrchestrator(
 
   // Emits the activePeriodChanged events every time the active Period changes.
   const activePeriodChanged$ = ActivePeriodEmitter(streamsArray).pipe(
-    filter((period) : period is Period => period !== null),
+    filter((period) : period is IPeriod => period !== null),
     map(period => {
       log.info("Stream: New active period", period.start);
       return EVENTS.activePeriodChanged(period);
@@ -216,10 +217,10 @@ export default function StreamOrchestrator(
    */
   function manageEveryStreams(
     bufferType : IBufferType,
-    basePeriod : Period
+    basePeriod : IPeriod
   ) : Observable<IStreamOrchestratorEvent> {
     // Each Period for which there is currently a Stream, chronologically
-    const periodList = new SortedList<Period>((a, b) => a.start - b.start);
+    const periodList = new SortedList<IPeriod>((a, b) => a.start - b.start);
     const destroyStreams$ = new Subject<void>();
 
     // When set to `true`, all the currently active PeriodStream will be destroyed
@@ -234,7 +235,7 @@ export default function StreamOrchestrator(
      * @returns {Observable}
      */
     function launchConsecutiveStreamsForPeriod(
-      period : Period
+      period : IPeriod
     ) : Observable<IStreamOrchestratorEvent> {
       return manageConsecutivePeriodStreams(bufferType, period, destroyStreams$).pipe(
         map((message) => {
@@ -289,7 +290,7 @@ export default function StreamOrchestrator(
     const restartStreamsWhenOutOfBounds$ = playbackObserver.observe(true).pipe(
       filterMap<
         IStreamOrchestratorPlaybackObservation,
-        Period,
+        IPeriod,
         null
       >(({ position, wantedTimeOffset }) => {
         const time = wantedTimeOffset + position;
@@ -400,13 +401,13 @@ export default function StreamOrchestrator(
    */
   function manageConsecutivePeriodStreams(
     bufferType : IBufferType,
-    basePeriod : Period,
+    basePeriod : IPeriod,
     destroy$ : Observable<void>
   ) : Observable<IMultiplePeriodStreamsEvent> {
     log.info("SO: Creating new Stream for", bufferType, basePeriod.start);
 
     // Emits the Period of the next Period Stream when it can be created.
-    const createNextPeriodStream$ = new Subject<Period>();
+    const createNextPeriodStream$ = new Subject<IPeriod>();
 
     // Emits when the Streams for the next Periods should be destroyed, if
     // created.

--- a/src/core/stream/period/create_empty_adaptation_stream.ts
+++ b/src/core/stream/period/create_empty_adaptation_stream.ts
@@ -21,7 +21,7 @@ import {
   of as observableOf,
 } from "rxjs";
 import log from "../../../log";
-import { Period } from "../../../manifest";
+import { IPeriod } from "../../../manifest";
 import { IReadOnlySharedReference } from "../../../utils/reference";
 import { IReadOnlyPlaybackObserver } from "../../api";
 import { IBufferType } from "../../segment_buffers";
@@ -42,7 +42,7 @@ export default function createEmptyAdaptationStream(
   playbackObserver : IReadOnlyPlaybackObserver<{ position : number }>,
   wantedBufferAhead : IReadOnlySharedReference<number>,
   bufferType : IBufferType,
-  content : { period : Period }
+  content : { period : IPeriod }
 ) : Observable<IStreamStatusEvent> {
   const { period } = content;
   let hasFinishedLoading = false;

--- a/src/core/stream/period/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/get_adaptation_switch_strategy.ts
@@ -16,8 +16,8 @@
 
 import config from "../../../config";
 import {
-  Adaptation,
-  Period,
+  IAdaptation,
+  IPeriod,
 } from "../../../manifest";
 import areCodecsCompatible from "../../../utils/are_codecs_compatible";
 import {
@@ -69,8 +69,8 @@ export interface IAdaptationSwitchOptions {
  */
 export default function getAdaptationSwitchStrategy(
   segmentBuffer : SegmentBuffer,
-  period : Period,
-  adaptation : Adaptation,
+  period : IPeriod,
+  adaptation : IAdaptation,
   playbackInfo : { currentTime : number; readyState : number },
   options : IAdaptationSwitchOptions
 ) : IAdaptationSwitchStrategy {
@@ -124,9 +124,8 @@ export default function getAdaptationSwitchStrategy(
       // We're playing the current Period
       isTimeInRange({ start, end }, currentTime) &&
       // There is data for the current position or the codecs are differents
-      (playbackInfo.readyState > 1 || !adaptation.getPlayableRepresentations()
-        .some(rep =>
-          areCodecsCompatible(rep.getMimeTypeString(), segmentBuffer.codec ?? ""))) &&
+      (playbackInfo.readyState > 1 || !hasCompatibleCodec(adaptation,
+                                                          segmentBuffer.codec ?? "")) &&
       // We're not playing the current wanted video Adaptation
       !isTimeInRanges(adaptationInBuffer, currentTime))
   {
@@ -205,7 +204,7 @@ export default function getAdaptationSwitchStrategy(
  * @returns {boolean}
  */
 function hasCompatibleCodec(
-  adaptation : Adaptation,
+  adaptation : IAdaptation,
   segmentBufferCodec : string
 ) : boolean {
   return adaptation.getPlayableRepresentations().some(rep =>
@@ -222,8 +221,8 @@ function hasCompatibleCodec(
  */
 function getBufferedRangesFromAdaptation(
   inventory : IBufferedChunk[],
-  period : Period,
-  adaptation : Adaptation
+  period : IPeriod,
+  adaptation : IAdaptation
 ) : IRange[] {
   return inventory.reduce<IRange[]>((acc : IRange[], chunk) : IRange[] => {
     if (chunk.infos.period.id !== period.id ||
@@ -249,7 +248,7 @@ function getBufferedRangesFromAdaptation(
  */
 function getLastSegmentBeforePeriod(
   inventory : IBufferedChunk[],
-  period : Period
+  period : IPeriod
 ) : IBufferedChunk | null {
   for (let i = 0; i < inventory.length; i++) {
     if (inventory[i].infos.period.start >= period.start) {
@@ -272,7 +271,7 @@ function getLastSegmentBeforePeriod(
  */
 function getFirstSegmentAfterPeriod(
   inventory : IBufferedChunk[],
-  period : Period
+  period : IPeriod
 ) : IBufferedChunk | null {
   for (let i = 0; i < inventory.length; i++) {
     if (inventory[i].infos.period.start > period.start) {

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -32,9 +32,10 @@ import {
 import config from "../../../config";
 import { formatError } from "../../../errors";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
-  Period,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
 } from "../../../manifest";
 import objectAssign from "../../../utils/object_assign";
 import { getLeftSizeOfRange } from "../../../utils/ranges";
@@ -91,8 +92,8 @@ export interface IPeriodStreamPlaybackObservation {
 export interface IPeriodStreamArguments {
   abrManager : ABRManager;
   bufferType : IBufferType;
-  content : { manifest : Manifest;
-              period : Period; };
+  content : { manifest : IManifest;
+              period : IPeriod; };
   garbageCollectors : WeakMapMemory<SegmentBuffer, Observable<never>>;
   segmentFetcherCreator : SegmentFetcherCreator;
   segmentBuffersStore : SegmentBuffersStore;
@@ -148,10 +149,10 @@ export default function PeriodStream({
 
   // Emits the chosen Adaptation for the current type.
   // `null` when no Adaptation is chosen (e.g. no subtitles)
-  const adaptation$ = new ReplaySubject<Adaptation|null>(1);
+  const adaptation$ = new ReplaySubject<IAdaptation|null>(1);
   return adaptation$.pipe(
     switchMap((
-      adaptation : Adaptation | null,
+      adaptation : IAdaptation | null,
       switchNb : number
     ) : Observable<IPeriodStreamEvent> => {
       /**
@@ -267,7 +268,7 @@ export default function PeriodStream({
    * @returns {Observable}
    */
   function createAdaptationStream(
-    adaptation : Adaptation,
+    adaptation : IAdaptation,
     segmentBuffer : SegmentBuffer
   ) : Observable<IAdaptationStreamEvent|IStreamWarningEvent> {
     const { manifest } = content;
@@ -311,7 +312,7 @@ export default function PeriodStream({
 function createOrReuseSegmentBuffer(
   segmentBuffersStore : SegmentBuffersStore,
   bufferType : IBufferType,
-  adaptation : Adaptation,
+  adaptation : IAdaptation,
   options: { textTrackOptions? : ITextTrackSegmentBufferOptions }
 ) : SegmentBuffer {
   const segmentBufferStatus = segmentBuffersStore.getStatus(bufferType);
@@ -332,7 +333,7 @@ function createOrReuseSegmentBuffer(
  * @param {Adaptation} adaptation
  * @returns {string}
  */
-function getFirstDeclaredMimeType(adaptation : Adaptation) : string {
+function getFirstDeclaredMimeType(adaptation : IAdaptation) : string {
   const { representations } = adaptation;
   if (representations[0] == null) {
     return "";

--- a/src/core/stream/reload_after_switch.ts
+++ b/src/core/stream/reload_after_switch.ts
@@ -18,7 +18,7 @@ import {
   map,
   Observable,
 } from "rxjs";
-import { Period } from "../../manifest";
+import { IPeriod } from "../../manifest";
 import { IReadOnlyPlaybackObserver } from "../api";
 import { IBufferType } from "../segment_buffers";
 import EVENTS from "./events_generators";
@@ -46,7 +46,7 @@ import { IWaitingMediaSourceReloadInternalEvent } from "./types";
  * @returns {Observable}
  */
 export default function reloadAfterSwitch(
-  period : Period,
+  period : IPeriod,
   bufferType : IBufferType,
   playbackObserver : IReadOnlyPlaybackObserver<{
     position : number;

--- a/src/core/stream/representation/check_for_discontinuity.ts
+++ b/src/core/stream/representation/check_for_discontinuity.ts
@@ -15,10 +15,11 @@
  */
 
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import { IBufferedChunk } from "../../segment_buffers";
 import { IBufferDiscontinuity } from "../types";
@@ -50,10 +51,10 @@ import { IBufferDiscontinuity } from "../types";
  * though the array given can be larger.
  */
 export default function checkForDiscontinuity(
-  content : { adaptation : Adaptation;
-              manifest : Manifest;
-              period : Period;
-              representation : Representation; },
+  content : { adaptation : IAdaptation;
+              manifest : IManifest;
+              period : IPeriod;
+              representation : IRepresentation; },
   checkedRange : { start : number; end : number },
   nextSegmentStart : number | null,
   hasFinishedLoading : boolean,

--- a/src/core/stream/representation/downloading_queue.ts
+++ b/src/core/stream/representation/downloading_queue.ts
@@ -32,11 +32,12 @@ import {
 } from "rxjs";
 import { ICustomError } from "../../../errors";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../../manifest";
 import {
   ISegmentParserParsedInitChunk,
@@ -482,13 +483,13 @@ interface ISegmentRequestObject<T> {
 /** Context for segments downloaded through the DownloadingQueue. */
 export interface IDownloadingQueueContext {
   /** Adaptation linked to the segments you want to load. */
-  adaptation : Adaptation;
+  adaptation : IAdaptation;
   /** Manifest linked to the segments you want to load. */
-  manifest : Manifest;
+  manifest : IManifest;
   /** Period linked to the segments you want to load. */
-  period : Period;
+  period : IPeriod;
   /** Representation linked to the segments you want to load. */
-  representation : Representation;
+  representation : IRepresentation;
 }
 
 /** Object describing a pending Segment request. */

--- a/src/core/stream/representation/get_buffer_status.ts
+++ b/src/core/stream/representation/get_buffer_status.ts
@@ -15,10 +15,11 @@
  */
 
 import config from "../../../config";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import { IReadOnlyPlaybackObserver } from "../../api";
 import {
@@ -79,10 +80,10 @@ export interface IBufferStatus {
  * @returns {Object}
  */
 export default function getBufferStatus(
-  content: { adaptation : Adaptation;
-             manifest : Manifest;
-             period : Period;
-             representation : Representation; },
+  content: { adaptation : IAdaptation;
+             manifest : IManifest;
+             period : IPeriod;
+             representation : IRepresentation; },
   wantedStartPosition : number,
   playbackObserver : IReadOnlyPlaybackObserver<unknown>,
   fastSwitchThreshold : number | undefined,
@@ -222,7 +223,7 @@ function getPlayableBufferedSegments(
     const { representation } = eltInventory.infos;
     if (!eltInventory.partiallyPushed &&
         representation.decipherable !== false &&
-        representation.isSupported)
+        representation.isCodecSupported)
     {
       const inventorySegment = eltInventory.infos.segment;
       const eltInventoryStart = inventorySegment.time /

--- a/src/core/stream/representation/get_needed_segments.ts
+++ b/src/core/stream/representation/get_needed_segments.ts
@@ -17,12 +17,13 @@
 // eslint-disable-next-line max-len
 import config from "../../../config";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
-  areSameContent,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
+  areSameContent,
 } from "../../../manifest";
 import objectAssign from "../../../utils/object_assign";
 import { IBufferedChunk } from "../../segment_buffers";
@@ -39,10 +40,10 @@ const { CONTENT_REPLACEMENT_PADDING,
 /** Arguments for `getNeededSegments`. */
 export interface IGetNeededSegmentsArguments {
   /** The content we want to load segments for */
-  content: { adaptation : Adaptation;
-             manifest : Manifest;
-             period : Period;
-             representation : Representation; };
+  content: { adaptation : IAdaptation;
+             manifest : IManifest;
+             period : IPeriod;
+             representation : IRepresentation; };
   /**
    * The current playing position.
    * Important to avoid asking for segments on the same exact position, which
@@ -61,9 +62,9 @@ export interface IGetNeededSegmentsArguments {
   /** The range we want to fill with segments. */
   neededRange : { start: number; end: number };
   /** The list of segments that are already in the process of being pushed. */
-  segmentsBeingPushed : Array<{ adaptation : Adaptation;
-                                period : Period;
-                                representation : Representation;
+  segmentsBeingPushed : Array<{ adaptation : IAdaptation;
+                                period : IPeriod;
+                                representation : IRepresentation;
                                 segment : ISegment; }>;
   /**
    * Information on the segments already in the buffer, in chronological order.
@@ -258,13 +259,13 @@ function getLastContiguousSegment(
  * @returns {boolean}
  */
 function shouldContentBeReplaced(
-  oldContent : { adaptation : Adaptation;
-                 period : Period;
-                 representation : Representation;
+  oldContent : { adaptation : IAdaptation;
+                 period : IPeriod;
+                 representation : IRepresentation;
                  segment : ISegment; },
-  currentContent : { adaptation : Adaptation;
-                     period : Period;
-                     representation : Representation; },
+  currentContent : { adaptation : IAdaptation;
+                     period : IPeriod;
+                     representation : IRepresentation; },
   currentPlaybackTime: number,
   fastSwitchThreshold? : number
 ) : boolean {
@@ -297,8 +298,8 @@ function shouldContentBeReplaced(
  * @returns {boolean}
  */
 function canFastSwitch(
-  oldSegmentRepresentation : Representation,
-  newSegmentRepresentation : Representation,
+  oldSegmentRepresentation : IRepresentation,
+  newSegmentRepresentation : IRepresentation,
   fastSwitchThreshold : number | undefined
 ) : boolean {
   const oldContentBitrate = oldSegmentRepresentation.bitrate;

--- a/src/core/stream/representation/push_init_segment.ts
+++ b/src/core/stream/representation/push_init_segment.ts
@@ -20,11 +20,12 @@ import {
   map,
   Observable,
 } from "rxjs";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../../manifest";
 import { IReadOnlyPlaybackObserver } from "../../api";
 import {
@@ -51,10 +52,10 @@ export default function pushInitSegment<T>(
     segmentBuffer } :
   { playbackObserver : IReadOnlyPlaybackObserver<{ position : number;
                                                    wantedTimeOffset : number; }>;
-    content: { adaptation : Adaptation;
-               manifest : Manifest;
-               period : Period;
-               representation : Representation; };
+    content: { adaptation : IAdaptation;
+               manifest : IManifest;
+               period : IPeriod;
+               representation : IRepresentation; };
     segmentData : T | null;
     segment : ISegment;
     segmentBuffer : SegmentBuffer; }

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -21,11 +21,12 @@ import {
   Observable,
 } from "rxjs";
 import config from "../../../config";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../../manifest";
 import { ISegmentParserParsedMediaChunk } from "../../../transports";
 import objectAssign from "../../../utils/object_assign";
@@ -54,10 +55,10 @@ export default function pushMediaSegment<T>(
     segmentBuffer } :
   { playbackObserver : IReadOnlyPlaybackObserver<{ position : number;
                                                    wantedTimeOffset : number; }>;
-    content: { adaptation : Adaptation;
-               manifest : Manifest;
-               period : Period;
-               representation : Representation; };
+    content: { adaptation : IAdaptation;
+               manifest : IManifest;
+               period : IPeriod;
+               representation : IRepresentation; };
     initSegmentData : T | null;
     parsedSegment : ISegmentParserParsedMediaChunk<T>;
     segment : ISegment;

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -42,11 +42,12 @@ import {
   withLatestFrom,
 } from "rxjs";
 import log from "../../../log";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../../manifest";
 import assertUnreachable from "../../../utils/assert_unreachable";
 import objectAssign from "../../../utils/object_assign";
@@ -109,10 +110,10 @@ export interface ITerminationOrder {
 /** Arguments to give to the RepresentationStream. */
 export interface IRepresentationStreamArguments<TSegmentDataType> {
   /** The context of the Representation you want to load. */
-  content: { adaptation : Adaptation;
-             manifest : Manifest;
-             period : Period;
-             representation : Representation; };
+  content: { adaptation : IAdaptation;
+             manifest : IManifest;
+             period : IPeriod;
+             representation : IRepresentation; };
   /** The `SegmentBuffer` on which segments will be pushed. */
   segmentBuffer : SegmentBuffer;
   /** Interface used to load new segments. */

--- a/src/core/stream/types.ts
+++ b/src/core/stream/types.ts
@@ -17,10 +17,10 @@
 import { Subject } from "rxjs";
 import { ICustomError } from "../../errors";
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Period,
-  Representation,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import { IEMSG } from "../../parsers/containers/isobmff";
 import { IContentProtection } from "../eme";
@@ -66,7 +66,7 @@ export interface IStreamStatusEvent {
   type : "stream-status";
   value : {
     /** Period concerned. */
-    period : Period;
+    period : IPeriod;
     /** Buffer type concerned. */
     bufferType : IBufferType;
     /**
@@ -119,9 +119,9 @@ export interface IStreamEventAddedSegment<T> {
   type : "added-segment";
   value : {
     /** Context about the content that has been added. */
-    content: { period : Period;
-               adaptation : Adaptation;
-               representation : Representation; };
+    content: { period : IPeriod;
+               adaptation : IAdaptation;
+               representation : IRepresentation; };
     /** The concerned Segment. */
     segment : ISegment;
     /** TimeRanges of the concerned SegmentBuffer after the segment was pushed. */
@@ -212,12 +212,12 @@ export interface IRepresentationChangeEvent {
     /** The type of buffer linked to that `RepresentationStream`. */
     type : IBufferType;
     /** The `Period` linked to the `RepresentationStream` we're creating. */
-    period : Period;
+    period : IPeriod;
     /**
      * The `Representation` linked to the `RepresentationStream` we're creating.
      * `null` when we're choosing no Representation at all.
      */
-    representation : Representation |
+    representation : IRepresentation |
                      null; };
 }
 
@@ -231,12 +231,12 @@ export interface IAdaptationChangeEvent {
     /** The type of buffer for which the Representation is changing. */
     type : IBufferType;
     /** The `Period` linked to the `RepresentationStream` we're creating. */
-    period : Period;
+    period : IPeriod;
     /**
      * The `Adaptation` linked to the `AdaptationStream` we're creating.
      * `null` when we're choosing no Adaptation at all.
      */
-    adaptation : Adaptation |
+    adaptation : IAdaptation |
                  null;
   };
 }
@@ -246,7 +246,7 @@ export interface IActivePeriodChangedEvent {
   type: "activePeriodChanged";
   value : {
     /** The Period we're now playing. */
-    period: Period;
+    period: IPeriod;
   };
 }
 
@@ -260,7 +260,7 @@ export interface IPeriodStreamReadyEvent {
     /** The type of buffer linked to the `PeriodStream` we want to create. */
     type : IBufferType;
     /** The `Period` linked to the `PeriodStream` we have created. */
-    period : Period;
+    period : IPeriod;
     /**
      * The subject through which any Adaptation (i.e. track) choice should be
      * emitted for that `PeriodStream`.
@@ -270,7 +270,7 @@ export interface IPeriodStreamReadyEvent {
      * You can send `null` through it to tell this `PeriodStream` that you don't
      * want any `Adaptation`.
      */
-    adaptation$ : Subject<Adaptation|null>;
+    adaptation$ : Subject<IAdaptation|null>;
   };
 }
 
@@ -296,7 +296,7 @@ export interface IPeriodStreamClearedEvent {
      * The combination of this and `Period` should give you enough information
      * about which `PeriodStream` has been removed.
      */
-    period : Period;
+    period : IPeriod;
   };
 }
 
@@ -360,7 +360,7 @@ export interface IWaitingMediaSourceReloadInternalEvent {
   type: "waiting-media-source-reload";
   value: {
     /** Period concerned. */
-    period : Period;
+    period : IPeriod;
     /** Buffer type concerned. */
     bufferType : IBufferType;
     /**
@@ -398,7 +398,7 @@ export interface ILockedStreamEvent {
   type : "locked-stream";
   value : {
     /** Period concerned. */
-    period : Period;
+    period : IPeriod;
     /** Buffer type concerned. */
     bufferType : IBufferType;
   };

--- a/src/experimental/tools/VideoThumbnailLoader/get_content_infos.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/get_content_infos.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Manifest from "../../../manifest";
+import { IManifest } from "../../../manifest";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import { IContentInfos } from "./types";
 
@@ -27,7 +27,7 @@ import { IContentInfos } from "./types";
  */
 export default function getContentInfos(
   time: number,
-  manifest: Manifest
+  manifest: IManifest
 ): IContentInfos|null {
   const period = manifest.getPeriodForTime(time);
   if (period === undefined ||

--- a/src/experimental/tools/VideoThumbnailLoader/push_data.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/push_data.ts
@@ -2,11 +2,12 @@ import {
   Observable,
 } from "rxjs";
 import { AudioVideoSegmentBuffer } from "../../../core/segment_buffers/implementations";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
 } from "../../../manifest";
 import { ISegmentParserParsedMediaChunk } from "../../../transports";
 
@@ -19,10 +20,10 @@ import { ISegmentParserParsedMediaChunk } from "../../../transports";
  * @returns
  */
 export default function pushData(
-  inventoryInfos: { manifest: Manifest;
-                    period: Period;
-                    adaptation: Adaptation;
-                    representation: Representation;
+  inventoryInfos: { manifest: IManifest;
+                    period: IPeriod;
+                    adaptation: IAdaptation;
+                    representation: IRepresentation;
                     segment: ISegment;
                     start: number;
                     end: number; },

--- a/src/experimental/tools/VideoThumbnailLoader/types.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/types.ts
@@ -15,19 +15,21 @@
  * limitations under the License.
  */
 
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../../manifest";
 import {
   ISegmentParser,
   ITransportPipelines,
 } from "../../../transports";
-export interface IContentInfos { manifest: Manifest;
-                                 period: Period;
-                                 adaptation: Adaptation;
-                                 representation: Representation; }
+
+export interface IContentInfos { manifest: IManifest;
+                                 period: IPeriod;
+                                 adaptation: IAdaptation;
+                                 representation: IRepresentation; }
 
 export type ILoaders = Partial<Record<string, ITransportPipelines>>;
 

--- a/src/manifest/__tests__/adaptation.test.ts
+++ b/src/manifest/__tests__/adaptation.test.ts
@@ -21,10 +21,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import {
-  IRepresentationInfos,
-} from "../adaptation";
-import Representation from "../representation";
+import { IRepresentationInfos } from "../adaptation";
+import { IRepresentation } from "../types";
 
 const minimalRepresentationIndex = {
   getInitSegment() { return null; },
@@ -191,7 +189,7 @@ describe("Manifest - Adaptation", () => {
     const representations = [rep1, rep2, rep3, rep4, rep5, rep6];
 
     const representationFilter = jest.fn((
-      representation : Representation,
+      representation : IRepresentation,
       adaptationInfos : IRepresentationInfos
     ) => {
       if (adaptationInfos.language === "fr" && representation.bitrate < 40) {

--- a/src/manifest/__tests__/period.test.ts
+++ b/src/manifest/__tests__/period.test.ts
@@ -27,24 +27,27 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no adaptation is given", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const args = { id: "12", adaptations: {}, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -55,37 +58,40 @@ describe("Manifest - Period", () => {
 
     expect((errorReceived as { code? : string }).code).toBe("MANIFEST_PARSE_ERROR");
     expect(errorReceived.message).toContain("No supported audio and video tracks.");
-    expect(adaptationSpy).not.toHaveBeenCalled();
+    expect(createAdaptationSpy).not.toHaveBeenCalled();
   });
 
   it("should throw if no audio nor video adaptation is given", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const fooAda1 = { type: "foo",
                       id: "54",
-                      isSupported: true,
+                      isCodecSupported: true,
                       representations: [{}] };
     const fooAda2 = { type: "foo",
                       id: "55",
-                      isSupported: true,
+                      isCodecSupported: true,
                       representations: [{}] };
     const foo = [fooAda1, fooAda2];
     const args = { id: "12", adaptations: { foo }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -98,30 +104,33 @@ describe("Manifest - Period", () => {
     expect((errorReceived as { type? : string }).type).toBe("MEDIA_ERROR");
     expect(errorReceived.message).toContain("No supported audio and video tracks.");
 
-    expect(adaptationSpy).toHaveBeenCalledTimes(2);
-    expect(adaptationSpy).toHaveBeenNthCalledWith(1, fooAda1, {});
-    expect(adaptationSpy).toHaveBeenNthCalledWith(2, fooAda2, {});
+    expect(createAdaptationSpy).toHaveBeenCalledTimes(2);
+    expect(createAdaptationSpy).toHaveBeenNthCalledWith(1, fooAda1, {});
+    expect(createAdaptationSpy).toHaveBeenNthCalledWith(2, fooAda2, {});
   });
 
   it("should throw if only empty audio and/or video adaptations is given", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const args = { id: "12", adaptations: { video: [], audio: [] }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -134,51 +143,54 @@ describe("Manifest - Period", () => {
     expect((errorReceived as { type? : string }).type).toBe("MEDIA_ERROR");
     expect(errorReceived.message).toContain("No supported audio and video tracks.");
 
-    expect(adaptationSpy).toHaveBeenCalledTimes(0);
+    expect(createAdaptationSpy).toHaveBeenCalledTimes(0);
   });
 
   it("should throw if we are left with no audio representation", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "57",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -193,47 +205,50 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no audio Adaptation is supported", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "57",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "58",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -248,47 +263,50 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if we are left with no video representation", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -303,47 +321,50 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no video adaptation is supported", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
+    let warnings = null;
     let errorReceived = null;
     try {
-      period = new Period(args);
+      [period, warnings] = createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
 
     expect(period).toBe(null);
+    expect(warnings).toEqual(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
 
@@ -358,304 +379,316 @@ describe("Manifest - Period", () => {
   });
 
   it("should set a parsing error if an unsupported adaptation is given", () => {
-    const adaptationSpy = jest.fn(arg => {
+    const createAdaptationSpy = jest.fn(arg => {
       return { ...arg };
     });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
 
     const videoAda1 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1];
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const video2 = [videoAda2];
     const args = { id: "12", adaptations: { video, video2 }, start: 0 };
-    const period = new Period(args);
-    expect(period.contentWarnings).toHaveLength(1);
+    const [period, warnings] = createPeriodObject(args);
+    expect(warnings).toHaveLength(1);
 
-    expect(adaptationSpy).toHaveBeenCalledTimes(2);
-    expect(adaptationSpy).toHaveReturnedTimes(2);
-    expect(adaptationSpy).toHaveBeenCalledWith(videoAda1, {});
-    expect(adaptationSpy).toHaveBeenCalledWith(videoAda2, {});
-    expect(adaptationSpy).toHaveReturnedWith(period.adaptations.video[0]);
+    expect(createAdaptationSpy).toHaveBeenCalledTimes(2);
+    expect(createAdaptationSpy).toHaveReturnedTimes(2);
+    expect(createAdaptationSpy).toHaveBeenCalledWith(videoAda1, {});
+    expect(createAdaptationSpy).toHaveBeenCalledWith(videoAda2, {});
+    expect(createAdaptationSpy).toHaveReturnedWith(period.adaptations.video[0]);
 
-    const [error] = period.contentWarnings;
+    const [error] = warnings;
     expect(error).toBeInstanceOf(Error);
     expect(error.code).toBe("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
     expect(error.type).toBe("MEDIA_ERROR");
   });
 
+  /* eslint-disable-next-line max-len */
   it("should not set a parsing error if an empty unsupported adaptation is given", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image", "foo"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
 
     const videoAda1 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1];
     const bar = undefined;
     const args = { id: "12", adaptations: { bar, video }, start: 0 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
     expect(period.adaptations).toEqual({
-      video: video.map(v => ({ ...v, contentWarnings: [] })),
+      video: video.map(v => ({ ...v })),
     });
-    expect(period.contentWarnings).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
 
-    expect(adaptationSpy).toHaveBeenCalledTimes(1);
-    expect(adaptationSpy).toHaveBeenCalledWith(videoAda1, {});
+    expect(createAdaptationSpy).toHaveBeenCalledTimes(1);
+    expect(createAdaptationSpy).toHaveBeenCalledWith(videoAda1, {});
   });
 
   it("should give a representationFilter to the adaptation", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     const representationFilter = jest.fn();
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0 };
-    const period = new Period(args, representationFilter);
+    const [period, warnings] = createPeriodObject(args, representationFilter);
 
-    expect(period.contentWarnings).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
     expect(period.adaptations.video).toHaveLength(2);
 
-    expect(adaptationSpy).toHaveBeenCalledTimes(2);
-    expect(adaptationSpy).toHaveBeenNthCalledWith(1, videoAda1, { representationFilter });
-    expect(adaptationSpy).toHaveBeenNthCalledWith(2, videoAda2, { representationFilter });
+    expect(createAdaptationSpy).toHaveBeenCalledTimes(2);
+    expect(createAdaptationSpy)
+      .toHaveBeenNthCalledWith(1, videoAda1, { representationFilter });
+    expect(createAdaptationSpy)
+      .toHaveBeenNthCalledWith(2, videoAda2, { representationFilter });
     expect(representationFilter).not.toHaveBeenCalled();
   });
 
-  it("should add contentWarnings if Adaptations are not supported", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg }));
+  it("should add warnings if Adaptations are not supported", () => {
+    const createAdaptationSpy = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const fooAda1 = { type: "foo",
                       id: "12",
-                      isSupported: false,
+                      isCodecSupported: false,
                       representations: [{}] };
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args);
+    const [_period, warnings] = createPeriodObject(args);
 
-    expect(period.contentWarnings).toHaveLength(2);
-    const error = period.contentWarnings[0];
+    expect(warnings).toHaveLength(2);
+    const error = warnings[0];
     expect(error.code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
     expect(error.type).toEqual("MEDIA_ERROR");
 
-    const error2 = period.contentWarnings[1];
+    const error2 = warnings[1];
     expect(error2.code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
     expect(error2.type).toEqual("MEDIA_ERROR");
   });
 
-  it("should not add contentWarnings if an Adaptation has no Representation", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg }));
+  /* eslint-disable-next-line max-len */
+  it("should not add warnings if an Adaptation has no Representation", () => {
+    const createAdaptationSpy = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: false,
+                        isCodecSupported: false,
                         representations: [] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const fooAda1 = { type: "foo",
                       id: "12",
-                      isSupported: false,
+                      isCodecSupported: false,
                       representations: [] };
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args);
+    const [_period, warnings] = createPeriodObject(args);
 
-    expect(period.contentWarnings).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
   });
 
   it("should set the given start", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 72 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
     expect(period.start).toEqual(72);
     expect(period.duration).toEqual(undefined);
     expect(period.end).toEqual(undefined);
+    expect(warnings).toEqual([]);
   });
 
   it("should set a given duration", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0, duration: 12 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
     expect(period.start).toEqual(0);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(12);
+    expect(warnings).toEqual([]);
   });
 
   it("should infer the end from the start and the duration", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
     expect(period.start).toEqual(50);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(62);
+    expect(warnings).toEqual([]);
   });
 
   it("should return every Adaptations combined with `getAdaptations`", () => {
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
 
     expect(period.getAdaptations()).toHaveLength(3);
     expect(period.getAdaptations()).toContain(period.adaptations.video[0]);
     expect(period.getAdaptations()).toContain(period.adaptations.video[1]);
     expect(period.getAdaptations()).toContain(period.adaptations.audio[0]);
+    expect(warnings).toEqual([]);
   });
 
   /* eslint-disable max-len */
   it("should return every Adaptations from a given type with `getAdaptationsForType`", () => {
   /* eslint-enable max-len */
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
 
     expect(period.getAdaptationsForType("video")).toHaveLength(2);
     expect(period.getAdaptationsForType("video"))
@@ -668,55 +701,86 @@ describe("Manifest - Period", () => {
 
     expect(period.getAdaptationsForType("image")).toHaveLength(0);
     expect(period.getAdaptationsForType("text")).toHaveLength(0);
+    expect(warnings).toEqual([]);
   });
 
   /* eslint-disable max-len */
   it("should return the first Adaptations with a given Id when calling `getAdaptation`", () => {
   /* eslint-enable max-len */
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
 
-    const Period = require("../period").default;
+    const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "55",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isSupported: true,
+                        isCodecSupported: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const [period, warnings] = createPeriodObject(args);
 
     expect(period.getAdaptation("54")).toEqual(period.adaptations.video[0]);
     expect(period.getAdaptation("55")).toEqual(period.adaptations.video[1]);
     expect(period.getAdaptation("56")).toEqual(period.adaptations.audio[0]);
+    expect(warnings).toEqual([]);
   });
 
-  /* eslint-disable max-len */
-  it("should return undefind if no adaptation has the given Id when calling `getAdaptation`", () => {
-  /* eslint-enable max-len */
-    const adaptationSpy = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+  /* eslint-disable-next-line max-len */
+  it("should return undefined if no adaptation has the given Id when calling `getAdaptation`", () => {
+    const createAdaptationSpy = jest.fn(arg => {
+      return arg;
+    });
     jest.mock("../adaptation", () => ({
-      __esModule: true as const,
-      default: adaptationSpy,
+      createAdaptationObject: createAdaptationSpy,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "image"],
     }));
+
+    const createPeriodObject = require("../period").createPeriodObject;
+    const videoAda1 = { type: "video",
+                        id: "54",
+                        isCodecSupported: true,
+                        representations: [{}] };
+    const videoAda2 = { type: "video",
+                        id: "55",
+                        isCodecSupported: true,
+                        representations: [{}] };
+    const videoAda3 = { type: "video",
+                        id: "55",
+                        isCodecSupported: true,
+                        representations: [{}] };
+    const video = [videoAda1, videoAda2, videoAda3];
+
+    const audioAda1 = { type: "audio",
+                        id: "56",
+                        isCodecSupported: true,
+                        representations: [{}] };
+    const audio = [audioAda1];
+
+    const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
+    const [period, warnings] = createPeriodObject(args);
+
+    expect(period.getAdaptation("88")).toEqual(undefined);
+    expect(period.getAdaptation("toto")).toEqual(undefined);
+    expect(warnings).toEqual([]);
   });
 });

--- a/src/manifest/__tests__/representation.test.ts
+++ b/src/manifest/__tests__/representation.test.ts
@@ -36,7 +36,7 @@ const minimalIndex = { getInitSegment() { return null; },
 
 const defaultIsCodecSupported = jest.fn(() => true);
 
-describe("Manifest - Representation", () => {
+describe.only("Manifest - Representation", () => {
   beforeEach(() => {
     jest.resetModules();
   });
@@ -44,14 +44,17 @@ describe("Manifest - Representation", () => {
     defaultIsCodecSupported.mockClear();
   });
 
+  /* eslint-disable-next-line max-len */
   it("should be able to create Representation with the minimum arguments given", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "audio" });
+    const representation = createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -62,17 +65,19 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe(undefined);
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a height attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12, id: "test", height: 57, index: minimalIndex };
-    const representation = new Representation(args, { type: "video" });
+    const representation = createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -83,17 +88,19 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe(undefined);
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a width attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12, id: "test", width: 2, index: minimalIndex };
-    const representation = new Representation(args, { type: "video" });
+    const representation = createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -104,20 +111,22 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe(undefined);
     expect(representation.width).toBe(2);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a codecs attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    codecs: "vp9",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "audio" });
+    const representation = createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -128,20 +137,22 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe(undefined);
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"vp9\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a mimeType attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    mimeType: "audio/mp4",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "audio" });
+    const representation = createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -152,15 +163,17 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe("audio/mp4");
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a contentProtections attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    index: minimalIndex,
@@ -170,7 +183,7 @@ describe("Manifest - Representation", () => {
                                          initData: { cenc: [{
                                            systemId: "EDEF",
                                            data: new Uint8Array([78]) }] } } };
-    const representation = new Representation(args, { type: "video" });
+    const representation = createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -181,22 +194,24 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe("video/mp4");
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("video/mp4;codecs=\"vp12\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to add a frameRate attribute", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    frameRate: "1/60",
                    mimeType: "audio/mp4",
                    codecs: "mp4a.40.2",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "audio" });
+    const representation = createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -207,56 +222,61 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe("audio/mp4");
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"mp4a.40.2\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
   it("should be able to return an exploitable codecs + mimeType string", () => {
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: defaultIsCodecSupported }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args1 = { bitrate: 12,
                     id: "test",
                     index: minimalIndex };
-    expect(new Representation(args1, { type: "audio" }).getMimeTypeString())
-      .toBe(";codecs=\"\"");
+    expect((createRepresentationObject(args1, { type: "audio" }))
+      .getMimeTypeString()).toBe(";codecs=\"\"");
 
     const args2 = { bitrate: 12,
                     id: "test",
                     mimeType: "foo",
                     index: minimalIndex };
-    expect(new Representation(args2, { type: "audio" }).getMimeTypeString())
-      .toBe("foo;codecs=\"\"");
+    expect((createRepresentationObject(args2, { type: "audio" }))
+      .getMimeTypeString()).toBe("foo;codecs=\"\"");
 
     const args3 = { bitrate: 12,
                     id: "test",
                     codecs: "bar",
                     index: minimalIndex };
-    expect(new Representation(args3, { type: "audio" }).getMimeTypeString())
-      .toBe(";codecs=\"bar\"");
+    expect((createRepresentationObject(args3, { type: "audio" }))
+      .getMimeTypeString()).toBe(";codecs=\"bar\"");
 
     const args4 = { bitrate: 12,
                     id: "test",
                     mimeType: "foo",
                     codecs: "bar",
                     index: minimalIndex };
-    expect(new Representation(args4, { type: "audio" }).getMimeTypeString())
-      .toBe("foo;codecs=\"bar\"");
+    expect((createRepresentationObject(args4, { type: "audio" }))
+      .getMimeTypeString()).toBe("foo;codecs=\"bar\"");
   });
 
-  it("should set `isSupported` of non-supported codecs or mime-type to `false`", () => {
+  /* eslint-disable-next-line max-len */
+  it("should set `isCodecSupported` of non-supported codecs or mime-type to `false`", () => {
     const notSupportedSpy = jest.fn(() => false);
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: notSupportedSpy }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: notSupportedSpy,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    frameRate: "1/60",
                    mimeType: "audio/mp4",
                    codecs: "mp4a.40.2",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "audio" });
+    const representation = createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -267,7 +287,7 @@ describe("Manifest - Representation", () => {
     expect(representation.mimeType).toBe("audio/mp4");
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"mp4a.40.2\"");
-    expect(representation.isSupported).toBe(false);
+    expect(representation.isCodecSupported).toBe(false);
     expect(representation.decipherable).toBe(undefined);
     expect(notSupportedSpy).toHaveBeenCalledTimes(1);
     expect(notSupportedSpy).toHaveBeenCalledWith("audio/mp4;codecs=\"mp4a.40.2\"");
@@ -275,20 +295,22 @@ describe("Manifest - Representation", () => {
 
   it("should not check support for a custom media buffer", () => {
     const notSupportedSpy = jest.fn(() => false);
-    jest.mock("../../compat", () => ({ __esModule: true as const,
-                                       isCodecSupported: notSupportedSpy }));
-    const Representation = require("../representation").default;
+    jest.mock("../../compat", () => ({
+      isCodecSupported: notSupportedSpy,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    frameRate: "1/60",
                    mimeType: "bip",
                    codecs: "boop",
                    index: minimalIndex };
-    const representation = new Representation(args, { type: "foo" });
+    const representation = createRepresentationObject(args, { type: "foo" });
     expect(representation.codec).toBe("boop");
     expect(representation.mimeType).toBe("bip");
     expect(representation.getMimeTypeString()).toBe("bip;codecs=\"boop\"");
-    expect(representation.isSupported).toBe(true);
+    expect(representation.isCodecSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(notSupportedSpy).toHaveBeenCalledTimes(0);
   });

--- a/src/manifest/__tests__/update_period_in_place.test.ts
+++ b/src/manifest/__tests__/update_period_in_place.test.ts
@@ -15,8 +15,10 @@
  */
 
 import log from "../../log";
-import type Period from "../period";
-import { MANIFEST_UPDATE_TYPE } from "../types";
+import {
+  type IPeriod,
+  MANIFEST_UPDATE_TYPE,
+} from "../types";
 import updatePeriodInPlace from "../update_period_in_place";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -152,7 +154,7 @@ describe("Manifest - updatePeriodInPlace", () => {
   });
 
 /* eslint-disable max-len */
-  it("should fully update the first Period given by the second one in a full update", () => {
+  it("should fully update the first IPeriod given by the second one in a full update", () => {
 /* eslint-enable max-len */
     const oldVideoAdaptation1 = { contentWarnings: [],
                                   id: "ada-video-1",
@@ -209,8 +211,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     const newPeriodAdaptationsSpy = jest.spyOn(newPeriod, "getAdaptations");
     const logSpy = jest.spyOn(log, "warn");
 
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Full);
 
     expect(oldPeriod.start).toEqual(500);
@@ -265,7 +267,7 @@ describe("Manifest - updatePeriodInPlace", () => {
   });
 
 /* eslint-disable max-len */
-  it("should partially update the first Period given by the second one in a partial update", () => {
+  it("should partially update the first IPeriod given by the second one in a partial update", () => {
 /* eslint-enable max-len */
     const oldVideoAdaptation1 = { contentWarnings: [],
                                   id: "ada-video-1",
@@ -322,8 +324,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     const newPeriodAdaptationsSpy = jest.spyOn(newPeriod, "getAdaptations");
     const logSpy = jest.spyOn(log, "warn");
 
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Partial);
 
     expect(oldPeriod.start).toEqual(500);
@@ -424,13 +426,13 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldPeriod.adaptations.video).toHaveLength(1);
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldPeriod.adaptations.video).toHaveLength(1);
@@ -483,8 +485,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
@@ -492,8 +494,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     logSpy.mockClear();
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
@@ -539,13 +541,13 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).not.toHaveBeenCalled();
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
@@ -587,8 +589,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     };
 
     const logSpy = jest.spyOn(log, "warn");
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Full);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(
@@ -596,8 +598,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(2);
     logSpy.mockClear();
-    updatePeriodInPlace(oldPeriod as unknown as Period,
-                        newPeriod as unknown as Period,
+    updatePeriodInPlace(oldPeriod as unknown as IPeriod,
+                        newPeriod as unknown as IPeriod,
                         MANIFEST_UPDATE_TYPE.Partial);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith(

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-import Adaptation, {
+import {
   IRepresentationFilter,
   IRepresentationInfos,
   SUPPORTED_ADAPTATIONS_TYPE,
 } from "./adaptation";
-import Manifest, {
+import {
+  createManifestObject,
   IManifestParsingOptions,
-  ISupplementaryImageTrack,
-  ISupplementaryTextTrack,
 } from "./manifest";
-import Period from "./period";
-import Representation from "./representation";
 import {
   IBaseContentInfos,
   IMetaPlaylistPrivateInfos,
@@ -34,16 +31,11 @@ import {
   StaticRepresentationIndex,
 } from "./representation_index";
 import {
-  IAdaptationType,
-  IHDRInformation,
-} from "./types";
-import {
   areSameContent,
   getLoggableSegmentId,
   IBufferedChunkInfos,
 } from "./utils";
 
-export default Manifest;
 export * from "./types";
 export {
   // utils
@@ -51,23 +43,17 @@ export {
   getLoggableSegmentId,
   IBufferedChunkInfos,
 
-  // classes
-  Period,
-  Adaptation,
-  Representation,
+  // Manifest creation
+  createManifestObject,
 
   // types
-  IAdaptationType,
   IBaseContentInfos,
-  IHDRInformation,
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,
   IRepresentationFilter,
   IRepresentationInfos,
   IRepresentationIndex,
   ISegment,
-  ISupplementaryImageTrack,
-  ISupplementaryTextTrack,
   StaticRepresentationIndex,
   SUPPORTED_ADAPTATIONS_TYPE,
 };

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -36,13 +36,16 @@ import {
  * of a content during a particular time period.
  * @param {Object} parsedPeriod
  * @param {function|undefined} representationFilter
- * @returns {Object}
+ * @returns {Array.<Object>} Tuple of two values:
+ *   1. The parsed Period as an object
+ *   2. Array containing every minor errors that happened when the Manifest has
+ *      been created, in the order they have happened..
  */
 export function createPeriodObject(
   args : IParsedPeriod,
   representationFilter? : IRepresentationFilter | undefined
-) : IPeriod {
-  const contentWarnings : ICustomError[] = [];
+) : [IPeriod, ICustomError[]] {
+  const warnings : ICustomError[] = [];
   const adaptations = (Object.keys(args.adaptations) as IAdaptationType[])
     .reduce<IManifestAdaptations>((acc, type) => {
       const adaptationsForType = args.adaptations[type];
@@ -59,7 +62,7 @@ export function createPeriodObject(
             const error =
               new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                              "An Adaptation contains only incompatible codecs.");
-            contentWarnings.push(error);
+            warnings.push(error);
           }
           return newAdaptation;
         })
@@ -99,14 +102,13 @@ export function createPeriodObject(
     start: args.start,
     duration: args.duration,
     end,
-    contentWarnings,
     streamEvents: args.streamEvents ?? [],
     getAdaptations,
     getAdaptationsForType,
     getAdaptation,
     getSupportedAdaptations,
   };
-  return periodObject;
+  return [periodObject, warnings];
 
   /** @link IPeriod */
   function getAdaptations() : IAdaptation[] {

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -17,157 +17,78 @@
 import { isCodecSupported } from "../compat";
 import { IContentProtection } from "../core/eme";
 import log from "../log";
-import {
-  IContentProtections,
-  IParsedRepresentation,
-} from "../parsers/manifest";
+import { IParsedRepresentation } from "../parsers/manifest";
 import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
-import { IRepresentationIndex } from "./representation_index";
 import {
   IAdaptationType,
-  IHDRInformation,
+  IRepresentation,
 } from "./types";
 
 /**
- * Normalized Representation structure.
- * @class Representation
+ * Create an `IRepresentation`-compatible object, which will declare a single
+ * "Representation" (i.e. quality) of a track.
+ * @param {Object} args
+ * @param {Object} opts
+ * @returns {Object}
  */
-class Representation {
-  /** ID uniquely identifying the Representation in the Adaptation. */
-  public readonly id : string;
+export function createRepresentationObject(
+  args : IParsedRepresentation,
+  opts : { type : IAdaptationType }
+) : IRepresentation {
+  const representationObj : IRepresentation = {
+    id: args.id,
+    bitrate: args.bitrate,
+    codec: args.codecs,
+    index: args.index,
+    getMimeTypeString,
+    getEncryptionData,
+    getAllEncryptionData,
+    _addProtectionData,
 
-  /**
-   * Interface allowing to get information about segments available for this
-   * Representation.
-   */
-  public index : IRepresentationIndex;
+    // Set first to default `false` value, to have a valid Representation object
+    // before calling `isCodecSupported`.
+    isCodecSupported: false,
+  };
 
-  /** Bitrate this Representation is in, in bits per seconds. */
-  public bitrate : number;
-
-  /**
-   * Frame-rate, when it can be applied, of this Representation, in any textual
-   * indication possible (often under a ratio form).
-   */
-  public frameRate? : string;
-
-  /**
-   * A string describing the codec used for this Representation.
-   * undefined if we do not know.
-   */
-  public codec : string | undefined;
-
-  /**
-   * A string describing the mime-type for this Representation.
-   * Examples: audio/mp4, video/webm, application/mp4, text/plain
-   * undefined if we do not know.
-   */
-  public mimeType? : string;
-
-  /**
-   * If this Representation is linked to video content, this value is the width
-   * in pixel of the corresponding video data.
-   */
-  public width? : number;
-
-  /**
-   * If this Representation is linked to video content, this value is the height
-   * in pixel of the corresponding video data.
-   */
-  public height? : number;
-
-  /** Encryption information for this Representation. */
-  public contentProtections? : IContentProtections;
-
-  /**
-   * If the track is HDR, give the characteristics of the content
-   */
-  public hdrInfo?: IHDRInformation;
-
-  /**
-   * Whether we are able to decrypt this Representation / unable to decrypt it or
-   * if we don't know yet:
-   *   - if `true`, it means that we know we were able to decrypt this
-   *     Representation in the current content.
-   *   - if `false`, it means that we know we were unable to decrypt this
-   *     Representation
-   *   - if `undefined` there is no certainty on this matter
-   */
-  public decipherable? : boolean  | undefined;
-
-  /** `true` if the Representation is in a supported codec, false otherwise. */
-  public isSupported : boolean;
-
-  /**
-   * @param {Object} args
-   */
-  constructor(args : IParsedRepresentation, opts : { type : IAdaptationType }) {
-    this.id = args.id;
-    this.bitrate = args.bitrate;
-    this.codec = args.codecs;
-
-    if (args.height !== undefined) {
-      this.height = args.height;
-    }
-
-    if (args.width !== undefined) {
-      this.width = args.width;
-    }
-
-    if (args.mimeType !== undefined) {
-      this.mimeType = args.mimeType;
-    }
-
-    if (args.contentProtections !== undefined) {
-      this.contentProtections = args.contentProtections;
-    }
-
-    if (args.frameRate !== undefined) {
-      this.frameRate = args.frameRate;
-    }
-
-    if (args.hdrInfo !== undefined) {
-      this.hdrInfo = args.hdrInfo;
-    }
-
-    this.index = args.index;
-    this.isSupported = opts.type === "audio" ||
-                       opts.type === "video" ?
-      isCodecSupported(this.getMimeTypeString()) :
-      true; // TODO for other types
+  if (args.height !== undefined) {
+    representationObj.height = args.height;
   }
 
-  /**
-   * Returns "mime-type string" which includes both the mime-type and the codec,
-   * which is often needed when interacting with the browser's APIs.
-   * @returns {string}
-   */
-  public getMimeTypeString() : string {
-    return `${this.mimeType ?? ""};codecs="${this.codec ?? ""}"`;
+  if (args.width !== undefined) {
+    representationObj.width = args.width;
   }
 
-  /**
-   * Returns encryption initialization data linked to the given DRM's system ID.
-   * This data may be useful to decrypt encrypted media segments.
-   *
-   * Returns an empty array if there is no data found for that system ID at the
-   * moment.
-   *
-   * When you know that all encryption data has been added to this
-   * Representation, you can also call the `getAllEncryptionData` method.
-   * This second function will return all encryption initialization data
-   * regardless of the DRM system, and might thus be used in all cases.
-   *
-   * /!\ Note that encryption initialization data may be progressively added to
-   * this Representation after `_addProtectionData` calls or Manifest updates.
-   * Because of this, the return value of this function might change after those
-   * events.
-   *
-   * @param {string} drmSystemId - The hexa-encoded DRM system ID
-   * @returns {Array.<Object>}
-   */
-  public getEncryptionData(drmSystemId : string) : IContentProtection[] {
-    const allInitData = this.getAllEncryptionData();
+  if (args.mimeType !== undefined) {
+    representationObj.mimeType = args.mimeType;
+  }
+
+  if (args.contentProtections !== undefined) {
+    representationObj.contentProtections = args.contentProtections;
+  }
+
+  if (args.frameRate !== undefined) {
+    representationObj.frameRate = args.frameRate;
+  }
+
+  if (args.hdrInfo !== undefined) {
+    representationObj.hdrInfo = args.hdrInfo;
+  }
+
+  representationObj.isCodecSupported = opts.type === "audio" ||
+                                       opts.type === "video" ?
+    isCodecSupported(getMimeTypeString()) :
+    true; // TODO for other types
+  return representationObj;
+
+  /** @link IRepresentation */
+  function getMimeTypeString() : string {
+    return `${representationObj.mimeType ?? ""};` +
+           `codecs="${representationObj.codec ?? ""}"`;
+  }
+
+  /** @link IRepresentation */
+  function getEncryptionData(drmSystemId : string) : IContentProtection[] {
+    const allInitData = getAllEncryptionData();
     const filtered = [];
     for (let i = 0; i < allInitData.length; i++) {
       let createdObjForType = false;
@@ -175,7 +96,8 @@ class Representation {
       for (let j = 0; j < initData.values.length; j++) {
         if (initData.values[j].systemId.toLowerCase() === drmSystemId.toLowerCase()) {
           if (!createdObjForType) {
-            const keyIds = this.contentProtections?.keyIds.map(val => val.keyId);
+            const keyIds = representationObj.contentProtections?.keyIds
+              .map(val => val.keyId);
             filtered.push({ type: initData.type,
                             keyIds,
                             values: [initData.values[j]] });
@@ -189,79 +111,40 @@ class Representation {
     return filtered;
   }
 
-
-  /**
-   * Returns all currently-known encryption initialization data linked to this
-   * Representation.
-   * Encryption initialization data is generally required to be able to decrypt
-   * those Representation's media segments.
-   *
-   * Unlike `getEncryptionData`, this method will return all available
-   * encryption data.
-   * It might as such might be used when either the current drm's system id is
-   * not known or when no encryption data specific to it was found. In that
-   * case, providing every encryption data linked to this Representation might
-   * still allow decryption.
-   *
-   * Returns an empty array in two cases:
-   *   - the content is not encrypted.
-   *   - We don't have any decryption data yet.
-   *
-   * /!\ Note that new encryption initialization data can be added progressively
-   * through the `_addProtectionData` method or through Manifest updates.
-   * It is thus highly advised to only rely on this method once every protection
-   * data related to this Representation has been known to be added.
-   *
-   * The main situation where new encryption initialization data is added is
-   * after parsing this Representation's initialization segment, if one exists.
-   * @returns {Array.<Object>}
-   */
-  public getAllEncryptionData() : IContentProtection[] {
-    if (this.contentProtections === undefined ||
-        this.contentProtections.initData.length === 0)
+  /** @link IRepresentation */
+  function getAllEncryptionData() : IContentProtection[] {
+    const { contentProtections } = representationObj;
+    if (contentProtections === undefined ||
+        contentProtections.initData.length === 0)
     {
       return [];
     }
-    const keyIds = this.contentProtections?.keyIds.map(val => val.keyId);
-    return this.contentProtections.initData.map((x) => {
+    const keyIds = contentProtections?.keyIds.map(val => val.keyId);
+    return contentProtections.initData.map((x) => {
       return { type: x.type,
                keyIds,
                values: x.values };
     });
   }
 
-  /**
-   * Add new encryption initialization data to this Representation if it was not
-   * already included.
-   *
-   * Returns `true` if new encryption initialization data has been added.
-   * Returns `false` if none has been added (e.g. because it was already known).
-   *
-   * /!\ Mutates the current Representation
-   *
-   * TODO better handle use cases like key rotation by not always grouping
-   * every protection data together? To check.
-   * @param {string} initDataArr
-   * @param {string} systemId
-   * @param {Uint8Array} data
-   * @returns {boolean}
-   */
-  public _addProtectionData(
+  /** @link IRepresentation */
+  function _addProtectionData(
     initDataType : string,
     data : Array<{
       systemId : string;
       data : Uint8Array;
     }>
   ) : boolean {
+    const { contentProtections } = representationObj;
     let hasUpdatedProtectionData = false;
-    if (this.contentProtections === undefined) {
-      this.contentProtections = { keyIds: [],
-                                  initData: [ { type: initDataType,
-                                                values: data } ] };
+    if (contentProtections === undefined) {
+      representationObj.contentProtections = { keyIds: [],
+                                               initData: [ { type: initDataType,
+                                                             values: data } ] };
       return true;
     }
 
-    const cInitData = this.contentProtections.initData;
+    const cInitData = contentProtections.initData;
     for (let i = 0; i < cInitData.length; i++) {
       if (cInitData[i].type === initDataType) {
         const cValues = cInitData[i].values;
@@ -289,12 +172,11 @@ class Representation {
         return hasUpdatedProtectionData;
       }
     }
+
     // If we are here, this means that we didn't find the corresponding
     // init data type in this.contentProtections.initData.
-    this.contentProtections.initData.push({ type: initDataType,
-                                            values: data });
+    contentProtections.initData.push({ type: initDataType,
+                                       values: data });
     return true;
   }
 }
-
-export default Representation;

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -15,10 +15,11 @@
  */
 
 import { ICustomError } from "../../errors";
-import Manifest, {
-  Adaptation,
-  Period,
-  Representation,
+import {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
 } from "../../manifest";
 import { IEMSG } from "../../parsers/containers/isobmff";
 import {
@@ -64,10 +65,10 @@ export interface ISmoothSegmentPrivateInfos {
 }
 
 /** Describes a given "real" Manifest for MetaPlaylist's segments. */
-export interface IBaseContentInfos { manifest: Manifest;
-                                     period: Period;
-                                     adaptation: Adaptation;
-                                     representation: Representation; }
+export interface IBaseContentInfos { manifest: IManifest;
+                                     period: IPeriod;
+                                     adaptation: IAdaptation;
+                                     representation: IRepresentation; }
 
 /** Supplementary information needed for segments in the "metaplaylist" transport. */
 export interface IMetaPlaylistPrivateInfos {

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -18,7 +18,6 @@ import {
   type IContentProtection,
   type IInitializationDataInfo,
 } from "../core/eme";
-import { type ICustomError } from "../errors";
 import {
   type IContentProtections,
   type IManifestStreamEvent,
@@ -131,11 +130,6 @@ export interface IManifest extends IEventEmitter<IManifestEvents> {
    * of manifest instances.
    */
   publishTime: number | undefined;
-  /**
-   * Array containing every minor errors that happened when the Manifest has
-   * been created, in the order they have happened.
-   */
-  contentWarnings : ICustomError[];
   /*
    * Difference between the server's clock in milliseconds and the return of the
    * JS function `performance.now`.
@@ -338,11 +332,6 @@ export interface IPeriod {
    * `undefined` for still-running Periods.
    */
   end : number | undefined;
-  /**
-   * Array containing every errors that happened when the Period has been
-   * created, in the order they have happened.
-   */
-  contentWarnings : ICustomError[];
   /** Array containing every stream event happening on the period */
   streamEvents : IManifestStreamEvent[];
   /**

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -14,6 +14,614 @@
  * limitations under the License.
  */
 
+import {
+  type IContentProtection,
+  type IInitializationDataInfo,
+} from "../core/eme";
+import { type ICustomError } from "../errors";
+import {
+  type IContentProtections,
+  type IManifestStreamEvent,
+} from "../parsers/manifest";
+import { type IEventEmitter } from "../utils/event_emitter";
+import { type IRepresentationIndex } from "./representation_index";
+
+/**
+ * Normalized Manifest structure.
+ *
+ * Details the current content being played:
+ *   - the duration of the content
+ *   - the available tracks
+ *   - the available qualities
+ *   - the segments defined in those qualities
+ *   - ...
+ * while staying agnostic of the transport protocol used (Smooth, DASH etc.).
+ *
+ * The Manifest and its contained information can evolve over time (like when
+ * updating a dynamic manifest or when right management forbid some tracks from
+ * being played).
+ * To perform actions on those changes, any module using this Manifest can
+ * listen to its sent events and react accordingly.
+ */
+export interface IManifest extends IEventEmitter<IManifestEvents> {
+  /**
+   * ID uniquely identifying this Manifest.
+   * No two Manifests should have this ID.
+   * This ID is automatically calculated each time a `Manifest` instance is
+   * created.
+   */
+  id : string;
+  /**
+   * Type of transport used by this Manifest (e.g. `"dash"` or `"smooth"`).
+   *
+   * TODO This should never be needed as this structure is transport-agnostic.
+   * But it is specified in the Manifest API. Deprecate?
+   */
+  transport : string;
+  /**
+   * List every Period in that Manifest chronologically (from start to end).
+   * A Period contains information about the content available for a specific
+   * period of time.
+   */
+  periods : IPeriod[];
+  /**
+   * When that promise resolves, the whole Manifest needs to be requested again
+   * so it can be refreshed.
+   */
+  expired : Promise<void> | null;
+  /**
+   * Deprecated. Equivalent to `manifest.periods[0].adaptations`.
+   * It is here to ensure compatibility with the way the v3.x.x manages
+   * adaptations at the Manifest level
+   * @deprecated
+   */
+  adaptations : IManifestAdaptations;
+  /**
+   * If true, the Manifest can evolve over time:
+   * New segments can become available in the future, properties of the manifest
+   * can change...
+   */
+  isDynamic : boolean;
+  /**
+   * If true, this Manifest describes a live content.
+   * A live content is a specific kind of content where you want to play very
+   * close to the maximum position (here called the "live edge").
+   * E.g., a TV channel is a live content.
+   */
+  isLive : boolean;
+  /**
+   * If `true`, no more periods will be added after the current last manifest's
+   * Period.
+   * `false` if we know that more Period is coming or if we don't know.
+   */
+  isLastPeriodKnown : boolean;
+  /*
+   * Every URI linking to that Manifest.
+   * They can be used for refreshing the Manifest.
+   * Listed from the most important to the least important.
+   */
+  uris : string[];
+  /** Optional URL that points to a shorter version of the Manifest used
+   * for updates only. */
+  updateUrl : string | undefined;
+  /**
+   * Suggested delay from the "live edge" (i.e. the position corresponding to
+   * the current broadcast for a live content) the content is suggested to start
+   * from.
+   * This only applies to live contents.
+   */
+  suggestedPresentationDelay : number | undefined;
+  /**
+   * Amount of time, in seconds, this Manifest is valid from the time when it
+   * has been fetched.
+   * If no lifetime is set, this Manifest does not become invalid after an
+   * amount of time.
+   */
+  lifetime : number | undefined;
+  /**
+   * Minimum time, in seconds, at which a segment defined in the Manifest
+   * can begin.
+   * This is also used as an offset for live content to apply to a segment's
+   * time.
+   */
+  availabilityStartTime : number | undefined;
+  /**
+   * It specifies the wall-clock time when the manifest was generated and published
+   * at the origin server. It is present in order to identify different versions
+   * of manifest instances.
+   */
+  publishTime: number | undefined;
+  /**
+   * Array containing every minor errors that happened when the Manifest has
+   * been created, in the order they have happened.
+   */
+  contentWarnings : ICustomError[];
+  /*
+   * Difference between the server's clock in milliseconds and the return of the
+   * JS function `performance.now`.
+   * This property allows to calculate the server time at any moment.
+   * `undefined` if we did not obtain the server's time
+   */
+  clockOffset : number | undefined;
+  /**
+   * Data allowing to calculate the minimum and maximum seekable positions at
+   * any given time.
+   * Instead of using it directly, you might prefer using the
+   * `getMinimumPosition` and `getMaximumPosition` methods instead.
+   */
+  timeBounds : {
+    /**
+     * The minimum time, in seconds, that was available the last time the
+     * Manifest was fetched.
+     *
+     * `undefined` if that value is unknown.
+     *
+     * Together with `timeshiftDepth` and the `maximumTimeData` object, this
+     * value allows to compute at any time the minimum seekable time:
+     *
+     *   - if `timeshiftDepth` is not set, the minimum seekable time is a
+     *     constant that corresponds to this value.
+     *
+     *    - if `timeshiftDepth` is set, `absoluteMinimumTime` will act as the
+     *      absolute minimum seekable time we can never seek below, even when
+     *      `timeshiftDepth` indicates a possible lower position.
+     *      This becomes useful for example when playing live contents which -
+     *      despite having a large window depth - just begun and as such only
+     *      have a few segment available for now.
+     *      Here, `absoluteMinimumTime` would be the start time of the initial
+     *      segment, and `timeshiftDepth` would be the whole depth that will
+     *      become available once enough segments have been generated.
+     */
+    absoluteMinimumTime? : number | undefined;
+    /**
+     * Some dynamic contents have the concept of a "window depth" (or "buffer
+     * depth") which allows to set a minimum position for all reachable
+     * segments, in function of the maximum reachable position.
+     *
+     * This is justified by the fact that a server might want to remove older
+     * segments when new ones become available, to free storage size.
+     *
+     * If this value is set to a number, it is the amount of time in seconds
+     * that needs to be substracted from the current maximum seekable position,
+     * to obtain the minimum seekable position.
+     * As such, this value evolves at the same rate than the maximum position
+     * does (if it does at all).
+     *
+     * If set to `null`, this content has no concept of a "window depth".
+     */
+    timeshiftDepth : number | null;
+    /** Data allowing to calculate the maximum position at any given time. */
+    maximumTimeData : {
+      /** Maximum seekable time in milliseconds calculated at `time`. */
+      value : number;
+      /**
+       * `Performance.now()` output at the time `value` was calculated.
+       * This can be used to retrieve the maximum position from `value` when it
+       * linearly evolves over time (see `isLinear` property).
+       */
+      time : number;
+      /**
+       * Whether the maximum seekable position evolves linearly over time.
+       *
+       * If set to `false`, `value` indicates the constant maximum position.
+       *
+       * If set to `true`, the maximum seekable time continuously increase at
+       * the same rate than the time since `time` does.
+       * For example, a `value` of 50000 (50 seconds) will indicate a maximum time
+       * of 51 seconds after 1 second have passed, of 56 seconds after 6 seconds
+       * have passed (we know how many seconds have passed since the initial
+       * calculation of value by checking the `time` property) etc.
+       */
+      isLinear: boolean;
+    };
+  };
+  /**
+   * Returns the Period corresponding to the given `id`.
+   * Returns `undefined` if there is none.
+   * @param {string} id
+   * @returns {Object|undefined}
+   */
+  getPeriod(id : string) : IPeriod | undefined;
+  /**
+   * Returns the Period encountered at the given time.
+   * Returns `undefined` if there is no Period exactly at the given time.
+   * @param {number} time
+   * @returns {Object|undefined}
+   */
+  getPeriodForTime(time : number) : IPeriod | undefined;
+  /**
+   * Returns the first Period starting strictly after the given time.
+   * Returns `undefined` if there is no Period starting after that time.
+   * @param {number} time
+   * @returns {Object|undefined}
+   */
+  getNextPeriod(time : number) : IPeriod | undefined;
+  /**
+   * Returns the Period coming chronologically just after another given Period.
+   * Returns `undefined` if not found.
+   * @param {Object} period
+   * @returns {Object|null}
+   */
+  getPeriodAfter(period : IPeriod) : IPeriod | null;
+  /**
+   * Returns the most important URL from which the Manifest can be refreshed.
+   * `undefined` if no URL is found.
+   * @returns {string|undefined}
+   */
+  getUrl() : string|undefined;
+  /**
+   * Update the current Manifest properties by giving a new updated version.
+   * This instance will be updated with the new information coming from it.
+   * @param {Object} newManifest
+   */
+  replace(newManifest : IManifest) : void;
+  /**
+   * Update the current Manifest properties by giving a new but shorter version
+   * of it.
+   * This instance will add the new information coming from it and will
+   * automatically clean old Periods that shouldn't be available anymore.
+   *
+   * /!\ Throws if the given Manifest cannot be used or is not sufficient to
+   * update the Manifest.
+   * @param {Object} newManifest
+   */
+  update(newManifest : IManifest) : void;
+  /**
+   * Get the minimum position currently defined by the Manifest, in seconds.
+   * @returns {number}
+   */
+  getMinimumPosition() : number;
+  /**
+   * Get the maximum position currently defined by the Manifest, in seconds.
+   * @returns {number}
+   */
+  getMaximumPosition() : number;
+  /**
+   * Look in the Manifest for Representations linked to the given key ID,
+   * and mark them as being impossible to decrypt.
+   * Then trigger a "decipherabilityUpdate" event to notify everyone of the
+   * changes performed.
+   * @param {Object} keyUpdates
+   */
+  updateDeciperabilitiesBasedOnKeyIds(
+    { whitelistedKeyIds,
+      blacklistedKeyIDs } : { whitelistedKeyIds : Uint8Array[];
+                              blacklistedKeyIDs : Uint8Array[]; }
+  ) : void;
+  /**
+   * Look in the Manifest for Representations linked to the given content
+   * protection initialization data and mark them as being impossible to
+   * decrypt.
+   * Then trigger a "decipherabilityUpdate" event to notify everyone of the
+   * changes performed.
+   * @param {Object} initData
+   */
+  addUndecipherableProtectionData(initData : IInitializationDataInfo) : void;
+
+  /**
+   * @deprecated only returns adaptations for the first period
+   * @returns {Array.<Object>}
+   */
+  getAdaptations() : IAdaptation[];
+
+  /**
+   * @deprecated only returns adaptations for the first period
+   * @returns {Array.<Object>}
+   */
+  getAdaptationsForType(adaptationType : IAdaptationType) : IAdaptation[];
+
+  /**
+   * @deprecated only returns adaptations for the first period
+   * @returns {Array.<Object>}
+   */
+  getAdaptation(wantedId : number|string) : IAdaptation|undefined;
+}
+
+/**
+ * Object representing the tracks and qualities available from a given time
+ * period in the the Manifest.
+ */
+export interface IPeriod {
+  /** ID uniquely identifying the Period in the Manifest. */
+  id : string;
+  /** Every 'Adaptation' in that Period, per type of Adaptation. */
+  adaptations : IManifestAdaptations;
+  /** Absolute start time of the Period, in seconds. */
+  start : number;
+  /**
+   * Duration of this Period, in seconds.
+   * `undefined` for still-running Periods.
+   */
+  duration : number | undefined;
+  /**
+   * Absolute end time of the Period, in seconds.
+   * `undefined` for still-running Periods.
+   */
+  end : number | undefined;
+  /**
+   * Array containing every errors that happened when the Period has been
+   * created, in the order they have happened.
+   */
+  contentWarnings : ICustomError[];
+  /** Array containing every stream event happening on the period */
+  streamEvents : IManifestStreamEvent[];
+  /**
+   * Returns every `Adaptations` (or `tracks`) linked to that Period, in an
+   * Array.
+   * @returns {Array.<Object>}
+   */
+  getAdaptations() : IAdaptation[];
+  /**
+   * Returns every `Adaptations` (or `tracks`) linked to that Period for a
+   * given type.
+   * @param {string} adaptationType
+   * @returns {Array.<Object>}
+   */
+  getAdaptationsForType(adaptationType : IAdaptationType) : IAdaptation[];
+  /**
+   * Returns the Adaptation linked to the given ID.
+   * @param {number|string} wantedId
+   * @returns {Object|undefined}
+   */
+  getAdaptation(wantedId : string) : IAdaptation|undefined;
+  /**
+   * Returns Adaptations that contain Representations in supported codecs.
+   * @param {string|undefined} type - If set filter on a specific Adaptation's
+   * type. Will return for all types if `undefined`.
+   * @returns {Array.<Adaptation>}
+   */
+  getSupportedAdaptations(type? : IAdaptationType) : IAdaptation[];
+}
+
+/**
+ * Normalized Adaptation structure.
+ * An Adaptation describes a single `Track`. For example a specific audio
+ * track (in a given language) or a specific video track.
+ * It istelf can be represented in different qualities, which we call here
+ * `Representation`.
+ */
+export interface IAdaptation {
+  /** ID uniquely identifying the Adaptation in the Period. */
+  id : string;
+  /**
+   * Different `Representations` (e.g. qualities) this Adaptation is available
+   * in.
+   */
+  representations : IRepresentation[];
+  /** Type of this Adaptation. */
+  type : IAdaptationType;
+  /** `true` if at least one Representation is in a supported codec. `false` otherwise. */
+  isCodecSupported : boolean;
+  /** Whether this track contains an audio description for the visually impaired. */
+  isAudioDescription? : boolean;
+  /** Whether this Adaptation contains closed captions for the hard-of-hearing. */
+  isClosedCaption? : boolean;
+  /** If true this Adaptation contains sign interpretation. */
+  isSignInterpreted? : boolean;
+  /**
+   * If `true`, this Adaptation is a "dub", meaning it was recorded in another
+   * language than the original one.
+   */
+  isDub? : boolean;
+  /** Language this Adaptation is in, as announced in the original Manifest. */
+  language? : string;
+  /** Language this Adaptation is in, when translated into an ISO639-3 code. */
+  normalizedLanguage? : string;
+  /**
+   * `true` if this Adaptation was not present in the original Manifest, but was
+   * manually added after through the corresponding APIs.
+   */
+  manuallyAdded? : boolean;
+  /** Tells if the track is a trick mode track. */
+  isTrickModeTrack? : boolean;
+  trickModeTracks? : IAdaptation[];
+  /**
+   * Returns unique bitrate for every Representation in this Adaptation.
+   * @returns {Array.<Number>}
+   */
+  getAvailableBitrates() : number[];
+  /**
+   * Returns all Representation in this Adaptation that can be played (that is:
+   * not undecipherable and with a supported codec).
+   * @returns {Array.<Representation>}
+   */
+  getPlayableRepresentations() : IRepresentation[];
+  /**
+   * Returns the Representation linked to the given ID.
+   * @param {number|string} wantedId
+   * @returns {Object|undefined}
+   */
+  getRepresentation(wantedId : number|string) : IRepresentation|undefined;
+}
+
+/**
+ * Normalized Representation structure.
+ * Represents a media quality in a specific track.
+ */
+export interface IRepresentation {
+  /** ID uniquely identifying the Representation in the Adaptation. */
+  id : string;
+  /**
+   * Interface allowing to get information about segments available for this
+   * Representation.
+   */
+  index : IRepresentationIndex;
+  /** Bitrate this Representation is in, in bits per seconds. */
+  bitrate : number;
+  /**
+   * Frame-rate, when it can be applied, of this Representation, in any textual
+   * indication possible (often under a ratio form).
+   */
+  frameRate? : string;
+  /**
+   * A string describing the codec used for this Representation.
+   * undefined if we do not know.
+   */
+  codec : string | undefined;
+  /**
+   * A string describing the mime-type for this Representation.
+   * Examples: audio/mp4, video/webm, application/mp4, text/plain
+   * undefined if we do not know.
+   */
+  mimeType? : string;
+  /**
+   * If this Representation is linked to video content, this value is the width
+   * in pixel of the corresponding video data.
+   */
+  width? : number;
+  /**
+   * If this Representation is linked to video content, this value is the height
+   * in pixel of the corresponding video data.
+   */
+  height? : number;
+  /** Encryption information for this Representation. */
+  contentProtections? : IContentProtections;
+  /**
+   * If the track is HDR, give the characteristics of the content
+   */
+  hdrInfo?: IHDRInformation;
+  /**
+   * Whether we are able to decrypt this Representation / unable to decrypt it or
+   * if we don't know yet:
+   *   - if `true`, it means that we know we were able to decrypt this
+   *     Representation in the current content.
+   *   - if `false`, it means that we know we were unable to decrypt this
+   *     Representation
+   *   - if `undefined` there is no certainty on this matter
+   */
+  decipherable? : boolean  | undefined;
+  /** `true` if the Representation is in a supported codec, false otherwise. */
+  isCodecSupported : boolean;
+  /**
+   * Returns "mime-type string" which includes both the mime-type and the codec,
+   * which is often needed when interacting with the browser's APIs.
+   * @returns {string}
+   */
+  getMimeTypeString() : string;
+  /**
+   * Returns encryption initialization data linked to the given DRM's system ID.
+   * This data may be useful to decrypt encrypted media segments.
+   *
+   * Returns an empty array if there is no data found for that system ID at the
+   * moment.
+   *
+   * When you know that all encryption data has been added to this
+   * Representation, you can also call the `getAllEncryptionData` method.
+   * This second function will return all encryption initialization data
+   * regardless of the DRM system, and might thus be used in all cases.
+   *
+   * /!\ Note that encryption initialization data may be progressively added to
+   * this Representation after `_addProtectionData` calls or Manifest updates.
+   * Because of this, the return value of this function might change after those
+   * events.
+   *
+   * @param {string} drmSystemId - The hexa-encoded DRM system ID
+   * @returns {Array.<Object>}
+   */
+  getEncryptionData(drmSystemId : string) : IContentProtection[];
+  /**
+   * Returns all currently-known encryption initialization data linked to this
+   * Representation.
+   * Encryption initialization data is generally required to be able to decrypt
+   * those Representation's media segments.
+   *
+   * Unlike `getEncryptionData`, this method will return all available
+   * encryption data.
+   * It might as such might be used when either the current drm's system id is
+   * not known or when no encryption data specific to it was found. In that
+   * case, providing every encryption data linked to this Representation might
+   * still allow decryption.
+   *
+   * Returns an empty array in two cases:
+   *   - the content is not encrypted.
+   *   - We don't have any decryption data yet.
+   *
+   * /!\ Note that new encryption initialization data can be added progressively
+   * through the `_addProtectionData` method or through Manifest updates.
+   * It is thus highly advised to only rely on this method once every protection
+   * data related to this Representation has been known to be added.
+   *
+   * The main situation where new encryption initialization data is added is
+   * after parsing this Representation's initialization segment, if one exists.
+   * @returns {Array.<Object>}
+   */
+  getAllEncryptionData() : IContentProtection[];
+  /**
+   * Add new encryption initialization data to this Representation if it was not
+   * already included.
+   *
+   * Returns `true` if new encryption initialization data has been added.
+   * Returns `false` if none has been added (e.g. because it was already known).
+   *
+   * /!\ Mutates the current Representation
+   *
+   * TODO better handle use cases like key rotation by not always grouping
+   * every protection data together? To check.
+   * @param {string} initDataArr
+   * @param {string} systemId
+   * @param {Uint8Array} data
+   * @returns {boolean}
+   */
+  _addProtectionData(
+    initDataType : string,
+    data : Array<{
+      systemId : string;
+      data : Uint8Array;
+    }>
+  ) : boolean;
+}
+
+
+/** Structure listing every `Adaptation` in a Period. */
+export type IManifestAdaptations = Partial<Record<IAdaptationType, IAdaptation[]>>;
+
+/** Events emitted by a `Manifest` instance */
+export interface IManifestEvents {
+  /** The Manifest has been updated */
+  manifestUpdate : null;
+  /** Some Representation's decipherability status has been updated */
+  decipherabilityUpdate : IDecipherabilityUpdateElement[];
+}
+
+/** Representation affected by a `decipherabilityUpdate` event. */
+export interface IDecipherabilityUpdateElement { manifest : IManifest;
+                                                 period : IPeriod;
+                                                 adaptation : IAdaptation;
+                                                 representation : IRepresentation; }
+
+/**
+ * Interface a manually-added supplementary image track should respect.
+ * @deprecated
+ */
+export interface ISupplementaryImageTrack {
+  /** mime-type identifying the type of container for the track. */
+  mimeType : string;
+  /** URL to the thumbnails file */
+  url : string;
+}
+
+/**
+ * Interface a manually-added supplementary text track should respect.
+ * @deprecated
+ */
+export interface ISupplementaryTextTrack {
+  /** mime-type identifying the type of container for the track. */
+  mimeType : string;
+  /** codecs in the container (mimeType can be enough) */
+  codecs? : string;
+  /** URL to the text track file */
+  url : string;
+  /** ISO639-{1,2,3} code for the language of the track */
+  language? : string;
+  /**
+   * Same as `language`, but in an Array.
+   * Kept for compatibility with old API.
+   * @deprecated
+   */
+  languages? : string[];
+  /** If true, the track are closed captions. */
+  closedCaption : boolean;
+}
 /** Enumerate the different ways a Manifest update can be done. */
 export enum MANIFEST_UPDATE_TYPE {
   /**

--- a/src/manifest/update_period_in_place.ts
+++ b/src/manifest/update_period_in_place.ts
@@ -16,8 +16,10 @@
 
 import log from "../log";
 import arrayFind from "../utils/array_find";
-import Period from "./period";
-import { MANIFEST_UPDATE_TYPE } from "./types";
+import {
+  IPeriod,
+  MANIFEST_UPDATE_TYPE,
+} from "./types";
 
 /**
  * Update oldPeriod attributes with the one from newPeriod (e.g. when updating
@@ -25,8 +27,8 @@ import { MANIFEST_UPDATE_TYPE } from "./types";
  * @param {Object} oldPeriod
  * @param {Object} newPeriod
  */
-export default function updatePeriodInPlace(oldPeriod : Period,
-                                            newPeriod : Period,
+export default function updatePeriodInPlace(oldPeriod : IPeriod,
+                                            newPeriod : IPeriod,
                                             updateType : MANIFEST_UPDATE_TYPE) : void
 {
   oldPeriod.start = newPeriod.start;

--- a/src/manifest/update_periods.ts
+++ b/src/manifest/update_periods.ts
@@ -17,8 +17,10 @@
 import { MediaError } from "../errors";
 import log from "../log";
 import arrayFindIndex from "../utils/array_find_index";
-import Period from "./period";
-import { MANIFEST_UPDATE_TYPE } from "./types";
+import {
+  IPeriod,
+  MANIFEST_UPDATE_TYPE,
+} from "./types";
 import updatePeriodInPlace from "./update_period_in_place";
 
 /**
@@ -28,8 +30,8 @@ import updatePeriodInPlace from "./update_period_in_place";
  * @param {Array.<Object>} newPeriods
  */
 export function replacePeriods(
-  oldPeriods: Period[],
-  newPeriods: Period[]
+  oldPeriods: IPeriod[],
+  newPeriods: IPeriod[]
 ) : void {
   let firstUnhandledPeriodIdx = 0;
   for (let i = 0; i < newPeriods.length; i++) {
@@ -73,8 +75,8 @@ export function replacePeriods(
  * @param {Array.<Object>} newPeriods
  */
 export function updatePeriods(
-  oldPeriods: Period[],
-  newPeriods: Period[]
+  oldPeriods: IPeriod[],
+  newPeriods: IPeriod[]
 ) : void {
   if (oldPeriods.length === 0) {
     oldPeriods.splice(0, 0, ...newPeriods);

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -15,15 +15,17 @@
  */
 
 import isNullOrUndefined from "../utils/is_null_or_undefined";
-import Adaptation from "./adaptation";
-import Period from "./period";
-import Representation from "./representation";
-import { ISegment } from "./representation_index";
+import { type ISegment } from "./representation_index";
+import {
+  IAdaptation,
+  IPeriod,
+  IRepresentation,
+} from "./types";
 
 /** All information needed to identify a given segment. */
-export interface IBufferedChunkInfos { adaptation : Adaptation;
-                                       period : Period;
-                                       representation : Representation;
+export interface IBufferedChunkInfos { adaptation : IAdaptation;
+                                       period : IPeriod;
+                                       representation : IRepresentation;
                                        segment : ISegment; }
 
 /**

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -23,7 +23,7 @@ import log from "../../../../../../log";
 import {
   IRepresentationIndex,
   ISegment,
-  Representation,
+  IRepresentation,
 } from "../../../../../../manifest";
 import { IEMSG } from "../../../../../containers/isobmff";
 import clearTimelineFromPosition from "../../../../utils/clear_timeline_from_position";
@@ -175,7 +175,7 @@ export interface ITimelineIndexContextArgument {
    * de-synchronization with what is actually on the server,
    * Use with moderation.
    */
-  unsafelyBaseOnPreviousRepresentation : Representation | null;
+  unsafelyBaseOnPreviousRepresentation : IRepresentation | null;
   /** Function that tells if an EMSG is whitelisted by the manifest */
   isEMSGWhitelisted: (inbandEvent: IEMSG) => boolean;
   /**

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../../../log";
-import { Period } from "../../../../manifest";
+import { IPeriod } from "../../../../manifest";
 import arrayFind from "../../../../utils/array_find";
 import arrayIncludes from "../../../../utils/array_includes";
 import isNonEmptyString from "../../../../utils/is_non_empty_string";
@@ -506,7 +506,7 @@ export interface IAdaptationSetContext extends IInheritedRepresentationContext {
    * de-synchronization with what is actually on the server,
    * Use with moderation.
    */
-  unsafelyBaseOnPreviousPeriod : Period | null;
+  unsafelyBaseOnPreviousPeriod : IPeriod | null;
 }
 
 /**

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -16,7 +16,7 @@
 
 import config from "../../../../config";
 import log from "../../../../log";
-import Manifest from "../../../../manifest";
+import { IManifest } from "../../../../manifest";
 import arrayFind from "../../../../utils/array_find";
 import { normalizeBaseURL } from "../../../../utils/resolve_url";
 import { IParsedManifest } from "../../types";
@@ -60,7 +60,7 @@ export interface IMPDParserArguments {
    * de-synchronization with what is actually on the server,
    * Use with moderation.
    */
-  unsafelyBaseOnPreviousManifest : Manifest | null;
+  unsafelyBaseOnPreviousManifest : IManifest | null;
   /** URL of the manifest (post-redirection if one). */
   url? : string | undefined;
 }

--- a/src/parsers/manifest/dash/common/parse_periods.ts
+++ b/src/parsers/manifest/dash/common/parse_periods.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../../../log";
-import Manifest from "../../../../manifest";
+import { IManifest } from "../../../../manifest";
 import flatMap from "../../../../utils/flat_map";
 import idGenerator from "../../../../utils/id_generator";
 import objectValues from "../../../../utils/object_values";
@@ -347,7 +347,7 @@ export interface IPeriodContext extends IInheritedAdaptationContext {
    * de-synchronization with what is actually on the server,
    * Use with moderation.
    */
-  unsafelyBaseOnPreviousManifest : Manifest | null;
+  unsafelyBaseOnPreviousManifest : IManifest | null;
   xlinkInfos : IXLinkInfos;
 
   /**

--- a/src/parsers/manifest/dash/common/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/common/parse_representation_index.ts
@@ -16,7 +16,7 @@
 
 import {
   IRepresentationIndex,
-  Representation,
+  IRepresentation,
 } from "../../../../manifest";
 import objectAssign from "../../../../utils/object_assign";
 import { IEMSG } from "../../../containers/isobmff";
@@ -180,5 +180,5 @@ export interface IRepresentationIndexContext {
    * /!\ If unexpected differences exist between both, there is a risk of
    * de-synchronization with what is actually on the server.
    */
-  unsafelyBaseOnPreviousRepresentation : Representation | null;
+  unsafelyBaseOnPreviousRepresentation : IRepresentation | null;
 }

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../../../log";
-import { Adaptation } from "../../../../manifest";
+import { IAdaptation } from "../../../../manifest";
 import { IHDRInformation } from "../../../../manifest/types";
 import arrayFind from "../../../../utils/array_find";
 import objectAssign from "../../../../utils/object_assign";
@@ -274,7 +274,7 @@ export interface IRepresentationContext extends IInheritedRepresentationIndexCon
    * de-synchronization with what is actually on the server,
    * Use with moderation.
    */
-  unsafelyBaseOnPreviousAdaptation : Adaptation | null;
+  unsafelyBaseOnPreviousAdaptation : IAdaptation | null;
 }
 
 /**

--- a/src/parsers/manifest/dash/js-parser/__tests__/parse_from_document.test.ts
+++ b/src/parsers/manifest/dash/js-parser/__tests__/parse_from_document.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Manifest from "../../../../../manifest";
+import { IManifest } from "../../../../../manifest";
 import parseFromDocument from "../index";
 
 describe("parseFromDocument", () => {
@@ -34,7 +34,7 @@ describe("parseFromDocument", () => {
       });
     }).toThrow("document root should be MPD");
     expect(function() {
-      const prevManifest = {} as unknown as Manifest;
+      const prevManifest = {} as unknown as IManifest;
       parseFromDocument(doc, {
         url: "",
         aggressiveMode: false,

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import Manifest, {
+import {
   IAdaptationType,
+  IManifest,
   StaticRepresentationIndex,
   SUPPORTED_ADAPTATIONS_TYPE,
 } from "../../../manifest";
@@ -33,7 +34,7 @@ export type IParserResponse<T> =
   { type : "needs-manifest-loader";
     value : {
       ressources : Array<{ url : string; transportType : string }>;
-      continue : (loadedRessources : Manifest[]) => IParserResponse<T>;
+      continue : (loadedRessources : IManifest[]) => IParserResponse<T>;
     }; } |
   { type : "done"; value : T };
 
@@ -125,7 +126,7 @@ export default function parseMetaPlaylist(
     type : "needs-manifest-loader",
     value : {
       ressources,
-      continue : function parseWholeMPL(loadedRessources : Manifest[]) {
+      continue : function parseWholeMPL(loadedRessources : IManifest[]) {
         const parsedManifest = createManifest(metaPlaylist,
                                               loadedRessources,
                                               parserOptions);
@@ -146,7 +147,7 @@ export default function parseMetaPlaylist(
  */
 function createManifest(
   mplData : IMetaPlaylist,
-  manifests : Manifest[],
+  manifests : IManifest[],
   parserOptions:  { url?: string | undefined;
                     serverSyncInfos?: { serverTimestamp: number;
                                         clientTime: number; } | undefined; }

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -17,7 +17,7 @@
 import { formatError } from "../../errors";
 import features from "../../features";
 import log from "../../log";
-import Manifest from "../../manifest";
+import { createManifestObject } from "../../manifest";
 import {
   IDashParserResponse,
   ILoadedResource,
@@ -142,7 +142,7 @@ export default function generateManifestParser(
         if (cancelSignal.isCancelled) {
           return PPromise.reject(cancelSignal.cancellationError);
         }
-        const manifest = new Manifest(parserResponse.value.parsed, options);
+        const manifest = createManifestObject(parserResponse.value.parsed, options);
         return { manifest, url };
       }
 

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -142,7 +142,11 @@ export default function generateManifestParser(
         if (cancelSignal.isCancelled) {
           return PPromise.reject(cancelSignal.cancellationError);
         }
-        const manifest = createManifestObject(parserResponse.value.parsed, options);
+        const [ manifest, mWarnings ] =
+          createManifestObject(parserResponse.value.parsed, options);
+        if (mWarnings.length > 0) {
+          onWarnings(parserResponse.value.warnings);
+        }
         return { manifest, url };
       }
 

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -27,6 +27,7 @@ import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
   ILoadedManifestFormat,
+  IManifestParserOptions,
   IManifestParserResult,
   IRequestedData,
   ITransportOptions,
@@ -65,13 +66,20 @@ export default function getLocalManifestPipelines(
         })(url, cancelSignal);
     },
 
-    parseManifest(manifestData : IRequestedData<unknown>) : IManifestParserResult {
+    parseManifest(
+      manifestData : IRequestedData<unknown>,
+      _parserOptions : IManifestParserOptions,
+      onWarnings : (warnings: Error[]) => void
+    ) : IManifestParserResult {
       const loadedManifest = manifestData.responseData;
       if (typeof manifestData !== "object") {
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const manifest = createManifestObject(parsed, options);
+      const [manifest, warnings] = createManifestObject(parsed, options);
+      if (warnings.length > 0) {
+        onWarnings(warnings);
+      }
       return { manifest, url: undefined };
     },
   };

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -19,7 +19,7 @@
  * It always should be imported through the `features` object.
  */
 
-import Manifest from "../../manifest";
+import { createManifestObject } from "../../manifest";
 import parseLocalManifest, {
   ILocalManifest,
 } from "../../parsers/manifest/local";
@@ -71,7 +71,7 @@ export default function getLocalManifestPipelines(
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const manifest = new Manifest(parsed, options);
+      const manifest = createManifestObject(parsed, options);
       return { manifest, url: undefined };
     },
   };

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -15,12 +15,14 @@
  */
 
 import features from "../../features";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  IManifest,
   IMetaPlaylistPrivateInfos,
+  IPeriod,
+  IRepresentation,
   ISegment,
-  Period,
-  Representation,
+  createManifestObject,
 } from "../../manifest";
 import parseMetaPlaylist, {
   IParserResponse as IMPLParserResponse,
@@ -59,10 +61,10 @@ import generateManifestLoader from "./manifest_loader";
  * @param {number} offset
  * @returns {Object}
  */
-function getOriginalContent(segment : ISegment) : { manifest : Manifest;
-                                                    period : Period;
-                                                    adaptation : Adaptation;
-                                                    representation : Representation;
+function getOriginalContent(segment : ISegment) : { manifest : IManifest;
+                                                    period : IPeriod;
+                                                    adaptation : IAdaptation;
+                                                    representation : IRepresentation;
                                                     segment : ISegment; }
 {
   if (segment.privateInfos?.metaplaylistInfos === undefined) {
@@ -155,7 +157,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
         parsedResult : IMPLParserResponse<IParsedManifest>
       ) : Promise<IManifestParserResult> {
         if (parsedResult.type === "done") {
-          const manifest = new Manifest(parsedResult.value, options);
+          const manifest = createManifestObject(parsedResult.value, options);
           return PPromise.resolve({ manifest });
         }
 

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -157,7 +157,10 @@ export default function(options : ITransportOptions): ITransportPipelines {
         parsedResult : IMPLParserResponse<IParsedManifest>
       ) : Promise<IManifestParserResult> {
         if (parsedResult.type === "done") {
-          const manifest = createManifestObject(parsedResult.value, options);
+          const [manifest, warnings] = createManifestObject(parsedResult.value, options);
+          if (warnings.length > 0) {
+            onWarnings(warnings);
+          }
           return PPromise.resolve({ manifest });
         }
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -16,8 +16,9 @@
 
 import features from "../../features";
 import log from "../../log";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
+  createManifestObject,
   ISegment,
 } from "../../manifest";
 import { getMDAT } from "../../parsers/containers/isobmff";
@@ -74,7 +75,7 @@ const WSX_REG = /\.wsx?(\?token=\S+)?/;
  * @param {Object} nextSegments
  */
 function addNextSegments(
-  adaptation : Adaptation,
+  adaptation : IAdaptation,
   nextSegments : INextSegmentsInfos[],
   dlSegment : ISegment
 ) : void {
@@ -151,7 +152,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                 url,
                                                 manifestReceivedTime);
 
-      const manifest = new Manifest(parserResult, {
+      const manifest = createManifestObject(parserResult, {
         representationFilter: options.representationFilter,
         supplementaryImageTracks: options.supplementaryImageTracks,
         supplementaryTextTracks: options.supplementaryTextTracks,

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -139,7 +139,8 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     parseManifest(
       manifestData : IRequestedData<unknown>,
-      parserOptions : IManifestParserOptions
+      parserOptions : IManifestParserOptions,
+      onWarnings : (warnings : Error[]) => void
     ) : IManifestParserResult {
       const url = manifestData.url ?? parserOptions.originalUrl;
       const { receivedTime: manifestReceivedTime, responseData } = manifestData;
@@ -152,11 +153,14 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                 url,
                                                 manifestReceivedTime);
 
-      const manifest = createManifestObject(parserResult, {
+      const [manifest, warnings] = createManifestObject(parserResult, {
         representationFilter: options.representationFilter,
         supplementaryImageTracks: options.supplementaryImageTracks,
         supplementaryTextTracks: options.supplementaryTextTracks,
       });
+      if (warnings.length > 0) {
+        onWarnings(warnings);
+      }
       return { manifest, url };
     },
   };

--- a/src/transports/smooth/utils.ts
+++ b/src/transports/smooth/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import isNonEmptyString from "../../utils/is_non_empty_string";
 import warnOnce from "../../utils/warn_once";
 
@@ -77,10 +77,10 @@ function resolveManifest(url : string) : string {
 /**
  * Returns `true` if the given Representation refers to segments in an MP4
  * container
- * @param {Representation} representation
+ * @param {Object} representation
  * @returns {Boolean}
  */
-function isMP4EmbeddedTrack(representation : Representation) : boolean {
+function isMP4EmbeddedTrack(representation : IRepresentation) : boolean {
   return typeof representation.mimeType === "string" &&
          representation.mimeType.indexOf("mp4") >= 0;
 }

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -15,19 +15,20 @@
  */
 
 import { IInbandEvent } from "../core/stream";
-import Manifest, {
-  Adaptation,
+import {
+  IAdaptation,
   IExposedAdaptation,
   IExposedManifest,
   IExposedPeriod,
   IExposedRepresentation,
   IExposedSegment,
+  IManifest,
+  IPeriod,
+  IRepresentation,
   IRepresentationFilter,
   ISegment,
   ISupplementaryImageTrack,
   ISupplementaryTextTrack,
-  Period,
-  Representation,
 } from "../manifest";
 import { IBifThumbnail } from "../parsers/images/bif";
 import { ILocalManifest } from "../parsers/manifest/local";
@@ -289,7 +290,7 @@ export interface IManifestParserOptions {
   /** Original URL used for the full version of the Manifest. */
   originalUrl : string | undefined;
   /** The previous value of the Manifest (when updating). */
-  previousManifest : Manifest | null;
+  previousManifest : IManifest | null;
   /**
    * If set to `true`, the Manifest parser can perform advanced optimizations
    * to speed-up the parsing process. Those optimizations might lead to a
@@ -364,7 +365,7 @@ export type IManifestParserRequestScheduler =
 /** Event emitted when a Manifest has been parsed by a Manifest parser. */
 export interface IManifestParserResult {
   /** The parsed Manifest Object itself. */
-  manifest : Manifest;
+  manifest : IManifest;
   /**
    * "Real" URL (post-redirection) at which the Manifest can be refreshed.
    *
@@ -553,13 +554,13 @@ export type ICustomManifestLoader = (
 
 export interface ISegmentContext {
   /** Manifest object related to this segment. */
-  manifest : Manifest;
-  /** Period object related to this segment. */
-  period : Period;
+  manifest : IManifest;
+  /** IPeriod object related to this segment. */
+  period : IPeriod;
   /** Adaptation object related to this segment. */
-  adaptation : Adaptation;
-  /** Representation Object related to this segment. */
-  representation : Representation;
+  adaptation : IAdaptation;
+  /** IRepresentation Object related to this segment. */
+  representation : IRepresentation;
   /** Segment we want to load. */
   segment : ISegment;
 }
@@ -676,7 +677,7 @@ export type ILoadedManifestFormat = Document |
                                     ArrayBuffer |
                                     IMetaPlaylist |
                                     ILocalManifest |
-                                    Manifest;
+                                    IManifest;
 
 /** Format of a loaded audio and video segment before parsing. */
 export type ILoadedAudioVideoSegmentFormat = Uint8Array |
@@ -712,11 +713,11 @@ export interface ISegmentParserParsedInitChunk<DataType> {
   initTimescale? : number | undefined;
   /**
    * If set to `true`, some protection information has been found in this
-   * initialization segment and lead the corresponding `Representation`
+   * initialization segment and lead the corresponding `IRepresentation`
    * object to be updated with that new information.
    *
    * In that case, you can re-check any encryption-related information with the
-   * `Representation` linked to that segment.
+   * `IRepresentation` linked to that segment.
    *
    * In the great majority of cases, this is set to `true` when new content
    * protection initialization data to have been encountered.
@@ -772,11 +773,11 @@ export interface ISegmentParserParsedMediaChunk<DataType> {
   needsManifestRefresh?: boolean;
   /**
    * If set to `true`, some protection information has been found in this
-   * media segment and lead the corresponding `Representation` object to be
+   * media segment and lead the corresponding `IRepresentation` object to be
    * updated with that new information.
    *
    * In that case, you can re-check any encryption-related information with the
-   * `Representation` linked to that segment.
+   * `IRepresentation` linked to that segment.
    *
    * In the great majority of cases, this is set to `true` when new content
    * protection initialization data to have been encountered.

--- a/src/transports/utils/__tests__/infer_segment_container.test.ts
+++ b/src/transports/utils/__tests__/infer_segment_container.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { Representation } from "../../../manifest";
+import type { IRepresentation } from "../../../manifest";
 import inferSegmentContainer from "../infer_segment_container";
 
 describe("Transport utils - inferSegmentContainer", () => {
@@ -23,25 +23,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as Representation))
+                                   mimeType: "audio/mp4" } as IRepresentation))
       .toEqual("mp4");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as Representation))
+                                   mimeType: "video/mp4" } as IRepresentation))
       .toEqual("mp4");
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as Representation))
+                                   mimeType: "video/mp4" } as IRepresentation))
       .toEqual("mp4");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as Representation))
+                                   mimeType: "audio/mp4" } as IRepresentation))
       .toEqual("mp4");
   });
 
@@ -52,25 +52,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as Representation))
+                                   mimeType: "audio/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as Representation))
+                                   mimeType: "video/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/mp4" } as Representation))
+                                   mimeType: "video/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/mp4" } as Representation))
+                                   mimeType: "audio/mp4" } as IRepresentation))
       .toEqual(undefined);
   });
 
@@ -81,25 +81,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as Representation))
+                                   mimeType: "audio/webm" } as IRepresentation))
       .toEqual("webm");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as Representation))
+                                   mimeType: "video/webm" } as IRepresentation))
       .toEqual("webm");
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as Representation))
+                                   mimeType: "video/webm" } as IRepresentation))
       .toEqual("webm");
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as Representation))
+                                   mimeType: "audio/webm" } as IRepresentation))
       .toEqual("webm");
   });
 
@@ -110,25 +110,25 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as Representation))
+                                   mimeType: "audio/webm" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as Representation))
+                                   mimeType: "video/webm" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "video/webm" } as Representation))
+                                   mimeType: "video/webm" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("image",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "audio/webm" } as Representation))
+                                   mimeType: "audio/webm" } as IRepresentation))
       .toEqual(undefined);
   });
 
@@ -139,47 +139,47 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as Representation))
+                                   mimeType: "application/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as Representation))
+                                   mimeType: "application/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as Representation))
+                                   mimeType: "" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as Representation))
+                                   mimeType: "" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "foo" } as Representation))
+                                   mimeType: "foo" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "bar" } as Representation))
+                                   mimeType: "bar" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("audio",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as Representation))
+                                   index: {} } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("video",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as Representation))
+                                   index: {} } as IRepresentation))
       .toEqual(undefined);
   });
 
@@ -188,7 +188,7 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "application/mp4" } as Representation))
+                                   mimeType: "application/mp4" } as IRepresentation))
       .toEqual("mp4");
   });
 
@@ -198,30 +198,30 @@ describe("Transport utils - inferSegmentContainer", () => {
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "text/mp4" } as Representation))
+                                   mimeType: "text/mp4" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "text/plain" } as Representation))
+                                   mimeType: "text/plain" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "" } as Representation))
+                                   mimeType: "" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
                                    index: {},
-                                   mimeType: "foo" } as Representation))
+                                   mimeType: "foo" } as IRepresentation))
       .toEqual(undefined);
     expect(inferSegmentContainer("text",
                                  { bitrate: 0,
                                    id: "1",
-                                   index: {} } as Representation))
+                                   index: {} } as IRepresentation))
       .toEqual(undefined);
   });
 });

--- a/src/transports/utils/infer_segment_container.ts
+++ b/src/transports/utils/infer_segment_container.ts
@@ -16,7 +16,7 @@
 
 import {
   IAdaptationType,
-  Representation,
+  IRepresentation,
 } from "../../manifest";
 
 /**
@@ -33,7 +33,7 @@ import {
  */
 export default function inferSegmentContainer(
   adaptationType : IAdaptationType,
-  representation : Representation
+  representation : IRepresentation
 ) : "webm" | "mp4" | undefined {
   if (adaptationType === "audio" || adaptationType === "video") {
     if (representation.mimeType === "video/mp4" ||

--- a/src/transports/utils/parse_text_track.ts
+++ b/src/transports/utils/parse_text_track.ts
@@ -16,9 +16,9 @@
 
 import log from "../../log";
 import {
-  Adaptation,
+  IAdaptation,
   ISegment,
-  Representation,
+  IRepresentation,
 } from "../../manifest";
 import { getMDAT } from "../../parsers/containers/isobmff";
 import { utf8ToStr } from "../../utils/string_parsing";
@@ -45,7 +45,7 @@ export function extractTextTrackFromISOBMFF(chunkBytes : Uint8Array) : string {
  * @returns {string}
  */
 export function getISOBMFFTextTrackFormat(
-  representation : Representation
+  representation : IRepresentation
 ) : "ttml" | "vtt" {
   const codec = representation.codec;
   if (codec === undefined) {
@@ -68,7 +68,7 @@ export function getISOBMFFTextTrackFormat(
  * @returns {string}
  */
 export function getPlainTextTrackFormat(
-  representation : Representation
+  representation : IRepresentation
 ) : "ttml" | "sami" | "vtt" | "srt" {
   const { mimeType = "" } = representation;
   switch (representation.mimeType) {
@@ -100,8 +100,8 @@ export function getISOBMFFEmbeddedTextTrackData(
   { segment,
     adaptation,
     representation } : { segment : ISegment;
-                         adaptation : Adaptation;
-                         representation : Representation; },
+                         adaptation : IAdaptation;
+                         representation : IRepresentation; },
   chunkBytes : Uint8Array,
   chunkInfos : IChunkTimeInfo | null,
   isChunked : boolean
@@ -147,8 +147,8 @@ export function getPlainTextTrackData(
   { segment,
     adaptation,
     representation } : { segment : ISegment;
-                         adaptation : Adaptation;
-                         representation : Representation; },
+                         adaptation : IAdaptation;
+                         representation : IRepresentation; },
   textTrackData : string,
   isChunked : boolean
 ) : ITextTrackSegmentData | null {

--- a/src/utils/__tests__/initialization_segment_cache.test.ts
+++ b/src/utils/__tests__/initialization_segment_cache.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Representation } from "../../manifest";
+import { IRepresentation } from "../../manifest";
 import InitializationSegmentCache from "../initialization_segment_cache";
 
 const representation1 = {
@@ -25,7 +25,7 @@ const representation1 = {
   index: {},
   getProtectionsInitializationData() : [] { return []; },
   _addProtectionData() : never { throw new Error("Not implemented"); },
-} as unknown as Representation;
+} as unknown as IRepresentation;
 
 const representation2 = {
   bitrate: 14,
@@ -35,7 +35,7 @@ const representation2 = {
   index: {},
   getProtectionsInitializationData() : [] { return []; },
   _addProtectionData() : never { throw new Error("Not implemented"); },
-} as unknown as Representation;
+} as unknown as IRepresentation;
 
 const initSegment1 = {
   id: "init1",

--- a/src/utils/event_emitter.ts
+++ b/src/utils/event_emitter.ts
@@ -28,8 +28,6 @@ export interface IEventEmitter<T> {
   removeEventListener<TEventName extends keyof T>(evt : TEventName,
                                                   fn : IListener<T, TEventName>) :
                                                    void;
-  trigger?<TEventName extends keyof T>(evt : TEventName,
-                                       arg : IArgs<T, TEventName>) : void;
 }
 
 // Type of the argument in the listener's callback

--- a/src/utils/initialization_segment_cache.ts
+++ b/src/utils/initialization_segment_cache.ts
@@ -16,7 +16,7 @@
 
 import {
   ISegment,
-  Representation,
+  IRepresentation,
 } from "../manifest";
 
 /**
@@ -25,7 +25,7 @@ import {
  * @class InitializationSegmentCache
  */
 class InitializationSegmentCache<T> {
-  private _cache : WeakMap<Representation, T>;
+  private _cache : WeakMap<IRepresentation, T>;
 
   constructor() {
     this._cache = new WeakMap();
@@ -37,7 +37,7 @@ class InitializationSegmentCache<T> {
    */
   public add(
     { representation,
-      segment } : { representation : Representation;
+      segment } : { representation : IRepresentation;
                     segment : ISegment; },
     response : T
   ) : void {
@@ -52,7 +52,7 @@ class InitializationSegmentCache<T> {
    */
   public get(
     { representation,
-      segment } : { representation : Representation;
+      segment } : { representation : IRepresentation;
                     segment : ISegment; }
   ) : T|null {
     if (segment.isInit) {


### PR DESCRIPTION
The `Manifest` object was until now a class describing a content regardless of the streaming protocol (e.g. DASH, Smooth etc.) used:
  - Its URL (at which it can be refreshed)
  - Its minimum and maximum seekable position
  - The description of the available audio/video/text tracks and qualities
  - How to request initialization and media segments
  - decryption initialization data
  - and many other things

It is thus a central part of the RxPlayer.

However, the fact that it is defined as a class despite it doing some processing at instantiation made us encounter several issues over time:
  1. No asynchronous operation can happen at object construction.

     This mainly have been problematic recently, as I wanted to use an asynchronous Web API (MediaCapabilities's decodingInfo object) to define a property of a `Representation` (which is another class inside the `Manifest`'s instance).

     In the end, I may decide to not continue this road (defining the property as instantiation) for various unrelated reasons, but the possible need to define asynchronous properties still stand for the future.

  2. At instantiation, no other value (excepted the constructed `Manifest` object) can be returned.

     This was already problematic as various minor issues can occur while instantiating a `Manifest` (e.g. a track has no supported codec).

     Due to this, the idea was previously to define a new property of the `Manifest`, called `contentWarnings`, which contained all those issues. This was kind of a hack.

  3. I remember wanting in the past to have multiple potential constructors, with different arguments given, to unlock advanced features while staying readable.

     This is not really possible with `classes`, at least not easily and readably.

Those are the reason why this PR is a proposal to define an `IManifest` interface instead and having regular functions constructing it.
However doing this has also several disadvantages:

  - Property names and method signatures are duplicated: once at type definition and the other time in the function that creates it.

    As they are in two separate places, we might also more easily forget to update e.g. the documentation when doing changes.

  - tsserver's "go to definition" feature found in most editors is going to favour the interface over the code.

    This can be good as     that's where the documentation is, but also bad as that's not where     the real logic is.

  - it's not possible to call `instanceof` anymore on it, and the most probable replacement is doing good ol' and ugly duck typing.

    However this was done at only one place in the code (checking if the `initialManifest` `loadVideo` option is a `Manifest` instance).
