### PR TITLE
DASH: initial S elements without a `t` attribute implicitely begin at `0`

### DIFF
--- a/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_elements.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_elements.ts
@@ -27,13 +27,10 @@ import parseSElement, {
  * first needed.
  * @param {HTMLCollection} elements - All S nodes constituting the corresponding
  * SegmentTimeline node.
- * @param {number} scaledPeriodStart - Absolute start of the concerned Period,
- * in the same scale than the segments found in `elements`.
  * @returns {Array.<Object>}
  */
 export default function constructTimelineFromElements(
-  elements : HTMLCollection,
-  scaledPeriodStart : number
+  elements : HTMLCollection
 ) : IIndexSegment[] {
   const initialTimeline : IParsedS[] = [];
   for (let i = 0; i < elements.length; i++) {
@@ -48,10 +45,7 @@ export default function constructTimelineFromElements(
     const nextItem = initialTimeline[i + 1] === undefined ?
       null :
       initialTimeline[i + 1];
-    const timelineElement = convertElementsToIndexSegment(item,
-                                                          previousItem,
-                                                          nextItem,
-                                                          scaledPeriodStart);
+    const timelineElement = convertElementsToIndexSegment(item, previousItem, nextItem);
     if (timelineElement !== null) {
       timeline.push(timelineElement);
     }

--- a/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_previous_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_previous_timeline.ts
@@ -25,15 +25,14 @@ import parseSElement, {
 
 export default function constructTimelineFromPreviousTimeline(
   newElements : HTMLCollection,
-  prevTimeline : IIndexSegment[],
-  scaledPeriodStart : number
+  prevTimeline : IIndexSegment[]
 ) : IIndexSegment[] {
 
   // Find first index in both timeline where a common segment is found.
   const commonStartInfo = findFirstCommonStartTime(prevTimeline, newElements);
   if (commonStartInfo === null) {
     log.warn("DASH: Cannot perform \"based\" update. Common segment not found.");
-    return constructTimelineFromElements(newElements, scaledPeriodStart);
+    return constructTimelineFromElements(newElements);
   }
   const { prevSegmentsIdx,
           newElementsIdx,
@@ -45,7 +44,7 @@ export default function constructTimelineFromPreviousTimeline(
   const lastCommonEltNewEltsIdx = numberCommonEltGuess + newElementsIdx - 1;
   if (lastCommonEltNewEltsIdx >= newElements.length) {
     log.info("DASH: Cannot perform \"based\" update. New timeline too short");
-    return constructTimelineFromElements(newElements, scaledPeriodStart);
+    return constructTimelineFromElements(newElements);
   }
 
   // Remove elements which are not available anymore
@@ -60,7 +59,7 @@ export default function constructTimelineFromPreviousTimeline(
   if (repeatNumberInNewElements > 0 && newElementsIdx !== 0) {
     log.info("DASH: Cannot perform \"based\" update. " +
              "The new timeline has a different form.");
-    return constructTimelineFromElements(newElements, scaledPeriodStart);
+    return constructTimelineFromElements(newElements);
   }
 
   const prevLastElement = newTimeline[newTimeline.length - 1];
@@ -72,7 +71,7 @@ export default function constructTimelineFromPreviousTimeline(
   {
     log.info("DASH: Cannot perform \"based\" update. " +
              "The new timeline has a different form at the beginning.");
-    return constructTimelineFromElements(newElements, scaledPeriodStart);
+    return constructTimelineFromElements(newElements);
   }
 
   if (newCommonElt.repeatCount !== undefined &&
@@ -94,10 +93,7 @@ export default function constructTimelineFromPreviousTimeline(
     const nextItem = items[i + 1] === undefined ?
       null :
       items[i + 1];
-    const timelineElement = convertElementToIndexSegment(item,
-                                                         previousItem,
-                                                         nextItem,
-                                                         scaledPeriodStart);
+    const timelineElement = convertElementToIndexSegment(item, previousItem, nextItem);
     if (timelineElement !== null) {
       newEltsToPush.push(timelineElement);
     }

--- a/src/parsers/manifest/dash/common/indexes/timeline/convert_element_to_index_segment.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/convert_element_to_index_segment.ts
@@ -28,22 +28,19 @@ import { IIndexSegment } from "../../../../utils/index_helpers";
  * segment.
  * @param {Object|null} nextItem - the `S` node coming next. If `null`, we're
  * talking about the last segment.
- * @param {number} timelineStart - Absolute start for the timeline. In the same
- * timescale than the given `S` nodes.
  * @returns {Object|null}
  */
 export default function convertElementsToIndexSegment(
   item : { start? : number; repeatCount? : number; duration? : number },
   previousItem : IIndexSegment|null,
-  nextItem : { start? : number; repeatCount? : number; duration? : number }|null,
-  timelineStart : number
+  nextItem : { start? : number; repeatCount? : number; duration? : number }|null
 ) : IIndexSegment|null {
   let start = item.start;
   let duration = item.duration;
   const repeatCount = item.repeatCount;
   if (start === undefined) {
     if (previousItem === null) {
-      start = timelineStart;
+      start = 0;
     } else if (!isNullOrUndefined(previousItem.duration)) {
       start = previousItem.start +
               (previousItem.duration * (previousItem.repeatCount + 1));

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -201,9 +201,6 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
   /** Absolute start of the period, timescaled and converted to index time. */
   private _scaledPeriodStart : number;
 
-  /** Actual un-scaled start of the Period as indicated in the MPD. */
-  private _periodStart : number;
-
   /** Absolute end of the period, timescaled and converted to index time. */
   private _scaledPeriodEnd : number | undefined;
 
@@ -308,7 +305,6 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
                     startNumber: index.startNumber,
                     timeline: index.timeline ?? null,
                     timescale };
-    this._periodStart = periodStart;
     this._scaledPeriodStart = toIndexTime(periodStart, this._index);
     this._scaledPeriodEnd = periodEnd === undefined ? undefined :
                                                       toIndexTime(periodEnd, this._index);
@@ -465,7 +461,6 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     this._index = newIndex._index;
     this._isDynamic = newIndex._isDynamic;
     this._scaledPeriodStart = newIndex._scaledPeriodStart;
-    this._periodStart = newIndex._periodStart;
     this._scaledPeriodEnd = newIndex._scaledPeriodEnd;
     this._lastUpdate = newIndex._lastUpdate;
     this._manifestBoundsCalculator = newIndex._manifestBoundsCalculator;
@@ -491,7 +486,6 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     }
     this._isDynamic = newIndex._isDynamic;
     this._scaledPeriodStart = newIndex._scaledPeriodStart;
-    this._periodStart = newIndex._periodStart;
     this._scaledPeriodEnd = newIndex._scaledPeriodEnd;
     this._lastUpdate = newIndex._lastUpdate;
     this._isLastPeriod = newIndex._isLastPeriod;
@@ -614,13 +608,12 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     const newElements = this._parseTimeline();
     this._parseTimeline = null; // Free memory
 
-    const actualPeriodStart = this._periodStart * this._index.timescale;
     const { MIN_DASH_S_ELEMENTS_TO_PARSE_UNSAFELY } = config.getCurrent();
     if (this._unsafelyBaseOnPreviousIndex === null ||
         newElements.length < MIN_DASH_S_ELEMENTS_TO_PARSE_UNSAFELY)
     {
       // Just completely parse the current timeline
-      return constructTimelineFromElements(newElements, actualPeriodStart);
+      return constructTimelineFromElements(newElements);
     }
 
     // Construct previously parsed timeline if not already done
@@ -633,9 +626,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     }
     this._unsafelyBaseOnPreviousIndex = null; // Free memory
 
-    return constructTimelineFromPreviousTimeline(newElements,
-                                                 prevTimeline,
-                                                 actualPeriodStart);
+    return constructTimelineFromPreviousTimeline(newElements, prevTimeline);
 
   }
 }


### PR DESCRIPTION
This is another attempt, after 161157a350de53debce09f3465834e3176d2b918, to calculate a default `t` attribute for the first `<S>` element of a DASH's `<SegmentTimeline>` when the first one omitted it (which happens quite rarely).

The initial logic basically made as if the first segment had a time of `Period@start - SegmentTemplate@presentationTimeOffset`. However, we did have issues with it with some of those rare streams.

The 161157a350de53debce09f3465834e3176d2b918 fix tried to only consider `Period@start` here to work-around those issues, this was mainly done this way because it seemed to fix the encountered cases, as I found the DASH specification unclear on that situation.

However, after doing one of our "beta-like" release (`dev` and `canal` releases), we saw that this broke other streams - which had no problem before.

This was when we actually tried to reverse engineer what other players are doing.

It seems that the consensus is actually doing as if the first `t` is actually set as if it was set to `0` (so we should actually go one step further and consider neither the Period's start nor the `presentationTimeOffset`):
 - dash.js: https://github.com/Dash-Industry-Forum/dash.js/blob/2602917b9743cfae51fdd934f8e0beb9631a72a7/src/dash/utils/TimelineSegmentsGetter.js#L60
 - shaka-player: https://github.com/shaka-project/shaka-player/blob/4fc7a4893fd081d4dafa26a2034361afd7b7e6ed/lib/dash/mpd_utils.js#L142
   (the shaka-player already removes the presentationTimeOffset in that calculation, like we can see line 154 of the same file, so it ends up  just being `-presentationTimeOffset` here).

In this commit, we thus chose to align with what those other players are doing.