### PR TITLE
Remove RxJS from the SegmentBuffer and related code

### DIFF
--- a/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/image/image_segment_buffer.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import {
-  defer as observableDefer,
-  Observable,
-  of as observableOf,
-} from "rxjs";
 import log from "../../../../log";
 import { IBifThumbnail } from "../../../../parsers/images/bif";
 import {
@@ -45,55 +40,57 @@ export default class ImageSegmentBuffer extends SegmentBuffer {
 
   /**
    * @param {Object} data
+   * @returns {Promise}
    */
   public pushChunk(
     infos : IPushChunkInfos<unknown>
-  ) : Observable<void> {
-    return observableDefer(() => {
-      log.debug("ISB: appending new data.");
-      if (infos.data.chunk === null) {
-        return observableOf(undefined);
-      }
-      const { appendWindow,
-              chunk } = infos.data;
+  ) : Promise<void> {
+    log.debug("ISB: appending new data.");
+    if (infos.data.chunk === null) {
+      return Promise.resolve();
+    }
+    const { appendWindow,
+            chunk } = infos.data;
 
-      // The following check is ugly. I don't care, the image buffer is there
-      // due to an ugly deprecated API that will soon disappear
-      const { start, end, timescale } = chunk as IImageTrackSegmentData;
-      const appendWindowStart = appendWindow[0] ?? 0;
-      const appendWindowEnd = appendWindow[1] ?? Infinity;
+    // The following check is ugly. I don't care, the image buffer is there
+    // due to an ugly deprecated API that will soon disappear
+    const { start, end, timescale } = chunk as IImageTrackSegmentData;
+    const appendWindowStart = appendWindow[0] ?? 0;
+    const appendWindowEnd = appendWindow[1] ?? Infinity;
 
-      const timescaledStart = start / timescale;
-      const timescaledEnd = end / timescale;
+    const timescaledStart = start / timescale;
+    const timescaledEnd = end / timescale;
 
-      const startTime = Math.max(appendWindowStart, timescaledStart);
-      const endTime = Math.min(appendWindowEnd, timescaledEnd);
+    const startTime = Math.max(appendWindowStart, timescaledStart);
+    const endTime = Math.min(appendWindowEnd, timescaledEnd);
 
+    try {
       this._buffered.insert(startTime, endTime);
       if (infos.inventoryInfos !== null) {
         this._segmentInventory.insertChunk(infos.inventoryInfos);
       }
-      return observableOf(undefined);
-    });
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve();
   }
 
   /**
    * @param {Number} from
    * @param {Number} to
+   * @returns {Promise}
    */
-  public removeBuffer(start : number, end : number) : Observable<void> {
-    return observableDefer(() => {
-      log.info("ISB: ignored image data remove order", start, end);
+  public removeBuffer(start : number, end : number) : Promise<void> {
+    log.info("ISB: ignored image data remove order", start, end);
 
-      // Logic removed as it caused more problems than it resolved:
-      // Image thumbnails are always downloaded as a single BIF file, meaning that
-      // any removing might necessitate to re-load the whole file in the future
-      // which seems pointless.
-      // In any case, image handling through the regular RxPlayer APIs has been
-      // completely deprecated now for several reasons, and should disappear in
-      // the next major version.
-      return observableOf(undefined);
-    });
+    // Logic removed as it caused more problems than it resolved:
+    // Image thumbnails are always downloaded as a single BIF file, meaning that
+    // any removing might necessitate to re-load the whole file in the future
+    // which seems pointless.
+    // In any case, image handling through the regular RxPlayer APIs has been
+    // completely deprecated now for several reasons, and should disappear in
+    // the next major version.
+    return Promise.resolve();
   }
 
   /**
@@ -103,13 +100,11 @@ export default class ImageSegmentBuffer extends SegmentBuffer {
    * The returned Observable will emit and complete successively once the whole
    * segment has been pushed and this indication is acknowledged.
    * @param {Object} infos
-   * @returns {Observable}
+   * @returns {Promise}
    */
-  public endOfSegment(_infos : IEndOfSegmentInfos) : Observable<void> {
-    return observableDefer(() => {
-      this._segmentInventory.completeSegment(_infos, this._buffered);
-      return observableOf(undefined);
-    });
+  public endOfSegment(_infos : IEndOfSegmentInfos) : Promise<void> {
+    this._segmentInventory.completeSegment(_infos, this._buffered);
+    return Promise.resolve();
   }
 
   /**

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -15,24 +15,15 @@
  */
 
 import {
-  concat as observableConcat,
-  interval as observableInterval,
-  map,
-  merge as observableMerge,
-  Observable,
-  of as observableOf,
-  startWith,
-  switchMap,
-  takeUntil,
-} from "rxjs";
-import {
   events,
   onHeightWidthChange,
 } from "../../../../../compat";
 import config from "../../../../../config";
 import log from "../../../../../log";
 import { ITextTrackSegmentData } from "../../../../../transports";
-import TaskCanceller from "../../../../../utils/task_canceller";
+import TaskCanceller, {
+  CancellationSignal,
+} from "../../../../../utils/task_canceller";
 import {
   IEndOfSegmentInfos,
   IPushChunkInfos,
@@ -43,31 +34,7 @@ import parseTextTrackToElements from "./parsers";
 import TextTrackCuesStore from "./text_track_cues_store";
 import updateProportionalElements from "./update_proportional_elements";
 
-const { onEnded$,
-        onSeeked$,
-        onSeeking$ } = events;
-
-
-/**
- * Generate the interval at which TextTrack HTML Cues should be refreshed.
- * @param {HTMLMediaElement} videoElement
- * @returns {Observable}
- */
-function generateRefreshInterval(videoElement : HTMLMediaElement) : Observable<boolean> {
-  const seeking$ = onSeeking$(videoElement);
-  const seeked$ = onSeeked$(videoElement);
-  const ended$ = onEnded$(videoElement);
-  const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config.getCurrent();
-  const manualRefresh$ = observableMerge(seeked$, ended$);
-  const autoRefresh$ = observableInterval(MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL)
-    .pipe(startWith(null));
-
-  return manualRefresh$.pipe(
-    startWith(null),
-    switchMap(() => observableConcat(autoRefresh$.pipe(map(() => true),
-                                                       takeUntil(seeking$)),
-                                     observableOf(false))));
-}
+const { onEnded, onSeeked, onSeeking } = events;
 
 /**
  * @param {Element} element
@@ -167,28 +134,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
     this._buffer = new TextTrackCuesStore();
     this._currentCues = [];
 
-    // update text tracks
-    const refreshSub = generateRefreshInterval(this._videoElement)
-      .subscribe((shouldDisplay) => {
-        if (!shouldDisplay) {
-          this._disableCurrentCues();
-          return;
-        }
-        const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config.getCurrent();
-        // to spread the time error, we divide the regular chosen interval.
-        const time = Math.max(this._videoElement.currentTime +
-                              (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
-                              0);
-        const cues = this._buffer.get(time);
-        if (cues.length === 0) {
-          this._disableCurrentCues();
-        } else {
-          this._displayCues(cues);
-        }
-      });
-    this._canceller.signal.register(() => {
-      refreshSub.unsubscribe();
-    });
+    this.autoRefreshSubtitles(this._canceller.signal);
   }
 
   /**
@@ -253,7 +199,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
    *
    * /!\ This method won't add any data to the linked inventory.
    * Please use the `pushChunk` method for most use-cases.
-   * @param {Object} data
+   * @param {Object} infos
    * @returns {boolean}
    */
   public pushChunkSync(infos : IPushChunkInfos<unknown>) : void {
@@ -375,7 +321,7 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
 
   /**
    * Display a new Cue. If one was already present, it will be replaced.
-   * @param {HTMLElement} element
+   * @param {HTMLElement} elements
    */
   private _displayCues(elements : HTMLElement[]) : void {
     const nothingChanged = this._currentCues.length === elements.length &&
@@ -420,6 +366,61 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
         }
       }, { clearSignal: this._sizeUpdateCanceller.signal,
            emitCurrentValue: true });
+    }
+  }
+
+  /**
+   * Auto-refresh the display of subtitles according to the media element's
+   * position and events.
+   * @param {Object} cancellationSignal
+   */
+  private autoRefreshSubtitles(
+    cancellationSignal : CancellationSignal
+  ) : void {
+    let autoRefreshCanceller : TaskCanceller | null = null;
+    const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config.getCurrent();
+
+    const startAutoRefresh = () => {
+      stopAutoRefresh();
+      autoRefreshCanceller = new TaskCanceller({ cancelOn: cancellationSignal });
+      const intervalId = setInterval(() => this.refreshSubtitles(),
+                                     MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL);
+      autoRefreshCanceller.signal.register(() => {
+        clearInterval(intervalId);
+      });
+      this.refreshSubtitles();
+    };
+
+    onSeeking(this._videoElement, () => {
+      stopAutoRefresh();
+      this._disableCurrentCues();
+    }, cancellationSignal);
+    onSeeked(this._videoElement, startAutoRefresh, cancellationSignal);
+    onEnded(this._videoElement, startAutoRefresh, cancellationSignal);
+
+    function stopAutoRefresh() {
+      if (autoRefreshCanceller !== null) {
+        autoRefreshCanceller.cancel();
+        autoRefreshCanceller = null;
+      }
+    }
+  }
+
+  /**
+   * Refresh current subtitles according to the current media element's
+   * position.
+   */
+  private refreshSubtitles() : void {
+    const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config.getCurrent();
+    // to spread the time error, we divide the regular chosen interval.
+    const time = Math.max(this._videoElement.currentTime +
+                            (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
+                          0);
+    const cues = this._buffer.get(time);
+    if (cues.length === 0) {
+      this._disableCurrentCues();
+    } else {
+      this._displayCues(cues);
     }
   }
 }

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Observable } from "rxjs";
 import {
   Adaptation,
   ISegment,
   Period,
   Representation,
 } from "../../../manifest";
+import { CancellationSignal } from "../../../utils/task_canceller";
 import SegmentInventory, {
   IBufferedChunk,
   IBufferedHistoryEntry,
@@ -112,28 +112,41 @@ export abstract class SegmentBuffer {
    * `data.chunk` argument to null.
    *
    * @param {Object} infos
-   * @returns {Observable}
+   * @param {Object} cancellationSignal
+   * @returns {Promise}
    */
-  public abstract pushChunk(infos : IPushChunkInfos<unknown>) : Observable<void>;
+  public abstract pushChunk(
+    infos : IPushChunkInfos<unknown>,
+    cancellationSignal : CancellationSignal
+  ) : Promise<void>;
 
   /**
    * Remove buffered data (added to the same FIFO queue than `pushChunk`).
    * @param {number} start - start position, in seconds
    * @param {number} end - end position, in seconds
-   * @returns {Observable}
+   * @param {Object} cancellationSignal
+   * @returns {Promise}
    */
-  public abstract removeBuffer(start : number, end : number) : Observable<void>;
+  public abstract removeBuffer(
+    start : number,
+    end : number,
+    cancellationSignal : CancellationSignal
+  ) : Promise<void>;
 
   /**
    * Indicate that every chunks from a Segment has been given to pushChunk so
    * far.
    * This will update our internal Segment inventory accordingly.
-   * The returned Observable will emit and complete successively once the whole
-   * segment has been pushed and this indication is acknowledged.
+   * The returned Promise will resolve once the whole segment has been pushed
+   * and this indication is acknowledged.
    * @param {Object} infos
-   * @returns {Observable}
+   * @param {Object} cancellationSignal
+   * @returns {Promise}
    */
-  public abstract endOfSegment(infos : IEndOfSegmentInfos) : Observable<void>;
+  public abstract endOfSegment(
+    infos : IEndOfSegmentInfos,
+    cancellationSignal : CancellationSignal
+  ) : Promise<void>;
 
   /**
    * Returns the currently buffered data, in a TimeRanges object.

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -52,6 +52,8 @@ import Manifest, {
 import assertUnreachable from "../../../utils/assert_unreachable";
 import objectAssign from "../../../utils/object_assign";
 import { createSharedReference } from "../../../utils/reference";
+import fromCancellablePromise from "../../../utils/rx-from_cancellable_promise";
+import TaskCanceller from "../../../utils/task_canceller";
 import { IReadOnlyPlaybackObserver } from "../../api";
 import { IPrioritizedSegmentFetcher } from "../../fetchers";
 import { SegmentBuffer } from "../../segment_buffers";
@@ -267,10 +269,11 @@ export default function RepresentationStream<TSegmentDataType>({
           0,
           initialWantedTime - UPTO_CURRENT_POSITION_CLEANUP);
         if (gcedPosition > 0) {
-          bufferRemoval = segmentBuffer
-            .removeBuffer(0, gcedPosition)
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            .pipe(ignoreElements());
+          const removalCanceller = new TaskCanceller();
+          bufferRemoval = fromCancellablePromise(removalCanceller, () =>
+            segmentBuffer.removeBuffer(0, gcedPosition, removalCanceller.signal)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ).pipe(ignoreElements());
         }
       }
       return status.shouldRefreshManifest ?
@@ -318,7 +321,10 @@ export default function RepresentationStream<TSegmentDataType>({
 
       case "end-of-segment": {
         const { segment } = evt.value;
-        return segmentBuffer.endOfSegment(objectAssign({ segment }, content))
+        const endOfSegmentCanceller = new TaskCanceller();
+        return fromCancellablePromise(endOfSegmentCanceller, () =>
+          segmentBuffer.endOfSegment(objectAssign({ segment }, content),
+                                     endOfSegmentCanceller.signal))
           // NOTE As of now (RxJS 7.4.0), RxJS defines `ignoreElements` default
           // first type parameter as `any` instead of the perfectly fine `unknown`,
           // leading to linter issues, as it forbids the usage of `any`.

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -299,8 +299,7 @@ export class CancellationSignal {
 export type ICancellationListener = (error : CancellationError) => void;
 
 /**
- * Error created when a task is cancelled through the TaskCanceller.
- *
+ * Error created when a task is cancelled.
  * @class CancellationError
  * @extends Error
  */


### PR DESCRIPTION
This is yet another PR to remove RxJS from parts of the code to raise the RxPlayer's "approachability", after #962 (for the transports code), #1042 (the content decryption code) and #1091 (from the adaptive code).

This time, this is the turn of a relatively smaller part of the code: the "SegmentBuffers (in `src/core/segment_buffers`) which is the code wrapping browser's buffers (or even implementing them in the case of subtitles and image buffers).

Like the other PR before it, this one makes heavy usage of:
  - `ISharedReference` objects, which are very similar to RXJS BehaviorSubjects (always-set Observable values which are not lazy and can be `get`ted at any time) to easily share values between blocks while allowing to trigger a callback when its inner state changes.
  - `TaskCanceller` and `CancellationSignal`, which are very similar to respectively the [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) and [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) APIs and which allows to easily and explicitly (generally unlike RxJS Observables where it often happens as a side-effect of unsubscription) abort cancellable asynchronous operations.