### PR TITLE
DRM: await potential pending `generateRequest` and `load` call before closing a MediaKeySession

### DIFF
--- a/src/compat/eme/generate_key_request.ts
+++ b/src/compat/eme/generate_key_request.ts
@@ -124,12 +124,10 @@ export function patchInitData(initData : Uint8Array) : Uint8Array {
  * Generate a request from session.
  * @param {MediaKeySession} session - MediaKeySession on which the request will
  * be done.
- * @param {Uint8Array} initData - Initialization data given e.g. by the
- * "encrypted" event for the corresponding request.
- * @param {string} initDataType - Initialization data type given e.g. by the
- * "encrypted" event for the corresponding request.
- * @param {string} sessionType - Type of session you want to generate. Consult
- * EME Specification for more information on session types.
+ * @param {string} initializationDataType - Initialization data type given e.g.
+ * by the "encrypted" event for the corresponding request.
+ * @param {Uint8Array} initializationData - Initialization data given e.g. by
+ * the "encrypted" event for the corresponding request.
  * @returns {Promise} - Emit when done. Errors if fails.
  */
 export default function generateKeyRequest(

--- a/src/core/decrypt/create_or_load_session.ts
+++ b/src/core/decrypt/create_or_load_session.ts
@@ -88,7 +88,10 @@ export default async function createOrLoadSession(
     throw cancelSignal.cancellationError; // stop here if cancelled since
   }
 
-  const evt = await createSession(stores, initializationData, wantedSessionType);
+  const evt = await createSession(stores,
+                                  initializationData,
+                                  wantedSessionType,
+                                  cancelSignal);
   return { type: evt.type,
            value: { mediaKeySession: evt.value.mediaKeySession,
                     sessionType: evt.value.sessionType,

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1058,36 +1058,6 @@ const DEFAULT_CONFIG = {
   EME_MAX_STORED_PERSISTENT_SESSION_INFORMATION: 1000,
 
     /**
-     * Attempts to closing a MediaKeySession can fail, most likely because the
-     * MediaKeySession was not initialized yet.
-     * When we consider that we're in one of these case, we will retry to close it.
-     *
-     * To avoid going into an infinite loop of retry, this number indicates a
-     * maximum number of attemps we're going to make (`0` meaning no retry at all,
-     * `1` only one retry and so on).
-     */
-  EME_SESSION_CLOSING_MAX_RETRY: 5,
-
-    /**
-     * When closing a MediaKeySession failed due to the reasons explained for the
-     * `EME_SESSION_CLOSING_MAX_RETRY` config property, we may (among other
-     * triggers) choose to wait a delay raising exponentially at each retry before
-     * that new attempt.
-     * This value indicates the initial value for this delay, in milliseconds.
-     */
-  EME_SESSION_CLOSING_INITIAL_DELAY: 100,
-
-    /**
-     * When closing a MediaKeySession failed due to the reasons explained for the
-     * `EME_SESSION_CLOSING_MAX_RETRY` config property, we may (among other
-     * triggers) choose to wait a delay raising exponentially at each retry before
-     * that new attempt.
-     * This value indicates the maximum possible value for this delay, in
-     * milliseconds.
-     */
-  EME_SESSION_CLOSING_MAX_DELAY: 1000,
-
-    /**
      * After loading a persistent MediaKeySession, the RxPlayer needs to ensure
      * that its keys still allow to decrypt a content.
      *


### PR DESCRIPTION
In the [EME specification](https://www.w3.org/TR/encrypted-media) it is implicitely indicated that closing a `MediaKeySession` cannot be done until `generateRequest` or `load` has been called on it.

Because we don't always trust platforms to perfectly implement the EME specification (I would say that those are the APIs with which we encounter the most issues), we had a less than ideal yet general solution which just retried closing a MediaKeySession (with an exponential backoff) when it couldn't be done due to an `InvalidStateError` - the error rejected when the MediaKeySession is not yet ready to be closed.

However, there was multiple issues, especially on low-end devices, that made me reconsider this solution:
  1. The exponential backoff could lead to large waiting time in some cases. This could in turn lead to longer content-loading time.
  2. If a `load` or `generateRequest` takes a LOT of time to respond (several seconds), we could be left in a case where we wouldn't be closing a session (because there's a limit to the amount of time we're re-trying to close a session) leading to a leak.
  3. Following the logic through logs in times of problems become very confusing for everyone involved in a debugging process

So this commit tries another solution instead.
What is done here is to always only call `MediaKeySession.close` once (and fail if it fails) but ensuring that it doesn't happen while a `generateRequest` or `load` call is pending. If one of those calls is pending, we will actually call `close` when one of those two - which both return Promises - either resolve or reject.

A `close` call before the first `generateRequest` or `load` call is still authorized to maximize compatibility but once `close` has been called, no `generateRequest` or `load` call will be performed.

This is enforced by always going through the `LoadedSessionStore` for any of those calls, a solution that is not perfect, but does the job easily.