### PR TITLE
Wait some time after pushing a segment before synchronizing SourceBuffer.buffered with it

### DIFF
--- a/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/audio_video/audio_video_segment_buffer.ts
@@ -399,7 +399,7 @@ export default class AudioVideoSegmentBuffer extends SegmentBuffer {
             }
             break;
           case SegmentBufferOperation.EndOfSegment:
-            this._segmentInventory.completeSegment(task.value, this.getBufferedRanges());
+            this._segmentInventory.completeSegment(task.value);
             break;
           case SegmentBufferOperation.Remove:
             this.synchronizeInventory();

--- a/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
@@ -107,7 +107,7 @@ export default class ImageSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos, this._buffered);
+      this._segmentInventory.completeSegment(_infos);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -230,7 +230,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos, this._buffered);
+      this._segmentInventory.completeSegment(_infos);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/native/native_text_segment_buffer.ts
@@ -206,7 +206,7 @@ export default class NativeTextSegmentBuffer extends SegmentBuffer {
    */
   public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
     return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos, this._buffered);
+      this._segmentInventory.completeSegment(_infos);
       return observableOf(undefined);
     });
   }

--- a/src/core/segment_buffers/inventory/buffered_history.ts
+++ b/src/core/segment_buffers/inventory/buffered_history.ts
@@ -75,18 +75,19 @@ export default class BufferedHistory {
    * @param {Object} context
    * @param {number} bufferedStart
    * @param {number} bufferedEnd
+   * @param {number} completeTimestamp
    */
   public addBufferedSegment(
     context : IChunkContext,
     bufferedStart : number,
-    bufferedEnd : number
+    bufferedEnd : number,
+    completeTimestamp : number
   ) : void {
-    const now = performance.now();
-    this._history.push({ date: now,
+    this._history.push({ date: completeTimestamp,
                          bufferedStart,
                          bufferedEnd,
                          context });
-    this._cleanHistory(now);
+    this._cleanHistory(performance.now());
 
   }
   /**

--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -748,7 +748,7 @@ export default class SegmentInventory {
 
     if (resSegments.length === 0) {
       log.warn("SI: Completed Segment not found", content);
-    } else {
+    } else if (config.getCurrent().SYNCHRONIZE_BUFFERED_ON_COMPLETE_SEGMENT) {
       this.synchronizeBuffered(newBuffered);
       for (const seg of resSegments) {
         if (seg.bufferedStart !== undefined && seg.bufferedEnd !== undefined) {

--- a/src/core/stream/orchestrator/get_blacklisted_ranges.ts
+++ b/src/core/stream/orchestrator/get_blacklisted_ranges.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import log from "../../../log";
 import {
   Adaptation,
   Period,
@@ -53,13 +52,9 @@ export default function getBlacklistedRanges(
     if (hasContent) {
       const { bufferedStart, bufferedEnd } = chunk;
       if (bufferedStart === undefined || bufferedEnd === undefined) {
-        log.warn("SO: No buffered start or end found from a segment.");
-        const buffered = segmentBuffer.getBufferedRanges();
-        const len = buffered.length;
-        if (len === 0) {
-          return [];
-        }
-        return [{ start: buffered.start(0), end: buffered.end(len - 1) }];
+        // Add and remove 2 seconds just to be sure each segment is correctly
+        // removed.
+        return [{ start: chunk.start - 2, end: chunk.end + 2 }];
       }
 
       const previousLastElement = accumulator[accumulator.length - 1];

--- a/src/core/stream/representation/get_needed_segments.ts
+++ b/src/core/stream/representation/get_needed_segments.ts
@@ -424,10 +424,7 @@ function doesStartSeemGarbageCollected(
 ) {
   const { MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT } = config.getCurrent();
   if (currentSeg.bufferedStart === undefined)  {
-    log.warn("Stream: Start of a segment unknown. " +
-             "Assuming it is garbage collected by default.",
-             currentSeg);
-    return true;
+    return false;
   }
 
   if (prevSeg !== null && prevSeg.bufferedEnd !== undefined &&
@@ -467,10 +464,7 @@ function doesEndSeemGarbageCollected(
 ) {
   const { MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT } = config.getCurrent();
   if (currentSeg.bufferedEnd === undefined)  {
-    log.warn("Stream: End of a segment unknown. " +
-             "Assuming it is garbage collected by default.",
-             currentSeg);
-    return true;
+    return false;
   }
 
   if (nextSeg !== null && nextSeg.bufferedStart !== undefined &&

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1230,16 +1230,16 @@ const DEFAULT_CONFIG = {
   MIN_BUFFER_DISTANCE_BEFORE_CLEAN_UP: 10,
 
   /**
-   * Since the RxPlayer v3.26.1, a SourceBuffer's `buffered` attribute may be
-   * read directly after the segment has been completely pushed (after the
-   * corresponding `updateend` event, for example).
-   * We fear that it might still be too early for some targets, which is why we
-   * set this feature under the `SYNCHRONIZE_BUFFERED_ON_COMPLETE_SEGMENT` flag.
+   * The RxPlayer regularly reads the audio and video SourceBuffers' buffered
+   * attribute to determinate the actual time boundaries of recently-pushed
+   * segments.
    *
-   * Note that if set to `false`, certain features and improvements might not
-   * work.
+   * Because the browser might indicate those time values after a delay due to
+   * performance issue, the RxPlayer will await at least
+   * `MS_BEFORE_BUFFERED_SYNCHRONIZATION` milliseconds before actually reading
+   * the buffer.
    */
-  SYNCHRONIZE_BUFFERED_ON_COMPLETE_SEGMENT: true,
+  MS_BEFORE_BUFFERED_SYNCHRONIZATION: 400,
 
   /**
    * Distance in seconds behind the current position

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1230,6 +1230,18 @@ const DEFAULT_CONFIG = {
   MIN_BUFFER_DISTANCE_BEFORE_CLEAN_UP: 10,
 
   /**
+   * Since the RxPlayer v3.26.1, a SourceBuffer's `buffered` attribute may be
+   * read directly after the segment has been completely pushed (after the
+   * corresponding `updateend` event, for example).
+   * We fear that it might still be too early for some targets, which is why we
+   * set this feature under the `SYNCHRONIZE_BUFFERED_ON_COMPLETE_SEGMENT` flag.
+   *
+   * Note that if set to `false`, certain features and improvements might not
+   * work.
+   */
+  SYNCHRONIZE_BUFFERED_ON_COMPLETE_SEGMENT: true,
+
+  /**
    * Distance in seconds behind the current position
    * the player will free up to in the case we agressively free up memory
    * It is set to avoid playback issues

--- a/tests/integration/scenarios/discontinuities.js
+++ b/tests/integration/scenarios/discontinuities.js
@@ -217,7 +217,7 @@ describe("discontinuities handling", () => {
     });
 
     it("should seek over discontinuity when seeking in one", async function() {
-      this.timeout(4000);
+      this.timeout(5000);
       let discontinuitiesWarningReceived = 0;
       player.addEventListener("warning", (err) => {
         if (err.type === "MEDIA_ERROR" &&
@@ -232,7 +232,7 @@ describe("discontinuities handling", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
       player.seekTo(25);
-      await sleep(2000);
+      await sleep(3000);
       expect(player.getPosition()).to.be.at.least(28);
       expect(player.getPlayerState()).to.equal("PLAYING");
       expect(discontinuitiesWarningReceived).to.be.at.least(1);


### PR DESCRIPTION
We recently saw a regression on ChromeCast and on some smart TVs where some media error would (very) randomly occur.

Investigations were especially difficult due to the random and rare-ness of the issue: sometimes it would appear after 5 minutes of playbacks and other time we were able to play for hours.
And after logging, no real weird behavior appeared before the issue.

We thus tried a strategy of "bisecting": we were testing on multiple devices a lot of releases each time at a new halfway point between what is known to work and what is known to not work.

Though even through that system, results were sometimes incoherent.

However, we may have found something that seems to have an impact:
Since the v3.26.1 a side-effect of a new feature (which allows to detect and avoid request loops due to the browser cropping content) lead to the fact that we were synchronizing much earlier between a `SourceBuffer`'s buffered property (which allows to know how much media data the browser has in its buffer) to our own representation of that buffer in the RxPlayer, the `SegmentInventory` (which also indicates which actual segment - e.g. which quality or track - is actually currently in the buffer and where).

It is possible that on some devices, and in rare conditions, this earlier synchronization is done before the browser had the time to properly update `SourceBuffer.buffered`.
This in turn would led the RxPlayer to believe that corresponding segments had not been pushed in full, and it may lead to all kind of issues such as request loop (which was what we tried to avoid in the first place!).

To fix that issue, I decided to add the `MS_BEFORE_BUFFERED_SYNCHRONIZATION` config property to the config.
That property allows to always wait for some hundred of milliseconds after a segment has been pushed before synchronizing its `bufferedStart` and `bufferedEnd` properties.
It can be set to `0`, or even `-1` to be disabled.

For now, I decided to add it to all platforms. To see if that causes issues.