### PR TITLE
[Proposal] Add "reload" `audioTrackSwitchingMode`

### DIFF
--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -662,12 +662,23 @@ There are two possible values:
   audio track before the new one can be heard.
 
 - `"direct"`: The player will try to switch to the new audio track as soon
-  as possible, which might lead to an interruption while it is doing so.
+  as possible, which might lead to a brief interruption and rebuffering period
+  (where the RxPlayer is in the `BUFFERING` state) while it is doing so.
 
-  Note that while switching audio track with a `"direct"`
-  `audioTrackSwitchingMode`, it is possible that the player goes into the
-  `"RELOADING"` state (during which the video will disappear and many APIs
-  will become unavailable) to be able to switch to the new track.
+- `"reload"` The player will directly switch to the new audio track (like
+  direct) but may reload the media to do so.
+  During this reloading step, there might be a black screen instead of the
+  video and the RxPlayer might go into the `RELOADING` state temporarily.
+
+  Although it provides a more aggressive transition than the `"direct"` mode
+  (because it goes through a reloading step with a black screen), the
+  `"reload"` mode might be preferable in specific situations where `"direct"`
+  is seen to have compatibility issues.
+
+  We observed such issues with some contents and devices combinations, if you
+  observe issues such as losing the audio or video glitches just after changing
+  the audio track while the `"direct"` mode is used, you may want to use the
+  `"reload"` mode instead.
 
   More information about the `"RELOADING"` state can be found in [the
   player states documentation](./Player_States.md).

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -954,6 +954,17 @@ describe("API - parseLoadVideoOptions", () => {
     });
 
     expect(parseLoadVideoOptions({
+      audioTrackSwitchingMode: "reload",
+      url: "foo",
+      transport: "bar",
+    })).toEqual({
+      ...defaultLoadVideoOptions,
+      url: "foo",
+      transport: "bar",
+      audioTrackSwitchingMode: "reload",
+    });
+
+    expect(parseLoadVideoOptions({
       audioTrackSwitchingMode: "seamless",
       url: "foo",
       transport: "bar",
@@ -985,6 +996,7 @@ describe("API - parseLoadVideoOptions", () => {
         `the following strategy name:
 - \`seamless\`
 - \`direct\`
+- \`reload\`
 If badly set, seamless strategy will be used as default`);
     logWarnMock.mockReset();
     logWarnMock.mockReturnValue(undefined);

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -37,6 +37,7 @@ import {
 import objectAssign from "../../utils/object_assign";
 import warnOnce from "../../utils/warn_once";
 import { IKeySystemOption } from "../decrypt";
+import { IAudioTrackSwitchingMode } from "../stream";
 import {
   IAudioTrackPreference,
   ITextTrackPreference,
@@ -236,7 +237,7 @@ export interface ILoadVideoOptions {
   textTrackElement? : HTMLElement;
   manualBitrateSwitchingMode? : "seamless"|"direct";
   enableFastSwitching? : boolean;
-  audioTrackSwitchingMode? : "seamless"|"direct";
+  audioTrackSwitchingMode? : IAudioTrackSwitchingMode;
   onCodecSwitch? : "continue"|"reload";
 
   /* eslint-disable import/no-deprecated */
@@ -266,7 +267,7 @@ interface IParsedLoadVideoOptionsBase {
   startAt : IParsedStartAtOption|undefined;
   manualBitrateSwitchingMode : "seamless"|"direct";
   enableFastSwitching : boolean;
-  audioTrackSwitchingMode : "seamless"|"direct";
+  audioTrackSwitchingMode : IAudioTrackSwitchingMode;
   onCodecSwitch : "continue"|"reload";
 }
 
@@ -649,11 +650,12 @@ function parseLoadVideoOptions(
   let audioTrackSwitchingMode = isNullOrUndefined(options.audioTrackSwitchingMode)
                                   ? DEFAULT_AUDIO_TRACK_SWITCHING_MODE
                                   : options.audioTrackSwitchingMode;
-  if (!arrayIncludes(["seamless", "direct"], audioTrackSwitchingMode)) {
+  if (!arrayIncludes(["seamless", "direct", "reload"], audioTrackSwitchingMode)) {
     log.warn("The `audioTrackSwitchingMode` loadVideo option must match one of " +
              "the following strategy name:\n" +
              "- `seamless`\n" +
              "- `direct`\n" +
+             "- `reload`\n" +
              "If badly set, " + DEFAULT_AUDIO_TRACK_SWITCHING_MODE +
              " strategy will be used as default");
     audioTrackSwitchingMode = DEFAULT_AUDIO_TRACK_SWITCHING_MODE;

--- a/src/core/init/initialize_media_source.ts
+++ b/src/core/init/initialize_media_source.ts
@@ -56,6 +56,7 @@ import {
   SegmentFetcherCreator,
 } from "../fetchers";
 import { ITextTrackSegmentBufferOptions } from "../segment_buffers";
+import { IAudioTrackSwitchingMode } from "../stream";
 import openMediaSource from "./create_media_source";
 import EVENTS from "./events_generators";
 import getInitialTime, {
@@ -105,7 +106,7 @@ export interface IInitializeArguments {
      */
     enableFastSwitching : boolean;
     /** Strategy when switching of audio track. */
-    audioTrackSwitchingMode : "seamless" | "direct";
+    audioTrackSwitchingMode : IAudioTrackSwitchingMode;
     /** Behavior when a new video and/or audio codec is encountered. */
     onCodecSwitch : "continue" | "reload";
   };

--- a/src/core/stream/index.ts
+++ b/src/core/stream/index.ts
@@ -18,6 +18,7 @@ import StreamOrchestrator, {
   IStreamOrchestratorOptions,
   IStreamOrchestratorPlaybackObservation,
 } from "./orchestrator";
+export { IAudioTrackSwitchingMode } from "./period";
 export * from "./types";
 
 export default StreamOrchestrator;

--- a/src/core/stream/period/index.ts
+++ b/src/core/stream/period/index.ts
@@ -19,6 +19,7 @@ import PeriodStream, {
   IPeriodStreamOptions,
   IPeriodStreamPlaybackObservation,
 } from "./period_stream";
+export { IAudioTrackSwitchingMode } from "./get_adaptation_switch_strategy";
 
 export default PeriodStream;
 

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -59,7 +59,9 @@ import {
   IStreamWarningEvent,
 } from "../types";
 import createEmptyStream from "./create_empty_adaptation_stream";
-import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
+import getAdaptationSwitchStrategy, {
+  IAudioTrackSwitchingMode,
+} from "./get_adaptation_switch_strategy";
 
 
 /** Playback observation required by the `PeriodStream`. */
@@ -105,21 +107,10 @@ export interface IPeriodStreamArguments {
 export type IPeriodStreamOptions =
   IAdaptationStreamOptions &
   {
-    /**
-     * Strategy to adopt when manually switching of audio adaptation.
-     * Can be either:
-     *    - "seamless": transitions are smooth but could be not immediate.
-     *    - "direct": strategy will be "smart", if the mimetype and the codec,
-     *    change, we will perform a hard reload of the media source, however, if it
-     *    doesn't change, we will just perform a small flush by removing buffered range
-     *    and performing, a small seek on the media element.
-     *    Transitions are faster, but, we could see appear a reloading or seeking state.
-     */
-    audioTrackSwitchingMode : "seamless" | "direct";
-
+    /** RxPlayer's behavior when switching the audio track. */
+    audioTrackSwitchingMode : IAudioTrackSwitchingMode;
     /** Behavior when a new video and/or audio codec is encountered. */
     onCodecSwitch : "continue" | "reload";
-
     /** Options specific to the text SegmentBuffer. */
     textTrackOptions? : ITextTrackSegmentBufferOptions;
   };

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -56,6 +56,7 @@ export {
   IPersistentSessionInfo,
   IPersistentSessionStorage,
 } from "./core/decrypt";
+export { IAudioTrackSwitchingMode } from "./core/stream";
 export { ICustomError as IPlayerError } from "./errors";
 export {
   IExposedAdaptation as IAdaptation,


### PR DESCRIPTION
I was considering adding the "reload" `audioTrackSwitchingMode` as we noticed that a specific Canal+ application (one linked to Media Asset Management) experienced issues with the `"direct"` `audioTrackSwitchingMode`, a mode allowing to switch between audio tracks directly at the cost of a brief rebuffering period while the new audio track is loaded - instead of the  smoother default `"seamless"` we use for example on the canalplus.com website, which still plays the old audio track for a few seconds before switching.

Though I could not yet reproduce this issue on my side (due to security mechanisms preventing me from testing it for now - though we're working on it), I'm wondering if adding a `"reload"` mode in any case - which would completely reload the `MediaSource` - would not make sense anyway.

The reason behind having this new mode would be to always provide the `"reload"` solution at worst, which is usually the more compatible way to change audio tracks.

Even if the `"direct"` mode was documented as possibly triggering a RELOADING step, it was not actually possible yet (this was only added to allow us to add it in the future without breaking the API). Thus it can be splitted in two without breaking anything:
  - `"direct"`: only try to "flush" the buffer, usually through a small seek

  - `"reload"`: reload the MediaSource