### PR TITLE
Do not re-download segments that are immediately GCed by the browser

### DIFF
--- a/src/core/segment_buffers/inventory/buffered_history.ts
+++ b/src/core/segment_buffers/inventory/buffered_history.ts
@@ -25,10 +25,17 @@ import { IChunkContext } from "./types";
 export interface IBufferedHistoryEntry {
   /** `performance.now()` when the event happened. */
   date : number;
-  /** Start time at which we observed that segment/chunk starts at, in seconds. */
-  bufferedStart : number;
-  /** *End time at which we observed that segment/chunk ends at, in seconds. */
-  bufferedEnd : number;
+
+  /**
+   * Timestamps of what has been buffered with that segment.
+   * `null` if it has been immediately garbage collected.
+   */
+  buffered : null | [
+    /** Start time at which we observed that segment/chunk starts at, in seconds. */
+    number,
+    /** *End time at which we observed that segment/chunk ends at, in seconds. */
+    number,
+  ];
   /** Content metadata linked to the segment, allowing to recognize it. */
   context : IChunkContext;
 
@@ -73,18 +80,15 @@ export default class BufferedHistory {
    * To call when the full range of a given segment becomes known.
    *
    * @param {Object} context
-   * @param {number} bufferedStart
-   * @param {number} bufferedEnd
+   * @param {Array.<number>|null} buffered
    */
   public addBufferedSegment(
     context : IChunkContext,
-    bufferedStart : number,
-    bufferedEnd : number
+    buffered : [number, number] | null
   ) : void {
     const now = performance.now();
     this._history.push({ date: now,
-                         bufferedStart,
-                         bufferedEnd,
+                         buffered,
                          context });
     this._cleanHistory(now);
 

--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -187,7 +187,7 @@ export default class SegmentInventory {
    * /!\ A SegmentInventory should not be associated to multiple media buffers
    * at a time, so each `synchronizeBuffered` call should be given a TimeRanges
    * coming from the same buffer.
-   * @param {TimeRanges}
+   * @param {TimeRanges} buffered
    */
   public synchronizeBuffered(buffered : TimeRanges) : void {
     const inventory = this._inventory;
@@ -244,7 +244,12 @@ export default class SegmentInventory {
           precizeEnd: lastDeletedSegment.precizeEnd,
         };
         log.debug(`SI: ${numberOfSegmentToDelete} segments GCed.`, bufferType);
-        inventory.splice(indexBefore, numberOfSegmentToDelete);
+        const removed = inventory.splice(indexBefore, numberOfSegmentToDelete);
+        for (const seg of removed) {
+          if (seg.bufferedStart === undefined && seg.bufferedEnd === undefined) {
+            this._bufferedHistory.addBufferedSegment(seg.infos, null);
+          }
+        }
         inventoryIndex = indexBefore;
       }
 
@@ -318,7 +323,12 @@ export default class SegmentInventory {
     if (thisSegment != null) {
       log.debug("SI: last segments have been GCed",
                 bufferType, inventoryIndex, inventory.length);
-      inventory.splice(inventoryIndex, inventory.length - inventoryIndex);
+      const removed = inventory.splice(inventoryIndex, inventory.length - inventoryIndex);
+      for (const seg of removed) {
+        if (seg.bufferedStart === undefined && seg.bufferedEnd === undefined) {
+          this._bufferedHistory.addBufferedSegment(seg.infos, null);
+        }
+      }
     }
     if (bufferType !== undefined && log.getLevel() === "DEBUG") {
       log.debug(`SI: current ${bufferType} inventory timeline:\n` +
@@ -752,9 +762,8 @@ export default class SegmentInventory {
       this.synchronizeBuffered(newBuffered);
       for (const seg of resSegments) {
         if (seg.bufferedStart !== undefined && seg.bufferedEnd !== undefined) {
-          this._bufferedHistory.addBufferedSegment(seg.infos,
-                                                   seg.bufferedStart,
-                                                   seg.bufferedEnd);
+          this._bufferedHistory.addBufferedSegment(seg.infos, [seg.bufferedStart,
+                                                               seg.bufferedEnd]);
         } else {
           log.debug("SI: buffered range not known after sync. Skipping history.",
                     seg);
@@ -916,9 +925,9 @@ function guessBufferedStartFromRangeStart(
 /**
  * Evaluate the given buffered Chunk's buffered end from its range's end,
  * considering that this chunk is the last one in it.
- * @param {Object} firstSegmentInRange
- * @param {number} rangeStart
- * @param {Object} infos
+ * @param {Object} lastSegmentInRange
+ * @param {number} rangeEnd
+ * @param {string} bufferType
  */
 function guessBufferedEndFromRangeEnd(
   lastSegmentInRange : IBufferedChunk,


### PR DESCRIPTION
We introduced in #990 (v3.26.1) the notion of an history of pushed segments to detect cases where the browser seems to garbage collect parts of pushed segments.

The idea is simple (yet surprising, it might sound ugly at first!): we register the recent history of segments pushed on browser-side buffers, particularly their start time and end time as [indirectly] reported by the browser [through the `buffered` TimeRanges object and some deduction].
If we notice that at least two times in a row, the browser is garbage collecting parts of a segment the same way (like 1 second at the beginning for example), we stop trying to load that segment (as long as the GCed pattern is the same one - if more/less is GCed, we may retry loading it).

This works actually very well and fixed most segment requesting loop occuring in the RxPlayer due to the browser acting weird - while still allowing us to retain the current architecture and features of our garbage-collection detection algorithm.

Yet it remains at least one credible case where it is still possible to have requests loops of the same segment: when the browser is just completely garbage collecting it each time (for the moment only seen when doing very wrong things with segments, like removing any notion of an intra video frame in one).

---

To fix this is however very straightforward: if previously we only added an entry to the the buffered history when a segment's actual buffered start and ends were known and set, we can now also add an entry if the segment was not actually being considered as buffered after being pushed.

Then, when deciding which segments to load, we check for each segment the possibility it was already pushed an immediately GCed. We only will skip segments that have been GCed immediately two times in a row, because sometimes browsers act up only temporarily (even sometimes for good reasons).

Though, as we're doing this with each segments at each playback observation (for simplicity reasons), and as we didn't really try to work on that code's performance yet, I'm wondering whether this has an important-enough negative impact on perfs. I will test that now.