### PR TITLE
ABR: update PlaybackObserver's `liveGap` prop to just `maximumPosition`

### DIFF
--- a/src/core/init/create_stream_playback_observer.ts
+++ b/src/core/init/create_stream_playback_observer.ts
@@ -63,9 +63,8 @@ export default function createStreamPlaybackObserver(
     return observableCombineLatest([observation$, speed.asObservable()]).pipe(
       map(([observation, lastSpeed]) => {
         return {
-          liveGap: manifest.isLive ?
-            manifest.getMaximumPosition() - observation.position :
-            undefined,
+          // TODO more exact according to the current Adaptation chosen?
+          maximumPosition: manifest.getMaximumPosition(),
           position: observation.position,
           duration: observation.duration,
           isPaused: initialPlayPerformed.getValue() ? observation.paused :

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -91,11 +91,8 @@ export interface IAdaptationStreamPlaybackObservation extends
     isPaused: boolean;
     /** Last "playback rate" asked by the user. */
     speed : number;
-    /**
-     * Only set for live contents.
-     * Difference between the live edge and the current position, in seconds.
-     */
-    liveGap : number | undefined;
+    /** Theoretical maximum position on the content that can currently be played. */
+    maximumPosition : number;
   }
 
 /** Arguments given when creating a new `AdaptationStream`. */

--- a/src/core/stream/adaptation/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/create_representation_estimator.ts
@@ -26,6 +26,7 @@ import {
 import { MediaError } from "../../../errors";
 import Manifest, {
   Adaptation,
+  Period,
   Representation,
 } from "../../../manifest";
 import { fromEvent } from "../../../utils/event_emitter";
@@ -53,13 +54,15 @@ import ABRManager, {
  * @returns {Object}
  */
 export default function createRepresentationEstimator(
-  { manifest, adaptation } : { manifest : Manifest;
-                               adaptation : Adaptation; },
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation; },
   abrManager : ABRManager,
   observation$ : Observable<IABRManagerPlaybackObservation>
 ) : { estimator$ : Observable<IABREstimate>;
       abrFeedbacks$ : Subject<IABRStreamEvents>; }
 {
+  const { manifest, adaptation } = content;
   const abrFeedbacks$ = new Subject<IABRStreamEvents>();
   const estimator$ = observableMerge(
     // subscribe "first" (hack as it is a merge here) to event
@@ -90,7 +93,7 @@ export default function createRepresentationEstimator(
       return true;
     }),
     switchMap((playableRepresentations) =>
-      abrManager.get$(adaptation.type,
+      abrManager.get$(content,
                       playableRepresentations,
                       observation$,
                       abrFeedbacks$)));

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -81,11 +81,8 @@ export interface IPeriodStreamPlaybackObservation {
    * which we actually want to download segments for.
    */
   wantedTimeOffset : number;
-  /**
-   * Only set for live contents.
-   * Difference between the live edge and the current position, in seconds.
-   */
-  liveGap : number | undefined;
+  /** Theoretical maximum position on the content that can currently be played. */
+  maximumPosition : number;
 }
 
 /** Arguments required by the `PeriodStream`. */


### PR DESCRIPTION
This is a minor commit that just renames the `liveGap` as produced by the `PlaybackObserver ` to provide the distance to the live edge to a more general `maximumPosition` which is just defined as the "theoretical maximum position on the content that can currently be played.".

Both are actually completely equivalent under the current code, but "live edge" implies that this was equal to the media data currently being broadcasted or at least the last media position currently available which would both be false assumptions (it is actually more: the maximum position for which there's media data regardless of the chosen Adaptation - yes it's a complex concept, I'm working on it now).

Because of the renaming, I had to add a `context` attribute to the `ABRManager`'s code:
It was before able to tell if the current content was live by checking the presence of the `liveGap` attribute, but with `maximumPosition` now set regardless of if the content is live or not, the `ABRManager` would now be unable to rely on this check.

So I added a way to communicate the `Manifest` structure to the `ABRManager`.
I don't see this as a problem anyway as things become much more explicit that way (and to me, that means better) and as it seems logical to me that the `ABRManager` knows which `Manifest`, `Period` and `Adaptation` it currently is choosing a `Representation` for.