### PR TITLE
TTML: set default font size for ttml subtitles on parent element

### DIFF
--- a/src/parsers/texttracks/ttml/html/create_element.ts
+++ b/src/parsers/texttracks/ttml/html/create_element.ts
@@ -311,6 +311,14 @@ function applyPStyle(
 ) {
   element.style.margin = "0px";
 
+  // Set on it the default font-size, more specific font sizes may then be set
+  // on children elements.
+  // Doing this on the parent <p> elements seems to fix some CSS issues we had
+  // with too large inner line breaks spacing when the text track element was
+  // too small, for some reasons.
+  addClassName(element, "proportional-style");
+  element.setAttribute("data-proportional-font-size", "1");
+
   // applies to body, div, p, region, span
   const paragraphBackgroundColor = style.backgroundColor;
   if (isNonEmptyString(paragraphBackgroundColor)) {


### PR DESCRIPTION
After investigating a weird subtitles cropping issue on some set-top boxes, we found out that the space between subtitle lines were in some situations not proportional to the choosen font's size of those same elements, leading after resizing elements to the impression that a line break was being "too large".

For example, reducing a media element enough may lead to space between lines being too large. In the end, that space (though we're only talking in our case to 2 or 3 pixel higher than it should be) may lead to subtitles being cropped.

Reasons behind this non-proportionality seems linked to a browser's default rendering rules on which I'm not well versed. However a simple fix that seems logical - which is setting the default font-size to the parent elements of those subtitles (which should not break anything) - seems to fix the issue.

I'm not sure why this fixes things, as in my comprehension it shouldn't change anything, yet it does not seem to change in any way cases that were previously working and this new CSS logic theoretically still appears sound to me.