### PR TITLE
api: allow switching to RELOADING state synchronously after LOADED

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1024,28 +1024,26 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const playerState$ = observableConcat(
       observableOf(PLAYER_STATES.LOADING), // Begin with LOADING
 
-      // LOADED as soon as the first "loaded" event is sent
-      loaded$.pipe(take(1), map(() => PLAYER_STATES.LOADED)),
-
-      observableMerge(
-        loadedStateUpdates$
-          .pipe(
-            // From the first reload onward, we enter another dynamic (below)
+      loaded$.pipe(switchMap((_, i) => {
+        const isFirstLoad = i === 0;
+        return observableMerge(
+          // Purposely subscribed first so a RELOADING triggered synchronously
+          // after a LOADED state is catched.
+          reloading$.pipe(map(() => PLAYER_STATES.RELOADING)),
+          // Only switch to LOADED state for the first (i.e. non-RELOADING) load
+          isFirstLoad ? observableOf(PLAYER_STATES.LOADED) :
+                        EMPTY,
+          // Purposely put last so any other state change happens after we've
+          // already switched to LOADED
+          loadedStateUpdates$.pipe(
             takeUntil(reloading$),
-            skipWhile(state => state === PLAYER_STATES.PAUSED)
-          ),
-
-        // when reloading
-        reloading$.pipe(
-          switchMap(() =>
-            loaded$.pipe(
-              take(1), // wait for the next loaded event
-              mergeMap(() => loadedStateUpdates$), // to update the state as usual
-              startWith(PLAYER_STATES.RELOADING) // Starts with "RELOADING" state
-            )
+            // For the first load, we prefer staying at the LOADED state over
+            // PAUSED when autoPlay is disabled.
+            // For consecutive loads however, there's no LOADED state.
+            skipWhile(state => isFirstLoad && state === PLAYER_STATES.PAUSED)
           )
-        )
-      )
+        );
+      }))
     ).pipe(distinctUntilChanged());
 
     let playbackSubscription : Subscription|undefined;


### PR DESCRIPTION
There was an issue in the RxPlayer where a RELOADING state triggered synchronously after a LOADED state (the only case I can see now is when an application provokes an action in the event listener of a `playerStateChange` event with a `LOADED` payload which lead to a reload - typically a video track change) would not be advertised through either the `playerStateChange` event nor the `getPlayerState` method.

This is because those state updates were based on Observables, and the Observable triggering the RELOADING state was only started/subscribed [synchronously] after the LOADED state was sent.

So we could be left in a state where:
  1. The RxPlayer switches to the `LOADED` state
  2. An application reacts to that state change by calling an API which triggers a reload
  3. A reloading signal is thus sent in the RxPlayer's internals but is not yet translated into a `RELOADING` state change by the API, as it isn't listening to it yet.
  4. The RxPlayer code starts listening for future reloading signals, here too late...

This code is now "fixed" by doing an admittedly ugly trick with Observables so we're sure we're listening for reloading signal before we've sent the LOADED state event: it is put first in a `merge`.

Though this is to be temporary, like for the rest of the code, we plan to progressively removes the RxJS dependency from our code to make this synchronous/asynchronous mess more explicit.