### PR TITLE
Better handle reverse playback by not skipping very small holes when paused

### DIFF
--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -138,6 +138,14 @@ export default class PlaybackObserver {
   }
 
   /**
+   * Returns the current playback rate advertised by the `HTMLMediaElement`.
+   * @returns {number}
+   */
+  public getPlaybackRate() : number {
+    return this._mediaElement.playbackRate;
+  }
+
+  /**
    * Returns the current `paused` status advertised by the `HTMLMediaElement`.
    *
    * Use this instead of the same status emitted on an observation when you want
@@ -479,6 +487,11 @@ export interface IPlaybackObservation extends IMediaInfos {
 export interface IReadOnlyPlaybackObserver<TObservationType> {
   /** Get the current playing position, in seconds. */
   getCurrentTime() : number;
+  /**
+   * Returns the current playback rate advertised by the `HTMLMediaElement`.
+   * @returns {number}
+   */
+  getPlaybackRate() : number;
   /** Get the HTMLMediaElement's current `readyState`. */
   getReadyState() : number;
   /**
@@ -862,6 +875,9 @@ function generateReadOnlyObserver<TSource, TDest>(
     },
     getReadyState() {
       return src.getReadyState();
+    },
+    getPlaybackRate() : number {
+      return src.getPlaybackRate();
     },
     getIsPaused() {
       return src.getIsPaused();

--- a/src/core/init/initialize_directfile.ts
+++ b/src/core/init/initialize_directfile.ts
@@ -170,7 +170,7 @@ export default function initializeDirectfileContent({
    * Observable trying to avoid various stalling situations, emitting "stalled"
    * events when it cannot, as well as "unstalled" events when it get out of one.
    */
-  const stallAvoider$ = StallAvoider(playbackObserver, null, EMPTY, EMPTY);
+  const stallAvoider$ = StallAvoider(playbackObserver, null, speed, EMPTY, EMPTY);
 
   /**
    * Emit a "loaded" events once the initial play has been performed and the

--- a/src/core/init/load_on_media_source.ts
+++ b/src/core/init/load_on_media_source.ts
@@ -212,6 +212,7 @@ export default function createMediaSourceLoader(
      */
     const stallAvoider$ = StallAvoider(playbackObserver,
                                        manifest,
+                                       speed,
                                        lockedStream$,
                                        discontinuityUpdate$);
 

