### PR TITLE
DASH: Now handle `endNumber` DASH attribute

### DIFF
--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -69,6 +69,8 @@ export interface IBaseIndex {
   segmentUrlTemplate : string | null;
   /** Number from which the first segments in this index starts with. */
   startNumber? : number | undefined;
+  /** Number associated to the last segment in this index. */
+  endNumber? : number | undefined;
   /** Every segments defined in this index. */
   timeline : IIndexSegment[];
   /**
@@ -90,6 +92,7 @@ export interface IBaseIndexIndexArgument {
   indexRange?: [number, number];
   initialization?: { media?: string; range?: [number, number] };
   startNumber? : number;
+  endNumber? : number;
   /**
    * Offset present in the index to convert from the mediaTime (time declared in
    * the media segments and in this index) to the presentationTime (time wanted
@@ -222,6 +225,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
                     initialization: { url: initializationUrl, range },
                     segmentUrlTemplate,
                     startNumber: index.startNumber,
+                    endNumber: index.endNumber,
                     timeline: index.timeline ?? [],
                     timescale };
     this._scaledPeriodStart = toIndexTime(periodStart, this._index);

--- a/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/get_segments_from_timeline.ts
@@ -55,6 +55,7 @@ export default function getSegmentsFromTimeline(
   index : { availabilityTimeComplete? : boolean | undefined;
             segmentUrlTemplate : string | null;
             startNumber? : number | undefined;
+            endNumber? : number | undefined;
             timeline : IIndexSegment[];
             timescale : number;
             indexTimeOffset : number; },
@@ -65,7 +66,7 @@ export default function getSegmentsFromTimeline(
 ) : ISegment[] {
   const scaledUp = toIndexTime(from, index);
   const scaledTo = toIndexTime(from + durationWanted, index);
-  const { timeline, timescale, segmentUrlTemplate, startNumber } = index;
+  const { timeline, timescale, segmentUrlTemplate, startNumber, endNumber } = index;
 
   let currentNumber = startNumber ?? 1;
   const segments : ISegment[] = [];
@@ -84,6 +85,9 @@ export default function getSegmentsFromTimeline(
     let segmentTime = start + segmentNumberInCurrentRange * duration;
     while (segmentTime < scaledTo && segmentNumberInCurrentRange <= repeat) {
       const segmentNumber = currentNumber + segmentNumberInCurrentRange;
+      if (endNumber !== undefined && segmentNumber > endNumber) {
+        break;
+      }
 
       const detokenizedURL = segmentUrlTemplate === null ?
         null :
@@ -121,6 +125,9 @@ export default function getSegmentsFromTimeline(
     }
 
     currentNumber += repeat + 1;
+    if (endNumber !== undefined && currentNumber > endNumber) {
+      return segments;
+    }
   }
 
   return segments;

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -94,6 +94,8 @@ export interface ITemplateIndex {
   presentationTimeOffset : number;
   /** Number from which the first segments in this index starts with. */
   startNumber? : number | undefined;
+  /** Number associated to the last segment in this index. */
+  endNumber? : number | undefined;
 }
 
 /**
@@ -109,6 +111,7 @@ export interface ITemplateIndexIndexArgument {
   media? : string | undefined;
   presentationTimeOffset? : number | undefined;
   startNumber? : number | undefined;
+  endNumber? : number | undefined;
   timescale? : number | undefined;
 }
 
@@ -213,7 +216,8 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
                         range: index.initialization.range },
                     url: segmentUrlTemplate,
                     presentationTimeOffset,
-                    startNumber: index.startNumber };
+                    startNumber: index.startNumber,
+                    endNumber: index.endNumber };
     this._isDynamic = isDynamic;
     this._periodStart = periodStart;
     this._scaledRelativePeriodEnd = periodEnd === undefined ?
@@ -239,6 +243,7 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     const index = this._index;
     const { duration,
             startNumber,
+            endNumber,
             timescale,
             url } = index;
 
@@ -276,6 +281,9 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
     ) {
       // To obtain the real number, adds the real number from the Period's start
       const realNumber = numberIndexedToZero + numberOffset;
+      if (endNumber !== undefined && realNumber > endNumber) {
+        return segments;
+      }
 
       const realDuration = scaledEnd != null &&
                            timeFromPeriodStart + duration > scaledEnd ?

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -88,6 +88,8 @@ export interface ITimelineIndex {
   segmentUrlTemplate : string | null ;
   /** Number from which the first segments in this index starts with. */
   startNumber? : number | undefined;
