### PR TITLE
Add IBitrateEstimate, IPositionUpdate and IPlayerState types to the API

### DIFF
--- a/doc/api/Typescript_Types.md
+++ b/doc/api/Typescript_Types.md
@@ -152,6 +152,27 @@ All of those can be imported from `"rx-player/types"` respectively as
 `IManifest`, `IPeriod`, `IAdaptation`, `IRepresentation` and `ISegment`
 
 
+### getPlayerState method / playerStateChange event
+
+The return type of the `getPlayerState` state method and of the
+`playerStateChange` events is a string describing the [current state of the
+RxPlayer](./Player_States.md).
+
+All values possible are defined through the `IPlayerState` type:
+
+```ts
+// the type(s) wanted
+import { IPlayerState } from "rx-player/types";
+
+// hypothetical file exporting an RxPlayer instance
+import rxPlayer from "./player";
+
+function getPlayerState() : IPlayerState {
+  return rxPlayer.getPlayerState();
+}
+```
+
+
 ### getAvailableAudioTracks method / availableAudioTracksChange event
 
 The return type of the `getAvailableAudioTracks` method is an array of objects.
@@ -165,9 +186,6 @@ import { IAvailableAudioTrack } from "rx-player/types";
 
 // hypothetical file exporting an RxPlayer instance
 import rxPlayer from "./player";
