### PR TITLE
Implement `segmentRequestTimeout` and `manifestRequestTimeout`

### DIFF
--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -824,6 +824,20 @@ This object can take the following properties (all are optional):
 
   Defaults to `Infinity`.
 
+- `manifestRequestTimeout` (`Number|undefined`): Timeout, in milliseconds, after
+  which manifest requests are aborted and, depending on other options, retried.
+
+  To set to `-1` for no timeout.
+
+  `undefined` (the default) will lead to a default, large, timeout being used.
+
+- `segmentRequestTimeout` (`Number|undefined`): Timeout, in milliseconds, after
+  which segment requests are aborted and, depending on other options, retried.
+
+  To set to `-1` for no timeout.
+
+  `undefined` (the default) will lead to a default, large, timeout being used.
+
 [1] To retry a request, one of the following condition should be met:
 
 - The request failed because of a `404` HTTP code

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -98,6 +98,13 @@ As you can see, this function takes two arguments:
        - *url* (`string`): The URL the segment request should normally be
          performed at.
 
+       - *timeout* (`number|undefined`: Timeout in milliseconds after which a
+         request should preferably be aborted, according to current
+         configuration.
+
+         This property is mainly indicative, you may or may not want to exploit
+         this information depending on your use cases.
+
        - *manifest* (`Object`) - the Manifest object containing the segment.
          More information on its structure can be found on the documentation
          linked below [1].
@@ -290,7 +297,7 @@ const customManifestLoader = (url, callbacks) => {
 };
 ```
 
-As you can see, this function takes two arguments:
+As you can see, this function takes three arguments:
 
   1. **url**: The URL the Manifest request should normally be performed at.
 
@@ -366,6 +373,17 @@ As you can see, this function takes two arguments:
 
        - **fallback**: Callback to call if you want to call our default
          implementation instead for this Manifest. No argument is needed.
+
+  3. **options**: Various other options. For the moment, it's an object with
+     only the following property:
+
+       - *timeout* (`number|undefined`): Timeout in milliseconds after which a
+         request should preferably be aborted, according to current
+         configuration.
+
+         This property is mainly indicative, you may or may not want to exploit
+         this information depending on your use cases.
+
 
 The `manifestLoader` can also return a function, which will be called if/when
 the request is aborted. You can define one to clean-up or dispose all resources.

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -210,6 +210,12 @@ properties, methods, events and so on.
       Maximum number of retries when a Manifest or segment request fails due to
       the user being offline.
 
+    - [`networkConfig.manifestRequestTimeout`](../api/Loading_a_Content.md#networkconfig):
+      Timeout after which manifest requests are aborted.
+
+    - [`networkConfig.segmentRequestTimeout`](../api/Loading_a_Content.md#networkconfig):
+      Timeout after which segment requests are aborted.
+
   - [`enableFastSwitching`](../api/Loading_a_Content.md#enablefastswitching):
     Enable or disable an optimization replacing segments of poor quality with
     segments of a better quality.

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -638,11 +638,7 @@ function parseLoadVideoOptions(
     }
   }
 
-  const networkConfig = isNullOrUndefined(options.networkConfig) ?
-    {} :
-    { manifestRetry: options.networkConfig.manifestRetry,
-      offlineRetry: options.networkConfig.offlineRetry,
-      segmentRetry: options.networkConfig.segmentRetry };
+  const networkConfig = options.networkConfig ?? {};
 
   // TODO without cast
   /* eslint-disable @typescript-eslint/consistent-type-assertions */

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -741,21 +741,28 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
       const transportPipelines = transportFn(transportOptions);
 
-      const { offlineRetry, segmentRetry, manifestRetry } = networkConfig;
+      const { offlineRetry,
+              segmentRetry,
+              manifestRetry,
+              manifestRequestTimeout,
+              segmentRequestTimeout } = networkConfig;
 
       /** Interface used to load and refresh the Manifest. */
-      const manifestFetcher = new ManifestFetcher(url,
-                                                  transportPipelines,
-                                                  { lowLatencyMode,
-                                                    maxRetryRegular: manifestRetry,
-                                                    maxRetryOffline: offlineRetry });
+      const manifestFetcher = new ManifestFetcher(
+        url,
+        transportPipelines,
+        { lowLatencyMode,
+          maxRetryRegular: manifestRetry,
+          maxRetryOffline: offlineRetry,
+          requestTimeout:  manifestRequestTimeout });
 
       /** Interface used to download segments. */
       const segmentFetcherCreator = new SegmentFetcherCreator(
         transportPipelines,
         { lowLatencyMode,
           maxRetryOffline: offlineRetry,
-          maxRetryRegular: segmentRetry });
+          maxRetryRegular: segmentRetry,
+          requestTimeout: segmentRequestTimeout });
 
       /** Observable emitting the initial Manifest */
       let manifest$ : Observable<IManifestFetcherParsedResult |

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -135,4 +135,11 @@ export interface ISegmentFetcherCreatorBackoffOptions {
   maxRetryRegular : number | undefined;
   /** Maximum number of time a request be retried when the user is offline. */
   maxRetryOffline : number | undefined;
+  /**
+   * Timeout after which request are aborted and, depending on other options,
+   * retried.
+   * To set to `-1` for no timeout.
+   * `undefined` will lead to a default, large, timeout being used.
+   */
+  requestTimeout : number | undefined;
 }

--- a/src/errors/custom_loader_error.ts
+++ b/src/errors/custom_loader_error.ts
@@ -31,9 +31,10 @@ export default class CustomLoaderError extends Error {
   public readonly xhr : XMLHttpRequest | undefined;
 
   /**
+   * @param {string} message
+   * @param {boolean} canRetry
+   * @param {boolean} isOfflineError
    * @param {XMLHttpRequest} xhr
-   * @param {string} url
-   * @param {string} type
    */
   constructor(
     message : string,

--- a/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/thumbnail_loader.ts
@@ -28,6 +28,7 @@ import {
   take,
   tap,
 } from "rxjs";
+import config from "../../../config";
 import Player from "../../../core/api";
 import createSegmentFetcher, {
   ISegmentFetcher,
@@ -214,7 +215,8 @@ export default class VideoThumbnailLoader {
       { baseDelay: 0,
         maxDelay: 0,
         maxRetryOffline: 0,
-        maxRetryRegular: 0 }
+        maxRetryRegular: 0,
+        requestTimeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT }
     ) as ISegmentFetcher<ArrayBuffer | Uint8Array>;
 
     const taskPromise: Promise<number> = lastValueFrom(observableRace(

--- a/src/experimental/tools/createMetaplaylist/get_duration_from_manifest.ts
+++ b/src/experimental/tools/createMetaplaylist/get_duration_from_manifest.ts
@@ -19,6 +19,7 @@ import {
   Observable,
   throwError,
 } from "rxjs";
+import config from "../../../config";
 import { IMetaPlaylist } from "../../../parsers/manifest/metaplaylist";
 import isNonEmptyString from "../../../utils/is_non_empty_string";
 import request from "../../../utils/request/xhr";
@@ -37,9 +38,7 @@ const iso8601Duration =
  *   2. the second value is a possible error encountered while parsing this
  *      value - set to `null` if no error was encountered.
  * @param {string} val - The value to parse
- * @param {string} displayName - The name of the property. Used for error
- * formatting.
- * @returns {Array.<number | Error | null>}
+ * @returns {number | null}
  */
 function parseDuration(val : string) : number | null {
 
@@ -90,6 +89,7 @@ function getDurationFromManifest(url: string,
       canceller,
       () => request({ url,
                       responseType: "document",
+                      timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
                       cancelSignal: canceller.signal })
     ).pipe(map((response) => {
       const { responseData } = response;
@@ -129,6 +129,7 @@ function getDurationFromManifest(url: string,
     canceller,
     () => request({ url,
                     responseType: "text",
+                    timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
                     cancelSignal: canceller.signal })
   ).pipe(map((response) => {
     const { responseData } = response;

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -364,24 +364,44 @@ export interface INetworkConfigOption {
    * request before failing on Error.
    * Set to `Infinity` for an infinite number of requests.
    */
-  manifestRetry? : number;
+  manifestRetry? : number | undefined;
+
+  /**
+   * Amount of time, in milliseconds, after which a manifest request should be
+   * aborted and optionally retried, depending on the current configuration.
+   *
+   * Setting it to `-1` allows to disable any timeout.
+   * `undefined` means that a default, large, timeout will be used instead.
+   */
+  manifestRequestTimeout? : number | undefined;
+
   /**
    * The amount of time maximum we should retry a request in general when the
    * user is offline.
    * Set to `Infinity` for an infinite number of requests.
    */
-  offlineRetry? : number;
+  offlineRetry? : number | undefined;
   /**
    * The amount of time maximum we should retry a segment or segment-related
    * request before failing on Error.
    * Set to `Infinity` for an infinite number of requests.
    */
-  segmentRetry? : number;
+  segmentRetry? : number | undefined;
+
+  /**
+   * Amount of time, in milliseconds, after which a segment request should be
+   * aborted and optionally retried, depending on the current configuration.
+   *
+   * Setting it to `-1` allows to disable any timeout.
+   * `undefined` means that a default, large, timeout will be used instead.
+   */
+  segmentRequestTimeout? : number | undefined;
 }
 
 export type ISegmentLoader = (
   // first argument: infos on the segment
   infos : { url : string;
+            timeout : number | undefined;
             manifest : IManifest;
             period : IPeriod;
             adaptation : IAdaptation;
@@ -423,7 +443,11 @@ export type IManifestLoader = (
                           => void;
 
                  reject : (err? : Error) => void;
-                 fallback : () => void; }
+                 fallback : () => void; },
+
+  options : {
+    timeout : number | undefined;
+  }
 ) =>
   // returns either the aborting callback or nothing
   (() => void)|void;

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -29,7 +29,7 @@ import inferSegmentContainer from "../utils/infer_segment_container";
 export default function addSegmentIntegrityChecks<T>(
   segmentLoader : ISegmentLoader<T>
 ) : ISegmentLoader<T> {
-  return (url, content, initialCancelSignal, callbacks) => {
+  return (url, content, loaderOptions, initialCancelSignal, callbacks) => {
     return new Promise((resolve, reject) => {
       const requestCanceller = new TaskCanceller({ cancelOn: initialCancelSignal });
 
@@ -37,7 +37,7 @@ export default function addSegmentIntegrityChecks<T>(
       // `stopRejectingOnCancel` here is a function allowing to stop this mechanism
       const stopRejectingOnCancel = requestCanceller.signal.register(reject);
 
-      segmentLoader(url, content, requestCanceller.signal, {
+      segmentLoader(url, content, loaderOptions, requestCanceller.signal, {
         ...callbacks,
         onNewChunk(data) {
           try {

--- a/src/transports/dash/image_pipelines.ts
+++ b/src/transports/dash/image_pipelines.ts
@@ -23,6 +23,7 @@ import {
   ILoadedImageSegmentFormat,
   ISegmentContext,
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultSegmentCreated,
   ISegmentLoaderResultSegmentLoaded,
   ISegmentParserParsedInitChunk,
@@ -33,6 +34,7 @@ import {
  * Loads an image segment.
  * @param {string|null} url
  * @param {Object} content
+ * @param {Object} options
  * @param {Object} cancelSignal
  * @param {Object} callbacks
  * @returns {Promise}
@@ -40,6 +42,7 @@ import {
 export async function imageLoader(
   url : string | null,
   content : ISegmentContext,
+  options : ISegmentLoaderOptions,
   cancelSignal : CancellationSignal,
   callbacks : ISegmentLoaderCallbacks<ILoadedImageSegmentFormat>
 ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedImageSegmentFormat> |
@@ -52,6 +55,7 @@ export async function imageLoader(
   }
   const data = await request({ url,
                                responseType: "arraybuffer",
+                               timeout: options.timeout,
                                onProgress: callbacks.onProgress,
                                cancelSignal });
   return { resultType: "segment-loaded",

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -20,6 +20,7 @@ import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultChunkedComplete,
   ISegmentLoaderResultSegmentCreated,
   ISegmentLoaderResultSegmentLoaded,
@@ -30,6 +31,7 @@ import byteRange from "../utils/byte_range";
  * Perform a request for an initialization segment, agnostic to the container.
  * @param {string} url
  * @param {Object} segment
+ * @param {Object} options
  * @param {CancellationSignal} cancelSignal
  * @param {Object} callbacks
  * @returns {Promise}
@@ -37,6 +39,7 @@ import byteRange from "../utils/byte_range";
 export default function initSegmentLoader(
   url : string,
   segment : ISegment,
+  options : ISegmentLoaderOptions,
   cancelSignal : CancellationSignal,
   callbacks : ISegmentLoaderCallbacks<ArrayBuffer | Uint8Array>
 ) : Promise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | Uint8Array> |
@@ -46,6 +49,7 @@ export default function initSegmentLoader(
   if (segment.range === undefined) {
     return request({ url,
                      responseType: "arraybuffer",
+                     timeout: options.timeout,
                      cancelSignal,
                      onProgress: callbacks.onProgress })
       .then(data => ({ resultType: "segment-loaded",
@@ -56,6 +60,7 @@ export default function initSegmentLoader(
     return request({ url,
                      headers: { Range: byteRange(segment.range) },
                      responseType: "arraybuffer",
+                     timeout: options.timeout,
                      cancelSignal,
                      onProgress: callbacks.onProgress })
       .then(data => ({ resultType: "segment-loaded",
@@ -68,6 +73,7 @@ export default function initSegmentLoader(
                      headers: { Range: byteRange([segment.range[0],
                                                   segment.indexRange[1] ]) },
                      responseType: "arraybuffer",
+                     timeout: options.timeout,
                      cancelSignal,
                      onProgress: callbacks.onProgress })
       .then(data => ({ resultType: "segment-loaded",
@@ -77,11 +83,13 @@ export default function initSegmentLoader(
   const rangeRequest$ = request({ url,
                                   headers: { Range: byteRange(segment.range) },
                                   responseType: "arraybuffer",
+                                  timeout: options.timeout,
                                   cancelSignal,
                                   onProgress: callbacks.onProgress });
   const indexRequest$ = request({ url,
                                   headers: { Range: byteRange(segment.indexRange) },
                                   responseType: "arraybuffer",
+                                  timeout: options.timeout,
                                   cancelSignal,
                                   onProgress: callbacks.onProgress });
 

--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -22,6 +22,7 @@ import { CancellationSignal } from "../../utils/task_canceller";
 import {
   ISegmentContext,
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultChunkedComplete,
 } from "../types";
 import byteRange from "../utils/byte_range";
@@ -34,6 +35,7 @@ import extractCompleteChunks from "./extract_complete_chunks";
  *
  * @param {string} url - URL of the segment to download.
  * @param {Object} content - Context of the segment needed.
+ * @param {Object} options
  * @param {Object} callbacks
  * @param {CancellationSignal} cancelSignal
  * @returns {Promise}
@@ -41,6 +43,7 @@ import extractCompleteChunks from "./extract_complete_chunks";
 export default function lowLatencySegmentLoader(
   url : string,
   content : ISegmentContext,
+  options : ISegmentLoaderOptions,
   callbacks : ISegmentLoaderCallbacks<Uint8Array>,
   cancelSignal : CancellationSignal
 ) : Promise<ISegmentLoaderResultChunkedComplete> {
@@ -77,6 +80,7 @@ export default function lowLatencySegmentLoader(
   return fetchRequest({ url,
                         headers,
                         onData,
+                        timeout: options.timeout,
                         cancelSignal })
     .then((res) => ({ resultType: "chunk-complete" as const,
                       resultData: res }));

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../../config";
 import { formatError } from "../../errors";
 import features from "../../features";
 import log from "../../log";
@@ -149,12 +150,15 @@ export default function generateManifestParser(
 
       const externalResources = value.urls.map(resourceUrl => {
         return scheduleRequest(() => {
+          const defaultTimeout = config.getCurrent().DEFAULT_REQUEST_TIMEOUT;
           return value.format === "string" ? request({ url: resourceUrl,
                                                        responseType: "text",
+                                                       timeout: defaultTimeout,
                                                        cancelSignal }) :
 
                                              request({ url: resourceUrl,
                                                        responseType: "arraybuffer",
+                                                       timeout: defaultTimeout,
                                                        cancelSignal });
         }).then((res) => {
           if (value.format === "string") {

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -27,6 +27,7 @@ import { ILoadedManifestFormat } from "../../public_types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
+  IManifestLoaderOptions,
   IManifestParserResult,
   IRequestedData,
   ITransportOptions,
@@ -39,17 +40,18 @@ import textTrackParser from "./text_parser";
 
 /**
  * Returns pipelines used for local Manifest streaming.
- * @param {Object} options
+ * @param {Object} transportOptions
  * @returns {Object}
  */
 export default function getLocalManifestPipelines(
-  options : ITransportOptions
+  transportOptions : ITransportOptions
 ) : ITransportPipelines {
 
-  const customManifestLoader = options.manifestLoader;
+  const customManifestLoader = transportOptions.manifestLoader;
   const manifestPipeline = {
     loadManifest(
       url : string | undefined,
+      loaderOptions : IManifestLoaderOptions,
       cancelSignal : CancellationSignal
     ) : Promise<IRequestedData<ILoadedManifestFormat>> {
       if (isNullOrUndefined(customManifestLoader)) {
@@ -62,7 +64,7 @@ export default function getLocalManifestPipelines(
         () : never => {
           throw new Error("Cannot fallback from the `manifestLoader` of a " +
                           "`local` transport");
-        })(url, cancelSignal);
+        })(url, loaderOptions, cancelSignal);
     },
 
     parseManifest(manifestData : IRequestedData<unknown>) : IManifestParserResult {
@@ -71,7 +73,7 @@ export default function getLocalManifestPipelines(
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const manifest = new Manifest(parsed, options);
+      const manifest = new Manifest(parsed, transportOptions);
       return { manifest, url: undefined };
     },
   };

--- a/src/transports/local/segment_loader.ts
+++ b/src/transports/local/segment_loader.ts
@@ -27,6 +27,7 @@ import {
 import {
   ISegmentContext,
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultSegmentLoaded,
 } from "../types";
 
@@ -45,7 +46,7 @@ function loadInitSegment(
 
     /**
      * Callback triggered when the custom segment loader has a response.
-     * @param {Object} args
+     * @param {Object} _args
      */
     const resolve = (_args : {
       data : ArrayBuffer | null;
@@ -113,7 +114,7 @@ function loadSegment(
 
     /**
      * Callback triggered when the custom segment loader has a response.
-     * @param {Object} args
+     * @param {Object} _args
      */
     const resolve = (_args : {
       data : ArrayBuffer | null;
@@ -188,6 +189,7 @@ function loadSegment(
 export default function segmentLoader(
   _url : string | null,
   content : ISegmentContext,
+  _loaderOptions : ISegmentLoaderOptions, // TODO use timeout?
   cancelSignal : CancellationSignal,
   _callbacks : ISegmentLoaderCallbacks<ArrayBuffer | null>
 ) : Promise<ISegmentLoaderResultSegmentLoaded<ArrayBuffer | null>> {

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -20,21 +20,27 @@ import {
 } from "../../public_types";
 import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
-import { IRequestedData } from "../types";
+import { IManifestLoaderOptions, IRequestedData } from "../types";
 import callCustomManifestLoader from "../utils/call_custom_manifest_loader";
 
 /**
  * Manifest loader triggered if there was no custom-defined one in the API.
  * @param {string} url
+ * @param {Object} loaderOptions
+ * @param {Object} cancelSignal
  */
 function regularManifestLoader(
   url : string | undefined,
+  loaderOptions : IManifestLoaderOptions,
   cancelSignal : CancellationSignal
 ) : Promise< IRequestedData<ILoadedManifestFormat> > {
   if (url === undefined) {
     throw new Error("Cannot perform HTTP(s) request. URL not known");
   }
-  return request({ url, responseType: "text", cancelSignal });
+  return request({ url,
+                   responseType: "text",
+                   timeout: loaderOptions.timeout,
+                   cancelSignal });
 }
 
 /**
@@ -46,6 +52,7 @@ export default function generateManifestLoader(
   { customManifestLoader } : { customManifestLoader?: IManifestLoader | undefined }
 ) : (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) => Promise<IRequestedData<ILoadedManifestFormat>>
 {

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../../config";
 import features from "../../features";
 import Manifest, {
   Adaptation,
@@ -41,6 +42,7 @@ import {
   IRequestedData,
   ISegmentContext,
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultChunkedComplete,
   ISegmentLoaderResultSegmentCreated,
   ISegmentLoaderResultSegmentLoaded,
@@ -171,7 +173,12 @@ export default function(options : ITransportOptions): ITransportPipelines {
                                                cancelSignal,
                                                scheduleRequest));
           function loadSubManifest() {
-            return transport.manifest.loadManifest(resource.url, cancelSignal);
+            /*
+             * Whether a ManifestLoader's timeout should be relied on here
+             * is ambiguous.
+             */
+            const manOpts = { timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT };
+            return transport.manifest.loadManifest(resource.url, manOpts, cancelSignal);
           }
         });
 
@@ -185,7 +192,6 @@ export default function(options : ITransportOptions): ITransportPipelines {
 
   /**
    * @param {Object} segment
-   * @param {Object} transports
    * @returns {Object}
    */
   function getTransportPipelinesFromSegment(
@@ -244,6 +250,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     loadSegment(
       url : string | null,
       content : ISegmentContext,
+      loaderOptions : ISegmentLoaderOptions,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
@@ -253,7 +260,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { segment } = content;
       const { audio } = getTransportPipelinesFromSegment(segment);
       const ogContent = getOriginalContent(segment);
-      return audio.loadSegment(url, ogContent, cancelToken, callbacks);
+      return audio.loadSegment(url, ogContent, loaderOptions, cancelToken, callbacks);
     },
 
     parseSegment(
@@ -281,6 +288,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     loadSegment(
       url : string | null,
       content : ISegmentContext,
+      loaderOptions : ISegmentLoaderOptions,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedAudioVideoSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedAudioVideoSegmentFormat> |
@@ -290,7 +298,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { segment } = content;
       const { video } = getTransportPipelinesFromSegment(segment);
       const ogContent = getOriginalContent(segment);
-      return video.loadSegment(url, ogContent, cancelToken, callbacks);
+      return video.loadSegment(url, ogContent, loaderOptions, cancelToken, callbacks);
     },
 
     parseSegment(
@@ -318,6 +326,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     loadSegment(
       url : string | null,
       content : ISegmentContext,
+      loaderOptions : ISegmentLoaderOptions,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedTextSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedTextSegmentFormat> |
@@ -327,7 +336,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { segment } = content;
       const { text } = getTransportPipelinesFromSegment(segment);
       const ogContent = getOriginalContent(segment);
-      return text.loadSegment(url, ogContent, cancelToken, callbacks);
+      return text.loadSegment(url, ogContent, loaderOptions, cancelToken, callbacks);
     },
 
     parseSegment(
@@ -355,6 +364,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
     loadSegment(
       url : string | null,
       content : ISegmentContext,
+      loaderOptions : ISegmentLoaderOptions,
       cancelToken : CancellationSignal,
       callbacks : ISegmentLoaderCallbacks<ILoadedImageSegmentFormat>
     ) : Promise<ISegmentLoaderResultSegmentLoaded<ILoadedImageSegmentFormat> |
@@ -364,7 +374,7 @@ export default function(options : ITransportOptions): ITransportPipelines {
       const { segment } = content;
       const { image } = getTransportPipelinesFromSegment(segment);
       const ogContent = getOriginalContent(segment);
-      return image.loadSegment(url, ogContent, cancelToken, callbacks);
+      return image.loadSegment(url, ogContent, loaderOptions, cancelToken, callbacks);
     },
 
     parseSegment(

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -25,6 +25,7 @@ import {
 import {
   ISegmentContext,
   ISegmentLoaderCallbacks,
+  ISegmentLoaderOptions,
   ISegmentLoaderResultSegmentCreated,
   ISegmentLoaderResultSegmentLoaded,
 } from "../types";
@@ -40,6 +41,7 @@ import { isMP4EmbeddedTrack } from "./utils";
  * Segment loader triggered if there was no custom-defined one in the API.
  * @param {string} url
  * @param {Object} content
+ * @param {Object} loaderOptions
  * @param {Object} callbacks
  * @param {Object} cancelSignal
  * @param {boolean} checkMediaSegmentIntegrity
@@ -49,6 +51,7 @@ function regularSegmentLoader(
   url : string,
   content : ISegmentContext,
   callbacks : ISegmentLoaderCallbacks<Uint8Array | ArrayBuffer | null>,
+  loaderOptions : ISegmentLoaderOptions,
   cancelSignal : CancellationSignal,
   checkMediaSegmentIntegrity? : boolean | undefined
 ) : Promise<ISegmentLoaderResultSegmentLoaded<Uint8Array | ArrayBuffer | null>> {
@@ -61,6 +64,7 @@ function regularSegmentLoader(
   return request({ url,
                    responseType: "arraybuffer",
                    headers,
+                   timeout: loaderOptions.timeout,
                    cancelSignal,
                    onProgress: callbacks.onProgress })
     .then((data) => {
@@ -89,6 +93,7 @@ const generateSegmentLoader = ({
 }) => (
   url : string | null,
   content : ISegmentContext,
+  loaderOptions : ISegmentLoaderOptions,
   cancelSignal : CancellationSignal,
   callbacks : ISegmentLoaderCallbacks<Uint8Array | ArrayBuffer | null>
 ) : Promise<ISegmentLoaderResultSegmentLoaded<Uint8Array | ArrayBuffer | null> |
@@ -154,12 +159,14 @@ const generateSegmentLoader = ({
                    representation,
                    segment,
                    transport: "smooth",
+                   timeout: loaderOptions.timeout,
                    url };
 
     if (typeof customSegmentLoader !== "function") {
       return regularSegmentLoader(url,
                                   content,
                                   callbacks,
+                                  loaderOptions,
                                   cancelSignal,
                                   checkMediaSegmentIntegrity);
     }
@@ -249,6 +256,7 @@ const generateSegmentLoader = ({
         regularSegmentLoader(url,
                              content,
                              callbacks,
+                             loaderOptions,
                              cancelSignal,
                              checkMediaSegmentIntegrity)
           .then(res, rej);

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -92,6 +92,7 @@ export interface ITransportManifestPipeline {
    */
   loadManifest : (
     url : string | undefined,
+    options : IManifestLoaderOptions,
     cancelSignal : CancellationSignal,
   ) => Promise<IRequestedData<ILoadedManifestFormat>>;
 
@@ -195,6 +196,20 @@ export interface ITransportManifestPipeline {
   ) => Promise<string | undefined>;
 }
 
+/**
+ * Options given to the `loadManifest` method of an
+ * `ITransportManifestPipeline` to configure its behavior.
+ */
+export interface IManifestLoaderOptions {
+  /**
+   * Timeout, in milliseconds, after which a manifest request should be aborted
+   * with the corresponding error.
+   *
+   * `undefined` means that no timeout will be enforced.
+   */
+  timeout? : number | undefined;
+}
+
 /** Functions allowing to load and parse segments of any type. */
 export interface ISegmentPipeline<
   TLoadedFormat,
@@ -224,11 +239,23 @@ export interface ISegmentPipeline<
 export type ISegmentLoader<TLoadedFormat> = (
   url : string | null,
   content : ISegmentContext,
+  options : ISegmentLoaderOptions,
   cancelSignal : CancellationSignal,
   callbacks : ISegmentLoaderCallbacks<TLoadedFormat>
 ) => Promise<ISegmentLoaderResultSegmentCreated<TLoadedFormat> |
              ISegmentLoaderResultSegmentLoaded<TLoadedFormat> |
              ISegmentLoaderResultChunkedComplete>;
+
+/** Options given to an `ISegmentLoader` to configure its behavior. */
+export interface ISegmentLoaderOptions {
+  /**
+   * Timeout, in milliseconds, after which a segment request should be aborted
+   * with the corresponding error.
+   *
+   * `undefined` means that no timeout will be enforced.
+   */
+  timeout? : number | undefined;
+}
 
 /**
  * Segment parser function, allowing to parse a chunk (which may be a sub-part

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -24,6 +24,7 @@ import {
   CancellationSignal,
 } from "../../utils/task_canceller";
 import {
+  IManifestLoaderOptions,
   IRequestedData,
 } from "../types";
 
@@ -31,15 +32,18 @@ export default function callCustomManifestLoader(
   customManifestLoader : IManifestLoader,
   fallbackManifestLoader : (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) => Promise< IRequestedData<ILoadedManifestFormat> >
 ) : (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) => Promise< IRequestedData<ILoadedManifestFormat> >
 {
   return (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) : Promise< IRequestedData<ILoadedManifestFormat> > => {
     return new Promise((res, rej) => {
@@ -114,11 +118,13 @@ export default function callCustomManifestLoader(
         }
         hasFinished = true;
         cancelSignal.deregister(abortCustomLoader);
-        fallbackManifestLoader(url, cancelSignal).then(res, rej);
+        fallbackManifestLoader(url, loaderOptions, cancelSignal).then(res, rej);
       };
 
       const callbacks = { reject, resolve, fallback };
-      const abort = customManifestLoader(url, callbacks);
+      const abort = customManifestLoader(url,
+                                         callbacks,
+                                         { timeout: loaderOptions.timeout });
 
       cancelSignal.register(abortCustomLoader);
 

--- a/src/transports/utils/generate_manifest_loader.ts
+++ b/src/transports/utils/generate_manifest_loader.ts
@@ -22,24 +22,27 @@ import assertUnreachable from "../../utils/assert_unreachable";
 import request from "../../utils/request";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
+  IManifestLoaderOptions,
   IRequestedData,
 } from "../types";
 import callCustomManifestLoader from "./call_custom_manifest_loader";
 
 /**
  * Manifest loader triggered if there was no custom-defined one in the API.
- * @param {string} url
- * @returns {Observable}
+ * @param {string} preferredType
+ * @returns {Function}
  */
 function generateRegularManifestLoader(
   preferredType: "arraybuffer" | "text" | "document"
 ) : (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) => Promise < IRequestedData<ILoadedManifestFormat> >
 {
   return function regularManifestLoader(
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) : Promise< IRequestedData<ILoadedManifestFormat> > {
     if (url === undefined) {
@@ -51,11 +54,20 @@ function generateRegularManifestLoader(
     // So I wrote that instead, temporarily of course ;)
     switch (preferredType) {
       case "arraybuffer":
-        return request({ url, responseType: "arraybuffer", cancelSignal });
+        return request({ url,
+                         responseType: "arraybuffer",
+                         timeout: loaderOptions.timeout,
+                         cancelSignal });
       case "text":
-        return request({ url, responseType: "text", cancelSignal });
+        return request({ url,
+                         responseType: "text",
+                         timeout: loaderOptions.timeout,
+                         cancelSignal });
       case "document":
-        return request({ url, responseType: "document", cancelSignal });
+        return request({ url,
+                         responseType: "document",
+                         timeout: loaderOptions.timeout,
+                         cancelSignal });
       default:
         assertUnreachable(preferredType);
     }
@@ -72,6 +84,7 @@ export default function generateManifestLoader(
   preferredType: "arraybuffer" | "text" | "document"
 ) : (
     url : string | undefined,
+    loaderOptions : IManifestLoaderOptions,
     cancelSignal : CancellationSignal
   ) => Promise<IRequestedData<ILoadedManifestFormat>>
 {

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import config from "../../config";
 import {
   NetworkErrorTypes,
   RequestError,
@@ -145,13 +144,13 @@ export default function fetchRequest(
     abortController.abort();
   }
 
-  const requestTimeout = isNullOrUndefined(options.timeout) ?
-    config.getCurrent().DEFAULT_REQUEST_TIMEOUT :
-    options.timeout;
-  const timeout = window.setTimeout(() => {
-    timeouted = true;
-    abortFetch();
-  }, requestTimeout);
+  let timeout : number | undefined;
+  if (options.timeout !== undefined) {
+    timeout = window.setTimeout(() => {
+      timeouted = true;
+      abortFetch();
+    }, options.timeout);
+  }
 
   const deregisterCancelLstnr = options.cancelSignal
     .register(function abortRequest(err : CancellationError) {

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import config from "../../config";
 import { RequestError } from "../../errors";
 import isNonEmptyString from "../is_non_empty_string";
 import isNullOrUndefined from "../is_null_or_undefined";
@@ -129,14 +128,12 @@ export default function request<T>(
   options : IRequestOptions< XMLHttpRequestResponseType | null | undefined >
 ) : Promise<IRequestResponse< T, XMLHttpRequestResponseType >> {
 
-  const { DEFAULT_REQUEST_TIMEOUT } = config.getCurrent();
   const requestOptions = {
     url: options.url,
     headers: options.headers,
     responseType: isNullOrUndefined(options.responseType) ? DEFAULT_RESPONSE_TYPE :
                                                             options.responseType,
-    timeout: isNullOrUndefined(options.timeout) ? DEFAULT_REQUEST_TIMEOUT :
-                                                  options.timeout,
+    timeout: options.timeout,
   };
 
   return new Promise((resolve, reject) => {
@@ -148,7 +145,7 @@ export default function request<T>(
     const xhr = new XMLHttpRequest();
     xhr.open("GET", url, true);
 
-    if (timeout >= 0) {
+    if (timeout !== undefined) {
       xhr.timeout = timeout;
     }
 
@@ -286,7 +283,7 @@ export interface IRequestOptions<ResponseType> {
   responseType? : ResponseType | undefined;
   /**
    * Optional timeout, in milliseconds, after which we will cancel a request.
-   * Set to DEFAULT_REQUEST_TIMEOUT by default.
+   * To not set or to set to `undefined` for disable.
    */
   timeout? : number | undefined;
   /**


### PR DESCRIPTION
I noticed that we still hadn't any way to let an application configures request timeouts for either the Manifest or the segments.

By default, both of those timeouts are for now set at 30 seconds, which is a lot. On platforms seen recently where frequent timeouts are occuring (presumably due to CDN issues), this may easily lead to a rebuffering, both for live and VoD contents (though sensibly more chance to have one when playing a live content, as there is less preloaded buffer).

Those high timeouts were set as a safe high value. They could make sense for large 10+ seconds segments for example.

But on most real encountered cases with 2 to 4 seconds segments, it is too high and may lead to poor user experience in case of network issues.

---

I though we already allowed its configuration, but turns out we didn't!

Thus I added both a `segmentRequestTimeout` option and a `manifestRequestTimeout` option to the `networkConfig` optionally given to a `loadVideo` call.

This also adds the possibility to just remove any timeout by setting the corresponding option to `-1` (as `undefined` will just lead to the default 30 seconds timeout used by the RxPlayer).

Though this seems simple, there was still some ambiguous cases:

  - should timeouts be used when an external `manifestLoader` or `segmentLoader` is used?

    Here, I chose to just send the timeout as a supplementary property to both callbacks. It will be to the application's responsability to implement it or not.

    It seemed logic to me as a `manifestLoader` or `segmentLoader` may be doing other things than requests or may not want to use timeouts in very specific cases.

  - should timeouts be used when loading `"local"` contents?

    I was really not sure here. On one side, I thought that we should because the application explicitely set a timeout when loading a "local" content as both are given on the same `loadVideo` call.

    On the other side, this would be a change of behavior and most local transport are not doing the usual "requests".

    So for now, I didn't use it there, but I would not be against actually using it in the future. Thankfully `"local"` is still experimental so we almost can do whatever we want with it ^^

  - What about files that are loaded while parsing a Manifest file, such as an DASH UTC Timing's clock or a DASH xlink? Or even more ambiguous, a MetaPlaylist sub-Manifest?

    For now, I chose to just use the default 30 seconds timeout here, as I wasn't sure at all what to do. Perhaps still another option, but naming it would be the hard part here!