### PR TITLE
DASH: implement forced-subtitles

### DIFF
--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -217,6 +217,12 @@ The array emitted contains object describing each available text track:
 - `closedCaption` (`Boolean`): Whether the track is specially adapted for
   the hard of hearing or not.
 
+- `forced` (`Boolean`): If `true` this text track is meant to be displayed by
+  default if no other text track is selected.
+
+  It is often used to clarify dialogue, alternate languages, texted graphics or
+  location and person identification.
+
 - `active` (`Boolean`): Whether the track is the one currently active or
   not.
 
@@ -259,9 +265,18 @@ The payload is an object describing the new track, with the following
 properties:
 
 - `id` (`Number|string`): The id used to identify the track.
+
 - `language` (`string`): The language the text track is in.
+
 - `closedCaption` (`Boolean`): Whether the track is specially adapted for
   the hard of hearing or not.
+
+- `forced` (`Boolean`): If `true` this text track is meant to be displayed by
+  default if no other text track is selected.
+
+  It is often used to clarify dialogue, alternate languages, texted graphics or
+  location and person identification.
+
 - `label` (`string|undefined`): A human readable label that may be displayed in
   the user interface providing a choice between text tracks.
 

--- a/doc/api/Track_Selection/getAvailableTextTracks.md
+++ b/doc/api/Track_Selection/getAvailableTextTracks.md
@@ -21,6 +21,12 @@ Each of the objects in the returned array have the following properties:
 - `closedCaption` (`Boolean`): Whether the track is specially adapted for
   the hard of hearing or not.
 
+- `forced` (`Boolean`): If `true` this text track is meant to be displayed by
+  default if no other text track is selected.
+
+  It is often used to clarify dialogue, alternate languages, texted graphics or
+  location and person identification.
+
 - `label` (`string|undefined`): A human readable label that may be displayed in
   the user interface providing a choice between text tracks.
 

