### PR TITLE
Re-create MediaKeys at each loadVideo on WebOS

### DIFF
--- a/src/compat/__tests__/can_reuse_media_keys.test.ts
+++ b/src/compat/__tests__/can_reuse_media_keys.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+describe("Compat - canReuseMediaKeys", () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it("should return true on any browser but WebOS 2021 and 2022", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isWebOs2021: false,
+               isWebOs2022: false };
+    });
+    const canReuseMediaKeys =
+      jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(true);
+  });
+
+  it("should return false on WebOs 2021", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isWebOs2021: true,
+               isWebOs2022: false };
+    });
+    const canReuseMediaKeys =
+      jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on WebOs 2022", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isWebOs2021: false,
+               isWebOs2022: true };
+    });
+    const canReuseMediaKeys =
+      jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false in the improbable case of both WebOs 2021 and 2022", () => {
+    jest.mock("../browser_detection", () => {
+      return { __esModule: true as const,
+               isWebOs2021: true,
+               isWebOs2022: true };
+    });
+    const canReuseMediaKeys =
+      jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+});

--- a/src/compat/__tests__/should_renew_media_key_system_access.test.ts
+++ b/src/compat/__tests__/should_renew_media_key_system_access.test.ts
@@ -21,7 +21,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-describe("compat - shouldRenewMediaKeys", () => {
+describe("compat - shouldRenewMediaKeySystemAccess", () => {
   beforeEach(() => {
     jest.resetModules();
   });
@@ -33,8 +33,9 @@ describe("compat - shouldRenewMediaKeys", () => {
         isIE11: false,
       };
     });
-    const shouldRenewMediaKeys = jest.requireActual("../should_renew_media_keys");
-    expect(shouldRenewMediaKeys.default()).toBe(false);
+    const shouldRenewMediaKeySystemAccess =
+      jest.requireActual("../should_renew_media_key_system_access");
+    expect(shouldRenewMediaKeySystemAccess.default()).toBe(false);
   });
 
   it("should return true if we are on IE11", () => {
@@ -44,8 +45,9 @@ describe("compat - shouldRenewMediaKeys", () => {
         isIE11: true,
       };
     });
-    const shouldRenewMediaKeys = jest.requireActual("../should_renew_media_keys");
-    expect(shouldRenewMediaKeys.default()).toBe(true);
+    const shouldRenewMediaKeySystemAccess =
+      jest.requireActual("../should_renew_media_key_system_access");
+    expect(shouldRenewMediaKeySystemAccess.default()).toBe(true);
   });
   beforeEach(() => {
     jest.resetModules();

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -50,6 +50,13 @@ const isSamsungBrowser : boolean = !isNode &&
 const isTizen : boolean = !isNode &&
                           /Tizen/.test(navigator.userAgent);
 
+const isWebOs : boolean = !isNode &&
+                          /Web0S/.test(navigator.userAgent);
+const isWebOs2021 : boolean = !isNode &&
+                              /WebOS.TV-2021/.test(navigator.userAgent);
+const isWebOs2022 : boolean = !isNode &&
+                              /WebOS.TV-2022/.test(navigator.userAgent);
+
 interface ISafariWindowObject extends Window {
   safari? : { pushNotification? : { toString() : string } };
 }
@@ -76,4 +83,7 @@ export {
   isSafariMobile,
   isSamsungBrowser,
   isTizen,
+  isWebOs,
+  isWebOs2021,
+  isWebOs2022,
 };

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,0 +1,19 @@
+import {
+  isWebOs2021,
+  isWebOs2022,
+} from "./browser_detection";
+
+/**
+ * Returns `true` if a `MediaKeys` instance (the  `Encrypted Media Extension`
+ * concept) can be reused between contents.
+ *
+ * This should usually be the case but we found rare devices where this would
+ * cause problem:
+ *   - (2022-10-26): WebOS (LG TVs) 2021 and 2022 just rebuffered indefinitely
+ *     when loading a content already-loaded on the HTMLMediaElement.
+ *
+ * @returns {boolean}
+ */
+export default function canReuseMediaKeys() : boolean {
+  return !(isWebOs2021 || isWebOs2022);
+}

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -22,6 +22,7 @@ import {
   MediaSource_,
 } from "./browser_compatibility_types";
 import canPatchISOBMFFSegment from "./can_patch_isobmff";
+import canReuseMediaKeys from "./can_reuse_media_keys";
 import tryToChangeSourceBufferType, {
   ICompatSourceBuffer,
 } from "./change_source_buffer_type";
@@ -58,7 +59,7 @@ import play from "./play";
 import setElementSrc$ from "./set_element_src";
 // eslint-disable-next-line max-len
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "./should_reload_media_source_on_decipherability_update";
-import shouldRenewMediaKeys from "./should_renew_media_keys";
+import shouldRenewMediaKeySystemAccess from "./should_renew_media_key_system_access";
 import shouldUnsetMediaKeys from "./should_unset_media_keys";
 import shouldValidateMetadata from "./should_validate_metadata";
 import shouldWaitForDataBeforeLoaded from "./should_wait_for_data_before_loaded";
@@ -73,6 +74,7 @@ export {
   addClassName,
   addTextTrack,
   canPatchISOBMFFSegment,
+  canReuseMediaKeys,
   clearElementSrc,
   closeSession,
   CustomMediaKeySystemAccess,
@@ -104,7 +106,7 @@ export {
   setElementSrc$,
   setMediaKeys,
   shouldReloadMediaSourceOnDecipherabilityUpdate,
-  shouldRenewMediaKeys,
+  shouldRenewMediaKeySystemAccess,
   shouldUnsetMediaKeys,
   shouldValidateMetadata,
   shouldWaitForDataBeforeLoaded,

--- a/src/compat/should_renew_media_key_system_access.ts
+++ b/src/compat/should_renew_media_key_system_access.ts
@@ -17,10 +17,10 @@
 import { isIE11 } from "./browser_detection";
 
 /**
- * Returns true if the current target require the media keys to be renewed on
- * each content.
+ * Returns true if the current target require the MediaKeySystemAccess to be
+ * renewed on each content.
  * @returns {Boolean}
  */
-export default function shouldRenewMediaKeys() : boolean {
+export default function shouldRenewMediaKeySystemAccess() : boolean {
   return isIE11;
 }

--- a/src/core/decrypt/__tests__/__global__/utils.ts
+++ b/src/core/decrypt/__tests__/__global__/utils.ts
@@ -286,6 +286,8 @@ export function mockCompat(exportedFunctions = {}) {
       setMediaKeys: mockSetMediaKeys,
       getInitData: mockGetInitData,
       generateKeyRequest: mockGenerateKeyRequest,
+      shouldRenewMediaKeySystemAccess: jest.fn(() => false),
+      canReuseMediaKeys: jest.fn(() => true),
       ...exportedFunctions }));
 
   return { mockEvents,

--- a/src/core/decrypt/find_key_system.ts
+++ b/src/core/decrypt/find_key_system.ts
@@ -17,7 +17,7 @@
 import {
   ICustomMediaKeySystemAccess,
   requestMediaKeySystemAccess,
-  shouldRenewMediaKeys,
+  shouldRenewMediaKeySystemAccess,
 } from "../../compat";
 import config from "../../config";
 import { EncryptedMediaError } from "../../errors";
@@ -74,7 +74,7 @@ function checkCachedMediaKeySystemAccess(
   keySystemAccess: MediaKeySystemAccess|ICustomMediaKeySystemAccess;
 } {
   const mksConfiguration = currentKeySystemAccess.getConfiguration();
-  if (shouldRenewMediaKeys() || mksConfiguration == null) {
+  if (shouldRenewMediaKeySystemAccess() || mksConfiguration == null) {
     return null;
   }
 

--- a/src/core/decrypt/get_media_keys.ts
+++ b/src/core/decrypt/get_media_keys.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  canReuseMediaKeys,
   ICustomMediaKeys,
   ICustomMediaKeySystemAccess,
 } from "../../compat";
@@ -95,7 +96,10 @@ export default async function getMediaKeysInfos(
   const currentState = MediaKeysInfosStore.getState(mediaElement);
   const persistentSessionsStore = createPersistentSessionsStorage(options);
 
-  if (currentState !== null && evt.type === "reuse-media-key-system-access") {
+  if (canReuseMediaKeys() &&
+      currentState !== null &&
+      evt.type === "reuse-media-key-system-access")
+  {
     const { mediaKeys, loadedSessionsStore } = currentState;
 
     // We might just rely on the currently attached MediaKeys instance.


### PR DESCRIPTION
We noticed of an issue on WebOS (LG TV) 2021 and 2022 models where loading an already-loaded encrypted content would not succeed: it would load indefinitely.

After investigation, nothing in the JavaScript code seemed to go wrong, licences were loaded, but nothing was playing.

However, we found out that re-creating the `MediaKeys` instance at each zap completely fixed the issue, with the cost of potential longer loading time (not measured yet).

This seems to be an issue linked to LG's software and we will share to them what we found, but we still chose to preemptively do a work-around specifically for WebOS 2021 and 2022 models so it works even know.

If the issue become fixed in the future, we may remove that work-around.

The major part of this commit are added tests on the code handling content decryption, to ensure that a MediaKeys is only re-created in some very specific cases (and keep being re-created in those).