### PR TITLE
[V4] Add FREEZING state

### DIFF
--- a/demo/full/scripts/modules/player/catchUp.js
+++ b/demo/full/scripts/modules/player/catchUp.js
@@ -64,6 +64,7 @@ export default function $handleCatchUpMode(
                playerState === "PLAYING" ||
                playerState === "PAUSED" ||
                playerState === "BUFFERING" ||
+               playerState === "FREEZING" ||
                playerState === "SEEKING";
       }),
       switchMap(canCatchUp => {

--- a/demo/full/scripts/modules/player/events.js
+++ b/demo/full/scripts/modules/player/events.js
@@ -105,7 +105,7 @@ const linkPlayerEventsToState = (player, state, $destroy) => {
       hasEnded: arg === "ENDED",
       hasCurrentContent: !["STOPPED", "LOADING"].includes(arg),
       isContentLoaded: !["STOPPED", "LOADING", "RELOADING"].includes(arg),
-      isBuffering: arg === "BUFFERING",
+      isBuffering: arg === "BUFFERING" || arg === "FREEZING",
       isLoading: arg === "LOADING",
       isReloading: arg === "RELOADING",
       isSeeking: arg === "SEEKING",

--- a/doc/api/Basic_Methods/getPlayerState.md
+++ b/doc/api/Basic_Methods/getPlayerState.md
@@ -25,6 +25,13 @@ Can be either one of those strings:
 - `"BUFFERING"`: the player has reached the end of the buffer and is waiting
   for data to be appended.
 
+- `"FREEZING"`: The player cannot play the content despite having enough data,
+  due to an unknown reason.
+  In most of those cases, the RxPlayer will be able to continue playback by
+  itself, after some time.
+  As such, most `FREEZING` cases can be treated exactly like a `BUFFERING`
+  state.
+
 - `"SEEKING"`: The player has reached the end of the buffer because a seek
   has been performed, new segments are being loaded.
 
@@ -58,25 +65,28 @@ switch (player.getPlayerState()) {
     console.log("The new content is loaded and ready to be played");
     break;
   case "PLAYING":
-    console.log("The content is currently playing");
+    console.log("The player is currently playing");
     break;
   case "PAUSED":
-    console.log("The content is currently paused");
+    console.log("The player is currently paused");
     break;
   case "BUFFERING":
-    console.log("The content is buffering new data");
+    console.log("The player is paused while buffering new data");
+    break;
+  case "FREEZING":
+    console.log("The player is frozen");
     break;
   case "SEEKING":
-    console.log("The content is still seeking, waiting for new data");
+    console.log("The player is still seeking, waiting for new data");
     break;
   case "ENDED":
-    console.log("The content has reached the end.");
+    console.log("The player has reached the end of the content.");
     break;
   case "RELOADING":
-    console.log("The content is currently reloading");
+    console.log("The player is currently reloading the content");
     break;
   default:
-    console.log("This is impossible (issue material!).");
+    console.log("This is impossible!");
     break;
 }
 ```

--- a/doc/api/Basic_Methods/pause.md
+++ b/doc/api/Basic_Methods/pause.md
@@ -4,8 +4,8 @@
 
 Pause the current loaded video. Equivalent to a video element's pause method.
 
-Note that a content can be paused even if its current state is `BUFFERING` or
-`SEEKING`.
+Note that a content can be paused even if its current state is `BUFFERING`,
+`SEEKING` or `FREEZING`.
 
 You might want for a content to be loaded before being able to pause (the
 current state has to be different than `LOADING`, `RELOADING` or `STOPPED`).

--- a/doc/api/Player_States.md
+++ b/doc/api/Player_States.md
@@ -16,7 +16,7 @@ rx-player, which is exactly the point of this page.
 
 ## List of possible states
 
-Today the player can have one of these 9 possible states:
+Today the player can have one of these 10 possible states:
 
 - `STOPPED`
 - `LOADING`
@@ -24,6 +24,7 @@ Today the player can have one of these 9 possible states:
 - `PLAYING`
 - `PAUSED`
 - `BUFFERING`
+- `FREEZING`
 - `SEEKING`
 - `ENDED`
 - `RELOADING`
@@ -77,9 +78,28 @@ Indicates that the player is currently paused in the content.
 
 ### The BUFFERING state
 
-The content is paused because it needs to build buffer.
+The player is paused because it needs to build buffer.
+
+TThe player cannot play the content despite having enough data, due to an
+unknown reason.
 
 The player will not play until it gets out of this state.
+
+### The FREEZING state
+
+TThe player cannot play the content despite having enough data, due to an
+unknown reason.
+
+This state might be due to either:
+  - poor performance
+  - an issue with the current device
+  - the key of an encrypted content not being loaded soon enough
+
+The player will not play until it gets out of this state.
+
+In most of those cases, the RxPlayer will be able to continue playback by itself,
+after some time.
+As such, most `FREEZING` cases can be treated exactly like a `BUFFERING` state.
 
 ### The SEEKING state
 

--- a/src/core/api/__tests__/get_player_state.test.ts
+++ b/src/core/api/__tests__/get_player_state.test.ts
@@ -81,7 +81,7 @@ describe("API - getLoadedContentState", () => {
     expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
   });
 
-  it("should be BUFFERING if not ended and stalled because of freezing", () => {
+  it("should be FREEZING if not ended and stalled because of freezing", () => {
     const fakeProps = {
       ended: false,
       duration: 10,
@@ -89,9 +89,9 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("FREEZING");
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "freezing")).toBe("FREEZING");
   });
 
   it("should be BUFFERING if not ended and stalled because of `not-ready`", () => {

--- a/src/core/api/get_player_state.ts
+++ b/src/core/api/get_player_state.ts
@@ -28,6 +28,7 @@ export const PLAYER_STATES =
     ENDED: "ENDED",
     BUFFERING: "BUFFERING",
     SEEKING: "SEEKING",
+    FREEZING : "FREEZING",
     RELOADING: "RELOADING" } as Record<IPlayerState, IPlayerState>;
 
 /**
@@ -61,8 +62,9 @@ export default function getLoadedContentState(
       return PLAYER_STATES.ENDED;
     }
 
-    return stalledStatus === "seeking" ? PLAYER_STATES.SEEKING :
-                                         PLAYER_STATES.BUFFERING;
+    return stalledStatus === "seeking"  ? PLAYER_STATES.SEEKING :
+           stalledStatus === "freezing" ? PLAYER_STATES.FREEZING :
+                                          PLAYER_STATES.BUFFERING;
   }
   return mediaElement.paused ? PLAYER_STATES.PAUSED :
                                PLAYER_STATES.PLAYING;

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -482,6 +482,7 @@ export type IPlayerState = "STOPPED" |
                            "PAUSED" |
                            "ENDED" |
                            "BUFFERING" |
+                           "FREEZING" |
                            "SEEKING" |
                            "RELOADING";
 

--- a/tests/integration/scenarios/dash_multi-track.js
+++ b/tests/integration/scenarios/dash_multi-track.js
@@ -34,7 +34,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     player.seekTo(120);
     await sleep(500);
     if (player.getPlayerState() !== "PAUSED") {
-      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
     expect(player.getPosition()).to.be.within(118, 122);
   }
@@ -43,7 +43,7 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     player.seekTo(5);
     await sleep(500);
     if (player.getPlayerState() !== "PAUSED") {
-      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
     expect(player.getPosition()).to.be.within(0, 10);
   }

--- a/tests/integration/scenarios/dash_multi_periods.js
+++ b/tests/integration/scenarios/dash_multi_periods.js
@@ -30,7 +30,7 @@ describe("DASH multi-Period with different choices", function () {
     player.seekTo(5);
     await sleep(500);
     if (player.getPlayerState() !== "PAUSED") {
-      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
     expect(player.getPosition()).to.be.within(0, 10);
   }
@@ -39,7 +39,7 @@ describe("DASH multi-Period with different choices", function () {
     player.seekTo(120);
     await sleep(500);
     if (player.getPlayerState() !== "PAUSED") {
-      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+      await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
     expect(player.getPosition()).to.be.within(118, 122);
   }


### PR DESCRIPTION
As already discussed internally at Canal+, this PR adds the `"FREEZING"` player state to the RxPlayer, for specific cases where enough data has been buffered but playback is still not advancing due to an unknown reason.

Previously, that state was either reported as `"BUFFERING"` or as `"PLAYING"` depending on other HTMLMediaElement's attributes.

We decided to add this new state (only in V4 as this is a breaking change), for the following reasons:
  - this is a situation where an interface might want to display what it does for regular `"BUFFERING"`, like a spinner (this is for the case that was previously categorized as `"PLAYING"`)
  - an application might want to report when that state is happening - and differentiate it from a `"BUFFERING"` - to help investigate issues in production
  - handling it in an application shouldn't be hard. If most want to just treat it as the same as a `"BUFFERING"`, they can do it very easily. This is exactly what we do for now in our demo page, with only two lines updated.