--- a/doc/api/Track_Selection/getPreferredTextTracks.md
+++ b/doc/api/Track_Selection/getPreferredTextTracks.md
@@ -12,8 +12,10 @@ it was called:
 {
   language: "fra", // {string} The wanted language
                    // (ISO 639-1, ISO 639-2 or ISO 639-3 language code)
-  closedCaption: false // {Boolean} Whether the text track should be a closed
-                       // caption for the hard of hearing
+  closedCaption: false, // {Boolean} Whether the text track should be a closed
+                        // caption for the hard of hearing
+  forced: false // {Boolean|undefined} If `true` this text track is meant to be
+                // displayed by default if no other text track is selected.
 }
 ```
 

--- a/doc/api/Track_Selection/getTextTrack.md
+++ b/doc/api/Track_Selection/getTextTrack.md
@@ -31,6 +31,12 @@ return an object with the following properties:
 - `closedCaption` (`Boolean`): Whether the track is specially adapted for
   the hard of hearing or not.
 
+- `forced` (`Boolean`): If `true` this text track is meant to be displayed by
+  default if no other text track is selected.
+
+  It is often used to clarify dialogue, alternate languages, texted graphics or
+  location and person identification.
+
 `undefined` if no text content has been loaded yet or if its information is
 unknown.
 

--- a/doc/api/Track_Selection/setPreferredTextTracks.md
+++ b/doc/api/Track_Selection/setPreferredTextTracks.md
@@ -13,14 +13,22 @@ apply to every future loaded content in the current RxPlayer instance.
 The first argument should be set as an array of objects, each object describing
 constraints a text track should respect.
 
+Here are the list of properties that can be set on each of those objects:
+
+  - **language** (`string`): The wanted language (preferably as an ISO 639-1,
+    ISO 639-2 or ISO 639-3 language code)
+
+  - **closedCaption** (`boolean`): Whether the text track should be a closed
+    caption for the hard of hearing
+
+  - **forced** (`boolean|undefined`): If `true` the text track should be a
+    "forced subtitle", which are default text tracks used when no other text
+    track is selected.
+
 Here is all the properties that should be set in a single object of that array.
 
 ```js
 {
-  language: "fra", // {string} The wanted language
-                   // (ISO 639-1, ISO 639-2 or ISO 639-3 language code)
-  closedCaption: false // {Boolean} Whether the text track should be a closed
-                       // caption for the hard of hearing
 }
 ```
 

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -56,6 +56,14 @@ export default class Adaptation {
   /** Whether this Adaptation contains closed captions for the hard-of-hearing. */
   public isClosedCaption? : boolean;
 
+  /**
+   * If `true` this Adaptation are subtitles Meant for display when no other text
+   * Adaptation is selected. It is used to clarify dialogue, alternate
+   * languages, texted graphics or location/person IDs that are not otherwise
+   * covered in the dubbed/localized audio Adaptation.
+   */
+  public isForcedSubtitles? : boolean;
+
   /** If true this Adaptation contains sign interpretation. */
   public isSignInterpreted? : boolean;
 

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -128,6 +128,9 @@ export default class Adaptation {
     if (parsedAdaptation.isDub !== undefined) {
       this.isDub = parsedAdaptation.isDub;
     }
+    if (parsedAdaptation.forcedSubtitles !== undefined) {
+      this.isForcedSubtitles = parsedAdaptation.forcedSubtitles;
+    }
     if (parsedAdaptation.isSignInterpreted !== undefined) {
       this.isSignInterpreted = parsedAdaptation.isSignInterpreted;
     }

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -147,14 +147,13 @@ function hasSignLanguageInterpretation(
 /**
  * Contruct Adaptation ID from the information we have.
  * @param {Object} adaptation
- * @param {Array.<Object>} representations
- * @param {Array.<Object>} representations
  * @param {Object} infos
  * @returns {string}
  */
 function getAdaptationID(
   adaptation : IAdaptationSetIntermediateRepresentation,
   infos : { isClosedCaption : boolean | undefined;
+            isForcedSubtitle : boolean | undefined;
             isAudioDescription : boolean | undefined;
             isSignInterpreted : boolean | undefined;
             isTrickModeTrack: boolean;
@@ -165,6 +164,7 @@ function getAdaptationID(
   }
 
   const { isClosedCaption,
+          isForcedSubtitle,
           isAudioDescription,
           isSignInterpreted,
           isTrickModeTrack,
@@ -175,6 +175,9 @@ function getAdaptationID(
     idString += `-${adaptation.attributes.language}`;
   }
   if (isClosedCaption === true) {
+    idString += "-cc";
+  }
+  if (isForcedSubtitle === true) {
     idString += "-cc";
   }
   if (isAudioDescription === true) {
@@ -369,6 +372,15 @@ export default function parseAdaptationSets(
         isClosedCaption = accessibilities.some(isHardOfHearing);
       }
 
+      let isForcedSubtitle;
+      if (type === "text" &&
+          roles !== undefined &&
+          roles.some((role) => role.value === "forced-subtitle" ||
+                               role.value === "forced_subtitle"))
+      {
+        isForcedSubtitle = true;
+      }
+
       let isAudioDescription;
       if (type !== "audio") {
         isAudioDescription = false;
@@ -385,6 +397,7 @@ export default function parseAdaptationSets(
 
       let adaptationID = getAdaptationID(adaptation,
                                          { isAudioDescription,
+                                           isForcedSubtitle,
                                            isClosedCaption,
                                            isSignInterpreted,
                                            isTrickModeTrack,
@@ -420,6 +433,9 @@ export default function parseAdaptationSets(
       }
       if (isDub === true) {
         parsedAdaptationSet.isDub = true;
+      }
+      if (isForcedSubtitle !== undefined) {
+        parsedAdaptationSet.forcedSubtitles = isForcedSubtitle;
       }
       if (isSignInterpreted === true) {
         parsedAdaptationSet.isSignInterpreted = true;

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -194,6 +194,13 @@ export interface IParsedAdaptation {
    */
   closedCaption? : boolean | undefined;
   /**
+   * If `true` this Adaptation are subtitles Meant for display when no other text
+   * Adaptation is selected. It is used to clarify dialogue, alternate
+   * languages, texted graphics or location/person IDs that are not otherwise
+   * covered in the dubbed/localized audio Adaptation.
+   */
+  forcedSubtitles? : boolean;
+  /**
    * If true this Adaptation is in a dub: it was recorded in another language
    * than the original(s) one(s).
    */

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -636,6 +636,7 @@ export type IAudioTrackPreference = null |
 /** Single preference for a text track Adaptation. */
 export type ITextTrackPreference = null |
                                    { language : string;
+                                     forced? : boolean | undefined;
                                      closedCaption : boolean; };
 
 /** Single preference for a video track Adaptation. */
@@ -763,6 +764,7 @@ export interface IAudioTrack { language : string;
 export interface ITextTrack { language : string;
                               normalized : string;
                               closedCaption : boolean;
+                              forced? : boolean | undefined;
                               label? : string | undefined;
                               id : number|string; }
 

--- a/tests/contents/DASH_static_SegmentTimeline/forced-subtitles.js
+++ b/tests/contents/DASH_static_SegmentTimeline/forced-subtitles.js
@@ -1,0 +1,23 @@
+const BASE_URL = "http://" +
+               /* eslint-disable no-undef */
+               __TEST_CONTENT_SERVER__.URL + ":" +
+               __TEST_CONTENT_SERVER__.PORT +
+               /* eslint-enable no-undef */
+               "/DASH_static_SegmentTimeline/media/";
+export default {
+  url: BASE_URL + "forced-subtitles.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  minimumPosition: 0,
+  maximumPosition: 101.568367,
+  duration: 101.568367,
+  availabilityStartTime: 0,
+
+  /**
+   * We don't care about that for now. As this content is only tested for track
+   * preferences.
+   * TODO still add it to our list of commonly tested contents?
+   */
+  periods: [],
+};

--- a/tests/contents/DASH_static_SegmentTimeline/index.js
+++ b/tests/contents/DASH_static_SegmentTimeline/index.js
@@ -1,19 +1,20 @@
 import manifestInfos from "./infos.js";
-import trickModeInfos from "./trickmode.js";
 import discontinuityInfos from "./discontinuity.js";
+import forcedSubtitles from "./forced-subtitles.js";
 import multiAdaptationSetsInfos from "./multi-AdaptationSets.js";
 import multiPeriodDifferentChoicesInfos from "./multi_period_different_choices";
 import multiPeriodSameChoicesInfos from "./multi_period_same_choices";
 import notStartingAt0ManifestInfos from "./not_starting_at_0.js";
-import streamEventsInfos from "./event-stream";
 import segmentTemplateInheritanceASRep from "./segment_template_inheritance_as_rep";
 import segmentTemplateInheritancePeriodAS from "./segment_template_inheritance_period_as";
 import segmentTimelineEndNumber from "./segment_timeline_end_number";
+import streamEventsInfos from "./event-stream";
+import trickModeInfos from "./trickmode.js";
 
 export {
   manifestInfos,
-  trickModeInfos,
   discontinuityInfos,
+  forcedSubtitles,
   multiAdaptationSetsInfos,
   multiPeriodDifferentChoicesInfos,
   multiPeriodSameChoicesInfos,
@@ -22,4 +23,5 @@ export {
   segmentTemplateInheritancePeriodAS,
   segmentTimelineEndNumber,
   streamEventsInfos,
+  trickModeInfos,
 };

--- a/tests/contents/DASH_static_SegmentTimeline/media/forced-subtitles.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/forced-subtitles.mpd
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" mediaPresentationDuration="PT1M41.568367S" maxSegmentDuration="PT5S" minBufferTime="PT10S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT1M41.568367S">
+    <BaseURL>dash/</BaseURL>
+    <!-- audio fr mp4a.40.2 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="fr"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+    <!-- audio de mp4a.40.2 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="de"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+    <!-- audio en mp4a.40.2 -->
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="en"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" /><S d="177152" /><S d="176128" r="1" /><S d="177152" /><S d="176128" /><S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr -->
+    <AdaptationSet id="0" contentType="text" lang="fr" subsegmentAlignment="true">
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr forced-subtitle -->
+    <AdaptationSet id="0" contentType="text" lang="fr" subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role" value="forced-subtitle"/>
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text fr caption -->
+    <AdaptationSet id="0" contentType="text" lang="fr" subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="caption"/>
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text de forced-subtitle -->
+    <AdaptationSet id="0" contentType="text" lang="de" subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role" value="forced-subtitle"/>
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+    <!-- text forced-subtitle -->
+    <AdaptationSet id="0" contentType="text" subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role" value="forced-subtitle"/>
+      <SegmentTemplate timescale="1" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" r="9"/></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="text" bandwidth="256" mimeType="text/vtt"></Representation>
+    </AdaptationSet>
+
+
+
+    <!-- video avc1 -->
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      minBandwidth="400000"
+      maxBandwidth="795000"
+      maxWidth="2221"
+      maxHeight="944"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+        <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+          <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive"></Representation>
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/DASH_static_SegmentTimeline/urls.js
+++ b/tests/contents/DASH_static_SegmentTimeline/urls.js
@@ -92,6 +92,11 @@ module.exports = [
     contentType: "application/dash+xml",
   },
   {
+    url: BASE_URL + "forced-subtitles.mpd",
+    path: path.join(__dirname, "media/forced-subtitles.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
     url: BASE_URL + "event-streams.mpd",
     path: path.join(__dirname, "media/event-streams.mpd"),
     contentType: "application/dash+xml",

--- a/tests/integration/scenarios/dash_forced-subtitles.js
+++ b/tests/integration/scenarios/dash_forced-subtitles.js
@@ -1,0 +1,148 @@
+import { expect } from "chai";
+import RxPlayer from "../../../src";
+import {
+  forcedSubtitles,
+} from "../../contents/DASH_static_SegmentTimeline";
+import XHRMock from "../../utils/request_mock";
+import {
+  waitForLoadedStateAfterLoadVideo,
+} from "../../utils/waitForPlayerState";
+
+describe("DASH forced-subtitles content (SegmentTimeline)", function () {
+  let player;
+  let xhrMock;
+
+  async function loadContent() {
+    player.loadVideo({ url: forcedSubtitles.url,
+                       transport: forcedSubtitles.transport });
+    await waitForLoadedStateAfterLoadVideo(player);
+  }
+
+  function checkNoTextTrack() {
+    const currentTextTrack = player.getTextTrack();
+    expect(currentTextTrack).to.equal(null);
+  }
+
+  function checkAudioTrack(language, normalizedLanguage, isAudioDescription) {
+    const currentAudioTrack = player.getAudioTrack();
+    expect(currentAudioTrack).to.not.equal(null);
+    expect(currentAudioTrack.language).to.equal(language);
+    expect(currentAudioTrack.normalized).to.equal(normalizedLanguage);
+    expect(currentAudioTrack.audioDescription).to.equal(isAudioDescription);
+  }
+
+  function checkTextTrack(language, normalizedLanguage, props) {
+    const currentTextTrack = player.getTextTrack();
+    expect(currentTextTrack).to.not.equal(null);
+    expect(currentTextTrack.language).to.equal(language);
+    expect(currentTextTrack.normalized).to.equal(normalizedLanguage);
+    expect(currentTextTrack.closedCaption).to.equal(
+      props.closedCaption,
+      `"closedCaption" not set to "${props.closedCaption}" but ` +
+      `to "${currentTextTrack.closedCaption}"`);
+    expect(currentTextTrack.forced).to.equal(
+      props.forced,
+      `"forced" not set to "${props.forced}" but ` +
+      `to "${currentTextTrack.forced}"`);
+  }
+
+  beforeEach(() => {
+    player = new RxPlayer();
+    player.setWantedBufferAhead(5); // We don't really care
+    xhrMock = new XHRMock();
+  });
+
+  afterEach(() => {
+    player.dispose();
+    xhrMock.restore();
+  });
+
+  it("should set the forced text track associated to the current audio track", async function () {
+    player.dispose();
+    player = new RxPlayer({
+      preferredAudioTracks: [{
+        language: "fr",
+        audioDescription: false,
+      }],
+    });
+
+    await loadContent();
+    checkAudioTrack("fr", "fra", false);
+    checkTextTrack("fr", "fra", { closedCaption: false, forced: true });
+
+    player.setPreferredAudioTracks([{ language: "de", audioDescription: false }]);
+    await loadContent();
+    checkAudioTrack("de", "deu", false);
+    checkTextTrack("de", "deu", { closedCaption: false, forced: true });
+  });
+
+  it("should set the forced text track associated to no language if none is linked to the audio track", async function () {
+    player.dispose();
+    player = new RxPlayer({
+      preferredAudioTracks: [{
+        language: "en",
+        audioDescription: false,
+      }],
+    });
+
+    await loadContent();
+    checkAudioTrack("en", "eng", false);
+    checkTextTrack("", "", {
+      closedCaption: false,
+      forced: true,
+    });
+  });
+
+  it("should still prefer preferences over forced subtitles", async function () {
+    player.dispose();
+    player = new RxPlayer({
+      preferredAudioTracks: [{
+        language: "fr",
+        audioDescription: false,
+      }],
+      preferredTextTracks: [{
+        language: "fr",
+        closedCaption: false,
+      }],
+    });
+
+    await loadContent();
+    checkAudioTrack("fr", "fra", false);
+    checkTextTrack("fr", "fra", { closedCaption: false, forced: undefined });
+
+    player.setPreferredTextTracks([{ language: "fr", closedCaption: true }]);
+    await loadContent();
+    checkAudioTrack("fr", "fra", false);
+    checkTextTrack("fr", "fra", { closedCaption: true, forced: undefined });
+
+    player.setPreferredAudioTracks([{ language: "de", audioDescription: undefined }]);
+    await loadContent();
+    checkAudioTrack("de", "deu", false);
+    checkTextTrack("fr", "fra", { closedCaption: true, forced: undefined });
+
+    player.setPreferredTextTracks([null]);
+    await loadContent();
+    checkNoTextTrack();
+  });
+
+  it("should fallback to forced subtitles if no preference match", async function () {
+    player.dispose();
+    player = new RxPlayer({
+      preferredAudioTracks: [{
+        language: "fr",
+        audioDescription: false,
+      }],
+      preferredTextTracks: [{
+        language: "swa",
+        closedCaption: false,
+      }, {
+        language: "de",
+        closedCaption: true,
+      }],
+    });
+
+    await loadContent();
+    checkAudioTrack("fr", "fra", false);
+    checkTextTrack("fr", "fra", { closedCaption: false, forced: true });
+  });
+});


### PR DESCRIPTION
This PR implements DASH forced-subtitles that are subtitles defined for when no other subtitle track is selected.

The idea is often to implement "Forced Narrative Subtitles" which allows to provide clarifications on different element in the screen. You can read more information on it here for example: https://partnerhelp.netflixstudios.com/hc/en-us/articles/217558918-Understanding-Forced-Narrative-Subtitles

With this PR, those text tracks will now have a `forced` attribute set to `true` in the various APIs where it is inspectable (`getAvailableTextTracks`, `getTextTrack` and the events `textTrackChange` and `availableTextTracksChange`).

Moreover, they are used as default text tracks, instead of no text track, when no set preference match the current choice, following a specific rule:
  - If there's a language associated to this forced subtitles, it is only set if this is the same language than for the used audio track.
  - If no forced subtitle is found associated to the language of the current audio track but a language-less forced subtitles track exists, then that one
  - In any other case, no subtitles are chosen by default.

This algorithm was chosen after pondering what the most logical would be. It is imperfect however (setting forced subtitles by default even if it is in a different language than the audio track could be preferred for example) and as such it may be changed in the future.
Though in any case, that track can be manually set by `setTextTrack` or preferences, which thus can be used for more precize settings.