### PR TITLE
Fix/multiple temporary drm session

### DIFF
--- a/src/core/decrypt/utils/key_session_record.ts
+++ b/src/core/decrypt/utils/key_session_record.ts
@@ -148,8 +148,8 @@ export default class KeySessionRecord {
       if (this._keyIds !== null && areAllKeyIdsContainedIn(keyIds, this._keyIds)) {
         return true;
       }
-      if (this._initializationData.keyIds !== undefined) {
-        return areAllKeyIdsContainedIn(keyIds, this._initializationData.keyIds);
+      if (this._initializationData.keyIds !== undefined && areAllKeyIdsContainedIn(keyIds, this._initializationData.keyIds)) {
+        return true;
       }
     }
     return this._checkInitializationDataCompatibility(initializationData);

--- a/src/core/decrypt/utils/key_session_record.ts
+++ b/src/core/decrypt/utils/key_session_record.ts
@@ -158,18 +158,9 @@ export default class KeySessionRecord {
   private _checkInitializationDataCompatibility(
     initializationData : IProcessedProtectionData
   ) : boolean {
-    if (initializationData.keyIds !== undefined &&
-        initializationData.keyIds.length > 0 &&
-        this._initializationData.keyIds !== undefined)
-    {
-      return areAllKeyIdsContainedIn(initializationData.keyIds,
-                                     this._initializationData.keyIds);
-    }
-
     if (this._initializationData.type !== initializationData.type) {
       return false;
     }
-
     return this._initializationData.values
       .isCompatibleWith(initializationData.values);
   }

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -83,6 +83,25 @@ export interface ISidxSegment {
 }
 
 /**
+ * Test if value equal zero. Used as a callback for array functions to test
+ * undefined keyId in the ISOBMFF init segment.
+ * @param {number} value The value to test
+ * @returns {Boolean} True if value equals zero
+ */
+function isZero(value: number) {
+  return value === 0;
+}
+
+/**
+ * Check if a keyId is valid. Zero filled keyId are invalid.
+ * @param {Uint8Array} keyId
+ * @returns {Boolean} True if keyId valid
+ */
+function isValidKeyId(keyId: Uint8Array) {
+  return !keyId.every(isZero);
+}
+
+/**
  * Parse the sidx part (segment index) of an ISOBMFF buffer and construct a
  * corresponding Array of available segments.
  *
@@ -539,7 +558,10 @@ function getKeyIdFromInitSegment(
   if (tenc === null || tenc.byteLength < 24) {
     return null;
   }
-  return tenc.subarray(8, 24);
+  const keyId = tenc.subarray(8, 24);
+  return isValidKeyId(keyId)
+    ? keyId
+    : null;
 }
 
 export {


### PR DESCRIPTION
On our live DASH + Widevine streams, the player creates many temporary DRM sessions and so trigger as many license resquest to our Widevine server. 

This pull request tend to fix 2 issues.

- The player tries to detect keyId in the MP4 initialization fragment in the `tenc` box to test it against our current DRM session's keyIds. In our streams, this keyId is filled with zero and will not be compatible with our current session's keyIds.
- In `KeySessionRecord.isCompatibleWith`, the `initializationData.values` was never tested because testing `initializationData.keys` returns `false` before.

Note: 
- I have removed testing keys again in `_checkInitializationDataCompatibility` as I am not sure how useful it is.
- Finally, after fixing the `initializationData.keys` test, the zero keyId does not fail the DRM session keyId tests. So I am not sure if we still want to key this test or consider the zero keyId as valid

Fix #1183 