### PR TITLE
[V4] Flatten transportOptions loadVideo option

### DIFF
--- a/doc/Getting_Started/Tutorials/Content_with_DRM.md
+++ b/doc/Getting_Started/Tutorials/Content_with_DRM.md
@@ -470,9 +470,9 @@ used by the RxPlayer.
 The application could then infer that other contents from the same right holders
 will have the same issues.
 In that case, an optimization is possible by using the `representationFilter`
-API which is part of the `transportOptions` `loadVideo` option, [documented
-here](../../api/Loading_a_Content.md#transportoptions). By using this API, we
-can filter out un-decipherable quality to avoid downloading them in the first
+API which is a `loadVideo` option, [documented
+here](../../api/Loading_a_Content.md#representationfilter). By using this API,
+we can filter out un-decipherable quality to avoid downloading them in the first
 place.
 
 ## Server certificate

--- a/doc/api/Miscellaneous/Initial_Position.md
+++ b/doc/api/Miscellaneous/Initial_Position.md
@@ -84,7 +84,7 @@ should be broadcasted at which time by either of those means:
   contents).
 - One was provided to `loadVideo` thanks to the `serverSyncInfos` transport
   option [see loadVideo
-  documentation](../Loading_a_Content.md#transportoptions).
+  documentation](../Loading_a_Content.md#serversyncinfos).
 
 [2] I wrote "close to" in every cases as we might substract some seconds from
 that value. How much we might do, depends on:

--- a/doc/api/Miscellaneous/Local_Contents.md
+++ b/doc/api/Miscellaneous/Local_Contents.md
@@ -33,20 +33,18 @@ You will just need to:
    in `loadVideo` to `"local"`
 2. As the generated Manifest object most likely won't be available through an
    URL but directly as a JavaScript object, you will need to communicate it
-   through the `manifestLoader` property in the `transportOptions` `loadVideo`
-   option.
+   through the `manifestLoader` option of `loadVideo`.
 
 Here is an example:
 
 ```js
 rxPlayer.loadVideo({
   transport: "local",
-  transportOptions: {
-    // Note: `_url` here will be `undefined`
-    manifestLoader(_url, callbacks) {
-      // where `localManifest` is the local Manifest in object form
-      callbacks.resolve({ data: localManifest });
-    },
+
+  // Note: `_url` here will be `undefined`
+  manifestLoader(_url, callbacks) {
+    // where `localManifest` is the local Manifest in object form
+    callbacks.resolve({ data: localManifest });
   },
   // ...
 });

--- a/doc/api/Miscellaneous/Local_Manifest_v0.1.md
+++ b/doc/api/Miscellaneous/Local_Manifest_v0.1.md
@@ -41,20 +41,18 @@ You will just need to:
    in `loadVideo` to `"local"`
 2. As the generated Manifest object most likely won't be available through an
    URL but directly as a JavaScript object, you will need to communicate it
-   through the `manifestLoader` property in the `transportOptions` `loadVideo`
-   option.
+   through the `manifestLoader` option in the `loadVideo` call.
 
 Here is an example:
 
 ```js
 rxPlayer.loadVideo({
   transport: "local",
-  transportOptions: {
-    // Note: `_url` here will be `undefined`
-    manifestLoader(_url, callbacks) {
-      // where `localManifest` is the local Manifest in object form
-      callbacks.resolve({ data: localManifest });
-    },
+
+  // Note: `_url` here will be `undefined`
+  manifestLoader(_url, callbacks) {
+    // where `localManifest` is the local Manifest in object form
+    callbacks.resolve({ data: localManifest });
   },
   // ...
 });

--- a/doc/api/Miscellaneous/Low_Latency.md
+++ b/doc/api/Miscellaneous/Low_Latency.md
@@ -88,10 +88,10 @@ could lose latency or worse: obtain playback issues.
 
 To work around that problem, the RxPlayer allows you to provide a
 synchronization mechanism to loadVideo. This is done through the
-`serverSyncInfos` `transportOptions`. Which itself is a `loadVideo` option.
+`serverSyncInfos` option of `loadVideo`.
 
 TL;DR You can look at the [API
-documentation](../Loading_a_Content.md#transportoptions) for a quick
+documentation](../Loading_a_Content.md#serversyncinfos) for a quick
 explanation of what to put in it.
 
 ---
@@ -150,7 +150,7 @@ const clientTime = performance.now();
 const serverSyncInfos = { serverTimestamp, clientTime };
 rxPlayer.loadVideo({
   // ...
-  transportOptions: { serverSyncInfos },
+  serverSyncInfos,
 });
 ```
 

--- a/doc/api/Miscellaneous/MetaPlaylist.md
+++ b/doc/api/Miscellaneous/MetaPlaylist.md
@@ -262,13 +262,12 @@ it, you can serve directly the file through the use of a Manifest Loader:
 ```js
 player.loadVideo({
   transport: "metaplaylist",
-  transportOptions: {
-    // Note: `_url` here will be `undefined`
-    manifestLoader(_url, callbacks) {
-      // where `myMetaPlaylistObject` is the MetaPlaylist in either Object or
-      // String form
-      callbacks.resolve({ data: myMetaPlaylistObject });
-    },
+
+  // Note: `_url` here will be `undefined`
+  manifestLoader(_url, callbacks) {
+    // where `myMetaPlaylistObject` is the MetaPlaylist in either Object or
+    // String form
+    callbacks.resolve({ data: myMetaPlaylistObject });
   },
 });
 ```
@@ -290,8 +289,8 @@ In those cases, you can make usage of the `serverSyncInfos` transport options
 when calling `loadVideo` to indicate the current time and construct the
 MetaPlaylist by using unix time for each content's `startTime` and `endTime`.
 
-The `serverSyncInfos` option is explained [in the `transportOptions`
-documentation](../Loading_a_Content.md#transportoptions).
+The `serverSyncInfos` option is explained [in the `loadVideo` options
+documentation](../Loading_a_Content.md#serversyncinfos).
 
 For example, if you trust the user's system clock to indicate the current live
 time (in most cases this is risky however), you can use the `Date.now()` api:
@@ -305,6 +304,6 @@ const serverSyncInfos = {
 player.loadVideo({
   transport: "metaplaylist",
   url: "https://www.example.com/metaplaylist",
-  transportOptions: { serverSyncInfos },
+  serverSyncInfos,
 });
 ```

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -9,8 +9,8 @@ Those plugins are often under the form of functions passed as an argument to the
 
 ## segmentLoader
 
-The `segmentLoader` is a function that can be included in the `transportOptions`
-of the `loadVideo` API call.
+The `segmentLoader` is a function that can be included as an option of the
+`loadVideo` API call.
 
 A `segmentLoader` allows to define a custom audio/video segment loader (it might
 on the future work for other types of segments, so always check the type if you
@@ -202,8 +202,8 @@ the request is aborted. You can define one to clean-up or dispose all resources.
 
 ## manifestLoader
 
-The `manifestLoader` is a function that can be included in the
-`transportOptions` of the `loadVideo` API call.
+The `manifestLoader` is a function that can be included as an option of the
+`loadVideo` API call.
 
 A manifestLoader allows to define a custom [Manifest](../../Getting_Started/Glossary.md#manifest)
 loader.
@@ -358,8 +358,8 @@ the request is aborted. You can define one to clean-up or dispose all resources.
 
 ## representationFilter
 
-The representationFilter is a function that can be included in the
-`transportOptions` of the `loadVideo` API call.
+The representationFilter is a function that can be included as an option of the
+`loadVideo` API call.
 
 A representationFilter allows you to filter out
 [Representations](../../Getting_Started/Glossary.md#representation) (i.e. media qualities) based on

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -281,7 +281,7 @@ An OtherError can have the following codes (`code` property):
 
 - `"INTEGRITY_ERROR"`: An integrity-checking mechanism in the RxPlayer
   detected that there was an error with some loaded data. Such mechanism can
-  be triggered for example when the `checkMediaSegmentIntegrity`
-  `transportOptions` is set to `loadVideo`.
+  be triggered for example when the `checkMediaSegmentIntegrity` option
+  is set on the `loadVideo` call.
 
 - `"NONE"`: The error cannot be characterized.

--- a/doc/api/Typescript_Types.md
+++ b/doc/api/Typescript_Types.md
@@ -98,11 +98,7 @@ exported:
   - `IPersistentSessionInfo`: type used by an `IPersistentSessionStorage`'s
     storage.
 
-  - `ITransportOptions`: type for the `transportOptions` property
-    optionally given to `loadVideo`.
-
-  - `IManifestLoader`: type for the `manifestLoader` function optionally set
-    on the `transportOptions` option of `loadVideo`.
+  - `IManifestLoader`: type for the `manifestLoader` option of `loadVideo`.
 
   - `IManifestLoaderInfo`: type for the first argument of the `manifestLoader`
     function (defined by `IManifestLoader`.)
@@ -110,8 +106,8 @@ exported:
   - `ILoadedManifestFormat`: type for the accepted Manifest formats as returned
      by a `IManifestLoader`.
 
-  - `IRepresentationFilter`: type for the `representationFilter` function
-    optionally set on the `transportOptions` option of `loadVideo`.
+  - `IRepresentationFilter`: type for the `representationFilter` option of
+  - `loadVideo`.
 
   - `IRepresentationFilterRepresentation`: type for the first argument of the
     `representationFilter` function (defined by `IRepresentationFilter`.)
@@ -122,14 +118,11 @@ exported:
   - `IRepresentationContext`: type for the second argument of the
     `representationFilter` function (defined by `IRepresentationFilter`.)
 
-  - `IServerSyncInfos`: type for the `serverSyncInfos` property
-    optionally set on the `transportOptions` option of `loadVideo`.
+  - `IServerSyncInfos`: type for the `serverSyncInfos` option of `loadVideo`.
 
-  - `IInitialManifest`: type for the `initialManifest` property
-    optionally set on the `transportOptions` option of `loadVideo`.
+  - `IInitialManifest`: type for the `initialManifest` option of `loadVideo`.
 
-  - `ISegmentLoader`: type for the `segmentLoader` function optionally set on
-    the `transportOptions` option of `loadVideo`.
+  - `ISegmentLoader`: type for the `segmentLoader` option of `loadVideo`.
 
   - `ISegmentLoaderContext`: type for the first argument of the `segmentLoader`
     function (defined by `ISegmentLoader`.)

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -127,38 +127,35 @@ properties, methods, events and so on.
   - [`startAt`](../api/Loading_a_Content.md#startat):
     Define the position at which the RxPlayer should start.
 
-  - [`transportOptions`](../api/Loading_a_Content.md#transportoptions):
-    Options relative to the current "transport".
+  - [`minimumManifestUpdateInterval`](../api/Loading_a_Content.md#minimummanifestupdateinterval):
+    Allows to limit the frequency of Manifest updates.
 
-    - [`transportOptions.minimumManifestUpdateInterval`](../api/Loading_a_Content.md#transportoptions):
-      Allows to limit the frequency of Manifest updates.
+  - [`initialManifest`](../api/Loading_a_Content.md#initialmanifest):
+    Allows to provide an initial Manifest to speed-up the content loading
 
-    - [`transportOptions.initialManifest`](../api/Loading_a_Content.md#transportoptions):
-      Allows to provide an initial Manifest to speed-up the content loading
+  - [`manifestUpdateUrl`](../api/Loading_a_Content.md#manifestupdateurl):
+    Provide another URL, potentially to a shorter Manifest, used only for
+    Manifest updates
 
-    - [`transportOptions.manifestUpdateUrl`](../api/Loading_a_Content.md#transportoptions):
-      Provide another URL, potentially to a shorter Manifest, used only for
-      Manifest updates
+  - [`representationFilter`](../api/Loading_a_Content.md#representationfilter):
+    Filter out qualities from the Manifest based on its characteristics.
 
-    - [`transportOptions.representationFilter`](../api/Loading_a_Content.md#transportoptions):
-      Filter out qualities from the Manifest based on its characteristics.
+  - [`segmentLoader`](../api/Loading_a_Content.md#segmentloader):
+    Provide a custom logic to fetch segments.
 
-    - [`transportOptions.segmentLoader`](../api/Loading_a_Content.md#transportoptions):
-      Provide a custom logic to fetch segments.
+  - [`manifestLoader`](../api/Loading_a_Content.md#manifestloader):
+    Provide a custom logic to fetch the Manifest.
 
-    - [`transportOptions.manifestLoader`](../api/Loading_a_Content.md#transportoptions):
-      Provide a custom logic to fetch the Manifest.
+  - [`checkMediaSegmentIntegrity`](../api/Loading_a_Content.md#checkmediasegmentintegrity):
+    Enable supplementary checks to retry a request if a segment appears
+    corrupted.
 
-    - [`transportOptions.checkMediaSegmentIntegrity`](../api/Loading_a_Content.md#transportoptions):
-      Enable supplementary checks to retry a request if a segment appears
-      corrupted.
+  - [`serverSyncInfos`](../api/Loading_a_Content.md#serversyncinfos):
+    Provide time synchronization mechanism between the client and server.
 
-    - [`transportOptions.serverSyncInfos`](../api/Loading_a_Content.md#transportoptions):
-      Provide time synchronization mechanism between the client and server.
-
-    - [`transportOptions.referenceDateTime`](../api/Loading_a_Content.md#transportoptions):
-      Default offset to add to the segment's time to obtain a live time. This is
-      in most cases not needed.
+  - [`referenceDateTime`](../api/Loading_a_Content.md#referencedatetime):
+    Default offset to add to the segment's time to obtain a live time. This is
+    in most cases not needed.
 
   - [`textTrackMode`](../api/Loading_a_Content.md#texttrackmode):
     The way in which the text tracks should be displayed.

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -398,9 +398,6 @@ describe("API - parseLoadVideoOptions", () => {
     startAt: undefined,
     textTrackElement: undefined,
     textTrackMode: "native",
-    transportOptions: {
-      lowLatencyMode: false,
-    },
     url: undefined,
   };
 
@@ -447,8 +444,8 @@ describe("API - parseLoadVideoOptions", () => {
     expect(err1.message).toEqual(
       "Unable to load a content: no url set on loadVideo.\n" +
       "Please provide at least either an `url` argument, a " +
-      "`transportOptions.initialManifest` option or a " +
-      "`transportOptions.manifestLoader` option so the RxPlayer can load the content."
+      "`initialManifest` option or a " +
+      "`manifestLoader` option so the RxPlayer can load the content."
     );
     expect(opt2).not.toBeDefined();
     expect(err2).toBeInstanceOf(Error);
@@ -460,8 +457,8 @@ describe("API - parseLoadVideoOptions", () => {
     expect(err2.message).toEqual(
       "Unable to load a content: no url set on loadVideo.\n" +
       "Please provide at least either an `url` argument, a " +
-      "`transportOptions.initialManifest` option or a " +
-      "`transportOptions.manifestLoader` option so the RxPlayer can load the content."
+      "`initialManifest` option or a " +
+      "`manifestLoader` option so the RxPlayer can load the content."
     );
   });
 
@@ -502,12 +499,12 @@ describe("API - parseLoadVideoOptions", () => {
     };
     expect(parseLoadVideoOptions({
       transport: "bar",
-      transportOptions: { manifestLoader },
+      manifestLoader,
     })).toEqual({
       ...defaultLoadVideoOptions,
       transport: "bar",
-      transportOptions: { lowLatencyMode: false,
-                          manifestLoader },
+      lowLatencyMode: false,
+      manifestLoader,
     });
   });
 
@@ -516,7 +513,7 @@ describe("API - parseLoadVideoOptions", () => {
   /* eslint-enable max-len */
     expect(parseLoadVideoOptions({
       transport: "bar",
-      transportOptions: { initialManifest: "test" },
+      initialManifest: "test",
     })).toEqual({
       ...defaultLoadVideoOptions,
       transport: "bar",
@@ -526,7 +523,7 @@ describe("API - parseLoadVideoOptions", () => {
 
   it("should authorize setting an initialManifest option", () => {
     expect(parseLoadVideoOptions({
-      transportOptions: { initialManifest: "baz" },
+      initialManifest: "baz",
       url: "foo",
       transport: "bar",
     })).toEqual({
@@ -538,7 +535,7 @@ describe("API - parseLoadVideoOptions", () => {
     expect(parseLoadVideoOptions({
       url: "foo",
       transport: "bar",
-      transportOptions: { initialManifest: "" },
+      initialManifest: "",
     })).toEqual({
       ...defaultLoadVideoOptions,
       url: "foo",
@@ -690,7 +687,6 @@ describe("API - parseLoadVideoOptions", () => {
       lowLatencyMode: true,
       transport: "bar",
       url: "foo",
-      transportOptions: { lowLatencyMode: true },
     });
   });
 
@@ -698,17 +694,13 @@ describe("API - parseLoadVideoOptions", () => {
     expect(parseLoadVideoOptions({
       url: "foo",
       transport: "bar",
-      transportOptions: {
-        minimumManifestUpdateInterval: 5400,
-      },
+      minimumManifestUpdateInterval: 5400,
     })).toEqual({
       ...defaultLoadVideoOptions,
       minimumManifestUpdateInterval: 5400,
       url: "foo",
       transport: "bar",
-      transportOptions: {
-        lowLatencyMode: false,
-      },
+      lowLatencyMode: false,
     });
   });
 
@@ -971,18 +963,18 @@ If badly set, continue will be used as default`);
     });
   });
 
-  it("should authorize setting a transportOptions option", () => {
+  it("should authorize setting a `segmentLoader` option", () => {
     const func = jest.fn();
     expect(parseLoadVideoOptions({
-      transportOptions: { segmentLoader: func },
+      segmentLoader: func,
       url: "foo",
       transport: "bar",
     })).toEqual({
       ...defaultLoadVideoOptions,
       url: "foo",
       transport: "bar",
-      transportOptions: { lowLatencyMode: false,
-                          segmentLoader: func },
+      lowLatencyMode: false,
+      segmentLoader: func,
     });
   });
 
@@ -1109,22 +1101,6 @@ If badly set, continue will be used as default`);
     expect(logWarnMock).toHaveBeenCalledTimes(1);
     expect(logWarnMock).toHaveBeenCalledWith("API: You have set a textTrackElement " +
       "without being in an \"html\" textTrackMode. It will be ignored.");
-  });
-
-  /* eslint-disable max-len */
-  it("should set non-documented variables in `transportOptions`", () => {
-  /* eslint-enable max-len */
-    expect(parseLoadVideoOptions({
-      url: "foo",
-      transport: "bar",
-      transportOptions: { __priv_toto: 4 } as any,
-    })).toEqual({
-      ...defaultLoadVideoOptions,
-      url: "foo",
-      transport: "bar",
-      transportOptions: { lowLatencyMode: false,
-                          __priv_toto: 4 },
-    });
   });
 });
 

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -44,18 +44,6 @@ export type IParsedStartAtOption = { position : number } |
                                    { fromLastPosition : number } |
                                    { fromFirstPosition : number };
 
-export interface IParsedTransportOptions {
-  checkMediaSegmentIntegrity? : boolean | undefined;
-  lowLatencyMode : boolean;
-  manifestLoader?: IManifestLoader | undefined;
-  manifestUpdateUrl? : string | undefined;
-  referenceDateTime? : number | undefined;
-  representationFilter? : IRepresentationFilter | undefined;
-  segmentLoader? : ISegmentLoader | undefined;
-  serverSyncInfos? : IServerSyncInfos | undefined;
-  __priv_patchLastSegmentInSidx? : boolean | undefined;
-}
-
 /** Options of the RxPlayer's constructor once parsed. */
 export interface IParsedConstructorOptions {
   maxBufferAhead : number;
@@ -87,11 +75,18 @@ interface IParsedLoadVideoOptionsBase {
   lowLatencyMode : boolean;
   minimumManifestUpdateInterval : number;
   networkConfig: INetworkConfigOption;
-  transportOptions : IParsedTransportOptions;
   startAt : IParsedStartAtOption|undefined;
   enableFastSwitching : boolean;
   defaultAudioTrackSwitchingMode : IAudioTrackSwitchingMode | undefined;
   onCodecSwitch : "continue"|"reload";
+  checkMediaSegmentIntegrity? : boolean | undefined;
+  manifestLoader?: IManifestLoader | undefined;
+  manifestUpdateUrl? : string | undefined;
+  referenceDateTime? : number | undefined;
+  representationFilter? : IRepresentationFilter | undefined;
+  segmentLoader? : ISegmentLoader | undefined;
+  serverSyncInfos? : IServerSyncInfos | undefined;
+  __priv_patchLastSegmentInSidx? : boolean | undefined;
 }
 
 /**
@@ -354,13 +349,13 @@ function parseLoadVideoOptions(
   if (!isNullOrUndefined(options.url)) {
     url = String(options.url);
   } else if (
-    isNullOrUndefined(options.transportOptions?.initialManifest) &&
-    isNullOrUndefined(options.transportOptions?.manifestLoader)
+    isNullOrUndefined(options.initialManifest) &&
+    isNullOrUndefined(options.manifestLoader)
   ) {
     throw new Error("Unable to load a content: no url set on loadVideo.\n" +
                     "Please provide at least either an `url` argument, a " +
-                    "`transportOptions.initialManifest` option or a " +
-                    "`transportOptions.manifestLoader` option so the RxPlayer " +
+                    "`initialManifest` option or a " +
+                    "`manifestLoader` option so the RxPlayer " +
                     "can load the content.");
   }
 
@@ -391,14 +386,9 @@ function parseLoadVideoOptions(
   const lowLatencyMode = options.lowLatencyMode === undefined ?
     false :
     !!options.lowLatencyMode;
-  const transportOptsArg = typeof options.transportOptions === "object" &&
-                                  options.transportOptions !== null ?
-    options.transportOptions :
-    {};
 
-  const initialManifest = options.transportOptions?.initialManifest;
-  const minimumManifestUpdateInterval =
-    options.transportOptions?.minimumManifestUpdateInterval ?? 0;
+  const initialManifest = options.initialManifest;
+  const minimumManifestUpdateInterval = options.minimumManifestUpdateInterval ?? 0;
 
   let defaultAudioTrackSwitchingMode = options.defaultAudioTrackSwitchingMode ??
                                        undefined;
@@ -426,14 +416,6 @@ function parseLoadVideoOptions(
              " will be used as default");
     onCodecSwitch = DEFAULT_CODEC_SWITCHING_BEHAVIOR;
   }
-
-  const transportOptions = objectAssign({}, transportOptsArg, {
-    lowLatencyMode,
-  });
-
-  // remove already parsed data to simplify the `transportOptions` object
-  delete transportOptions.initialManifest;
-  delete transportOptions.minimumManifestUpdateInterval;
 
   if (isNullOrUndefined(options.textTrackMode)) {
     textTrackMode = DEFAULT_TEXT_TRACK_MODE;
@@ -484,24 +466,37 @@ function parseLoadVideoOptions(
       offlineRetry: options.networkConfig.offlineRetry,
       segmentRetry: options.networkConfig.segmentRetry };
 
-  // TODO without cast
-  /* eslint-disable @typescript-eslint/consistent-type-assertions */
-  return { autoPlay,
-           enableFastSwitching,
-           keySystems,
-           initialManifest,
-           lowLatencyMode,
+
+  // All those eslint disable are needed because the option is voluntarily
+  // hidden from the base type to limit discovery of this hidden API.
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  return { __priv_patchLastSegmentInSidx: (options as any).__priv_patchLastSegmentInSidx,
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  /* eslint-enable @typescript-eslint/no-unsafe-assignment */
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+           checkMediaSegmentIntegrity: options.checkMediaSegmentIntegrity,
+           autoPlay,
            defaultAudioTrackSwitchingMode,
+           enableFastSwitching,
+           initialManifest,
+           keySystems,
+           lowLatencyMode,
+           manifestLoader: options.manifestLoader,
+           manifestUpdateUrl: options.manifestUpdateUrl,
            minimumManifestUpdateInterval,
            networkConfig,
            onCodecSwitch,
+           referenceDateTime: options.referenceDateTime,
+           representationFilter: options.representationFilter,
+           segmentLoader: options.segmentLoader,
+           serverSyncInfos: options.serverSyncInfos,
            startAt,
            textTrackElement,
            textTrackMode,
            transport,
-           transportOptions,
            url } as IParsedLoadVideoOptions;
-  /* eslint-enable @typescript-eslint/consistent-type-assertions */
 }
 
 export {

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -598,7 +598,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             onCodecSwitch,
             startAt,
             transport,
-            transportOptions,
+            checkMediaSegmentIntegrity,
+            manifestLoader,
+            manifestUpdateUrl,
+            referenceDateTime,
+            representationFilter,
+            segmentLoader,
+            serverSyncInfos,
+            __priv_patchLastSegmentInSidx,
             url } = options;
 
     // Perform multiple checks on the given options
@@ -657,7 +664,15 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         throw new Error(`transport "${transport}" not supported`);
       }
 
-      const transportPipelines = transportFn(transportOptions);
+      const transportPipelines = transportFn({ lowLatencyMode,
+                                               checkMediaSegmentIntegrity,
+                                               manifestLoader,
+                                               manifestUpdateUrl,
+                                               referenceDateTime,
+                                               representationFilter,
+                                               segmentLoader,
+                                               serverSyncInfos,
+                                               __priv_patchLastSegmentInSidx });
 
       const { offlineRetry, segmentRetry, manifestRetry } = networkConfig;
 

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -59,43 +59,108 @@ export interface IConstructorOptions {
 
 /** Every options that can be given to the RxPlayer's `loadVideo` method. */
 export interface ILoadVideoOptions {
+  /**
+   * Streaming protocol used (e.g. "dash" or "smooth").
+   *
+   * It is a mandatory property.
+   */
   transport : string;
 
+  /** Main URL to the content (Manifest or video file for directfile contents. */
   url? : string;
+  /** If `true` the Content will automatically play once loaded. */
   autoPlay? : boolean;
-  keySystems? : IKeySystemOption[];
-  transportOptions? : ITransportOptions|undefined;
-  lowLatencyMode? : boolean;
-  networkConfig? : INetworkConfigOption;
-  startAt? : IStartAtOption;
-  textTrackMode? : "native"|"html";
-  textTrackElement? : HTMLElement;
-  enableFastSwitching? : boolean;
-  defaultAudioTrackSwitchingMode? : IAudioTrackSwitchingMode;
-  onCodecSwitch? : "continue"|"reload";
-}
 
-/** Value of the `transportOptions` option of the `loadVideo` method. */
-export interface ITransportOptions {
+  /**
+   * Decryption-related options.
+   * Can be left to undefined if no decryption is wanted.
+   */
+  keySystems? : IKeySystemOption[];
+
+  /**
+   * If set to `true`, and if the content is compatible, it will be played in a
+   * special mode where the latency is greatly reduced.
+   *
+   * Should only be set for known to be compatible contents.
+   */
+  lowLatencyMode? : boolean;
+
+  // XXX TODO should it also be flattened or just renamed?
+  networkConfig? : INetworkConfigOption;
+
+  /** Indicate the position the RxPlayer should start at on the loaded content. */
+  startAt? : IStartAtOption;
+
+  /**
+   * The "mode" in which the text tracks will be displayed.
+   *
+   * The default `"native"` mode will use HTMLMediaElement's `track`elements and
+   * poor stylization capabilities.
+   *
+   * The `"html"` mode use the `textTrackElement` option to display subtitles
+   * with rich stylization capabilities inside that `HTMLElement`.
+   */
+  textTrackMode? : "native"|"html";
+
+  /**
+   * The HTMLElement in which text track will be pushed in a `"html"`
+   * `textTrackMode`.
+   *
+   * Mandatory if `textTrackMode` is set to `"html"`.
+   *
+   * Has no effect when `textTrackMode` is not set or set to `"native"`.
+   */
+  textTrackElement? : HTMLElement;
+
+  /**
+   * `true` by default.
+   *
+   * If set to `false`, the RxPlayer won't use the "fast-switching" optimization
+   * that allows to see raise in qualities quicker.
+   *
+   * You might want to set to `false` when the current device does not support
+   * segment replacement well.
+   */
+  enableFastSwitching? : boolean;
+
+  /** Default behavior when switching to a different audio track. */
+  defaultAudioTrackSwitchingMode? : IAudioTrackSwitchingMode;
+
+  /**
+   * Behavior when a audio or video codec just switched to another
+   * non-compatible one.
+   *
+   * This value might depend on the device's capabilities.
+   */
+  onCodecSwitch? : "continue"|"reload";
+
   /**
    * Whether we should check that an obtain segment is truncated and retry the
    * request if that's the case.
    */
   checkMediaSegmentIntegrity? : boolean;
+
   /** Manifest object that will be used initially. */
   initialManifest? : IInitialManifest;
+
   /** Custom implementation for performing Manifest requests. */
   manifestLoader? : IManifestLoader;
+
   /** Possible custom URL pointing to a shorter form of the Manifest. */
   manifestUpdateUrl? : string;
+
   /** Minimum bound for Manifest updates, in milliseconds. */
   minimumManifestUpdateInterval? : number;
+
   /** Custom implementation for performing segment requests. */
   segmentLoader? : ISegmentLoader;
+
   /** Custom logic to filter out unwanted qualities. */
   representationFilter? : IRepresentationFilter;
+
   /** Base time for the segments in case it is not found in the Manifest. */
   referenceDateTime? : number;
+
   /** Allows to synchronize the server's time with the client's. */
   serverSyncInfos? : IServerSyncInfos;
 }

--- a/tests/integration/scenarios/dash_live_utc_timings.js
+++ b/tests/integration/scenarios/dash_live_utc_timings.js
@@ -48,11 +48,9 @@ describe("DASH live - UTCTimings", () => {
       const serverTimestamp = +new Date("2019-03-25T13:54:08.000Z");
       player.loadVideo({ url: manifestInfos.url,
                          transport:manifestInfos.transport,
-                         transportOptions: {
-                           serverSyncInfos: {
-                             serverTimestamp,
-                             clientTime: performance.now(),
-                           },
+                         serverSyncInfos: {
+                           serverTimestamp,
+                           clientTime: performance.now(),
                          } });
 
       await sleep(100);
@@ -111,11 +109,9 @@ describe("DASH live - UTCTimings", () => {
       player.loadVideo({
         url: manifestInfos.url,
         transport:manifestInfos.transport,
-        transportOptions: {
-          serverSyncInfos: {
-            serverTimestamp,
-            clientTime: performance.now(),
-          },
+        serverSyncInfos: {
+          serverTimestamp,
+          clientTime: performance.now(),
         },
       });
 
@@ -174,11 +170,9 @@ describe("DASH live - UTCTimings", () => {
       player.loadVideo({
         url: manifestInfos.url,
         transport:manifestInfos.transport,
-        transportOptions: {
-          serverSyncInfos: {
-            serverTimestamp,
-            clientTime: performance.now(),
-          },
+        serverSyncInfos: {
+          serverTimestamp,
+          clientTime: performance.now(),
         },
       });
 
@@ -233,11 +227,9 @@ describe("DASH live - UTCTimings", () => {
       player.loadVideo({
         url: manifestInfos.url,
         transport:manifestInfos.transport,
-        transportOptions: {
-          serverSyncInfos: {
-            serverTimestamp,
-            clientTime: performance.now(),
-          },
+        serverSyncInfos: {
+          serverTimestamp,
+          clientTime: performance.now(),
         },
       });
 

--- a/tests/integration/scenarios/dash_static.js
+++ b/tests/integration/scenarios/dash_static.js
@@ -179,9 +179,7 @@ describe("DASH non-linear content with a \"broken\" sidx", function() {
 
     player.loadVideo({ url: brokenSidxManifestInfos.url,
                        transport: brokenSidxManifestInfos.transport,
-                       transportOptions: {
-                         checkMediaSegmentIntegrity: true,
-                       },
+                       checkMediaSegmentIntegrity: true,
                        autoPlay: false });
     await waitForPlayerState(player, "LOADED");
 
@@ -206,10 +204,8 @@ describe("DASH non-linear content with a \"broken\" sidx", function() {
     // Play a second time with the option
     player.loadVideo({ url: brokenSidxManifestInfos.url,
                        transport: brokenSidxManifestInfos.transport,
-                       transportOptions: {
-                         checkMediaSegmentIntegrity: true,
-                         __priv_patchLastSegmentInSidx: true,
-                       },
+                       checkMediaSegmentIntegrity: true,
+                       __priv_patchLastSegmentInSidx: true,
                        autoPlay: false });
     await waitForPlayerState(player, "LOADED");
 

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -286,188 +286,184 @@ describe("loadVideo Options", () => {
     });
   });
 
-  describe("transportOptions", () => {
-    describe("representationFilter", () => {
-      it("should filter out Representations", async () => {
-        const videoRepresentations = manifestInfos
-          .periods[0].adaptations.video[0].representations;
-        const initialNumberOfRepresentations = videoRepresentations.length;
-        expect(initialNumberOfRepresentations).to.be.above(1);
-        const representationInTheMiddle = videoRepresentations[
-          Math.floor(initialNumberOfRepresentations / 2)
-        ];
+  describe("representationFilter", () => {
+    it("should filter out Representations", async () => {
+      const videoRepresentations = manifestInfos
+        .periods[0].adaptations.video[0].representations;
+      const initialNumberOfRepresentations = videoRepresentations.length;
+      expect(initialNumberOfRepresentations).to.be.above(1);
+      const representationInTheMiddle = videoRepresentations[
+        Math.floor(initialNumberOfRepresentations / 2)
+      ];
 
-        let numberOfTimeRepresentationFilterIsCalledForVideo = 0;
-        player.loadVideo({
-          transport: manifestInfos.transport,
-          url: manifestInfos.url,
-          transportOptions: {
-            representationFilter(representation, infos) {
-              if (infos.bufferType === "video") {
-                numberOfTimeRepresentationFilterIsCalledForVideo++;
-                return representation.bitrate <
-                  representationInTheMiddle.bitrate;
-              }
-              return true;
-            },
-          },
-        });
-        await waitForLoadedStateAfterLoadVideo(player);
-
-        expect(numberOfTimeRepresentationFilterIsCalledForVideo)
-          .to.equal(initialNumberOfRepresentations);
-
-        const currentVideoTrack = player.getAvailableVideoTracks()
-          .find(track => track.active);
-
-        expect(currentVideoTrack.representations).to.have.length(
-          Math.floor(initialNumberOfRepresentations / 2)
-        );
+      let numberOfTimeRepresentationFilterIsCalledForVideo = 0;
+      player.loadVideo({
+        transport: manifestInfos.transport,
+        url: manifestInfos.url,
+        representationFilter(representation, infos) {
+          if (infos.bufferType === "video") {
+            numberOfTimeRepresentationFilterIsCalledForVideo++;
+            return representation.bitrate <
+              representationInTheMiddle.bitrate;
+          }
+          return true;
+        },
       });
+      await waitForLoadedStateAfterLoadVideo(player);
+
+      expect(numberOfTimeRepresentationFilterIsCalledForVideo)
+        .to.equal(initialNumberOfRepresentations);
+
+      const currentVideoTrack = player.getAvailableVideoTracks()
+        .find(track => track.active);
+
+      expect(currentVideoTrack.representations).to.have.length(
+        Math.floor(initialNumberOfRepresentations / 2)
+      );
+    });
+  });
+
+  describe("segmentLoader", () => {
+    let numberOfTimeCustomSegmentLoaderWasCalled = 0;
+    let numberOfTimeCustomSegmentLoaderWentThrough = 0;
+
+    beforeEach(() => {
+      numberOfTimeCustomSegmentLoaderWasCalled = 0;
+      numberOfTimeCustomSegmentLoaderWentThrough = 0;
     });
 
-    describe("segmentLoader", () => {
-      let numberOfTimeCustomSegmentLoaderWasCalled = 0;
-      let numberOfTimeCustomSegmentLoaderWentThrough = 0;
+    const customSegmentLoader = (info, callbacks) => {
+      numberOfTimeCustomSegmentLoaderWasCalled++;
 
-      beforeEach(() => {
-        numberOfTimeCustomSegmentLoaderWasCalled = 0;
-        numberOfTimeCustomSegmentLoaderWentThrough = 0;
-      });
+      // we will only use this custom loader for videos segments.
+      if (info.type !== "video") {
+        callbacks.fallback();
+        return;
+      }
 
-      const customSegmentLoader = (info, callbacks) => {
-        numberOfTimeCustomSegmentLoaderWasCalled++;
+      numberOfTimeCustomSegmentLoaderWentThrough++;
+      const xhr = new XMLHttpRequest();
+      const sendingTime = Date.now();
 
-        // we will only use this custom loader for videos segments.
-        if (info.type !== "video") {
-          callbacks.fallback();
-          return;
-        }
-
-        numberOfTimeCustomSegmentLoaderWentThrough++;
-        const xhr = new XMLHttpRequest();
-        const sendingTime = Date.now();
-
-        xhr.onload = (r) => {
-          if (200 <= xhr.status && xhr.status < 300) {
-            const duration = Date.now() - sendingTime;
-            const size = r.total;
-            const data = xhr.response;
-            callbacks.resolve({ duration, size, data });
-          } else {
-            const err = new Error("didn't work");
-            err.xhr = xhr;
-            callbacks.reject(err);
-          }
-        };
-
-        xhr.onerror = () => {
+      xhr.onload = (r) => {
+        if (200 <= xhr.status && xhr.status < 300) {
+          const duration = Date.now() - sendingTime;
+          const size = r.total;
+          const data = xhr.response;
+          callbacks.resolve({ duration, size, data });
+        } else {
           const err = new Error("didn't work");
           err.xhr = xhr;
           callbacks.reject(err);
-        };
-
-        xhr.open("GET", info.url);
-        xhr.responseType = "arraybuffer";
-
-        const range = info.range;
-        if (range) {
-          if (range[1] && range[1] !== Infinity) {
-            xhr.setRequestHeader("Range", `bytes=${range[0]}-${range[1]}`);
-          } else {
-            xhr.setRequestHeader("Range", `bytes=${range[0]}-`);
-          }
         }
-
-        xhr.send();
-
-        return () => {
-          xhr.abort();
-        };
       };
 
-      it("should pass through the custom segmentLoader for segment requests", async () => {
-        xhrMock.lock();
-        let nbVideoSegmentRequests = 0;
-        player.loadVideo({
-          transport: manifestInfos.transport,
-          url: manifestInfos.url,
-          transportOptions: { segmentLoader: customSegmentLoader },
-        });
+      xhr.onerror = () => {
+        const err = new Error("didn't work");
+        err.xhr = xhr;
+        callbacks.reject(err);
+      };
 
-        await sleep(1);
-        await xhrMock.flush(); // Manifest request
-        await sleep(1);
-        expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(4); // init + media Segment requests
-        nbVideoSegmentRequests += xhrMock.getLockedXHR()
-          .filter(r => r.url && r.url.includes("ateam-video"))
-          .length;
-        await xhrMock.flush();
-        await sleep(1);
-        expect(numberOfTimeCustomSegmentLoaderWasCalled)
-          .to.equal(6); // Segment requests
-        nbVideoSegmentRequests += xhrMock.getLockedXHR()
-          .filter(r => r.url && r.url.includes("ateam-video"))
-          .length;
-        expect(numberOfTimeCustomSegmentLoaderWentThrough)
-          .to.equal(nbVideoSegmentRequests);
-        expect(nbVideoSegmentRequests).to.be.above(0);
+      xhr.open("GET", info.url);
+      xhr.responseType = "arraybuffer";
+
+      const range = info.range;
+      if (range) {
+        if (range[1] && range[1] !== Infinity) {
+          xhr.setRequestHeader("Range", `bytes=${range[0]}-${range[1]}`);
+        } else {
+          xhr.setRequestHeader("Range", `bytes=${range[0]}-`);
+        }
+      }
+
+      xhr.send();
+
+      return () => {
+        xhr.abort();
+      };
+    };
+
+    it("should pass through the custom segmentLoader for segment requests", async () => {
+      xhrMock.lock();
+      let nbVideoSegmentRequests = 0;
+      player.loadVideo({
+        transport: manifestInfos.transport,
+        url: manifestInfos.url,
+        segmentLoader: customSegmentLoader,
       });
+
+      await sleep(1);
+      await xhrMock.flush(); // Manifest request
+      await sleep(1);
+      expect(numberOfTimeCustomSegmentLoaderWasCalled)
+        .to.equal(4); // init + media Segment requests
+      nbVideoSegmentRequests += xhrMock.getLockedXHR()
+        .filter(r => r.url && r.url.includes("ateam-video"))
+        .length;
+      await xhrMock.flush();
+      await sleep(1);
+      expect(numberOfTimeCustomSegmentLoaderWasCalled)
+        .to.equal(6); // Segment requests
+      nbVideoSegmentRequests += xhrMock.getLockedXHR()
+        .filter(r => r.url && r.url.includes("ateam-video"))
+        .length;
+      expect(numberOfTimeCustomSegmentLoaderWentThrough)
+        .to.equal(nbVideoSegmentRequests);
+      expect(nbVideoSegmentRequests).to.be.above(0);
+    });
+  });
+
+  describe("manifestLoader", () => {
+    let numberOfTimeCustomManifestLoaderWasCalled = 0;
+
+    beforeEach(() => {
+      numberOfTimeCustomManifestLoaderWasCalled = 0;
     });
 
-    describe("manifestLoader", () => {
-      let numberOfTimeCustomManifestLoaderWasCalled = 0;
+    const customManifestLoader = ({ url }, callbacks) => {
+      numberOfTimeCustomManifestLoaderWasCalled++;
+      const xhr = new XMLHttpRequest();
+      const sendingTime = Date.now();
 
-      beforeEach(() => {
-        numberOfTimeCustomManifestLoaderWasCalled = 0;
-      });
-
-      const customManifestLoader = ({ url }, callbacks) => {
-        numberOfTimeCustomManifestLoaderWasCalled++;
-        const xhr = new XMLHttpRequest();
-        const sendingTime = Date.now();
-
-        xhr.onload = (r) => {
-          if (200 <= xhr.status && xhr.status < 300) {
-            const duration = Date.now() - sendingTime;
-            const size = r.total;
-            const data = xhr.response;
-            callbacks.resolve({ duration, size, data });
-          } else {
-            const err = new Error("didn't work");
-            err.xhr = xhr;
-            callbacks.reject(err);
-          }
-        };
-
-        xhr.onerror = () => {
+      xhr.onload = (r) => {
+        if (200 <= xhr.status && xhr.status < 300) {
+          const duration = Date.now() - sendingTime;
+          const size = r.total;
+          const data = xhr.response;
+          callbacks.resolve({ duration, size, data });
+        } else {
           const err = new Error("didn't work");
           err.xhr = xhr;
           callbacks.reject(err);
-        };
-
-        xhr.open("GET", url);
-        xhr.responseType = "document";
-
-        xhr.send();
-
-        return () => {
-          xhr.abort();
-        };
+        }
       };
 
-      it("should pass through the custom manifestLoader for manifest requests", async () => {
-        player.loadVideo({
-          transport: manifestInfos.transport,
-          url: manifestInfos.url,
-          transportOptions: { manifestLoader: customManifestLoader },
-        });
-        await waitForLoadedStateAfterLoadVideo(player);
+      xhr.onerror = () => {
+        const err = new Error("didn't work");
+        err.xhr = xhr;
+        callbacks.reject(err);
+      };
 
-        expect(numberOfTimeCustomManifestLoaderWasCalled)
-          .to.equal(1);
+      xhr.open("GET", url);
+      xhr.responseType = "document";
+
+      xhr.send();
+
+      return () => {
+        xhr.abort();
+      };
+    };
+
+    it("should pass through the custom manifestLoader for manifest requests", async () => {
+      player.loadVideo({
+        transport: manifestInfos.transport,
+        url: manifestInfos.url,
+        manifestLoader: customManifestLoader,
       });
+      await waitForLoadedStateAfterLoadVideo(player);
+
+      expect(numberOfTimeCustomManifestLoaderWasCalled)
+        .to.equal(1);
     });
   });
 });

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -136,7 +136,7 @@ export default function launchTestsForContent(manifestInfos) {
           xhrMock.lock();
           player.loadVideo({ url: manifestInfos.url,
                              transport,
-                             transportOptions: { initialManifest } });
+                             initialManifest });
 
           await sleep(100);
           expect(xhrMock.getLockedXHR().length).to.be.at.least(1);
@@ -150,7 +150,7 @@ export default function launchTestsForContent(manifestInfos) {
           xhrMock.lock();
           player.loadVideo({ url: manifestInfos.url,
                              transport,
-                             transportOptions: { initialManifest } });
+                             initialManifest });
 
           await sleep(100);
           expect(xhrMock.getLockedXHR().length).to.be.at.least(1);


### PR DESCRIPTION
Proposal update for the future V4 where we "flatten" the `transportOptions` `loadVideo` option, i.e. all options that were before properties of the `transportOptions` are now directly property of the `loadVideo` API.

This was done because the `transportOptions` was more of an implementation detail that a real API concept and what or what should not be in it was unclear. Sometimes even us had troubles knowing if an option was part of the `transportOptions` object.