### PR TITLE
For stopAtEnd option, rely directly on RxPlayer state changes

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1046,16 +1046,14 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     // Handle state updates
     playerState$
       .pipe(takeUntil(stoppedContent$))
-      .subscribe(x => this._priv_setPlayerState(x));
+      .subscribe(newState => {
+        this._priv_setPlayerState(newState);
 
-    const endedEvent$ = observation$.pipe(filter(o => {
-      return o.event === "ended";
-    }));
-    (this._priv_stopAtEnd ? endedEvent$ :
-                            EMPTY)
-      .pipe(takeUntil(stoppedContent$))
-      .subscribe(() => {
-        currentContentCanceller.cancel();
+        // Previous call could have performed all kind of side-effects, thus,
+        // we re-check the current state associated to the RxPlayer
+        if (this.state === "ENDED" && this._priv_stopAtEnd) {
+          currentContentCanceller.cancel();
+        }
       });
 
     // Link playback events to the corresponding callbacks


### PR DESCRIPTION
We had an issue on LG TV which presumably was linked to a race condition on this device.

On some LG TVs only, and only when playing two consecutive unencrypted directfile contents, the second one would never play if:
  - the `stopAtEnd` constructor option was set to `true`
  - the second content was loaded immediately once the RxPlayer switched to the `"ENDED"` state.

This was because of a weird race condition, where:
  1. An initial unencrypted directfile content is played until its end.
  2. The browser set the media element's `ended` attribute to `true`
  3. Some event (e.g. "timeupdate" or "pause") is then triggered through that media element.
      That's when the RxPlayer first notices that the `ended` attribute is set to `true`, switches its state to `"ENDED"`, and trigger the corresponding `playerStateChange` event.
  4. On that event, the application loaded the second directfile content.
  5. The RxPlayer set on the media element the url of the new wanted unencrypted directfile content, as its `src` attribute.
  6. The LG TV's browser decides now, after being back to the event loop, to trigger the `"ended"` event for the previous content, despite the fact that the content actually changed
  7. The RxPlayer based itself on the `"ended"` event to implement the stopAtEnd functionality. Here, it immediately stopped the new content, thinking it is the one that just ended (because this is now the current one). Here I'm thinking that LG's behavior is non-standard

To work around this issue, I decided to simplify things and just rely directly on the same internal trigger than for the `"ENDED"` state change (which is when the `ended` attribute of the media element is first seen to be set at `true`) to stop the content when `stopAtEnd` is set to `true`, and not on the `"ended"` event anymore.

The stopping logic then happens just after triggering the state change for the application and only if the state stood as ENDED and if the corresponding content was not already stopped.