### PR TITLE
Use the first compatible codec of the current AdaptationSet when creating a SourceBuffer

### DIFF
--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -30,7 +30,10 @@ import {
   switchMap,
 } from "rxjs";
 import config from "../../../config";
-import { formatError } from "../../../errors";
+import {
+  formatError,
+  MediaError,
+} from "../../../errors";
 import log from "../../../log";
 import Manifest, {
   Adaptation,
@@ -332,9 +335,12 @@ function createOrReuseSegmentBuffer(
  * @returns {string}
  */
 function getFirstDeclaredMimeType(adaptation : Adaptation) : string {
-  const { representations } = adaptation;
-  if (representations[0] == null) {
-    return "";
+  const representations = adaptation.getPlayableRepresentations();
+  if (representations.length === 0) {
+    const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
+                                    "No Representation in the chosen " +
+                                    adaptation.type + " Adaptation can be played");
+    throw noRepErr;
   }
   return representations[0].getMimeTypeString();
 }


### PR DESCRIPTION
The previous logic used the codec of the first (lowest quality?) Representation of the first AdaptationSet chosen when creating initially the SourceBuffer.

This can fail if the lowest quality is not supported.

This PR uses the first "compatible" (supported and not non-decipherable) Representation instead.