### PR TITLE
DASH: Fix potential infinite rebuffering when a KID is not anounced in the MPD

### DIFF
--- a/src/core/decrypt/content_decryptor.ts
+++ b/src/core/decrypt/content_decryptor.ts
@@ -780,16 +780,18 @@ function updateDecipherability(
       return representation.decipherable;
     }
     const contentKIDs = representation.contentProtections.keyIds;
-    for (let i = 0; i < contentKIDs.length; i++) {
-      const elt = contentKIDs[i];
-      for (let j = 0; j < blacklistedKeyIDs.length; j++) {
-        if (areKeyIdsEqual(blacklistedKeyIDs[j], elt.keyId)) {
-          return false;
+    if (contentKIDs !== undefined) {
+      for (let i = 0; i < contentKIDs.length; i++) {
+        const elt = contentKIDs[i];
+        for (let j = 0; j < blacklistedKeyIDs.length; j++) {
+          if (areKeyIdsEqual(blacklistedKeyIDs[j], elt.keyId)) {
+            return false;
+          }
         }
-      }
-      for (let j = 0; j < whitelistedKeyIds.length; j++) {
-        if (areKeyIdsEqual(whitelistedKeyIds[j], elt.keyId)) {
-          return true;
+        for (let j = 0; j < whitelistedKeyIds.length; j++) {
+          if (areKeyIdsEqual(whitelistedKeyIds[j], elt.keyId)) {
+            return true;
+          }
         }
       }
     }
@@ -1157,7 +1159,7 @@ function addKeyIdsFromPeriod(
   for (const adaptation of period.getAdaptations()) {
     for (const representation of adaptation.representations) {
       if (representation.contentProtections !== undefined &&
-          representation.contentProtections.keyIds.length >= - 1)
+          representation.contentProtections.keyIds !== undefined)
       {
         for (const kidInf of representation.contentProtections.keyIds) {
           set.add(kidInf.keyId);

--- a/src/core/decrypt/utils/key_session_record.ts
+++ b/src/core/decrypt/utils/key_session_record.ts
@@ -144,7 +144,7 @@ export default class KeySessionRecord {
     initializationData : IProcessedProtectionData
   ) : boolean {
     const { keyIds } = initializationData;
-    if (keyIds !== undefined) {
+    if (keyIds !== undefined && keyIds.length > 0) {
       if (this._keyIds !== null && areAllKeyIdsContainedIn(keyIds, this._keyIds)) {
         return true;
       }
@@ -159,6 +159,7 @@ export default class KeySessionRecord {
     initializationData : IProcessedProtectionData
   ) : boolean {
     if (initializationData.keyIds !== undefined &&
+        initializationData.keyIds.length > 0 &&
         this._initializationData.keyIds !== undefined)
     {
       return areAllKeyIdsContainedIn(initializationData.keyIds,

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -174,7 +174,7 @@ class Representation {
       for (let j = 0; j < initData.values.length; j++) {
         if (initData.values[j].systemId.toLowerCase() === drmSystemId.toLowerCase()) {
           if (!createdObjForType) {
-            const keyIds = this.contentProtections?.keyIds.map(val => val.keyId);
+            const keyIds = this.contentProtections?.keyIds?.map(val => val.keyId);
             filtered.push({ type: initData.type,
                             keyIds,
                             values: [initData.values[j]] });
@@ -221,7 +221,7 @@ class Representation {
     {
       return [];
     }
-    const keyIds = this.contentProtections?.keyIds.map(val => val.keyId);
+    const keyIds = this.contentProtections?.keyIds?.map(val => val.keyId);
     return this.contentProtections.initData.map((x) => {
       return { type: x.type,
                keyIds,

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -225,7 +225,12 @@ export default function parseRepresentations(
               .toLowerCase();
           }
           if (cp.attributes.keyId !== undefined && cp.attributes.keyId.length > 0) {
-            acc.keyIds.push({ keyId: cp.attributes.keyId, systemId });
+            const kidObj = { keyId: cp.attributes.keyId, systemId };
+            if (acc.keyIds === undefined) {
+              acc.keyIds = [kidObj];
+            } else {
+              acc.keyIds.push(kidObj);
+            }
           }
           if (systemId !== undefined) {
             const { cencPssh } = cp.children;
@@ -244,9 +249,10 @@ export default function parseRepresentations(
             }
           }
           return acc;
-        }, { keyIds: [], initData: [] });
+        }, { keyIds: undefined, initData: [] });
       if (Object.keys(contentProtections.initData).length > 0 ||
-          contentProtections.keyIds.length > 0)
+          (contentProtections.keyIds !== undefined &&
+            contentProtections.keyIds.length > 0))
       {
         parsedRepresentation.contentProtections = contentProtections;
       }

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -69,8 +69,13 @@ export interface IContentProtectionInitData {
  */
 /** Describes every encryption protection parsed for a given media. */
 export interface IContentProtections {
-  /** The different encryption key IDs associated with that content. */
-  keyIds : IContentProtectionKID[];
+  /**
+   * The different encryption key IDs associated with that content.
+   *
+   * `undefined` if the key id(s) associated with that content may exist but are
+   * not known.
+   */
+  keyIds : IContentProtectionKID[] | undefined;
   /** The different encryption initialization data associated with that content. */
   initData : IContentProtectionInitData[];
 }


### PR DESCRIPTION
We introduced a regression in the v3.27.0 which can lead to infinite rebuffering/loading when playing MPD which do not anounce the key ids in a `@cenc:default_KID` attribute (which seems to be required by the DASH-IF IOP? That's why I understand from Chapter 7.6.2.1 of the v4.3, though I'm unsure and we chose to be resilient anyway).

Basically the source of the error is a difference in semantics between what our MPD parser parses and what the `ContentDecryptor` takes in input to trigger the whole decryption logic.

Especially, the difference is how the `keyIds` property, defined in both places is defined:

  - for the parser, it is the array of just the "key IDs associated with that content" and is always set as long as the content is encrypted.

  - for the `ContentDecryptor`, it's much more precize: it is the "key ids linked to [some] initialization data" - and more importantly:
    it is **"`undefined` when not known (different from an empty array - which would just mean that there's no key id involved)."**

So here, the parser is setting an empty array which means for it: "I don't know".
Yet the `ContentDecryptor` receives that same information and it understands: "There's no such concept of key id in there".

---

To fix that situation, I chose what I think is the more compatible (less error-prone) solution: to make it `undefined` by default and handle the empty array as an ambiguous case in the `ContentDecryptor`.

I first added the possibility on the manifest parser-side of defining an `undefined` `keyIds`, which would mean: "the key id(s) associated with that content may exist but are not known" while the `ContentDecryptor`'s definition doesn't change.

I also updated the MPD parser so it is always `undefined` if we didn't find one in the MPD. This should prevent most `keyIds` array from being empty (with the exception of offline "local" contents which may still be).

Moreover, parts of the `ContentDecryptor` that made comparison of key ids - mostly to check if a key id was already handled - now treat the empty array as if its key ids are ambiguous: a Representation with an empty `keyIds` array will never be assumed to already have been handled for example, only that "we don't know if it has been handled or not just based on its key id".

Thankfully, the `ContentDecryptor` is then generally resilient when it cannot use key IDs and just rely on the whole initialization data instead.