### PR TITLE
[v4] Replace autoTrackSwitch event by a more useful trackUpdate event

### DIFF
--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -514,6 +514,92 @@ This event is not sent in <i>DirectFile</i> mode (see
 <a href="./Loading_a_Content.md#transport">transport option</a>)
 </div>
 
+### trackUpdate
+
+_payload type_: `Object`
+
+Event triggered if a video, audio or text track chosen for any
+[Period](../Getting_Started/Glossary.md#period) is changed by the RxPlayer.
+
+This event is triggered just after the track is updated but before any of the
+corresponding data is actually loaded, thus allowing you to edit track or
+Representations settings before the RxPlayer can continue.
+
+However keep in mind that this event is not triggered for the initial default
+track choice made by the RxPlayer. If you want to react to this event instead,
+you can rely on the `newAvailablePeriods` event.
+
+Cases where the track changes include:
+
+  - when the application updates a track manually (for example through a
+    `setAudioTrack` call)
+
+  - when it had to be done as a side-effect of another API (for example after
+    enabling trickmode video tracks through a `setPlaybackRate` call)
+
+  - or in the extremely rare situation where the RxPlayer had to do it by itself
+    automatically (one situation would be when a refreshed content's Manifest
+    removes the previously-chosen track. There, the RxPlayer will send the
+    `trackUpdate` event and - if no new track is chosen since - will
+    automatically switch to that track so playback can continue).
+
+The payload for this event is an object with the following properties:
+
+  - `trackType` (`string`): The type of track concerned. Can for example be
+    `audio` for an audio track, `video` for a video track or `text` for a text
+    track.
+
+  - `period` (`Object`): Information about the concerned
+    [Period](../Getting_Started/Glossary.md#period). This object contains as
+    properties:
+
+    - `start` (`number`): The starting position at which the Period starts, in
+      seconds.
+
+    - `end` (`number|undefined`): The position at which the Period ends, in
+      seconds.
+
+      `undefined` either if not known or if the Period has no end yet (e.g. for
+      live contents, the end might not be known for now).
+
+    - `id` (`string`): `id` of the Period, allowing to call track and
+      Representation selection APIs (such as `setAudioTrack` and
+      `lockVideoRepresentations` for example) even when the Period changes.
+
+  - `reason` (`string`): The reason for the track update.
+    For now, it can be set to:
+
+      - `"manual"`: the track was updated because the application called a
+        method to directly update it.
+
+        This event is the direct consequence of calling `setAudioTrack`,
+        `setTextTrack`, `setVideoTrack`, `disableTextTrack` or
+        `disableVideoTrack`, so it corresponds to track updates you should
+        already be aware of.
+
+      - `"trickmode-enabled"`: The track is being updated because the
+        application wanted to enable video trickmode tracks (usually by setting
+        the `preferTrickModeTracks` option of the `setPlaybackRate` method to
+        `true`).
+
+      - `"trickmode-disabled"`: The track is being updated because the
+        application wanted to disable video trickmode tracks (usually by setting
+        the `preferTrickModeTracks` option of the `setPlaybackRate` method to
+        `false`).
+
+      - `"missing"` the previously-chosen track was missing from the content's
+        refreshed Manifest.
+
+    Though other reasons may be added in the future (for future reasons not
+    covered by those values), so you should expect this possibility in your
+    application's logic.
+
+
+<div class="warning">
+This event is not sent in <i>DirectFile</i> mode (see
+<a href="./Loading_a_Content.md#transport">transport option</a>)
+</div>
+
 ### brokenRepresentationsLock
 
 _payload type_: `Object`
@@ -549,53 +635,6 @@ The payload for this event is an object with the following properties:
 
   - `trackType` (`string`): The type of track concerned. Can for example be
     `audio` for audio Representations or `video` for video Representations.
-
-
-<div class="warning">
-This event is not sent in <i>DirectFile</i> mode (see
-<a href="./Loading_a_Content.md#transport">transport option</a>)
-</div>
-
-
-### autoTrackSwitch
-
-_payload type_: `Object`
-
-Extremely rare event triggered if a video, audio or text track set for any
-[Period](../Getting_Started/Glossary.md#period) was automatically changed by the
-RxPlayer, due to an unexpected event.
-
-For now this only happens in the extremely rare situation (it was actually never
-seen, but it is possible) where a refreshed content's Manifest would remove the
-previously-chosen track. There, the RxPlayer will send the `autoTrackSwitch`
-event and - if no new track is chosen - will automatically switch to another
-track so playback can continue.
-
-The payload for this event is an object with the following properties:
-  - `trackType` (`string`): The type of track concerned. Can for example be
-    `audio` for an audio track, `video` for a video track or `text` for a text
-    track.
-
-  - `period` (`Object`): Information about the concerned
-    [Period](../Getting_Started/Glossary.md#period). This object contains as
-    properties:
-
-    - `start` (`number`): The starting position at which the Period starts, in
-      seconds.
-
-    - `end` (`number|undefined`): The position at which the Period ends, in
-      seconds.
-
-      `undefined` either if not known or if the Period has no end yet (e.g. for
-      live contents, the end might not be known for now).
-
-    - `id` (`string`): `id` of the Period, allowing to call track and
-      Representation selection APIs (such as `setAudioTrack` and
-      `lockVideoRepresentations` for example) even when the Period changes.
-
-  - `reason` (`string`): The reason for the automatic track switch. For now,
-    can only be `"missing"` indicating that the previously chosen track was
-    missing from the content's refreshed Manifest.
 
 
 <div class="warning">

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -79,7 +79,7 @@ import {
   ILoadVideoOptions,
   ILockedAudioRepresentationsSettings,
   ILockedVideoRepresentationsSettings,
-  IAutoTrackSwitchEventPayload,
+  ITrackUpdateEventPayload,
   IPeriod,
   IPeriodChangeEvent,
   IPlayerError,
@@ -2201,8 +2201,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_tracksStore.addEventListener("brokenRepresentationsLock", (e) => {
       this.trigger("brokenRepresentationsLock", e);
     });
-    this._priv_tracksStore.addEventListener("autoTrackSwitch", (e) => {
-      this.trigger("autoTrackSwitch", e);
+    this._priv_tracksStore.addEventListener("trackUpdate", (e) => {
+      this.trigger("trackUpdate", e);
     });
 
     this._priv_tracksStore.updatePeriodList(manifest);
@@ -2603,7 +2603,7 @@ interface IPublicAPIEvent {
   availableVideoTracksChange : IAvailableVideoTrack[];
   newAvailablePeriods : IPeriod[];
   brokenRepresentationsLock : IBrokenRepresentationsLockContext;
-  autoTrackSwitch : IAutoTrackSwitchEventPayload;
+  trackUpdate : ITrackUpdateEventPayload;
   seeking : null;
   seeked : null;
   streamEvent : IStreamEvent;

--- a/src/core/api/track_management/tracks_store.ts
+++ b/src/core/api/track_management/tracks_store.ts
@@ -32,7 +32,7 @@ import {
   IAudioRepresentationsSwitchingMode,
   IAudioTrack,
   IAudioTrackSwitchingMode,
-  IAutoTrackSwitchEventPayload,
+  ITrackUpdateEventPayload,
   IAvailableAudioTrack,
   IAvailableTextTrack,
   IAvailableVideoTrack,
@@ -160,9 +160,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
             log.warn("TracksStore: Chosen text Adaptation not available anymore");
             const periodInfo =  this._storedPeriodInfo[i];
             periodInfo.text.storedSettings = null;
-            this.trigger("autoTrackSwitch", { period: toExposedPeriod(newPeriod),
-                                              trackType: "text",
-                                              reason: "missing" });
+            this.trigger("trackUpdate", { period: toExposedPeriod(newPeriod),
+                                          trackType: "text",
+                                          reason: "missing" });
 
             // The previous event trigger could have had side-effects, so we
             // re-check if we're still mostly in the same state
@@ -199,9 +199,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
                                  lockedRepresentations };
             }
             periodItem.video.storedSettings = storedSettings;
-            this.trigger("autoTrackSwitch", { period: toExposedPeriod(newPeriod),
-                                              trackType: "video",
-                                              reason: "missing" });
+            this.trigger("trackUpdate", { period: toExposedPeriod(newPeriod),
+                                          trackType: "video",
+                                          reason: "missing" });
 
             // The previous event trigger could have had side-effects, so we
             // re-check if we're still mostly in the same state
@@ -233,9 +233,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
                 switchingMode: this._defaultAudioTrackSwitchingMode,
                 lockedRepresentations: createSharedReference(null) };
             periodItem.audio.storedSettings = storedSettings;
-            this.trigger("autoTrackSwitch", { period: toExposedPeriod(newPeriod),
-                                              trackType: "audio",
-                                              reason: "missing" });
+            this.trigger("trackUpdate", { period: toExposedPeriod(newPeriod),
+                                          trackType: "audio",
+                                          reason: "missing" });
 
             // The previous event trigger could have had side-effects, so we
             // re-check if we're still mostly in the same state
@@ -424,7 +424,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       return;
     }
     this._isTrickModeTrackEnabled = false;
-    this._resetVideoTrackChoices();
+    this._resetVideoTrackChoices("trickmode-disabled");
   }
 
   public enableVideoTrickModeTracks() : void {
@@ -432,7 +432,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       return;
     }
     this._isTrickModeTrackEnabled = true;
-    this._resetVideoTrackChoices();
+    this._resetVideoTrackChoices("trickmode-enabled");
   }
 
   /**
@@ -538,12 +538,25 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       });
     }
 
-    typeInfo.storedSettings = { adaptation: wantedAdaptation,
-                                switchingMode,
-                                lockedRepresentations };
+    const storedSettings = { adaptation: wantedAdaptation,
+                             switchingMode,
+                             lockedRepresentations };
+    typeInfo.storedSettings = storedSettings;
+    this.trigger("trackUpdate", { period: toExposedPeriod(period),
+                                  trackType: bufferType,
+                                  reason: "manual" });
 
-    if (typeInfo.dispatcher !== null) {
-      typeInfo.dispatcher.updateTrack(typeInfo.storedSettings);
+    // The previous event trigger could have had side-effects, so we
+    // re-check if we're still mostly in the same state
+    if (this._isDisposed) {
+      return; // Someone disposed the `TracksStore` on the previous side-effect
+    }
+    const newPeriodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+    if (
+      newPeriodItem !== undefined &&
+      newPeriodItem[bufferType].storedSettings === storedSettings
+    ) {
+      newPeriodItem[bufferType].dispatcher?.updateTrack(storedSettings);
     }
   }
 
@@ -589,14 +602,27 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       });
     }
 
-    typeInfo.storedSettings = { adaptationBase: wantedAdaptation,
-                                switchingMode: switchingMode ??
-                                               DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
-                                adaptation: newAdaptation,
-                                lockedRepresentations };
+    const storedSettings = { adaptationBase: wantedAdaptation,
+                             switchingMode: switchingMode ??
+                                            DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
+                             adaptation: newAdaptation,
+                             lockedRepresentations };
+    typeInfo.storedSettings = storedSettings;
+    this.trigger("trackUpdate", { period: toExposedPeriod(period),
+                                  trackType: "video",
+                                  reason: "manual" });
 
-    if (typeInfo.dispatcher !== null) {
-      typeInfo.dispatcher.updateTrack(typeInfo.storedSettings);
+    // The previous event trigger could have had side-effects, so we
+    // re-check if we're still mostly in the same state
+    if (this._isDisposed) {
+      return; // Someone disposed the `TracksStore` on the previous side-effect
+    }
+    const newPeriodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+    if (
+      newPeriodItem !== undefined &&
+      newPeriodItem.video.storedSettings === storedSettings
+    ) {
+      newPeriodItem.video.dispatcher?.updateTrack(storedSettings);
     }
   }
 
@@ -622,8 +648,21 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     }
 
     trackInfo.storedSettings = null;
-    if (trackInfo.dispatcher !== null) {
-      trackInfo.dispatcher.updateTrack(null);
+    this.trigger("trackUpdate", { period: toExposedPeriod(periodObj.period),
+                                  trackType: bufferType,
+                                  reason: "manual" });
+
+    // The previous event trigger could have had side-effects, so we
+    // re-check if we're still mostly in the same state
+    if (this._isDisposed) {
+      return; // Someone disposed the `TracksStore` on the previous side-effect
+    }
+    const newPeriodItem = getPeriodItem(this._storedPeriodInfo, periodObj.period.id);
+    if (
+      newPeriodItem !== undefined &&
+      newPeriodItem[bufferType].storedSettings === null
+    ) {
+      newPeriodItem[bufferType].dispatcher?.updateTrack(null);
     }
   }
 
@@ -920,7 +959,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     return periodObj;
   }
 
-  private _resetVideoTrackChoices() {
+  private _resetVideoTrackChoices(reason : "trickmode-enabled" | "trickmode-disabled") {
     for (let i = 0; i < this._storedPeriodInfo.length; i++) {
       const periodObj = this._storedPeriodInfo[i];
       if (periodObj.video.storedSettings !== null) {
@@ -938,9 +977,24 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     // or added while the loop is running.
     const sliced = this._storedPeriodInfo.slice();
     for (let i = 0; i < sliced.length; i++) {
+      const period = sliced[i].period;
       const videoItem = sliced[i].video;
-      if (videoItem.dispatcher !== null) {
-        videoItem.dispatcher.updateTrack(videoItem.storedSettings);
+      const storedSettings = videoItem.storedSettings;
+      this.trigger("trackUpdate", { period: toExposedPeriod(period),
+                                    trackType: "video",
+                                    reason });
+
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+      const newPeriodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+      if (
+        newPeriodItem !== undefined &&
+        newPeriodItem.video.storedSettings === storedSettings
+      ) {
+        newPeriodItem.video.dispatcher?.updateTrack(storedSettings);
       }
     }
   }
@@ -1345,7 +1399,7 @@ type IVideoStoredSettings = {
 interface ITracksStoreEvents {
   newAvailablePeriods : IPeriod[];
   brokenRepresentationsLock : IBrokenRepresentationsLockContext;
-  autoTrackSwitch : IAutoTrackSwitchEventPayload;
+  trackUpdate : ITrackUpdateEventPayload;
 }
 
 export interface IAudioRepresentationsLockSettings {

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -828,10 +828,13 @@ export interface IBrokenRepresentationsLockContext {
   trackType : ITrackType;
 }
 
-export interface IAutoTrackSwitchEventPayload {
+export interface ITrackUpdateEventPayload {
   period : IPeriod;
   trackType : ITrackType;
-  reason : "missing" |
+  reason : "missing" | // Missing from Manifest update
+           "manual" | // Manually and explicitely updated
+           "trickmode-enabled" | // Video trickmode tracks being enabled
+           "trickmode-disabled" | // Video trickmode tracks being disabled
            string;
 }
 


### PR DESCRIPTION
Until now, the RxPlayer v4.0.0 was scheduled to introduce the `autoTrackSwitch` event to signal that the track of any type (audio, video, text...) and Period had to be changed automatically by the RxPlayer (for now the only - improbable - case is when the corresponding track just disappears after a Manifest update - e.g. the corresponding `AdaptationSet` element is removed from a DASH MPD).

This event was needed to perfectly replace the track preferences and bitrate APIs - which are removed from the v4.0.0 for more powerful API - as the track and wanted Representations would without this event just silently be updated by the RxPlayer, without the application knowing about it and being able to react upon it.

But after some tests, it seems that adding a much more general `trackUpdate` event, signaling any type of track change for any type and Period (that is, even when changed manually for example through a `setAudioTrack` call) is much more easy-to-understand and useful. And it isn't hard to implement.

Because an application might still want to know the reason for that event (is it due to the track disappearing from the Manifest? It is linked to a `setAudioTrack` call?), the `reason` property of that event has been updated accordingly. It can now be set to:
  - `"manual"`: Explicit track modification, e.g. `setAudioTrack`
  - `"trickmode-enabled"`: Trickmode tracks have been enabled through `setPlaybackRate` (generally, this is linked to newly set video trickmode tracks)
  - `"trickmode-disabled"`: Trickmode tracks have been disabled through `setPlaybackRate` (generally, this is linked to newly unset video trickmode tracks).
  - `"missing"`: The track does not exist in the Manifest anymore

We still reserve the right to add new, non-colliding, reasons in the future.