+  /** Number associated to the last segment in this index. */
+  endNumber? : number | undefined;
   /**
    * Every segments defined in this index.
    * `null` at the beginning as this property is parsed lazily (only when first
@@ -125,6 +127,7 @@ export interface ITimelineIndexIndexArgument {
                     undefined;
   media? : string | undefined;
   startNumber? : number | undefined;
+  endNumber? : number | undefined;
   timescale? : number | undefined;
   /**
    * Offset present in the index to convert from the mediaTime (time declared in
@@ -306,6 +309,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
                       },
                     segmentUrlTemplate,
                     startNumber: index.startNumber,
+                    endNumber: index.endNumber,
                     timeline: index.timeline ?? null,
                     timescale };
     this._scaledPeriodStart = toIndexTime(periodStart, this._index);
@@ -336,11 +340,13 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     // destructuring to please TypeScript
     const { segmentUrlTemplate,
             startNumber,
+            endNumber,
             timeline,
             timescale,
             indexTimeOffset } = this._index;
     return getSegmentsFromTimeline({ segmentUrlTemplate,
                                      startNumber,
+                                     endNumber,
                                      timeline,
                                      timescale,
                                      indexTimeOffset },
@@ -536,6 +542,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     if (hasReplaced) {
       this._index.startNumber = newIndex._index.startNumber;
     }
+    this._index.endNumber = newIndex._index.endNumber;
     this._isDynamic = newIndex._isDynamic;
     this._scaledPeriodStart = newIndex._scaledPeriodStart;
     this._scaledPeriodEnd = newIndex._scaledPeriodEnd;

--- a/src/parsers/manifest/dash/js-parser/node_parsers/SegmentBase.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/SegmentBase.ts
@@ -99,6 +99,12 @@ export default function parseSegmentBase(
                                  parser: parseMPDInteger,
                                  dashName: "startNumber" });
         break;
+
+      case "endNumber":
+        parseValue(attr.value, { asKey: "endNumber",
+                                 parser: parseMPDInteger,
+                                 dashName: "endNumber" });
+        break;
     }
   }
 

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -285,6 +285,7 @@ export interface ISegmentBaseIntermediateRepresentation {
   media?: string;
   presentationTimeOffset?: number;
   startNumber? : number;
+  endNumber? : number;
   timescale?: number;
 }
 
@@ -299,6 +300,7 @@ export interface ISegmentListIntermediateRepresentation {
   media?: string;
   presentationTimeOffset?: number;
   startNumber? : number;
+  endNumber? : number;
   timescale?: number;
 }
 
@@ -348,6 +350,7 @@ export interface ISegmentTemplateIntermediateRepresentation {
   media? : string | undefined;
   presentationTimeOffset? : number | undefined;
   startNumber? : number | undefined;
+  endNumber? : number | undefined;
   timescale? : number | undefined;
   initialization? : { media?: string } | undefined;
   timeline? : ISegmentTimelineElement[] | undefined;

--- a/src/parsers/manifest/dash/wasm-parser/rs/events.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/events.rs
@@ -282,6 +282,15 @@ pub enum AttributeName {
     Label = 71, // String
 
     ServiceLocation = 72, // String
+
+    QueryBeforeStart = 73, // Boolean
+
+    ProxyServerUrl = 74, // String
+
+    DefaultServiceLocation = 75,
+
+    // SegmentTemplate
+    EndNumber = 76, // f64
 }
 
 impl TagName {

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
@@ -173,6 +173,8 @@ pub fn report_segment_template_attrs(tag_bs : &quick_xml::events::BytesStart) {
                     Duration.try_report_as_u64(&attr),
                 b"startNumber" =>
                     StartNumber.try_report_as_u64(&attr),
+                b"endNumber" =>
+                    EndNumber.try_report_as_u64(&attr),
                 b"media" => Media.try_report_as_string(&attr),
                 b"bitstreamSwitching" => BitstreamSwitching.try_report_as_bool(&attr),
                 _ => {},
@@ -201,6 +203,8 @@ pub fn report_segment_base_attrs(tag_bs : &quick_xml::events::BytesStart) {
                     Duration.try_report_as_u64(&attr),
                 b"startNumber" =>
                     StartNumber.try_report_as_u64(&attr),
+                b"endNumber" =>
+                    EndNumber.try_report_as_u64(&attr),
                 _ => {},
             },
             Err(err) => ParsingError::from(err).report_err(),

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentBase.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentBase.ts
@@ -104,6 +104,12 @@ export function generateSegmentBaseAttrParser(
         break;
       }
 
+      case AttributeName.EndNumber: {
+        const dataView = new DataView(linearMemory.buffer);
+        segmentBaseAttrs.endNumber = dataView.getFloat64(ptr, true);
+        break;
+      }
+
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentTemplate.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentTemplate.ts
@@ -121,6 +121,13 @@ export function generateSegmentTemplateAttrParser(
         break;
       }
 
+      case AttributeName.EndNumber: {
+        const dataView = new DataView(linearMemory.buffer);
+        segmentTemplateAttrs.endNumber =
+          dataView.getFloat64(ptr, true);
+        break;
+      }
+
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/types.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/types.ts
@@ -290,4 +290,7 @@ export const enum AttributeName {
   ProxyServerUrl = 74, // String
 
   DefaultServiceLocation = 75,
+
+  // SegmentTemplate
+  EndNumber = 76, // f64
 }


### PR DESCRIPTION
This commit adds handling of the `endNumber` attribute found on some DASH contents, which is the number the last segment should have.

We decided to add it after seeing it used in the wild, most notably by some of Canal+ partners.
Without it, there might be issues if the duration announced on the corresponding Period or MPD lead the RxPlayer to believe that there's one more segment that there actually is.

This attribute is only present in newer 2019+ DASH specifications we funnily enough did not have access to until now. It was not in the latest DASH-IF specification neither.

---

The `endNumber` attribute creates however an ambiguity: What should we do if a `<SegmentTimeline>` declares `$Number$`-based segments which should be impossible under `endNumber` rules? For now, I chose to rely on the highest constraints: whichever lead to the less segments.