### PR TITLE
HTMLMediaElement's related error have now the initial message if it exists

### DIFF
--- a/src/core/init/throw_on_media_error.ts
+++ b/src/core/init/throw_on_media_error.ts
@@ -20,6 +20,7 @@ import {
   Observable,
 } from "rxjs";
 import { MediaError } from "../../errors";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 
 /**
  * Returns an observable which throws the right MediaError as soon an "error"
@@ -32,27 +33,36 @@ export default function throwOnMediaError(
 ) : Observable<never> {
   return observableFromEvent(mediaElement, "error")
     .pipe(mergeMap(() => {
-      const errorCode = mediaElement.error == null ? 0 :
-                                                    mediaElement.error.code;
+      const mediaError = mediaElement.error;
+      let errorCode : number | undefined;
+      let errorMessage : string | undefined;
+      if (!isNullOrUndefined(mediaError)) {
+        errorCode = mediaError.code;
+        errorMessage = mediaError.message;
+      }
+
       switch (errorCode) {
         case 1:
-          throw new MediaError("MEDIA_ERR_ABORTED",
-                               "The fetching of the associated resource was aborted " +
-                               "by the user's request.");
+          errorMessage = errorMessage ??
+            "The fetching of the associated resource was aborted by the user's request.";
+          throw new MediaError("MEDIA_ERR_ABORTED", errorMessage);
         case 2:
-          throw new MediaError("MEDIA_ERR_NETWORK",
-                               "A network error occurred which prevented the media " +
-                               "from being successfully fetched");
+          errorMessage = errorMessage ??
+            "A network error occurred which prevented the media from being " +
+            "successfully fetched";
+          throw new MediaError("MEDIA_ERR_NETWORK", errorMessage);
         case 3:
-          throw new MediaError("MEDIA_ERR_DECODE",
-                               "An error occurred while trying to decode the media " +
-                               "resource");
+          errorMessage = errorMessage ??
+            "An error occurred while trying to decode the media resource";
+          throw new MediaError("MEDIA_ERR_DECODE", errorMessage);
         case 4:
-          throw new MediaError("MEDIA_ERR_SRC_NOT_SUPPORTED",
-                               "The media resource has been found to be unsuitable.");
+          errorMessage = errorMessage ??
+            "The media resource has been found to be unsuitable.";
+          throw new MediaError("MEDIA_ERR_SRC_NOT_SUPPORTED", errorMessage);
         default:
-          throw new MediaError("MEDIA_ERR_UNKNOWN",
-                               "The HTMLMediaElement errored due to an unknown reason.");
+          errorMessage = errorMessage ??
+            "The HTMLMediaElement errored due to an unknown reason.";
+          throw new MediaError("MEDIA_ERR_UNKNOWN", errorMessage);
       }
     }));
 }


### PR DESCRIPTION
I was very shamefully not aware that `MediaError`s as emitted by HTMLMediaElement could have a `message` property describing the actual problem.

For my defense, this was not always the case for MediaErrors (I found some w3c and chromium issue reports to prove it!).
Yet it apparently is since 2017, so my defense is still pretty weak.

Relying on those could definitely have saved us many hours of debugging over the years, where we were trying to find which segment of which type provoked a MEDIA_ERR_DECODE and why.

Anyway, I prefer not to think to much about it, here it is, and now it's available: the corresponding error message will actually be the message of the corresponding `RxPlayer`'s `MediaError`'s message (yes, both the native browser error and the RxPlayer supplementary layer have the exact same name, and no, it cannot be a source of confusion at all, why would you say that?).