### PR TITLE
[V4] DRM: Remove persistentLicense keySystems option and rename licenseStorage to persistentLicenseConfig

### DIFF
--- a/doc/Getting_Started/Tutorials/Content_with_DRM.md
+++ b/doc/Getting_Started/Tutorials/Content_with_DRM.md
@@ -522,13 +522,9 @@ the user is offline.
 After loading a persistent license, it is automatically stored on the browser's
 side, but the RxPlayer still has to store an ID to be able to retrieve the right
 session when reloading the same content later.
-Because of that, persistent-license management comes in two part in the RxPlayer
-API (as usual here, those should be set in `keySystems`):
 
-1. You'll have to set the `persistentLicense` boolean to `true`
-
-2. You'll have to provide a license storage mechanism and set it as the
-   `licenseStorage` property.
+Because of that, you'll have to provide a storage mechanism and set it as a
+`persistentLicenseConfig` property of `loadVideo`'s `keySystems` option:
 
 ```js
 rxPlayer.loadVideo({
@@ -538,17 +534,16 @@ rxPlayer.loadVideo({
     {
       type: "widevine",
       getLicense,
-      persistentLicense: true,
-      licenseStorage,
+      persistentLicenseConfig,
     },
   ],
 });
 ```
 
-### licenseStorage property
+### persistentLicenseConfig property
 
-The `licenseStorage` property is an object allowing the RxPlayer to load and
-saved stored IDs.
+The `persistentLicenseConfig` property is an object allowing the RxPlayer to
+load and saved stored session identifiers, to be able to retrieve them later.
 
 It needs to contain two functions:
 
@@ -557,6 +552,10 @@ It needs to contain two functions:
 - `load`: Called without any argument, it has to return what was given to the
   last `save` call. Any return value which is not an Array will be ignored
   (example: when `save` has never been called).
