### PR TITLE
DASH: set a minimum for the first available position of an index

### DIFF
--- a/src/core/stream/orchestrator/active_period_emitter.ts
+++ b/src/core/stream/orchestrator/active_period_emitter.ts
@@ -62,11 +62,7 @@ type IPeriodsList = Partial<Record<string, IPeriodObject>>;
  * already inform that it is the current Period.
  * ```
  *
- * @param {Array.<string>} bufferTypes - Every buffer types in the content.
- * @param {Observable} addPeriodStream$ - Emit PeriodStream information when
- * one is added.
- * @param {Observable} removePeriodStream$ - Emit PeriodStream information when
- * one is removed.
+ * @param {Array.<Observable>} buffers$
  * @returns {Observable}
  */
 export default function ActivePeriodEmitter(

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -169,6 +169,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   /** Underlying structure to retrieve segment information. */
   private _index : IBaseIndex;
 
+  /** Absolute start of the period, timescaled and converted to index time. */
+  private _scaledPeriodStart : number;
+
   /** Absolute end of the period, timescaled and converted to index time. */
   private _scaledPeriodEnd : number | undefined;
 
@@ -222,6 +225,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                     startNumber: index.startNumber,
                     timeline: index.timeline ?? [],
                     timescale };
+    this._scaledPeriodStart = toIndexTime(periodStart, this._index);
     this._scaledPeriodEnd = periodEnd == null ? undefined :
                                                 toIndexTime(periodEnd, this._index);
     this._isInitialized = this._index.timeline.length > 0;
@@ -275,7 +279,9 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
     if (index.timeline.length === 0) {
       return null;
     }
-    return fromIndexTime(index.timeline[0].start, index);
+    return fromIndexTime(Math.max(this._scaledPeriodStart,
+                                  index.timeline[0].start),
+                         index);
   }
 
   /**

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -372,7 +372,8 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     }
     const timeline = this._index.timeline;
     return timeline.length === 0 ? null :
-                                   fromIndexTime(timeline[0].start,
+                                   fromIndexTime(Math.max(this._scaledPeriodStart,
+                                                          timeline[0].start),
                                                  this._index);
   }
 


### PR DESCRIPTION
The previous RxPlayer's behavior could lead to consider that the first playable media data in a Period starts before the Period's start, or even before a `0` position which should not be possible.

In turn, this could lead to strange behaviors, like producing a negative initial time (which seems to just lead to infinite rebuffering).

This commit ensure that an index never communicates it has media data before the related Period's start.