### PR TITLE
Fix race condition leading to a JS error instead of a NO_PLAYABLE_REPRESENTATION

### DIFF
--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -234,6 +234,16 @@ function getEstimateReference(
     representations : Representation[],
     innerCancellationSignal : CancellationSignal
   ) : ISharedReference<IABREstimate> {
+    if (representations.length === 0) {
+      // No Representation given, return `null` as documented
+      return createSharedReference({
+        representation: null,
+        bitrate: undefined,
+        knownStableBitrate: undefined,
+        manual: false,
+        urgent: true,
+      });
+    }
     if (manualBitrateVal >= 0) {
       // A manual bitrate has been set. Just choose Representation according to it.
       const manualRepresentation = selectOptimalRepresentation(representations,
@@ -583,8 +593,10 @@ export interface IABREstimate {
   /**
    * The Representation considered as the most adapted to the current network
    * and playback conditions.
+   * `null` in the rare occurence where there is no `Representation` to choose
+   * from.
    */
-  representation: Representation;
+  representation: Representation | null;
   /**
    * If `true`, the current `representation` suggested should be switched to as
    * soon as possible. For example, you might want to interrupt all pending

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -166,6 +166,9 @@ export default function AdaptationStream<T>(
       cancelOn: adapStreamCanceller.signal,
     });
     const { representation, manual } = estimateRef.getValue();
+    if (representation === null) {
+      return;
+    }
 
     // A manual bitrate switch might need an immediate feedback.
     // To do that properly, we need to reload the MediaSource
@@ -210,7 +213,9 @@ export default function AdaptationStream<T>(
 
     /** Allows to stop listening to estimateRef on the following line. */
     estimateRef.onUpdate((estimate) => {
-      if (estimate.representation.id === representation.id) {
+      if (estimate.representation === null ||
+          estimate.representation.id === representation.id)
+      {
         return;
       }
       if (estimate.urgent) {


### PR DESCRIPTION
A `NO_PLAYABLE_REPRESENTATION` error is what happen if fallbacks are enabled for encrypted contents but all qualities have been fallbacked from.

We had a race conditions if that situation arised before setting the corresponding track (I'm not too sure when this does happen but it did) where a random JS error (along the lines of "cannot read the property bitrate of undefined") i would be sent as an error nstead of the expected `NO_PLAYABLE_REPRESENTATION` error.

This race condition was linked to our handling of RxJS, so I'm unsure if it's still reproducible on our current `dev` branch (as we've removed RxJS from the source code since then). Still, I added in this PR supplementary checks and resilience code that would handle this situation should it ever happen again.

I chose to write the fix on top of the `next` branch, instead of the more usual fix on top of the `master` branch, because the corresponding code has completely been refactored since, and there's a higher chance of us releasing a `3.30.0` than a `3.29.1` release, that issue being relatively rare to reproduce. 

If we ever should release a `v3.29.1` instead, I will backport that fix.