### PR TITLE
[Proposal] Use MediaCapabilities API when creating an `IManifest` object

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -50,6 +50,9 @@ const isSamsungBrowser : boolean = !isNode &&
 const isTizen : boolean = !isNode &&
                           /Tizen/.test(navigator.userAgent);
 
+const isChromeCast : boolean = !isNode &&
+                               /CrKey/.test(navigator.userAgent);
+
 interface ISafariWindowObject extends Window {
   safari? : { pushNotification? : { toString() : string } };
 }
@@ -68,6 +71,7 @@ const isSafariMobile : boolean = !isNode &&
                                  /iPad|iPhone|iPod/.test(navigator.platform);
 
 export {
+  isChromeCast,
   isEdgeChromium,
   isIE11,
   isIEOrEdge,

--- a/src/compat/check_decoding_capabilities_support.ts
+++ b/src/compat/check_decoding_capabilities_support.ts
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import log from "../log";
+import { IRepresentation } from "../manifest";
+import objectAssign from "../utils/object_assign";
+import {
+  isChromeCast,
+  isSafariDesktop,
+  isSafariMobile,
+} from "./browser_detection";
+import isNode from "./is_node";
+
+/**
+ * Object allowing to store short-term information on decoding capabilities, to
+ * avoid calling multiple times the same API when video characteristics are
+ * similar.
+ */
+let VideoDecodingInfoMemory : IVideoDecodingCharacteristics = {};
+
+/**
+ * Contains the timeout id of the timer used to clear `VideoDecodingInfoMemory`.
+ */
+let VideoCapabilitiesTimeout : number | undefined;
+
+/**
+ * If `false`, MediaCapability APIs cannot be relied on.
+ * Most of the exception here are set due to Shaka-Player also avoiding to use
+ * the API on them.
+ */
+const CanUseMediaCapabilitiesApi = !isNode &&
+                                   !isChromeCast &&
+                                   !isSafariMobile &&
+                                   !isSafariDesktop &&
+                                   typeof navigator.mediaCapabilities === "object";
+
+/**
+ * Use the `MediaCapabilities` web APIs to detect if the given Representation is
+ * supported or not.
+ * Returns `true` if it is supported, false it is not and `undefined if it
+ * cannot tell.
+ * @param {Object} representation
+ * @param {string} adaptationType
+ * @returns {Promise.<boolean|undefined>}
+ */
+export default async function checkDecodingCapabilitiesSupport(
+  representation : IRepresentation,
+  adaptationType : "audio" | "video"
+) : Promise<boolean | undefined> {
+  if (!CanUseMediaCapabilitiesApi || adaptationType !== "video") {
+    return undefined;
+  }
+  const mimeTypeStr = representation.getMimeTypeString();
+  const tmpFrameRate = representation.frameRate !== undefined ?
+    parseMaybeDividedNumber(representation.frameRate) :
+    null;
+  const framerate = tmpFrameRate !== null &&
+                    !isNaN(tmpFrameRate) &&
+                    isFinite(tmpFrameRate) ? tmpFrameRate :
+                                             1;
+  const width = representation.width ?? 1;
+  const height = representation.height ?? 1;
+  const bitrate = representation.bitrate ?? 1;
+
+  const decodingForMimeType = VideoDecodingInfoMemory[mimeTypeStr];
+  if (decodingForMimeType === undefined) {
+    return runCheck();
+  }
+  for (const characteristics of decodingForMimeType) {
+    if (characteristics.bitrate === bitrate &&
+        characteristics.width === width &&
+        characteristics.height === height &&
+        characteristics.framerate === framerate)
+    {
+      return characteristics.result.supported;
+    }
+  }
+
+  async function runCheck() : Promise<boolean> {
+    try {
+      const videoCharacs = { contentType: mimeTypeStr,
+                             width,
+                             height,
+                             bitrate,
+                             framerate };
+      const supportObj = await navigator.mediaCapabilities.decodingInfo({
+        type: "media-source",
+        video: videoCharacs,
+      });
+      if (VideoDecodingInfoMemory[mimeTypeStr] === undefined) {
+        VideoDecodingInfoMemory[mimeTypeStr] = [];
+      }
+      VideoDecodingInfoMemory[mimeTypeStr].push(objectAssign({ result: supportObj },
+                                                             videoCharacs));
+      if (VideoCapabilitiesTimeout === undefined) {
+        VideoCapabilitiesTimeout = window.setTimeout(() => {
+          VideoCapabilitiesTimeout = undefined;
+          VideoDecodingInfoMemory = {};
+        }, 0);
+      }
+      return supportObj.supported;
+    } catch (err) {
+      log.warn("Compat: mediaCapabilities.decodingInfo API failed for video content",
+               err);
+      throw err;
+    }
+  }
+}
+
+/**
+ * Frame rates can be expressed as divisions of integers.
+ * This function tries to convert it to a floating point value.
+ * TODO in v4, declares `frameRate` as number directly
+ * @param {string} val
+ * @param {string} displayName
+ * @returns {Array.<number | Error | null>}
+ */
+function parseMaybeDividedNumber(val : string) : number | null {
+  const matches = /^(\d+)\/(\d+)$/.exec(val);
+  if (matches !== null) {
+    // No need to check, we know both are numbers
+    return +matches[1] / +matches[2];
+  }
+  return Number.parseFloat(val);
+}
+
+interface IVideoDecodingCharacteristics {
+  [x : string] : Array<{ width : number;
+                         height : number;
+                         bitrate : number;
+                         framerate : number;
+                         contentType : string;
+                         result: MediaCapabilitiesDecodingInfo; }>;
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -25,6 +25,7 @@ import canPatchISOBMFFSegment from "./can_patch_isobmff";
 import tryToChangeSourceBufferType, {
   ICompatSourceBuffer,
 } from "./change_source_buffer_type";
+import checkDecodingCapabilitiesSupport from "./check_decoding_capabilities_support";
 import clearElementSrc from "./clear_element_src";
 import {
   closeSession,
@@ -72,6 +73,7 @@ export {
   addClassName,
   addTextTrack,
   canPatchISOBMFFSegment,
+  checkDecodingCapabilitiesSupport,
   clearElementSrc,
   closeSession,
   CustomMediaKeySystemAccess,

--- a/src/compat/is_codec_supported.ts
+++ b/src/compat/is_codec_supported.ts
@@ -25,15 +25,16 @@ import { MediaSource_ } from "./browser_compatibility_types";
  * codecs used within the file.
  * @returns {Boolean}
  */
-export default function isCodecSupported(mimeType : string) : boolean {
+export default function isCodecSupported(
+  mimeTypeStr : string
+) : boolean {
   if (MediaSource_ == null) {
     return false;
   }
 
-  /* eslint-disable @typescript-eslint/unbound-method */
+  /* eslint-disable-next-line @typescript-eslint/unbound-method */
   if (typeof MediaSource_.isTypeSupported === "function") {
-  /* eslint-enable @typescript-eslint/unbound-method */
-    return MediaSource_.isTypeSupported(mimeType);
+    return MediaSource_.isTypeSupported(mimeTypeStr);
   }
 
   return true;

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -42,7 +42,7 @@ describe("Manifest - Manifest", () => {
 
   });
 
-  it("should create a normalized Manifest structure", () => {
+  it("should create a normalized Manifest structure", async () => {
     const simpleFakeManifest = { id: "man",
                                  isDynamic: false,
                                  isLive: false,
@@ -55,7 +55,7 @@ describe("Manifest - Manifest", () => {
                                  periods: [] };
 
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(simpleFakeManifest, {});
+    const [manifest, warnings] = await createManifestObject(simpleFakeManifest, {});
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(undefined);
@@ -76,7 +76,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should create a Period for each manifest.periods given", () => {
+  it("should create a Period for each manifest.periods given", async () => {
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -91,12 +91,13 @@ describe("Manifest - Manifest", () => {
                                  periods: [period1, period2] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}`, adaptations: {} }, []];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}`, adaptations: {} }, []]);
     });
     jest.mock("../period", () =>  ({ createPeriodObject: createPeriodSpy }));
 
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(simpleFakeManifest, {});
+    const [manifest, warnings] = await createManifestObject(simpleFakeManifest, {});
     expect(createPeriodSpy).toHaveBeenCalledTimes(2);
     expect(createPeriodSpy).toHaveBeenCalledWith(period1, undefined);
     expect(createPeriodSpy).toHaveBeenCalledWith(period2, undefined);
@@ -114,7 +115,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should pass a `representationFilter` to the Period if given", () => {
+  it("should pass a `representationFilter` to the Period if given", async () => {
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -131,13 +132,14 @@ describe("Manifest - Manifest", () => {
     const representationFilter = function() { return false; };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}` }, []];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}` }, []]);
     });
     jest.mock("../period", () =>  ({ createPeriodObject: createPeriodSpy }));
     const createManifestObject = require("../manifest").createManifestObject;
 
     /* eslint-disable @typescript-eslint/no-unused-expressions */
-    createManifestObject(simpleFakeManifest, { representationFilter });
+    await createManifestObject(simpleFakeManifest, { representationFilter });
     /* eslint-enable @typescript-eslint/no-unused-expressions */
 
     expect(createPeriodSpy).toHaveBeenCalledTimes(2);
@@ -149,7 +151,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should expose the adaptations of the first period if set", () => {
+  it("should expose the adaptations of the first period if set", async () => {
     const adapP1 = {};
     const adapP2 = {};
     const period1 = { id: "0", start: 4, adaptations: adapP1 };
@@ -166,12 +168,13 @@ describe("Manifest - Manifest", () => {
                                  periods: [period1, period2] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [{ ...period, id: `foo${period.id}` }, []];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ ...period, id: `foo${period.id}` }, []]);
     });
     jest.mock("../period", () =>  ({ createPeriodObject: createPeriodSpy }));
     const createManifestObject = require("../manifest").createManifestObject;
 
-    const [manifest, warnings] = createManifestObject(simpleFakeManifest, {});
+    const [manifest, warnings] = await createManifestObject(simpleFakeManifest, {});
     expect(createPeriodSpy).toHaveBeenCalledTimes(2);
     expect(createPeriodSpy).toHaveBeenCalledWith(period1, undefined);
     expect(createPeriodSpy).toHaveBeenCalledWith(period2, undefined);
@@ -189,7 +192,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should push any parsing errors from the Period parsing", () => {
+  it("should push any parsing errors from the Period parsing", async () => {
     const period1 = { id: "0", start: 4, adaptations: {} };
     const period2 = { id: "1", start: 12, adaptations: {} };
     const simpleFakeManifest = { id: "man",
@@ -204,16 +207,17 @@ describe("Manifest - Manifest", () => {
                                  periods: [period1, period2] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [ { ...period, id: `foo${period.id}` },
-               [ new Error(`a${period.id}`),
-                 new Error(period.id) ] ];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([ { ...period, id: `foo${period.id}` },
+                               [ new Error(`a${period.id}`),
+                                 new Error(period.id) ] ]);
     });
     jest.mock("../period", () =>  ({
       createPeriodObject: createPeriodSpy,
     }));
     const createManifestObject = require("../manifest").createManifestObject;
 
-    const [_manifest, warnings] = createManifestObject(simpleFakeManifest, {});
+    const [_manifest, warnings] = await createManifestObject(simpleFakeManifest, {});
     expect(warnings).toHaveLength(4);
     expect(warnings).toContainEqual(new Error("a0"));
     expect(warnings).toContainEqual(new Error("a1"));
@@ -226,7 +230,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should correctly parse every manifest information given", () => {
+  it("should correctly parse every manifest information given", async () => {
     const oldPeriod1 = { id: "0", start: 4, adaptations: {} };
     const oldPeriod2 = { id: "1", start: 12, adaptations: {} };
     const time = performance.now();
@@ -246,13 +250,14 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [ { ...period,
-                 id: `foo${period.id}` },
-               [new Error(period.id)] ];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([ { ...period,
+                                 id: `foo${period.id}` },
+                               [new Error(period.id)] ]);
     });
     jest.mock("../period", () =>  ({ createPeriodObject: createPeriodSpy }));
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(5);
@@ -275,10 +280,11 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should return the first URL given with `getUrl`", () => {
+  it("should return the first URL given with `getUrl`", async () => {
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}`, adaptations: {} },
-              [new Error(period.id)]];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}`, adaptations: {} },
+                              [new Error(period.id)]]);
     });
     jest.mock("../period", () =>  ({
       createPeriodObject: createPeriodSpy,
@@ -301,7 +307,7 @@ describe("Manifest - Manifest", () => {
                                suggestedPresentationDelay: 99,
                                uris: ["url1", "url2"] };
 
-    const [manifest1, warnings1] = createManifestObject(oldManifestArgs1, {});
+    const [manifest1, warnings1] = await createManifestObject(oldManifestArgs1, {});
     expect(manifest1.getUrl()).toEqual("url1");
     expect(warnings1).toEqual([new Error("0"), new Error("1")]);
 
@@ -320,15 +326,16 @@ describe("Manifest - Manifest", () => {
                                                                 value: 10,
                                                                 time: 10 } },
                                uris: [] };
-    const [manifest2, warnings2] = createManifestObject(oldManifestArgs2, {});
+    const [manifest2, warnings2] = await createManifestObject(oldManifestArgs2, {});
     expect(manifest2.getUrl()).toEqual(undefined);
     expect(warnings2).toEqual([new Error("0"), new Error("1")]);
   });
 
-  it("should replace with a new Manifest when calling `replace`", () => {
+  it("should replace with a new Manifest when calling `replace`", async () => {
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}`, adaptations: {} },
-              [new Error(period.id)]];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}`, adaptations: {} },
+                              [new Error(period.id)]]);
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -359,7 +366,7 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
     let nbOfManifestUpdates = 0;
     function onManifestUpdate() {
       nbOfManifestUpdates++;
@@ -413,7 +420,7 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should prepend older Periods when calling `replace`", () => {
+  it("should prepend older Periods when calling `replace`", async () => {
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -430,9 +437,10 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [ { ...period,
-                 id: `foo${period.id}` },
-               [new Error(period.id)] ];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([ { ...period,
+                                 id: `foo${period.id}` },
+                               [new Error(period.id)] ]);
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -448,7 +456,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
     expect(warnings).toEqual([new Error("1")]);
     let nbOfManifestUpdates = 0;
     function onManifestUpdate() {
@@ -501,7 +509,7 @@ describe("Manifest - Manifest", () => {
     //   "Manifest: Adding new Period pre1 after update.");
   });
 
-  it("should append newer Periods when calling `replace`", () => {
+  it("should append newer Periods when calling `replace`", async () => {
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -518,9 +526,10 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [ { ...period,
-                 id: `foo${period.id}` },
-               [new Error(period.id)] ];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([ { ...period,
+                                 id: `foo${period.id}` },
+                               [new Error(period.id)] ]);
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -534,7 +543,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
     expect(warnings).toEqual([new Error("1")]);
     const [oldPeriod1] = manifest.periods;
 
@@ -577,7 +586,7 @@ describe("Manifest - Manifest", () => {
     // .toHaveBeenCalledWith("Manifest: Adding new Periods after update.");
   });
 
-  it("should replace different Periods when calling `replace`", () => {
+  it("should replace different Periods when calling `replace`", async () => {
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -594,8 +603,9 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}`, adaptations: {} },
-              [new Error(period.id)]];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}`, adaptations: {} },
+                              [new Error(period.id)]]);
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -609,7 +619,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
 
     let nbOfManifestUpdates = 0;
     function onManifestUpdate() {
@@ -648,7 +658,7 @@ describe("Manifest - Manifest", () => {
     // expect(fakeLogger.info).toHaveBeenCalledTimes(4);
   });
 
-  it("should merge overlapping Periods when calling `replace`", () => {
+  it("should merge overlapping Periods when calling `replace`", async () => {
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
@@ -667,8 +677,9 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const createPeriodSpy = jest.fn((period) => {
-      return [{ id: `foo${period.id}`, adaptations: {} },
-              [new Error(period.id)]];
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve([{ id: `foo${period.id}`, adaptations: {} },
+                              [new Error(period.id)]]);
     });
     const fakeUpdatePeriodInPlace = jest.fn((oldPeriod, newPeriod) => {
       Object.keys(oldPeriod).forEach(key => {
@@ -683,7 +694,7 @@ describe("Manifest - Manifest", () => {
       default: fakeUpdatePeriodInPlace,
     }));
     const createManifestObject = require("../manifest").createManifestObject;
-    const [manifest, warnings] = createManifestObject(oldManifestArgs, {});
+    const [manifest, warnings] = await createManifestObject(oldManifestArgs, {});
     expect(warnings).toEqual([new Error("1"), new Error("2"), new Error("3")]);
     const [oldPeriod1, oldPeriod2] = manifest.periods;
 

--- a/src/manifest/__tests__/period.test.ts
+++ b/src/manifest/__tests__/period.test.ts
@@ -26,9 +26,10 @@ describe("Manifest - Period", () => {
     jest.resetModules();
   });
 
-  it("should throw if no adaptation is given", () => {
+  it("should throw if no adaptation is given", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -41,7 +42,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -61,9 +62,10 @@ describe("Manifest - Period", () => {
     expect(createAdaptationSpy).not.toHaveBeenCalled();
   });
 
-  it("should throw if no audio nor video adaptation is given", () => {
+  it("should throw if no audio nor video adaptation is given", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -73,11 +75,11 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const fooAda1 = { type: "foo",
                       id: "54",
-                      isCodecSupported: true,
+                      hasSupport: true,
                       representations: [{}] };
     const fooAda2 = { type: "foo",
                       id: "55",
-                      isCodecSupported: true,
+                      hasSupport: true,
                       representations: [{}] };
     const foo = [fooAda1, fooAda2];
     const args = { id: "12", adaptations: { foo }, start: 0 };
@@ -85,7 +87,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -109,9 +111,10 @@ describe("Manifest - Period", () => {
     expect(createAdaptationSpy).toHaveBeenNthCalledWith(2, fooAda2, {});
   });
 
-  it("should throw if only empty audio and/or video adaptations is given", () => {
+  it("should throw if only empty audio and/or video adaptations is given", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -124,7 +127,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -146,9 +149,10 @@ describe("Manifest - Period", () => {
     expect(createAdaptationSpy).toHaveBeenCalledTimes(0);
   });
 
-  it("should throw if we are left with no audio representation", () => {
+  it("should throw if we are left with no audio representation", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -158,25 +162,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "57",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
@@ -184,7 +188,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -204,9 +208,10 @@ describe("Manifest - Period", () => {
     expect(errorReceived.message).toContain("No supported audio adaptations");
   });
 
-  it("should throw if no audio Adaptation is supported", () => {
+  it("should throw if no audio Adaptation is supported", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -216,25 +221,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "57",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "58",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
@@ -242,7 +247,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -262,9 +267,10 @@ describe("Manifest - Period", () => {
     expect(errorReceived.message).toContain("No supported audio adaptations");
   });
 
-  it("should throw if we are left with no video representation", () => {
+  it("should throw if we are left with no video representation", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -274,25 +280,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
@@ -300,7 +306,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -320,9 +326,10 @@ describe("Manifest - Period", () => {
     expect(errorReceived.message).toContain("No supported video adaptation");
   });
 
-  it("should throw if no video adaptation is supported", () => {
+  it("should throw if no video adaptation is supported", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -332,25 +339,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "56",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audioAda2 = { type: "audio",
                         id: "59",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
@@ -358,7 +365,7 @@ describe("Manifest - Period", () => {
     let warnings = null;
     let errorReceived = null;
     try {
-      [period, warnings] = createPeriodObject(args);
+      [period, warnings] = await createPeriodObject(args);
     } catch (e) {
       errorReceived = e;
     }
@@ -378,7 +385,7 @@ describe("Manifest - Period", () => {
     expect(errorReceived.message).toContain("No supported video adaptation");
   });
 
-  it("should set a parsing error if an unsupported adaptation is given", () => {
+  it("should set a parsing error if an unsupported adaptation is given", async () => {
     const createAdaptationSpy = jest.fn(arg => {
       return { ...arg };
     });
@@ -391,16 +398,16 @@ describe("Manifest - Period", () => {
 
     const videoAda1 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1];
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const video2 = [videoAda2];
     const args = { id: "12", adaptations: { video, video2 }, start: 0 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
     expect(warnings).toHaveLength(1);
 
     expect(createAdaptationSpy).toHaveBeenCalledTimes(2);
@@ -416,9 +423,10 @@ describe("Manifest - Period", () => {
   });
 
   /* eslint-disable-next-line max-len */
-  it("should not set a parsing error if an empty unsupported adaptation is given", () => {
+  it("should not set a parsing error if an empty unsupported adaptation is given", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -429,12 +437,12 @@ describe("Manifest - Period", () => {
 
     const videoAda1 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1];
     const bar = undefined;
     const args = { id: "12", adaptations: { bar, video }, start: 0 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
     expect(period.adaptations).toEqual({
       video: video.map(v => ({ ...v })),
     });
@@ -444,9 +452,10 @@ describe("Manifest - Period", () => {
     expect(createAdaptationSpy).toHaveBeenCalledWith(videoAda1, {});
   });
 
-  it("should give a representationFilter to the adaptation", () => {
+  it("should give a representationFilter to the adaptation", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     const representationFilter = jest.fn();
     jest.mock("../adaptation", () => ({
@@ -457,15 +466,15 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0 };
-    const [period, warnings] = createPeriodObject(args, representationFilter);
+    const [period, warnings] = await createPeriodObject(args, representationFilter);
 
     expect(warnings).toHaveLength(0);
     expect(period.adaptations.video).toHaveLength(2);
@@ -478,7 +487,7 @@ describe("Manifest - Period", () => {
     expect(representationFilter).not.toHaveBeenCalled();
   });
 
-  it("should add warnings if Adaptations are not supported", () => {
+  it("should add warnings if Adaptations are not supported", async () => {
     const createAdaptationSpy = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -488,20 +497,20 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const fooAda1 = { type: "foo",
                       id: "12",
-                      isCodecSupported: false,
+                      hasSupport: false,
                       representations: [{}] };
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const [_period, warnings] = createPeriodObject(args);
+    const [_period, warnings] = await createPeriodObject(args);
 
     expect(warnings).toHaveLength(2);
     const error = warnings[0];
@@ -514,7 +523,7 @@ describe("Manifest - Period", () => {
   });
 
   /* eslint-disable-next-line max-len */
-  it("should not add warnings if an Adaptation has no Representation", () => {
+  it("should not add warnings if an Adaptation has no Representation", async () => {
     const createAdaptationSpy = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -524,27 +533,28 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: false,
+                        hasSupport: false,
                         representations: [] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const fooAda1 = { type: "foo",
                       id: "12",
-                      isCodecSupported: false,
+                      hasSupport: false,
                       representations: [] };
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const [_period, warnings] = createPeriodObject(args);
+    const [_period, warnings] = await createPeriodObject(args);
 
     expect(warnings).toHaveLength(0);
   });
 
-  it("should set the given start", () => {
+  it("should set the given start", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -554,24 +564,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 72 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
     expect(period.start).toEqual(72);
     expect(period.duration).toEqual(undefined);
     expect(period.end).toEqual(undefined);
     expect(warnings).toEqual([]);
   });
 
-  it("should set a given duration", () => {
+  it("should set a given duration", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -581,24 +592,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
     expect(period.start).toEqual(0);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(12);
     expect(warnings).toEqual([]);
   });
 
-  it("should infer the end from the start and the duration", () => {
+  it("should infer the end from the start and the duration", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -608,24 +620,25 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 50, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
     expect(period.start).toEqual(50);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(62);
     expect(warnings).toEqual([]);
   });
 
-  it("should return every Adaptations combined with `getAdaptations`", () => {
+  it("should return every Adaptations combined with `getAdaptations`", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -635,22 +648,22 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
 
     expect(period.getAdaptations()).toHaveLength(3);
     expect(period.getAdaptations()).toContain(period.adaptations.video[0]);
@@ -660,10 +673,11 @@ describe("Manifest - Period", () => {
   });
 
   /* eslint-disable max-len */
-  it("should return every Adaptations from a given type with `getAdaptationsForType`", () => {
+  it("should return every Adaptations from a given type with `getAdaptationsForType`", async () => {
   /* eslint-enable max-len */
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -673,22 +687,22 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
 
     expect(period.getAdaptationsForType("video")).toHaveLength(2);
     expect(period.getAdaptationsForType("video"))
@@ -705,10 +719,11 @@ describe("Manifest - Period", () => {
   });
 
   /* eslint-disable max-len */
-  it("should return the first Adaptations with a given Id when calling `getAdaptation`", () => {
+  it("should return the first Adaptations with a given Id when calling `getAdaptation`", async () => {
   /* eslint-enable max-len */
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -718,26 +733,26 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
 
     expect(period.getAdaptation("54")).toEqual(period.adaptations.video[0]);
     expect(period.getAdaptation("55")).toEqual(period.adaptations.video[1]);
@@ -746,9 +761,10 @@ describe("Manifest - Period", () => {
   });
 
   /* eslint-disable-next-line max-len */
-  it("should return undefined if no adaptation has the given Id when calling `getAdaptation`", () => {
+  it("should return undefined if no adaptation has the given Id when calling `getAdaptation`", async () => {
     const createAdaptationSpy = jest.fn(arg => {
-      return arg;
+      /* eslint-disable-next-line no-restricted-properties */
+      return Promise.resolve(arg);
     });
     jest.mock("../adaptation", () => ({
       createAdaptationObject: createAdaptationSpy,
@@ -758,26 +774,26 @@ describe("Manifest - Period", () => {
     const createPeriodObject = require("../period").createPeriodObject;
     const videoAda1 = { type: "video",
                         id: "54",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda2 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const videoAda3 = { type: "video",
                         id: "55",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "56",
-                        isCodecSupported: true,
+                        hasSupport: true,
                         representations: [{}] };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const [period, warnings] = createPeriodObject(args);
+    const [period, warnings] = await createPeriodObject(args);
 
     expect(period.getAdaptation("88")).toEqual(undefined);
     expect(period.getAdaptation("toto")).toEqual(undefined);

--- a/src/manifest/__tests__/representation.test.ts
+++ b/src/manifest/__tests__/representation.test.ts
@@ -35,6 +35,8 @@ const minimalIndex = { getInitSegment() { return null; },
                        _update() { /* noop */ } };
 
 const defaultIsCodecSupported = jest.fn(() => true);
+/* eslint-disable-next-line no-restricted-properties */
+const defaultCheckDecodingCapabilitiesSupport = jest.fn(() => Promise.resolve(undefined));
 
 describe.only("Manifest - Representation", () => {
   beforeEach(() => {
@@ -45,16 +47,17 @@ describe.only("Manifest - Representation", () => {
   });
 
   /* eslint-disable-next-line max-len */
-  it("should be able to create Representation with the minimum arguments given", () => {
+  it("should be able to create Representation with the minimum arguments given", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
     const args = { bitrate: 12,
                    id: "test",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "audio" });
+    const representation = await createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -66,18 +69,20 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a height attribute", () => {
+  it("should be able to add a height attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
     const args = { bitrate: 12, id: "test", height: 57, index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "video" });
+    const representation = await createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -89,18 +94,20 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a width attribute", () => {
+  it("should be able to add a width attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
     const args = { bitrate: 12, id: "test", width: 2, index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "video" });
+    const representation = await createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -112,13 +119,15 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(2);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a codecs attribute", () => {
+  it("should be able to add a codecs attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -126,7 +135,7 @@ describe.only("Manifest - Representation", () => {
                    id: "test",
                    codecs: "vp9",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "audio" });
+    const representation = await createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -138,13 +147,15 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe(";codecs=\"vp9\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a mimeType attribute", () => {
+  it("should be able to add a mimeType attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -152,7 +163,7 @@ describe.only("Manifest - Representation", () => {
                    id: "test",
                    mimeType: "audio/mp4",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "audio" });
+    const representation = await createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -164,13 +175,15 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a contentProtections attribute", () => {
+  it("should be able to add a contentProtections attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -183,7 +196,7 @@ describe.only("Manifest - Representation", () => {
                                          initData: { cenc: [{
                                            systemId: "EDEF",
                                            data: new Uint8Array([78]) }] } } };
-    const representation = createRepresentationObject(args, { type: "video" });
+    const representation = await createRepresentationObject(args, { type: "video" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -195,13 +208,15 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("video/mp4;codecs=\"vp12\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to add a frameRate attribute", () => {
+  it("should be able to add a frameRate attribute", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -211,7 +226,7 @@ describe.only("Manifest - Representation", () => {
                    mimeType: "audio/mp4",
                    codecs: "mp4a.40.2",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "audio" });
+    const representation = await createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -223,34 +238,36 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"mp4a.40.2\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(defaultIsCodecSupported).toHaveBeenCalledTimes(1);
   });
 
-  it("should be able to return an exploitable codecs + mimeType string", () => {
+  it("should be able to return an exploitable codecs + mimeType string", async () => {
     jest.mock("../../compat", () => ({
       isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
     const args1 = { bitrate: 12,
                     id: "test",
                     index: minimalIndex };
-    expect((createRepresentationObject(args1, { type: "audio" }))
+    expect((await createRepresentationObject(args1, { type: "audio" }))
       .getMimeTypeString()).toBe(";codecs=\"\"");
 
     const args2 = { bitrate: 12,
                     id: "test",
                     mimeType: "foo",
                     index: minimalIndex };
-    expect((createRepresentationObject(args2, { type: "audio" }))
+    expect((await createRepresentationObject(args2, { type: "audio" }))
       .getMimeTypeString()).toBe("foo;codecs=\"\"");
 
     const args3 = { bitrate: 12,
                     id: "test",
                     codecs: "bar",
                     index: minimalIndex };
-    expect((createRepresentationObject(args3, { type: "audio" }))
+    expect((await createRepresentationObject(args3, { type: "audio" }))
       .getMimeTypeString()).toBe(";codecs=\"bar\"");
 
     const args4 = { bitrate: 12,
@@ -258,15 +275,16 @@ describe.only("Manifest - Representation", () => {
                     mimeType: "foo",
                     codecs: "bar",
                     index: minimalIndex };
-    expect((createRepresentationObject(args4, { type: "audio" }))
+    expect((await createRepresentationObject(args4, { type: "audio" }))
       .getMimeTypeString()).toBe("foo;codecs=\"bar\"");
   });
 
   /* eslint-disable-next-line max-len */
-  it("should set `isCodecSupported` of non-supported codecs or mime-type to `false`", () => {
+  it("should set `isCodecSupported` of non-supported codecs or mime-type to `false`", async () => {
     const notSupportedSpy = jest.fn(() => false);
     jest.mock("../../compat", () => ({
       isCodecSupported: notSupportedSpy,
+      checkDecodingCapabilitiesSupport: defaultCheckDecodingCapabilitiesSupport,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -276,7 +294,7 @@ describe.only("Manifest - Representation", () => {
                    mimeType: "audio/mp4",
                    codecs: "mp4a.40.2",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "audio" });
+    const representation = await createRepresentationObject(args, { type: "audio" });
     expect(representation.id).toBe("test");
     expect(representation.bitrate).toBe(12);
     expect(representation.index).toBe(minimalIndex);
@@ -288,15 +306,52 @@ describe.only("Manifest - Representation", () => {
     expect(representation.width).toBe(undefined);
     expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"mp4a.40.2\"");
     expect(representation.isCodecSupported).toBe(false);
+    expect(representation.isSupported).toBe(undefined);
     expect(representation.decipherable).toBe(undefined);
     expect(notSupportedSpy).toHaveBeenCalledTimes(1);
     expect(notSupportedSpy).toHaveBeenCalledWith("audio/mp4;codecs=\"mp4a.40.2\"");
   });
 
-  it("should not check support for a custom media buffer", () => {
+  /* eslint-disable-next-line max-len */
+  it("should set `isSupported` of non-supported characteristics to `false`", async () => {
+    /* eslint-disable-next-line no-restricted-properties */
+    const checkSpy = jest.fn(() => Promise.resolve(false));
+    jest.mock("../../compat", () => ({
+      isCodecSupported: defaultIsCodecSupported,
+      checkDecodingCapabilitiesSupport: checkSpy,
+    }));
+    const createRepresentationObject =
+      require("../representation").createRepresentationObject;
+    const args = { bitrate: 12,
+                   id: "test",
+                   frameRate: "1/60",
+                   mimeType: "audio/mp4",
+                   codecs: "mp4a.40.2",
+                   index: minimalIndex };
+    const representation = await createRepresentationObject(args, { type: "audio" });
+    expect(representation.id).toBe("test");
+    expect(representation.bitrate).toBe(12);
+    expect(representation.index).toBe(minimalIndex);
+    expect(representation.codec).toBe("mp4a.40.2");
+    expect(representation.contentProtections).toBe(undefined);
+    expect(representation.frameRate).toBe("1/60");
+    expect(representation.height).toBe(undefined);
+    expect(representation.mimeType).toBe("audio/mp4");
+    expect(representation.width).toBe(undefined);
+    expect(representation.getMimeTypeString()).toBe("audio/mp4;codecs=\"mp4a.40.2\"");
+    expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(false);
+    expect(representation.decipherable).toBe(undefined);
+    expect(checkSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not check support for a custom media buffer", async () => {
     const notSupportedSpy = jest.fn(() => false);
+    /* eslint-disable-next-line no-restricted-properties */
+    const checkSpy = jest.fn(() => Promise.resolve(undefined));
     jest.mock("../../compat", () => ({
       isCodecSupported: notSupportedSpy,
+      checkDecodingCapabilitiesSupport: checkSpy,
     }));
     const createRepresentationObject =
       require("../representation").createRepresentationObject;
@@ -306,12 +361,14 @@ describe.only("Manifest - Representation", () => {
                    mimeType: "bip",
                    codecs: "boop",
                    index: minimalIndex };
-    const representation = createRepresentationObject(args, { type: "foo" });
+    const representation = await createRepresentationObject(args, { type: "foo" });
     expect(representation.codec).toBe("boop");
     expect(representation.mimeType).toBe("bip");
     expect(representation.getMimeTypeString()).toBe("bip;codecs=\"boop\"");
     expect(representation.isCodecSupported).toBe(true);
+    expect(representation.isSupported).toBe(true);
     expect(representation.decipherable).toBe(undefined);
     expect(notSupportedSpy).toHaveBeenCalledTimes(0);
+    expect(checkSpy).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -24,6 +24,7 @@ import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
 import arrayFind from "../utils/array_find";
 import EventEmitter from "../utils/event_emitter";
 import idGenerator from "../utils/id_generator";
+import PPromise from "../utils/promise";
 import warnOnce from "../utils/warn_once";
 import {
   createAdaptationObject,
@@ -61,10 +62,10 @@ const generateNewManifestId = idGenerator();
  *   2. Array containing every minor errors that happened when the Manifest has
  *      been created, in the order they have happened..
  */
-export function createManifestObject(
+export async function createManifestObject(
   parsedManifest : IParsedManifest,
   options : IManifestParsingOptions
-) : [IManifest, ICustomError[]] {
+) : Promise<[IManifest, ICustomError[]]> {
   const eventEmitter = new EventEmitter<IManifestEvents>();
   const { supplementaryTextTracks = [],
           supplementaryImageTracks = [],
@@ -72,11 +73,18 @@ export function createManifestObject(
 
   const warnings : ICustomError[] = [];
 
-  const _periods = parsedManifest.periods.map((parsedPeriod) => {
-    const [period, pWarnings] = createPeriodObject(parsedPeriod, representationFilter);
+  const _periodProms : Array<Promise<[IPeriod, ICustomError[]]>> = [];
+  for (const parsedPeriod of parsedManifest.periods) {
+    _periodProms.push(createPeriodObject(parsedPeriod,
+                                         representationFilter));
+  }
+
+  const _periods : IPeriod[] = [];
+  for (const [period, pWarnings] of await PPromise.all(_periodProms)) {
     warnings.push(...pWarnings);
-    return period;
-  }).sort((a, b) => a.start - b.start);
+    _periods.push(period);
+  }
+  _periods.sort((a, b) => a.start - b.start);
 
   const manifestObject : IManifest = {
     id: generateNewManifestId(),
@@ -115,10 +123,10 @@ export function createManifestObject(
   };
 
   if (supplementaryImageTracks.length > 0) {
-    _addSupplementaryImageAdaptations(supplementaryImageTracks);
+    await _addSupplementaryImageAdaptations(supplementaryImageTracks);
   }
   if (supplementaryTextTracks.length > 0) {
-    _addSupplementaryTextAdaptations(supplementaryTextTracks);
+    await _addSupplementaryTextAdaptations(supplementaryTextTracks);
   }
 
   return [manifestObject, warnings];
@@ -315,15 +323,16 @@ export function createManifestObject(
    * Add supplementary image Adaptation(s) to the manifest.
    * @param {Object|Array.<Object>} imageTracks
    */
-  function _addSupplementaryImageAdaptations(
+  async function _addSupplementaryImageAdaptations(
     /* eslint-disable-next-line import/no-deprecated */
     imageTracks : ISupplementaryImageTrack | ISupplementaryImageTrack[]
-  ) : void {
+  ) : Promise<void> {
     const _imageTracks = Array.isArray(imageTracks) ? imageTracks : [imageTracks];
-    const newImageTracks = _imageTracks.map(({ mimeType, url }) => {
+    const newImageTracks : IAdaptation[] = [];
+    for (const { mimeType, url } of _imageTracks) {
       const adaptationID = "gen-image-ada-" + generateSupplementaryTrackID();
       const representationID = "gen-image-rep-" + generateSupplementaryTrackID();
-      const newAdaptation = createAdaptationObject({
+      const newAdaptation = await createAdaptationObject({
         id: adaptationID,
         type: "image",
         representations: [{
@@ -334,15 +343,15 @@ export function createManifestObject(
         }],
       }, { isManuallyAdded: true });
       if (newAdaptation.representations.length > 0 &&
-          newAdaptation.isCodecSupported)
+          newAdaptation.hasSupport)
       {
         const error =
           new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                          "An Adaptation contains only incompatible codecs.");
         warnings.push(error);
       }
-      return newAdaptation;
-    });
+      newImageTracks.push(newAdaptation);
+    }
 
     if (newImageTracks.length > 0 && manifestObject.periods.length > 0) {
       const { adaptations } = manifestObject.periods[0];
@@ -356,28 +365,28 @@ export function createManifestObject(
    * Add supplementary text Adaptation(s) to the manifest.
    * @param {Object|Array.<Object>} textTracks
    */
-  function _addSupplementaryTextAdaptations(
+  async function _addSupplementaryTextAdaptations(
     /* eslint-disable-next-line import/no-deprecated */
     textTracks : ISupplementaryTextTrack|ISupplementaryTextTrack[]
-  ) : void {
+  ) : Promise<void> {
     const _textTracks = Array.isArray(textTracks) ? textTracks : [textTracks];
-    const newTextAdaptations = _textTracks.reduce((allSubs : IAdaptation[], {
-      mimeType,
-      codecs,
-      url,
-      language,
-      /* eslint-disable-next-line import/no-deprecated */
-      languages,
-      closedCaption,
-    }) => {
+    const newTextAdaptations : IAdaptation[] = [];
+    for (const textTrack of _textTracks) {
+      const { mimeType,
+              codecs,
+              url,
+              language,
+              /* eslint-disable-next-line import/no-deprecated */
+              languages,
+              closedCaption } = textTrack;
       const langsToMapOn : string[] = language != null ? [language] :
                                       languages != null ? languages :
                                                           [];
 
-      return allSubs.concat(langsToMapOn.map((_language) => {
+      for (const _language of langsToMapOn) {
         const adaptationID = "gen-text-ada-" + generateSupplementaryTrackID();
         const representationID = "gen-text-rep-" + generateSupplementaryTrackID();
-        const newAdaptation = createAdaptationObject({
+        const newAdaptation = await createAdaptationObject({
           id: adaptationID,
           type: "text",
           language: _language,
@@ -392,16 +401,16 @@ export function createManifestObject(
         }, { isManuallyAdded: true });
 
         if (newAdaptation.representations.length > 0 &&
-            !newAdaptation.isCodecSupported)
+            !newAdaptation.hasSupport)
         {
           const error =
             new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                            "An Adaptation contains only incompatible codecs.");
           warnings.push(error);
         }
-        return newAdaptation;
-      }));
-    }, []);
+        newTextAdaptations.push(newAdaptation);
+      }
+    }
 
     if (newTextAdaptations.length > 0 && manifestObject.periods.length > 0) {
       const { adaptations } = manifestObject.periods[0];

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -20,6 +20,7 @@ import {
 import { IParsedPeriod } from "../parsers/manifest";
 import arrayFind from "../utils/array_find";
 import objectValues from "../utils/object_values";
+import PPromise from "../utils/promise";
 import {
   createAdaptationObject,
   IRepresentationFilter,
@@ -41,49 +42,52 @@ import {
  *   2. Array containing every minor errors that happened when the Manifest has
  *      been created, in the order they have happened..
  */
-export function createPeriodObject(
+export async function createPeriodObject(
   args : IParsedPeriod,
   representationFilter? : IRepresentationFilter | undefined
-) : [IPeriod, ICustomError[]] {
+) : Promise<[IPeriod, ICustomError[]]> {
   const warnings : ICustomError[] = [];
-  const adaptations = (Object.keys(args.adaptations) as IAdaptationType[])
-    .reduce<IManifestAdaptations>((acc, type) => {
-      const adaptationsForType = args.adaptations[type];
-      if (adaptationsForType == null) {
-        return acc;
-      }
-      const filteredAdaptations = adaptationsForType
-        .map((adaptation) : IAdaptation => {
-          const newAdaptation = createAdaptationObject(adaptation,
-                                                       { representationFilter });
-          if (newAdaptation.representations.length > 0 &&
-              !newAdaptation.isCodecSupported)
-          {
-            const error =
-              new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-                             "An Adaptation contains only incompatible codecs.");
-            warnings.push(error);
-          }
-          return newAdaptation;
-        })
-        .filter((adaptation) : adaptation is IAdaptation =>
-          adaptation.representations.length > 0
-        );
-
-      if (
-        filteredAdaptations.every(adaptation => !adaptation.isCodecSupported) &&
-        adaptationsForType.length > 0 &&
-        (type === "video" || type === "audio"))
+  const adaptations : IManifestAdaptations = {};
+  for (const type of Object.keys(args.adaptations)) {
+    const adapType = type as IAdaptationType;
+    const adaptationsForType = args.adaptations[adapType];
+    if (adaptationsForType == null) {
+      continue;
+    }
+    const adaptationProms : Array<Promise<IAdaptation>> = [];
+    for (const adaptation of adaptationsForType) {
+      adaptationProms.push(createAdaptationObject(adaptation,
+                                                  { representationFilter }));
+    }
+    const adaptationArr = await PPromise.all(adaptationProms);
+    const filteredAdaptations : IAdaptation[] = [];
+    for (const newAdaptation of adaptationArr) {
+      if (newAdaptation.representations.length > 0 &&
+          !newAdaptation.hasSupport)
       {
-        throw new MediaError("MANIFEST_PARSE_ERROR",
-                             "No supported " + type + " adaptations");
+        const error =
+          new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
+                         "An Adaptation contains only incompatible codecs.");
+        warnings.push(error);
       }
+      if (newAdaptation.representations.length > 0) {
+        filteredAdaptations.push(newAdaptation);
+      }
+    }
 
-      if (filteredAdaptations.length > 0) {
-        acc[type] = filteredAdaptations;
-      }
-      return acc;
-    }, {});
+    if (
+      filteredAdaptations.every(adaptation => !adaptation.hasSupport) &&
+      adaptationsForType.length > 0 &&
+      (adapType === "video" || adapType === "audio"))
+    {
+      throw new MediaError("MANIFEST_PARSE_ERROR",
+                           "No supported " + adapType + " adaptations");
+    }
+
+    if (filteredAdaptations.length > 0) {
+      adaptations[adapType] = filteredAdaptations;
+    }
+  }
 
   if (!Array.isArray(adaptations.video) &&
       !Array.isArray(adaptations.audio))
@@ -132,7 +136,7 @@ export function createPeriodObject(
   function getSupportedAdaptations(aType? : IAdaptationType) : IAdaptation[] {
     if (aType === undefined) {
       return getAdaptations().filter(ada => {
-        return ada.isCodecSupported;
+        return ada.hasSupport;
       });
     }
     const adaptationsForType = adaptations[aType];
@@ -140,7 +144,7 @@ export function createPeriodObject(
       return [];
     }
     return adaptationsForType.filter(ada => {
-      return ada.isCodecSupported;
+      return ada.hasSupport;
     });
   }
 }

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -379,8 +379,8 @@ export interface IAdaptation {
   representations : IRepresentation[];
   /** Type of this Adaptation. */
   type : IAdaptationType;
-  /** `true` if at least one Representation is in a supported codec. `false` otherwise. */
-  isCodecSupported : boolean;
+  /** Whether at least one Representation should be decodable. */
+  hasSupport : boolean;
   /** Whether this track contains an audio description for the visually impaired. */
   isAudioDescription? : boolean;
   /** Whether this Adaptation contains closed captions for the hard-of-hearing. */
@@ -481,6 +481,15 @@ export interface IRepresentation {
   decipherable? : boolean  | undefined;
   /** `true` if the Representation is in a supported codec, false otherwise. */
   isCodecSupported : boolean;
+  /**
+   * If `true` the main characteristics (resolution, framerate, bitrate ...) of
+   * this Representation have been checked and there's a high chance of this
+   * Representation to be decodable by the browser.
+   * If `false` one of the characteristics make this Representation not
+   * decodable.
+   * If `undefined`, we could not determine this.
+   */
+  isSupported : boolean | undefined;
   /**
    * Returns "mime-type string" which includes both the mime-type and the codec,
    * which is often needed when interacting with the browser's APIs.

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -132,9 +132,9 @@ export default function generateManifestParser(
      * @param {Object} parserResponse - Response returned from a MPD parser.
      * @returns {Observable}
      */
-    function processMpdParserResponse(
+    async function processMpdParserResponse(
       parserResponse : IDashParserResponse<string> | IDashParserResponse<ArrayBuffer>
-    ) : IManifestParserResult | Promise<IManifestParserResult> {
+    ) : Promise<IManifestParserResult> {
       if (parserResponse.type === "done") {
         if (parserResponse.value.warnings.length > 0) {
           onWarnings(parserResponse.value.warnings);
@@ -143,7 +143,7 @@ export default function generateManifestParser(
           return PPromise.reject(cancelSignal.cancellationError);
         }
         const [ manifest, mWarnings ] =
-          createManifestObject(parserResponse.value.parsed, options);
+          await createManifestObject(parserResponse.value.parsed, options);
         if (mWarnings.length > 0) {
           onWarnings(parserResponse.value.warnings);
         }

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -66,17 +66,17 @@ export default function getLocalManifestPipelines(
         })(url, cancelSignal);
     },
 
-    parseManifest(
+    async parseManifest(
       manifestData : IRequestedData<unknown>,
       _parserOptions : IManifestParserOptions,
       onWarnings : (warnings: Error[]) => void
-    ) : IManifestParserResult {
+    ) : Promise<IManifestParserResult> {
       const loadedManifest = manifestData.responseData;
       if (typeof manifestData !== "object") {
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const [manifest, warnings] = createManifestObject(parsed, options);
+      const [manifest, warnings] = await createManifestObject(parsed, options);
       if (warnings.length > 0) {
         onWarnings(warnings);
       }

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -153,11 +153,12 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
       return handleParsedResult(parsed);
 
-      function handleParsedResult(
+      async function handleParsedResult(
         parsedResult : IMPLParserResponse<IParsedManifest>
       ) : Promise<IManifestParserResult> {
         if (parsedResult.type === "done") {
-          const [manifest, warnings] = createManifestObject(parsedResult.value, options);
+          const [manifest, warnings] = await createManifestObject(parsedResult.value,
+                                                                  options);
           if (warnings.length > 0) {
             onWarnings(warnings);
           }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -137,11 +137,11 @@ export default function(options : ITransportOptions) : ITransportPipelines {
 
     loadManifest: manifestLoader,
 
-    parseManifest(
+    async parseManifest(
       manifestData : IRequestedData<unknown>,
       parserOptions : IManifestParserOptions,
       onWarnings : (warnings : Error[]) => void
-    ) : IManifestParserResult {
+    ) : Promise <IManifestParserResult> {
       const url = manifestData.url ?? parserOptions.originalUrl;
       const { receivedTime: manifestReceivedTime, responseData } = manifestData;
 
@@ -153,7 +153,7 @@ export default function(options : ITransportOptions) : ITransportPipelines {
                                                 url,
                                                 manifestReceivedTime);
 
-      const [manifest, warnings] = createManifestObject(parserResult, {
+      const [manifest, warnings] = await createManifestObject(parserResult, {
         representationFilter: options.representationFilter,
         supplementaryImageTracks: options.supplementaryImageTracks,
         supplementaryTextTracks: options.supplementaryTextTracks,

--- a/tests/contents/DASH_static_SegmentBase/media/multi_codecs.mpd
+++ b/tests/contents/DASH_static_SegmentBase/media/multi_codecs.mpd
@@ -83,31 +83,31 @@
       </Representation>
     </AdaptationSet>
     <AdaptationSet id="8" contentType="video" maxWidth="768" maxHeight="576" frameRate="1000000/40000" par="4:3">
-      <Representation id="11" bandwidth="362665" codecs="vp9" mimeType="video/webm" sar="1:1" width="480" height="360">
+      <Representation id="11" bandwidth="362665" codecs="vp09.00.21.08.00.02.02.02.00" mimeType="video/webm" sar="1:1" width="480" height="360">
         <BaseURL>v-0360p-0550k-vp9.webm</BaseURL>
         <SegmentBase indexRange="298-541" timescale="1000000">
           <Initialization range="0-297"/>
         </SegmentBase>
       </Representation>
-      <Representation id="14" bandwidth="81505" codecs="vp9" mimeType="video/webm" sar="1:1" width="192" height="144">
+      <Representation id="14" bandwidth="81505" codecs="vp09.00.21.08.00.02.02.02.00" mimeType="video/webm" sar="1:1" width="192" height="144">
         <BaseURL>v-0144p-0100k-vp9.webm</BaseURL>
         <SegmentBase indexRange="294-535" timescale="1000000">
           <Initialization range="0-293"/>
         </SegmentBase>
       </Representation>
-      <Representation id="19" bandwidth="485260" codecs="vp9" mimeType="video/webm" sar="1:1" width="640" height="480">
+      <Representation id="19" bandwidth="485260" codecs="vp09.00.21.08.00.02.02.02.00" mimeType="video/webm" sar="1:1" width="640" height="480">
         <BaseURL>v-0480p-0750k-vp9.webm</BaseURL>
         <SegmentBase indexRange="298-541" timescale="1000000">
           <Initialization range="0-297"/>
         </SegmentBase>
       </Representation>
-      <Representation id="21" bandwidth="203461" codecs="vp9" mimeType="video/webm" sar="1:1" width="320" height="240">
+      <Representation id="21" bandwidth="203461" codecs="vp09.00.21.08.00.02.02.02.00" mimeType="video/webm" sar="1:1" width="320" height="240">
         <BaseURL>v-0240p-0300k-vp9.webm</BaseURL>
         <SegmentBase indexRange="296-539" timescale="1000000">
           <Initialization range="0-295"/>
         </SegmentBase>
       </Representation>
-      <Representation id="23" bandwidth="620659" codecs="vp9" mimeType="video/webm" sar="1:1" width="768" height="576">
+      <Representation id="23" bandwidth="620659" codecs="vp09.00.21.08.00.02.02.02.00" mimeType="video/webm" sar="1:1" width="768" height="576">
         <BaseURL>v-0576p-1000k-vp9.webm</BaseURL>
         <SegmentBase indexRange="298-541" timescale="1000000">
           <Initialization range="0-297"/>

--- a/tests/contents/DASH_static_SegmentBase/multi_codecs.js
+++ b/tests/contents/DASH_static_SegmentBase/multi_codecs.js
@@ -434,7 +434,7 @@ export default {
                 height: 144,
                 width: 192,
                 frameRate: "1000000/40000",
-                codec: "vp9",
+                codec: "vp09.00.21.08.00.02.02.02.00",
                 mimeType: "video/webm",
                 index: {
                   init: {
@@ -450,7 +450,7 @@ export default {
                 height: 240,
                 width: 320,
                 frameRate: "1000000/40000",
-                codec: "vp9",
+                codec: "vp09.00.21.08.00.02.02.02.00",
                 mimeType: "video/webm",
                 index: {
                   init: {
@@ -466,7 +466,7 @@ export default {
                 height: 360,
                 width: 480,
                 frameRate: "1000000/40000",
-                codec: "vp9",
+                codec: "vp09.00.21.08.00.02.02.02.00",
                 mimeType: "video/webm",
                 index: {
                   init: {
@@ -482,7 +482,7 @@ export default {
                 height: 480,
                 width: 640,
                 frameRate: "1000000/40000",
-                codec: "vp9",
+                codec: "vp09.00.21.08.00.02.02.02.00",
                 mimeType: "video/webm",
                 index: {
                   init: {
@@ -498,7 +498,7 @@ export default {
                 height: 576,
                 width: 768,
                 frameRate: "1000000/40000",
-                codec: "vp9",
+                codec: "vp09.00.21.08.00.02.02.02.00",
                 mimeType: "video/webm",
                 index: {
                   init: {

--- a/tests/integration/scenarios/dash_live.js
+++ b/tests/integration/scenarios/dash_live.js
@@ -29,7 +29,7 @@ describe("DASH live content (SegmentTimeline)", function () {
     await sleep(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest request
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getPlayerState()).to.equal("LOADING");
 
@@ -206,7 +206,7 @@ describe("DASH live content (SegmentTimeline)", function () {
 
     await sleep(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getAvailableAudioBitrates()).to.eql([48000]);
     expect(player.getAvailableVideoBitrates()).to.eql([300000]);
@@ -225,7 +225,7 @@ describe("DASH live content (SegmentTimeline)", function () {
       await sleep(1);
       expect(player.getAvailableAudioTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const audioTracks = player.getAvailableAudioTracks();
 
@@ -272,7 +272,7 @@ describe("DASH live content (SegmentTimeline)", function () {
       await sleep(1);
       expect(player.getAvailableTextTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const textTracks = player.getAvailableTextTracks();
 
@@ -320,7 +320,7 @@ describe("DASH live content (SegmentTimeline)", function () {
       await sleep(1);
       expect(player.getAvailableVideoTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const videoTracks = player.getAvailableVideoTracks();
 
@@ -375,7 +375,7 @@ describe("DASH live content (SegmentTimeline)", function () {
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1527507768, 1);
     });
@@ -392,7 +392,7 @@ describe("DASH live content (SegmentTimeline)", function () {
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMaximumPosition()).to.be
         .closeTo(1527508062, 1);
     });
@@ -423,7 +423,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
     await sleep(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1); // Manifest request
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getPlayerState()).to.equal("LOADING");
 
@@ -603,7 +603,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
 
     await sleep(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getAvailableAudioBitrates()).to.eql([48000]);
     expect(player.getAvailableVideoBitrates()).to.eql([300000]);
@@ -622,7 +622,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
       await sleep(1);
       expect(player.getAvailableAudioTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const audioTracks = player.getAvailableAudioTracks();
 
@@ -669,7 +669,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
       await sleep(1);
       expect(player.getAvailableTextTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const textTracks = player.getAvailableTextTracks();
 
@@ -717,7 +717,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
       await sleep(1);
       expect(player.getAvailableVideoTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const videoTracks = player.getAvailableVideoTracks();
 
@@ -774,7 +774,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.equal(6);
     });
   });
@@ -790,7 +790,7 @@ describe("DASH live content with no timeShiftBufferDepth (SegmentTimeline)", fun
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMaximumPosition()).to.be
         .closeTo(1527508062, 1);
     });

--- a/tests/integration/scenarios/dash_live_SegmentTemplate.js
+++ b/tests/integration/scenarios/dash_live_SegmentTemplate.js
@@ -32,7 +32,7 @@ describe("DASH live content (SegmentTemplate)", function() {
     await sleep(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);
@@ -137,7 +137,7 @@ describe("DASH live content (SegmentTemplate)", function() {
 
     await sleep(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getAvailableAudioBitrates()).to.eql([48000]);
     expect(player.getAvailableVideoBitrates()).to.eql([300000]);
@@ -156,7 +156,7 @@ describe("DASH live content (SegmentTemplate)", function() {
       await sleep(1);
       expect(player.getAvailableAudioTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const audioTracks = player.getAvailableAudioTracks();
 
@@ -204,7 +204,7 @@ describe("DASH live content (SegmentTemplate)", function() {
       await sleep(1);
       expect(player.getAvailableTextTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const textTracks = player.getAvailableTextTracks();
 
@@ -252,7 +252,7 @@ describe("DASH live content (SegmentTemplate)", function() {
       await sleep(1);
       expect(player.getAvailableVideoTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const videoTracks = player.getAvailableVideoTracks();
 
@@ -309,7 +309,7 @@ describe("DASH live content (SegmentTemplate)", function() {
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be.closeTo(1553521448, 1);
     });
   });
@@ -325,7 +325,7 @@ describe("DASH live content (SegmentTemplate)", function() {
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMaximumPosition()).to.be.closeTo(1553521748, 1);
     });
   });
@@ -356,7 +356,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
     await sleep(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);
@@ -461,7 +461,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
 
     await sleep(1);
     await xhrMock.flush();
-    await sleep(1);
+    await sleep(100);
 
     expect(player.getAvailableAudioBitrates()).to.eql([48000]);
     expect(player.getAvailableVideoBitrates()).to.eql([300000]);
@@ -480,7 +480,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
       await sleep(1);
       expect(player.getAvailableAudioTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const audioTracks = player.getAvailableAudioTracks();
 
@@ -528,7 +528,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
       await sleep(1);
       expect(player.getAvailableTextTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const textTracks = player.getAvailableTextTracks();
 
@@ -576,7 +576,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
       await sleep(1);
       expect(player.getAvailableVideoTracks()).to.eql([]);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
 
       const videoTracks = player.getAvailableVideoTracks();
 
@@ -633,7 +633,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.equal(1553515200);
     });
   });
@@ -649,7 +649,7 @@ describe("DASH live content without timeShiftBufferDepth (SegmentTemplate)", fun
 
       await sleep(1);
       await xhrMock.flush();
-      await sleep(1);
+      await sleep(100);
       expect(player.getMaximumPosition()).to.be
         .closeTo(1553521448, 3);
     });

--- a/tests/integration/scenarios/dash_live_multi_periods.js
+++ b/tests/integration/scenarios/dash_live_multi_periods.js
@@ -50,7 +50,7 @@ describe("DASH live content multi-periods (SegmentTemplate)", function() {
     await sleepWithoutSinonStub(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1);
     await xhrMock.flush();
-    await sleepWithoutSinonStub(1);
+    await sleepWithoutSinonStub(100);
 
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);
@@ -73,7 +73,7 @@ describe("DASH live content multi-periods (SegmentTemplate)", function() {
     await sleepWithoutSinonStub(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1);
     await xhrMock.flush();
-    await sleepWithoutSinonStub(1);
+    await sleepWithoutSinonStub(100);
 
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);
@@ -96,7 +96,7 @@ describe("DASH live content multi-periods (SegmentTemplate)", function() {
     await sleepWithoutSinonStub(1);
     expect(xhrMock.getLockedXHR().length).to.equal(1);
     await xhrMock.flush();
-    await sleepWithoutSinonStub(1);
+    await sleepWithoutSinonStub(100);
 
     const manifest = player.getManifest();
     expect(manifest).not.to.equal(null);

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -493,6 +493,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
   });
 
   it("setting a track should not be persisted between Periods", async () => {
+    this.timeout(4000);
     await loadContent();
     await sleep(300);
 
@@ -517,6 +518,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
   });
 
   it("setting a track should be persisted when seeking back to that Period", async () => {
+    this.timeout(4000);
     await loadContent();
 
     // TODO AUDIO codec

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -100,7 +100,7 @@ export default function launchTestsForContent(manifestInfos) {
         expect(xhrMock.getLockedXHR()[0].url).to.equal(manifestInfos.url);
 
         await xhrMock.flush(); // only wait for the manifest request
-        await sleep(1);
+        await sleep(100);
 
         expect(player.getPlayerState()).to.equal("LOADING");
 
@@ -1659,7 +1659,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(1);
         expect(player.getAvailableVideoTracks()).to.eql([]);
         await xhrMock.flush();
-        await sleep(50);
+        await sleep(100);
 
         const videoTracks = player.getAvailableVideoTracks();
 


### PR DESCRIPTION
_(Based on `misc/manifest-as-interface` to facilitate PR reading on GitHub)_

Previously, the RxPlayer only relied on the `MediaSource.isTyepSupported` API to detect browser support, which only does a check for codec support.

However, there's a newer set of APIs, the Media Capabilities APIs, which allows to be more precize (by e.g. providing the resolution, framerate etc.) and thus to detect if any of the characteristics of a content make it non-decodable by the current platform.
Previously we did not rely on it both by fear of bringing regressions (content which was playable becoming non-playable) and because codec checks usually did the job.

However, we've seen a recent issue on Samsung TV that may be (we couldn't test it for now sadly) detected by the Media Capabilities API: 4k contents led to a decoding error on 720p TVs.
After seeing what other players were doing, especially the shaka-player, I decided to try this development which use the `mediaCapabilities.decodingInfo` method to check support of video contents.

This is kind of risky, and as such has to be tested on most targets, yet this could fix current and future issues and the other information returned by this API (about smoothness and power efficiency) may be very useful for future improvements.

To test on 720p samsung TVs and other targets.

