### PR TITLE
[Proposal] Extract key id from initialization segments if found

### DIFF
--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -271,9 +271,16 @@ export default function RepresentationStream<TSegmentDataType>({
    */
   let hasSentEncryptionData = false;
   let encryptionEvent$ : Observable<IEncryptionDataEncounteredEvent> = EMPTY;
+
+  // If the DRM system id is already known, and if we already have encryption data
+  // for it, we may not need to wait until the initialization segment is loaded to
+  // signal required protection data, thus performing License negotiations sooner
   if (drmSystemId !== undefined) {
     const encryptionData = representation.getEncryptionData(drmSystemId);
-    if (encryptionData.length > 0) {
+
+    // If some key ids are not known yet, it may be safer to wait for this initialization
+    // segment to be loaded first
+    if (encryptionData.length > 0 && encryptionData.every(e => e.keyIds !== undefined)) {
       encryptionEvent$ = observableOf(...encryptionData.map(d =>
         EVENTS.encryptionDataEncountered(d, content)));
       hasSentEncryptionData = true;

--- a/src/parsers/containers/isobmff/get_box.ts
+++ b/src/parsers/containers/isobmff/get_box.ts
@@ -22,6 +22,29 @@ import {
 } from "../../../utils/byte_parsing";
 
 /**
+ * From a given buffer representing ISOBMFF data, browses inner boxes in
+ * `childNames`, each element being a child box of the one before it.
+ * Returns `null` if one of the child (or if the parent) is not found.
+ * @param {Uint8Array} buf
+ * @param {number[]} childNames
+ * @returns {Uint8Array|null}
+ */
+function getChildBox(
+  buf : Uint8Array,
+  childNames : number[]
+) : Uint8Array | null {
+  let currBox = buf;
+  for (const childName of childNames) {
+    const box = getBoxContent(currBox, childName);
+    if (box === null) {
+      return null;
+    }
+    currBox = box;
+  }
+  return currBox;
+}
+
+/**
  * Returns the content of a box based on its name.
  * `null` if not found.
  * @param {Uint8Array} buf - the isobmff data
@@ -249,6 +272,7 @@ export {
   getBoxContent,
   getBoxesContent,
   getBoxOffsets,
+  getChildBox,
   getNextBoxOffsets,
   getUuidContent,
 };

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -19,7 +19,10 @@ import {
   getSegmentsFromSidx,
   takePSSHOut,
 } from "../../parsers/containers/isobmff";
-import { parseEmsgBoxes } from "../../parsers/containers/isobmff/utils";
+import {
+  getKeyIdFromInitSegment,
+  parseEmsgBoxes,
+} from "../../parsers/containers/isobmff/utils";
 import {
   getSegmentsFromCues,
   getTimeCodeScale,
@@ -88,8 +91,12 @@ export default function generateAudioVideoSegmentParser(
     let protectionDataUpdate = false;
     if (seemsToBeMP4) {
       const psshInfo = takePSSHOut(chunkData);
-      if (psshInfo.length > 0) {
-        protectionDataUpdate = representation._addProtectionData("cenc", psshInfo);
+      let keyId;
+      if (segment.isInit) {
+        keyId = getKeyIdFromInitSegment(chunkData) ?? undefined;
+      }
+      if (psshInfo.length > 0 || keyId !== undefined) {
+        protectionDataUpdate = representation._addProtectionData("cenc", keyId, psshInfo);
       }
     }
 

--- a/src/transports/local/segment_parser.ts
+++ b/src/transports/local/segment_parser.ts
@@ -18,6 +18,7 @@ import {
   getMDHDTimescale,
   takePSSHOut,
 } from "../../parsers/containers/isobmff";
+import { getKeyIdFromInitSegment } from "../../parsers/containers/isobmff/utils";
 import { getTimeCodeScale } from "../../parsers/containers/matroska";
 import takeFirstSet from "../../utils/take_first_set";
 import {
@@ -65,8 +66,12 @@ export default function segmentParser(
   let protectionDataUpdate = false;
   if (seemsToBeMP4) {
     const psshInfo = takePSSHOut(chunkData);
-    if (psshInfo.length > 0) {
-      protectionDataUpdate = representation._addProtectionData("cenc", psshInfo);
+    let keyId;
+    if (segment.isInit) {
+      keyId = getKeyIdFromInitSegment(chunkData) ?? undefined;
+    }
+    if (psshInfo.length > 0 || keyId !== undefined) {
+      protectionDataUpdate = representation._addProtectionData("cenc", keyId, psshInfo);
     }
   }
 


### PR DESCRIPTION
The RxPlayer has some advanced encryption-related features making use of an encrypted Representation's key-id - which is an identifier for the key used to decrypt the segment.

Such advanced features are for example the ability to obtain all keys - excluding those for which the license server does not trust the current device enough - a given content or DASH Period(s) needs from a single license request and not just a single key. In turn, this allows to reduce load and synchronization effects on the license server (as well as potentially reducing the loading time of a content).

When key ids are not known (mostly when they aren't in the Manifest file), the RxPlayer tries to stay resilient and should still be able to provide most features, though things may not be as efficient as they could be (e.g. multiple license requests could be performed instead of one).
Moreover, we already had bugs in the past linked to that exact situation (e.g.: #1113).

Listing the exact influences the omission of key-id in the Manifest lead to is difficult however, as layers of optimizations and resilience code made it hard to clearly paint a picture of everything that would go on! But it probably has multiple negative effects, even if the content can play.

---

Anyway, while working on another Proof-of-Concept, I noticed that the key id of encrypted media was actually present in MP4 files, in the `tenc` box. 

_In retrospect, this makes total sense, it may (or may not!) be how the lower-level code/CDM is able to identify which key it should currently use when multiple decryption keys are currently actively used (e.g. for different qualities)._

---

This commit is thus a proposal to read the key id directly from the initialization segment to obtain it even when it is not in the Manifest file.

Moreover, if the key id is not in the Manifest, I disabled the optimization which may lead to decryption negotiation being performed as soon as the Manifest is loaded (comparatively to the default: after the corresponding initialization segment is loaded) because the key id might in most cases be known once the initialization segment is parsed, and that in turn might lead to be able to deduce that a license request might not even be needed (because the corresponding key has already been obtained).