### PR TITLE
Deprecate methods and options removed in the future v4

### DIFF
--- a/doc/api/Buffer_Information/.docConfig.json
+++ b/doc/api/Buffer_Information/.docConfig.json
@@ -3,14 +3,6 @@
     {
       "path": "./getVideoBufferGap.md",
       "displayName": "getVideoBufferGap"
-    },
-    {
-      "path": "./getVideoLoadedTime.md",
-      "displayName": "getVideoLoadedTime"
-    },
-    {
-      "path": "./getVideoPlayedTime.md",
-      "displayName": "getVideoPlayedTime"
     }
   ]
 }

--- a/doc/api/Creating_a_Player.md
+++ b/doc/api/Creating_a_Player.md
@@ -308,7 +308,7 @@ is currently buffered and an estimation of the size of the next segments.
 
 <div class="warning">
 In <i>DirectFile</i> mode (see <a
-href="../Loading_a_Content.md#transport">loadVideo options</a>),
+href="./Loading_a_Content.md#transport">loadVideo options</a>),
 this method has no effect.
 </div>
 

--- a/doc/api/Decryption_Options.md
+++ b/doc/api/Decryption_Options.md
@@ -503,6 +503,12 @@ updated.
 
 ### onKeyStatusesChange
 
+<div class="warning">
+This option is deprecated, it will disappear in the next major release
+`v4.0.0` (see <a href="./Miscellaneous/Deprecated_APIs.md">Deprecated
+APIs</a>).
+</div>
+
 _type_: `Function | undefined`
 
 Callback triggered each time one of the key's

--- a/doc/api/Deprecated/.docConfig.json
+++ b/doc/api/Deprecated/.docConfig.json
@@ -31,6 +31,14 @@
     {
       "path": "./getNativeTextTrack.md",
       "displayName": "getNativeTextTrack"
+    },
+    {
+      "path": "./getVideoLoadedTime.md",
+      "displayName": "getVideoLoadedTime"
+    },
+    {
+      "path": "./getVideoPlayedTime.md",
+      "displayName": "getVideoPlayedTime"
     }
   ]
 }

--- a/doc/api/Deprecated/getVideoLoadedTime.md
+++ b/doc/api/Deprecated/getVideoLoadedTime.md
@@ -1,5 +1,11 @@
 # getVideoLoadedTime
 
+<div class="warning">
+This method is deprecated, it will disappear in the next major release
+`v4.0.0` (see <a href="../Miscellaneous/Deprecated_APIs.md">Deprecated
+APIs</a>).
+</div>
+
 ## Description
 
 Returns in seconds the difference between:

--- a/doc/api/Deprecated/getVideoPlayedTime.md
+++ b/doc/api/Deprecated/getVideoPlayedTime.md
@@ -1,5 +1,11 @@
 # getVideoPlayedTime
 
+<div class="warning">
+This method is deprecated, it will disappear in the next major release
+`v4.0.0` (see <a href="../Miscellaneous/Deprecated_APIs.md">Deprecated
+APIs</a>).
+</div>
+
 ## Description
 
 Returns in seconds the difference between:

--- a/doc/api/Deprecated/isFullscreen.md
+++ b/doc/api/Deprecated/isFullscreen.md
@@ -1,7 +1,7 @@
 # isFullscreen
 
 <div class="warning">
-This option is deprecated, it will disappear in the next major release
+This method is deprecated, it will disappear in the next major release
 `v4.0.0` (see <a href="../Miscellaneous/Deprecated_APIs.md">Deprecated
 APIs</a>).
 </div>

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -533,6 +533,12 @@ considered stable:
 
 - **aggressiveMode** (`boolean|undefined`):
 
+<div class="warning">
+This option is deprecated, it will disappear in the next major release
+`v4.0.0` (see <a href="./Miscellaneous/Deprecated_APIs.md">Deprecated
+APIs</a>).
+</div>
+
   If set to true, we will try to download segments very early, even if we are
   not sure they had time to be completely generated.
 

