### PR TITLE
Avoid infinite loop due to rounding errors while parsing multi-Periods MPDs

### DIFF
--- a/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
+++ b/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
@@ -62,7 +62,16 @@ export default function flattenOverlappingPeriods(
                parsedPeriod.start);
       lastFlattenedPeriod.duration = parsedPeriod.start - lastFlattenedPeriod.start;
       lastFlattenedPeriod.end = parsedPeriod.start;
-      if (lastFlattenedPeriod.duration <= 0) {
+      if (lastFlattenedPeriod.duration > 0) {
+        // Note: Calling `break` to quit the while loop should theoritically be
+        // unnecessary as the previous operations should ensure we do not re-enter
+        // the loop's condition.
+        // Yet we dit encounter infinite loops without it because of float-related
+        // rounding errors.
+        break;
+      } else {
+        // `lastFlattenedPeriod` has now a negative or `0` duration.
+        // Remove it, consider the next Period in its place, and re-start the loop.
         flattenedPeriods.pop();
         lastFlattenedPeriod = flattenedPeriods[flattenedPeriods.length - 1];
       }


### PR DESCRIPTION
Fixes #1110.

This PR fixes an infinite loop that could occur on multi-Period MPDs due to a rounding error linked to floating-point operations.

This issue was very easy to work-around because one of the two inner branches of that loop actually always led to a loop exit (because it would always break the loop's condition - though here it didn't due to that damned rounding error).

Explicitly writing a `break` instruction when that branch is taken is thus here a quick and easy fix, though it may not be the most elegant way of dealing with it (if you have more simple and idiomatic ways, I'll change to it).

I also added comments and inverted the inner conditions, in the hope I made what that function is doing clearer.