### PR TITLE
DRM: Update persisted info after reloading a MediaKeySession

### DIFF
--- a/src/core/decrypt/utils/persistent_sessions_store.ts
+++ b/src/core/decrypt/utils/persistent_sessions_store.ts
@@ -143,14 +143,20 @@ export default class PersistentSessionsStore {
       return;
     }
     const { sessionId } = session;
-    const currentEntry = this.get(initData);
-    if (currentEntry !== null && currentEntry.sessionId === sessionId) {
-      return;
-    } else if (currentEntry !== null) { // currentEntry has a different sessionId
-      this.delete(currentEntry.sessionId);
+    const currentIndex = this._getIndex(initData);
+    if (currentIndex >= 0) {
+      const currVersion = keyIds === undefined ? 3 :
+                                                 4;
+      const currentEntry = this._entries[currentIndex];
+      const entryVersion = currentEntry.version ?? -1;
+      if (entryVersion >= currVersion && sessionId === currentEntry.sessionId) {
+        return;
+      }
+      log.info("DRM-PSS: Updating session info.", sessionId);
+      this._entries.splice(currentIndex, 1);
+    } else {
+      log.info("DRM-PSS: Add new session", sessionId);
     }
-
-    log.info("DRM-PSS: Add new session", sessionId);
 
     const storedValues = prepareValuesForStore(initData.values.getFormattedValues());
     if (keyIds === undefined) {


### PR DESCRIPTION
This commit allows to update information stored with a persisted MediaKeySession if the format's version was anterior to what can be set now.

As higher versions today always mean strictly more information, this will allow to migrate re-loaded MediaKeySessions to the newer format and thus, to progressively store more information on already-stored session as they are re-loaded.