### PR TITLE
Add support for percent based thickness for textOutline in TTML Subtitles

### DIFF
--- a/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
+++ b/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
@@ -30,14 +30,16 @@ export default function generateCSSTextOutline(
   color : string,
   thickness : string|number
 ) : string {
-  if (isNonEmptyString(thickness) && thickness.trim().endsWith("%")){
-    // As em and % are basically equivalent in CSS ( they both are relative to the parent )
-    //  we converted the non supported % into the supported em
-    thickness = thickness.trim().slice(0,-1)
-    thickness = (parseInt(thickness)/100).toString() + "em"
+  let thick = thickness;
+  if (isNonEmptyString(thickness) && thickness.trim().endsWith("%")) {
+    // As em and % are basically equivalent in CSS
+    // (they both are relative to the parent)
+    // We convert the non supported % into the supported em
+    thick = thickness.trim().slice(0, -1);
+    thick = (parseInt(thick, 10) / 100).toString() + "em";
   }
-  return `-1px -1px ${thickness} ${color},` +
-         `1px -1px ${thickness} ${color},` +
-         `-1px 1px ${thickness} ${color},` +
-         `1px 1px ${thickness} ${color}`;
+  return `-1px -1px ${thick} ${color},` +
+         `1px -1px ${thick} ${color},` +
+         `-1px 1px ${thick} ${color},` +
+         `1px 1px ${thick} ${color}`;
 }

--- a/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
+++ b/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import isNonEmptyString from "../../../../utils/is_non_empty_string";
+
 /**
  * Try to replicate the textOutline TTML style property into CSS.
  *
@@ -28,6 +30,12 @@ export default function generateCSSTextOutline(
   color : string,
   thickness : string|number
 ) : string {
+  if (isNonEmptyString(thickness) && thickness.trim().endsWith("%")){
+    // As em and % are basically equivalent in CSS ( they both are relative to the parent )
+    //  we converted the non supported % into the supported em
+    thickness = thickness.trim().slice(0,-1)
+    thickness = (parseInt(thickness)/100).toString() + "em"
+  }
   return `-1px -1px ${thickness} ${color},` +
          `1px -1px ${thickness} ${color},` +
          `-1px 1px ${thickness} ${color},` +

--- a/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
+++ b/src/parsers/texttracks/ttml/html/generate_css_test_outline.ts
@@ -33,7 +33,8 @@ export default function generateCSSTextOutline(
   let thick = thickness;
   if (isNonEmptyString(thickness) && thickness.trim().endsWith("%")) {
     // As em and % are basically equivalent in CSS
-    // (they both are relative to the parent)
+    // (they both are relative to the font-size 
+    // of the current element)
     // We convert the non supported % into the supported em
     thick = thickness.trim().slice(0, -1);
     thick = (parseInt(thick, 10) / 100).toString() + "em";


### PR DESCRIPTION
We mock the `textOutline` property in TTML Subtitles through the CSS `textShadow` property.
We try to preserve as many values as possible but the issue arise when we set a thickness based on percent ( which is allowed in TTML ) for the `textOutline`, but percent based values are not allowed in the t`extShadow `property

The solution is to convert the percent into `em` which are basically equivalent as both are relative to the current element's font size