### PR TITLE
 Avoid staying in LOADING/BUFFERING/SEEKING state in directfile when nothing is buffered

### DIFF
--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -264,7 +264,9 @@ export default class PlaybackObserver {
         startedInternalSeekTime = this._internalSeeksIncoming.shift();
       }
       const _lastObservation = lastObservation ?? this._generateInitialObservation();
-      const mediaTimings = getMediaInfos(this._mediaElement, tmpEvt);
+      const mediaTimings = getMediaInfos(this._mediaElement,
+                                         tmpEvt,
+                                         this._withMediaSource);
       let pendingInternalSeek : number | null = null;
       if (mediaTimings.seeking) {
         if (typeof startedInternalSeekTime === "number") {
@@ -350,7 +352,9 @@ export default class PlaybackObserver {
   }
 
   private _generateInitialObservation() : IPlaybackObservation {
-    return objectAssign(getMediaInfos(this._mediaElement, "init"),
+    return objectAssign(getMediaInfos(this._mediaElement,
+                                      "init",
+                                      this._withMediaSource),
                         { rebuffering: null,
                           freezing: null,
                           pendingInternalSeek: null });
@@ -388,14 +392,23 @@ export type IPlaybackObserverEventType =
 
 /** Information recuperated on the media element on each playback observation. */
 interface IMediaInfos {
-  /** Gap between `currentTime` and the next position with un-buffered data. */
-  bufferGap : number;
+  /**
+   * Gap between `currentTime` and the next position with un-buffered data.
+   * `Infinity` if we don't have buffered data right now.
+   * `undefined` if we cannot determine the buffer gap.
+   */
+  bufferGap : number | undefined;
   /** Value of `buffered` (buffered ranges) for the media element. */
   buffered : TimeRanges;
-  /** The buffered range we are currently playing. */
+  /**
+   * The buffered range we are currently playing.
+   * `null` if no range is currently available.
+   * `undefined` if we cannot tell which range is currently available.
+   */
   currentRange : { start : number;
                    end : number; } |
-                 null;
+                 null |
+                 undefined;
   /**
    * `currentTime` (position) set on the media element at the time of the
    * PlaybackObserver's measure.
@@ -435,8 +448,9 @@ export interface IRebufferingStatus {
   /**
    * Position, in seconds, at which data is awaited.
    * If `null` the player is rebuffering but not because it is awaiting future data.
+   * If `undefined`, that position is unknown.
    */
-  position : number | null;
+  position : number | null | undefined;
 }
 
 /**
@@ -585,13 +599,18 @@ function getRebufferingEndGap(
  * @returns {Boolean}
  */
 function hasLoadedUntilTheEnd(
-  currentRange : { start : number; end : number }|null,
+  currentTime : number,
+  currentRange : { start : number; end : number } | null | undefined,
+  ended : boolean,
   duration : number,
   lowLatencyMode : boolean
 ) : boolean {
   const { REBUFFERING_GAP } = config.getCurrent();
   const suffix : "LOW_LATENCY" | "DEFAULT" = lowLatencyMode ? "LOW_LATENCY" :
                                                               "DEFAULT";
+  if (currentRange === undefined) {
+    return ended && Math.abs(duration - currentTime) <= REBUFFERING_GAP[suffix];
+  }
   return currentRange !== null &&
          (duration - currentRange.end) <= REBUFFERING_GAP[suffix];
 }
@@ -604,7 +623,8 @@ function hasLoadedUntilTheEnd(
  */
 function getMediaInfos(
   mediaElement : HTMLMediaElement,
-  event : IPlaybackObserverEventType
+  event : IPlaybackObserverEventType,
+  withMediaSource : boolean
 ) : IMediaInfos {
   const { buffered,
           currentTime,
@@ -615,11 +635,23 @@ function getMediaInfos(
           readyState,
           seeking } = mediaElement;
 
-  const currentRange = getRange(buffered, currentTime);
-  return { bufferGap: currentRange !== null ? currentRange.end - currentTime :
-                                              // TODO null/0 would probably be
-                                              // more appropriate
-                                              Infinity,
+  let currentRange;
+  let bufferGap;
+  if (!withMediaSource && buffered.length === 0 && readyState >= 3) {
+    // Sometimes `buffered` stay empty for directfile contents yet we are able
+    // to play. This seems to be linked to browser-side issues but has been
+    // encountered on enough platforms (Chrome desktop and PlayStation 4's
+    // WebKit for us to do something about it in the player.
+    currentRange = undefined;
+    bufferGap = undefined;
+  } else {
+    currentRange = getRange(buffered, currentTime);
+    bufferGap = currentRange !== null ? currentRange.end - currentTime :
+                                        // TODO null/0 would probably be
+                                        // more appropriate
+                                        Infinity;
+  }
+  return { bufferGap,
            buffered,
            currentRange,
            position: currentTime,
@@ -652,7 +684,6 @@ function getRebufferingStatus(
 
   const { REBUFFERING_GAP } = config.getCurrent();
   const { event: currentEvt,
-          buffered,
           position: currentTime,
           bufferGap,
           currentRange,
@@ -665,14 +696,18 @@ function getRebufferingStatus(
           event: prevEvt,
           position: prevTime } = prevObservation;
 
-  const fullyLoaded = hasLoadedUntilTheEnd(currentRange, duration, lowLatencyMode);
+  const fullyLoaded = hasLoadedUntilTheEnd(currentTime,
+                                           currentRange,
+                                           ended,
+                                           duration,
+                                           lowLatencyMode);
 
   const canSwitchToRebuffering = (readyState >= 1 &&
                                   currentEvt !== "loadedmetadata" &&
                                   prevRebuffering === null &&
                                   !(fullyLoaded || ended));
 
-  let rebufferEndPosition : number | null = null;
+  let rebufferEndPosition : number | null | undefined = null;
   let shouldRebuffer : boolean | undefined;
   let shouldStopRebuffer : boolean | undefined;
 
@@ -681,22 +716,32 @@ function getRebufferingStatus(
 
   if (withMediaSource) {
     if (canSwitchToRebuffering) {
-      if (bufferGap <= rebufferGap) {
-        shouldRebuffer = true;
-        rebufferEndPosition = currentTime + bufferGap;
-      } else if (bufferGap === Infinity) {
+      if (bufferGap === Infinity) {
         shouldRebuffer = true;
         rebufferEndPosition = currentTime;
+      } else if (bufferGap === undefined) {
+        if (readyState < 3) {
+          shouldRebuffer = true;
+          rebufferEndPosition = undefined;
+        }
+      } else if (bufferGap <= rebufferGap) {
+        shouldRebuffer = true;
+        rebufferEndPosition = currentTime + bufferGap;
       }
     } else if (prevRebuffering !== null) {
       const resumeGap = getRebufferingEndGap(prevRebuffering, lowLatencyMode);
       if (shouldRebuffer !== true && prevRebuffering !== null && readyState > 1 &&
-          (fullyLoaded || ended || (bufferGap < Infinity && bufferGap > resumeGap)))
+          (fullyLoaded || ended ||
+            (bufferGap !== undefined && isFinite(bufferGap) && bufferGap > resumeGap)) ||
+            (bufferGap === undefined && readyState >= 3))
       {
         shouldStopRebuffer = true;
-      } else if (bufferGap === Infinity || bufferGap <= resumeGap) {
-        rebufferEndPosition = bufferGap === Infinity ? currentTime :
-                                                       currentTime + bufferGap;
+      } else if (bufferGap === undefined) {
+        rebufferEndPosition = undefined;
+      } else if (bufferGap === Infinity) {
+        rebufferEndPosition = currentTime;
+      } else if (bufferGap <= resumeGap) {
+        rebufferEndPosition = currentTime + bufferGap;
       }
     }
   }
@@ -714,10 +759,7 @@ function getRebufferingStatus(
           ) ||
           (
             currentEvt === "seeking" && (
-              // Sometimes `buffered` stay empty for directfile contents but are
-              // able to play. In those case, we don't buffer if readyState is
-              // at 3 or 4.
-              bufferGap === Infinity && (buffered.length > 0 || readyState < 3)
+              bufferGap === Infinity || (bufferGap === undefined && readyState < 3)
             )
           )
         )
@@ -728,12 +770,9 @@ function getRebufferingStatus(
       (
         (currentEvt !== "seeking" && currentTime !== prevTime) ||
         currentEvt === "canplay" ||
-        // Sometimes `buffered` stay empty for directfile contents but are
-        // able to play. In those case, we don't buffer if readyState is
-        // at 3 or 4.
-        (buffered.length === 0 && readyState >= 3) ||
+        (bufferGap === undefined && readyState >= 3) ||
         (
-          bufferGap < Infinity &&
+          bufferGap !== undefined && bufferGap < Infinity &&
           (
             bufferGap > getRebufferingEndGap(prevRebuffering, lowLatencyMode) ||
             fullyLoaded || ended
@@ -799,6 +838,7 @@ function getFreezingStatus(
   }
 
   return currentInfo.event === "timeupdate" &&
+         currentInfo.bufferGap !== undefined &&
          currentInfo.bufferGap > MINIMUM_BUFFER_AMOUNT_BEFORE_FREEZING &&
          !currentInfo.ended &&
          !currentInfo.paused &&

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2932,9 +2932,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       playbackRate: observation.playbackRate,
       maximumBufferTime: maximumPosition,
 
-      // TODO fix higher up?
-      bufferGap: isFinite(observation.bufferGap) ? observation.bufferGap :
-                                                   0,
+      // TODO bufferGap may be undefined
+      bufferGap: observation.bufferGap === undefined ||
+                 !isFinite(observation.bufferGap) ?
+        0 :
+        observation.bufferGap,
     };
 
     if (manifest !== null &&

--- a/src/core/init/emit_loaded_event.ts
+++ b/src/core/init/emit_loaded_event.ts
@@ -59,15 +59,7 @@ export default function emitLoadedEvent(
                                            null;
       }
 
-      // Seen with multiple versions of Chrome and WebKit: sometimes, for
-      // unknown reasons, directfile contents do not announced ranges of
-      // currently buffered data (`HTMLMediaElement.prototype.buffered`).
-      //
-      // That's why we add an exception to directfile contents.
-      // If the readyState is greater or equal than 3.
-      if (observation.readyState >= 3 &&
-          (observation.currentRange !== null || isDirectfile))
-      {
+      if (observation.readyState >= 3 && observation.currentRange !== null) {
         if (!shouldValidateMetadata() || mediaElement.duration > 0) {
           return EVENTS.loaded(segmentBuffersStore);
         }

--- a/src/core/init/emit_loaded_event.ts
+++ b/src/core/init/emit_loaded_event.ts
@@ -59,7 +59,15 @@ export default function emitLoadedEvent(
                                            null;
       }
 
-      if (observation.readyState >= 3 && observation.currentRange !== null) {
+      // Seen with multiple versions of Chrome and WebKit: sometimes, for
+      // unknown reasons, directfile contents do not announced ranges of
+      // currently buffered data (`HTMLMediaElement.prototype.buffered`).
+      //
+      // That's why we add an exception to directfile contents.
+      // If the readyState is greater or equal than 3.
+      if (observation.readyState >= 3 &&
+          (observation.currentRange !== null || isDirectfile))
+      {
         if (!shouldValidateMetadata() || mediaElement.duration > 0) {
           return EVENTS.loaded(segmentBuffersStore);
         }

--- a/src/core/init/stall_avoider.ts
+++ b/src/core/init/stall_avoider.ts
@@ -314,7 +314,10 @@ export default function StallAvoider(
       /** Position at which data is awaited. */
       const { position: stalledPosition } = rebuffering;
 
-      if (stalledPosition !== null && speed.getValue() > 0) {
+      if (stalledPosition !== null &&
+          stalledPosition !== undefined &&
+          speed.getValue() > 0)
+      {
         const skippableDiscontinuity = findSeekableDiscontinuity(discontinuitiesStore,
                                                                  manifest,
                                                                  stalledPosition);


### PR DESCRIPTION
This commit fixes an issue we encountered sometimes with rare directfile
contents, especially on recent Chrome versions and also on the PlayStation
4's WebKit-based one where the RxPlayer would stay in the `LOADING` state
after loading a directfile content, despite the fact that the player is
actively playing the content.

This issue is due to the fact that when playing some directfile
contents, the `buffered` property of the video/audio element stay empty
even when data is obviously buffered as playback is going on.

The RxPlayer then uses that `buffered` property to check if enough data
is buffered to begin playback or go into a `BUFFERING` phase. When
empty, The RxPlayer considers that no data is buffered and that it
should wait until data around the wanted position is before
(re-)starting playback.

After re-checking the WHATWG spec, this browser behavior is not normal
but as we've seen, is actually frequent enough to have been seen in two
separate occasions on two different platforms (chrome desktop and
PlayStation 4).

I chose to provide a work-around for directfile contents by specifically
consider that an empty `buffered` and a `HTMLMediaElement`'s
`readyState` property set to 3 or more, for directfile contents only,
is roughly equivalent to having buffered data for the current time range.

This is done implicitly by authorizing some of the `PlaybackObserver`'s
emitted data (like `currentRange` and `bufferGap`) to be set to `undefined`
only in those conditions and to add supplementary resilience logic in that
case.

Because a `readyState` superior to 2 (or even equal to 2?) should in
principle not occur when `buffered` has a `0` length, this may have
no bad effect, though as we've seen, the specification does't really
translate what actually can be seen on a browser, so we never really
know.