### PR TITLE
tests: Raise timer awaiting discontinuity seek in integration tests

### DIFF
--- a/tests/integration/scenarios/dash_live_utc_timings.js
+++ b/tests/integration/scenarios/dash_live_utc_timings.js
@@ -33,9 +33,9 @@ describe("DASH live - UTCTimings", () => {
         transport:manifestInfos.transport,
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521448, 3);
       expect(player.getMaximumPosition()).to.be
@@ -55,9 +55,9 @@ describe("DASH live - UTCTimings", () => {
                            },
                          } });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521748, 1);
       expect(player.getMaximumPosition()).to.be
@@ -93,13 +93,13 @@ describe("DASH live - UTCTimings", () => {
         transport:manifestInfos.transport,
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush(); // Manifest request
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush(); // time request
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush(); // Once for the init segment
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521448, 3);
     });
@@ -119,9 +119,9 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521748, 1);
       expect(player.getMaximumPosition()).to.be
@@ -152,9 +152,9 @@ describe("DASH live - UTCTimings", () => {
         transport:manifestInfos.transport,
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
 
       const { availabilityStartTime } = player.getManifest();
       const timeShiftBufferDepth = 5 * 60;
@@ -183,9 +183,9 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521748, 1);
       expect(player.getMaximumPosition()).to.be
@@ -216,9 +216,9 @@ describe("DASH live - UTCTimings", () => {
         transport:manifestInfos.transport,
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521448, 3);
 
@@ -242,9 +242,9 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(10);
+      await sleep(100);
       await xhrMock.flush();
-      await sleep(10);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1553521748, 1);
       expect(player.getMaximumPosition()).to.be

--- a/tests/integration/scenarios/discontinuities.js
+++ b/tests/integration/scenarios/discontinuities.js
@@ -173,7 +173,7 @@ describe("discontinuities handling", () => {
   describe("discontinuities in Period announced in Manifest", () => {
     const { url, transport } = discontinuityInfos;
     it("should seek over discontinuities in a Period", async function () {
-      this.timeout(7000);
+      this.timeout(8000);
       let discontinuitiesWarningReceived = 0;
       player.addEventListener("warning", (err) => {
         if (err.type === "MEDIA_ERROR" &&
@@ -189,7 +189,7 @@ describe("discontinuities handling", () => {
                          startAt: { position: 22 } });
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
-      await sleep(2000);
+      await sleep(4000);
       expect(player.getPosition()).to.be.above(28);
       expect(player.getPlayerState()).to.equal("PLAYING");
       expect(discontinuitiesWarningReceived).to.equal(1);

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -905,10 +905,10 @@ export default function launchTestsForContent(manifestInfos) {
 
         expect(player.getAvailableAudioBitrates()).to.eql([]);
 
-        await sleep(5);
+        await sleep(100);
         expect(player.getAvailableAudioBitrates()).to.eql([]);
         await xhrMock.flush();
-        await sleep(10);
+        await sleep(100);
 
         expect(player.getAvailableAudioBitrates()).to.eql(audioBitrates);
       });

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -192,9 +192,9 @@ export default function launchTestsForContent(manifestInfos) {
         xhrMock.lock();
         player.loadVideo({ url: manifestInfos.url, transport });
 
-        await sleep(10);
+        await sleep(100);
         await xhrMock.flush(); // only wait for the manifest request
-        await sleep(10);
+        await sleep(100);
 
         const manifest = player.getManifest();
         expect(manifest).not.to.equal(null);


### PR DESCRIPTION
It's that time again where an integration test seems to randomly fail -
only in our CI - presumingly due to poor performance from the instance
doing the testing.

I'll do the usual fix of raising the time awaited, first in a Pull
Request to see if it has any effect.