### PR TITLE
DASH: fix awkward typo which would calculate wrong segment estimates

### DIFF
--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -389,7 +389,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
       this._index.timeline = this._getTimeline();
     }
     const lastTime = TimelineRepresentationIndex.getIndexEnd(this._index.timeline,
-                                                             this._scaledPeriodStart);
+                                                             this._scaledPeriodEnd);
     return lastTime === null ? null :
                                fromIndexTime(lastTime, this._index);
   }


### PR DESCRIPTION
This commit fixes a dumb typo which could lead to multiple issues related to miscalculating the maximum position reachable by segments within a Period.

Thankfully, the conditions for the RxPlayer to rely on the problematic code were rare: we needed to have a `SegmentTimeline` with the last segment having a `S@r` attribute set to `-1` and a Period with a set `Period@end` attribute. In that condition, the wrong ending position would be calculated for the last segment in the Period, which would lead to difficult-to-predict issues.

Because `S@r` attributes set to `-1` are rare in the wild, we didn't hear of any application having the issue for now - it is thus for now only a theoretical problem.