### PR TITLE
DASH: RepresentationIndex' `getLastPosition` is now limited by the Period's end

### DIFF
--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -268,10 +268,15 @@ export interface IRepresentationIndex {
   getFirstPosition() : number | null | undefined;
 
   /**
-   * Returns the ending time, in seconds, of the last segment currently
-   * available in this index.
+   * Returns the ending time, in seconds, of the last playable position
+   * currently available in this index.
    * Returns `null` if nothing is in the index
    * Returns `undefined` if we cannot know this value.
+   *
+   * The last playable position is generally equivalent to the end of the last
+   * segment associated to this index, excepted when it goes over the end limit
+   * of the corresponding `Period`, in which case it will be equal to this end
+   * instead.
    * @returns {Number|null|undefined}
    */
   getLastPosition() : number | null | undefined;

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -288,9 +288,10 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
       return null;
     }
     const lastTimelineElement = timeline[timeline.length - 1];
-    const lastTime = getIndexSegmentEnd(lastTimelineElement,
-                                        null,
-                                        this._scaledPeriodEnd);
+    const lastTime = Math.min(getIndexSegmentEnd(lastTimelineElement,
+                                                 null,
+                                                 this._scaledPeriodEnd),
+                              this._scaledPeriodEnd ?? Infinity);
     return fromIndexTime(lastTime, this._index);
   }
 

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -106,6 +106,8 @@ export interface IListIndexIndexArgument {
 export interface IListIndexContextArgument {
   /** Start of the period concerned by this RepresentationIndex, in seconds. */
   periodStart : number;
+  /** End of the period concerned by this RepresentationIndex, in seconds. */
+  periodEnd : number | undefined;
   /** Base URL for the Representation concerned. */
   representationBaseURLs : IResolvedBaseUrl[];
   /** ID of the Representation concerned. */
@@ -121,6 +123,8 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
   private _index : IListIndex;
   /** Start of the period concerned by this RepresentationIndex, in seconds. */
   protected _periodStart : number;
+  /** End of the period concerned by this RepresentationIndex, in seconds. */
+  protected _periodEnd : number | undefined;
   /* Function that tells if an EMSG is whitelisted by the manifest */
   private _isEMSGWhitelisted: (inbandEvent: IEMSG) => boolean;
 
@@ -134,12 +138,14 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
     }
 
     const { periodStart,
+            periodEnd,
             representationBaseURLs,
             representationId,
             representationBitrate,
             isEMSGWhitelisted } = context;
     this._isEMSGWhitelisted = isEMSGWhitelisted;
     this._periodStart = periodStart;
+    this._periodEnd = periodEnd;
     const presentationTimeOffset =
       index.presentationTimeOffset != null ? index.presentationTimeOffset :
                                              0;
@@ -248,7 +254,8 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
   getLastPosition() : number {
     const index = this._index;
     const { duration, list } = index;
-    return ((list.length * duration) / index.timescale) + this._periodStart;
+    return Math.min(((list.length * duration) / index.timescale) + this._periodStart,
+                    this._periodEnd ?? Infinity);
   }
 
   /**

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -218,8 +218,9 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                     startNumber: index.startNumber };
     this._isDynamic = isDynamic;
     this._periodStart = periodStart;
-    this._scaledPeriodEnd = periodEnd == null ? undefined :
-                                                (periodEnd - periodStart) * timescale;
+    this._scaledPeriodEnd = periodEnd === undefined ?
+      undefined :
+      (periodEnd - periodStart) * timescale;
     this._isEMSGWhitelisted = isEMSGWhitelisted;
   }
 
@@ -334,7 +335,11 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
       // the two functions. So, we return the result of the latter.
       return lastSegmentStart;
     }
-    const lastSegmentEnd = lastSegmentStart + this._index.duration;
+
+    const lastSegmentEnd = Math.min(
+      lastSegmentStart + this._index.duration,
+      this._scaledPeriodEnd ?? Infinity
+    );
     return (lastSegmentEnd / this._index.timescale) + this._periodStart;
   }
 

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -389,7 +389,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
       this._index.timeline = this._getTimeline();
     }
     const lastTime = TimelineRepresentationIndex.getIndexEnd(this._index.timeline,
-                                                             this._scaledPeriodStart);
+                                                             this._scaledPeriodEnd);
     return lastTime === null ? null :
                                fromIndexTime(lastTime, this._index);
   }

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -47,7 +47,6 @@ import constructTimelineFromElements from "./construct_timeline_from_elements";
 // eslint-disable-next-line max-len
 import constructTimelineFromPreviousTimeline from "./construct_timeline_from_previous_timeline";
 
-
 /**
  * Index property defined for a SegmentTimeline RepresentationIndex
  * This object contains every property needed to generate an ISegment for a
@@ -307,8 +306,8 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
                     timeline: index.timeline ?? null,
                     timescale };
     this._scaledPeriodStart = toIndexTime(periodStart, this._index);
-    this._scaledPeriodEnd = periodEnd == null ? undefined :
-                                                toIndexTime(periodEnd, this._index);
+    this._scaledPeriodEnd = periodEnd === undefined ? undefined :
+                                                      toIndexTime(periodEnd, this._index);
   }
 
   /**
@@ -566,9 +565,10 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     if (timeline.length <= 0) {
       return null;
     }
-    return getIndexSegmentEnd(timeline[timeline.length - 1],
-                              null,
-                              scaledPeriodEnd);
+    return Math.min(getIndexSegmentEnd(timeline[timeline.length - 1],
+                                       null,
+                                       scaledPeriodEnd),
+                    scaledPeriodEnd ?? Infinity);
   }
 
   /**


### PR DESCRIPTION
Based on #1098

The `getLastPosition` method of `RepresentationIndex`es was previously ambiguous in that it returned the "end of the last segment in a given Representation" but without precizing what happens if the parent `Period` is shorter (in which case the segment will be cropped to not go further than this last value before being played).

This PR sets a new - more precize - definition that changes a little the behavior but should not break anything: it returns now the theoretical last playable position in the Representation.
As such it is now always bounded by the Period's end.

I did this to raise its usefulness: the last reachable position (the new value) should be much more useful than the maximum position the last segment contains media data for (the old value).
Moreover, we never really needed usage for the latter now, as the Period's end was still relied on anyway.