-
-// hypothetical file exporting a configuration object
-import config from "./config"; // define a global config
 
 function getAvailableAudioTracks() : IAvailableAudioTrack[] {
   return rxPlayer.getAvailableAudioTracks();
@@ -301,6 +319,25 @@ function getCurrentlyDownloadedVideoTrack() : IVideoTrack {
 }
 ```
 
+### positionUpdate event
+
+The type `IPositionUpdate` corresponds to the payload of a
+`positionUpdate` event.
+
+Example:
+
+```ts
+// the type(s) wanted
+import { IPositionUpdate } from "rx-player/types";
+
+// hypothetical file exporting an RxPlayer instance
+import rxPlayer from "./player";
+
+rxPlayer.addEventListener("positionUpdate", (evt : IPositionUpdate) {
+  console.log(evt);
+});
+```
+
 ### streamEvent / streamEventSkip events
 
 The type `IStreamEvent` corresponds to the payload of either a `streamEvent` or
@@ -325,6 +362,25 @@ function processEventData(eventData : IStreamEventData) {
 
 rxPlayer.addEventListener("streamEvent", (evt : IStreamEvent) {
   processEventData(evt.data);
+});
+```
+
+### bitrateEstimationChange event
+
+The type `IBitrateEstimate` corresponds to the payload of a
+`bitrateEstimationChange` event.
+
+Example:
+
+```ts
+// the type(s) wanted
+import { IBitrateEstimate } from "rx-player/types";
+
+// hypothetical file exporting an RxPlayer instance
+import rxPlayer from "./player";
+
+rxPlayer.addEventListener("bitrateEstimationChange", (evt : IBitrateEstimate) {
+  console.log(evt);
 });
 ```
 

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -17,10 +17,13 @@
 import PlaybackObserver from "./playback_observer";
 import Player from "./public_api";
 export {
+  IBitrateEstimate,
+  IPositionUpdateItem,
   IStreamEvent,
   IStreamEventData,
 } from "./public_api";
 export { PlaybackObserver };
+export { IPlayerState } from "./get_player_state";
 export {
   IPlaybackObservation,
   IPlaybackObserverEventType,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -151,74 +151,6 @@ const { isPageActive,
         onTextTrackChanges$,
         videoWidth$ } = events;
 
-/** Payload emitted with a `positionUpdate` event. */
-interface IPositionUpdateItem {
-  /** current position the player is in, in seconds. */
-  position : number;
-  /** Last position set for the current media currently, in seconds. */
-  duration : number;
-  /** Playback rate (i.e. speed) at which the current media is played. */
-  playbackRate : number;
-  /** Amount of buffer available for now in front of the current position, in seconds. */
-  bufferGap : number;
-  /** Current maximum seekable position. */
-  maximumBufferTime? : number | undefined;
-  wallClockTime? : number | undefined;
-  /**
-   * Only for live contents. Difference between the "live edge" and the current
-   * position, in seconds.
-   */
-  liveGap? : number | undefined;
-}
-
-/** Payload emitted with a `bitrateEstimationChange` event. */
-interface IBitrateEstimate {
-  /** The type of buffer this estimate was done for (e.g. "audio). */
-  type : IBufferType;
-  /** The calculated bitrate, in bits per seconds. */
-  bitrate : number | undefined;
-}
-
-export type IStreamEvent = { data: IStreamEventData;
-                             start: number;
-                             end: number;
-                             onExit?: () => void; } |
-                           { data: IStreamEventData;
-                             start: number; };
-
-/** Every events sent by the RxPlayer's public API. */
-interface IPublicAPIEvent {
-  playerStateChange : string;
-  positionUpdate : IPositionUpdateItem;
-  audioTrackChange : ITMAudioTrack | null;
-  textTrackChange : ITMTextTrack | null;
-  videoTrackChange : ITMVideoTrack | null;
-  audioBitrateChange : number;
-  videoBitrateChange : number;
-  imageTrackUpdate : { data: IBifThumbnail[] };
-  fullscreenChange : boolean;
-  bitrateEstimationChange : IBitrateEstimate;
-  volumeChange : number;
-  error : ICustomError | Error;
-  warning : ICustomError | Error;
-  nativeTextTracksChange : TextTrack[];
-  periodChange : Period;
-  availableAudioBitratesChange : number[];
-  availableVideoBitratesChange : number[];
-  availableAudioTracksChange : ITMAudioTrackListItem[];
-  availableTextTracksChange : ITMTextTrackListItem[];
-  availableVideoTracksChange : ITMVideoTrackListItem[];
-  decipherabilityUpdate : Array<{ manifest : Manifest;
-                                  period : Period;
-                                  adaptation : Adaptation;
-                                  representation : Representation; }>;
-  seeking : null;
-  seeked : null;
-  streamEvent : IStreamEvent;
-  streamEventSkip : IStreamEvent;
-  inbandEvents : IInbandEvent[];
-}
-
 /**
  * @class Player
  * @extends EventEmitter
@@ -2993,6 +2925,74 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 }
 Player.version = /* PLAYER_VERSION */"3.26.2";
+
+/** Payload emitted with a `positionUpdate` event. */
+export interface IPositionUpdateItem {
+  /** current position the player is in, in seconds. */
+  position : number;
+  /** Last position set for the current media currently, in seconds. */
+  duration : number;
+  /** Playback rate (i.e. speed) at which the current media is played. */
+  playbackRate : number;
+  /** Amount of buffer available for now in front of the current position, in seconds. */
+  bufferGap : number;
+  /** Current maximum seekable position. */
+  maximumBufferTime? : number | undefined;
+  wallClockTime? : number | undefined;
+  /**
+   * Only for live contents. Difference between the "live edge" and the current
+   * position, in seconds.
+   */
+  liveGap? : number | undefined;
+}
+
+/** Payload emitted with a `bitrateEstimationChange` event. */
+export interface IBitrateEstimate {
+  /** The type of buffer this estimate was done for (e.g. "audio). */
+  type : IBufferType;
+  /** The calculated bitrate, in bits per seconds. */
+  bitrate : number | undefined;
+}
+
+export type IStreamEvent = { data: IStreamEventData;
+                             start: number;
+                             end: number;
+                             onExit?: () => void; } |
+                           { data: IStreamEventData;
+                             start: number; };
+
+/** Every events sent by the RxPlayer's public API. */
+interface IPublicAPIEvent {
+  playerStateChange : string;
+  positionUpdate : IPositionUpdateItem;
+  audioTrackChange : ITMAudioTrack | null;
+  textTrackChange : ITMTextTrack | null;
+  videoTrackChange : ITMVideoTrack | null;
+  audioBitrateChange : number;
+  videoBitrateChange : number;
+  imageTrackUpdate : { data: IBifThumbnail[] };
+  fullscreenChange : boolean;
+  bitrateEstimationChange : IBitrateEstimate;
+  volumeChange : number;
+  error : ICustomError | Error;
+  warning : ICustomError | Error;
+  nativeTextTracksChange : TextTrack[];
+  periodChange : Period;
+  availableAudioBitratesChange : number[];
+  availableVideoBitratesChange : number[];
+  availableAudioTracksChange : ITMAudioTrackListItem[];
+  availableTextTracksChange : ITMTextTrackListItem[];
+  availableVideoTracksChange : ITMVideoTrackListItem[];
+  decipherabilityUpdate : Array<{ manifest : Manifest;
+                                  period : Period;
+                                  adaptation : Adaptation;
+                                  representation : Representation; }>;
+  seeking : null;
+  seeked : null;
+  streamEvent : IStreamEvent;
+  streamEventSkip : IStreamEvent;
+  inbandEvents : IInbandEvent[];
+}
 
 export default Player;
 export { IStreamEventData };

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -45,6 +45,10 @@ export {
   ITextTrackPreference,
   IVideoTrackPreference,
 
+  IBitrateEstimate,
+  IPositionUpdateItem as IPositionUpdate,
+  IPlayerState,
+
   IStreamEvent,
   IStreamEventData,
 } from "./core/api";


### PR DESCRIPTION
This commit adds to the `rx-player/types` path the following types:
  - IBitrateEstimate (payload of a `bitrateEstimationChange` event)
  - IPositionUpdate (payload of the `positionUpdate` event)
  - IPlayerState (return value of the `getPlayerState` method and payload of the `playerStateChange` event).

Those were missing and an issue was open (#1076) to ask us to add them.

I also profited from this commit to move type definitions in `src/core/api/public_api.ts` at the end of the file as we do now to improve code readability when first reading it).

There's however a remaining problem in that VSCode (and I suppose every other editors relying on tsserver's auto-import feature) seems to prefer the real source file of the type definition on some auto-imports and not the re-export done in the `rx-player/types` path (which is a file generated at build time which re-exports everything from `src/public_types.ts` which itself re-exports all API-exposed types in one place).
This last issue leads to some types being auto-imported from deep inside the RxPlayer code, which is moreover not part of the API.

Because it is a harder and completely different problem to solve however, this is not fixed here.