### PR TITLE
Fix directfile audiotrack selection on Tizen

### DIFF
--- a/src/compat/__tests__/enable_audio_track.test.ts
+++ b/src/compat/__tests__/enable_audio_track.test.ts
@@ -1,0 +1,341 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+describe("compat - enableAudioTrack", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("should enable the wanted audioTrack", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isTizen: false,
+      };
+    });
+    const fakeAudioTracks = [
+      {
+        id: "id1",
+        kind: "descriptions",
+        label: "Toto",
+        language: "swa",
+        enabled: true,
+      },
+      {
+        id: "id2",
+        kind: "normal",
+        label: "Titi",
+        language: "fre",
+        enabled: false,
+      },
+      {
+        id: "id26",
+        kind: "bloop",
+        label: "hay",
+        language: "hay",
+        enabled: false,
+      },
+    ];
+    const enableAudioTrack = jest.requireActual("../enable_audio_track");
+    expect(enableAudioTrack.default(fakeAudioTracks, 2)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(true);
+    expect(enableAudioTrack.default(fakeAudioTracks, 1)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(true);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(enableAudioTrack.default(fakeAudioTracks, 0)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(true);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+  });
+
+  it("should enable the wanted audioTrack on Tizen", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isTizen: true,
+      };
+    });
+    const fakeAudioTracks = [
+      {
+        id: "id1",
+        kind: "descriptions",
+        label: "Toto",
+        language: "swa",
+        enabled: true,
+      },
+      {
+        id: "id2",
+        kind: "normal",
+        label: "Titi",
+        language: "fre",
+        enabled: false,
+      },
+      {
+        id: "id26",
+        kind: "bloop",
+        label: "hay",
+        language: "hay",
+        enabled: false,
+      },
+    ];
+    const enableAudioTrack = jest.requireActual("../enable_audio_track");
+    expect(enableAudioTrack.default(fakeAudioTracks, 2)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(true);
+    expect(enableAudioTrack.default(fakeAudioTracks, 1)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(true);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(enableAudioTrack.default(fakeAudioTracks, 0)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(true);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+  });
+
+  it("should return false if the audio track index does not exist", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isTizen: false,
+      };
+    });
+    const fakeAudioTracks = [
+      {
+        id: "id1",
+        kind: "descriptions",
+        label: "Toto",
+        language: "swa",
+        enabled: true,
+      },
+      {
+        id: "id2",
+        kind: "normal",
+        label: "Titi",
+        language: "fre",
+        enabled: false,
+      },
+      {
+        id: "id26",
+        kind: "bloop",
+        label: "hay",
+        language: "hay",
+        enabled: false,
+      },
+    ];
+    const enableAudioTrack = jest.requireActual("../enable_audio_track");
+    expect(enableAudioTrack.default(fakeAudioTracks, -1)).toEqual(false);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(enableAudioTrack.default(fakeAudioTracks, 0)).toEqual(true);
+    expect(fakeAudioTracks[0].enabled).toBe(true);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(enableAudioTrack.default(fakeAudioTracks, 4)).toEqual(false);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(false);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+  });
+
+  it("should return false if the audio track index does not exist on Tizen", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isTizen: false,
+      };
+    });
+    let track1IsEnabled = true;
+    let track2IsEnabled = false;
+    let track3IsEnabled = false;
+    let track1WasDisabled = 0;
+    let track2WasDisabled = 0;
+    let track3WasDisabled = 0;
+    let track1WasEnabled = 0;
+    let track2WasEnabled = 0;
+    let track3WasEnabled = 0;
+    const fakeAudioTracks = [
+      {
+        id: "id1",
+        kind: "descriptions",
+        label: "Toto",
+        language: "swa",
+        enabled: true,
+      },
+      {
+        id: "id2",
+        kind: "normal",
+        label: "Titi",
+        language: "fre",
+        enabled: false,
+      },
+      {
+        id: "id26",
+        kind: "bloop",
+        label: "hay",
+        language: "hay",
+        enabled: false,
+      },
+    ];
+    Object.defineProperty(fakeAudioTracks[0], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track1IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track1WasDisabled++;
+        } else {
+          track1WasEnabled++;
+        }
+        track1IsEnabled = enabled;
+      },
+    });
+    Object.defineProperty(fakeAudioTracks[1], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track2IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track2WasDisabled++;
+        } else {
+          track2WasEnabled++;
+        }
+        track2IsEnabled = enabled;
+      },
+    });
+    Object.defineProperty(fakeAudioTracks[2], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track3IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track3WasDisabled++;
+        } else {
+          track3WasEnabled++;
+        }
+        track3IsEnabled = enabled;
+      },
+    });
+    const enableAudioTrack = jest.requireActual("../enable_audio_track");
+    expect(enableAudioTrack.default(fakeAudioTracks, 1)).toBe(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(true);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(track1IsEnabled).toBe(false);
+    expect(track2IsEnabled).toBe(true);
+    expect(track3IsEnabled).toBe(false);
+    expect(track1WasDisabled).toBe(1);
+    expect(track2WasDisabled).toBe(1);
+    expect(track3WasDisabled).toBe(1);
+    expect(track1WasEnabled).toBe(0);
+    expect(track2WasEnabled).toBe(1);
+    expect(track3WasEnabled).toBe(0);
+  });
+
+  // eslint-disable-next-line max-len
+  it("should first disable all audioTracks except the one wanted by default on Tizen", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isTizen: true,
+      };
+    });
+    let track1IsEnabled = true;
+    let track2IsEnabled = false;
+    let track3IsEnabled = false;
+    let track1WasDisabled = 0;
+    let track2WasDisabled = 0;
+    let track3WasDisabled = 0;
+    let track1WasEnabled = 0;
+    let track2WasEnabled = 0;
+    let track3WasEnabled = 0;
+    const fakeAudioTracks = [
+      {
+        id: "id1",
+        kind: "descriptions",
+        label: "Toto",
+        language: "swa",
+        enabled: true,
+      },
+      {
+        id: "id2",
+        kind: "normal",
+        label: "Titi",
+        language: "fre",
+        enabled: false,
+      },
+      {
+        id: "id26",
+        kind: "bloop",
+        label: "hay",
+        language: "hay",
+        enabled: false,
+      },
+    ];
+    Object.defineProperty(fakeAudioTracks[0], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track1IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track1WasDisabled++;
+        } else {
+          track1WasEnabled++;
+        }
+        track1IsEnabled = enabled;
+      },
+    });
+    Object.defineProperty(fakeAudioTracks[1], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track2IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track2WasDisabled++;
+        } else {
+          track2WasEnabled++;
+        }
+        track2IsEnabled = enabled;
+      },
+    });
+    Object.defineProperty(fakeAudioTracks[2], "enabled", {
+      enumerable: true,
+      get() : boolean {
+        return track3IsEnabled;
+      },
+      set(enabled : boolean) {
+        if (!enabled) {
+          track3WasDisabled++;
+        } else {
+          track3WasEnabled++;
+        }
+        track3IsEnabled = enabled;
+      },
+    });
+    const enableAudioTrack = jest.requireActual("../enable_audio_track");
+    expect(enableAudioTrack.default(fakeAudioTracks, 1)).toBe(true);
+    expect(fakeAudioTracks[0].enabled).toBe(false);
+    expect(fakeAudioTracks[1].enabled).toBe(true);
+    expect(fakeAudioTracks[2].enabled).toBe(false);
+    expect(track1IsEnabled).toBe(false);
+    expect(track2IsEnabled).toBe(true);
+    expect(track3IsEnabled).toBe(false);
+    expect(track1WasDisabled).toBe(1);
+    expect(track2WasDisabled).toBe(0);
+    expect(track3WasDisabled).toBe(1);
+    expect(track1WasEnabled).toBe(0);
+    expect(track2WasEnabled).toBe(1);
+    expect(track3WasEnabled).toBe(0);
+  });
+});

