### PR TITLE
Fix minor buffer-related problems

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -31,5 +31,3 @@ class ConfigHandler {
 }
 const configHandler = new ConfigHandler();
 export default configHandler;
-
-

--- a/src/core/stream/representation/get_needed_segments.ts
+++ b/src/core/stream/representation/get_needed_segments.ts
@@ -123,7 +123,7 @@ export default function getNeededSegments({
         }
         log.debug("Stream: skipping segment gc-ed at the start", currentSeg);
       }
-      if (doesEndSeemGarbageCollected(currentSeg, nextSeg, neededRange.start)) {
+      if (doesEndSeemGarbageCollected(currentSeg, nextSeg, neededRange.end)) {
         lazySegmentHistory = lazySegmentHistory ?? getBufferedHistory(currentSeg.infos);
         if (shouldReloadSegmentGCedAtTheEnd(lazySegmentHistory,
                                             currentSeg.bufferedEnd)) {

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1125,7 +1125,7 @@ const DEFAULT_CONFIG = {
      * @type {Object}
      */
   ADAPTATION_SWITCH_BUFFER_PADDINGS: {
-    video: { before: 2, after: 2.5 },
+    video: { before: 5, after: 5 },
     audio: { before: 2, after: 2.5 },
     text: { before: 0, after: 0 }, // not managed natively, so no problem here
     image: { before: 0, after: 0 }, // not managed natively, so no problem here


### PR DESCRIPTION
This PR fixes two minor issues both seen while working on a future 4.0.0 version:

  1. I noticed an issue where discontinuities created by either browser garbage collection or due to the `SourceBuffer.remove` API would not be re-filled when re-encountered but directly skipped instead.

      This is because the current logic had a typo which led the RxPlayer to ignore some segments GCed at their end.
      Thankfully, instead of staying in rebuffering when that hole is encountered, another module of the RxPlayer, the `StallAvoider` understood that this hole won't be filled by any segment and directly seeked over it when encountered.
  
       By fixing the typo, this gap is now filled as expected.

  2. I noticed that the previous paddings used for video adaptation switches were sometimes insufficient.
      Removing data according to these paddings could sometimes remove the date under the current position too.

      Setting higher paddings such as 5 seconds before and after fixed the issue.