### PR TITLE
[Proposal] The demo page now uses the Minimal RxPlayer (and optionally the WASM MPD parser)

### DIFF
--- a/demo/full/mpd-parser.wasm
+++ b/demo/full/mpd-parser.wasm
@@ -1,0 +1,1 @@
+../../dist/mpd-parser.wasm

--- a/demo/full/scripts/controllers/Main.jsx
+++ b/demo/full/scripts/controllers/Main.jsx
@@ -1,4 +1,4 @@
-import RxPlayer from "../../../../src/index.ts";
+import RxPlayer from "../../../../src/minimal.ts";
 import React from "react";
 import Player from "./Player.jsx";
 

--- a/demo/full/scripts/modules/player/index.js
+++ b/demo/full/scripts/modules/player/index.js
@@ -10,12 +10,52 @@ import {
   Subject,
   takeUntil,
 } from "rxjs";
-import RxPlayer from "../../../../../src/index.ts";
+import {
+  BIF_PARSER,
+  DASH,
+  DIRECTFILE,
+  EME,
+  HTML_SAMI_PARSER,
+  HTML_SRT_PARSER,
+  HTML_TEXT_BUFFER,
+  HTML_TTML_PARSER,
+  HTML_VTT_PARSER,
+  IMAGE_BUFFER,
+  SMOOTH,
+} from "../../../../../src/features/list";
+import {
+  DASH_WASM,
+  METAPLAYLIST,
+} from "../../../../../src/experimental/features";
+import RxPlayer from "../../../../../src/minimal.ts";
 import { linkPlayerEventsToState } from "./events.js";
 import $handleCatchUpMode from "./catchUp";
 import VideoThumbnailLoader, {
   DASH_LOADER
 } from "../../../../../src/experimental/tools/VideoThumbnailLoader";
+
+RxPlayer.addFeatures([
+  BIF_PARSER,
+  DASH,
+  DIRECTFILE,
+  EME,
+  HTML_SAMI_PARSER,
+  HTML_SRT_PARSER,
+  HTML_TEXT_BUFFER,
+  HTML_TTML_PARSER,
+  HTML_VTT_PARSER,
+  IMAGE_BUFFER,
+  SMOOTH,
+  METAPLAYLIST,
+]);
+
+/* eslint-disable no-undef */
+if (__INCLUDE_WASM_PARSER__) {
+/* eslint-enable no-undef */
+
+  RxPlayer.addFeatures([DASH_WASM]);
+  DASH_WASM.initialize({ wasmUrl: "./mpd-parser.wasm" });
+}
 
 VideoThumbnailLoader.addLoader(DASH_LOADER);
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
     "prepublishOnly": "npm run build:modular",
     "standalone": "node ./scripts/run_standalone_demo.js",
     "start": "node ./scripts/start_demo_web_server.js",
+    "start:wasm": "node ./scripts/start_demo_web_server.js --include-wasm",
     "s": "node ./scripts/start_demo_web_server.js --fast",
+    "s:wasm": "node ./scripts/start_demo_web_server.js --fast --include-wasm",
     "wasm-strip": "node scripts/wasm-strip.js dist/mpd-parser.wasm",
     "test:appveyor": "npm run test:unit && npm run test:memory",
     "test:integration": "node tests/integration/run.js --bchromehl --bfirefoxhl",
