### PR TITLE
Fix: add dfxp mime type

### DIFF
--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -83,6 +83,7 @@ const MIME_TYPES : Partial<Record<string, string>> = {
   AVC1: "video/mp4",
   H264: "video/mp4",
   TTML: "application/ttml+xml+mp4",
+  DFXP: "application/ttml+xml+mp4",
 };
 
 export interface IHSSParserConfiguration {


### PR DESCRIPTION
Some Smooth manifest comes with `FourCC="DFXP"` and subtitles are not shown.

<img width="1354" alt="manifest" src="https://user-images.githubusercontent.com/18331751/157425848-60ae9bfc-cc4b-4b47-9c46-ab45c83f7463.png">

Adding `DFXP` to mime types map solve the issue.
