### PR TITLE
[Proposal] Consider __RX_PLAYER_DEBUG_MODE__ boolean if declared in window

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,9 @@ import logger from "./log";
 // set initial features according to environment variables
 initializeFeatures();
 
-if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
+if (typeof __RX_PLAYER_DEBUG_MODE__ === "boolean" && __RX_PLAYER_DEBUG_MODE__) {
+  logger.setLevel("DEBUG");
+} else if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
 }
 

--- a/src/minimal.ts
+++ b/src/minimal.ts
@@ -28,7 +28,9 @@ import {
 } from "./features";
 import logger from "./log";
 
-if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
+if (typeof __RX_PLAYER_DEBUG_MODE__ === "boolean" && __RX_PLAYER_DEBUG_MODE__) {
+  logger.setLevel("DEBUG");
+} else if (__ENVIRONMENT__.CURRENT_ENV === __ENVIRONMENT__.DEV as number) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
 }
 

--- a/src/typings/globals.d.ts
+++ b/src/typings/globals.d.ts
@@ -77,3 +77,4 @@ declare const __LOGGER_LEVEL__ : {
   CURRENT_LEVEL : string;
 };
 
+declare const __RX_PLAYER_DEBUG_MODE__ : boolean | undefined;


### PR DESCRIPTION
This change allows to simplify debugging sessions when either done through [RxPaired](https://github.com/peaBerberian/RxPaired) (once https://github.com/peaBerberian/RxPaired/pull/1 is merged) or any other tool by just setting `window.__RX_PLAYER_DEBUG_MODE__` to `true` before the RxPlayer is evaluated.

The only influence this boolean has for now is to set the highest log verbosity, a necessity to unlock all RxPaired features.
But we may add other features in the future.

This is not only restricted to the RxPaired tool by the way, any other log-redirecting script could make use of that boolean.

The only risk I can think of is to have conflicting variables into window but the name chosen seems rare enough to me for it being a real problem.