### PR TITLE
DASH: Prioritize `selectionPriority` attribute over a "main" Role when ordering AdaptationSets

### DIFF
--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -15,14 +15,18 @@
  */
 
 import log from "../../../../log";
-import { Period } from "../../../../manifest";
+import {
+  IAdaptationType,
+  Period,
+  SUPPORTED_ADAPTATIONS_TYPE,
+} from "../../../../manifest";
 import arrayFind from "../../../../utils/array_find";
+import arrayFindIndex from "../../../../utils/array_find_index";
 import arrayIncludes from "../../../../utils/array_includes";
 import isNonEmptyString from "../../../../utils/is_non_empty_string";
 import {
   IParsedAdaptation,
   IParsedAdaptations,
-  IParsedAdaptationType,
 } from "../../types";
 import {
   IAdaptationSetIntermediateRepresentation,
@@ -235,30 +239,31 @@ export default function parseAdaptationSets(
   adaptationsIR : IAdaptationSetIntermediateRepresentation[],
   context : IAdaptationSetContext
 ): IParsedAdaptations {
-  const parsedAdaptations : IParsedAdaptations = {};
+  const parsedAdaptations : Record<
+    IAdaptationType,
+    Array<[ IParsedAdaptation,
+            IAdaptationSetOrderingData ]>
+  > = { video: [],
+        audio: [],
+        text: [],
+        image: [] };
   const trickModeAdaptations: Array<{ adaptation: IParsedAdaptation;
                                       trickModeAttachedAdaptationIds: string[]; }> = [];
   const adaptationSwitchingInfos : IAdaptationSwitchingInfos = {};
+
   const parsedAdaptationsIDs : string[] = [];
 
   /**
-   * Index of the last parsed AdaptationSet with a Role set as "main" in
-   * `parsedAdaptations` for a given type.
-   * Not defined for a type with no main Adaptation inside.
-   * This is used to put main AdaptationSet first in the resulting array of
-   * Adaptation while still preserving the MPD order among them.
+   * Index of the last parsed Video AdaptationSet with a Role set as "main" in
+   * `parsedAdaptations.video`.
+   * `-1` if not yet encountered.
+   * Used as we merge all main video AdaptationSet due to a comprehension of the
+   * DASH-IF IOP.
    */
-  const lastMainAdaptationIndex : Partial<Record<IParsedAdaptationType, number>> = {};
+  let lastMainVideoAdapIdx = -1;
 
-  // first sort AdaptationSets by absolute priority.
-  adaptationsIR.sort((a, b) => {
-    /* As of DASH-IF 4.3, `1` is the default value. */
-    const priority1 = a.attributes.selectionPriority ?? 1;
-    const priority2 = b.attributes.selectionPriority ?? 1;
-    return priority2 - priority1;
-  });
-
-  for (const adaptation of adaptationsIR) {
+  for (let adaptationIdx = 0; adaptationIdx < adaptationsIR.length; adaptationIdx++) {
+    const adaptation = adaptationsIR[adaptationIdx];
     const adaptationChildren = adaptation.children;
     const { essentialProperties,
             roles } = adaptationChildren;
@@ -291,6 +296,7 @@ export default function parseAdaptationSets(
       continue;
     }
 
+    const priority = adaptation.attributes.selectionPriority ?? 1;
     const originalID = adaptation.attributes.id;
     let newID : string;
     const adaptationSetSwitchingIDs = getAdaptationSetSwitchingIDs(adaptation);
@@ -334,14 +340,11 @@ export default function parseAdaptationSets(
 
     if (type === "video" &&
         isMainAdaptation &&
-        parsedAdaptations.video !== undefined &&
-        parsedAdaptations.video.length > 0 &&
-        lastMainAdaptationIndex.video !== undefined &&
+        lastMainVideoAdapIdx >= 0 &&
+        parsedAdaptations.video.length > lastMainVideoAdapIdx &&
         !isTrickModeTrack)
     {
-      // Add to the already existing main video adaptation
-      // TODO remove that ugly custom logic?
-      const videoMainAdaptation = parsedAdaptations.video[lastMainAdaptationIndex.video];
+      const videoMainAdaptation = parsedAdaptations.video[lastMainVideoAdapIdx][0];
       reprCtxt.unsafelyBaseOnPreviousAdaptation = context
         .unsafelyBaseOnPreviousPeriod?.getAdaptation(videoMainAdaptation.id) ?? null;
       const representations = parseRepresentations(representationsIR,
@@ -422,65 +425,56 @@ export default function parseAdaptationSets(
         parsedAdaptationSet.isSignInterpreted = true;
       }
 
-      const adaptationsOfTheSameType = parsedAdaptations[type];
       if (trickModeAttachedAdaptationIds !== undefined) {
         trickModeAdaptations.push({ adaptation: parsedAdaptationSet,
                                     trickModeAttachedAdaptationIds });
-      } else if (adaptationsOfTheSameType === undefined) {
-        parsedAdaptations[type] = [parsedAdaptationSet];
-        if (isMainAdaptation) {
-          lastMainAdaptationIndex[type] = 0;
-        }
       } else {
-        let mergedInto : IParsedAdaptation|null = null;
 
         // look if we have to merge this into another Adaptation
+        let mergedIntoIdx = -1;
         for (const id of adaptationSetSwitchingIDs) {
           const switchingInfos = adaptationSwitchingInfos[id];
-          if (switchingInfos != null &&
+          if (switchingInfos !== undefined &&
               switchingInfos.newID !== newID &&
               arrayIncludes(switchingInfos.adaptationSetSwitchingIDs, originalID))
           {
-            const adaptationToMergeInto = arrayFind(adaptationsOfTheSameType,
-                                                    (a) => a.id === id);
-            if (adaptationToMergeInto != null &&
-                adaptationToMergeInto.audioDescription ===
+            mergedIntoIdx = arrayFindIndex(parsedAdaptations[type],
+                                           (a) => a[0].id === id);
+            const mergedInto = parsedAdaptations[type][mergedIntoIdx];
+            if (mergedInto !== undefined &&
+                mergedInto[0].audioDescription ===
                   parsedAdaptationSet.audioDescription &&
-                adaptationToMergeInto.closedCaption ===
+                mergedInto[0].closedCaption ===
                   parsedAdaptationSet.closedCaption &&
-                adaptationToMergeInto.language === parsedAdaptationSet.language)
+                mergedInto[0].language === parsedAdaptationSet.language)
             {
               log.info("DASH Parser: merging \"switchable\" AdaptationSets",
                        originalID, id);
-              adaptationToMergeInto.representations
-                .push(...parsedAdaptationSet.representations);
-              mergedInto = adaptationToMergeInto;
+              mergedInto[0].representations.push(...parsedAdaptationSet.representations);
+              if (type === "video" &&
+                  isMainAdaptation &&
+                  !mergedInto[1].isMainAdaptation)
+              {
+                lastMainVideoAdapIdx = Math.max(lastMainVideoAdapIdx, mergedIntoIdx);
+              }
+              mergedInto[1] = {
+                priority: Math.max(priority, mergedInto[1].priority),
+                isMainAdaptation: isMainAdaptation ||
+                                  mergedInto[1].isMainAdaptation,
+                indexInMpd: Math.min(adaptationIdx, mergedInto[1].indexInMpd),
+              };
             }
           }
         }
 
-        if (isMainAdaptation) {
-          const oldLastMainIdx = lastMainAdaptationIndex[type];
-          const newLastMainIdx = oldLastMainIdx === undefined ? 0 :
-                                                                oldLastMainIdx + 1;
-          if (mergedInto === null) {
-            // put "main" Adaptation after all other Main Adaptations
-            adaptationsOfTheSameType.splice(newLastMainIdx, 0, parsedAdaptationSet);
-            lastMainAdaptationIndex[type] = newLastMainIdx;
-          } else {
-            const indexOf = adaptationsOfTheSameType.indexOf(mergedInto);
-            if (indexOf < 0) { // Weird, not found
-              adaptationsOfTheSameType.splice(newLastMainIdx, 0, parsedAdaptationSet);
-              lastMainAdaptationIndex[type] = newLastMainIdx;
-            } else if (oldLastMainIdx === undefined || indexOf > oldLastMainIdx) {
-              // Found but was not main
-              adaptationsOfTheSameType.splice(indexOf, 1);
-              adaptationsOfTheSameType.splice(newLastMainIdx, 0, mergedInto);
-              lastMainAdaptationIndex[type] = newLastMainIdx;
-            }
+        if (mergedIntoIdx < 0) {
+          parsedAdaptations[type].push([ parsedAdaptationSet,
+                                         { priority,
+                                           isMainAdaptation,
+                                           indexInMpd: adaptationIdx }]);
+          if (type === "video" && isMainAdaptation) {
+            lastMainVideoAdapIdx = parsedAdaptations.video.length - 1;
           }
-        } else if (mergedInto === null) {
-          adaptationsOfTheSameType.push(parsedAdaptationSet);
         }
       }
     }
@@ -490,8 +484,59 @@ export default function parseAdaptationSets(
                                                adaptationSetSwitchingIDs };
     }
   }
-  attachTrickModeTrack(parsedAdaptations, trickModeAdaptations);
-  return parsedAdaptations;
+
+  const adaptationsPerType = SUPPORTED_ADAPTATIONS_TYPE
+    .reduce((acc : IParsedAdaptations, adaptationType : IAdaptationType) => {
+      const adaptationsParsedForType = parsedAdaptations[adaptationType];
+      if (adaptationsParsedForType.length > 0) {
+        adaptationsParsedForType.sort(compareAdaptations);
+        acc[adaptationType] = adaptationsParsedForType
+          .map(([parsedAdaptation]) => parsedAdaptation);
+      }
+      return acc;
+    }, {});
+  parsedAdaptations.video.sort(compareAdaptations);
+  attachTrickModeTrack(adaptationsPerType, trickModeAdaptations);
+  return adaptationsPerType;
+}
+
+/** Metadata allowing to order AdaptationSets between one another. */
+interface IAdaptationSetOrderingData {
+  /**
+   * If `true`, this AdaptationSet is considered as a "main" one (e.g. it had a
+   * Role set to "main").
+   */
+  isMainAdaptation : boolean;
+  /**
+   * Set to the `selectionPriority` attribute of the corresponding AdaptationSet
+   * or to `1` by default.
+   */
+  priority : number;
+  /** Index of this AdaptationSet in the original MPD, starting from `0`. */
+  indexInMpd : number;
+}
+
+/**
+ * Compare groups of parsed AdaptationSet, alongside some ordering metadata,
+ * allowing to easily sort them through JavaScript's `Array.prototype.sort`
+ * method.
+ * @param {Array.<Object>} a
+ * @param {Array.<Object>} b
+ * @returns {number}
+ */
+function compareAdaptations(
+  a : [IParsedAdaptation, IAdaptationSetOrderingData],
+  b : [IParsedAdaptation, IAdaptationSetOrderingData]
+) : number {
+  const priorityDiff = b[1].priority - a[1].priority;
+  if (priorityDiff !== 0) {
+    return priorityDiff;
+  }
+  if (a[1].isMainAdaptation !== b[1].isMainAdaptation) {
+    return a[1].isMainAdaptation ? -1 :
+      1;
+  }
+  return a[1].indexInMpd - b[1].indexInMpd;
 }
 
 /** Context needed when calling `parseAdaptationSets`. */

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi-AdaptationSets.mpd
@@ -380,6 +380,28 @@
     </AdaptationSet>
 
 
+    <!-- audio fr mp4a.40.5 audioDescription priority 100 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      selectionPriority="100"
+      codecs="mp4a.40.5"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
     <!-- audio de mp4a.40.2 priority 100 -->
     <AdaptationSet
       group="1"
@@ -391,27 +413,6 @@
       codecs="mp4a.40.2"
       selectionPriority="100"
       startWithSAP="1">
-      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
-      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
-        <SegmentTimeline>
-          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
-        </SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="audio=128000" bandwidth="128000"></Representation>
-    </AdaptationSet>
-
-
-    <!-- audio fr mp4a.40.5 audioDescription -->
-    <AdaptationSet
-      group="1"
-      contentType="audio"
-      lang="fr"
-      segmentAlignment="true"
-      audioSamplingRate="44100"
-      mimeType="audio/mp4"
-      codecs="mp4a.40.5"
-      startWithSAP="1">
-      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
       <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
         <SegmentTimeline>
@@ -484,6 +485,27 @@
       <Representation id="audio=128000" bandwidth="128000"></Representation>
     </AdaptationSet>
 
+
+    <!-- audio be mp4a.40.2 audioDescription -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="be"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <Accessibility schemeIdUri="urn:tva:metadata:cs:AudioPurposeCS:2007" value= "1" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
 
     <!-- audio be mp4a.40.2 main -->
     <AdaptationSet
@@ -639,28 +661,6 @@
     </AdaptationSet>
 
 
-
-    <!-- video main avc1.640028 -->
-    <AdaptationSet
-      group="2"
-      contentType="video"
-      par="40:17"
-      minBandwidth="400000"
-      maxBandwidth="1996000"
-      maxWidth="2221"
-      maxHeight="944"
-      segmentAlignment="true"
-      mimeType="video/mp4"
-      startWithSAP="1">
-        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
-        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
-          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
-      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
-    </AdaptationSet>
-
-
     <!-- video avc1 + priority 50 + sign interpreted -->
     <AdaptationSet
       group="2"
@@ -682,6 +682,27 @@
       <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
     </AdaptationSet>
 
+
+    <!-- video main + priority 50 + avc1.640028 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      selectionPriority="50"
+      startWithSAP="1">
+        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
 
     <!-- video avc1.640028 + priority 2 + sign interpreted -->
     <AdaptationSet

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi_period_different_choices.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi_period_different_choices.mpd
@@ -107,6 +107,7 @@
       maxBandwidth="1996000"
       maxWidth="2221"
       maxHeight="944"
+      selectionPriority="2"
       segmentAlignment="true"
       mimeType="video/mp4"
       startWithSAP="1">

--- a/tests/contents/DASH_static_SegmentTimeline/media/multi_period_same_choices.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/multi_period_same_choices.mpd
@@ -253,7 +253,7 @@
 
 
 
-    <!-- video main avc1.640028 -->
+    <!-- video avc1.640028 + priority 50 -->
     <AdaptationSet
       group="2"
       contentType="video"
@@ -263,9 +263,9 @@
       maxWidth="2221"
       maxHeight="944"
       segmentAlignment="true"
+      selectionPriority="50"
       mimeType="video/mp4"
       startWithSAP="1">
-        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
         <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
           <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
       </SegmentTemplate>
@@ -567,26 +567,6 @@
 
 
 
-    <!-- video main avc1.640028 -->
-    <AdaptationSet
-      group="2"
-      contentType="video"
-      par="40:17"
-      minBandwidth="400000"
-      maxBandwidth="1996000"
-      maxWidth="2221"
-      maxHeight="944"
-      segmentAlignment="true"
-      mimeType="video/mp4"
-      startWithSAP="1">
-        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
-        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
-          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
-      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
-    </AdaptationSet>
-
 
     <!-- video avc1 + priority 50 + sign interpreted -->
     <AdaptationSet
@@ -607,6 +587,27 @@
       </SegmentTemplate>
       <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
       <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+
+    <!-- video avc1 + priority 50 + main -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="1996000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      selectionPriority="50"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive"></Representation>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
     </AdaptationSet>
 
 

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -116,7 +116,6 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
 
   function checkVideoTrack(codecRules, isSignInterpreted) {
     const currentVideoTrack = player.getVideoTrack();
-    expect(currentVideoTrack).to.not.equal(null);
 
     if (isSignInterpreted === undefined) {
       expect(Object.prototype.hasOwnProperty.call(currentVideoTrack,
@@ -169,11 +168,12 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     // TODO AUDIO codec
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("be", "bel", false);
+    checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
 
@@ -326,7 +326,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     // TODO AUDIO codec
     checkAudioTrack("de", "deu", false);
     checkTextTrack("de", "deu", false);
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
 
     await goToSecondPeriod();
     checkAudioTrack("de", "deu", false);
@@ -356,17 +356,18 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     // TODO AUDIO codec
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("be", "bel", false);
+    checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
 
   it("should not update the current tracks for non-applied preferences", async () => {
     await loadContent();
-    player.setPreferredAudioTracks([ { language: "fr",
+    player.setPreferredAudioTracks([ { language: "be",
                                        audioDescription: true } ]);
     player.setPreferredVideoTracks([ { codec: { all: false,
                                                 test: /avc1\.640028/},
@@ -376,10 +377,10 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     await sleep(100);
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("fr", "fra", true);
+    checkAudioTrack("be", "bel", true);
     checkTextTrack("de", "deu", false);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
   });
@@ -389,7 +390,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     await sleep(100);
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
     player.setPreferredAudioTracks([ { language: "fr",
@@ -403,7 +404,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     await goToFirstPeriod();
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
   });
 
   it("should update the current tracks for applied preferences", async () => {
@@ -431,7 +432,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     await sleep(100);
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
     player.setPreferredAudioTracks([ { language: "fr",
@@ -458,7 +459,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("be", "bel", false);
+    checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -487,7 +488,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkNoVideoTrack();
 
     await goToSecondPeriod();
-    checkAudioTrack("be", "bel", false);
+    checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
     checkNoVideoTrack();
   });
@@ -499,7 +500,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     // TODO AUDIO codec
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     setAudioTrack("fr", true);
     setTextTrack("de", false);
@@ -511,8 +512,9 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
 
     await goToSecondPeriod();
-    checkAudioTrack("be", "bel", false);
+    checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
 
@@ -522,22 +524,22 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     // TODO AUDIO codec
     checkAudioTrack("de", "deu", false);
     checkNoTextTrack();
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     setAudioTrack("fr", true);
     setTextTrack("de", false);
-    setVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+    setVideoTrack({ all: true, test: /avc1\.42C014/ }, undefined);
 
     await sleep(50);
     checkAudioTrack("fr", "fra", true);
     checkTextTrack("de", "deu", false);
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
 
     await goToSecondPeriod();
     await goToFirstPeriod();
     checkAudioTrack("fr", "fra", true);
     checkTextTrack("de", "deu", false);
-    checkVideoTrack({ all: false, test: /avc1\.640028/ }, true);
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
   });
 
   it("preferences should be persisted if already set for a given Period", async function() {


### PR DESCRIPTION
A new platform (from italia) using the RxPlayer recently noticed us that the default audio track chosen on some DASH contents was wrong according to them.

For example, on some American film with two audio tracks, one in english (the original language) and the other in italian (which is dubbed) the RxPlayer would select the english one if no preference was given.
For the application developers, it was an error as the italian audio `AdaptationSet` had both a `selectionPriority` higher than the english one and was higher in the MPD.

However, it turned out that the english AdaptationSet had a `<Role>` element set to "main" - indicating that it was the "main" audio track - and the itialian one also had a `<Role>` element but set to "dub" this time - indicating that this track is dubbed.

And that's where the DASH-IF IOP are kind of ambiguous.
In the chapter `3.9.5.2. Generic Processing Model`, it indicates that to make the initial audio track selection, a player has first to:
```
The DASH client looks for main content, i.e. any Adaptation Set with annotation
Role@schemeIdUri="urn:mpeg:dash:role:2011" and
Role@value="alternative" is excluded initially for selection.
```
What's difficult to interpret there is that `Role@value="alternative"` doesn't seem to exist in the same spec, letting me to believe that it may be referencing an older version of the spec with only two possible Roles: "main" and "alternative" (there's now much more than that).
That and the beginning of the sentence, led me originally to believe that a DASH player is supposed to select a "main" Role initially over any other Role.

However, due to the ambiguity, I looked at what other players were doing:
  - The shaka-player seemed to also put the "main" AdaptationSet first but I'm under the impression that they don't use the  `selectionPriority` attribute at all.
  - dash.js' code is a little more complicated to follow - it seemed that they order both by selectionPriority or by Role depending on the context - but use `selectionPriority` when testing on their demo page.

In the end, I decided to put `selectionPriority` over a "main" Role for initial track selection, as it seems to make the more sense (priority ordering AdaptationSet, regardless of if that AdaptationSet is considered the main one), as well as being the more flexible (without that, impossible to prefer a non-main AdaptationSet server-side), even if it could mean "breaking" other usages which had the same comprehension of the specification than me.

---

This commit implement a solution to order by:
  1. `AdaptationSet@selectionPriority` ascending, which is `1` by default.
  2. `<Role>` ("main" over all other AdaptationSet for the same `SelectionPriority`)
  3. Order in the MPD.

I tried several solutions, but I ended up with the simpler one - which may not be the most efficient in terms of performance - but is by far the most readable:
When parsing AdaptationSets, ordering-related metadata (the selectionPriority attribute etc.) is added alongside it in a tuple parsed object - ordering metadata.
After all AdaptationSets are parsed, they are sorted according to that metadata by type (audio, video, text...) and then the metadata is removed.