### PR TITLE
Try to work-around yet another case of Tizen seeking back

### DIFF
--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -342,7 +342,7 @@ const DEFAULT_CONFIG = {
      * small enough so this (arguably rare) situation won't lead to too much
      * waiting time.
      */
-  FORCE_DISCONTINUITY_SEEK_DELAY: 2000,
+  FORCE_DISCONTINUITY_SEEK_DELAY: 3000,
 
     /**
      * Ratio used to know if an already loaded segment should be re-buffered.


### PR DESCRIPTION
Some devices relying on the Tizen OS, like Samsung TVs, have a peculiar behavior - initially created on their side as an optimization - which breaks many of the RxPlayer's own and sometimes create playback issues:

When seeking on these devices, it is possible that the device itself re-seek at a different time instead, because for example it judges that playback may restart faster when starting from a position with a video I-frame instead of the position actually seeked to.

We understand that point of view (even if I personally don't think it should be done - the WHATWG HTML spec does seem to agrees with me here when it comes to seeking by mutating the `currentTime` attribute, for IMO good reasons).
Anyway, issues may be created when no audio data has been loaded - or even is present - for that position, as playback may not be able to start in that case.
When this arises, the RxPlayer may decide by itself to jump automatically at the first position with both audio and video, either if it is close enough or if there's no other way to actually begin playback.

When both this RxPlayer auto-gap skipping logic and Tizen auto-seek are in play, we may stay in a deadlock where both logic think that the position should be updated to a new one.

To work around this, we discussed with Tizen engineer who told us that in most cases, if a very small gap-skip is actually needed, the browser will actually do it by itself without our help.
However, we still wanted to have a remaining logic for other cases where it didn't (e.g. when the gap was too big, with its definition being unknown and browser-specific).

The solution we settled with was to try to detect each time Tizen OS seemed to have seeked back by itself, by comparing the `currentTime` attribute at the time of the `seeking` event, with the `currentTime` attribute at the time the seek actually ended.

When this happened, the RxPlayer let the browser handle by itself any gap jumping for some seconds. If after thost multiple seconds, playback was still stuck, the RxPlayer took the role of skipping the gap.

---

That solution worked well but we recently saw a closely related one recently on some [italian] contents loaded by one of Canal+
applications.

Here, it seemed as if our work-around was never called. After deeper inspection, it seems that this is yet another behavior of Tizen when it seeks back, where the initial `currentTime` attribute would return a value already different at the time of the `seeking` event, than the one actually seeked to by the RxPlayer.

As the RxPlayer previously relied on this event to compare this attribute, the work around was never triggered here.

To fix this, I tried a more complex solution where the original seeking position we compare to is actually the maximum between:

  - the value actually set on `currentTime` originally by the RxPlayer
    To keep that value, I chose to store it in a PlaybackObserver's observation object where a so-called "internal-seek" (seek performed internally by the RxPlayer) is pending.

  - the `currentTime` value advertised on the related `seeking` event

By taking the maximum, we raise the chance of considering an abnormal seek-back done by Tizen.

This has been tested with success on the corresponding TVs and contents, to check if it doesn't break anything else.