--- a/src/core/init/stall_avoider.ts
+++ b/src/core/init/stall_avoider.ts
@@ -221,7 +221,6 @@ export default function StallAvoider(
               position,
               readyState,
               rebuffering,
-              paused,
               freezing } = observation;
 
       const { BUFFER_DISCONTINUITY_THRESHOLD,
@@ -315,7 +314,7 @@ export default function StallAvoider(
       /** Position at which data is awaited. */
       const { position: stalledPosition } = rebuffering;
 
-      if (stalledPosition !== null && !paused && speed.getValue() > 0) {
+      if (stalledPosition !== null && speed.getValue() > 0) {
         const skippableDiscontinuity = findSeekableDiscontinuity(discontinuitiesStore,
                                                                  manifest,
                                                                  stalledPosition);
@@ -345,7 +344,6 @@ export default function StallAvoider(
       // case of small discontinuity in the content.
       const nextBufferRangeGap = getNextRangeGap(buffered, freezePosition);
       if (
-        !paused &&
         speed.getValue() > 0 &&
         nextBufferRangeGap < BUFFER_DISCONTINUITY_THRESHOLD
       ) {

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -180,11 +180,17 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
           this._disableCurrentCues();
           return;
         }
+        const videoElt = this._videoElement;
         const { MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL } = config.getCurrent();
-        // to spread the time error, we divide the regular chosen interval.
-        const time = Math.max(this._videoElement.currentTime +
-                              (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
-                              0);
+        let time;
+        if (videoElt.paused || videoElt.playbackRate <= 0) {
+          time = videoElt.currentTime;
+        } else {
+          // to spread the time error, we divide the regular chosen interval.
+          time = Math.max(this._videoElement.currentTime +
+                           (MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL / 1000) / 2,
+                          0);
+        }
         const cues = this._buffer.get(time);
         if (cues.length === 0) {
           this._disableCurrentCues();

--- a/src/core/stream/representation/get_buffer_status.ts
+++ b/src/core/stream/representation/get_buffer_status.ts
@@ -100,8 +100,12 @@ export default function getBufferStatus(
   segmentBuffer.synchronizeInventory();
 
   const { representation } = content;
+  const askedStart = playbackObserver.getIsPaused() ||
+                     playbackObserver.getPlaybackRate() <= 0 ?
+    initialWantedTime - 0.1 :
+    initialWantedTime;
   const neededRange = getRangeOfNeededSegments(content,
-                                               initialWantedTime,
+                                               askedStart,
                                                bufferGoal);
   const shouldRefreshManifest = representation.index.shouldRefresh(neededRange.start,
                                                                    neededRange.end);
@@ -139,7 +143,7 @@ export default function getBufferStatus(
 
   const prioritizedNeededSegments: IQueuedSegment[] = segmentsToLoad.map((segment) => (
     {
-      priority: getSegmentPriority(segment.time, initialWantedTime),
+      priority: getSegmentPriority(segment.time, askedStart),
       segment,
     }
   ));
@@ -228,7 +232,7 @@ function getRangeOfNeededSegments(
   {
     wantedStartPosition = lastIndexPosition - 1;
   } else {
-    wantedStartPosition = initialWantedTime;
+    wantedStartPosition = initialWantedTime - 0.1;
   }
 
   const wantedEndPosition = wantedStartPosition + bufferGoal;

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -754,22 +754,22 @@ const DEFAULT_CONFIG = {
     END: 0.1,
   },
 
-    /**
-     * Maximum interval at which text tracks are refreshed in an "html"
-     * textTrackMode.
-     *
-     * The text tracks are also refreshed on various video events, this interval
-     * will only trigger a refresh if none of those events was received during
-     * that timespan.
-     *
-     * Note that if the TextTrack cue did not change between two intervals or
-     * events, the DOM won't be refreshed.
-     * The TextTrack cues structure is also optimized for fast retrieval.
-     * We should thus not have much of a performance impact here if we set a low
-     * interval.
-     *
-     * @type {Number}
-     */
+  /**
+   * Maximum interval at which text tracks are refreshed in an "html"
+   * textTrackMode.
+   *
+   * The text tracks are also refreshed on various video events, this interval
+   * will only trigger a refresh if none of those events was received during
+   * that timespan.
+   *
+   * Note that if the TextTrack cue did not change between two intervals or
+   * events, the DOM won't be refreshed.
+   * The TextTrack cues structure is also optimized for fast retrieval.
+   * We should thus not have much of a performance impact here if we set a low
+   * interval.
+   *
+   * @type {Number}
+   */
   MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL: 50,
 
     /**

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -737,12 +737,12 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(1500);
         expect(player.getVideoPlayedTime()).to.be.closeTo(9, 0.001);
 
-        player.seekTo(minimumPosition + 30);
+        player.seekTo(minimumPosition + 31);
         await sleep(1500);
         const initialLoadedTime = player.getVideoPlayedTime();
-        expect(initialLoadedTime).to.be.closeTo(0, 4);
+        expect(initialLoadedTime).to.be.closeTo(1, 4);
 
-        player.seekTo(minimumPosition + 30 + 5);
+        player.seekTo(minimumPosition + 31 + 5);
         expect(player.getVideoPlayedTime()).to.be
           .closeTo(initialLoadedTime + 5, 1);
       });


### PR DESCRIPTION
__UPDATE: automatic gap-jumping has been re-established when the media element is paused, as not doing it may prevent discontinuities skip when the content is `LOADING` or `RELOADING`. In any case, only doing it when the application explicitely set the `playbackRate` at `0` or at a negative number seems logical and sufficient.__


An application using the RxPlayer to implement a frame-to-frame feature where it's possible to go forward or backward, and also a fake reverse playback, based on multiple very close seeks at a quick interval, is having issues when seeking a very small amount of time backward at the start boundary of a segment.

Once that boundary is reached, seeking back a very small amount of time (let's say 0.04 second), actually lead to the RxPlayer seeking back automatically to the start of the next segment in most cases.

This is because of an optimization of the RxPlayer where:
  - if a very small amount of time in a segment is needed (less than 0.2 seconds)
  - AND that segment is not yet loaded and buffered
  - AND if the next segment is already loaded and buffered

then we can directly seek to the start of the already buffered segment instead, so playback can start right away (instead of having to wait the loading of the previous segment).

This optimization makes sense in a condition of regular playback but it does break frame-to-frame use cases.

A simple and non-breaking tweak we could perform is to just perform that kind of optimisation when the video is actually clearly playing in a regular manner, that is it is not paused, at a `0` `playbackRate` or at a negative `playbackRate`.

---

The same logic has been repeated for the "locked stream" handling, which likewise seek at the start of the next Period in very specific conditions.

Doing this here may be more problematic, as it might mean a visual infinite rebuffering until either the player is unpaused or until the application seeks again, though this is a much smaller inconvenience that just not being able to seek back.

---

In our reflections, we also thought and even tried to implement optimal reverse playback where e.g. media segments would be loaded in the reverse order (a segment N, then a segment N-1 etc.), but it appeared that doing that would not be trivial, for a usage that still stay limited.

So for now, this kind of more complete solution is put on hold, and we'll make them test this [much much much] more simple but limited solution (among issues, as segments are still loaded in regular order, they might see a rebufferings after passing a segment boundary in the reverse order, I'm also unsure of how it reacts with browser's garbage collection algorithms which tend also to consider that playback goes in the "regular direction" when choosing which segments to evict).