### PR TITLE
Fix issues that could arise when handling segments starting at a negative position

### DIFF
--- a/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
@@ -72,16 +72,9 @@ export default function getSegmentsFromTimeline(
 
   const timelineLength = timeline.length;
 
-  // TODO(pierre): use @maxSegmentDuration if possible
-  let maxEncounteredDuration = timeline.length > 0 &&
-                               timeline[0].duration != null ? timeline[0].duration :
-                                                               0;
-
   for (let i = 0; i < timelineLength; i++) {
     const timelineItem = timeline[i];
     const { duration, start, range } = timelineItem;
-
-    maxEncounteredDuration = Math.max(maxEncounteredDuration, duration);
 
     const repeat = calculateRepeat(timelineItem, timeline[i + 1], maximumTime);
     const complete = index.availabilityTimeComplete !== false ||
@@ -96,11 +89,17 @@ export default function getSegmentsFromTimeline(
         null :
         mediaURLs.map(createDashUrlDetokenizer(segmentTime, segmentNumber));
 
-      const time = segmentTime - index.indexTimeOffset;
+      let time = segmentTime - index.indexTimeOffset;
+      let realDuration = duration;
+      if (time < 0) {
+        realDuration = duration + time; // Remove from duration the part before `0`
+        time = 0;
+      }
+
       const segment = { id: String(segmentTime),
                         time: time / timescale,
-                        end: (time + duration) / timescale,
-                        duration: duration / timescale,
+                        end: (time + realDuration) / timescale,
+                        duration: realDuration / timescale,
                         isInit: false,
                         range,
                         timescale: 1 as const,

--- a/src/transports/utils/get_isobmff_timing_infos.ts
+++ b/src/transports/utils/get_isobmff_timing_infos.ts
@@ -47,10 +47,17 @@ export default function getISOBMFFTimingInfos(
     return null;
   }
 
-  const startTime = segment.timestampOffset !== undefined ?
-                      baseDecodeTime + (segment.timestampOffset * initTimescale) :
-                      baseDecodeTime;
-  const trunDuration = getDurationFromTrun(buffer);
+  let startTime = segment.timestampOffset !== undefined ?
+                    baseDecodeTime + (segment.timestampOffset * initTimescale) :
+                    baseDecodeTime;
+  let trunDuration = getDurationFromTrun(buffer);
+  if (startTime < 0) {
+    if (trunDuration !== undefined) {
+      trunDuration += startTime; // remove from duration what comes before `0`
+    }
+    startTime = 0;
+  }
+
   if (isChunked || !segment.complete) {
     if (trunDuration === undefined) {
       log.warn("DASH: Chunked segments should indicate a duration through their" +


### PR DESCRIPTION
After doing some experimentation with the `@presentationTimeOffset` attribute of a DASH MPD to omit certain parts in the beginning of various contents, we noticed that the RxPlayer had a poor handling of segments starting at a negative time.

As media data before `0` will be ignored anyway, the easy solution is just to make as if the media data before the `0` position did not exist.

This is what this PR does.