### PR TITLE
Prevent subtle race conditions linked to `paused` attribute when reloading the content

### DIFF
--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -433,14 +433,6 @@ const onFullscreenChange$ = compatibleListener(
  * @param {HTMLMediaElement} mediaElement
  * @returns {Observable}
  */
-const onPlayPause$ = (mediaElement : HTMLMediaElement) : Observable<Event> =>
-  observableMerge(compatibleListener(["play"])(mediaElement),
-                  compatibleListener(["pause"])(mediaElement));
-
-/**
- * @param {HTMLMediaElement} mediaElement
- * @returns {Observable}
- */
 const onTextTrackChanges$ =
   (textTrackList : TextTrackList) : Observable<TrackEvent> =>
     observableMerge(compatibleListener<TrackEvent>(["addtrack"])(textTrackList),
@@ -544,7 +536,6 @@ export {
   onKeyMessage$,
   onKeyStatusesChange$,
   onLoadedMetadata$,
-  onPlayPause$,
   onRemoveSourceBuffers$,
   onSeeked$,
   onSeeking$,

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -297,7 +297,7 @@ function getEstimateReference(
       }
       const { position, speed } = lastPlaybackObservation;
       const timeRanges = val.buffered;
-      const bufferGap = getLeftSizeOfRange(timeRanges, position);
+      const bufferGap = getLeftSizeOfRange(timeRanges, position.last);
       const { representation } = val.content;
       const scoreData = scoreCalculator.getEstimate(representation);
       const currentScore = scoreData?.[0];
@@ -409,7 +409,7 @@ function getEstimateReference(
       if (lowLatencyMode &&
           currentRepresentationVal !== null &&
           context.manifest.isDynamic &&
-          maximumPosition - position < 40)
+          maximumPosition - position.last < 40)
       {
         chosenRepFromGuessMode = guessBasedChooser
           .getGuess(representations,
@@ -621,10 +621,27 @@ export interface IRepresentationEstimatorPlaybackObservation {
    */
   bufferGap : number;
   /**
-   * The position, in seconds, the media element was in at the time of the
-   * observation.
+   * Information on the current media position in seconds at the time of a
+   * Playback Observation.
    */
-  position : number;
+  position : {
+    /**
+     * Known position at the time the Observation was emitted, in seconds.
+     *
+     * Note that it might have changed since. If you want truly precize
+     * information, you should recuperate it from the HTMLMediaElement directly
+     * through another mean.
+     */
+    last : number;
+    /**
+     * Actually wanted position in seconds that is not yet reached.
+     *
+     * This might for example be set to the initial position when the content is
+     * loading (and thus potentially at a `0` position) but which will be seeked
+     * to a given position once possible.
+     */
+    pending : number | undefined;
+  };
   /**
    * Last "playback rate" set by the user. This is the ideal "playback rate" at
    * which the media should play.

--- a/src/core/api/__tests__/get_player_state.test.ts
+++ b/src/core/api/__tests__/get_player_state.test.ts
@@ -23,22 +23,25 @@ describe("API - getLoadedContentState", () => {
       ended: true,
       duration: 100000,
       currentTime: 0,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
 
     // we can just do every possibility here
-    expect(getLoadedContentState(mediaElement, true, null))
+    expect(getLoadedContentState(mediaElement, null))
       .toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, null))
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, null))
       .toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "freezing")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    fakeProps.paused = false;
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
   });
 
   it("should be PLAYING if not stalled nor ended and if not paused", () => {
@@ -46,9 +49,10 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 10, // worst case -> currentTime === duration
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, null))
+    expect(getLoadedContentState(mediaElement, null))
       .toBe("PLAYING");
   });
 
@@ -57,9 +61,10 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 10, // worst case -> currentTime === duration
+      paused: true,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, false, null))
+    expect(getLoadedContentState(mediaElement, null))
       .toBe("PAUSED");
   });
 
@@ -68,10 +73,12 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 5,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "buffering")).toBe("BUFFERING");
-    expect(getLoadedContentState(mediaElement, false, "buffering")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
   });
 
   it("should be BUFFERING if not ended and stalled because of freezing", () => {
@@ -79,10 +86,12 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 5,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "freezing")).toBe("BUFFERING");
-    expect(getLoadedContentState(mediaElement, false, "freezing")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
   });
 
   it("should be BUFFERING if not ended and stalled because of `not-ready`", () => {
@@ -90,10 +99,12 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 5,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "not-ready")).toBe("BUFFERING");
-    expect(getLoadedContentState(mediaElement, false, "not-ready")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
   });
 
   it("should be SEEKING if not ended and stalled because of `seeking`", () => {
@@ -101,10 +112,12 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 5,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "seeking")).toBe("SEEKING");
-    expect(getLoadedContentState(mediaElement, false, "seeking")).toBe("SEEKING");
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
   });
 
   it("should be ENDED if stalled and currentTime is equal to duration", () => {
@@ -112,16 +125,18 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 10,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "freezing")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
   });
 
   it("should be ENDED if stalled and currentTime is very close to the duration", () => {
@@ -129,46 +144,52 @@ describe("API - getLoadedContentState", () => {
       ended: false,
       duration: 10,
       currentTime: 10 - config.getCurrent().FORCED_ENDED_THRESHOLD,
+      paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, true, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, true, "freezing")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, false, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    fakeProps.paused = true;
+    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
   });
   it("should be ENDED if stalled and currentTime is very close to the duration", () => {
     const fakeProps1 = {
       ended: false,
       duration: 10,
       currentTime: 10 - config.getCurrent().FORCED_ENDED_THRESHOLD,
+      paused: false,
     };
     const mediaElement1 = fakeProps1 as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement1, true, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, false, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, true, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, false, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, true, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, false, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, true, "freezing")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, false, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "freezing")).toBe("ENDED");
+    fakeProps1.paused = true;
+    expect(getLoadedContentState(mediaElement1, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "freezing")).toBe("ENDED");
 
     const fakeProps2 = {
       ended: false,
       duration: 10,
       currentTime: config.getCurrent().FORCED_ENDED_THRESHOLD + 10,
+      paused: false,
     };
     const mediaElement2 = fakeProps2 as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement2, true, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, false, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, true, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, false, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, true, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, false, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, true, "freezing")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, false, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "freezing")).toBe("ENDED");
+    fakeProps2.paused = true;
+    expect(getLoadedContentState(mediaElement2, "seeking")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "buffering")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "not-ready")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "freezing")).toBe("ENDED");
   });
 });

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -33,7 +33,6 @@ export const PLAYER_STATES =
 /**
  * Get state string for a _loaded_ content.
  * @param {HTMLMediaElement} mediaElement
- * @param {boolean} isPlaying - false when the player is paused. true otherwise.
  * @param {Object} stalledStatus - Current stalled state:
  *   - null when not stalled
  *   - a description of the situation if stalled.
@@ -41,7 +40,6 @@ export const PLAYER_STATES =
  */
 export default function getLoadedContentState(
   mediaElement : HTMLMediaElement,
-  isPlaying : boolean,
   stalledStatus : IStallingSituation |
                   null
 ) : IPlayerState {
@@ -66,6 +64,6 @@ export default function getLoadedContentState(
     return stalledStatus === "seeking" ? PLAYER_STATES.SEEKING :
                                          PLAYER_STATES.BUFFERING;
   }
-  return isPlaying ? PLAYER_STATES.PLAYING :
-                     PLAYER_STATES.PAUSED;
+  return mediaElement.paused ? PLAYER_STATES.PAUSED :
+                               PLAYER_STATES.PLAYING;
 }

--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -127,6 +127,17 @@ export default class PlaybackObserver {
   }
 
   /**
+   * Returns the current `paused` status advertised by the `HTMLMediaElement`.
+   *
+   * Use this instead of the same status emitted on an observation when you want
+   * to be sure you're using the current value.
+   * @returns {boolean}
+   */
+  public getIsPaused() : boolean {
+    return this._mediaElement.paused;
+  }
+
+  /**
    * Update the current position (seek) on the `HTMLMediaElement`, by giving a
    * new position in seconds.
    *
@@ -134,7 +145,7 @@ export default class PlaybackObserver {
    * "internal" seeks. They don't result into the exact same playback
    * observation than regular seeks (which most likely comes from the outside,
    * e.g. the user).
-   * @param {number}
+   * @param {number} time
    */
   public setCurrentTime(time: number) : void {
     this._internalSeekingEventsIncomingCounter += 1;
@@ -449,6 +460,14 @@ export interface IReadOnlyPlaybackObserver<TObservationType> {
   getCurrentTime() : number;
   /** Get the HTMLMediaElement's current `readyState`. */
   getReadyState() : number;
+  /**
+   * Returns the current `paused` status advertised by the `HTMLMediaElement`.
+   *
+   * Use this instead of the same status emitted on an observation when you want
+   * to be sure you're using the current value.
+   * @returns {boolean}
+   */
+  getIsPaused() : boolean;
   /**
    * Returns an Observable regularly emitting playback observation, optionally
    * starting with the last one.
@@ -820,6 +839,9 @@ function generateReadOnlyObserver<TSource, TDest>(
     },
     getReadyState() {
       return src.getReadyState();
+    },
+    getIsPaused() {
+      return src.getIsPaused();
     },
     observe(includeLastObservation : boolean) : Observable<TDest> {
       return includeLastObservation ? newObs :

--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -40,6 +40,7 @@ import { CancellationSignal } from "../../utils/task_canceller";
  * @type {Array.<string>}
  */
 const SCANNED_MEDIA_ELEMENTS_EVENTS : IPlaybackObserverEventType[] = [ "canplay",
+                                                                       "ended",
                                                                        "play",
                                                                        "pause",
                                                                        "seeking",
@@ -338,6 +339,8 @@ export type IPlaybackObserverEventType =
   "timeupdate" |
   /** On the HTML5 event with the same name */
   "canplay" |
+  /** On the HTML5 event with the same name */
+  "ended" |
   /** On the HTML5 event with the same name */
   "canplaythrough" | // HTML5 Event
   /** On the HTML5 event with the same name */

--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -41,6 +41,7 @@ import { CancellationSignal } from "../../utils/task_canceller";
  */
 const SCANNED_MEDIA_ELEMENTS_EVENTS : IPlaybackObserverEventType[] = [ "canplay",
                                                                        "play",
+                                                                       "pause",
                                                                        "seeking",
                                                                        "seeked",
                                                                        "loadedmetadata",
@@ -330,6 +331,8 @@ export type IPlaybackObserverEventType =
   "canplaythrough" | // HTML5 Event
   /** On the HTML5 event with the same name */
   "play" |
+  /** On the HTML5 event with the same name */
+  "pause" |
   /** On the HTML5 event with the same name */
   "seeking" |
   /** On the HTML5 event with the same name */

--- a/src/core/init/create_stream_playback_observer.ts
+++ b/src/core/init/create_stream_playback_observer.ts
@@ -44,6 +44,7 @@ export interface IStreamPlaybackObserverArguments {
 
 /**
  * Create PlaybackObserver for the `Stream` part of the code.
+ * @param {Object} manifest
  * @param {Object} playbackObserver
  * @param {Object} args
  * @returns {Observable}
@@ -62,37 +63,41 @@ export default function createStreamPlaybackObserver(
   ) : Observable<IStreamOrchestratorPlaybackObservation> {
     return observableCombineLatest([observation$, speed.asObservable()]).pipe(
       map(([observation, lastSpeed]) => {
-        let wantedTimeOffset = 0;
+        let pendingPosition : number | undefined;
         if (!initialSeekPerformed.getValue()) {
-          wantedTimeOffset = startTime - observation.position;
+          pendingPosition = startTime;
         } else if (!manifest.isDynamic || manifest.isLastPeriodKnown) {
+          // HACK: When the position is actually further than the maximum
+          // position for a finished content, we actually want to be loading
+          // the last segment before ending.
+          // For now, this behavior is implicitely forced by making as if we
+          // want to seek one second before the period's end (despite never
+          // doing it).
           const lastPeriod = manifest.periods[manifest.periods.length - 1];
           if (lastPeriod !== undefined &&
               lastPeriod.end !== undefined &&
               observation.position > lastPeriod.end)
           {
-            wantedTimeOffset = lastPeriod.end -
-                               observation.position -
-                               1;
+            pendingPosition = lastPeriod.end - 1;
           }
         }
 
         return {
           // TODO more exact according to the current Adaptation chosen?
           maximumPosition: manifest.getMaximumSafePosition(),
-          position: observation.position,
+          position: {
+            last: observation.position,
+            pending: pendingPosition,
+          },
           duration: observation.duration,
-          isPaused: initialPlayPerformed.getValue() ? observation.paused :
-                                                      !autoPlay,
+          paused: {
+            last: observation.paused,
+            pending: initialPlayPerformed.getValue() ?
+              undefined :
+              !autoPlay,
+          },
           readyState: observation.readyState,
           speed: lastSpeed,
-          // wantedTimeOffset is an offset to add to the timing's current time to have
-          // the "real" wanted position.
-          // For now, this is seen when the media element has not yet seeked to its
-          // initial position, the currentTime will most probably be 0 where the
-          // effective starting position will be _startTime_.
-          // Thus we initially set a wantedTimeOffset equal to startTime.
-          wantedTimeOffset,
         };
       }));
   });

--- a/src/core/init/create_stream_playback_observer.ts
+++ b/src/core/init/create_stream_playback_observer.ts
@@ -92,9 +92,9 @@ export default function createStreamPlaybackObserver(
           duration: observation.duration,
           paused: {
             last: observation.paused,
-            pending: initialPlayPerformed.getValue() ?
-              undefined :
-              !autoPlay,
+            pending: initialPlayPerformed.getValue()  ? undefined :
+                     !autoPlay === observation.paused ? undefined :
+                                                        !autoPlay,
           },
           readyState: observation.readyState,
           speed: lastSpeed,

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -76,91 +76,6 @@ import {
 } from "../types";
 import createRepresentationEstimator from "./create_representation_estimator";
 
-
-/** Regular playback information needed by the AdaptationStream. */
-export interface IAdaptationStreamPlaybackObservation extends
-  IRepresentationStreamPlaybackObservation {
-    /**
-     * For the current SegmentBuffer, difference in seconds between the next position
-     * where no segment data is available and the current position.
-     */
-    bufferGap : number;
-    /** `duration` property of the HTMLMediaElement on which the content plays. */
-    duration : number;
-    /** If true, the player has been put on pause. */
-    isPaused: boolean;
-    /** Last "playback rate" asked by the user. */
-    speed : number;
-    /** Theoretical maximum position on the content that can currently be played. */
-    maximumPosition : number;
-  }
-
-/** Arguments given when creating a new `AdaptationStream`. */
-export interface IAdaptationStreamArguments {
-  /** Regularly emit playback conditions. */
-  playbackObserver : IReadOnlyPlaybackObserver<IAdaptationStreamPlaybackObservation>;
-  /** Content you want to create this Stream for. */
-  content : { manifest : Manifest;
-              period : Period;
-              adaptation : Adaptation; };
-  options: IAdaptationStreamOptions;
-  /** Estimate the right Representation to play. */
-  representationEstimator : IRepresentationEstimator;
-  /** SourceBuffer wrapper - needed to push media segments. */
-  segmentBuffer : SegmentBuffer;
-  /** Module used to fetch the wanted media segments. */
-  segmentFetcherCreator : SegmentFetcherCreator;
-  /**
-   * "Buffer goal" wanted, or the ideal amount of time ahead of the current
-   * position in the current SegmentBuffer. When this amount has been reached
-   * this AdaptationStream won't try to download new segments.
-   */
-  wantedBufferAhead : IReadOnlySharedReference<number>;
-  maxVideoBufferSize : IReadOnlySharedReference<number>;
-}
-
-/**
- * Various specific stream "options" which tweak the behavior of the
- * AdaptationStream.
- */
-export interface IAdaptationStreamOptions {
-  /**
-   * Hex-encoded DRM "system ID" as found in:
-   * https://dashif.org/identifiers/content_protection/
-   *
-   * Allows to identify which DRM system is currently used, to allow potential
-   * optimizations.
-   *
-   * Set to `undefined` in two cases:
-   *   - no DRM system is used (e.g. the content is unencrypted).
-   *   - We don't know which DRM system is currently used.
-   */
-  drmSystemId : string | undefined;
-  /**
-   * Strategy taken when the user switch manually the current Representation:
-   *   - "seamless": the switch will happen smoothly, with the Representation
-   *     with the new bitrate progressively being pushed alongside the old
-   *     Representation.
-   *   - "direct": hard switch. The Representation switch will be directly
-   *     visible but may necessitate the current MediaSource to be reloaded.
-   */
-  manualBitrateSwitchingMode : "seamless" | "direct";
-  /**
-   * If `true`, the AdaptationStream might replace segments of a lower-quality
-   * (with a lower bitrate) with segments of a higher quality (with a higher
-   * bitrate). This allows to have a fast transition when network conditions
-   * improve.
-   * If `false`, this strategy will be disabled: segments of a lower-quality
-   * will not be replaced.
-   *
-   * Some targeted devices support poorly segment replacement in a
-   * SourceBuffer.
-   * As such, this option can be used to disable that unnecessary behavior on
-   * those devices.
-   */
-  enableFastSwitching : boolean;
-}
-
 /**
  * Create new AdaptationStream Observable, which task will be to download the
  * media data for a given Adaptation (i.e. "track").
@@ -417,4 +332,111 @@ export default function AdaptationStream({
         }));
     });
   }
+}
+
+/** Regular playback information needed by the AdaptationStream. */
+export interface IAdaptationStreamPlaybackObservation extends
+  IRepresentationStreamPlaybackObservation {
+    /**
+     * For the current SegmentBuffer, difference in seconds between the next position
+     * where no segment data is available and the current position.
+     */
+    bufferGap : number;
+    /** `duration` property of the HTMLMediaElement on which the content plays. */
+    duration : number;
+    /**
+     * Information on whether the media element was paused at the time of the
+     * Observation.
+     */
+    paused : IPausedPlaybackObservation;
+    /** Last "playback rate" asked by the user. */
+    speed : number;
+    /** Theoretical maximum position on the content that can currently be played. */
+    maximumPosition : number;
+  }
+
+/** Pause-related information linked to an emitted Playback observation. */
+export interface IPausedPlaybackObservation {
+  /**
+   * Known paused state at the time the Observation was emitted.
+   *
+   * `true` indicating that the HTMLMediaElement was in a paused state.
+   *
+   * Note that it might have changed since. If you want truly precize
+   * information, you should recuperate it from the HTMLMediaElement directly
+   * through another mean.
+   */
+  last : boolean;
+  /**
+   * Actually wanted paused state not yet reached.
+   * This might for example be set to `false` when the content is currently
+   * loading (and thus paused) but with autoPlay enabled.
+   */
+  pending : boolean | undefined;
+}
+
+/** Arguments given when creating a new `AdaptationStream`. */
+export interface IAdaptationStreamArguments {
+  /** Regularly emit playback conditions. */
+  playbackObserver : IReadOnlyPlaybackObserver<IAdaptationStreamPlaybackObservation>;
+  /** Content you want to create this Stream for. */
+  content : { manifest : Manifest;
+              period : Period;
+              adaptation : Adaptation; };
+  options: IAdaptationStreamOptions;
+  /** Estimate the right Representation to play. */
+  representationEstimator : IRepresentationEstimator;
+  /** SourceBuffer wrapper - needed to push media segments. */
+  segmentBuffer : SegmentBuffer;
+  /** Module used to fetch the wanted media segments. */
+  segmentFetcherCreator : SegmentFetcherCreator;
+  /**
+   * "Buffer goal" wanted, or the ideal amount of time ahead of the current
+   * position in the current SegmentBuffer. When this amount has been reached
+   * this AdaptationStream won't try to download new segments.
+   */
+  wantedBufferAhead : IReadOnlySharedReference<number>;
+  maxVideoBufferSize : IReadOnlySharedReference<number>;
+}
+
+/**
+ * Various specific stream "options" which tweak the behavior of the
+ * AdaptationStream.
+ */
+export interface IAdaptationStreamOptions {
+  /**
+   * Hex-encoded DRM "system ID" as found in:
+   * https://dashif.org/identifiers/content_protection/
+   *
+   * Allows to identify which DRM system is currently used, to allow potential
+   * optimizations.
+   *
+   * Set to `undefined` in two cases:
+   *   - no DRM system is used (e.g. the content is unencrypted).
+   *   - We don't know which DRM system is currently used.
+   */
+  drmSystemId : string | undefined;
+  /**
+   * Strategy taken when the user switch manually the current Representation:
+   *   - "seamless": the switch will happen smoothly, with the Representation
+   *     with the new bitrate progressively being pushed alongside the old
+   *     Representation.
+   *   - "direct": hard switch. The Representation switch will be directly
+   *     visible but may necessitate the current MediaSource to be reloaded.
+   */
+  manualBitrateSwitchingMode : "seamless" | "direct";
+  /**
+   * If `true`, the AdaptationStream might replace segments of a lower-quality
+   * (with a lower bitrate) with segments of a higher quality (with a higher
+   * bitrate). This allows to have a fast transition when network conditions
+   * improve.
+   * If `false`, this strategy will be disabled: segments of a lower-quality
+   * will not be replaced.
+   *
+   * Some targeted devices support poorly segment replacement in a
+   * SourceBuffer.
+   * As such, this option can be used to disable that unnecessary behavior on
+   * those devices.
+   */
+  enableFastSwitching : boolean;
 }

--- a/src/core/stream/adaptation/index.ts
+++ b/src/core/stream/adaptation/index.ts
@@ -18,6 +18,7 @@ import AdaptationStream, {
   IAdaptationStreamArguments,
   IAdaptationStreamPlaybackObservation,
   IAdaptationStreamOptions,
+  IPausedPlaybackObservation,
 } from "./adaptation_stream";
 
 export default AdaptationStream;
@@ -25,4 +26,5 @@ export {
   IAdaptationStreamArguments,
   IAdaptationStreamPlaybackObservation,
   IAdaptationStreamOptions,
+  IPausedPlaybackObservation,
 };

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -327,7 +327,7 @@ export default function StreamOrchestrator(
             take(1),
             mergeMap((observation) => {
               const shouldAutoPlay = !(observation.paused.pending ??
-                                       observation.paused.last);
+                                       playbackObserver.getIsPaused());
               return observableConcat(
                 observableOf(EVENTS.needsDecipherabilityFlush(observation.position.last,
                                                               shouldAutoPlay,

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -142,7 +142,7 @@ export default function StreamOrchestrator(
       return BufferGarbageCollector({
         segmentBuffer,
         currentTime$: playbackObserver.observe(true)
-          .pipe(map(o => o.position + o.wantedTimeOffset)),
+          .pipe(map(o => o.position.pending ?? o.position.last)),
         maxBufferBehind$: maxBufferBehind.asObservable().pipe(
           map(val => Math.min(val, defaultMaxBehind))),
         maxBufferAhead$: maxBufferAhead.asObservable().pipe(
@@ -268,8 +268,8 @@ export default function StreamOrchestrator(
         IStreamOrchestratorPlaybackObservation,
         Period,
         null
-      >(({ position, wantedTimeOffset }) => {
-        const time = wantedTimeOffset + position;
+      >(({ position }) => {
+        const time = position.pending ?? position.last;
         if (!enableOutOfBoundsCheck || !isOutOfPeriodList(time)) {
           return null;
         }
@@ -281,7 +281,7 @@ export default function StreamOrchestrator(
         log.info("SO: Current position out of the bounds of the active periods," +
                  "re-creating Streams.",
                  bufferType,
-                 position + wantedTimeOffset);
+                 time);
         enableOutOfBoundsCheck = false;
         destroyStreams$.next();
         return nextPeriod;
@@ -326,13 +326,15 @@ export default function StreamOrchestrator(
           playbackObserver.observe(true).pipe(
             take(1),
             mergeMap((observation) => {
+              const shouldAutoPlay = !(observation.paused.pending ??
+                                       observation.paused.last);
               return observableConcat(
-                observableOf(EVENTS.needsDecipherabilityFlush(observation.position,
-                                                              !observation.isPaused,
+                observableOf(EVENTS.needsDecipherabilityFlush(observation.position.last,
+                                                              shouldAutoPlay,
                                                               observation.duration)),
                 observableDefer(() => {
-                  const lastPosition = observation.position +
-                                       observation.wantedTimeOffset;
+                  const lastPosition = observation.position.pending ??
+                                       observation.position.last;
                   const newInitialPeriod = manifest.getPeriodForTime(lastPosition);
                   if (newInitialPeriod == null) {
                     throw new MediaError(
@@ -392,9 +394,9 @@ export default function StreamOrchestrator(
 
     // Emits when the current position goes over the end of the current Stream.
     const endOfCurrentStream$ = playbackObserver.observe(true)
-      .pipe(filter(({ position, wantedTimeOffset }) =>
+      .pipe(filter(({ position }) =>
         basePeriod.end != null &&
-                    (position + wantedTimeOffset) >= basePeriod.end));
+                    (position.pending ?? position.last) >= basePeriod.end));
 
     // Create Period Stream for the next Period.
     const nextPeriodStream$ = createNextPeriodStream$

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -53,10 +53,13 @@ import SegmentBuffersStore, {
   SegmentBuffer,
 } from "../../segment_buffers";
 import AdaptationStream, {
-  IAdaptationStreamOptions, IAdaptationStreamPlaybackObservation,
+  IAdaptationStreamOptions,
+  IAdaptationStreamPlaybackObservation,
+  IPausedPlaybackObservation,
 } from "../adaptation";
 import EVENTS from "../events_generators";
 import reloadAfterSwitch from "../reload_after_switch";
+import { IPositionPlaybackObservation } from "../representation";
 import {
   IAdaptationStreamEvent,
   IPeriodStreamEvent,
@@ -68,21 +71,22 @@ import getAdaptationSwitchStrategy from "./get_adaptation_switch_strategy";
 
 /** Playback observation required by the `PeriodStream`. */
 export interface IPeriodStreamPlaybackObservation {
-  /** The position we are in the video in seconds at the time of the observation. */
-  position : number;
+  /**
+   * Information on whether the media element was paused at the time of the
+   * Observation.
+   */
+  paused : IPausedPlaybackObservation;
+  /**
+   * Information on the current media position in seconds at the time of the
+   * Observation.
+   */
+  position : IPositionPlaybackObservation;
   /** `duration` property of the HTMLMediaElement. */
   duration : number;
-  /** If `true`, the player is currently paused. */
-  isPaused: boolean;
   /** `readyState` property of the HTMLMediaElement. */
   readyState : number;
   /** Target playback rate at which we want to play the content. */
   speed : number;
-  /**
-   * Offset, in seconds to add to `position` to obtain the starting position at
-   * which we actually want to download segments for.
-   */
-  wantedTimeOffset : number;
   /** Theoretical maximum position on the content that can currently be played. */
   maximumPosition : number;
 }
@@ -365,6 +369,6 @@ function createAdaptationStreamPlaybackObserver(
     return objectAssign({},
                         baseObservation,
                         { bufferGap: getLeftSizeOfRange(buffered,
-                                                        baseObservation.position) });
+                                                        baseObservation.position.last) });
   }
 }

--- a/src/core/stream/reload_after_switch.ts
+++ b/src/core/stream/reload_after_switch.ts
@@ -61,7 +61,7 @@ export default function reloadAfterSwitch(
       // Bind to Period start and end
       const reloadAt = Math.min(Math.max(period.start, pos),
                                 period.end ?? Infinity);
-      const autoPlay = !(observation.paused.pending ?? observation.paused.last);
+      const autoPlay = !(observation.paused.pending ?? playbackObserver.getIsPaused());
       return EVENTS.waitingMediaSourceReload(bufferType, period, reloadAt, autoPlay);
     }));
 }

--- a/src/core/stream/reload_after_switch.ts
+++ b/src/core/stream/reload_after_switch.ts
@@ -49,8 +49,7 @@ export default function reloadAfterSwitch(
   period : Period,
   bufferType : IBufferType,
   playbackObserver : IReadOnlyPlaybackObserver<{
-    position : number;
-    isPaused : boolean;
+    paused : { last: boolean; pending: boolean | undefined };
   }>,
   deltaPos : number
 ) : Observable<IWaitingMediaSourceReloadInternalEvent> {
@@ -62,9 +61,7 @@ export default function reloadAfterSwitch(
       // Bind to Period start and end
       const reloadAt = Math.min(Math.max(period.start, pos),
                                 period.end ?? Infinity);
-      return EVENTS.waitingMediaSourceReload(bufferType,
-                                             period,
-                                             reloadAt,
-                                             !observation.isPaused);
+      const autoPlay = !(observation.paused.pending ?? observation.paused.last);
+      return EVENTS.waitingMediaSourceReload(bufferType, period, reloadAt, autoPlay);
     }));
 }

--- a/src/core/stream/representation/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/append_segment_to_buffer.ts
@@ -33,6 +33,7 @@ import {
   SegmentBuffer,
 } from "../../segment_buffers";
 import forceGarbageCollection from "./force_garbage_collection";
+import { IRepresentationStreamPlaybackObservation } from "./representation_stream";
 
 /**
  * Append a segment to the given segmentBuffer.
@@ -45,8 +46,7 @@ import forceGarbageCollection from "./force_garbage_collection";
  * @returns {Observable}
  */
 export default function appendSegmentToBuffer<T>(
-  playbackObserver : IReadOnlyPlaybackObserver<{ position : number;
-                                                 wantedTimeOffset: number; }>,
+  playbackObserver : IReadOnlyPlaybackObserver<IRepresentationStreamPlaybackObservation>,
   segmentBuffer : SegmentBuffer,
   dataInfos : IPushChunkInfos<T>
 ) : Observable<unknown> {
@@ -64,7 +64,8 @@ export default function appendSegmentToBuffer<T>(
       return playbackObserver.observe(true).pipe(
         take(1),
         mergeMap((observation) => {
-          const currentPos = observation.position + observation.wantedTimeOffset;
+          const currentPos = observation.position.pending ??
+                             observation.position.last;
           return observableConcat(
             forceGarbageCollection(currentPos, segmentBuffer).pipe(ignoreElements()),
             append$

--- a/src/core/stream/representation/index.ts
+++ b/src/core/stream/representation/index.ts
@@ -15,6 +15,7 @@
  */
 
 import RepresentationStream, {
+  IPositionPlaybackObservation,
   IRepresentationStreamArguments,
   IRepresentationStreamPlaybackObservation,
   ITerminationOrder,
@@ -22,6 +23,7 @@ import RepresentationStream, {
 
 export default RepresentationStream;
 export {
+  IPositionPlaybackObservation,
   IRepresentationStreamArguments,
   IRepresentationStreamPlaybackObservation,
   ITerminationOrder,

--- a/src/core/stream/representation/push_init_segment.ts
+++ b/src/core/stream/representation/push_init_segment.ts
@@ -34,6 +34,7 @@ import {
 import EVENTS from "../events_generators";
 import { IStreamEventAddedSegment } from "../types";
 import appendSegmentToBuffer from "./append_segment_to_buffer";
+import { IRepresentationStreamPlaybackObservation } from "./representation_stream";
 
 /**
  * Push the initialization segment to the SegmentBuffer.
@@ -49,8 +50,9 @@ export default function pushInitSegment<T>(
     segment,
     segmentData,
     segmentBuffer } :
-  { playbackObserver : IReadOnlyPlaybackObserver<{ position : number;
-                                                   wantedTimeOffset : number; }>;
+  { playbackObserver : IReadOnlyPlaybackObserver<
+      IRepresentationStreamPlaybackObservation
+    >;
     content: { adaptation : Adaptation;
                manifest : Manifest;
                period : Period;

--- a/src/core/stream/representation/push_media_segment.ts
+++ b/src/core/stream/representation/push_media_segment.ts
@@ -34,6 +34,7 @@ import { SegmentBuffer } from "../../segment_buffers";
 import EVENTS from "../events_generators";
 import { IStreamEventAddedSegment } from "../types";
 import appendSegmentToBuffer from "./append_segment_to_buffer";
+import { IRepresentationStreamPlaybackObservation } from "./representation_stream";
 
 
 /**
@@ -51,8 +52,9 @@ export default function pushMediaSegment<T>(
     parsedSegment,
     segment,
     segmentBuffer } :
-  { playbackObserver : IReadOnlyPlaybackObserver<{ position : number;
-                                                   wantedTimeOffset : number; }>;
+  { playbackObserver : IReadOnlyPlaybackObserver<
+      IRepresentationStreamPlaybackObservation
+    >;
     content: { adaptation : Adaptation;
                manifest : Manifest;
                period : Period;

--- a/src/utils/rx-next-tick.ts
+++ b/src/utils/rx-next-tick.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import nextTick from "next-tick";
+import { Observable } from "rxjs";
+
+/**
+ * Create Observable that emits and complete on the next micro-task.
+ *
+ * This Observable can be useful to prevent race conditions based on
+ * synchronous task being performed in the wrong order.
+ * By awaiting nextTickObs before performing a task, you ensure that all other
+ * tasks that might have run synchronously either before or after it all already
+ * ran.
+ * @returns {Observable}
+ */
+export default function nextTickObs(): Observable<void> {
+  return new Observable<void>((obs) => {
+    let isFinished = false;
+    nextTick(() => {
+      if (!isFinished) {
+        obs.next();
+        obs.complete();
+      }
+    });
+    return () => {
+      isFinished = true;
+    };
+  });
+}


### PR DESCRIPTION
While working on integration tests (of a closed-source nature, not the ones in the RxPlayer project :/), I noticed a strange issue:

If a user triggered an action which led to a `RELOADING` state synchronously after the player's state updated to the `PAUSED` state (for example switching the video track when `PAUSED` is received), the RxPlayer might reload in a playing state instead of a paused state.

Arguably the situation is rare and the problem is not a big one either. Yet that issue was a real huge pain to fix, as it is linked to subtle race conditions between event listeners, the RxPlayer's API and the internal RxPlayer's code. Consequently it needed multiple fixes for that specific case not to be an issue anymore:

  - First I added more events that may trigger a playback observation, on which the internal RxPlayer's code rely to know the current media state (it was the `paused` state in the corresponding observation which was here not updated soon enough).
    Now an observation is also triggered for "pause" and "ended" events.

  - Then, as a cleaner and more workable implementation of advertising not only what the current media state is, but also what we plan it to be (e.g. the initial position before the initial seek has been done, and the playing state goal before autoplay was performed), I added the concept of a `pending` (relatively to `last`) to both the `position` and `paused` property of an Observation.

     When reloading, this allows to easily and explicitly know:
        - What is the known state at time of observation through the `last` property, and
        - What is the wanted state (e.g. after loading) through the `pending` property
      In turn, we would go to the wanted state, if set when RELOADING, instead of the current one (this was already done but in a very implicit manner).

     Nicely, this replaces the ugly `wantedTimeOffset` that was previously used for the position by a better, more understandable `position.pending` property - with also the advantage of it being close to the `position.last` property.

  - State updates in the API now depend on the exact same event listener used by the RxPlayer's internal code, which is the one done by the `PlaybackObserver`. Without doing this, concurrent listeners are called after another turn of the event loop, a situation that is hard to work-around when it causes problems, at least in a "not-very-ugly" way (see next point).

  - Reloading operation, which need the current last updated media state and are not needed to be performed synchronously now begin on a scheduled microtask, with comments expliciting that we're doing that to be sure all synchronous operations have been performed.

  - When reloading, the RxPlayer does not check the `observation.paused` property to see if playback is paused anymore but calls a `playbackObserver.getIsPaused()` method instead which directly get it from the media element.
    This was done because of even subtler race conditions where the `pause` method (on either the RxPlayer of the media element) would be called but the PlaybackObserver would not be yet notified. It seems from reading the specification and seeing implementations that `paused` from the media element (on which `getIsPaused` relies) is set synchronously after calling either `play` or `pause` on the media element, which is just what we want.

  - The RxPlayer's API now rely directly on the media element's `paused` attribute to announce through its state if it is currently PAUSED or PLAYING, for the same considerations.

Most of  these modifications are a little fragile because they might be easy to revert accidentally, so better solution might be found in the future.
In the meantime, it actually fixes the real issue we found.