### PR TITLE
Implement ContentSteering

### DIFF
--- a/src/Content_Steering.md
+++ b/src/Content_Steering.md
@@ -1,0 +1,87 @@
+# Content Steering implementation
+
+**LAST UPDATE: 2022-08-04**
+
+## Overview
+
+Content steering is a mechanism allowing a content provider to deterministically
+prioritize a, or multiple, CDN over others - even during content playback - on the
+server-side when multiple CDNs are available to load a given content.
+
+For example, a distributor may want to rebalance load between multiple servers while final
+users are watching the corresponding stream, though many other use cases and reasons
+exist.
+
+As of now, content steering only exist for HLS and DASH OTT streaming technologies. In
+both cases it takes the form of a separate file, in DASH called the "DASH Content Steering
+Manifest" (or DCSM), giving the current priority. This separate file has its own syntax,
+semantic and refreshing logic.
+
+## Architecture in the RxPlayer
+
+```
+               /parsers/SteeringManifest
+      +----------------------------------+
+      | Content Steering Manifest parser | Parse DCSM[1] into a
+      +----------------------------------+ transport-agnostic steering
+              ^                            Manifest structure
+              |
+              | Uses when parsing
+              |
+              |
+              | /transports
+      +---------------------------+
+      |        Transport          |
+      |                           |
+      | new functions:            |
+      |   - loadSteeringManifest  | Construct DCSM[1]'s URL, performs
+      |   - parseSteeringManifest | requests and parses it.
+      +---------------------------+
+              ^
+              |
+              | Relies on
+              |
+              |
+              | /core/fetchers/steering_manifest
+      +-------------------------+
+      | SteeringManifestFetcher | Fetches and parses a Content Steering
+      +-------------------------+ Manifest in a transport-agnostic way
+              ^                   + handle retries and error formatting
+              |
+              | Uses an instance of to load, parse and refresh the
+              | Steering Manifest periodically according to its TTL[2]
+              |
+              |
+              | /core/fetchers/cdn_prioritizer.ts
+      +----------------+ Signals the priority between multiple
+      | CdnPrioritizer | potential CDNs for each resource.
+      +----------------+ (This is done on demand, the `CdnPrioritizer`
+             ^           knows of no resource in advance).
+             |
+             | Asks to sort a segment's available base urls by order of
+             | priority (and to filter out those that should not be
+             | used).
+             | Also signals when it should prevent a base url from
+             | being used temporarily (e.g. due to request issues).
+             |
+             |
+             | /core/fetchers/segment
+      +----------------+
+      | SegmentFetcher | Fetches and parses a segment in a
+      +----------------+ transport-agnostic way
+             ^           + handle retries and error formatting
+             |
+             | Ask to load segment(s)
+             |
+             | /core/stream/representation
+      +----------------+
+      | Representation | Logic behind finding the right segment to
+      |    Stream      | load, loading it and pushing it to the buffer.
+      +----------------+ One RepresentationStream is created per
+                         actively-loaded Period and one per
+                         actively-loaded buffer type.
+
+
+[1] DCSM: DASH Content Steering Manifest
+[2] TTL: Time To Live: a delay after which a Content Steering Manifest should be refreshed
+```

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -165,18 +165,6 @@ export default class ContentPreparer {
         },
       );
 
-      const cdnPrioritizer = new CdnPrioritizer(contentCanceller.signal);
-      const segmentQueueCreator = new SegmentQueueCreator(
-        transportPipelines,
-        cdnPrioritizer,
-        cmcdDataBuilder,
-        context.segmentRetryOptions,
-      );
-      const fetchThumbnailData = createThumbnailFetcher(
-        transportPipelines.thumbnails,
-        cdnPrioritizer,
-      );
-
       const trackChoiceSetter = new TrackChoiceSetter();
 
       const [mediaSource, segmentSinksStore, coreTextSender] =
@@ -201,8 +189,8 @@ export default class ContentPreparer {
         manifestFetcher,
         representationEstimator,
         segmentSinksStore,
-        segmentQueueCreator,
-        fetchThumbnailData,
+        segmentQueueCreator: null,
+        fetchThumbnailData: null,
         coreTextSender,
         trackChoiceSetter,
         mseInWorker: playbackSupport.mseInWorker,
@@ -239,8 +227,27 @@ export default class ContentPreparer {
             return;
           }
           manifest = man;
+
+          const cdnPrioritizer = new CdnPrioritizer(
+            manifest,
+            transportPipelines,
+            contentCanceller.signal,
+          );
+          const segmentQueueCreator = new SegmentQueueCreator({
+            cdnPrioritizer,
+            transportPipelines,
+            cmcdDataBuilder,
+            backoffOptions: context.segmentRetryOptions,
+          });
+          const fetchThumbnailData = createThumbnailFetcher(
+            transportPipelines.thumbnails,
+            cdnPrioritizer,
+          );
+
           if (this._currentContent !== null) {
             this._currentContent.manifest = manifest;
+            this._currentContent.segmentQueueCreator = segmentQueueCreator;
+            this._currentContent.fetchThumbnailData = fetchThumbnailData;
           }
           checkIfReadyAndValidate();
         },
