### PR TITLE
decrypt: be more resilient when calling setServerCertificate

### DIFF
--- a/src/core/decrypt/content_decryptor.ts
+++ b/src/core/decrypt/content_decryptor.ts
@@ -273,7 +273,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
         if (!isNullOrUndefined(serverCertificate)) {
           const resSsc = await setServerCertificate(mediaKeys, serverCertificate);
-          if (typeof resSsc !== "boolean") {
+          if (resSsc.type === "error") {
             this.trigger("warning", resSsc.value);
           }
         }


### PR DESCRIPTION
Amazingly, the `setServerCertificate` method seems to return a `Promise<undefined>` instead of the usual `Promise<boolean>` at least on my Firefox windows.

This commit rewrites that logic a little so it becomes more resilient to those kind of cases.