### PR TITLE
Add `updateContentUrls` API

### DIFF
--- a/doc/api/Content_Information/.docConfig.json
+++ b/doc/api/Content_Information/.docConfig.json
@@ -5,6 +5,10 @@
       "displayName": "getUrl"
     },
     {
+      "path": "./updateContentUrls.md",
+      "displayName": "updateContentUrls"
+    },
+    {
       "path": "./isLive.md",
       "displayName": "isLive"
     },

--- a/doc/api/Content_Information/updateContentUrls.md
+++ b/doc/api/Content_Information/updateContentUrls.md
@@ -24,7 +24,7 @@ this method has no effect.
 ```js
 player.updateContentUrls(urls);
 // or
-player.updateContentUrls(urls, refreshNow);
+player.updateContentUrls(urls, params);
 ```
 
   - **arguments**:
@@ -32,8 +32,13 @@ player.updateContentUrls(urls, refreshNow);
      1. _urls_ `Array.<string>|under`: URLs to reach that content / Manifest
      from the most prioritized URL to the least prioritized URL.
 
-     2. _refreshNow_ `boolean`: If `true` the resource in question (e.g.
-     DASH's MPD) will be refreshed immediately.
+     2. _params_ `Object|undefined`: Optional parameters linked to this URL
+     change.
+
+     Can contain the following properties:
+
+       - _refresh_ `boolean`: If `true` the resource in question (e.g.
+         DASH's MPD) will be refreshed immediately.
 
 ## Examples
 
@@ -52,5 +57,5 @@ player.updateContentUrls([
 player.updateContentUrls(undefined);
 
 // Update and ask to refresh immediately
-player.updateContentUrls(["http://my.new.url"], true);
+player.updateContentUrls(["http://my.new.url"], { refresh: true });
 ```

--- a/doc/api/Content_Information/updateContentUrls.md
+++ b/doc/api/Content_Information/updateContentUrls.md
@@ -1,0 +1,56 @@
+# updateContentUrls
+
+## Description
+
+Update URL of the content currently being played (e.g. of DASH's MPD),
+optionally also allowing to request an immediate refresh of it.
+
+This method can for example be called when you would prefer that the content and
+its associated resources to be reached through another URL than what has been
+used until now.
+
+Note that if a request through one of the given URL lead to a HTTP redirect, the
+RxPlayer will generally prefer the redirected URL over the URL explicitely
+communicated (to prevent more HTTP redirect).
+
+<div class="warning">
+In <i>DirectFile</i> mode (see <a
+href="../Loading_a_Content.md#transport">loadVideo options</a>),
+this method has no effect.
+</div>
+
+## Syntax
+
+```js
+player.updateContentUrls(urls);
+// or
+player.updateContentUrls(urls, refreshNow);
+```
+
+  - **arguments**:
+
+     1. _urls_ `Array.<string>|under`: URLs to reach that content / Manifest
+     from the most prioritized URL to the least prioritized URL.
+
+     2. _refreshNow_ `boolean`: If `true` the resource in question (e.g.
+     DASH's MPD) will be refreshed immediately.
+
+## Examples
+
+```js
+// Update with only one URL
+player.updateContentUrls(["http://my.new.url"]);
+
+// Update with multiple URLs
+player.updateContentUrls([
+  "http://more.prioritized.url",
+  "http://less.prioritized.url",
+]);
+
+// Set no URL (only is useful in some very specific situations, like for content
+// with no Manifest refresh or when a `manifestLoader` is set).
+player.updateContentUrls(undefined);
+
+// Update and ask to refresh immediately
+player.updateContentUrls(["http://my.new.url"], true);
+```

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -453,6 +453,9 @@ properties, methods, events and so on.
   - [`getUrl`](../api/Content_Information/getUrl.md):
     Get URL of the currently-played content.
 
+  - [`updateContentUrls`](../api/Content_Information/updateContentUrls.md):
+    Update URL(s) of the content currently being played.
+
   - [`isLive`](../api/Content_Information/isLive.md):
     Returns `true` if the content is a "live" content.
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1134,13 +1134,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * Update URL of the content currently being played (e.g. DASH's MPD).
    * @param {Array.<string>|undefined} urls - URLs to reach that content /
    * Manifest from the most prioritized URL to the least prioritized URL.
-   * @param {boolean} refreshNow - If `true` the resource in question (e.g.
-   * DASH's MPD) will be refreshed immediately.
+   * @param {Object|undefined} [params]
+   * @param {boolean} params.refresh - If `true` the resource in question
+   * (e.g. DASH's MPD) will be refreshed immediately.
    */
-  public updateContentUrls(urls : string[] | undefined, refreshNow : boolean) : void {
+  public updateContentUrls(
+    urls : string[] | undefined,
+    params? : { refresh?: boolean } | undefined
+  ) : void {
     if (this._priv_contentInfos === null) {
       throw new Error("No content loaded");
     }
+    const refreshNow = params?.refresh === true;
     this._priv_contentInfos.initializer.updateContentUrls(urls, refreshNow);
   }
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -777,6 +777,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       contentId: generateContentId(),
       originalUrl: url,
       currentContentCanceller,
+      initializer,
       isDirectFile,
       segmentBuffersStore: null,
       thumbnails: null,
@@ -1127,6 +1128,20 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return manifest.getUrl();
     }
     return undefined;
+  }
+
+  /**
+   * Update URL of the content currently being played (e.g. DASH's MPD).
+   * @param {Array.<string>|undefined} urls - URLs to reach that content /
+   * Manifest from the most prioritized URL to the least prioritized URL.
+   * @param {boolean} refreshNow - If `true` the resource in question (e.g.
+   * DASH's MPD) will be refreshed immediately.
+   */
+  public updateContentUrls(urls : string[] | undefined, refreshNow : boolean) : void {
+    if (this._priv_contentInfos === null) {
+      throw new Error("No content loaded");
+    }
+    this._priv_contentInfos.initializer.updateContentUrls(urls, refreshNow);
   }
 
   /**
@@ -2851,6 +2866,8 @@ interface IPublicApiContentInfos {
   contentId : string;
   /** Original URL set to load the content. */
   originalUrl : string | undefined;
+  /** `ContentInitializer` used to load the content. */
+  initializer : ContentInitializer;
   /** TaskCanceller triggered when it's time to stop the current content. */
   currentContentCanceller : TaskCanceller;
   /**

--- a/src/core/init/directfile_content_initializer.ts
+++ b/src/core/init/directfile_content_initializer.ts
@@ -123,6 +123,10 @@ export default class DirectFileContentInitializer extends ContentInitializer {
     }, { emitCurrentValue: true, clearSignal: cancelSignal });
   }
 
+  public updateContentUrls(_urls : string[] | undefined, _refreshNow : boolean) : void {
+    throw new Error("Cannot update content URL of directfile contents");
+  }
+
   public dispose(): void {
     this._initCanceller.cancel();
   }

--- a/src/core/init/media_source_content_initializer.ts
+++ b/src/core/init/media_source_content_initializer.ts
@@ -173,6 +173,17 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       });
   }
 
+  /**
+   * Update URL of the Manifest.
+   * @param {Array.<string>|undefined} urls - URLs to reach that Manifest from
+   * the most prioritized URL to the least prioritized URL.
+   * @param {boolean} refreshNow - If `true` the resource in question (e.g.
+   * DASH's MPD) will be refreshed immediately.
+   */
+  public updateContentUrls(urls : string[] | undefined, refreshNow : boolean) : void {
+    this._manifestFetcher.updateContentUrls(urls, refreshNow);
+  }
+
   public dispose(): void {
     this._initCanceller.cancel();
   }

--- a/src/core/init/types.ts
+++ b/src/core/init/types.ts
@@ -84,6 +84,18 @@ export abstract class ContentInitializer extends EventEmitter<IContentInitialize
   ) : void;
 
   /**
+   * Update URL of the content currently being played (e.g. DASH's MPD).
+   * @param {Array.<string>|undefined} urls - URLs to reach that content /
+   * Manifest from the most prioritized URL to the least prioritized URL.
+   * @param {boolean} refreshNow - If `true` the resource in question (e.g.
+   * DASH's MPD) will be refreshed immediately.
+   */
+  public abstract updateContentUrls(
+    urls : string[] | undefined,
+    refreshNow : boolean
+  ) : void;
+
+  /**
    * Stop playing the content linked to this `ContentInitializer` on the
    * `HTMLMediaElement` linked to it and dispose of every resources taken while
    * trying to do so.


### PR DESCRIPTION
This commit adds the `updateContentUrls` API allowing to update at any time and during playback, the URL through which a content's Manifest is reached.

This may be used anytime an application prefer a new Manifest URLs to be used, whether it is because the previous URL will soon expire, because the new URL is seen as more qualitative or to rebalance load.

The first argument given to `updateContentUrls` is actually an array of strings, listing new URLs from the most prioritized to the least prioritized. This is not used for now, but should soon be used to define fallback URLs when former one fail to fetch the resource.

`updateContentUrls` can be given a second argument named `refreshNow` which can be used to ask the RxPlayer to refresh immediately the Manifest behind the given URL.

For now, this API will throw for directfile contents, I'm not sure whether it is pertinent to enable it also in this case.