@@ -133,7 +135,9 @@
   "scripts-list": {
     "Build a demo page (e.g. to test a code change)": {
       "start": "Build the \"full\" demo (with a UI) with the non-minified RxPlayer and serve it on a local server. Re-build on file updates.",
+      "start:wasm": "Build the \"full\" demo (with a UI) with the non-minified RxPlayer including the DASH WebAssembly MPD parser and serve it on a local server. Re-build on file updates.",
       "s": "Very fast version of `start` which does not perform type-checking. This script can be useful for quick testing",
+      "s:wasm": "Very fast version of `start:wasm` which does not perform type-checking. This script can be useful for quick testing",
       "demo": "Build the demo in demo/bundle.js",
       "demo:min": "Build the demo and minify it in demo/bundle.js",
       "demo:watch": "Build the demo in demo/bundle.js each times the files update.",

--- a/scripts/fast_demo_build.js
+++ b/scripts/fast_demo_build.js
@@ -24,9 +24,11 @@ if (require.main === module) {
   const shouldWatch = argv.includes("-w") || argv.includes("--watch");
   const shouldMinify = argv.includes("-m") || argv.includes("--minify");
   const production = argv.includes("-p") || argv.includes("--production-mode");
+  const includeWasmParser = argv.includes("--include-wasm");
   fastDemoBuild({
     watch: shouldWatch,
     minify: shouldMinify,
+    includeWasmParser,
     production,
   });
 } else {
@@ -42,11 +44,14 @@ if (require.main === module) {
  * in "development" mode, which has supplementary assertions.
  * @param {boolean} [options.watch] - If `true`, the RxPlayer's files involve
  * will be watched and the code re-built each time one of them changes.
+ * @param {boolean} [options.includeWasmParser] - If `true`, the WebAssembly MPD
+ * parser of the RxPlayer will be used (if it can be requested).
  */
 function fastDemoBuild(options) {
   const minify = !!options.minify;
   const watch = !!options.watch;
   const isDevMode = !options.production;
+  const includeWasmParser = !!options.includeWasmParser;
   let beforeTime = process.hrtime.bigint();
 
   esbuild.build({
@@ -74,33 +79,14 @@ function fastDemoBuild(options) {
     },
     define: {
       "process.env.NODE_ENV": JSON.stringify(isDevMode ? "development" : "production"),
-      __FEATURES__: JSON.stringify({
-        IS_DISABLED: 0,
-        IS_ENABLED: 1,
-
-        BIF_PARSER: 1,
-        DASH: 1,
-        DIRECTFILE: 1,
-        EME: 1,
-        HTML_SAMI: 1,
-        HTML_SRT: 1,
-        HTML_TTML: 1,
-        HTML_VTT: 1,
-        LOCAL_MANIFEST: 1,
-        METAPLAYLIST: 1,
-        NATIVE_SAMI: 1,
-        NATIVE_SRT: 1,
-        NATIVE_TTML: 1,
-        NATIVE_VTT: 1,
-        SMOOTH: 1,
-      }),
+      __INCLUDE_WASM_PARSER__: includeWasmParser,
       __ENVIRONMENT__: JSON.stringify({
         PRODUCTION: 0,
         DEV: 1,
         CURRENT_ENV: isDevMode ? 1 : 0,
       }),
       __LOGGER_LEVEL__: JSON.stringify({
-        CURRENT_LEVEL: "INFO",
+        CURRENT_LEVEL: isDevMode ? "DEBUG" : "INFO",
       }),
     }
   }).then(

--- a/scripts/generate_full_demo.js
+++ b/scripts/generate_full_demo.js
@@ -30,10 +30,12 @@ if (require.main === module) {
   const shouldWatch = argv.includes("-w") || argv.includes("--watch");
   const shouldMinify = argv.includes("-m") || argv.includes("--minify");
   const production = argv.includes("-p") || argv.includes("--production-mode");
+  const includeWasmParser = argv.includes("--include-wasm");
   generateFullDemo({
     watch: shouldWatch,
     minify: shouldMinify,
     production,
+    includeWasmParser,
   });
 } else {
   // This script is loaded as a module
@@ -48,10 +50,13 @@ if (require.main === module) {
  * in "development" mode, which has supplementary assertions.
  * @param {boolean} [options.watch] - If `true`, the RxPlayer's files involve
  * will be watched and the code re-built each time one of them changes.
+ * @param {boolean} [options.includeWasmParser] - If `true`, the WebAssembly MPD
+ * parser of the RxPlayer will be used (if it can be requested).
  */
 function generateFullDemo(options) {
   const shouldMinify = options.minify === true;
   const isDevMode = options.production !== true;
+  const includeWasmParser = options.includeWasmParser === true;
 
   const webpackDemoConfig = {
     mode: isDevMode ? "development" : "production",
@@ -101,33 +106,14 @@ function generateFullDemo(options) {
     },
     plugins: [
       new Webpack.DefinePlugin({
-        __FEATURES__: {
-          IS_DISABLED: 0,
-          IS_ENABLED: 1,
-
-          BIF_PARSER: 1,
-          DASH: 1,
-          DIRECTFILE: 1,
-          EME: 1,
-          HTML_SAMI: 1,
-          HTML_SRT: 1,
-          HTML_TTML: 1,
-          HTML_VTT: 1,
-          LOCAL_MANIFEST: 1,
-          METAPLAYLIST: 1,
-          NATIVE_SAMI: 1,
-          NATIVE_SRT: 1,
-          NATIVE_TTML: 1,
-          NATIVE_VTT: 1,
-          SMOOTH: 1,
-        },
+        __INCLUDE_WASM_PARSER__: includeWasmParser,
         __ENVIRONMENT__: {
           PRODUCTION: 0,
           DEV: 1,
           CURRENT_ENV: isDevMode ? 1 : 0,
         },
         __LOGGER_LEVEL__: {
-          CURRENT_LEVEL: "\"INFO\"",
+          CURRENT_LEVEL: isDevMode ? "DEBUG" : "\"INFO\"",
         },
       }),
     ],

--- a/scripts/start_demo_web_server.js
+++ b/scripts/start_demo_web_server.js
@@ -22,14 +22,18 @@ const launchStaticServer = require("./launch_static_server");
 const shouldRunFastVersion = process.argv.includes("--fast") ||
                              process.argv.includes("-f");
 
+const includeWasmParser = process.argv.includes("--include-wasm");
+
 if (shouldRunFastVersion) {
   fastBuild({ watch: true,
               minify: false,
-              production: false });
+              production: false,
+             includeWasmParser });
 } else {
   slowBuild({ watch: true,
               minify: false,
-              production: false });
+              production: false,
+              includeWasmParser });
 }
 
 launchStaticServer(path.join(__dirname, "../demo/full/"),


### PR DESCRIPTION
This PR is a proposal to use the Minimal RxPlayer (the one with feature switching) instead of awkwardly modifying a `__FEATURES__` global to chose which feature to include while using the "main" RxPlayer exported.

As importing the minimal RxPlayer instead of the legacy default one is something we advise to all applications, I felt it wasn't coherent to not follow our own advice here!

In the future, I think that we may want to get rid of the `__FEATURES__` object altogether (we still need it now to define the wanted default feature included in our legacy builds and for tests) to simplify the code.

---

But mostly those modifications were just a [nice] side-effect of the real improvement of this PR: I added to npm scripts, `npm run start:wasm` and `npm run s:wasm` which are like respectively `npm run start` and `npm run s` except they also import the `DASH_WASM` feature (the WebAssembly-powered MPD parser), as I felt it was too inconvenient to test until now.

This also means that I didn't make it the default. Why? For now I think that checking the stability of the default JavaScript one is the most important, though testing the WebAssembly one should also be periodically done.

I wondered if we couldn't directly have a checkbox in the demo page instead, but considering that you cannot "remove" the `DASH_WASM` feature, doing this is in an understandable way is not easy.

---

Last but not least, non-prod demo builds (the ones we do ourselves when calling `npm run start`/`npm run s` and so on) will now use a `DEBUG` log level by default.

I felt that it was a more sensible setting there.