### PR TITLE
Add autoPlay `reload` option and improve autoplay default logic in it

### DIFF
--- a/doc/api/Basic_Methods/reload.md
+++ b/doc/api/Basic_Methods/reload.md
@@ -22,11 +22,36 @@ The options argument is an object containing :
   - _position_ (`string`|`undefined`) : absolute position at which we should
     start playback
 
-If no reload position is defined, start playback at the last playback position.
+  If no reload position is defined, start playback at the last playback
+  position.
+
+- _autoPlay_ (`boolean | undefined`): If set to `true`, the reloaded content
+  will automatically play after being `"LOADED"`.
+
+  If set to `false`, it will stay in the `"LOADED"` state (and paused) once
+  loaded, without automatically played.
+
+  If unset or set to `undefined`, the content will automatically play if the
+  content was playing the last time it was played and stay in the `"LOADED"`
+  state (and paused) if it was paused last time it was played.
 
 Note that despite this method's name, the player will not go through the
 `RELOADING` state while reloading the content but through the regular `LOADING`
 state - as if `loadVideo` was called on that same content again.
+
+<div class="note">
+On some browsers, auto-playing a media without user interaction is blocked
+due to the browser's policy.
+<br>
+<br>
+In that case, the player won't be able to play (it will stay in a `LOADED`
+state) and you will receive a <a href="./Player_Errors.md">warning event</a>
+containing a `MEDIA_ERROR` with the code: `MEDIA_ERR_BLOCKED_AUTOPLAY`.
+<br>
+<br>
+A solution in that case would be to propose to your users an UI element to
+trigger the play with an interaction.
+</div>
 
 ## Syntax
 


### PR DESCRIPTION
Fixes #1159

The `reload` method is a method allowing to load again - and generally more optimally - the last loaded content, even if the player was stopped before the `reload` call.

As we know it, this method is mainly used to restart loading a content even if an unusual and fatal error happened during playback.

By default, this method re-considered all options given to the initial `loadVideo` call, with the exception of the `startAt` API - where the last known position was considered instead. It was also possible to signal a wanted initial position on the `reload` call.

As #1159 suggested, we also should have put more considerations into the `autoPlay` setting. Whereas until now we only considered the `autoPlay` setting of the last `loadVideo` call, it seems to make more sense to respect the last playing state the content was actually last seen in: if it was paused, we should reload in pause, if it was playing, we should reload in a playing state.

Rules are actually a little more complicated and depend both on the player's state and on the current playing condition.

I tried to implement this (in the API part of the code), but the code I was modifying seemed prone to race conditions: both the playing conditions and the player's state may rely on each other.

I ended up regrouping the logic updating the player's state, the logic updating the reloading metadata AND the logic sending position updates into the same place and in the same order (basically 1. reloading metadata, 2. state updates and 3. position updates) to put more control into our hands.

There still remain some "racy" code here and there though:

  - the reloading metadata only bases itself on the current playback information, which may not reflect the actual goal (for example if a future seek was scheduled but not yet done, we would not know it when reloading - we would just reload at the last actual position instead).

    This is however relatively minor and can be fixed if it leads to actual true issues.

  - If an application seeks then reload synchronously, the reload operation would not yet consider that seek.

    Here a solution could be to force `reload` to wait a turn to the browser's event loop before actually capturing the last known position. However, this could lead to a whole new class of errors. I decided here not to handle it for now.

Moreover, a new `autoPlay` property has been added to the `reload` method, for force an autoPlay behavior.