### PR TITLE
DRM: Request PR recommendation when PlayReady is asked and try default recommendation robustnesses

### DIFF
--- a/src/core/decrypt/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/core/decrypt/__tests__/__global__/media_key_system_access.test.ts
@@ -27,6 +27,7 @@
 import { ICustomMediaKeySystemAccess } from "../../../../compat";
 import {
   defaultKSConfig,
+  defaultPRRecommendationKSConfig,
   defaultWidevineConfig,
   mockCompat,
   testContentDecryptorError,
@@ -291,13 +292,17 @@ describe("core - decrypt - global tests - media key system access", () => {
     mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
     await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
                                                      getLicense: neverCalledFn }]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(3);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(4);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(1,
+                               "com.microsoft.playready.recommendation",
+                               defaultPRRecommendationKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(2, "com.microsoft.playready", defaultKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(3, "com.youtube.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(3, "com.chromecast.playready", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess)
+      .toHaveBeenNthCalledWith(4, "com.youtube.playready", defaultKSConfig);
   });
 
   it("should translate a `fairplay` keySystem", async () => {
@@ -317,17 +322,21 @@ describe("core - decrypt - global tests - media key system access", () => {
                                                      getLicense: neverCalledFn },
                                                    { type: "clearkey",
                                                      getLicense: neverCalledFn }]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(5);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(1,
+                               "com.microsoft.playready.recommendation",
+                               defaultPRRecommendationKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(2, "com.microsoft.playready", defaultKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(3, "com.youtube.playready", defaultKSConfig);
+      .toHaveBeenNthCalledWith(3, "com.chromecast.playready", defaultKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(4, "webkit-org.w3.clearkey", defaultKSConfig);
+      .toHaveBeenNthCalledWith(4, "com.youtube.playready", defaultKSConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(5, "org.w3.clearkey", defaultKSConfig);
+      .toHaveBeenNthCalledWith(5, "webkit-org.w3.clearkey", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess)
+      .toHaveBeenNthCalledWith(6, "org.w3.clearkey", defaultKSConfig);
   });
 
   /* eslint-disable max-len */
@@ -341,6 +350,13 @@ describe("core - decrypt - global tests - media key system access", () => {
                                                    { type: "clearkey",
                                                      distinctiveIdentifierRequired: true,
                                                      getLicense: neverCalledFn }]);
+    const expectedPRRecommendationPersistentConfig =
+      defaultPRRecommendationKSConfig.map(conf => {
+        return { ...conf,
+                 persistentState: "required",
+                 sessionTypes: ["temporary",
+                                "persistent-license"] };
+      });
     const expectedPersistentConfig = defaultKSConfig.map(conf => {
       return { ...conf,
                persistentState: "required",
@@ -350,49 +366,21 @@ describe("core - decrypt - global tests - media key system access", () => {
     const expectedIdentifierConfig = defaultKSConfig.map(conf => {
       return { ...conf, distinctiveIdentifier: "required" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(5);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", expectedPersistentConfig);
+      .toHaveBeenNthCalledWith(1,
+                               "com.microsoft.playready.recommendation",
+                               expectedPRRecommendationPersistentConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", expectedPersistentConfig);
+      .toHaveBeenNthCalledWith(2, "com.microsoft.playready", expectedPersistentConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(3, "com.youtube.playready", expectedPersistentConfig);
+      .toHaveBeenNthCalledWith(3, "com.chromecast.playready", expectedPersistentConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(4, "webkit-org.w3.clearkey", expectedIdentifierConfig);
+      .toHaveBeenNthCalledWith(4, "com.youtube.playready", expectedPersistentConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(5, "org.w3.clearkey", expectedIdentifierConfig);
-  });
-
-  /* eslint-disable max-len */
-  it("should set widevine robustnesses for a `com.widevine.alpha` keySystem", async () => {
-  /* eslint-enable max-len */
-    const mockRequestMediaKeySystemAccess = jest.fn(() => Promise.reject("nope"));
-    mockCompat({ requestMediaKeySystemAccess: mockRequestMediaKeySystemAccess });
-    await checkIncompatibleKeySystemsErrorMessage([{ type: "playready",
-                                                     persistentLicense: true,
-                                                     getLicense: neverCalledFn },
-                                                   { type: "clearkey",
-                                                     distinctiveIdentifierRequired: true,
-                                                     getLicense: neverCalledFn }]);
-    const expectedPersistentConfig = defaultKSConfig.map(conf => {
-      return { ...conf,
-               persistentState: "required",
-               sessionTypes: ["temporary", "persistent-license"] };
-    });
-    const expectedIdentifierConfig = defaultKSConfig.map(conf => {
-      return { ...conf,  distinctiveIdentifier: "required" };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(5);
+      .toHaveBeenNthCalledWith(5, "webkit-org.w3.clearkey", expectedIdentifierConfig);
     expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(1, "com.microsoft.playready", expectedPersistentConfig);
-    expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(2, "com.chromecast.playready", expectedPersistentConfig);
-    expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(3, "com.youtube.playready", expectedPersistentConfig);
-    expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(4, "webkit-org.w3.clearkey", expectedIdentifierConfig);
-    expect(mockRequestMediaKeySystemAccess)
-      .toHaveBeenNthCalledWith(5, "org.w3.clearkey", expectedIdentifierConfig);
+      .toHaveBeenNthCalledWith(6, "org.w3.clearkey", expectedIdentifierConfig);
   });
 
   /* eslint-disable max-len */

--- a/src/core/decrypt/__tests__/__global__/utils.ts
+++ b/src/core/decrypt/__tests__/__global__/utils.ts
@@ -52,6 +52,37 @@ export const defaultKSConfig = [{
                        { contentType: "video/webm;codecs=\"vp8\"" } ],
 }];
 
+/**
+ * Default "com.microsoft.playready.recommendation" MediaKeySystemAccess
+ * configuration used by the RxPlayer.
+ */
+export const defaultPRRecommendationKSConfig = [{
+  audioCapabilities: [ { robustness: "3000",
+                         contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                       { robustness: "3000",
+                         contentType: "audio/webm;codecs=opus" },
+                       { robustness: "2000",
+                         contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                       { robustness: "2000",
+                         contentType: "audio/webm;codecs=opus" } ],
+  distinctiveIdentifier: "optional" as const,
+  initDataTypes: ["cenc"] as const,
+  persistentState: "optional" as const,
+  sessionTypes: ["temporary"] as const,
+  videoCapabilities: [ { robustness: "3000",
+                         contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                       { robustness: "3000",
+                         contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                       { robustness: "3000",
+                         contentType: "video/webm;codecs=\"vp8\"" },
+                       { robustness: "2000",
+                         contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                       { robustness: "2000",
+                         contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                       { robustness: "2000",
+                         contentType: "video/webm;codecs=\"vp8\"" } ],
+}];
+
 /** Default Widevine MediaKeySystemAccess configuration used by the RxPlayer. */
 export const defaultWidevineConfig = (() => {
   const ROBUSTNESSES = [ "HW_SECURE_ALL",

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -938,6 +938,17 @@ const DEFAULT_CONFIG = {
                                        "SW_SECURE_DECODE",
                                        "SW_SECURE_CRYPTO" ],
 
+  /**
+   * Robustnesses used in the {audio,video}Capabilities of the
+   * MediaKeySystemConfiguration (DRM).
+   *
+   * Only used for "com.microsoft.playready.recommendation" key system.
+   *
+   * Defined in order of importance (first will be tested first etc.)
+   * @type {Array.<string>}
+   */
+  EME_DEFAULT_PLAYREADY_ROBUSTNESSES: [ "3000", "2000" ],
+
     /**
      * Link canonical key systems names to their respective reverse domain name,
      * used in the EME APIs.
@@ -950,7 +961,8 @@ const DEFAULT_CONFIG = {
     clearkey:  [ "webkit-org.w3.clearkey",
                  "org.w3.clearkey" ],
     widevine:  [ "com.widevine.alpha" ],
-    playready: [ "com.microsoft.playready",
+    playready: [ "com.microsoft.playready.recommendation",
+                 "com.microsoft.playready",
                  "com.chromecast.playready",
                  "com.youtube.playready" ],
     fairplay: [ "com.apple.fps.1_0" ],


### PR DESCRIPTION
Quick Pull Request as we were debugging PlayReady issues to by default use the now recommended `"com.microsoft.playready.recommendation"` key system when only "playready" is asked for through the `keySystems[].type` property.

A second improvement performed here is to by default ask for `"3000"` then `"2000"` audio and video robustnesses when the current keysystem wanted is `"com.microsoft.playready.recommendation"`.

This greatly simplify the usage of SL3000 for applications just asking for `"playready"`