### PR TITLE
 Separate the concept of "livePosition" from the concept of "maximumPosition"

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2878,13 +2878,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     };
 
     if (manifest !== null &&
-        maximumPosition !== undefined &&
         manifest.isLive &&
         observation.position > 0
     ) {
       const ast = manifest.availabilityStartTime ?? 0;
       positionData.wallClockTime = observation.position + ast;
-      positionData.liveGap = maximumPosition - observation.position;
+      const livePosition = manifest.getLivePosition();
+      if (livePosition !== undefined) {
+        positionData.liveGap = livePosition - observation.position;
+      }
     } else if (isDirectFile && this.videoElement !== null) {
       const startDate = getStartDate(this.videoElement);
       if (startDate !== undefined) {

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1606,7 +1606,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     let seekAt = positionWanted;
     if (manifest !== null && !manifest.isLive) {
-      const maximumTime = manifest.getMaximumPosition();
+      const maximumTime = manifest.getMaximumSafePosition();
       seekAt = maximumTime !== undefined ? Math.min(positionWanted,
                                                     maximumTime - 0.001) :
                                            positionWanted;
@@ -2235,7 +2235,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     const { manifest } = this._priv_contentInfos;
     if (manifest !== null) {
-      return manifest.getMinimumPosition();
+      return manifest.getMinimumSafePosition();
     }
     return null;
   }
@@ -2259,7 +2259,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     if (manifest !== null) {
-      return manifest.getMaximumPosition();
+      return manifest.getMaximumSafePosition();
     }
     return null;
   }
@@ -2864,7 +2864,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     this._priv_lastContentPlaybackInfos.lastPlaybackPosition = observation.position;
 
-    const maximumPosition = manifest !== null ? manifest.getMaximumPosition() :
+    const maximumPosition = manifest !== null ? manifest.getMaximumSafePosition() :
                                                 undefined;
     const positionData : IPositionUpdateItem = {
       position: observation.position,

--- a/src/core/init/create_stream_playback_observer.ts
+++ b/src/core/init/create_stream_playback_observer.ts
@@ -64,7 +64,7 @@ export default function createStreamPlaybackObserver(
       map(([observation, lastSpeed]) => {
         return {
           liveGap: manifest.isLive ?
-            manifest.getMaximumPosition() - observation.position :
+            manifest.getMaximumSafePosition() - observation.position :
             undefined,
           position: observation.position,
           duration: observation.duration,

--- a/src/core/init/duration_updater.ts
+++ b/src/core/init/duration_updater.ts
@@ -120,7 +120,7 @@ function setMediaSourceDuration(
       let newDuration : number;
       if (manifest.isDynamic) {
         const maxPotentialPos = manifest.getLivePosition() ??
-                                manifest.getMaximumPosition();
+                                manifest.getMaximumSafePosition();
 
         // Some targets poorly support setting a very high number for durations.
         // Yet, in dynamic contents, we would prefer setting a value as high as possible
@@ -130,7 +130,7 @@ function setMediaSourceDuration(
         // we authorize exceptionally going over it.
         newDuration =  Math.max(Math.pow(2, 32), maxPotentialPos + YEAR_IN_SECONDS);
       } else {
-        newDuration = manifest.getMaximumPosition();
+        newDuration = manifest.getMaximumSafePosition();
       }
 
       if (mediaSource.duration >= newDuration ||

--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -71,13 +71,13 @@ export default function getInitialTime(
   startAt? : IInitialTimeOptions
 ) : number {
   if (startAt != null) {
-    const min = manifest.getMinimumPosition();
+    const min = manifest.getMinimumSafePosition();
     let max;
     if (manifest.isLive) {
       max = manifest.getLivePosition();
     }
     if (max === undefined) {
-      max = manifest.getMaximumPosition();
+      max = manifest.getMaximumSafePosition();
     }
     if (!isNullOrUndefined(startAt.position)) {
       log.debug("Init: using startAt.minimumPosition");
@@ -116,11 +116,11 @@ export default function getInitialTime(
     }
   }
 
-  const minimumPosition = manifest.getMinimumPosition();
+  const minimumPosition = manifest.getMinimumSafePosition();
   if (manifest.isLive) {
     const { suggestedPresentationDelay,
             clockOffset } = manifest;
-    const maximumPosition = manifest.getMaximumPosition();
+    const maximumPosition = manifest.getMaximumSafePosition();
     let liveTime : number;
     const { DEFAULT_LIVE_GAP } = config.getCurrent();
 

--- a/src/core/init/get_initial_time.ts
+++ b/src/core/init/get_initial_time.ts
@@ -72,7 +72,13 @@ export default function getInitialTime(
 ) : number {
   if (startAt != null) {
     const min = manifest.getMinimumPosition();
-    const max = manifest.getMaximumPosition();
+    let max;
+    if (manifest.isLive) {
+      max = manifest.getLivePosition();
+    }
+    if (max === undefined) {
+      max = manifest.getMaximumPosition();
+    }
     if (!isNullOrUndefined(startAt.position)) {
       log.debug("Init: using startAt.minimumPosition");
       return Math.max(Math.min(startAt.position, max), min);

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -158,12 +158,12 @@ export default function StreamOrchestrator(
       { position, wantedTimeOffset }
     ) => {
       const offsetedPosition = wantedTimeOffset + position;
-      if (offsetedPosition < manifest.getMinimumPosition()) {
+      if (offsetedPosition < manifest.getMinimumSafePosition()) {
         const warning = new MediaError("MEDIA_TIME_BEFORE_MANIFEST",
                                        "The current position is behind the " +
                                        "earliest time announced in the Manifest.");
         return EVENTS.warning(warning);
-      } else if (offsetedPosition > manifest.getMaximumPosition()) {
+      } else if (offsetedPosition > manifest.getMaximumSafePosition()) {
         const warning = new MediaError("MEDIA_TIME_AFTER_MANIFEST",
                                        "The current position is after the latest " +
                                        "time announced in the Manifest.");

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -47,11 +47,13 @@ describe("Manifest - Manifest", () => {
                                  isDynamic: false,
                                  isLive: false,
                                  duration: 5,
-                                 timeBounds: { absoluteMinimumTime: 0,
+                                 timeBounds: { minimumSafePosition: 0,
                                                timeshiftDepth: null,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 10,
-                                                                  time: 10 } },
+                                               maximumTimeData: {
+                                                 isLinear: false,
+                                                 maximumSafePosition: 10,
+                                                 time: 10,
+                                               } },
                                  periods: [] };
 
     const Manifest = require("../manifest").default;
@@ -63,8 +65,8 @@ describe("Manifest - Manifest", () => {
     expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(undefined);
-    expect(manifest.getMaximumPosition()).toEqual(10);
-    expect(manifest.getMinimumPosition()).toEqual(0);
+    expect(manifest.getMaximumSafePosition()).toEqual(10);
+    expect(manifest.getMinimumSafePosition()).toEqual(0);
     expect(manifest.contentWarnings).toEqual([]);
     expect(manifest.periods).toEqual([]);
     expect(manifest.suggestedPresentationDelay).toEqual(undefined);
@@ -83,11 +85,13 @@ describe("Manifest - Manifest", () => {
                                  isDynamic: false,
                                  isLive: false,
                                  duration: 5,
-                                 timeBounds: { absoluteMinimumTime: 0,
+                                 timeBounds: { minimumSafePosition: 0,
                                                timeshiftDepth: null,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 10,
-                                                                  time: 10 } },
+                                               maximumTimeData: {
+                                                 isLinear: false,
+                                                 maximumSafePosition: 10,
+                                                 time: 10,
+                                               } },
                                  periods: [period1, period2] };
 
     const fakePeriod = jest.fn((period) => {
@@ -123,11 +127,13 @@ describe("Manifest - Manifest", () => {
                                  isDynamic: false,
                                  isLive: false,
                                  duration: 5,
-                                 timeBounds: { absoluteMinimumTime: 0,
+                                 timeBounds: { minimumSafePosition: 0,
                                                timeshiftDepth: null,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 10,
-                                                                  time: 10 } },
+                                               maximumTimeData: {
+                                                 isLinear: false,
+                                                 maximumSafePosition: 10,
+                                                 time: 10,
+                                               } },
                                  periods: [period1, period2] };
 
     const representationFilter = function() { return false; };
@@ -161,11 +167,13 @@ describe("Manifest - Manifest", () => {
                                  isDynamic: false,
                                  isLive: false,
                                  duration: 5,
-                                 timeBounds: { absoluteMinimumTime: 0,
+                                 timeBounds: { minimumSafePosition: 0,
                                                timeshiftDepth: null,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 10,
-                                                                  time: 10 } },
+                                               maximumTimeData: {
+                                                 isLinear: false,
+                                                 maximumSafePosition: 10,
+                                                 time: 10,
+                                               } },
                                  periods: [period1, period2] };
 
     const fakePeriod = jest.fn((period) => {
@@ -199,11 +207,13 @@ describe("Manifest - Manifest", () => {
                                  isDynamic: false,
                                  isLive: false,
                                  duration: 5,
-                                 timeBounds: { absoluteMinimumTime: 0,
+                                 timeBounds: { minimumSafePosition: 0,
                                                timeshiftDepth: null,
-                                               maximumTimeData: { isLinear: false,
-                                                                  value: 10,
-                                                                  time: 10 } },
+                                               maximumTimeData: {
+                                                 isLinear: false,
+                                                 maximumSafePosition: 10,
+                                                 time: 10,
+                                               } },
                                  periods: [period1, period2] };
 
     const fakePeriod = jest.fn((period) => {
@@ -242,10 +252,10 @@ describe("Manifest - Manifest", () => {
                               lifetime: 13,
                               contentWarnings: [new Error("a"), new Error("b")],
                               periods: [oldPeriod1, oldPeriod2],
-                              timeBounds: { absoluteMinimumTime: 5,
+                              timeBounds: { minimumSafePosition: 5,
                                             timeshiftDepth: null,
                                             maximumTimeData: { isLinear: false,
-                                                               value: 10,
+                                                               maximumSafePosition: 10,
                                                                time } },
                               suggestedPresentationDelay: 99,
                               uris: ["url1", "url2"] };
@@ -267,8 +277,8 @@ describe("Manifest - Manifest", () => {
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(13);
     expect(manifest.contentWarnings).toEqual([new Error("0"), new Error("1")]);
-    expect(manifest.getMaximumPosition()).toEqual(10);
-    expect(manifest.getMinimumPosition()).toEqual(5);
+    expect(manifest.getMaximumSafePosition()).toEqual(10);
+    expect(manifest.getMinimumSafePosition()).toEqual(5);
     expect(manifest.periods).toEqual([
       { id: "foo0", contentWarnings: [new Error("0")], adaptations: {}, start: 4 },
       { id: "foo1", contentWarnings: [new Error("1")], adaptations: {}, start: 12 },
@@ -301,11 +311,13 @@ describe("Manifest - Manifest", () => {
                                isDynamic: false,
                                isLive: false,
                                lifetime: 13,
-                               timeBounds: { absoluteMinimumTime: 0,
+                               timeBounds: { minimumSafePosition: 0,
                                              timeshiftDepth: null,
-                                             maximumTimeData: { isLinear: false,
-                                                                value: 10,
-                                                                time: 10 } },
+                                             maximumTimeData: {
+                                               isLinear: false,
+                                               maximumSafePosition: 10,
+                                               time: 10,
+                                             } },
                                contentWarnings: [new Error("a"), new Error("b")],
                                periods: [ { id: "0", start: 4, adaptations: {} },
                                           { id: "1", start: 12, adaptations: {} } ],
@@ -325,11 +337,13 @@ describe("Manifest - Manifest", () => {
                                periods: [ { id: "0", start: 4, adaptations: {} },
                                           { id: "1", start: 12, adaptations: {} } ],
                                suggestedPresentationDelay: 99,
-                               timeBounds: { absoluteMinimumTime: 0,
+                               timeBounds: { minimumSafePosition: 0,
                                              timeshiftDepth: null,
-                                             maximumTimeData: { isLinear: false,
-                                                                value: 10,
-                                                                time: 10 } },
+                                             maximumTimeData: {
+                                               isLinear: false,
+                                               maximumSafePosition: 10,
+                                               time: 10,
+                                             } },
                                uris: [] };
     const manifest2 = new Manifest(oldManifestArgs2, {});
     expect(manifest2.getUrl()).toEqual(undefined);
@@ -362,11 +376,13 @@ describe("Manifest - Manifest", () => {
                                                  new Error("b") ],
                               periods: [ { id: "0", start: 4, adaptations: {} },
                                          { id: "1", start: 12, adaptations: {} } ],
-                              timeBounds: { absoluteMinimumTime: 7,
+                              timeBounds: { minimumSafePosition: 7,
                                             timeshiftDepth: 10,
-                                            maximumTimeData: { isLinear: true,
-                                                               value: 30,
-                                                               time: 30000 } },
+                                            maximumTimeData: {
+                                              isLinear: true,
+                                              maximumSafePosition: 30,
+                                              time: 30000,
+                                            } },
                               suggestedPresentationDelay: 99,
                               uris: ["url1", "url2"] };
 
@@ -389,11 +405,13 @@ describe("Manifest - Manifest", () => {
                           contentWarnings: [new Error("c"), new Error("d")],
                           suggestedPresentationDelay: 100,
                           timeShiftBufferDepth: 3,
-                          _timeBounds: { absoluteMinimumTime: 7,
+                          _timeBounds: { minimumSafePosition: 7,
                                          timeshiftDepth: 5,
-                                         maximumTimeData: { isLinear: false,
-                                                            value: 40,
-                                                            time: 30000 } },
+                                         maximumTimeData: {
+                                           isLinear: false,
+                                           maximumSafePosition: 40,
+                                           time: 30000,
+                                         } },
                           periods: [newPeriod1, newPeriod2],
                           uris: ["url3", "url4"] };
 
@@ -405,8 +423,8 @@ describe("Manifest - Manifest", () => {
     expect(manifest.isLive).toEqual(true);
     expect(manifest.lifetime).toEqual(14);
     expect(manifest.contentWarnings).toEqual([new Error("c"), new Error("d")]);
-    expect(manifest.getMinimumPosition()).toEqual(40 - 5);
-    expect(manifest.getMaximumPosition()).toEqual(40);
+    expect(manifest.getMinimumSafePosition()).toEqual(40 - 5);
+    expect(manifest.getMaximumSafePosition()).toEqual(40);
     expect(manifest.suggestedPresentationDelay).toEqual(100);
     expect(manifest.uris).toEqual(["url3", "url4"]);
 
@@ -431,11 +449,13 @@ describe("Manifest - Manifest", () => {
                               isDynamic: false,
                               isLive: false,
                               lifetime: 13,
-                              timeBounds: { absoluteMinimumTime: 0,
+                              timeBounds: { minimumSafePosition: 0,
                                             timeshiftDepth: null,
-                                            maximumTimeData: { isLinear: false,
-                                                               value: 10,
-                                                               time: 10 } },
+                                            maximumTimeData: {
+                                              isLinear: false,
+                                              maximumSafePosition: 10,
+                                              time: 10,
+                                            } },
                               contentWarnings: [new Error("a"), new Error("b")],
                               periods: [{ id: "1", start: 4, adaptations: {} }],
                               suggestedPresentationDelay: 99,
@@ -493,10 +513,10 @@ describe("Manifest - Manifest", () => {
                           periods: [ newPeriod1,
                                      newPeriod2,
                                      newPeriod3 ],
-                          timeBounds: { absoluteMinimumTime: 0,
+                          timeBounds: { minimumSafePosition: 0,
                                         timeshiftDepth: null,
                                         maximumTimeData: { isLinear: false,
-                                                           value: 10,
+                                                           maximumSafePosition: 10,
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
@@ -528,11 +548,13 @@ describe("Manifest - Manifest", () => {
                               contentWarnings: [new Error("a"), new Error("b")],
                               periods: [{ id: "1" }],
                               suggestedPresentationDelay: 99,
-                              timeBounds: { absoluteMinimumTime: 0,
+                              timeBounds: { minimumSafePosition: 0,
                                             timeshiftDepth: null,
-                                            maximumTimeData: { isLinear: false,
-                                                               value: 10,
-                                                               time: 10 } },
+                                            maximumTimeData: {
+                                              isLinear: false,
+                                              maximumSafePosition: 10,
+                                              time: 10,
+                                            } },
                               uris: ["url1", "url2"] };
 
     const fakePeriod = jest.fn((period) => {
@@ -570,10 +592,10 @@ describe("Manifest - Manifest", () => {
                           contentWarnings: [new Error("c"), new Error("d")],
                           suggestedPresentationDelay: 100,
                           periods: [newPeriod1, newPeriod2, newPeriod3],
-                          timeBounds: { absoluteMinimumTime: 0,
+                          timeBounds: { minimumSafePosition: 0,
                                         timeshiftDepth: null,
                                         maximumTimeData: { isLinear: false,
-                                                           value: 10,
+                                                           maximumSafePosition: 10,
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
@@ -603,11 +625,13 @@ describe("Manifest - Manifest", () => {
                               contentWarnings: [new Error("a"), new Error("b")],
                               periods: [{ id: "1" }],
                               suggestedPresentationDelay: 99,
-                              timeBounds: { absoluteMinimumTime: 0,
+                              timeBounds: { minimumSafePosition: 0,
                                             timeshiftDepth: null,
-                                            maximumTimeData: { isLinear: false,
-                                                               value: 10,
-                                                               time: 10 } },
+                                            maximumTimeData: {
+                                              isLinear: false,
+                                              maximumSafePosition: 10,
+                                              time: 10,
+                                            } },
                               uris: ["url1", "url2"] };
 
     const fakePeriod = jest.fn((period) => {
@@ -644,10 +668,10 @@ describe("Manifest - Manifest", () => {
                           contentWarnings: [new Error("c"), new Error("d")],
                           suggestedPresentationDelay: 100,
                           periods: [newPeriod1, newPeriod2, newPeriod3],
-                          timeBounds: { absoluteMinimumTime: 0,
+                          timeBounds: { minimumSafePosition: 0,
                                         timeshiftDepth: null,
                                         maximumTimeData: { isLinear: false,
-                                                           value: 10,
+                                                           maximumSafePosition: 10,
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 
@@ -675,11 +699,13 @@ describe("Manifest - Manifest", () => {
                               periods: [{ id: "1", start: 2 },
                                         { id: "2", start: 4 },
                                         { id: "3", start: 6 }],
-                              timeBounds: { absoluteMinimumTime: 0,
+                              timeBounds: { minimumSafePosition: 0,
                                             timeshiftDepth: null,
-                                            maximumTimeData: { isLinear: false,
-                                                               value: 10,
-                                                               time: 10 } },
+                                            maximumTimeData: {
+                                              isLinear: false,
+                                              maximumSafePosition: 10,
+                                              time: 10,
+                                            } },
                               suggestedPresentationDelay: 99,
                               uris: ["url1", "url2"] };
 
@@ -725,10 +751,10 @@ describe("Manifest - Manifest", () => {
                                      newPeriod3,
                                      newPeriod4,
                                      newPeriod5 ],
-                          timeBounds: { absoluteMinimumTime: 0,
+                          timeBounds: { minimumSafePosition: 0,
                                         timeshiftDepth: null,
                                         maximumTimeData: { isLinear: false,
-                                                           value: 10,
+                                                           maximumSafePosition: 10,
                                                            time: 10 } },
                           uris: ["url3", "url4"] };
 

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -479,10 +479,11 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   }
 
   /**
+   * XXX TODO better comment
    * Get the minimum position currently defined by the Manifest, in seconds.
    * @returns {number}
    */
-  public getMinimumPosition() : number {
+  public getMinimumSafePosition() : number {
     const windowData = this._timeBounds;
     if (windowData.timeshiftDepth === null) {
       return windowData.minimumSafePosition ?? 0;
@@ -518,10 +519,11 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
   }
 
   /**
+   * XXX TODO better comment
    * Get the maximum position currently defined by the Manifest, in seconds.
    * @returns {number}
    */
-  public getMaximumPosition() : number {
+  public getMaximumSafePosition() : number {
     const { maximumTimeData } = this._timeBounds;
     if (!maximumTimeData.isLinear) {
       return maximumTimeData.maximumSafePosition;
@@ -727,7 +729,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
       // Partial updates do not remove old Periods.
       // This can become a memory problem when playing a content long enough.
       // Let's clean manually Periods behind the minimum possible position.
-      const min = this.getMinimumPosition();
+      const min = this.getMinimumSafePosition();
       while (this.periods.length > 0) {
         const period = this.periods[0];
         if (period.end === undefined || period.end > min) {

--- a/src/manifest/representation_index/types.ts
+++ b/src/manifest/representation_index/types.ts
@@ -268,10 +268,15 @@ export interface IRepresentationIndex {
   getFirstPosition() : number | null | undefined;
 
   /**
-   * Returns the ending time, in seconds, of the last segment currently
-   * available in this index.
+   * Returns the ending time, in seconds, of the last playable position
+   * currently available in this index.
    * Returns `null` if nothing is in the index
    * Returns `undefined` if we cannot know this value.
+   *
+   * The last playable position is generally equivalent to the end of the last
+   * segment associated to this index, excepted when it goes over the end limit
+   * of the corresponding `Period`, in which case it will be equal to this end
+   * instead.
    * @returns {Number|null|undefined}
    */
   getLastPosition() : number | null | undefined;

--- a/src/parsers/manifest/dash/common/get_minimum_and_maximum_positions.ts
+++ b/src/parsers/manifest/dash/common/get_minimum_and_maximum_positions.ts
@@ -15,20 +15,25 @@
  */
 
 import { IParsedPeriod } from "../../types";
-import getMaximumPosition from "../../utils/get_maximum_position";
+import getMaximumPositions from "../../utils/get_maximum_positions";
 import getMinimumPosition from "../../utils/get_minimum_position";
 
 /**
  * @param {Object} periods
  * @returns {Array.<number>}
  */
-export default function getMinimumAndMaximumPosition(
+export default function getMinimumAndMaximumPositions(
   periods: IParsedPeriod[]
-) : [number|undefined, number|undefined] {
+) : { minimumSafePosition : number | undefined;
+      maximumSafePosition : number | undefined;
+      maximumUnsafePosition : number | undefined; } {
   if (periods.length === 0) {
     throw new Error("DASH Parser: no period available for a dynamic content");
   }
 
-  return [ getMinimumPosition(periods),
-           getMaximumPosition(periods) ];
+  const minimumSafePosition = getMinimumPosition(periods);
+  const maxPositions = getMaximumPositions(periods);
+  return { minimumSafePosition,
+           maximumSafePosition: maxPositions.safe,
+           maximumUnsafePosition: maxPositions.unsafe };
 }

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -61,10 +61,11 @@ export default function parseLocalManifest(
            isLastPeriodKnown: isFinished,
            isLive: false,
            uris: [],
-           timeBounds: { absoluteMinimumTime: minimumPosition ?? 0,
+           timeBounds: { minimumSafePosition: minimumPosition ?? 0,
                          timeshiftDepth: null,
                          maximumTimeData: { isLinear: false,
-                                            value: maximumPosition,
+                                            maximumSafePosition: maximumPosition,
+                                            livePosition: undefined,
                                             time: performance.now() } },
            periods: parsedPeriods };
 }

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -308,11 +308,16 @@ function createManifest(
                      isLastPeriodKnown,
                      uris: url == null ? [] :
                                          [url],
-                     timeBounds: { minimumTime,
+
+                     // TODO more precize time bounds?
+                     timeBounds: { minimumSafePosition: minimumTime,
                                    timeshiftDepth: null,
-                                   maximumTimeData: { isLinear: false,
-                                                      value: maximumTime,
-                                                      time } },
+                                   maximumTimeData: {
+                                     isLinear: false,
+                                     maximumSafePosition: maximumTime,
+                                     livePosition: undefined,
+                                     time,
+                                   } },
                      lifetime: mplData.pollInterval };
 
   return manifest;

--- a/src/parsers/manifest/utils/get_maximum_positions.ts
+++ b/src/parsers/manifest/utils/get_maximum_positions.ts
@@ -24,7 +24,9 @@ import getLastPositionFromAdaptation from "./get_last_time_from_adaptation";
  */
 export default function getMaximumPosition(
   periods : IParsedPeriod[]
-) : number | undefined {
+) : { safe : number | undefined;
+      unsafe : number | undefined; }
+{
   for (let i = periods.length - 1; i >= 0; i--) {
     const periodAdaptations = periods[i].adaptations;
     const firstAudioAdaptationFromPeriod = periodAdaptations.audio === undefined ?
@@ -44,7 +46,7 @@ export default function getMaximumPosition(
         const lastPosition =
           getLastPositionFromAdaptation(firstAudioAdaptationFromPeriod);
         if (lastPosition === undefined) {
-          return undefined;
+          return { safe: undefined, unsafe: undefined };
         }
         maximumAudioPosition = lastPosition;
       }
@@ -52,7 +54,7 @@ export default function getMaximumPosition(
         const lastPosition =
           getLastPositionFromAdaptation(firstVideoAdaptationFromPeriod);
         if (lastPosition === undefined) {
-          return undefined;
+          return { safe: undefined, unsafe: undefined };
         }
         maximumVideoPosition = lastPosition;
       }
@@ -64,18 +66,22 @@ export default function getMaximumPosition(
       ) {
         log.info("Parser utils: found Period with no segment. ",
                  "Going to previous one to calculate last position");
-        return undefined;
+        return { safe: undefined, unsafe: undefined };
       }
 
       if (maximumVideoPosition !== null) {
         if (maximumAudioPosition !== null) {
-          return Math.min(maximumAudioPosition, maximumVideoPosition);
+          return { safe: Math.min(maximumAudioPosition, maximumVideoPosition),
+                   unsafe: Math.max(maximumAudioPosition, maximumVideoPosition) };
         }
-        return maximumVideoPosition;
+        return { safe: maximumVideoPosition,
+                 unsafe: maximumVideoPosition };
       }
       if (maximumAudioPosition !== null) {
-        return maximumAudioPosition;
+        return { safe: maximumAudioPosition,
+                 unsafe: maximumAudioPosition };
       }
     }
   }
+  return { safe: undefined, unsafe: undefined };
 }

--- a/tests/integration/scenarios/video_thumbnail_loader.js
+++ b/tests/integration/scenarios/video_thumbnail_loader.js
@@ -73,7 +73,7 @@ describe("Video Thumbnail Loader", () => {
     let error;
     try {
       time = await videoThumbnailLoader
-        .setTime(manifest.getMaximumPosition() + 10);
+        .setTime(manifest.getMaximumSafePosition() + 10);
     } catch (err) {
       error = err;
     }

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -205,8 +205,8 @@ export default function launchTestsForContent(manifestInfos) {
         expect(manifest.isLive).to.equal(isLive);
         expect(manifest.getUrl()).to.equal(manifestInfos.url);
 
-        expect(manifest.getMaximumPosition()).to.equal(maximumPosition);
-        expect(manifest.getMinimumPosition()).to.equal(minimumPosition);
+        expect(manifest.getMaximumSafePosition()).to.equal(maximumPosition);
+        expect(manifest.getMinimumSafePosition()).to.equal(minimumPosition);
         expect(manifest.availabilityStartTime).to.equal(availabilityStartTime);
 
         expect(manifest.periods.length).to.equal(periodsInfos.length);


### PR DESCRIPTION
This commit continues our efforts to improve on the RxPlayer management of the maximum position.
The idea here is to divide the previously-ambiguous `maximumPosition` notion to two separate values:

  - `maximumSafePosition`: which is the maximum playable position regardless of the currently chosen Adaptation (track)
     It is basically the last position on which we're sure to have
     content in every audio and video tracks.

  - `livePosition`: which should be set to the edge of what is being broadcasted.
    Right now in DASH, it is just set to the maximum position that can be reached in the various audio and video Adaptations.

    It can be set to `undefined` for non-live contents.

This way instead of just relying on a vague `maximumPosition` to perform very diverse operations such as calculating the distance to the live edge, setting the content's duration, sending warnings when the current position is over it and so on, we can instead use the more explicit value of the two in function of what we want to do.