--- a/doc/api/Miscellaneous/Deprecated_APIs.md
+++ b/doc/api/Miscellaneous/Deprecated_APIs.md
@@ -269,6 +269,88 @@ from the former:
     example, `"com.widevine.alpha"`.
 
 
+### getVideoLoadedTime
+
+The `getVideoLoadedTime` method has been deprecated and won't be replaced in the
+next major version because it was poorly named, poorly understood, and it is
+easy to replace.
+
+#### How to replace that method
+
+To replace it, you can write:
+```js
+function getVideoLoadedTime() {
+  const position = rxPlayer.getPosition();
+  const mediaElement = rxPlayer.getVideoElement();
+  if (mediaElement === null) {
+    console.error("The RxPlayer is disposed");
+  } else {
+    const range = getRange(mediaElement.buffered, currentTime);
+    return range !== null ? range.end - range.start :
+                            0;
+  }
+}
+
+/**
+ * Get range object of a specific time in a TimeRanges object.
+ * @param {TimeRanges} timeRanges
+ * @returns {Object}
+ */
+function getRange(timeRanges, time) {
+  for (let i = timeRanges.length - 1; i >= 0; i--) {
+    const start = timeRanges.start(i);
+    if (time >= start) {
+      const end = timeRanges.end(i);
+      if (time < end) {
+        return { start, end };
+      }
+    }
+  }
+  return null;
+}
+```
+
+### getVideoPlayedTime
+
+The `getVideoPlayedTime` method has been deprecated and won't be replaced in the
+next major version because it was poorly named, poorly understood, and it is
+easy to replace.
+
+#### How to replace that method
+
+To replace it, you can write:
+```js
+function getVideoPlayedTime() {
+  const position = rxPlayer.getPosition();
+  const mediaElement = rxPlayer.getVideoElement();
+  if (mediaElement === null) {
+    console.error("The RxPlayer is disposed");
+  } else {
+    const range = getRange(mediaElement.buffered, currentTime);
+    return range !== null ? currentTime - range.start :
+  }
+}
+
+/**
+ * Get range object of a specific time in a TimeRanges object.
+ * @param {TimeRanges} timeRanges
+ * @returns {Object}
+ */
+function getRange(timeRanges, time) {
+  for (let i = timeRanges.length - 1; i >= 0; i--) {
+    const start = timeRanges.start(i);
+    if (time >= start) {
+      const end = timeRanges.end(i);
+      if (time < end) {
+        return { start, end };
+      }
+    }
+  }
+  return null;
+}
+```
+
+
 ## RxPlayer Events
 
 The following RxPlayer events has been deprecated.