+
+If the ability to retrieve persistent-licenses from older RxPlayer version is
+not important to you, you can also add a `disableRetroCompatibility` property
+set to `true`, this will unlock supplementary optimizations on contents.
 
 This API can very simply be implemented with the
 [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
@@ -570,13 +569,12 @@ rxPlayer.loadVideo({
     {
       type: "widevine",
       getLicense,
-      persistentLicense: true,
-      licenseStorage: {
+      persistentLicenseConfig: {
         save(data) {
-          localStorage.setItem("RxPlayer-licenseStorage", JSON.stringify(data));
+          localStorage.setItem("RxPlayer-persistent-storage", JSON.stringify(data));
         },
         load() {
-          const item = localStorage.getItem("RxPlayer-licenseStorage");
+          const item = localStorage.getItem("RxPlayer-persistent-storage");
           return item === null ? [] : JSON.parse(item);
         },
       },

--- a/doc/api/Decryption_Options.md
+++ b/doc/api/Decryption_Options.md
@@ -212,25 +212,13 @@ still continue to try deciphering the content (albeit a
 `"LICENSE_SERVER_CERTIFICATE_ERROR"`).
 
 
-### persistentLicense
-
-_type_: `Boolean | undefined`
-
-Set it to `true` if you want the ability to persist the license for later
-retrieval.
-
-In that case, you will also need to set the `licenseStorage` attribute to
-be able to persist the license through your preferred method.
-
-Note that not all licenses can be persisted, this is dependent both on the
-loaded licenses and on the Content Decryption Module used in the browser.
-
-
-### licenseStorage
+### persistentLicenseConfig
 
 _type_: `Object | undefined`
 
-Required only if `persistentLicense` has been set to `true`.
+Set it only if you want to load persistent-license(s) for later retrieval.
+Note that not all licenses can be persisted, this is dependent both on the
+loaded licenses and on the Content Decryption Module used in the browser.
 
 This is an object containing the following properties:
 
@@ -465,7 +453,7 @@ This includes session data and any other type of state, but does not include
 identifiers](https://www.w3.org/TR/2017/REC-encrypted-media-20170918/#distinctive-identifier),
 for which there's another `keySystems` option, `distinctiveIdentifier`.
 
-If the `persistentLicense` `keySystems` option has been set to `true`,
+If the `persistentLicenseConfig` `keySystems` option has been set to `true`,
 setting this value to `"required"` is redundant and therefore unnecessary (as
 exploiting persistent licenses already necessitate the ability to persist
 session state).

--- a/doc/api/Typescript_Types.md
+++ b/doc/api/Typescript_Types.md
@@ -92,8 +92,8 @@ exported:
     To clarify, the `keySystems` property in a `loadVideo` call is an
     optional array of one or multiple `IKeySystemOption`.
 
-  - `IPersistentSessionStorage`: type of the `licenseStorage` property of the
-    `keySystems` option given to `loadVideo`.
+  - `IPersistentLicenseConfig`: type of the `persistentLicenseConfig` property
+    of the `keySystems` option given to `loadVideo`.
 
   - `IPersistentSessionInfo`: type used by an `IPersistentSessionStorage`'s
     storage.

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -82,10 +82,7 @@ properties, methods, events and so on.
       Eventual certificate encrypting exchanges between the CDM and license
       server.
 
-    - [`keySystems[].persistentLicense`](../api/Decryption_Options.md#persistentlicense):
-      Allows to ask for the DRM session to persist the license.
-
-    - [`keySystems[].licenseStorage`](../api/Decryption_Options.md#licensestorage):
+    - [`keySystems[].persistentLicenseConfig`](../api/Decryption_Options.md#persistentLicenseConfig):
       Allows to ask for the DRM session to persist the license.
 
     - [`keySystems[].fallbackOn`](../api/Decryption_Options.md#fallbackon):

--- a/src/core/decrypt/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/core/decrypt/__tests__/__global__/media_key_system_access.test.ts
@@ -245,29 +245,16 @@ describe("core - decrypt - global tests - media key system access", () => {
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
   });
 
-  it("should do nothing if just licenseStorage is set", async () => {
-    const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
-    mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
-    const licenseStorage = { save() { throw new Error("Should not save."); },
-                             load() { throw new Error("Should not load."); } };
-    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
-                                                     getLicense: neverCalledFn,
-                                                     licenseStorage }]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
-  });
-
   /* eslint-disable max-len */
-  it("should want persistent sessions if both persistentLicense and licenseStorage are set", async () => {
+  it("should want persistent sessions if persistentLicenseConfig is set", async () => {
   /* eslint-enable max-len */
     const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
-    const licenseStorage = { save() { throw new Error("Should not save."); },
-                             load() { throw new Error("Should not load."); } };
+    const persistentLicenseConfig = { save() { throw new Error("Should not save."); },
+                                      load() { throw new Error("Should not load."); } };
     await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
                                                      getLicense: neverCalledFn,
-                                                     licenseStorage,
-                                                     persistentLicense: true }]);
+                                                     persistentLicenseConfig }]);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
 
     const expectedConfig = defaultKSConfig.map(conf => {
@@ -279,30 +266,24 @@ describe("core - decrypt - global tests - media key system access", () => {
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
   });
 
-  /* eslint-disable max-len */
-  it("should want persistent sessions if just persistentLicense is set to true", async () => {
-  /* eslint-enable max-len */
+  it("should do nothing if persistentLicenseConfig is set to null", async () => {
     const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
     await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
                                                      getLicense: neverCalledFn,
-                                                     persistentLicense: true }]);
+                                                     persistentLicenseConfig: null }]);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-
-    const expectedConfig = defaultKSConfig.map(conf => {
-      return { ...conf,
-               persistentState: "required",
-               sessionTypes: ["temporary", "persistent-license"] };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
   });
 
-  it("should do nothing if persistentLicense is set to false", async () => {
+  it("should do nothing if persistentLicenseConfig is set to undefined", async () => {
     const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
-    await checkIncompatibleKeySystemsErrorMessage([{ type: "foo",
-                                                     getLicense: neverCalledFn,
-                                                     persistentLicense: false }]);
+    await checkIncompatibleKeySystemsErrorMessage([{
+      type: "foo",
+      getLicense: neverCalledFn,
+      persistentLicenseConfig: undefined,
+    }]);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
   });
@@ -389,7 +370,10 @@ describe("core - decrypt - global tests - media key system access", () => {
     const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
     await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
-                                                     persistentLicense: true,
+                                                     persistentLicenseConfig: {
+                                                       load() { return []; },
+                                                       save() { return []; },
+                                                     },
                                                      getLicense: neverCalledFn },
                                                    { type: "clearkey",
                                                      distinctiveIdentifier: "required",
@@ -432,7 +416,10 @@ describe("core - decrypt - global tests - media key system access", () => {
     const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
     await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
-                                                     persistentLicense: true,
+                                                     persistentLicenseConfig: {
+                                                       load() { return []; },
+                                                       save() { return []; },
+                                                     },
                                                      getLicense: neverCalledFn },
                                                    { type: "clearkey",
                                                      distinctiveIdentifier: "required",

--- a/src/core/decrypt/content_decryptor.ts
+++ b/src/core/decrypt/content_decryptor.ts
@@ -196,8 +196,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
          * MediaKeySessions persisted in older RxPlayer's versions.
          */
         let systemId : string | undefined;
-        if (isNullOrUndefined(options.licenseStorage) ||
-            options.licenseStorage.disableRetroCompatibility === true)
+        if (isNullOrUndefined(options.persistentLicenseConfig) ||
+            options.persistentLicenseConfig.disableRetroCompatibility === true)
         {
           systemId = getDrmSystemId(mediaKeySystemAccess.keySystem);
         }
@@ -437,7 +437,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     this._lockInitDataQueue();
 
     let wantedSessionType : MediaKeySessionType;
-    if (options.persistentLicense !== true) {
+    if (isNullOrUndefined(options.persistentLicenseConfig)) {
       wantedSessionType = "temporary";
     } else if (!canCreatePersistentSession(mediaKeySystemAccess)) {
       log.warn("DRM: Cannot create \"persistent-license\" session: not supported");

--- a/src/core/decrypt/find_key_system.ts
+++ b/src/core/decrypt/find_key_system.ts
@@ -86,7 +86,8 @@ function checkCachedMediaKeySystemAccess(
       return false;
     }
 
-    if ((ks.persistentLicense === true || ks.persistentState === "required") &&
+    if ((!isNullOrUndefined(ks.persistentLicenseConfig) ||
+         ks.persistentState === "required") &&
         mksConfiguration.persistentState !== "required")
     {
       return false;
@@ -138,7 +139,7 @@ function buildKeySystemConfigurations(
   let persistentState: MediaKeysRequirement = "optional";
   let distinctiveIdentifier: MediaKeysRequirement = "optional";
 
-  if (keySystem.persistentLicense === true) {
+  if (!isNullOrUndefined(keySystem.persistentLicenseConfig)) {
     persistentState = "required";
     sessionTypes.push("persistent-license");
   }

--- a/src/core/decrypt/get_media_keys.ts
+++ b/src/core/decrypt/get_media_keys.ts
@@ -38,18 +38,19 @@ import ServerCertificateStore from "./utils/server_certificate_store";
 function createPersistentSessionsStorage(
   keySystemOptions : IKeySystemOption
 ) : PersistentSessionsStore|null {
-  if (keySystemOptions.persistentLicense !== true) {
+  if (isNullOrUndefined(keySystemOptions.persistentLicenseConfig)) {
     return null;
   }
 
-  const { licenseStorage } = keySystemOptions;
-  if (licenseStorage == null) {
+  const { persistentLicenseConfig } = keySystemOptions;
+  if (persistentLicenseConfig == null) {
     throw new EncryptedMediaError("INVALID_KEY_SYSTEM",
-                                  "No license storage found for persistent license.");
+                                  "No `persistentLicenseConfig` found for " +
+                                  "persistent license.");
   }
 
   log.debug("DRM: Set the given license storage");
-  return new PersistentSessionsStore(licenseStorage);
+  return new PersistentSessionsStore(persistentLicenseConfig);
 }
 
 /** Object returned by `getMediaKeysInfos`. */

--- a/src/core/decrypt/utils/persistent_sessions_store.ts
+++ b/src/core/decrypt/utils/persistent_sessions_store.ts
@@ -17,8 +17,8 @@
 import { ICustomMediaKeySession } from "../../../compat";
 import log from "../../../log";
 import {
+  IPersistentLicenseConfig,
   IPersistentSessionInfo,
-  IPersistentSessionStorage,
 } from "../../../public_types";
 import areArraysOfNumbersEqual from "../../../utils/are_arrays_of_numbers_equal";
 import { assertInterface } from "../../../utils/assert";
@@ -36,15 +36,15 @@ import SerializableBytes from "./serializable_bytes";
  * Throw if the given storage does not respect the right interface.
  * @param {Object} storage
  */
-function checkStorage(storage : IPersistentSessionStorage) : void {
+function checkStorage(storage : IPersistentLicenseConfig) : void {
   assertInterface(storage,
                   { save: "function", load: "function" },
-                  "licenseStorage");
+                  "persistentLicenseConfig");
 }
 
 /**
- * Set representing persisted licenses. Depends on a simple local-
- * storage implementation with a `save`/`load` synchronous interface
+ * Set representing persisted licenses. Depends on a simple
+ * implementation with a `save`/`load` synchronous interface
  * to persist information on persisted sessions.
  *
  * This set is used only for a cdm/keysystem with license persistency
@@ -52,14 +52,14 @@ function checkStorage(storage : IPersistentSessionStorage) : void {
  * @class PersistentSessionsStore
  */
 export default class PersistentSessionsStore {
-  private readonly _storage : IPersistentSessionStorage;
+  private readonly _storage : IPersistentLicenseConfig;
   private _entries : IPersistentSessionInfo[];
 
   /**
    * Create a new PersistentSessionsStore.
    * @param {Object} storage
    */
-  constructor(storage : IPersistentSessionStorage) {
+  constructor(storage : IPersistentLicenseConfig) {
     checkStorage(storage);
     this._entries = [];
     this._storage = storage;
@@ -338,7 +338,9 @@ export default class PersistentSessionsStore {
     try {
       this._storage.save(this._entries);
     } catch (e) {
-      log.warn("DRM-PSS: Could not save licenses in localStorage");
+      const err = e instanceof Error ? e :
+                                       undefined;
+      log.warn("DRM-PSS: Could not save MediaKeySession information", err);
     }
   }
 }

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -422,13 +422,8 @@ export interface IKeySystemOption {
    * set.
    */
   serverCertificate? : BufferSource | null;
-  /**
-   * If `true`, we will try to persist the licenses obtained as well as try to
-   * load already-persisted licenses.
-   */
-  persistentLicense? : boolean;
   /** Storage mechanism used to store and retrieve information on stored licenses. */
-  licenseStorage? : IPersistentSessionStorage;
+  persistentLicenseConfig? : IPersistentLicenseConfig;
   /**
    * Wanted value for the `persistentState` property of this
    * `MediaKeySystemConfiguration` according to the EME API.
@@ -552,7 +547,7 @@ export type IPersistentSessionInfo = IPersistentSessionInfoV4 |
                                      IPersistentSessionInfoV0;
 
 /** Persistent MediaKeySession storage interface. */
-export interface IPersistentSessionStorage {
+export interface IPersistentLicenseConfig {
   /** Load persistent MediaKeySessions previously saved through the `save` callback. */
   load() : IPersistentSessionInfo[] | undefined | null;
   /**


### PR DESCRIPTION
This PR simplifies and gives a better name to API relative to persistent licenses.

Previously, an application needed to set both a `persistentLicense` property to `true` and a `licenseStorage` object - which in reality does not store any license but identifiers allowing to retrieve MediaKeySessions persisted by the browser/CDM - to profit from persistent licenses.

This PR removes the need of setting the former (as long as the latter is set) and rename the latter to `persistentLicenseConfig`, thus both correcting the "wrongness" of the previous API but also removing notion of "storage" to pave the way for potential supplementary options in it (like we already did with the `licenseConfig.disableRetroCompatibility` boolean).

Of course, this is a breaking chang and is thus planned for V4