### PR TITLE
Also consider an AudioTrack with a `kind` set to `"description"` as audio description

### DIFF
--- a/src/core/api/tracks_management/media_element_track_choice_manager.ts
+++ b/src/core/api/tracks_management/media_element_track_choice_manager.ts
@@ -102,7 +102,10 @@ function createAudioTracks(
     const track = { language: audioTrack.language,
                     id,
                     normalized: normalizeLanguage(audioTrack.language),
-                    audioDescription: audioTrack.kind === "descriptions",
+                    audioDescription: audioTrack.kind === "descriptions" ||
+                      // Safari seem to prefer the non-standard singular
+                      // version, funnily enough
+                      audioTrack.kind === "description",
                     representations: [] as Representation[] };
     newAudioTracks.push({ track,
                           nativeTrack: audioTrack });


### PR DESCRIPTION
We saw an issue when playing HLS through the RxPlayer by using the `"directfile"` mode - where audio-description audio tracks weren't advertised as such despite the HLS MultivariantPlaylist having the corresponding information.

After a brief investigation, it seems that this is because Safari wrongly set (only sometimes? not sure) an `AudioTrack`'s kind to `"description"` [instead of the `"descriptions"` (with an s) that should probably be set in that
case](https://html.spec.whatwg.org/multipage/media.html#value-track-kind-descriptions).

Anyway, seeing `"description"` in singular form is not ambiguous, so it should not be breaking anything if we also support it.

Though in my opinion, Safari should probably just fix that thing (issue to open?) and a player should generally [not try to be robust](https://datatracker.ietf.org/doc/html/rfc3117#section-4.5) as being resilient in already well-specified matters slowly contributes at making future media players harder.
But I still want to close the related issue quickly, and other players might also support that case (kind of a prisoner's dillema here), so I just do it anyway!