@@ -431,10 +438,15 @@ export interface IPreparedContentData {
   /**
    * Allows to create `SegmentQueue` which simplifies complex media segment
    * fetching.
+   *
+   * Set to `null` until the Manifest has been fetched.
    */
-  segmentQueueCreator: SegmentQueueCreator;
-  /** Allows to load image thumbnails. */
-  fetchThumbnailData: IThumbnailFetcher;
+  segmentQueueCreator: SegmentQueueCreator | null;
+  /**
+   * Allows to load image thumbnails.
+   * Set to `null` until the Manifest has been fetched.
+   */
+  fetchThumbnailData: IThumbnailFetcher | null;
   /**
    * Allows to store and update the wanted tracks and Representation inside that
    * track.

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -619,7 +619,11 @@ function loadPreparedContent(
     > = new Map();
 
     const preparedContent = contentPreparer.getCurrentContent();
-    if (preparedContent === null || preparedContent.manifest === null) {
+    if (
+      preparedContent === null ||
+      preparedContent.manifest === null ||
+      preparedContent.segmentQueueCreator === null
+    ) {
       const error = new OtherError("NONE", "Loading content when none is prepared");
       sendMessage({
         type: CoreMessageType.Error,
@@ -1204,6 +1208,7 @@ function sendThumbnailData(
   if (
     preparedContent === null ||
     preparedContent.manifest === null ||
+    preparedContent.fetchThumbnailData === null ||
     preparedContent.contentId !== msg.contentId
   ) {
     return respondWithError(new Error("Content changed"));

--- a/src/core/fetchers/cdn_prioritizer.ts
+++ b/src/core/fetchers/cdn_prioritizer.ts
@@ -15,27 +15,56 @@
  */
 
 import config from "../../config.ts";
-import type { ICdnMetadata } from "../../parsers/manifest/index.ts";
+import { formatError } from "../../errors/index.ts";
+import log from "../../log.ts";
+import type { IManifest } from "../../manifest/index.ts";
+import type {
+  ICdnMetadata,
+  IContentSteeringMetadata,
+} from "../../parsers/manifest/index.ts";
+import type { ISteeringManifest } from "../../parsers/SteeringManifest/index.ts";
+import type { IPlayerError } from "../../public_types.ts";
+import type { ITransportPipelines } from "../../transports/index.ts";
 import arrayFindIndex from "../../utils/array_find_index.ts";
+import arrayIncludes from "../../utils/array_includes.ts";
 import EventEmitter from "../../utils/event_emitter.ts";
+import globalScope from "../../utils/global_scope.ts";
+import SharedReference from "../../utils/reference.ts";
+import SyncOrAsync from "../../utils/sync_or_async.ts";
+import type { ISyncOrAsyncValue } from "../../utils/sync_or_async.ts";
 import type { CancellationSignal } from "../../utils/task_canceller.ts";
+import TaskCanceller, { CancellationError } from "../../utils/task_canceller.ts";
+import SteeringManifestFetcher from "./steering_manifest/index.ts";
 
 /**
  * Class storing and signaling the priority between multiple CDN available for
  * any given resource.
  *
- * This class was first created to implement the complexities behind
- * Content Steering features, though its handling hasn't been added yet as we
- * wait for its specification to be both standardized and relied on in the wild.
- * In the meantime, it acts as an abstraction for the simple concept of
- * avoiding to request a CDN for any segment when an issue is encountered with
- * one (e.g. HTTP 500 statuses) and several CDN exist for a given resource. It
- * should be noted that this is also one of the planified features of the
- * Content Steering specification.
+ * It might rely behind the hood on a fetched document giving priorities such as
+ * a Content Steering Manifest and also on issues that appeared with some given
+ * CDN in the [close] past.
+ *
+ * This class might perform requests and schedule timeouts by itself to keep its
+ * internal list of CDN priority up-to-date.
+ * When it is not needed anymore, you should call the `dispose` method to clear
+ * all resources.
+ *
+ * This class was created to implement the complexities behind Content Steering
+ * features.
  *
  * @class CdnPrioritizer
  */
 export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> {
+  /**
+   * Metadata parsed from the last Content Steering Manifest loaded.
+   *
+   * `null` either if there's no such Manifest or if it is currently being
+   * loaded for the first time.
+   */
+  private _lastSteeringManifest: ISteeringManifest | null;
+
+  private _defaultCdnId: string | undefined;
+
   /**
    * Structure keeping a list of CDN currently downgraded.
    * Downgraded CDN immediately have a lower priority than any non-downgraded
@@ -60,12 +89,107 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
   };
 
   /**
+   * TaskCanceller allowing to abort the process of loading and refreshing the
+   * Content Steering Manifest.
+   * Set to `null` when no such process is pending.
+   */
+  private _steeringManifestUpdateCanceller: TaskCanceller | null;
+
+  private _readyState: SharedReference<ICdnPrioritizerReadyState>;
+
+  /**
+   * @param {Object} manifest
+   * @param {Object} transport
    * @param {Object} destroySignal
    */
-  constructor(destroySignal: CancellationSignal) {
+  constructor(
+    manifest: IManifest,
+    transport: ITransportPipelines,
+    destroySignal: CancellationSignal,
+  ) {
     super();
+    this._lastSteeringManifest = null;
     this._downgradedCdnList = { metadata: [], timeouts: [] };
+    this._steeringManifestUpdateCanceller = null;
+    this._defaultCdnId = manifest.contentSteering?.defaultId;
+
+    const steeringManifestFetcher =
+      transport.steeringManifest === null
+        ? null
+        : new SteeringManifestFetcher(transport.steeringManifest, {
+            maxRetry: undefined,
+          });
+
+    let currentContentSteering = manifest.contentSteering;
+
+    manifest.addEventListener(
+      "manifestUpdate",
+      () => {
+        const prevContentSteering = currentContentSteering;
+        currentContentSteering = manifest.contentSteering;
+        if (prevContentSteering === null) {
+          if (currentContentSteering !== null) {
+            if (steeringManifestFetcher === null) {
+              log.warn("Core", "Steering manifest declared but no way to fetch it");
+            } else {
+              log.info("Core", "A Steering Manifest is declared in a new Manifest");
+              this._autoRefreshSteeringManifest(
+                steeringManifestFetcher,
+                currentContentSteering,
+              );
+            }
+          }
+        } else if (currentContentSteering === null) {
+          log.info("Core", "A Steering Manifest is removed in a new Manifest");
+          this._steeringManifestUpdateCanceller?.cancel(
+            "new MPD removed ContentSteering",
+          );
+          this._steeringManifestUpdateCanceller = null;
+        } else if (
+          prevContentSteering.url !== currentContentSteering.url ||
+          prevContentSteering.proxyUrl !== currentContentSteering.proxyUrl
+        ) {
+          log.info("Core", "A Steering Manifest's information changed in a new Manifest");
+          this._steeringManifestUpdateCanceller?.cancel(
+            "new MPD updated ContentSteering URL",
+          );
+          this._steeringManifestUpdateCanceller = null;
+          if (steeringManifestFetcher === null) {
+            log.warn("Core", "Steering manifest changed but no way to fetch it");
+          } else {
+            this._autoRefreshSteeringManifest(
+              steeringManifestFetcher,
+              currentContentSteering,
+            );
+          }
+        }
+      },
+      destroySignal,
+    );
+
+    if (manifest.contentSteering !== null) {
+      if (steeringManifestFetcher === null) {
+        log.warn("Core", "Steering Manifest initially present but no way to fetch it.");
+        this._readyState = new SharedReference<ICdnPrioritizerReadyState>("ready");
+      } else {
+        const readyState = manifest.contentSteering.queryBeforeStart
+          ? "not-ready"
+          : "ready";
+        this._readyState = new SharedReference<ICdnPrioritizerReadyState>(readyState);
+        this._autoRefreshSteeringManifest(
+          steeringManifestFetcher,
+          manifest.contentSteering,
+        );
+      }
+    } else {
+      this._readyState = new SharedReference<ICdnPrioritizerReadyState>("ready");
+    }
     destroySignal.register(() => {
+      this._readyState.setValue("disposed");
+      this._readyState.finish();
+      this._steeringManifestUpdateCanceller?.cancel("CdnPrioritizer disposed");
+      this._steeringManifestUpdateCanceller = null;
+      this._lastSteeringManifest = null;
       for (const timeout of this._downgradedCdnList.timeouts) {
         clearTimeout(timeout);
       }
@@ -87,20 +211,50 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
    * @param {Array.<string>} everyCdnForResource - Array of ALL available CDN
    * able to reach the wanted resource - even those which might not be used in
    * the end.
-   * @returns {Array.<Object>} - Array of CDN that can be tried to reach the
+   * @returns {Object} - Array of CDN that can be tried to reach the
    * resource, sorted by order of CDN preference, according to the
    * `CdnPrioritizer`'s own list of priorities.
+   *
+   * This value is wrapped in a `ISyncOrAsyncValue` as in relatively rare
+   * scenarios, the order can only be known once the steering Manifest has been
+   * fetched.
    */
   public getCdnPreferenceForResource(
     everyCdnForResource: ICdnMetadata[],
-  ): ICdnMetadata[] {
+  ): ISyncOrAsyncValue<ICdnMetadata[]> {
     if (everyCdnForResource.length <= 1) {
       // The huge majority of contents have only one CDN available.
       // Here, prioritizing make no sense.
-      return everyCdnForResource;
+      return SyncOrAsync.createSync(everyCdnForResource);
     }
 
-    return this._innerGetCdnPreferenceForResource(everyCdnForResource);
+    if (this._readyState.getValue() === "not-ready") {
+      const val = new Promise<ICdnMetadata[]>((res, rej) => {
+        this._readyState.onUpdate(
+          (readyState) => {
+            if (readyState === "ready") {
+              res(this._innerGetCdnPreferenceForResource(everyCdnForResource));
+            } else if (readyState === "disposed") {
+              rej(
+                new CancellationError(
+                  "Preferred CDN obtention",
+                  "CdnPrioritizer disposed",
+                ),
+              );
+            }
+          },
+          {
+            // NOTE: It is guaranteed in this class that `this._readyState` will
+            // never hang
+            clearSignal: new TaskCanceller("").signal,
+          },
+        );
+      });
+      return SyncOrAsync.createAsync(val);
+    }
+    return SyncOrAsync.createSync(
+      this._innerGetCdnPreferenceForResource(everyCdnForResource),
+    );
   }
 
   /**
@@ -119,7 +273,8 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
     }
 
     const { DEFAULT_CDN_DOWNGRADE_TIME } = config.getCurrent();
-    const downgradeTime = DEFAULT_CDN_DOWNGRADE_TIME;
+    const downgradeTime =
+      this._lastSteeringManifest?.lifetime ?? DEFAULT_CDN_DOWNGRADE_TIME;
     this._downgradedCdnList.metadata.push(metadata);
     const timeout = setTimeout(() => {
       const newIndex = indexOfMetadata(this._downgradedCdnList.metadata, metadata);
@@ -153,7 +308,37 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
   private _innerGetCdnPreferenceForResource(
     everyCdnForResource: ICdnMetadata[],
   ): ICdnMetadata[] {
-    const [allowedInOrder, downgradedInOrder] = everyCdnForResource.reduce(
+    let cdnBase;
+    if (this._lastSteeringManifest !== null) {
+      const priorities = this._lastSteeringManifest.priorities;
+      const inSteeringManifest = everyCdnForResource.filter(
+        (available) =>
+          available.id !== undefined && arrayIncludes(priorities, available.id),
+      );
+      if (inSteeringManifest.length > 0) {
+        cdnBase = inSteeringManifest;
+      }
+    }
+
+    // (If using the SteeringManifest gave nothing, or if it just didn't exist.) */
+    if (cdnBase === undefined) {
+      // (If a default CDN was indicated, try to use it) */
+      if (this._defaultCdnId !== undefined) {
+        const indexOf = arrayFindIndex(
+          everyCdnForResource,
+          (x) => x.id !== undefined && x.id === this._defaultCdnId,
+        );
+        if (indexOf >= 0) {
+          const elem = everyCdnForResource.splice(indexOf, 1)[0];
+          everyCdnForResource.unshift(elem);
+        }
+      }
+
+      if (cdnBase === undefined) {
+        cdnBase = everyCdnForResource;
+      }
+    }
+    const [allowedInOrder, downgradedInOrder] = cdnBase.reduce(
       (acc: [ICdnMetadata[], ICdnMetadata[]], elt: ICdnMetadata) => {
         if (
           this._downgradedCdnList.metadata.some(
@@ -171,6 +356,65 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
     return allowedInOrder.concat(downgradedInOrder);
   }
 
+  private _autoRefreshSteeringManifest(
+    steeringManifestFetcher: SteeringManifestFetcher,
+    contentSteering: IContentSteeringMetadata,
+  ) {
+    if (this._steeringManifestUpdateCanceller === null) {
+      const steeringManifestUpdateCanceller = new TaskCanceller(
+        "ContentSteering Manifest update",
+      );
+      this._steeringManifestUpdateCanceller = steeringManifestUpdateCanceller;
+    }
+    const canceller: TaskCanceller = this._steeringManifestUpdateCanceller;
+    steeringManifestFetcher
+      .fetch(
+        contentSteering.url,
+        (err: IPlayerError) => this.trigger("warnings", [err]),
+        canceller.signal,
+      )
+      .then((parse) => {
+        const parsed = parse((errs) => this.trigger("warnings", errs));
+        const prevSteeringManifest = this._lastSteeringManifest;
+        this._lastSteeringManifest = parsed;
+        if (parsed.lifetime > 0) {
+          const timeout = globalScope.setTimeout(() => {
+            canceller.signal.deregister(onTimeoutEnd);
+            this._autoRefreshSteeringManifest(steeringManifestFetcher, contentSteering);
+          }, parsed.lifetime * 1000);
+          const onTimeoutEnd = () => {
+            clearTimeout(timeout);
+          };
+          canceller.signal.register(onTimeoutEnd);
+        }
+        if (this._readyState.getValue() === "not-ready") {
+          this._readyState.setValue("ready");
+        }
+        if (canceller.isUsed()) {
+          return;
+        }
+        if (
+          prevSteeringManifest === null ||
+          prevSteeringManifest.priorities.length !== parsed.priorities.length ||
+          prevSteeringManifest.priorities.some(
+            (val, idx) => val !== parsed.priorities[idx],
+          )
+        ) {
+          this.trigger("priorityChange", null);
+        }
+      })
+      .catch((err) => {
+        if (err instanceof CancellationError) {
+          return;
+        }
+        const formattedError = formatError(err, {
+          defaultCode: "NONE",
+          defaultReason: "Unknown error when fetching and parsing the steering Manifest",
+        });
+        this.trigger("warnings", [formattedError]);
+      });
+  }
+
   /**
    * @param {number} index
    */
@@ -181,6 +425,8 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
   }
 }
 
+type ICdnPrioritizerReadyState = "not-ready" | "ready" | "disposed";
+
 /** Events sent by a `CdnPrioritizer` */
 export interface ICdnPrioritizerEvents {
   /**
@@ -190,6 +436,8 @@ export interface ICdnPrioritizerEvents {
    * is triggered.
    */
   priorityChange: null;
+
+  warnings: IPlayerError[];
 }
 
 /**

--- a/src/core/fetchers/segment/segment_queue_creator.ts
+++ b/src/core/fetchers/segment/segment_queue_creator.ts
@@ -61,19 +61,26 @@ export default class SegmentQueueCreator {
   private _cmcdDataBuilder: CmcdDataBuilder | null;
 
   /**
-   * @param {Object} transport
-   * @param {Object} cdnPrioritizer
-   * @param {Object|null} cmcdDataBuilder
-   * @param {Object} options
+   * @param {Object} args
+   * @param {Object} args.transportPipelines
+   * @param {Object} args.cdnPrioritizer
+   * @param {Object} args.manifest
+   * @param {Object|null} args.cmcdDataBuilder
+   * @param {Object} args.backoffOptions
    */
-  constructor(
-    transport: ITransportPipelines,
-    cdnPrioritizer: CdnPrioritizer,
-    cmcdDataBuilder: CmcdDataBuilder | null,
-    options: ISegmentQueueCreatorBackoffOptions,
-  ) {
+  constructor({
+    cdnPrioritizer,
+    transportPipelines,
+    cmcdDataBuilder,
+    backoffOptions,
+  }: {
+    cdnPrioritizer: CdnPrioritizer;
+    transportPipelines: ITransportPipelines;
+    cmcdDataBuilder: CmcdDataBuilder | null;
+    backoffOptions: ISegmentQueueCreatorBackoffOptions;
+  }) {
     const { MIN_CANCELABLE_PRIORITY, MAX_HIGH_PRIORITY_LEVEL } = config.getCurrent();
-    this._transport = transport;
+    this._transport = transportPipelines;
     this._prioritizer = new TaskPrioritizer({
       prioritySteps: {
         high: MAX_HIGH_PRIORITY_LEVEL,
@@ -81,7 +88,7 @@ export default class SegmentQueueCreator {
       },
     });
     this._cdnPrioritizer = cdnPrioritizer;
-    this._backoffOptions = options;
+    this._backoffOptions = backoffOptions;
     this._cmcdDataBuilder = cmcdDataBuilder;
   }
 

--- a/src/core/fetchers/steering_manifest/index.ts
+++ b/src/core/fetchers/steering_manifest/index.ts
@@ -1,0 +1,9 @@
+import type {
+  ISteeringManifestFetcherSettings,
+  ISteeringManifestParser,
+} from "./steering_manifest_fetcher.ts";
+
+import SteeringManifestFetcher from "./steering_manifest_fetcher.ts";
+
+export default SteeringManifestFetcher;
+export type { ISteeringManifestFetcherSettings, ISteeringManifestParser };

--- a/src/core/fetchers/steering_manifest/steering_manifest_fetcher.ts
+++ b/src/core/fetchers/steering_manifest/steering_manifest_fetcher.ts
@@ -1,0 +1,160 @@
+import config from "../../../config.ts";
+import { formatError } from "../../../errors/index.ts";
+import type { ISteeringManifest } from "../../../parsers/SteeringManifest/index.ts";
+import type { IPlayerError } from "../../../public_types.ts";
+import type {
+  IRequestedData,
+  ITransportSteeringManifestPipeline,
+} from "../../../transports/index.ts";
+import type { CancellationSignal } from "../../../utils/task_canceller.ts";
+import errorSelector from "../utils/error_selector.ts";
+import type { IBackoffSettings } from "../utils/schedule_request.ts";
+import { scheduleRequestPromise } from "../utils/schedule_request.ts";
+
+/** Response emitted by a SteeringManifestFetcher fetcher. */
+export type ISteeringManifestParser =
+  /** Allows to parse a fetched Steering Manifest into a `ISteeringManifest` structure. */
+  (onWarnings: (warnings: IPlayerError[]) => void) => ISteeringManifest;
+
+/** Options used by the `SteeringManifestFetcher`. */
+export interface ISteeringManifestFetcherSettings {
+  /** Maximum number of time a request on error will be retried. */
+  maxRetry: number | undefined;
+}
+
+/**
+ * Class allowing to facilitate the task of loading and parsing a Content
+ * Steering Manifest, which is an optional document associated to a content,
+ * communicating the priority between several CDN.
+ * @class SteeringManifestFetcher
+ */
+export default class SteeringManifestFetcher {
+  private _settings: ISteeringManifestFetcherSettings;
+  private _pipelines: ITransportSteeringManifestPipeline;
+
+  /**
+   * Construct a new SteeringManifestFetcher.
+   * @param {Object} pipelines - Transport pipelines used to perform the
+   * Content Steering Manifest loading and parsing operations.
+   * @param {Object} settings - Configure the `SteeringManifestFetcher`.
+   */
+  constructor(
+    pipelines: ITransportSteeringManifestPipeline,
+    settings: ISteeringManifestFetcherSettings,
+  ) {
+    this._pipelines = pipelines;
+    this._settings = settings;
+  }
+
+  /**
+   * (re-)Load the Content Steering Manifest.
+   * This method does not yet parse it, parsing will then be available through
+   * a callback available on the response.
+   *
+   * You can set an `url` on which that Content Steering Manifest will be
+   * requested.
+   * If not set, the regular Content Steering Manifest url - defined on the
+   * `SteeringManifestFetcher` instanciation - will be used instead.
+   *
+   * @param {string|undefined} url
+   * @param {Function} onRetry
+   * @param {Object} cancelSignal
+   * @returns {Promise}
+   */
+  public async fetch(
+    url: string,
+    onRetry: (error: IPlayerError) => void,
+    cancelSignal: CancellationSignal,
+  ): Promise<ISteeringManifestParser> {
+    const pipelines = this._pipelines;
+    const backoffSettings = this._getBackoffSetting((err) => {
+      onRetry(errorSelector(err));
+    });
+    const callLoader = () => pipelines.loadSteeringManifest(url, cancelSignal);
+    const response = await scheduleRequestPromise(
+      callLoader,
+      backoffSettings,
+      cancelSignal,
+    );
+    return (onWarnings: (error: IPlayerError[]) => void) => {
+      return this._parseSteeringManifest(response, onWarnings);
+    };
+  }
+
+  /**
+   * Parse an already loaded Content Steering Manifest.
+   *
+   * This method should be reserved for Content Steering Manifests for which no
+   * request has been done.
+   * In other cases, it's preferable to go through the `fetch` method, so
+   * information on the request can be used by the parsing process.
+   * @param {*} steeringManifest
+   * @param {Function} onWarnings
+   * @returns {Observable}
+   */
+  public parse(
+    steeringManifest: unknown,
+    onWarnings: (error: IPlayerError[]) => void,
+  ): ISteeringManifest {
+    return this._parseSteeringManifest(
+      { responseData: steeringManifest, size: undefined, requestDuration: undefined },
+      onWarnings,
+    );
+  }
+
+  /**
+   * Parse a Content Steering Manifest.
+   * @param {Object} loaded - Information about the loaded Content Steering Manifest.
+   * @param {Function} onWarnings
+   * @returns {Observable}
+   */
+  private _parseSteeringManifest(
+    loaded: IRequestedData<unknown>,
+    onWarnings: (error: IPlayerError[]) => void,
+  ): ISteeringManifest {
+    try {
+      return this._pipelines.parseSteeringManifest(
+        loaded,
+        function onTransportWarnings(errs) {
+          const warnings = errs.map((e) => formatParsingError(e));
+          onWarnings(warnings);
+        },
+      );
+    } catch (err) {
+      throw formatParsingError(err);
+    }
+
+    /**
+     * Format the given Error and emit it through `obs`.
+     * Either through a `"warning"` event, if `isFatal` is `false`, or through
+     * a fatal Observable error, if `isFatal` is set to `true`.
+     * @param {*} err
+     * @returns {Error}
+     */
+    function formatParsingError(err: unknown): IPlayerError {
+      return formatError(err, {
+        defaultCode: "PIPELINE_PARSE_ERROR",
+        defaultReason: "Unknown error when parsing the Content Steering Manifest",
+      });
+    }
+  }
+
+  /**
+   * Construct "backoff settings" that can be used with a range of functions
+   * allowing to perform multiple request attempts
+   * @param {Function} onRetry
+   * @returns {Object}
+   */
+  private _getBackoffSetting(onRetry: (err: unknown) => void): IBackoffSettings {
+    const {
+      DEFAULT_MAX_CONTENT_STEERING_MANIFEST_REQUEST_RETRY,
+      INITIAL_BACKOFF_DELAY_BASE,
+      MAX_BACKOFF_DELAY_BASE,
+    } = config.getCurrent();
+    const { maxRetry: ogRegular } = this._settings;
+    const baseDelay = INITIAL_BACKOFF_DELAY_BASE.REGULAR;
+    const maxDelay = MAX_BACKOFF_DELAY_BASE.REGULAR;
+    const maxRetry = ogRegular ?? DEFAULT_MAX_CONTENT_STEERING_MANIFEST_REQUEST_RETRY;
+    return { onRetry, baseDelay, maxDelay, maxRetry };
+  }
+}

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -25,6 +25,8 @@ import cancellableSleep from "../../../utils/cancellable_sleep.ts";
 import getFuzzedDelay from "../../../utils/get_fuzzed_delay.ts";
 import getTimestamp from "../../../utils/monotonic_timestamp.ts";
 import { RequestError } from "../../../utils/request/index.ts";
+import type { ISyncOrAsyncValue } from "../../../utils/sync_or_async.ts";
+import SyncOrAsync from "../../../utils/sync_or_async.ts";
 import type { CancellationSignal } from "../../../utils/task_canceller.ts";
 import TaskCanceller from "../../../utils/task_canceller.ts";
 import type CdnPrioritizer from "../cdn_prioritizer.ts";
@@ -171,8 +173,17 @@ export async function scheduleRequestWithCdns<T>(
   }
 
   const missedAttempts: Map<ICdnMetadata | null, ICdnAttemptMetadata> = new Map();
-  const initialCdnToRequest = getCdnToRequest();
-  if (initialCdnToRequest === undefined) {
+  const cdnsResponse = getCdnToRequest();
+  let initialCdnToRequest;
+  if (cdnsResponse.syncValue === null) {
+    initialCdnToRequest = await cdnsResponse.getValueAsAsync();
+  } else {
+    initialCdnToRequest = cdnsResponse.syncValue;
+  }
+
+  if (initialCdnToRequest === "no-http") {
+    initialCdnToRequest = null;
+  } else if (initialCdnToRequest === undefined) {
     throw new Error("No CDN to request");
   }
   return requestCdn(initialCdnToRequest);
@@ -180,25 +191,35 @@ export async function scheduleRequestWithCdns<T>(
   /**
    * Returns what is now the most prioritary CDN to request the wanted resource.
    *
-   * A return value of `null` indicates that the resource can be requested
+   * A return value of `"no-http"` indicates that the resource can be requested
    * through another mean than by doing an HTTP request.
    *
    * A return value of `undefined` indicates that there's no CDN left to request
    * the resource.
    * @returns {Object|null|undefined}
    */
-  function getCdnToRequest(): ICdnMetadata | null | undefined {
+  function getCdnToRequest(): ISyncOrAsyncValue<ICdnMetadata | "no-http" | undefined> {
     if (cdns === null) {
       const nullAttemptObject = missedAttempts.get(null);
       if (nullAttemptObject !== undefined && nullAttemptObject.isBlacklisted) {
-        return undefined;
+        return SyncOrAsync.createSync(undefined);
       }
-      return null;
+      return SyncOrAsync.createSync("no-http");
     } else if (cdnPrioritizer === null) {
-      return getPrioritaryRequestableCdnFromSortedList(cdns);
+      return SyncOrAsync.createSync(getPrioritaryRequestableCdnFromSortedList(cdns));
     } else {
       const prioritized = cdnPrioritizer.getCdnPreferenceForResource(cdns);
-      return getPrioritaryRequestableCdnFromSortedList(prioritized);
+      // TODO order by `blockedUntil` DESC if `missedAttempts` is not empty
+      if (prioritized.syncValue !== null) {
+        return SyncOrAsync.createSync(
+          getPrioritaryRequestableCdnFromSortedList(prioritized.syncValue),
+        );
+      }
+      return SyncOrAsync.createAsync(
+        prioritized
+          .getValueAsAsync()
+          .then((v) => getPrioritaryRequestableCdnFromSortedList(v)),
+      );
     }
   }
 
@@ -269,13 +290,21 @@ export async function scheduleRequestWithCdns<T>(
    * @returns {Promise}
    */
   async function retryWithNextCdn(prevRequestError: unknown): Promise<T> {
-    const nextCdn = getCdnToRequest();
+    const currCdnResponse = getCdnToRequest();
+    let nextCdn;
+    if (currCdnResponse.syncValue === null) {
+      nextCdn = await currCdnResponse.getValueAsAsync();
+    } else {
+      nextCdn = currCdnResponse.syncValue;
+    }
 
     if (cancellationSignal.isCancelled()) {
       throw cancellationSignal.cancellationError;
     }
 
-    if (nextCdn === undefined) {
+    if (nextCdn === "no-http") {
+      nextCdn = null;
+    } else if (nextCdn === undefined) {
       throw prevRequestError;
     }
 
@@ -317,12 +346,20 @@ export async function scheduleRequestWithCdns<T>(
     return new Promise<T>((res, rej) => {
       cdnPrioritizer?.addEventListener(
         "priorityChange",
-        () => {
-          const updatedPrioritaryCdn = getCdnToRequest();
+        async () => {
+          const newCdnsResponse = getCdnToRequest();
+          let updatedPrioritaryCdn;
+          if (newCdnsResponse.syncValue === null) {
+            updatedPrioritaryCdn = await newCdnsResponse.getValueAsAsync();
+          } else {
+            updatedPrioritaryCdn = newCdnsResponse.syncValue;
+          }
           if (cancellationSignal.isCancelled()) {
             return;
           }
-          if (updatedPrioritaryCdn === undefined) {
+          if (updatedPrioritaryCdn === "no-http") {
+            updatedPrioritaryCdn = null;
+          } else if (updatedPrioritaryCdn === undefined) {
             return cleanAndReject(prevRequestError);
           }
           if (updatedPrioritaryCdn !== nextWantedCdn) {

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -275,6 +275,21 @@ const DEFAULT_CONFIG = {
   DEFAULT_MAX_MANIFEST_REQUEST_RETRY: 4,
 
   /**
+   * The default number of times a Content Steering Manifest request will be
+   * re-performed when loaded/refreshed if the request finishes on an error
+   * which justify an retry.
+   *
+   * Note that some errors do not use this counter:
+   *   - if the error is not due to the xhr, no retry will be peformed
+   *   - if the error is an HTTP error code, but not a 500-smthg or a 404, no
+   *     retry will be performed.
+   *   - if it has a high chance of being due to the user being offline, a
+   *     separate counter is used (see DEFAULT_MAX_REQUESTS_RETRY_ON_OFFLINE).
+   * @type Number
+   */
+  DEFAULT_MAX_CONTENT_STEERING_MANIFEST_REQUEST_RETRY: 4,
+
+  /**
    * Default delay, in seconds, during which a CDN will be "downgraded".
    *
    * For example in case of media content being available on multiple CDNs, the

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -184,6 +184,7 @@ export default class VideoThumbnailLoader {
       const segmentFetcher = createSegmentFetcher({
         bufferType: "video",
         pipeline: loader.video,
+        // TODO implement ContentSteering for the VideoThumbnailLoader?
         cdnPrioritizer: null,
         cmcdDataBuilder: null,
         requestOptions: {

--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -17,7 +17,10 @@
 import { MediaError } from "../../errors/index.ts";
 import log from "../../log.ts";
 import { getCodecsWithUnknownSupport } from "../../main_thread/init/utils/update_manifest_codec_support.ts";
-import type { IParsedManifest } from "../../parsers/manifest/index.ts";
+import type {
+  IContentSteeringMetadata,
+  IParsedManifest,
+} from "../../parsers/manifest/index.ts";
 import type { ITrackType, IRepresentationFilter } from "../../public_types.ts";
 import arrayFind from "../../utils/array_find.ts";
 import EventEmitter from "../../utils/event_emitter.ts";
@@ -217,6 +220,8 @@ export default class Manifest
    */
   public clockOffset: number | undefined;
 
+  public contentSteering: IContentSteeringMetadata | null;
+
   /**
    * Data allowing to calculate the minimum and maximum seekable positions at
    * any given time.
@@ -360,6 +365,7 @@ export default class Manifest
     this.suggestedPresentationDelay = parsedManifest.suggestedPresentationDelay;
     this.availabilityStartTime = parsedManifest.availabilityStartTime;
     this.publishTime = parsedManifest.publishTime;
+    this.contentSteering = parsedManifest.contentSteering;
   }
 
   /**
@@ -685,6 +691,7 @@ export default class Manifest
     this.suggestedPresentationDelay = newManifest.suggestedPresentationDelay;
     this.transport = newManifest.transport;
     this.publishTime = newManifest.publishTime;
+    this.contentSteering = newManifest.contentSteering;
 
     let updatedPeriodsResult;
     if (updateType === MANIFEST_UPDATE_TYPE.Full) {

--- a/src/parsers/SteeringManifest/DCSM/parse_dcsm.ts
+++ b/src/parsers/SteeringManifest/DCSM/parse_dcsm.ts
@@ -1,0 +1,51 @@
+import type { ISteeringManifest } from "../types.ts";
+
+export default function parseDashContentSteeringManifest(
+  input: string | Partial<Record<string, unknown>>,
+): [ISteeringManifest, Error[]] {
+  const warnings: Error[] = [];
+  let json;
+  if (typeof input === "string") {
+    json = JSON.parse(input) as Partial<Record<string, unknown>>;
+  } else {
+    json = input;
+  }
+
+  if (json.VERSION !== 1) {
+    throw new Error("Unhandled DCSM version. Only `1` can be proccessed.");
+  }
+
+  const initialPriorities = json["SERVICE-LOCATION-PRIORITY"];
+  if (!Array.isArray(initialPriorities)) {
+    throw new Error("The DCSM's SERVICE-LOCATION-URI in in the wrong format");
+  } else if (initialPriorities.length === 0) {
+    warnings.push(
+      new Error("The DCSM's SERVICE-LOCATION-URI should contain at least one element"),
+    );
+  }
+
+  const priorities: string[] = initialPriorities.filter(
+    (elt): elt is string => typeof elt === "string",
+  );
+  if (priorities.length !== initialPriorities.length) {
+    warnings.push(
+      new Error("The DCSM's SERVICE-LOCATION-URI contains URI in a wrong format"),
+    );
+  }
+  let lifetime = 300;
+
+  if (typeof json.TTL === "number") {
+    lifetime = json.TTL;
+  } else if (json.TTL !== undefined) {
+    warnings.push(new Error("The DCSM's TTL in in the wrong format"));
+  }
+
+  let reloadUri;
+  if (typeof json["RELOAD-URI"] === "string") {
+    reloadUri = json["RELOAD-URI"];
+  } else if (json["RELOAD-URI"] !== undefined) {
+    warnings.push(new Error("The DCSM's RELOAD-URI in in the wrong format"));
+  }
+
+  return [{ lifetime, reloadUri, priorities }, warnings];
+}

--- a/src/parsers/SteeringManifest/index.ts
+++ b/src/parsers/SteeringManifest/index.ts
@@ -1,0 +1,4 @@
+import parseDashContentSteeringManifest from "./DCSM/parse_dcsm.ts";
+
+export type { ISteeringManifest } from "./types.ts";
+export default parseDashContentSteeringManifest;

--- a/src/parsers/SteeringManifest/types.ts
+++ b/src/parsers/SteeringManifest/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2015 CANAL+ Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ISteeringManifest {
+  lifetime: number;
+  reloadUri?: string | undefined;
+  priorities: string[];
+}

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -18,10 +18,11 @@ import config from "../../../../config.ts";
 import log from "../../../../log.ts";
 import type { IManifest } from "../../../../manifest/index.ts";
 import arrayFind from "../../../../utils/array_find.ts";
+import getLastItemFromArray from "../../../../utils/get_last_item_from_array.ts";
 import isNullOrUndefined from "../../../../utils/is_null_or_undefined.ts";
 import getMonotonicTimeStamp from "../../../../utils/monotonic_timestamp.ts";
 import { getFilenameIndexInUrl } from "../../../../utils/url-utils.ts";
-import type { IParsedManifest } from "../../types.ts";
+import type { IContentSteeringMetadata, IParsedManifest } from "../../types.ts";
 import type {
   IMPDIntermediateRepresentation,
   IPeriodIntermediateRepresentation,
@@ -301,6 +302,18 @@ function parseCompleteIntermediateRepresentation(
     time: number;
   };
 
+  let contentSteering: IContentSteeringMetadata | null = null;
+  const lastContentSteering = getLastItemFromArray(rootChildren.ContentSteering);
+  if (lastContentSteering !== undefined) {
+    const { attributes } = lastContentSteering;
+    contentSteering = {
+      url: lastContentSteering.value,
+      defaultId: attributes.defaultServiceLocation,
+      queryBeforeStart: attributes.queryBeforeStart === true,
+      proxyUrl: attributes.proxyServerUrl,
+    };
+  }
+
   if (
     rootAttributes.minimumUpdatePeriod !== undefined &&
     rootAttributes.minimumUpdatePeriod >= 0
@@ -423,6 +436,7 @@ function parseCompleteIntermediateRepresentation(
   const parsedMPD: IParsedManifest = {
     availabilityStartTime,
     clockOffset: args.externalClockOffset,
+    contentSteering,
     isDynamic,
     isLive: isDynamic,
     isLastPeriodKnown,

--- a/src/parsers/manifest/dash/common/resolve_base_urls.ts
+++ b/src/parsers/manifest/dash/common/resolve_base_urls.ts
@@ -36,7 +36,7 @@ export default function resolveBaseURLs(
   }
 
   const newBaseUrls: IResolvedBaseUrl[] = newBaseUrlsIR.map((ir) => {
-    return { url: ir.value };
+    return { url: ir.value, serviceLocation: ir.attributes.serviceLocation };
   });
   if (currentBaseURLs.length === 0) {
     return newBaseUrls;

--- a/src/parsers/manifest/dash/js-parser/node_parsers/BaseURL.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/BaseURL.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
 import type { IBaseUrlIntermediateRepresentation } from "../../node_parser_types.ts";
 import { textContent } from "./utils.ts";
@@ -25,12 +26,23 @@ import { textContent } from "./utils.ts";
  * @returns {Array.<Object|undefined>}
  */
 export default function parseBaseURL(
-  root: ITNode | string,
+  root: ITNode,
 ): [IBaseUrlIntermediateRepresentation | undefined, Error[]] {
+  const attributes: { serviceLocation?: string } = {};
   const value = typeof root === "string" ? root : textContent(root.children);
   const warnings: Error[] = [];
   if (value === null || value.length === 0) {
     return [undefined, warnings];
   }
-  return [{ value }, warnings];
+
+  for (const attributeName of Object.keys(root.attributes)) {
+    const attributeVal = root.attributes[attributeName];
+    if (isNullOrUndefined(attributeVal)) {
+      continue;
+    }
+    if (attributeName === "serviceLocation") {
+      attributes.serviceLocation = attributeVal;
+    }
+  }
+  return [{ value, attributes }, warnings];
 }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/ContentSteering.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/ContentSteering.ts
@@ -1,0 +1,50 @@
+import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
+import type { ITNode } from "../../../../../utils/xml-parser.ts";
+import type { IContentSteeringIntermediateRepresentation } from "../../node_parser_types.ts";
+import { parseBoolean, textContent, ValueParser } from "./utils.ts";
+
+/**
+ * Parse an ContentSteering element into an ContentSteering intermediate
+ * representation.
+ * @param {Object} root - The ContentSteering root element.
+ * @returns {Array.<Object|undefined>}
+ */
+export default function parseContentSteering(
+  root: ITNode,
+): [IContentSteeringIntermediateRepresentation | undefined, Error[]] {
+  const attributes: {
+    defaultServiceLocation?: string;
+    queryBeforeStart?: boolean;
+    proxyServerUrl?: string;
+  } = {};
+  const value = typeof root === "string" ? root : textContent(root.children);
+  const warnings: Error[] = [];
+  if (value === null || value.length === 0) {
+    return [undefined, warnings];
+  }
+  const parseValue = ValueParser(attributes, warnings);
+  for (const attributeName of Object.keys(root.attributes)) {
+    const attributeVal = root.attributes[attributeName];
+    if (isNullOrUndefined(attributeVal)) {
+      continue;
+    }
+    switch (attributeName) {
+      case "defaultServiceLocation":
+        attributes.defaultServiceLocation = attributeVal;
+        break;
+
+      case "queryBeforeStart":
+        parseValue(attributeVal, {
+          parser: parseBoolean,
+          name: "queryBeforeStart",
+        });
+        break;
+
+      case "proxyServerUrl":
+        attributes.proxyServerUrl = attributeVal;
+        break;
+    }
+  }
+
+  return [{ value, attributes }, warnings];
+}

--- a/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
@@ -24,6 +24,7 @@ import type {
 } from "../../node_parser_types.ts";
 import parseBaseURL from "./BaseURL.ts";
 import parseContentProtection from "./ContentProtection.ts";
+import parseContentSteering from "./ContentSteering.ts";
 import { createPeriodIntermediateRepresentation } from "./Period.ts";
 import {
   parseDateTime,
@@ -48,6 +49,7 @@ function parseMPDChildren(
     Period: [],
     UTCTiming: [],
     ContentProtection: [],
+    ContentSteering: [],
   };
 
   let warnings: Error[] = [];
@@ -65,6 +67,17 @@ function parseMPDChildren(
         warnings = warnings.concat(baseURLWarnings);
         break;
       }
+
+      case "ContentSteering":
+        {
+          const [contentSteeringObj, contentSteeringWarnings] =
+            parseContentSteering(currentNode);
+          if (contentSteeringObj !== undefined) {
+            ret.ContentSteering.push(contentSteeringObj);
+          }
+          warnings = warnings.concat(contentSteeringWarnings);
+        }
+        break;
 
       case "Location":
         ret.Location.push({ value: textContent(currentNode.children) });

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -44,6 +44,11 @@ export interface IMPDChildren {
    */
   BaseURL: IBaseUrlIntermediateRepresentation[];
   /**
+   * Information on a potential Content Steering Manifest linked to this
+   * content.
+   */
+  ContentSteering: IContentSteeringIntermediateRepresentation[];
+  /**
    * Location(s) at which the Manifest can be refreshed.
    *
    * This is the content of all `Location` elements encountered in this MPD
@@ -410,6 +415,43 @@ export interface IBaseUrlIntermediateRepresentation {
    * This is the inner content of a BaseURL node.
    */
   value: string;
+
+  /** Attributes assiociated to the BaseURL node. */
+  attributes: {
+    /**
+     * Potential value for a `serviceLocation` attribute, used in content
+     * steering mechanisms.
+     */
+    serviceLocation?: string;
+  };
+}
+
+/** Intermediate representation for a ContentSteering node. */
+export interface IContentSteeringIntermediateRepresentation {
+  /**
+   * The Content Steering Manifest's URL.
+   *
+   * This is the inner content of a ContentSteering node.
+   */
+  value: string;
+
+  /** Attributes assiociated to the ContentSteering node. */
+  attributes: {
+    /** Default ServiceLocation to be used. */
+    defaultServiceLocation?: string;
+    /**
+     * If `true`, the Content Steering Manifest should be loaded before the
+     * first resources depending on it are loaded.
+     */
+    queryBeforeStart?: boolean;
+    /**
+     * If set, a proxy URL has been configured.
+     * Requests for the Content Steering Manifest should actually go through
+     * this proxy, the node URL being added to an `url` query parameter
+     * alongside potential other query parameters.
+     */
+    proxyServerUrl?: string;
+  };
 }
 
 /** Intermediate representation for a Node following a "scheme" format. */

--- a/src/parsers/manifest/dash/wasm-parser/rs/events.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/events.rs
@@ -92,6 +92,9 @@ pub enum TagName {
 
     /// Indicate an <Initialization> node
     Initialization = 22,
+
+    /// Indicate a <ContentSteering> node
+    ContentSteering = 23,
 }
 
 #[derive(PartialEq, Clone, Copy)]
@@ -283,6 +286,12 @@ pub enum AttributeName {
     Namespace = 70,
 
     ServiceLocation = 72, // String
+
+    QueryBeforeStart = 73, // Boolean
+
+    ProxyServerUrl = 74, // String
+
+    DefaultServiceLocation = 75,
 
     // SegmentTemplate
     EndNumber = 76, // f64

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
@@ -153,6 +153,20 @@ pub fn report_base_url_attrs(tag_bs: &quick_xml::events::BytesStart) {
     }
 }
 
+pub fn report_content_steering_attrs(tag_bs: &quick_xml::events::BytesStart) {
+    for res_attr in tag_bs.attributes() {
+        match res_attr {
+            Ok(attr) => match attr.key.as_ref() {
+                b"defaultServiceLocation" => DefaultServiceLocation.try_report_as_string(&attr),
+                b"proxyServerUrl" => ProxyServerUrl.try_report_as_string(&attr),
+                b"queryBeforeStart" => QueryBeforeStart.try_report_as_bool(&attr),
+                _ => {}
+            },
+            Err(err) => ParsingError::from(err).report_err(),
+        };
+    }
+}
+
 pub fn report_segment_template_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
@@ -115,6 +115,11 @@ impl MPDProcessor {
                         attributes::report_base_url_attrs(&tag);
                         self.process_base_url_element();
                     }
+                    b"ContentSteering" => {
+                        TagName::ContentSteering.report_tag_open();
+                        attributes::report_content_steering_attrs(&tag);
+                        self.process_content_steering_element();
+                    }
                     b"cenc:pssh" => self.process_cenc_element(),
                     b"Location" => self.process_location_element(),
                     b"Label" => {
@@ -335,6 +340,47 @@ impl MPDProcessor {
                 }
                 Ok(Event::Eof) => {
                     ParsingError("Unexpected end of file in a BaseURL.".to_owned()).report_err();
+                    break;
+                }
+                Err(e) => {
+                    ParsingError::from(e).report_err();
+                    break;
+                }
+                _ => (),
+            }
+            self.reader_buf.clear();
+        }
+    }
+
+    fn process_content_steering_element(&mut self) {
+        // Count inner ContentSteering tags if it exists.
+        // Allowing to not close the current node when it is an inner that is closed
+        let mut inner_tag: u32 = 0;
+
+        loop {
+            match self.read_next_event() {
+                Ok(Event::Text(t)) => {
+                    if t.len() > 0 {
+                        match t.unescape() {
+                            Ok(unescaped) => AttributeName::Text.report(unescaped),
+                            Err(err) => ParsingError::from(err).report_err(),
+                        }
+                    }
+                }
+                Ok(Event::Start(tag)) if tag.name().as_ref() == b"ContentSteering" => {
+                    inner_tag += 1
+                }
+                Ok(Event::End(tag)) if tag.name().as_ref() == b"ContentSteering" => {
+                    if inner_tag > 0 {
+                        inner_tag -= 1;
+                    } else {
+                        TagName::ContentSteering.report_tag_close();
+                        break;
+                    }
+                }
+                Ok(Event::Eof) => {
+                    ParsingError("Unexpected end of file in a ContentSteering.".to_owned())
+                        .report_err();
                     break;
                 }
                 Err(e) => {

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentSteering.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentSteering.ts
@@ -14,30 +14,51 @@
  * limitations under the License.
  */
 
-import type { IBaseUrlIntermediateRepresentation } from "../../../node_parser_types.ts";
+import type { IContentSteeringIntermediateRepresentation } from "../../../node_parser_types.ts";
 import type { IAttributeParser } from "../parsers_stack.ts";
 import { AttributeName } from "../types.ts";
 import { parseString } from "../utils.ts";
 
 /**
- * Generate an "attribute parser" once inside a `BaseURL` node.
- * @param {Object} baseUrlAttrs
+ * Generate an "attribute parser" once inside a `ContentSteering` node.
+ * @param {Object} contentSteeringAttrs
  * @param {WebAssembly.Memory} linearMemory
  * @returns {Function}
  */
-export function generateBaseUrlAttrParser(
-  baseUrlAttrs: IBaseUrlIntermediateRepresentation,
+export function generateContentSteeringAttrParser(
+  contentSteeringAttrs: IContentSteeringIntermediateRepresentation,
   linearMemory: WebAssembly.Memory,
 ): IAttributeParser {
   const textDecoder = new TextDecoder();
-  return function onMPDAttribute(attr: AttributeName, ptr: number, len: number) {
+  return function onMPDAttribute(attr: number, ptr: number, len: number) {
     switch (attr) {
       case AttributeName.Text:
-        baseUrlAttrs.value = parseString(textDecoder, linearMemory.buffer, ptr, len);
+        contentSteeringAttrs.value = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
         break;
 
-      case AttributeName.ServiceLocation: {
-        baseUrlAttrs.attributes.serviceLocation = parseString(
+      case AttributeName.DefaultServiceLocation: {
+        contentSteeringAttrs.attributes.defaultServiceLocation = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
+        break;
+      }
+
+      case AttributeName.QueryBeforeStart: {
+        contentSteeringAttrs.attributes.queryBeforeStart =
+          new DataView(linearMemory.buffer).getUint8(0) === 0;
+        break;
+      }
+
+      case AttributeName.ProxyServerUrl: {
+        contentSteeringAttrs.attributes.proxyServerUrl = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
@@ -27,6 +27,7 @@ import { AttributeName, TagName } from "../types.ts";
 import { parseString } from "../utils.ts";
 import { generateBaseUrlAttrParser } from "./BaseURL.ts";
 import { generateContentProtectionAttrParser } from "./ContentProtection.ts";
+import { generateContentSteeringAttrParser } from "./ContentSteering.ts";
 import { generatePeriodAttrParser, generatePeriodChildrenParser } from "./Period.ts";
 import { generateSchemeAttrParser } from "./Scheme.ts";
 
@@ -52,6 +53,19 @@ export function generateMPDChildrenParser(
 
         const childrenParser = noop; // BaseURL have no sub-element
         const attributeParser = generateBaseUrlAttrParser(baseUrl, linearMemory);
+        parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
+        break;
+      }
+
+      case TagName.ContentSteering: {
+        const contentSteering = { value: "", attributes: {} };
+        mpdChildren.ContentSteering.push(contentSteering);
+
+        const childrenParser = noop; // ContentSteering have no sub-element
+        const attributeParser = generateContentSteeringAttrParser(
+          contentSteering,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
@@ -43,6 +43,7 @@ export function generateRootChildrenParser(
             Period: [],
             UTCTiming: [],
             ContentProtection: [],
+            ContentSteering: [],
           },
           attributes: {},
         };

--- a/src/parsers/manifest/dash/wasm-parser/ts/types.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/types.ts
@@ -114,6 +114,9 @@ export const enum TagName {
 
   /// Indicate an <Initialization> node
   Initialization = 22,
+
+  /// Indicate a <ContentSteering> node
+  ContentSteering = 23,
 }
 
 /**

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -57,6 +57,7 @@ export default function parseLocalManifest(
 
   return {
     availabilityStartTime: 0,
+    contentSteering: null,
     expired: localManifest.expired,
     transportType: "local",
     isDynamic: !isFinished,

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -339,6 +339,7 @@ function createManifest(
   const manifest = {
     availabilityStartTime: 0,
     clockOffset,
+    contentSteering: null,
     suggestedPresentationDelay: 10,
     periods,
     transportType: "metaplaylist",

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -674,6 +674,7 @@ function createSmoothStreamingParser(
       availabilityStartTime:
         availabilityStartTime === undefined ? 0 : availabilityStartTime,
       clockOffset: serverTimeOffset,
+      contentSteering: null,
       isLive,
       isDynamic: isLive,
       isLastPeriodKnown: true,

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -98,7 +98,8 @@ export interface ICdnMetadata {
   baseUrl: string;
 
   /**
-   * Identifier that might be re-used in other documents.
+   * Identifier that might be re-used in other documents, for example a
+   * Content Steering Manifest, to identify this CDN.
    */
   id?: string | undefined;
 }
@@ -456,4 +457,13 @@ export interface IParsedManifest {
   suggestedPresentationDelay?: number | undefined;
   /** URIs where the manifest can be refreshed by order of importance. */
   uris?: string[] | undefined;
+
+  contentSteering: IContentSteeringMetadata | null;
+}
+
+export interface IContentSteeringMetadata {
+  url: string;
+  defaultId: string | undefined;
+  queryBeforeStart: boolean;
+  proxyUrl: string | undefined;
 }

--- a/src/transports/dash/pipelines.ts
+++ b/src/transports/dash/pipelines.ts
@@ -21,6 +21,10 @@ import { addManifestIntegrityChecks } from "./integrity_checks.ts";
 import generateManifestParser from "./manifest_parser.ts";
 import generateSegmentLoader from "./segment_loader.ts";
 import generateAudioVideoSegmentParser from "./segment_parser.ts";
+import {
+  loadSteeringManifest,
+  parseSteeringManifest,
+} from "./steering_manifest_pipeline.ts";
 import generateTextTrackLoader from "./text_loader.ts";
 import generateTextTrackParser from "./text_parser.ts";
 import { loadThumbnail, parseThumbnail } from "./thumbnails.ts";
@@ -60,6 +64,7 @@ export default function (options: ITransportOptions): ITransportPipelines {
       loadThumbnail,
       parseThumbnail,
     },
+    steeringManifest: { loadSteeringManifest, parseSteeringManifest },
   };
 }
 

--- a/src/transports/dash/steering_manifest_pipeline.ts
+++ b/src/transports/dash/steering_manifest_pipeline.ts
@@ -1,0 +1,43 @@
+import parseDashContentSteeringManifest, {
+  type ISteeringManifest,
+} from "../../parsers/SteeringManifest/index.ts";
+import request from "../../utils/request/index.ts";
+import type { CancellationSignal } from "../../utils/task_canceller.ts";
+import type { IRequestedData } from "../types.ts";
+
+/**
+ * Loads DASH's Content Steering Manifest.
+ * @param {string|null} url
+ * @param {Object} cancelSignal
+ * @returns {Promise}
+ */
+export async function loadSteeringManifest(
+  url: string,
+  cancelSignal: CancellationSignal,
+): Promise<IRequestedData<string>> {
+  return request({ url, responseType: "text", cancelSignal });
+}
+
+/**
+ * Parses DASH's Content Steering Manifest.
+ * @param {Object} loadedSegment
+ * @param {Function} onWarnings
+ * @returns {Object}
+ */
+export function parseSteeringManifest(
+  { responseData }: IRequestedData<unknown>,
+  onWarnings: (warnings: Error[]) => void,
+): ISteeringManifest {
+  if (
+    typeof responseData !== "string" &&
+    (typeof responseData !== "object" || responseData === null)
+  ) {
+    throw new Error("Invalid loaded format for DASH's Content Steering Manifest.");
+  }
+
+  const parsed = parseDashContentSteeringManifest(responseData);
+  if (parsed[1].length > 0) {
+    onWarnings(parsed[1]);
+  }
+  return parsed[0];
+}

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -101,5 +101,6 @@ export default function getLocalManifestPipelines(
         throw new Error("Thumbnail tracks aren't implemented with the local transport");
       },
     },
+    steeringManifest: null,
   };
 }

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -410,5 +410,6 @@ export default function (options: ITransportOptions): ITransportPipelines {
         throw new Error("Thumbnail tracks aren't implemented with MetaPlaylist");
       },
     },
+    steeringManifest: null,
   };
 }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -430,6 +430,7 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
         throw new Error("Thumbnail tracks aren't implemented with smooth");
       },
     },
+    steeringManifest: null,
   };
 }
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -18,6 +18,7 @@ import type { IInbandEvent } from "../core/types.ts";
 import type { IManifest, ISegment } from "../manifest/index.ts";
 import type { IThumbnailTrackMetadata } from "../manifest/types.ts";
 import type { ICdnMetadata } from "../parsers/manifest/index.ts";
+import type { ISteeringManifest } from "../parsers/SteeringManifest/index.ts";
 import type {
   ITrackType,
   ILoadedManifestFormat,
@@ -64,6 +65,20 @@ export interface ITransportPipelines {
   text: ISegmentPipeline<ILoadedTextSegmentFormat, ITextTrackSegmentData | null>;
   /** Functions allowing to load image thumbnails. */
   thumbnails: IThumbnailPipeline;
+  /**
+   * Functions allowing to load and parse a Content Steering Manifest for this
+   * transport.
+   *
+   * A Content Steering Manifest is an external document allowing to obtain the
+   * current priority between multiple available CDN. A Content Steering
+   * Manifest also may or may not be available depending on the content. You
+   * might know its availability by parsing the content's Manifest or any other
+   * resource.
+   *
+   * `null` if the notion of a Content Steering Manifest does not exist for this
+   * transport or if it does but it isn't handled right now.
+   */
+  steeringManifest: ITransportSteeringManifestPipeline | null;
 }
 
 /** Name describing the transport pipeline. */
@@ -188,6 +203,71 @@ export interface IManifestLoaderOptions {
    * the request.
    */
   cmcdPayload: ICmcdPayload | undefined;
+}
+
+/**
+ * Functions allowing to load and parse a potential Content Steering Manifest,
+ * which gives an order of preferred CDN to serve the content.
+ */
+export interface ITransportSteeringManifestPipeline {
+  /**
+   * "Loader" of the Steering Manifest pipeline, allowing to request a Steering
+   * Manifest so it can later be parsed by the `parseSteeringManifest` function.
+   *
+   * @param {string} url - URL of the Steering Manifest we want to load.
+   * @param {CancellationSignal} cancellationSignal - Signal which will allow to
+   * cancel the loading operation if the Steering Manifest is not needed anymore
+   * (for example, if the content has just been stopped).
+   * When cancelled, the promise returned by this function will reject with a
+   * `CancellationError`.
+   * @returns {Promise.<Object>} - Promise emitting the loaded Steering
+   * Manifest, that then can be parsed through the `parseSteeringManifest`
+   * function.
+   *
+   * Rejects in two cases:
+   *   - The loading operation has been cancelled through the `cancelSignal`
+   *     given in argument.
+   *     In that case, this Promise will reject with a `CancellationError`.
+   *   - The loading operation failed, most likely due to a request error.
+   *     In that case, this Promise will reject with the corresponding Error.
+   */
+  loadSteeringManifest: (
+    url: string,
+    cancelSignal: CancellationSignal,
+  ) => Promise<IRequestedData<string | Partial<Record<string, unknown>>>>;
+
+  /**
+   * "Parser" of the Steering Manifest pipeline, allowing to parse a loaded
+   * Steering Manifest so it can be exploited by the rest of the RxPlayer's
+   * logic.
+   *
+   * @param {Object} data - Response obtained from the `loadSteeringManifest`
+   * function.
+   * @param {Function} onWarnings - Callbacks called when minor Steering
+   * Manifest parsing errors are found.
+   * @param {CancellationSignal} cancelSignal - Cancellation signal which will
+   * allow to abort the parsing operation if you do not want the Steering
+   * Manifest anymore.
+   *
+   * That cancellationSignal can be triggered at any time, such as:
+   *   - after a warning is received
+   *   - while a request scheduled through the `scheduleRequest` argument is
+   *     pending.
+   *
+   * `parseSteeringManifest` will interrupt all operations if the signal has
+   * been triggered in one of those scenarios, and will automatically reject
+   * with the corresponding `CancellationError` instance.
+   * @returns {Object | Promise.<Object>} - Returns the Steering Manifest data.
+   * Throws if a fatal error happens while doing so.
+   *
+   * If this error is due to a cancellation (indicated through the
+   * `cancelSignal` argument), then the rejected error should be the
+   * corresponding `CancellationError` instance.
+   */
+  parseSteeringManifest: (
+    data: IRequestedData<unknown>,
+    onWarnings: (warnings: Error[]) => void,
+  ) => ISteeringManifest;
 }
 
 /** Functions allowing to load and parse segments of any type. */
@@ -424,6 +504,13 @@ export interface IManifestParserResult {
    * retrieve the whole data.
    */
   url?: string | undefined;
+}
+
+export interface IDASHContentSteeringManifest {
+  VERSION: number; // REQUIRED, must be an integer
+  TTL?: number; // REQUIRED, number of seconds
+  ["RELOAD-URI"]?: string; // OPTIONAL, URI
+  ["SERVICE-LOCATION-PRIORITY"]: string[]; // REQUIRED, array of ServiceLocation
 }
 
 /**

--- a/tests/unit/mocks/manifest.ts
+++ b/tests/unit/mocks/manifest.ts
@@ -61,6 +61,7 @@ export const DummyManifest = makeMockedClass<Manifest>(
     availabilityStartTime: undefined,
     publishTime: undefined,
     clockOffset: undefined,
+    contentSteering: null,
     timeBounds: {
       minimumSafePosition: undefined,
       timeshiftDepth: null,

--- a/tests/unit/src/core/fetchers/cdn_prioritizer.test.ts
+++ b/tests/unit/src/core/fetchers/cdn_prioritizer.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import CdnPrioritizer from "../../../../../src/core/fetchers/cdn_prioritizer.ts";
+import type { ITransportPipelines } from "../../../../../src/transports/types.ts";
+import { DummyManifest } from "../../../mocks/manifest.ts";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
@@ -28,6 +30,10 @@ vi.mock("../../../../../src/utils/event_emitter", () => {
   return { default: MockEventEmitter };
 });
 
+const dummyManifest = new DummyManifest();
+// Patch it so it doesn't throw
+vi.spyOn(dummyManifest, "addEventListener").mockImplementation(vi.fn());
+
 function makeCancellationSignal(): any {
   let _cb: (() => void) | null = null;
   return {
@@ -49,36 +55,64 @@ describe("CdnPrioritizer", () => {
     vi.useRealTimers();
   });
 
+  const transportPipeline: ITransportPipelines = {
+    transportName: "dash",
+    manifest: {
+      loadManifest: vi.fn(),
+      parseManifest: vi.fn(),
+    },
+    video: {
+      loadSegment: vi.fn(),
+      parseSegment: vi.fn(),
+    },
+    audio: {
+      loadSegment: vi.fn(),
+      parseSegment: vi.fn(),
+    },
+    text: {
+      loadSegment: vi.fn(),
+      parseSegment: vi.fn(),
+    },
+    thumbnails: {
+      loadThumbnail: vi.fn(),
+      parseThumbnail: vi.fn(),
+    },
+    steeringManifest: {
+      loadSteeringManifest: vi.fn(),
+      parseSteeringManifest: vi.fn(),
+    },
+  };
+
   it("returns single CDN as-is without prioritization", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdns = [{ id: "cdn1", baseUrl: "https://cdn1.example.com" }];
-    expect(prioritizer.getCdnPreferenceForResource(cdns)).toEqual(cdns);
+    expect(prioritizer.getCdnPreferenceForResource(cdns).syncValue).toEqual(cdns);
   });
 
   it("returns multiple CDNs in original order when none are downgraded", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdns = [
       { id: "cdn1", baseUrl: "https://cdn1.example.com" },
       { id: "cdn2", baseUrl: "https://cdn2.example.com" },
     ];
-    expect(prioritizer.getCdnPreferenceForResource(cdns)).toEqual(cdns);
+    expect(prioritizer.getCdnPreferenceForResource(cdns).syncValue).toEqual(cdns);
   });
 
   it("puts downgraded CDN last", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn1 = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     const cdn2 = { id: "cdn2", baseUrl: "https://cdn2.example.com" };
     prioritizer.downgradeCdn(cdn1);
     const result = prioritizer.getCdnPreferenceForResource([cdn1, cdn2]);
-    expect(result).toEqual([cdn2, cdn1]);
+    expect(result.syncValue).toEqual([cdn2, cdn1]);
   });
 
   it("triggers priorityChange when downgrading a CDN", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     prioritizer.downgradeCdn(cdn);
     expect((prioritizer as any).trigger).toHaveBeenCalledWith("priorityChange", null);
@@ -87,7 +121,7 @@ describe("CdnPrioritizer", () => {
   it("triggers priorityChange when downgrade expires", () => {
     mockGetCurrent.mockReturnValue({ DEFAULT_CDN_DOWNGRADE_TIME: 5000 });
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     prioritizer.downgradeCdn(cdn);
     const triggerMock = (prioritizer as any).trigger;
@@ -99,19 +133,19 @@ describe("CdnPrioritizer", () => {
   it("CDN is no longer downgraded after timeout expires", () => {
     mockGetCurrent.mockReturnValue({ DEFAULT_CDN_DOWNGRADE_TIME: 5000 });
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn1 = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     const cdn2 = { id: "cdn2", baseUrl: "https://cdn2.example.com" };
     prioritizer.downgradeCdn(cdn1);
     vi.advanceTimersByTime(5000);
     const result = prioritizer.getCdnPreferenceForResource([cdn1, cdn2]);
-    expect(result[0]).toEqual(cdn1);
+    expect(result.syncValue?.[0]).toEqual(cdn1);
   });
 
   it("re-downgrading a CDN resets its downgrade timer", () => {
     mockGetCurrent.mockReturnValue({ DEFAULT_CDN_DOWNGRADE_TIME: 5000 });
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn1 = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     const cdn2 = { id: "cdn2", baseUrl: "https://cdn2.example.com" };
 
@@ -120,22 +154,22 @@ describe("CdnPrioritizer", () => {
     prioritizer.downgradeCdn(cdn1); // reset
     vi.advanceTimersByTime(3000); // only 3s since reset, should still be downgraded
     const result = prioritizer.getCdnPreferenceForResource([cdn1, cdn2]);
-    expect(result[0]).toEqual(cdn2);
+    expect(result.syncValue?.[0]).toEqual(cdn2);
   });
 
   it("matches CDN by baseUrl when id is undefined", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn1 = { baseUrl: "https://cdn1.example.com" } as any;
     const cdn2 = { baseUrl: "https://cdn2.example.com" } as any;
     prioritizer.downgradeCdn(cdn1);
     const result = prioritizer.getCdnPreferenceForResource([cdn1, cdn2]);
-    expect(result).toEqual([cdn2, cdn1]);
+    expect(result.syncValue).toEqual([cdn2, cdn1]);
   });
 
   it("clears timeouts and resets on destroy signal", () => {
     const { signal, cancel } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     prioritizer.downgradeCdn(cdn);
     cancel();
@@ -146,21 +180,21 @@ describe("CdnPrioritizer", () => {
 
   it("returns empty array when given empty array", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
-    expect(prioritizer.getCdnPreferenceForResource([])).toEqual([]);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
+    expect(prioritizer.getCdnPreferenceForResource([]).syncValue).toEqual([]);
   });
 
   it("handles multiple downgraded CDNs correctly", () => {
     const { signal } = makeCancellationSignal();
-    const prioritizer = new CdnPrioritizer(signal);
+    const prioritizer = new CdnPrioritizer(dummyManifest, transportPipeline, signal);
     const cdn1 = { id: "cdn1", baseUrl: "https://cdn1.example.com" };
     const cdn2 = { id: "cdn2", baseUrl: "https://cdn2.example.com" };
     const cdn3 = { id: "cdn3", baseUrl: "https://cdn3.example.com" };
     prioritizer.downgradeCdn(cdn1);
     prioritizer.downgradeCdn(cdn2);
     const result = prioritizer.getCdnPreferenceForResource([cdn1, cdn2, cdn3]);
-    expect(result[0]).toEqual(cdn3);
-    expect(result).toContain(cdn1);
-    expect(result).toContain(cdn2);
+    expect(result.syncValue?.[0]).toEqual(cdn3);
+    expect(result.syncValue).toContain(cdn1);
+    expect(result.syncValue).toContain(cdn2);
   });
 });

--- a/tests/unit/src/manifest/classes/manifest.test.ts
+++ b/tests/unit/src/manifest/classes/manifest.test.ts
@@ -107,6 +107,7 @@ describe("Manifest - Manifest", () => {
         },
       },
       periods: [],
+      contentSteering: null,
     };
 
     const manifest = new Manifest(simpleFakeManifest, {});
@@ -149,6 +150,7 @@ describe("Manifest - Manifest", () => {
         },
       },
       periods: [period1, period2],
+      contentSteering: null,
     };
 
     mocks.fakePeriod.mockImplementation(function (period: IPeriod) {
@@ -200,6 +202,7 @@ describe("Manifest - Manifest", () => {
         },
       },
       periods: [period1, period2],
+      contentSteering: null,
     };
 
     const representationFilter = function () {
@@ -254,6 +257,7 @@ describe("Manifest - Manifest", () => {
         },
       },
       periods: [period1, period2],
+      contentSteering: null,
     };
 
     mocks.fakePeriod.mockImplementation(function (period: IParsedPeriod): IPeriod {
@@ -310,6 +314,7 @@ describe("Manifest - Manifest", () => {
       },
       suggestedPresentationDelay: 99,
       uris: ["url1", "url2"],
+      contentSteering: null,
     };
 
     mocks.fakePeriod.mockImplementation(function (period: IParsedPeriod): IPeriod {
@@ -378,6 +383,7 @@ describe("Manifest - Manifest", () => {
       periods: [oldPeriod1, oldPeriod2],
       suggestedPresentationDelay: 99,
       uris: ["url1", "url2"],
+      contentSteering: null,
     };
 
     const manifest1 = new Manifest(oldManifestArgs1, {});
@@ -408,6 +414,7 @@ describe("Manifest - Manifest", () => {
         },
       },
       uris: [],
+      contentSteering: null,
     };
     const manifest2 = new Manifest(oldManifestArgs2, {});
     expect(manifest2.getUrls()).toEqual([]);
@@ -447,6 +454,7 @@ describe("Manifest - Manifest", () => {
       },
       suggestedPresentationDelay: 99,
       uris: ["url1", "url2"],
+      contentSteering: null,
     };
 
     const manifest = new Manifest(oldManifestArgs, {});

--- a/tests/unit/src/parsers/manifest/dash/common/get_http_utc-timing_url.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/common/get_http_utc-timing_url.test.ts
@@ -15,6 +15,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
         Period: [],
         UTCTiming: [],
         ContentProtection: [],
+        ContentSteering: [],
       },
       attributes: {},
     };
@@ -42,6 +43,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
           },
         ],
         ContentProtection: [],
+        ContentSteering: [],
       },
       attributes: {},
     };
@@ -73,6 +75,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
             },
           },
         ],
+        ContentSteering: [],
       },
       attributes: {},
     };
@@ -94,6 +97,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
             },
           },
         ],
+        ContentSteering: [],
       },
       attributes: {},
     };
@@ -127,6 +131,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
             },
           },
         ],
+        ContentSteering: [],
       },
       attributes: {},
     };
@@ -172,6 +177,7 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
             },
           },
         ],
+        ContentSteering: [],
       },
       attributes: {},
     };

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.test.ts
@@ -1102,7 +1102,7 @@ describe("DASH Node Parsers - AdaptationSet", () => {
         attributes: {},
         children: {
           Accessibility: [],
-          BaseURL: [{ value: "a" }],
+          BaseURL: [{ value: "a", attributes: { serviceLocation: "foo" } }],
           ContentComponent: [],
           ContentProtection: [],
           EssentialProperty: [],
@@ -1127,7 +1127,7 @@ describe("DASH Node Parsers - AdaptationSet", () => {
         attributes: {},
         children: {
           Accessibility: [],
-          BaseURL: [{ value: "foo bar" }],
+          BaseURL: [{ value: "foo bar", attributes: { serviceLocation: "4" } }],
           Representation: [],
           ContentComponent: [],
           ContentProtection: [],
@@ -1154,7 +1154,10 @@ describe("DASH Node Parsers - AdaptationSet", () => {
         attributes: {},
         children: {
           Accessibility: [],
-          BaseURL: [{ value: "a" }, { value: "b" }],
+          BaseURL: [
+            { value: "a", attributes: { serviceLocation: "" } },
+            { value: "b", attributes: { serviceLocation: "http://test.com" } },
+          ],
           Representation: [],
           ContentComponent: [],
           ContentProtection: [],


### PR DESCRIPTION
__Status: It should work with the current draft of the Content Steering specification for DASH contents. There are still some missing features (proxy handling, bandwidth reporting...) but the main chunk of the logic should already be there.__

## Preliminary notes

### What is Content Steering?

Content Steering is a mechanism allowing to prioritize CDN over others from the server-side for a given content, allowing thus to deterministically reorient requests done by several player instances.
One of the use case would be to adaptively redistribute load between multiple CDN as playback is still going on in the users' device, though they are several other use cases that can rely on this mechanism.

This mechanism is standardized and is a associated with the streaming protocol chosen: [HLS now includes a chapter and attributes on it](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-7) and the DASH-IF is currently drafting another for DASH based on the HLS specification (though slightly different), [here](https://dashif.org/docs/DASH-IF-CTS-00XX-Content-Steering-Community-Review.pdf).
It is the latter that this PR is trying to implement.

The DASH' Content Steering mechanism work by declaring the presence of "DASH Content Steering Manifest", or "DCSM", requestable through an URL which returns a JSON giving the current priorities.

This DCSM has its own "TTL" (time to live) which is the time in seconds after which it should be refreshed.

## Implementation

The implementation was unexpectedly pretty complex. I will start describing on a higher level before going down in the details.

### Macro-architecture

The idea was to add a `CdnPrioritizer` class in the `fetchers`' code, whose role would be to put in order the CDN that should be requested for each segment.
That `CdnPrioritizer` would also handle the refreshing logic of DASH's Content Steering Manifest, through a new fetcher element: the `SteeringManifestFetcher`.

Here is  how the different blocks depend on one another:
```
               /parsers/SteeringManifest
      +----------------------------------+
      | Content Steering Manifest parser | Parse DCSM[1] into a
      +----------------------------------+ transport-agnostic steering
              ^                            Manifest structure
              |
              | Uses when parsing
              |
              |
              | /transports
      +---------------------------+
      |        Transport          |
      |                           |
      | new functions:            |
      |   - loadSteeringManifest  | Construct DCSM[1]'s URL, performs
      |   - parseSteeringManifest | requests and parses it.
      +---------------------------+
              ^
              |
              | Relies on
              |
              |
              | /core/fetchers/steering_manifest
      +-------------------------+
      | SteeringManifestFetcher | Fetches and parses a Content Steering
      +-------------------------+ Manifest in a transport-agnostic way
              ^                   + handle retries and error formatting
              |
              | Uses an instance of to load, parse and refresh the
              | Steering Manifest periodically according to its TTL[2]
              |
              |
              | /core/fetchers/cdn_prioritizer.ts
      +----------------+ Signals the priority between multiple
      | CdnPrioritizer | potential CDNs for each resource.
      +----------------+ (This is done on demand, the `CdnPrioritizer`
             ^           knows of no resource in advance).
             |
             | Asks to sort a segment's available base urls by order of
             | priority (and to filter out those that should not be
             | used).
             | Also signals when it should prevent a base url from
             | being used temporarily (e.g. due to request issues).
             |
             |
             | /core/fetchers/segment
      +----------------+
      | SegmentFetcher | Fetches and parses a segment in a
      +----------------+ transport-agnostic way
             ^           + handle retries and error formatting
             |
             | Ask to load segment(s)
             |
             | /core/stream/representation
      +----------------+
      | Representation | Logic behind finding the right segment to
      |    Stream      | load, loading it and pushing it to the buffer.
      +----------------+ One RepresentationStream is created per
                         actively-loaded Period and one per
                         actively-loaded buffer type.


[1] DCSM: DASH Content Steering Manifest
[2] TTL: Time To Live: a delay after which a Content Steering Manifest should be refreshed
```
## CDN identification

Different ways to access a content, what  is called "ServiceLocations" in DASH' content steering spec (but what we abusively called the available "CDN" in the current implementation), need here to be clearly identified, to allow easy re-prioritization.

However in the old RxPlayer code, those ServiceLocations were not clearly identified and grouped:
Instead each segment was associated directly to one or several absolute URL, with no relation created between segments. For example, detecting whether 2 segments shared a common ServiceLocation/base URL was difficult to do without resorting to substring comparison.
This caused implementation difficulties when it comes to prioritization-handling and "downgrading" (our terms for when a specific ServiceLocation is avoided for some time due to an observed issue with it).

The proposed implementation now only associates a _relative_ URL to each segment, corresponding to the segment's unique filename. The part common between all segments from a given `Representation` (the "ServiceLocations") are moved at the `Representation`-level instead, through a property called `cdnMetadata`.
As a special case, the segment's relative URL could be set to `null` or to the empty string when the `Representation`'s URL(s) found in `cdnMetadata` was sufficient to load the data.

This only works if all ServiceLocations follow a logic of concatenation between a base URL per-ServiceLocation and a segment's common relative URL. Thankfully, it appears for now to always be the case in transport protocols where multiple ServiceLocations for a given resource is possible.

We also could have moved a property doing ServiceLocation-identification on each segment;s URL and keep them absolute, but it seemed less practical while I was writing it

The `cdnMetadata` property present on `Representation`s takes the form of an array of all detected ServiceLocations. Each elements of this array contains information on a single available ServiceLocation:
  - its base URL
  - an optional `id`, used for identification purposes, for example when compared with the output of a Content Steering Manifest. 
This is based on the value of the `serviceLocation` `<BaseURL>` attribute found in the MPD

### Handling of the `queryBeforeStart` attribute

The MPD may indicate that the Content Steering Manifest should either be requested before any segment or may be loaded later, so the stream can begin playback more shortly.

This is done through an MPD attribute on the `<ContentSteering>` element, called `queryBeforeStart`.
Handling this attribute has been somewhat of a pain, because its before-or-not nature under the current RxPlayer architecture would mean that it could not always be cleanly and opaquely done in the Manifest-parsing logic.
If the request needed to be performed after (or parallely to when) segments are first loaded, we had to involve some other core logic in this process of starting and handling this request.
I finally decided to only handle this initial fetch in one place (through the `fetchers`' `CdnPrioritizer`) and not repeat it in the Manifest-parsing code, for simplicity's sake.

Though I now observed a new problem: we had to communicate in some ways when the segments can actually be loaded:
  - directly if no Content Steering Manifest exists or if `queryBeforeStart` is not set or set to `false`
  - after the Content Steering Manifest has been fetched if the `queryBeforeStart` attribute is set to `true`

This could easily be done through a new event, but I disliked the opt-in nature of adding an event listener for this, as forgetting it was very simple to do and would be considered a big-enough bug.

What I preferred to do is to make the `CdnPrioritizer`'s callback used to prioritize ServiceLocations between one another asynchronous: if the Content Steering Manifest was fetched or if `queryBeforeStart` was not set / set to `false`, it would return directly. But if both `queryBeforeStart` was set to true and the Content Steering Manifest was not yet fetched, it would await that request to finish, before giving an educated answer.

I prefer that solution because it opaquely forced the right "queryBeforeStart" implementation when a `CdnPrioritizer` is used to order ServiceLocations - this is even nicer when considering that the `CdnPrioritizer` also is the class fetching and refreshing the Content Steering Manifest, meaning that forgetting to use it would also mean not relying on a Content Steering Manifest anyway.

This also means that no outside block need to understand this intricacy: only the `CdnPrioritizer` does, which is also one of the [very rare] blocks implementing most of the Content Steering mechanisms. 

### Handling of the refreshing logic

The refreshing logic of the Content Steering Manifest is also performed by the `CdnPrioritizer`.
The implementation is somewhat simple: after the previous Steering Manifest's TTL (in seconds), we refresh it.

There is additional logic for if a `<ContentSteering>` appears or disappear after a MPD update. But what to do in those case appeared relatively straightforward.

In huge parts because of this refreshing logic, I also had to implement a system of events on the `CdnPrioritizer` for the following events:

  - a Content Steering Manifest request/parsing operation error arised, so it can be translated into a player event through our API. This is communicated through a "warnings" event

  - More importantly, a `priorityChange` event has been added, for when the order of priorities between ServiceLocations changed. 
    This was added to work-around a subtle but complex-enough situation where the priority between ServiceLocations changed while the player is waiting to retry requesting a segment through another now non-prioritized ServiceLocations.
    More details on the next chapter.

### Request scheduling modifications

Another specificity to take into account was how the Content Steering mechanism interacts with our request scheduling logic, especially with what we call the "exponential backoff".

This concept designates the notion that we might want to wait a delay before re-attempting a request that previously failed on a server, progressively raising that delay after each consecutive unsuccessful attempt to avoid overwhelming the server.

When considering multiple server for each resource and - even more complex - when considering that the priority between those can change while a delay is awaited, properly handling this exponential backoff mechanism became a little more complex.

What I ended-up to do was to register  in an object a per-CDN (monotonically raising) timestamp at which the last request was done for a particular resource, alongside the amount of attempts already done on that same CDN.
This way, exponential backoff could be applied per-CDN and even be interrupted and restarted at any time if the priority between CDN changed in the meantime. This change of priority is known of when the `CdnPrioritizer` sends the `priorityChange` event.

Moreover, CDN on which the request fails are temporarily "downgraded" - meaning moved at the end of the priority list - for a period of time equal to the Steering Manifest's TTL (as it is specified in the DASH's Content Steering spec) - or for 60 seconds if no such TTL exists.
This also automatically allows to nicely test the second most prioritary CDN when a request through the first one fails, and still allows to loop over once all CDNs are downgraded.