@@ -399,7 +481,7 @@ Or at any time, through the `setPreferredTextTracks` method:
 player.setPreferredTextTracks([{ language: "fra", closedCaption: false }]);
 ```
 
-### supplementaryTextTracks
+### transportOptions.supplementaryTextTracks
 
 The `supplementaryTextTracks` has been deprecated for multiple reasons:
 
@@ -447,7 +529,7 @@ the transition might take some time.
 
 The `TextTrackRenderer` tool is documented [here](../Tools/TextTrackRenderer.md).
 
-### supplementaryImageTracks
+### transportOptions.supplementaryImageTracks
 
 The `supplementaryImageTracks` events have been deprecated like most API related
 to BIF thumbnail parsing.
@@ -455,6 +537,15 @@ You can read [the related chapter](#bif-apis) for more information.
 
 You can replace this API by using the
 [parseBifThumbnails](../Tools/parseBifThumbnails.md) tool.
+
+
+## transportOptions.aggressiveMode
+
+The `aggressiveMode` boolean from the `transportOptions` option will be removed
+from the next major version.
+
+It has no planned replacement. Please open an issue if you need it.
+
 
 ### hideNativeSubtitle
 
@@ -502,10 +593,18 @@ rxPlayer.loadVideo({
 ```
 
 You can have more information on the `onKeyExpiration` option [in the
-correspnding API documentation](./Decryption_Options.md#onkeyexpiration).
+correspnding API documentation](../Decryption_Options.md#onkeyexpiration).
 
 If you previously set `throwOnLicenseExpiration` to `true` or `undefined`, you
 can just remove this property as this still the default behavior.
+
+
+### keySystems[].onKeyStatusesChange
+
+The `onKeyStatusesChange` callback from the `keySystems` option will be removed
+from the next major version.
+
+It has no planned replacement. Please open an issue if you need it.
 
 
 ## RxPlayer constructor options

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -442,13 +442,13 @@ properties, methods, events and so on.
     Returns in seconds the difference between the current position and the end
     of the current media time range.
 
-  - [`getVideoLoadedTime`](../api/Buffer_Information/getVideoLoadedTime.md):
-    Returns in seconds the difference between the start and the end of the
-    current media time range.
+  - [`getVideoLoadedTime`](../api/Deprecated/getVideoLoadedTime.md):
+    [Deprecated] Returns in seconds the difference between the start and the end
+    of the current media time range.
 
-  - [`getVideoPlayedTime`](../api/Buffer_Information/getVideoPlayedTime.md):
-    Returns in seconds the difference between the start of the current media
-    time range and the current position.
+  - [`getVideoPlayedTime`](../api/Deprecated/getVideoPlayedTime.md):
+    [Deprecated] Returns in seconds the difference between the start of the
+    current media time range and the current position.
 
   - [`getUrl`](../api/Content_Information/getUrl.md):
     Get URL of the currently-played content.

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -469,6 +469,12 @@ function parseLoadVideoOptions(
     transport = String(options.transport);
   }
 
+  if (!isNullOrUndefined(options.transportOptions?.aggressiveMode)) {
+    warnOnce("`transportOptions.aggressiveMode` is deprecated and won't " +
+             "be present in the next major version. " +
+             "Please open an issue if you still need this.");
+  }
+
   const autoPlay = isNullOrUndefined(options.autoPlay) ? DEFAULT_AUTO_PLAY :
                                                          !!options.autoPlay;
 
@@ -483,6 +489,16 @@ function parseLoadVideoOptions(
       ) {
         throw new Error("Invalid key system given: Missing type string or " +
                         "getLicense callback");
+      }
+      if (!isNullOrUndefined(keySystem.onKeyStatusesChange)) {
+        warnOnce("`keySystems[].onKeyStatusesChange` is deprecated and won't " +
+                 "be present in the next major version. " +
+                 "Please open an issue if you still need this.");
+      }
+      if (!isNullOrUndefined(keySystem.throwOnLicenseExpiration)) {
+        warnOnce("`keySystems[].throwOnLicenseExpiration` is deprecated and won't " +
+                 "be present in the next major version. " +
+                 "Please open an issue if you still need this.");
       }
     }
   }

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1194,6 +1194,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Number}
    */
   getVideoLoadedTime() : number {
+    warnOnce("`getVideoLoadedTime` is deprecated and won't be present in the " +
+             "next major version");
     if (this.videoElement === null) {
       throw new Error("Disposed player");
     }
@@ -1208,6 +1210,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {Number}
    */
   getVideoPlayedTime() : number {
+    warnOnce("`getVideoPlayedTime` is deprecated and won't be present in the " +
+             "next major version");
     if (this.videoElement === null) {
       throw new Error("Disposed player");
     }


### PR DESCRIPTION
To make sure that some API planned to be removed in the incoming v4 aren't still in use and/or haven't a use we didn't realize until now, I chose to deprecate some of them in the next v3.30.0 minor version.

The v4 is still planned to stay a long time in beta and we still plan to maintain the v3 as long as needed for our close partners, but deprecating options also in the v3 ensure we're not breaking use-cases for people with not enough resource to make the switch for the v4 beta by putting more visibility on those API (console.warn call, deprecation documentation etc.).

The following API are here deprecated:
  - The `getVideoLoadedTime` method
  - The `getVideoPlayedTime` method
  - The `transportOptions.aggressiveMode` property of `loadVideo`
  - The `keySystems[].onKeyStatusesChange` callback of `loadVideo`