### PR TITLE
[Proposal] [v4] Remove initialVideoBitrate and initialAudioBitrate, add baseBandwidth

### DIFF
--- a/demo/full/scripts/components/Options/AudioAdaptiveSettings.jsx
+++ b/demo/full/scripts/components/Options/AudioAdaptiveSettings.jsx
@@ -10,10 +10,8 @@ import DEFAULT_VALUES from "../../lib/defaultOptionsValues";
  * @returns {Object}
  */
 function AudioAdaptiveSettings({
-  initialAudioBr,
   minAudioBr,
   maxAudioBr,
-  onInitialAudioBrInput,
   onMinAudioBrInput,
   onMaxAudioBrInput,
 }) {
@@ -46,36 +44,6 @@ function AudioAdaptiveSettings({
 
   return (
     <Fragment>
-      <li>
-        <div className="playerOptionInput">
-          <label htmlFor="initialAudioBitrate">Initial Audio Bitrate</label>
-          <span className="wrapperInputWithResetBtn">
-            <input
-              type="number"
-              name="initialAudioBitrate"
-              id="initialAudioBitrate"
-              aria-label="Initial audio bitrate option"
-              placeholder="Number"
-              onChange={(evt) => onInitialAudioBrInput(evt.target.value)}
-              value={initialAudioBr}
-              className="optionInput"
-            />
-            <Button
-              className={
-                parseFloat(initialAudioBr) === DEFAULT_VALUES.initialAudioBr
-                  ? "resetBtn disabledResetBtn"
-                  : "resetBtn"
-              }
-              ariaLabel="Reset option to default value"
-              title="Reset option to default value"
-              onClick={() => {
-                onInitialAudioBrInput(DEFAULT_VALUES.initialAudioBr);
-              }}
-              value={String.fromCharCode(0xf021)}
-            />
-          </span>
-        </div>
-      </li>
       <li>
         <div className="playerOptionInput">
           <label htmlFor="minAudioBitrate">Min Audio Bitrate</label>

--- a/demo/full/scripts/components/Options/VideoAdaptiveSettings.jsx
+++ b/demo/full/scripts/components/Options/VideoAdaptiveSettings.jsx
@@ -10,10 +10,8 @@ import DEFAULT_VALUES from "../../lib/defaultOptionsValues";
  * @returns {Object}
  */
 function VideoAdaptiveSettings({
-  initialVideoBr,
   minVideoBr,
   maxVideoBr,
-  onInitialVideoBrInput,
   onMinVideoBrInput,
   onMaxVideoBrInput,
   limitVideoWidth,
@@ -50,36 +48,6 @@ function VideoAdaptiveSettings({
 
   return (
     <Fragment>
-      <li>
-        <div className="playerOptionInput">
-          <label htmlFor="initialVideoBitrate">Initial Video Bitrate</label>
-          <span className="wrapperInputWithResetBtn">
-            <input
-              type="number"
-              name="initialVideoBitrate"
-              id="initialVideoBitrate"
-              aria-label="Initial video bitrate option"
-              placeholder="Number"
-              onChange={(evt) => onInitialVideoBrInput(evt.target.value)}
-              value={initialVideoBr}
-              className="optionInput"
-            />
-            <Button
-              className={
-                parseFloat(initialVideoBr) === DEFAULT_VALUES.initialVideoBr
-                  ? "resetBtn disabledResetBtn"
-                  : "resetBtn"
-              }
-              ariaLabel="Reset option to default value"
-              title="Reset option to default value"
-              onClick={() => {
-                onInitialVideoBrInput(DEFAULT_VALUES.initialVideoBr);
-              }}
-              value={String.fromCharCode(0xf021)}
-            />
-          </span>
-        </div>
-      </li>
       <li>
         <div className="playerOptionInput">
           <label htmlFor="minVideoBitrate">Min Video Bitrate</label>

--- a/demo/full/scripts/controllers/Settings.jsx
+++ b/demo/full/scripts/controllers/Settings.jsx
@@ -21,8 +21,6 @@ class Settings extends React.Component {
 
   getOptions() {
     const {
-      initialVideoBr,
-      initialAudioBr,
       minVideoBr,
       minAudioBr,
       maxVideoBr,
@@ -43,8 +41,6 @@ class Settings extends React.Component {
     } = this.state;
     return {
       initOpts: {
-        initialVideoBitrate: parseFloat(initialVideoBr),
-        initialAudioBitrate: parseFloat(initialAudioBr),
         minVideoBitrate: parseFloat(minVideoBr),
         minAudioBitrate: parseFloat(minAudioBr),
         maxVideoBitrate: parseFloat(maxVideoBr),
@@ -72,14 +68,6 @@ class Settings extends React.Component {
 
   onAutoPlayClick(evt) {
     this.setState({ autoPlay: getCheckBoxValue(evt.target) });
-  }
-
-  onInitialVideoBrInput(value) {
-    this.setState({ initialVideoBr: value });
-  }
-
-  onInitialAudioBrInput(value) {
-    this.setState({ initialAudioBr: value });
   }
 
   onMinVideoBrInput(value) {
@@ -151,8 +139,6 @@ class Settings extends React.Component {
   render() {
     const {
       autoPlay,
-      initialVideoBr,
-      initialAudioBr,
       minVideoBr,
       minAudioBr,
       maxVideoBr,
@@ -172,16 +158,12 @@ class Settings extends React.Component {
     } = this.state;
 
     const initialSettings = {
-      initialVideoBr,
-      initialAudioBr,
       minAudioBr,
       minVideoBr,
       maxVideoBr,
       maxAudioBr,
       limitVideoWidth,
       throttleVideoBitrateWhenHidden,
-      onInitialVideoBrInput: this.onInitialVideoBrInput,
-      onInitialAudioBrInput: this.onInitialAudioBrInput,
       onMinAudioBrInput: this.onMinAudioBrInput,
       onMinVideoBrInput: this.onMinVideoBrInput,
       onMaxAudioBrInput: this.onMaxAudioBrInput,

--- a/doc/api/Creating_a_Player.md
+++ b/doc/api/Creating_a_Player.md
@@ -44,63 +44,25 @@ const videoElement = player.getVideoElement();
 document.body.appendChild(videoElement);
 ```
 
-### initialVideoBitrate
+### baseBandwidth
 
 _type_: `Number|undefined`
 
 _defaults_: `0`
 
-This is a ceil value for the initial video bitrate chosen.
+The initial value used for bandwidth calculations, in bits per seconds.
 
-That is, the first video
-[Representation](../Getting_Started/Glossary.md#representation) chosen will be
-both:
+The RxPlayer will base itself on this value initially before estimating it
+itself.
+You can set this value either if you have a rough-enough idea of the user's
+current bandwidth and/or if you prefer to start loading specific media qualities
+initially.
 
-- inferior or equal to this value.
-- the closest possible to this value (after filtering out the ones with a
-  superior bitrate).
-
-If no Representation is found to respect those rules, the Representation with
-the lowest bitrate will be chosen instead. Thus, the default value - `0` -
-will lead to the lowest bitrate being chosen at first.
-
+For example, to set an initial bandwidth of 700 kilobits per seconds, you can
+set:
 ```js
-// Begin either by the video bitrate just below or equal to 700000 bps if found
-// or the lowest bitrate available if not.
 const player = new Player({
-  initialVideoBitrate: 700000,
-});
-```
-
-<div class="warning">
-This option will have no effect for contents loaded in <i>Directfile</i>
-mode (see <a href="./Loading_a_Content.md#transport">loadVideo options</a>).
-</div>
-
-### initialAudioBitrate
-
-_type_: `Number|undefined`
-
-_defaults_: `0`
-
-This is a ceil value for the initial audio bitrate chosen.
-
-That is, the first audio
-[Representation](../Getting_Started/Glossary.md#representation) chosen will be:
-
-- inferior or equal to this value.
-- the closest possible to this value (after filtering out the ones with a
-  superior bitrate).
-
-If no Representation is found to respect those rules, the Representation with
-the lowest bitrate will be chosen instead. Thus, the default value - `0` -
-will lead to the lowest bitrate being chosen at first.
-
-```js
-// Begin either by the audio bitrate just below or equal to 5000 bps if found
-// or the lowest bitrate available if not.
-const player = new Player({
-  initialAudioBitrate: 5000,
+  baseBandwidth: 700000,
 });
 ```
 

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -20,11 +20,8 @@ properties, methods, events and so on.
   - [`videoElement`](../api/Creating_a_Player.md#videoElement): specifies the
     media element on which the content will play.
 
-  - [`initialVideoBitrate`](../api/Creating_a_Player.md#initialvideobitrate):
-    Ceil value for the initial video bitrate wanted.
-
-  - [`initialAudioBitrate`](../api/Creating_a_Player.md#initialaudiobitrate):
-    Ceil value for the initial audio bitrate wanted.
+  - [`baseBandwidth`](../api/Creating_a_Player.md#basebandwidth):
+    Base value for the bandwidth calculated by the RxPlayer.
 
   - [`minVideoBitrate`](../api/Creating_a_Player.md#minvideobitrate):
     Minimum video bitrate reachable through adaptive streaming.

--- a/src/core/api/__tests__/option_utils.test.ts
+++ b/src/core/api/__tests__/option_utils.test.ts
@@ -51,7 +51,7 @@ describe("API - parseConstructorOptions", () => {
   const videoElement = document.createElement("video");
   const {
     // DEFAULT_AUTO_PLAY,
-    DEFAULT_INITIAL_BITRATES,
+    DEFAULT_BASE_BANDWIDTH,
     DEFAULT_LIMIT_VIDEO_WIDTH,
     // DEFAULT_MANUAL_BITRATE_SWITCHING_MODE,
     DEFAULT_MIN_BITRATES,
@@ -71,8 +71,7 @@ describe("API - parseConstructorOptions", () => {
     limitVideoWidth: DEFAULT_LIMIT_VIDEO_WIDTH,
     throttleVideoBitrateWhenHidden: DEFAULT_THROTTLE_VIDEO_BITRATE_WHEN_HIDDEN,
     videoElement,
-    initialVideoBitrate: DEFAULT_INITIAL_BITRATES.video,
-    initialAudioBitrate: DEFAULT_INITIAL_BITRATES.audio,
+    baseBandwidth: DEFAULT_BASE_BANDWIDTH,
     minAudioBitrate: DEFAULT_MIN_BITRATES.audio,
     minVideoBitrate: DEFAULT_MIN_BITRATES.video,
     maxAudioBitrate: DEFAULT_MAX_BITRATES.audio,
@@ -170,41 +169,22 @@ describe("API - parseConstructorOptions", () => {
     expect(parsed2.videoElement).toBe(audioElement);
   });
 
-  it("should authorize setting an initialVideoBitrate", () => {
-    expect(parseConstructorOptions({ initialVideoBitrate: -1 })).toEqual({
+  it("should authorize setting an baseBandwidth", () => {
+    expect(parseConstructorOptions({ baseBandwidth: -1 })).toEqual({
       ...defaultConstructorOptions,
-      initialVideoBitrate: -1,
+      baseBandwidth: -1,
     });
-    expect(parseConstructorOptions({ initialVideoBitrate: 0 })).toEqual({
+    expect(parseConstructorOptions({ baseBandwidth: 0 })).toEqual({
       ...defaultConstructorOptions,
-      initialVideoBitrate: 0,
+      baseBandwidth: 0,
     });
-    expect(parseConstructorOptions({ initialVideoBitrate: 10 })).toEqual({
+    expect(parseConstructorOptions({ baseBandwidth: 10 })).toEqual({
       ...defaultConstructorOptions,
-      initialVideoBitrate: 10,
+      baseBandwidth: 10,
     });
-    expect(parseConstructorOptions({ initialVideoBitrate: Infinity })).toEqual({
+    expect(parseConstructorOptions({ baseBandwidth: Infinity })).toEqual({
       ...defaultConstructorOptions,
-      initialVideoBitrate: Infinity,
-    });
-  });
-
-  it("should authorize setting an initialAudioBitrate", () => {
-    expect(parseConstructorOptions({ initialAudioBitrate: -1 })).toEqual({
-      ...defaultConstructorOptions,
-      initialAudioBitrate: -1,
-    });
-    expect(parseConstructorOptions({ initialAudioBitrate: 0 })).toEqual({
-      ...defaultConstructorOptions,
-      initialAudioBitrate: 0,
-    });
-    expect(parseConstructorOptions({ initialAudioBitrate: 10 })).toEqual({
-      ...defaultConstructorOptions,
-      initialAudioBitrate: 10,
-    });
-    expect(parseConstructorOptions({ initialAudioBitrate: Infinity })).toEqual({
-      ...defaultConstructorOptions,
-      initialAudioBitrate: Infinity,
+      baseBandwidth: Infinity,
     });
   });
 
@@ -339,16 +319,10 @@ describe("API - parseConstructorOptions", () => {
     })).toThrow();
   });
 
-  it("should throw if the initialVideoBitrate given is not a number", () => {
-    expect(() => parseConstructorOptions({ initialVideoBitrate: "a" as any })).toThrow();
-    expect(() => parseConstructorOptions({ initialVideoBitrate: /a/ as any })).toThrow();
-    expect(() => parseConstructorOptions({ initialVideoBitrate: {} as any })).toThrow();
-  });
-
-  it("should throw if the initialAudioBitrate given is not a number", () => {
-    expect(() => parseConstructorOptions({ initialAudioBitrate: "a" as any })).toThrow();
-    expect(() => parseConstructorOptions({ initialAudioBitrate: /a/ as any })).toThrow();
-    expect(() => parseConstructorOptions({ initialAudioBitrate: {} as any })).toThrow();
+  it("should throw if the baseBandwidth given is not a number", () => {
+    expect(() => parseConstructorOptions({ baseBandwidth: "a" as any })).toThrow();
+    expect(() => parseConstructorOptions({ baseBandwidth: /a/ as any })).toThrow();
+    expect(() => parseConstructorOptions({ baseBandwidth: {} as any })).toThrow();
   });
 
   it("should throw if the minVideoBitrate given is not a number", () => {

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -54,8 +54,7 @@ export interface IParsedConstructorOptions {
   throttleVideoBitrateWhenHidden : boolean;
 
   videoElement : HTMLMediaElement;
-  initialVideoBitrate : number;
-  initialAudioBitrate : number;
+  baseBandwidth : number;
   minAudioBitrate : number;
   minVideoBitrate : number;
   maxAudioBitrate : number;
@@ -132,14 +131,13 @@ function parseConstructorOptions(
   let maxVideoBufferSize : number;
 
   let videoElement : HTMLMediaElement;
-  let initialVideoBitrate : number;
-  let initialAudioBitrate : number;
+  let baseBandwidth : number;
   let minAudioBitrate : number;
   let minVideoBitrate : number;
   let maxAudioBitrate : number;
   let maxVideoBitrate : number;
 
-  const { DEFAULT_INITIAL_BITRATES,
+  const { DEFAULT_BASE_BANDWIDTH,
           DEFAULT_LIMIT_VIDEO_WIDTH,
           DEFAULT_MIN_BITRATES,
           DEFAULT_MAX_BITRATES,
@@ -209,24 +207,13 @@ function parseConstructorOptions(
     /* eslint-enable max-len */
   }
 
-  if (isNullOrUndefined(options.initialVideoBitrate)) {
-    initialVideoBitrate = DEFAULT_INITIAL_BITRATES.video;
+  if (isNullOrUndefined(options.baseBandwidth)) {
+    baseBandwidth = DEFAULT_BASE_BANDWIDTH;
   } else {
-    initialVideoBitrate = Number(options.initialVideoBitrate);
-    if (isNaN(initialVideoBitrate)) {
+    baseBandwidth = Number(options.baseBandwidth);
+    if (isNaN(baseBandwidth)) {
       /* eslint-disable max-len */
-      throw new Error("Invalid initialVideoBitrate parameter. Should be a number.");
-      /* eslint-enable max-len */
-    }
-  }
-
-  if (isNullOrUndefined(options.initialAudioBitrate)) {
-    initialAudioBitrate = DEFAULT_INITIAL_BITRATES.audio;
-  } else {
-    initialAudioBitrate = Number(options.initialAudioBitrate);
-    if (isNaN(initialAudioBitrate)) {
-      /* eslint-disable max-len */
-      throw new Error("Invalid initialAudioBitrate parameter. Should be a number.");
+      throw new Error("Invalid baseBandwidth parameter. Should be a number.");
       /* eslint-enable max-len */
     }
   }
@@ -282,8 +269,7 @@ function parseConstructorOptions(
            wantedBufferAhead,
            maxVideoBufferSize,
            throttleVideoBitrateWhenHidden,
-           initialAudioBitrate,
-           initialVideoBitrate,
+           baseBandwidth,
            minAudioBitrate,
            minVideoBitrate,
            maxAudioBitrate,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -412,8 +412,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   constructor(options : IConstructorOptions = {}) {
     super();
-    const { initialAudioBitrate,
-            initialVideoBitrate,
+    const { baseBandwidth,
             limitVideoWidth,
             minAudioBitrate,
             minVideoBitrate,
@@ -456,8 +455,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     };
 
     this._priv_bitrateInfos = {
-      lastBitrates: { audio: initialAudioBitrate,
-                      video: initialVideoBitrate },
+      lastBitrates: { audio: baseBandwidth,
+                      video: baseBandwidth },
       minAutoBitrates: { audio: createSharedReference(minAudioBitrate),
                          video: createSharedReference(minVideoBitrate) },
       maxAutoBitrates: { audio: createSharedReference(maxAudioBitrate),

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -182,13 +182,7 @@ const DEFAULT_CONFIG = {
      * play will always take the last set one.
      * @type {Object}
      */
-  DEFAULT_INITIAL_BITRATES: {
-    audio: 0, // only "audio" segments
-    video: 0, // only "video" segments
-    other: 0, // tracks which are not audio/video (like text).
-                // Though those are generally at a single bitrate, so no adaptive
-                // mechanism is triggered for them.
-  },
+  DEFAULT_BASE_BANDWIDTH: 0,
 
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     /**

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -48,8 +48,7 @@ export interface IConstructorOptions {
   throttleVideoBitrateWhenHidden? : boolean;
 
   videoElement? : HTMLMediaElement;
-  initialVideoBitrate? : number;
-  initialAudioBitrate? : number;
+  baseBandwidth? : number;
   minAudioBitrate? : number;
   minVideoBitrate? : number;
   maxAudioBitrate? : number;


### PR DESCRIPTION
This commit removes both `initialAudioBitrate` and `initialVideoBitrate` APIs, replacing it by just a `baseBandwidth` API.
`baseBandwidth` should be set to a global bandwidth estimate of the user.

If, for the upcoming v4, the other commits related to bitrate APIs are all merged, this would have been the last documented APIs forcing the RxPlayer to separate audio and video bandwidth calculations.

I propose removing it for the following reasons:

  - Applications used it for the wrong reasons for the most part:
    thinking the set value will correlate exactly to the first video or audio segments seen by the user.

    In reality, things are much more complex. True bandwidth calculations could be performed before pushing the initially-played media segments, fast-switching could replace an initially-lower quality, factors may be used between that value and the true one relied on etc.

  - It finally allows us to remove the separation between audio bandwidth and video bandwidth calculations if we want to.

    This may be helpful if we ever support HLS contents, or if we ever want to globalize our adaptive logic.

  - Indicating a single bandwidth, instead of one for video and one for audio, should be easier to understand as an API.

---

In the RxPlayer code, `baseBandwidth` is then set as the initial bitrate both for video and audio. As such, the RxPlayer internals do not change much.

This logic may be problematic however as we should probably take into account the addition of at least the audio and video Representations when choosing one, not them individually.
By just using `baseBandwidth` for both individually, we thus may be too optimistic.

However, this is not as bad as it sounds:

  - There should be factors in play which leads to safer Representation choices than just the highest compatible one.

  - For now, applications may consider that fact to set a lower `baseBandwidth`.

  - Also, in case of too high bitrates being initially chosen, the RxPlayer should realize soon enough that this is the case.

    We may just end-up with the first content taking a little longer to play than expected.

Still a better handling of this value should probably be written in the future.

Thoughts?