### PR TITLE
If seeking after the last potential position, load last segments before ending

### DIFF
--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -301,9 +301,9 @@ export default function RepresentationStream<TSegmentDataType>({
                    IStreamNeedsManifestRefresh |
                    IStreamTerminatingEvent>
     {
-      const wantedStartPosition = observation.position + observation.wantedTimeOffset;
+      const initialWantedTime = observation.position + observation.wantedTimeOffset;
       const status = getBufferStatus(content,
-                                     wantedStartPosition,
+                                     initialWantedTime,
                                      playbackObserver,
                                      fastSwitchThreshold,
                                      bufferGoal,
@@ -383,7 +383,7 @@ export default function RepresentationStream<TSegmentDataType>({
       if (status.isBufferFull) {
         const gcedPosition = Math.max(
           0,
-          wantedStartPosition - UPTO_CURRENT_POSITION_CLEANUP);
+          initialWantedTime - UPTO_CURRENT_POSITION_CLEANUP);
         if (gcedPosition > 0) {
           bufferRemoval = segmentBuffer
             .removeBuffer(0, gcedPosition)

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -185,4 +185,14 @@ export default class Period {
       return ada.isSupported;
     });
   }
+
+  /**
+   * Returns true if the give time is in the time boundaries of this `Period`.
+   * @param {number} time
+   * @returns {boolean}
+   */
+  containsTime(time : number) : boolean {
+    return time >= this.start && (this.end === undefined ||
+                                  time < this.end);
+  }
 }


### PR DESCRIPTION
This PR fixes a theoretical issue that could arise if an user seeked after the last possible position.

Doing this is difficult to reproduce but is for example possible when multiple audio or video AdaptationSets have different durations, with at least one inferior to the corresponding Period and/or Manifest's duration.
In that situation, the media element's duration may be set higher than the maximum time on the shorter AdaptationSet and it will thus be possible to seek further than the latter.

After the seek is done, the RxPlayer would notice that we are after the last position, call the `endOfStream` API to notify that playback is done, and switch the `ended` state.

Without putting much thoughts into it, this could seem like the right thing to do. However, `endOfStream` will have the problematic side-effect of updating the duration of the media element to the current last buffered position (which would be the one before the seek was done) and may show the corresponding last buffered frame at the time, instead of the last frame of the content, which may be more logical.

---

To implement this, I chose for now to isolate the code of the `RepresentationStream` where the time range of segments that should be loaded is calculated, to include an exception when the position is after the last Period if it is not still pending (if the Period is not still going on == if we're on a finished live or on an on-demand content).
This exception would offset the range so it loads starting from the last second of the content and not from the current position.

I'm not too proud of this solution however as this kind of check is unusual in the `RepresentationStream`. The main job of this module being to just find which segments to load, to then load them and push them without considering the grander scheme of how playback is going.

But it was so much easier to add this exception there, so for now I decided to do the developement there!