### PR TITLE
Add timeout manually on XMLHttpRequests to take place of native one as a fallback

### DIFF
--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -145,8 +145,20 @@ export default function request<T>(
     const xhr = new XMLHttpRequest();
     xhr.open("GET", url, true);
 
+    let timeoutId : undefined | number;
     if (timeout !== undefined) {
       xhr.timeout = timeout;
+
+      // We've seen on some browser (mainly on some LG TVs), that `xhr.timeout`
+      // was either not supported or did not function properly despite the
+      // browser being recent enough to support it.
+      // That's why we also start a manual timeout. We do this a little later
+      // than the "native one" performed on the xhr assuming that the latter
+      // is more precise, it might also be more efficient.
+      timeoutId = window.setTimeout(() => {
+        clearCancellingProcess();
+        reject(new RequestError(url, xhr.status, "TIMEOUT", xhr));
+      }, timeout + 3000);
     }
 
     xhr.responseType = responseType;
@@ -171,6 +183,7 @@ export default function request<T>(
     if (cancelSignal !== undefined) {
       deregisterCancellationListener = cancelSignal
         .register(function abortRequest(err : CancellationError) {
+          clearCancellingProcess();
           if (!isNullOrUndefined(xhr) && xhr.readyState !== 4) {
             xhr.abort();
           }
@@ -183,16 +196,12 @@ export default function request<T>(
     }
 
     xhr.onerror = function onXHRError() {
-      if (deregisterCancellationListener !== null) {
-        deregisterCancellationListener();
-      }
+      clearCancellingProcess();
       reject(new RequestError(url, xhr.status, "ERROR_EVENT", xhr));
     };
 
     xhr.ontimeout = function onXHRTimeout() {
-      if (deregisterCancellationListener !== null) {
-        deregisterCancellationListener();
-      }
+      clearCancellingProcess();
       reject(new RequestError(url, xhr.status, "TIMEOUT", xhr));
     };
 
@@ -210,9 +219,7 @@ export default function request<T>(
 
     xhr.onload = function onXHRLoad(event : ProgressEvent) {
       if (xhr.readyState === 4) {
-        if (deregisterCancellationListener !== null) {
-          deregisterCancellationListener();
-        }
+        clearCancellingProcess();
         if (xhr.status >= 200 && xhr.status < 300) {
           const receivedTime = performance.now();
           const totalSize = xhr.response instanceof
@@ -256,6 +263,18 @@ export default function request<T>(
     };
 
     xhr.send();
+
+    /**
+     * Clear resources and timers created to handle cancellation and timeouts.
+     */
+    function clearCancellingProcess() {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      if (deregisterCancellationListener !== null) {
+        deregisterCancellationListener();
+      }
+    }
   });
 }
 


### PR DESCRIPTION
We noticed today that on some LG TVs, setting a timeout through a `XMLHttpRequest`'s `timeout` property didn't have any effect.

The browser version was recent enough, so it seems more of an issue either due to a bug in the specific browser version integrated there or linked to an issue brought during the integration of the browser on the TVs.

Anyway, I propose to add a manual timeout to support the "native" one in the case where it would fail, to completely avoid issues which can be problematic enough:

To give an example of such problematic situations, we were investigating a case where it appeared that some CDN just - relatively rarely - chose to hang requests forever.
Without any effective timeout solution, this could just lead to infinite rebuffering as the RxPlayer would just wait for e.g. that segment request to end before going to the next.

I still chose to rely on the "native" timeout by default and to postpone the manual one for some seconds, mainly in the perhaps-wrong assumption that the native one is more precise (also, it might be more efficient, though here we're speaking of a very rare situation anyway, so this is not a real argument).