--- a/src/compat/enable_audio_track.ts
+++ b/src/compat/enable_audio_track.ts
@@ -1,0 +1,33 @@
+import { ICompatAudioTrack } from "./browser_compatibility_types";
+import { isTizen } from "./browser_detection";
+
+/**
+ * Enable the audio track at the given index while disabling all others in the
+ * `audioTracks` array.
+ *
+ * Returns false if the given index is not found in the `audioTracks` array.
+ * @param {array.<audioTrack>} audioTracks
+ * @param {number} indexToEnable
+ * @returns {boolean}
+ */
+export default function enableAudioTrack(
+  audioTracks : ICompatAudioTrack[],
+  indexToEnable : number
+) : boolean {
+  // Seen on Safari MacOS only (2022-02-14), not disabling ALL audio tracks
+  // first (even the wanted one), can lead to the media not playing.
+  for (let i = 0; i < audioTracks.length; i++) {
+    // However, Tizen just plays no audio if it is disabled then enabled
+    // synchronously (2022-10-12)
+    if (!isTizen || i !== indexToEnable) {
+      audioTracks[i].enabled = false;
+    }
+  }
+
+  if (indexToEnable < 0 ||  indexToEnable >= audioTracks.length) {
+    return false;
+  }
+
+  audioTracks[indexToEnable].enabled = true;
+  return true;
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -38,6 +38,7 @@ import {
   requestMediaKeySystemAccess,
   setMediaKeys,
 } from "./eme";
+import enableAudioTrack from "./enable_audio_track";
 import * as events from "./event_listeners";
 import {
   exitFullscreen,
@@ -75,6 +76,7 @@ export {
   clearElementSrc,
   closeSession,
   CustomMediaKeySystemAccess,
+  enableAudioTrack,
   events,
   exitFullscreen,
   generateKeyRequest,

--- a/src/core/api/tracks_management/media_element_track_choice_manager.ts
+++ b/src/core/api/tracks_management/media_element_track_choice_manager.ts
@@ -19,6 +19,7 @@
  * It always should be imported through the `features` object.
  */
 
+import { enableAudioTrack } from "../../../compat";
 import {
   ICompatAudioTrack,
   ICompatAudioTrackList,
@@ -39,7 +40,6 @@ import {
   IAvailableAudioTrack,
   IAvailableTextTrack,
 } from "../../../public_types";
-import assert from "../../../utils/assert";
 import EventEmitter from "../../../utils/event_emitter";
 import normalizeLanguage from "../../../utils/languages";
 
@@ -913,16 +913,8 @@ export default class MediaElementTrackChoiceManager
    * @param {number} index}
    */
   private _enableAudioTrackFromIndex(index : number) : void {
-    assert(index < this._audioTracks.length);
-
-    // Seen on Safari MacOS only (2022-02-14), not disabling ALL audio tracks
-    // first (even the wanted one), can lead to the media not playing.
-    for (const audioTrack of this._audioTracks) {
-      audioTrack.nativeTrack.enabled = false;
-    }
-
-    this._audioTracks[index].nativeTrack.enabled = true;
-    return;
+    enableAudioTrack(this._audioTracks.map(({ nativeTrack }) => nativeTrack),
+                     index);
   }
 }
 


### PR DESCRIPTION
We noticed an issue on some Samsung TVs where some (but not all) directfile contents were playing without sound.

After investigation, it seems that what breaks was the action of disabling __ALL__ of an `HTMLMediaElement`'s audio tracks before enabling the one wanted, which is something we did (instead of just disabling the unwanted tracks first) due to a playback issue on Safari which would happen without (Safari would just decide to not play).

So basically, an ugly-but-functional-and-still-logically-sound work-around fixed Safari but broke Tizen.
In the end, I chose to keep the ugly-but-functional-... solution by default and just perform the original not-ugly solution for Tizen, because it seems to me there's more chance to re-encounter the Safari issue (e.g. because another device rely on a similar webkit build) than re-encounter the Tizen issue (which is especially known to be a broken target anyway in terms of compat - much more than safari in general) on a future new device.

Though the more broken target is the only one which profit from the more elegant logic, which seems counter-intuitive!

I added that in `src/compat` to make it clear that this whole logic is an ugly compat-oriented work-around.