### PR TITLE
Clean-up cancellation to avoid memory leak

### DIFF
--- a/src/compat/eme/close_session.ts
+++ b/src/compat/eme/close_session.ts
@@ -86,7 +86,7 @@ export default function closeSession(
     try {
       await session.update(new Uint8Array(1));
     } catch (err) {
-      if (timeoutCanceller.isUsed) { // Reminder: cancelled == session closed
+      if (timeoutCanceller.isUsed()) { // Reminder: cancelled == session closed
         return;
       }
 
@@ -102,7 +102,7 @@ export default function closeSession(
       await cancellableSleep(1000, timeoutCanceller.signal);
     }
 
-    if (timeoutCanceller.isUsed) { // Reminder: cancelled == session closed
+    if (timeoutCanceller.isUsed()) { // Reminder: cancelled == session closed
       return;
     }
 

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -125,7 +125,7 @@ function createCompatibleEventListener(
     listener: (event? : unknown) => void,
     cancelSignal: CancellationSignal
   ) => {
-    if (cancelSignal.isCancelled) {
+    if (cancelSignal.isCancelled()) {
       return;
     }
 

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -215,7 +215,8 @@ function getEstimateReference(
    * This TaskCanceller is used both for restarting estimates with a new
    * configuration and to cancel them altogether.
    */
-  let currentEstimatesCanceller = new TaskCanceller({ cancelOn: stopAllEstimates });
+  let currentEstimatesCanceller = new TaskCanceller();
+  currentEstimatesCanceller.linkToSignal(stopAllEstimates);
 
   // Create `ISharedReference` on which estimates will be emitted.
   const estimateRef = createEstimateReference(manualBitrate.getValue(),
@@ -491,7 +492,8 @@ function getEstimateReference(
     const manualBitrateVal = manualBitrate.getValue();
     const representations = representationsRef.getValue();
     currentEstimatesCanceller.cancel();
-    currentEstimatesCanceller = new TaskCanceller({ cancelOn: stopAllEstimates });
+    currentEstimatesCanceller = new TaskCanceller();
+    currentEstimatesCanceller.linkToSignal(stopAllEstimates);
     const newRef = createEstimateReference(
       manualBitrateVal,
       representations,

--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -217,7 +217,7 @@ export default class PlaybackObserver {
     options? : { includeLastObservation? : boolean | undefined;
                  clearSignal? : CancellationSignal | undefined; }
   ) {
-    if (this._canceller.isUsed || options?.clearSignal?.isCancelled === true) {
+    if (this._canceller.isUsed() || options?.clearSignal?.isCancelled() === true) {
       return noop;
     }
     this._observationRef.onUpdate(cb, {
@@ -971,7 +971,9 @@ function generateReadOnlyObserver<TSource, TDest>(
       options? : { includeLastObservation? : boolean | undefined;
                    clearSignal? : CancellationSignal | undefined; }
     ) : void {
-      if (cancellationSignal.isCancelled || options?.clearSignal?.isCancelled === true) {
+      if (cancellationSignal.isCancelled() ||
+          options?.clearSignal?.isCancelled() === true)
+      {
         return ;
       }
       mappedRef.onUpdate(cb, {

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -764,7 +764,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           defaultTextTrack,
           currentContentCanceller.signal
         );
-      if (currentContentCanceller.isUsed) {
+      if (currentContentCanceller.isUsed()) {
         return;
       }
       initializer = new features.directfile.initDirectFile({ autoPlay,
@@ -943,7 +943,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       updateReloadingMetadata(newState);
       this._priv_setPlayerState(newState);
 
-      if (currentContentCanceller.isUsed) {
+      if (currentContentCanceller.isUsed()) {
         return;
       }
 
@@ -2468,20 +2468,20 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this._priv_triggerAvailableBitratesChangeEvent("availableAudioBitratesChange",
                                                    this.getAvailableAudioBitrates(),
                                                    cancelSignal);
-    if (contentInfos.currentContentCanceller.isUsed) {
+    if (contentInfos.currentContentCanceller.isUsed()) {
       return;
     }
     this._priv_triggerAvailableBitratesChangeEvent("availableVideoBitratesChange",
                                                    this.getAvailableVideoBitrates(),
                                                    cancelSignal);
-    if (contentInfos.currentContentCanceller.isUsed) {
+    if (contentInfos.currentContentCanceller.isUsed()) {
       return;
     }
     const audioBitrate = this._priv_getCurrentRepresentations()?.audio?.bitrate ?? -1;
     this._priv_triggerCurrentBitrateChangeEvent("audioBitrateChange",
                                                 audioBitrate,
                                                 cancelSignal);
-    if (contentInfos.currentContentCanceller.isUsed) {
+    if (contentInfos.currentContentCanceller.isUsed()) {
       return;
     }
 
@@ -2833,7 +2833,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     currentContentCancelSignal  : CancellationSignal
   ) : void {
     const prevVal = this._priv_contentEventsMemory[event];
-    if (!currentContentCancelSignal.isCancelled &&
+    if (!currentContentCancelSignal.isCancelled() &&
         (prevVal === undefined || !areArraysOfNumbersEqual(newVal, prevVal)))
     {
       this._priv_contentEventsMemory[event] = newVal;
@@ -2853,7 +2853,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     newVal : number,
     currentContentCancelSignal  : CancellationSignal
   ) : void {
-    if (!currentContentCancelSignal.isCancelled &&
+    if (!currentContentCancelSignal.isCancelled() &&
         newVal !== this._priv_contentEventsMemory[event])
     {
       this._priv_contentEventsMemory[event] = newVal;
@@ -2886,7 +2886,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     arg : IEventPayload<IPublicAPIEvent, TEventName>,
     currentContentCancelSignal  : CancellationSignal
   ) {
-    if (!currentContentCancelSignal.isCancelled) {
+    if (!currentContentCancelSignal.isCancelled()) {
       this.trigger(evt, arg);
     }
   }

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -953,9 +953,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           seekEventsCanceller = null;
         }
       } else if (isLoadedState(this.state)) {
-        seekEventsCanceller = new TaskCanceller({
-          cancelOn: currentContentCanceller.signal,
-        });
+        seekEventsCanceller = new TaskCanceller();
+        seekEventsCanceller.linkToSignal(currentContentCanceller.signal);
         emitSeekEvents(videoElement,
                        playbackObserver,
                        () => this.trigger("seeking", null),

--- a/src/core/api/utils.ts
+++ b/src/core/api/utils.ts
@@ -48,14 +48,14 @@ export function emitSeekEvents(
   onSeeked: () => void,
   cancelSignal : CancellationSignal
 ) : void {
-  if (cancelSignal.isCancelled || mediaElement === null) {
+  if (cancelSignal.isCancelled() || mediaElement === null) {
     return ;
   }
 
   let wasSeeking = playbackObserver.getReference().getValue().seeking;
   if (wasSeeking) {
     onSeeking();
-    if (cancelSignal.isCancelled) {
+    if (cancelSignal.isCancelled()) {
       return;
     }
   }
@@ -94,7 +94,7 @@ export function constructPlayerStateReference(
   initializer.addEventListener("loaded", () => {
     if (playerStateRef.getValue() === PLAYER_STATES.LOADING) {
       playerStateRef.setValue(PLAYER_STATES.LOADED);
-      if (!cancelSignal.isCancelled) {
+      if (!cancelSignal.isCancelled()) {
         const newState = getLoadedContentState(mediaElement, null);
         if (newState !== PLAYER_STATES.PAUSED) {
           playerStateRef.setValue(newState);

--- a/src/core/decrypt/attach_media_keys.ts
+++ b/src/core/decrypt/attach_media_keys.ts
@@ -62,7 +62,7 @@ export default async function attachMediaKeys(
 
   // If this task has been cancelled while we were closing previous sessions,
   // stop now (and thus avoid setting the new media keys);
-  if (cancelSignal.isCancelled) {
+  if (cancelSignal.isCancelled()) {
     throw cancelSignal.cancellationError;
   }
 

--- a/src/core/decrypt/content_decryptor.ts
+++ b/src/core/decrypt/content_decryptor.ts
@@ -727,7 +727,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * formatted and sent in an "error" event.
    */
   private _onFatalError(err : unknown) : void {
-    if (this._canceller.isUsed) {
+    if (this._canceller.isUsed()) {
       return;
     }
     const formattedErr = err instanceof Error ?

--- a/src/core/decrypt/session_events_listener.ts
+++ b/src/core/decrypt/session_events_listener.ts
@@ -64,7 +64,7 @@ export default function SessionEventsListener(
     session.closed
       .then(() => manualCanceller.cancel())
       .catch((err) => { // Should never happen
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return;
         }
         manualCanceller.cancel();
@@ -79,8 +79,8 @@ export default function SessionEventsListener(
 
   onKeyStatusesChange(session, (keyStatusesEvent) => {
     handleKeyStatusesChangeEvent(keyStatusesEvent as Event).catch(error => {
-      if (cancelSignal.isCancelled ||
-          (manualCanceller.isUsed && error instanceof CancellationSignal))
+      if (cancelSignal.isCancelled() ||
+          (manualCanceller.isUsed() && error instanceof CancellationSignal))
       {
         return;
       }
@@ -104,7 +104,7 @@ export default function SessionEventsListener(
                             backoffOptions,
                             manualCanceller.signal)
       .then((licenseObject) => {
-        if (manualCanceller.isUsed) {
+        if (manualCanceller.isUsed()) {
           return Promise.resolve();
         }
         if (isNullOrUndefined(licenseObject)) {
@@ -114,7 +114,7 @@ export default function SessionEventsListener(
         }
       })
       .catch((err : unknown) => {
-        if (manualCanceller.isUsed) {
+        if (manualCanceller.isUsed()) {
           return;
         }
         manualCanceller.cancel();
@@ -148,18 +148,18 @@ export default function SessionEventsListener(
     ]);
 
     async function runOnKeyStatusesChangeCallback() {
-      if (manualCanceller.isUsed) {
+      if (manualCanceller.isUsed()) {
         return;
       }
       if (typeof keySystemOptions.onKeyStatusesChange === "function") {
         let ret;
         try {
           ret = await keySystemOptions.onKeyStatusesChange(keyStatusesEvent, session);
-          if (manualCanceller.isUsed) {
+          if (manualCanceller.isUsed()) {
             return;
           }
         } catch (error) {
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return;
           }
           const err = new EncryptedMediaError("KEY_STATUS_CHANGE_ERROR",
@@ -186,14 +186,14 @@ export default function SessionEventsListener(
      *   - call onKeyUpdate callback when the MediaKeyStatus of any key is updated
      */
     function handleKeyStatusEvent() : void {
-      if (manualCanceller.isUsed || session.keyStatuses.size === 0) {
+      if (manualCanceller.isUsed() || session.keyStatuses.size === 0) {
         return ;
       }
       const { warning, blacklistedKeyIds, whitelistedKeyIds } =
         checkKeyStatuses(session, keySystemOptions, keySystem);
       if (warning !== undefined) {
         callbacks.onWarning(warning);
-        if (manualCanceller.isUsed) {
+        if (manualCanceller.isUsed()) {
           return;
         }
       }

--- a/src/core/decrypt/session_events_listener.ts
+++ b/src/core/decrypt/session_events_listener.ts
@@ -58,7 +58,8 @@ export default function SessionEventsListener(
   const { getLicenseConfig = {} } = keySystemOptions;
 
   /** Allows to manually cancel everything the `SessionEventsListener` is doing. */
-  const manualCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+  const manualCanceller = new TaskCanceller();
+  manualCanceller.linkToSignal(cancelSignal);
 
   if (!isNullOrUndefined(session.closed)) {
     session.closed

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -155,7 +155,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     manifestProm
       .then((val : IManifestFetcherParsedResult) => {
         this.trigger("manifestReady", val.manifest);
-        if (!this._canceller.isUsed) {
+        if (!this._canceller.isUsed()) {
           this._recursivelyRefreshManifest(val.manifest, val);
         }
       })
@@ -362,7 +362,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      */
     function onWarnings(warnings : Error[]) : void {
       for (const warning of warnings) {
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return;
         }
         const formattedError = formatError(warning, {
@@ -669,7 +669,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
   }
 
   private _onFatalError(err : unknown) : void {
-    if (this._canceller.isUsed) {
+    if (this._canceller.isUsed()) {
       return;
     }
     this.trigger("error", err);

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -470,7 +470,8 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      * be effectively considered.
      * `nextRefreshCanceller` will allow to cancel every other when one is triggered.
      */
-    const nextRefreshCanceller = new TaskCanceller({ cancelOn: this._canceller.signal });
+    const nextRefreshCanceller = new TaskCanceller();
+    nextRefreshCanceller.linkToSignal(this._canceller.signal);
 
     /* Function to manually schedule a Manifest refresh */
     this.scheduleManualRefresh = (settings : IManifestRefreshSettings) => {

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -184,14 +184,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
                                           id: requestId,
                                           content });
 
-    cancellationSignal.register(() => {
-      if (requestInfo !== undefined) {
-        return; // Request already terminated
-      }
-      log.debug("SF: Segment request cancelled", segmentIdString);
-      requestInfo = null;
-      lifecycleCallbacks.onRequestEnd?.({ id: requestId });
-    });
+    cancellationSignal.register(onCancellation);
 
     try {
       const res = await scheduleRequestWithCdns(content.representation.cdnMetadata,
@@ -226,14 +219,26 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
         // a "requestEnd" again as it has already been sent on cancellation.
         lifecycleCallbacks.onRequestEnd?.({ id: requestId });
       }
+      cancellationSignal.deregister(onCancellation);
     } catch (err) {
+      cancellationSignal.deregister(onCancellation);
       requestInfo = null;
       if (err instanceof CancellationError) {
         log.debug("SF: Segment request aborted", segmentIdString);
         throw err;
       }
       log.debug("SF: Segment request failed", segmentIdString);
+      lifecycleCallbacks.onRequestEnd?.({ id: requestId });
       throw errorSelector(err);
+    }
+
+    function onCancellation() {
+      if (requestInfo !== undefined) {
+        return; // Request already terminated
+      }
+      log.debug("SF: Segment request cancelled", segmentIdString);
+      requestInfo = null;
+      lifecycleCallbacks.onRequestEnd?.({ id: requestId });
     }
 
     /**

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -213,7 +213,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
         requestInfo = null;
       }
 
-      if (!cancellationSignal.isCancelled) {
+      if (!cancellationSignal.isCancelled()) {
         // The current task could have been canceled as a result of one
         // of the previous callbacks call. In that case, we don't want to send
         // a "requestEnd" again as it has already been sent on cancellation.

--- a/src/core/fetchers/segment/task_prioritizer.ts
+++ b/src/core/fetchers/segment/task_prioritizer.ts
@@ -76,7 +76,7 @@ export default class TaskPrioritizer<T> {
         newTask.interrupter = interrupter;
         interrupter.signal.register(() => {
           newTask.interrupter = null;
-          if (!cancelSignal.isCancelled) {
+          if (!cancelSignal.isCancelled()) {
             callbacks.beforeInterrupted();
           }
         });
@@ -89,8 +89,8 @@ export default class TaskPrioritizer<T> {
         newTask.taskFn(interrupter.signal)
           .then(onResolve)
           .catch((err) => {
-            if (!cancelSignal.isCancelled &&
-                interrupter.isUsed &&
+            if (!cancelSignal.isCancelled() &&
+                interrupter.isUsed() &&
                 err instanceof CancellationError)
             {
               return;

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -315,7 +315,7 @@ export async function scheduleRequestWithCdns<T>(
   async function retryWithNextCdn(prevRequestError : unknown) : Promise<T> {
     const nextCdn = getCdnToRequest();
 
-    if (cancellationSignal.isCancelled) {
+    if (cancellationSignal.isCancelled()) {
       throw cancellationSignal.cancellationError;
     }
 
@@ -324,7 +324,7 @@ export async function scheduleRequestWithCdns<T>(
     }
 
     onRetry(prevRequestError);
-    if (cancellationSignal.isCancelled) {
+    if (cancellationSignal.isCancelled()) {
       throw cancellationSignal.cancellationError;
     }
 
@@ -363,7 +363,7 @@ export async function scheduleRequestWithCdns<T>(
       /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
       cdnPrioritizer?.addEventListener("priorityChange", () => {
         const updatedPrioritaryCdn = getCdnToRequest();
-        if (cancellationSignal.isCancelled) {
+        if (cancellationSignal.isCancelled()) {
           throw cancellationSignal.cancellationError;
         }
         if (updatedPrioritaryCdn === undefined) {

--- a/src/core/init/directfile_content_initializer.ts
+++ b/src/core/init/directfile_content_initializer.ts
@@ -167,7 +167,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
             }
           }, { emitCurrentValue: true, clearSignal: cancelSignal }))
       .catch((err) => {
-        if (!cancelSignal.isCancelled) {
+        if (!cancelSignal.isCancelled()) {
           this._onFatalError(err);
         }
       });

--- a/src/core/init/media_source_content_initializer.ts
+++ b/src/core/init/media_source_content_initializer.ts
@@ -192,7 +192,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   private _onFatalError(err : unknown) {
-    if (this._initCanceller.isUsed) {
+    if (this._initCanceller.isUsed()) {
       return;
     }
     this._initCanceller.cancel();
@@ -254,7 +254,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             }
           })
           .catch((err) => {
-            if (mediaSourceCanceller.isUsed) {
+            if (mediaSourceCanceller.isUsed()) {
               return;
             }
             this._onFatalError(err);
@@ -311,7 +311,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                                                             initCanceller.signal);
 
     this.trigger("manifestReady", manifest);
-    if (initCanceller.isUsed) {
+    if (initCanceller.isUsed()) {
       return ;
     }
 
@@ -359,11 +359,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                         autoPlay : boolean; }
       ) : void {
         currentCanceller.cancel();
-        if (initCanceller.isUsed) {
+        if (initCanceller.isUsed()) {
           return;
         }
         triggerEvent("reloadingMediaSource", null);
-        if (initCanceller.isUsed) {
+        if (initCanceller.isUsed()) {
           return;
         }
 
@@ -376,7 +376,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                                          newCanceller);
           })
           .catch((err) => {
-            if (newCanceller.isUsed) {
+            if (newCanceller.isUsed()) {
               return;
             }
             onFatalError(err);
@@ -431,7 +431,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                                 (err) => this.trigger("warning", err),
                                 cancelSignal);
 
-    if (cancelSignal.isCancelled) {
+    if (cancelSignal.isCancelled()) {
       return;
     }
 
@@ -483,7 +483,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           }, { emitCurrentValue: true, clearSignal: cancelSignal });
       })
       .catch((err) => {
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return; // Current loading cancelled, no need to trigger the error
         }
         this._onFatalError(err);
@@ -519,7 +519,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             discontinuity: imminentDiscontinuity,
             position,
           });
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return; // Previous call has stopped streams due to a side-effect
           }
 
@@ -560,7 +560,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
         adaptationChange: (value) => {
           self.trigger("adaptationChange", value);
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return; // Previous call has stopped streams due to a side-effect
           }
           contentTimeBoundariesObserver.onAdaptationChange(value.type,
@@ -570,7 +570,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
         representationChange: (value) => {
           self.trigger("representationChange", value);
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return; // Previous call has stopped streams due to a side-effect
           }
           contentTimeBoundariesObserver.onRepresentationChange(value.type, value.period);
@@ -584,7 +584,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
         periodStreamCleared: (value) => {
           contentTimeBoundariesObserver.onPeriodCleared(value.type, value.period);
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return; // Previous call has stopped streams due to a side-effect
           }
           self.trigger("periodStreamCleared", value);
@@ -615,7 +615,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         encryptionDataEncountered: (value) => {
           for (const protectionData of value) {
             protectionRef.setValue(protectionData);
-            if (cancelSignal.isCancelled) {
+            if (cancelSignal.isCancelled()) {
               return; // Previous call has stopped streams due to a side-effect
             }
           }

--- a/src/core/init/media_source_content_initializer.ts
+++ b/src/core/init/media_source_content_initializer.ts
@@ -227,9 +227,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         }
         stopListeningToDrmUpdates();
 
-        const mediaSourceCanceller = new TaskCanceller({
-          cancelOn: initCanceller.signal,
-        });
+        const mediaSourceCanceller = new TaskCanceller();
+        mediaSourceCanceller.linkToSignal(initCanceller.signal);
         openMediaSource(mediaElement, mediaSourceCanceller.signal)
           .then((mediaSource) => {
             const lastDrmStatus = drmInitRef.getValue();
@@ -367,7 +366,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           return;
         }
 
-        const newCanceller = new TaskCanceller({ cancelOn: initCanceller.signal });
+        const newCanceller = new TaskCanceller();
+        newCanceller.linkToSignal(initCanceller.signal);
         openMediaSource(mediaElement, newCanceller.signal)
           .then(newMediaSource => {
             recursivelyLoadOnMediaSource(newMediaSource,
@@ -674,7 +674,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     });
     contentTimeBoundariesObserver.addEventListener("endOfStream", () => {
       if (endOfStreamCanceller === null) {
-        endOfStreamCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+        endOfStreamCanceller = new TaskCanceller();
+        endOfStreamCanceller.linkToSignal(cancelSignal);
         log.debug("Init: end-of-stream order received.");
         maintainEndOfStream(mediaSource, endOfStreamCanceller.signal);
       }

--- a/src/core/init/utils/content_time_boundaries_observer.ts
+++ b/src/core/init/utils/content_time_boundaries_observer.ts
@@ -112,7 +112,7 @@ export default class ContentTimeBoundariesObserver
 
     manifest.addEventListener("manifestUpdate", () => {
       this.trigger("durationUpdate", getManifestDuration());
-      if (cancelSignal.isCancelled) {
+      if (cancelSignal.isCancelled()) {
         return;
       }
       this._checkEndOfStream();
@@ -161,7 +161,7 @@ export default class ContentTimeBoundariesObserver
         }
       }
     }
-    if (this._canceller.isUsed) {
+    if (this._canceller.isUsed()) {
       return;
     }
     if (adaptation === null) {

--- a/src/core/init/utils/end_of_stream.ts
+++ b/src/core/init/utils/end_of_stream.ts
@@ -70,7 +70,8 @@ export default function triggerEndOfStream(
 
   log.debug("Init: Waiting SourceBuffers to be updated before calling endOfStream.");
 
-  const innerCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+  const innerCanceller = new TaskCanceller();
+  innerCanceller.linkToSignal(cancelSignal);
   for (const sourceBuffer of updatingSourceBuffers) {
     onSourceBufferUpdate(sourceBuffer, () => {
       innerCanceller.cancel();
@@ -94,10 +95,12 @@ export function maintainEndOfStream(
   mediaSource : MediaSource,
   cancelSignal : CancellationSignal
 ) : void {
-  let endOfStreamCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+  let endOfStreamCanceller = new TaskCanceller();
+  endOfStreamCanceller.linkToSignal(cancelSignal);
   onSourceOpen(mediaSource, () => {
     endOfStreamCanceller.cancel();
-    endOfStreamCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+    endOfStreamCanceller = new TaskCanceller();
+    endOfStreamCanceller.linkToSignal(cancelSignal);
     triggerEndOfStream(mediaSource, endOfStreamCanceller.signal);
   }, cancelSignal);
   triggerEndOfStream(mediaSource, endOfStreamCanceller.signal);

--- a/src/core/init/utils/get_loaded_reference.ts
+++ b/src/core/init/utils/get_loaded_reference.ts
@@ -43,7 +43,8 @@ export default function getLoadedReference(
   isDirectfile : boolean,
   cancelSignal : CancellationSignal
 ) : IReadOnlySharedReference<boolean> {
-  const listenCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+  const listenCanceller = new TaskCanceller();
+  listenCanceller.linkToSignal(cancelSignal);
   const isLoaded = createSharedReference(false, listenCanceller.signal);
   playbackObserver.listen((observation) => {
     if (observation.rebuffering !== null ||

--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -112,7 +112,7 @@ export default function performInitialSeekAndPlay(
                                    "falsely announced having loaded the content.");
       onWarning(error);
     }
-    if (cancelSignal.isCancelled) {
+    if (cancelSignal.isCancelled()) {
       return ;
     }
 
@@ -149,7 +149,7 @@ export default function performInitialSeekAndPlay(
     }
     playResult
       .then(() => {
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return;
         }
         initialPlayPerformed.setValue(true);
@@ -159,7 +159,7 @@ export default function performInitialSeekAndPlay(
       })
       .catch((playError : unknown) => {
         deregisterCancellation();
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return;
         }
         if (playError instanceof Error && playError.name === "NotAllowedError") {
@@ -171,7 +171,7 @@ export default function performInitialSeekAndPlay(
                                        "Cannot trigger auto-play automatically: " +
                                        "your browser does not allow it.");
           onWarning(error);
-          if (cancelSignal.isCancelled) {
+          if (cancelSignal.isCancelled()) {
             return;
           }
           return resolveAutoPlay({ type: "autoplay-blocked" as const });

--- a/src/core/init/utils/initialize_content_decryption.ts
+++ b/src/core/init/utils/initialize_content_decryption.ts
@@ -82,7 +82,8 @@ export default function initializeContentDecryption(
     return ref;
   }
 
-  const decryptorCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+  const decryptorCanceller = new TaskCanceller();
+  decryptorCanceller.linkToSignal(cancelSignal);
   const drmStatusRef = createSharedReference<IDrmInitializationStatus>({
     initializationState: { type: "uninitialized", value: null },
     drmSystemId: undefined,

--- a/src/core/init/utils/media_duration_updater.ts
+++ b/src/core/init/utils/media_duration_updater.ts
@@ -67,7 +67,8 @@ export default class MediaDurationUpdater {
                                                                this._canceller.signal);
 
     /** TaskCanceller triggered each time the MediaSource open status changes. */
-    let msUpdateCanceller = new TaskCanceller({ cancelOn: this._canceller.signal });
+    let msUpdateCanceller = new TaskCanceller();
+    msUpdateCanceller.linkToSignal(this._canceller.signal);
 
     isMediaSourceOpened.onUpdate(onMediaSourceOpenedStatusChanged,
                                  { emitCurrentValue: true,
@@ -79,18 +80,17 @@ export default class MediaDurationUpdater {
       if (!isMediaSourceOpened.getValue()) {
         return;
       }
-      msUpdateCanceller = new TaskCanceller({ cancelOn: canceller.signal });
+      msUpdateCanceller = new TaskCanceller();
+      msUpdateCanceller.linkToSignal(canceller.signal);
 
-      /** TaskCanceller triggered each time the content's duration may have change */
-      let durationChangeCanceller = new TaskCanceller({
-        cancelOn: msUpdateCanceller.signal,
-      });
+      /** TaskCanceller triggered each time the content's duration may have changed */
+      let durationChangeCanceller = new TaskCanceller();
+      durationChangeCanceller.linkToSignal(msUpdateCanceller.signal);
 
       const reSetDuration = () => {
         durationChangeCanceller.cancel();
-        durationChangeCanceller = new TaskCanceller({
-          cancelOn: msUpdateCanceller.signal,
-        });
+        durationChangeCanceller = new TaskCanceller();
+        durationChangeCanceller.linkToSignal(msUpdateCanceller.signal);
         onDurationMayHaveChanged(durationChangeCanceller.signal);
       };
 
@@ -112,10 +112,12 @@ export default class MediaDurationUpdater {
       );
 
       /** TaskCanceller triggered each time SourceBuffers' updating status changes */
-      let sourceBuffersUpdatingCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+      let sourceBuffersUpdatingCanceller = new TaskCanceller();
+      sourceBuffersUpdatingCanceller.linkToSignal(cancelSignal);
       return areSourceBuffersUpdating.onUpdate((areUpdating) => {
         sourceBuffersUpdatingCanceller.cancel();
-        sourceBuffersUpdatingCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+        sourceBuffersUpdatingCanceller = new TaskCanceller();
+        sourceBuffersUpdatingCanceller.linkToSignal(cancelSignal);
         if (areUpdating) {
           return;
         }

--- a/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -161,7 +161,7 @@ export default function streamEventsEmitter(
         } else {
           onEventSkip(event.value);
         }
-        if (stopSignal.isCancelled) {
+        if (stopSignal.isCancelled()) {
           return;
         }
       }
@@ -172,7 +172,7 @@ export default function streamEventsEmitter(
         if (typeof event.onExit === "function") {
           event.onExit();
         }
-        if (stopSignal.isCancelled) {
+        if (stopSignal.isCancelled()) {
           return;
         }
       }

--- a/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -56,13 +56,15 @@ export default function streamEventsEmitter(
   }, cancelSignal);
 
   let isPollingEvents = false;
-  let cancelCurrentPolling = new TaskCanceller({ cancelOn: cancelSignal });
+  let cancelCurrentPolling = new TaskCanceller();
+  cancelCurrentPolling.linkToSignal(cancelSignal);
 
   scheduledEventsRef.onUpdate(({ length: scheduledEventsLength }) => {
     if (scheduledEventsLength === 0) {
       if (isPollingEvents) {
         cancelCurrentPolling.cancel();
-        cancelCurrentPolling = new TaskCanceller({ cancelOn: cancelSignal });
+        cancelCurrentPolling = new TaskCanceller();
+        cancelCurrentPolling.linkToSignal(cancelSignal);
         isPollingEvents = false;
       }
       return;

--- a/src/core/init/utils/throw_on_media_error.ts
+++ b/src/core/init/utils/throw_on_media_error.ts
@@ -28,7 +28,7 @@ export default function listenToMediaError(
   onError : (error : MediaError) => void,
   cancelSignal : CancellationSignal
 ) : void {
-  if (cancelSignal.isCancelled) {
+  if (cancelSignal.isCancelled()) {
     return;
   }
 

--- a/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
+++ b/src/core/segment_buffers/implementations/text/html/html_text_segment_buffer.ts
@@ -353,7 +353,8 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
                                element : HTMLElement; } => cue.resolution !== null);
 
     if (proportionalCues.length > 0) {
-      this._sizeUpdateCanceller = new TaskCanceller({ cancelOn: this._canceller.signal });
+      this._sizeUpdateCanceller = new TaskCanceller();
+      this._sizeUpdateCanceller.linkToSignal(this._canceller.signal);
       const { TEXT_TRACK_SIZE_CHECKS_INTERVAL } = config.getCurrent();
       // update propertionally-sized elements periodically
       const heightWidthRef = onHeightWidthChange(this._textTrackElement,
@@ -382,7 +383,8 @@ export default class HTMLTextSegmentBuffer extends SegmentBuffer {
 
     const startAutoRefresh = () => {
       stopAutoRefresh();
-      autoRefreshCanceller = new TaskCanceller({ cancelOn: cancellationSignal });
+      autoRefreshCanceller = new TaskCanceller();
+      autoRefreshCanceller.linkToSignal(cancellationSignal);
       const intervalId = setInterval(() => this.refreshSubtitles(),
                                      MAXIMUM_HTML_TEXT_TRACK_UPDATE_INTERVAL);
       autoRefreshCanceller.signal.register(() => {

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -84,7 +84,8 @@ export default function AdaptationStream<T>(
   const { manifest, period, adaptation } = content;
 
   /** Allows to cancel everything the `AdaptationStream` is doing. */
-  const adapStreamCanceller = new TaskCanceller({ cancelOn: parentCancelSignal });
+  const adapStreamCanceller = new TaskCanceller();
+  adapStreamCanceller.linkToSignal(parentCancelSignal);
 
   /**
    * The buffer goal ratio base itself on the value given by `wantedBufferAhead`
@@ -162,9 +163,8 @@ export default function AdaptationStream<T>(
      * terminating and as such the next one might be immediately created
      * recursively.
      */
-    const repStreamTerminatingCanceller = new TaskCanceller({
-      cancelOn: adapStreamCanceller.signal,
-    });
+    const repStreamTerminatingCanceller = new TaskCanceller();
+    repStreamTerminatingCanceller.linkToSignal(adapStreamCanceller.signal);
     const { representation, manual } = estimateRef.getValue();
     if (representation === null) {
       return;
@@ -306,9 +306,8 @@ export default function AdaptationStream<T>(
      * `TaskCanceller` triggered when the `RepresentationStream` calls its
      * `terminating` callback.
      */
-    const terminatingRepStreamCanceller = new TaskCanceller({
-      cancelOn: adapStreamCanceller.signal,
-    });
+    const terminatingRepStreamCanceller = new TaskCanceller();
+    terminatingRepStreamCanceller.linkToSignal(adapStreamCanceller.signal);
     const bufferGoal = createMappedReference(wantedBufferAhead, prev => {
       return prev * getBufferGoalRatio(representation);
     }, terminatingRepStreamCanceller.signal);

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -247,11 +247,11 @@ export default function AdaptationStream<T>(
 
     const repInfo = { type: adaptation.type, period, representation };
     currentRepresentation.setValue(representation);
-    if (adapStreamCanceller.isUsed) {
+    if (adapStreamCanceller.isUsed()) {
       return ; // previous callback has stopped everything by side-effect
     }
     callbacks.representationChange(repInfo);
-    if (adapStreamCanceller.isUsed) {
+    if (adapStreamCanceller.isUsed()) {
       return ; // previous callback has stopped everything by side-effect
     }
 
@@ -268,13 +268,13 @@ export default function AdaptationStream<T>(
       },
       addedSegment(segmentInfo) {
         abrCallbacks.addedSegment(segmentInfo);
-        if (adapStreamCanceller.isUsed) {
+        if (adapStreamCanceller.isUsed()) {
           return;
         }
         callbacks.addedSegment(segmentInfo);
       },
       terminating() {
-        if (repStreamTerminatingCanceller.isUsed) {
+        if (repStreamTerminatingCanceller.isUsed()) {
           return; // Already handled
         }
         repStreamTerminatingCanceller.cancel();

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -167,7 +167,8 @@ export default function StreamOrchestrator(
     let enableOutOfBoundsCheck = false;
 
     /** Cancels currently created `PeriodStream`s. */
-    let currentCanceller = new TaskCanceller({ cancelOn: orchestratorCancelSignal });
+    let currentCanceller = new TaskCanceller();
+    currentCanceller.linkToSignal(orchestratorCancelSignal);
 
     // Restart the current Stream when the wanted time is in another period
     // than the ones already considered
@@ -186,7 +187,8 @@ export default function StreamOrchestrator(
         callbacks.periodStreamCleared({ type: bufferType, period });
       }
       currentCanceller.cancel();
-      currentCanceller = new TaskCanceller({ cancelOn: orchestratorCancelSignal });
+      currentCanceller = new TaskCanceller();
+      currentCanceller.linkToSignal(orchestratorCancelSignal);
 
       const nextPeriod = manifest.getPeriodForTime(time) ??
                          manifest.getNextPeriod(time);
@@ -316,7 +318,8 @@ export default function StreamOrchestrator(
       }
 
       currentCanceller.cancel();
-      currentCanceller = new TaskCanceller({ cancelOn: orchestratorCancelSignal });
+      currentCanceller = new TaskCanceller();
+      currentCanceller.linkToSignal(orchestratorCancelSignal);
 
       /** Remove from the `SegmentBuffer` all the concerned time ranges. */
       for (const { start, end } of [...undecipherableRanges, ...rangesToRemove]) {
@@ -417,7 +420,8 @@ export default function StreamOrchestrator(
     } | null = null;
 
     /** Emits when the `PeriodStream` linked to `basePeriod` should be destroyed. */
-    const currentStreamCanceller = new TaskCanceller({ cancelOn: cancelSignal });
+    const currentStreamCanceller = new TaskCanceller();
+    currentStreamCanceller.linkToSignal(cancelSignal);
 
     // Stop current PeriodStream when the current position goes over the end of
     // that Period.
@@ -490,7 +494,9 @@ export default function StreamOrchestrator(
                                                         period: nextStreamInfo.period });
         nextStreamInfo.canceller.cancel();
       }
-      nextStreamInfo = { canceller: new TaskCanceller({ cancelOn: cancelSignal }),
+      const nextStreamCanceller = new TaskCanceller();
+      nextStreamCanceller.linkToSignal(cancelSignal);
+      nextStreamInfo = { canceller: nextStreamCanceller,
                          period: nextPeriod };
       manageConsecutivePeriodStreams(bufferType,
                                      nextPeriod,

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -329,7 +329,7 @@ export default function StreamOrchestrator(
       // to reduce the risk of race conditions where the next observation
       // was going to be emitted synchronously.
       nextTick(() => {
-        if (orchestratorCancelSignal.isCancelled) {
+        if (orchestratorCancelSignal.isCancelled()) {
           return ;
         }
         const observation = playbackObserver.getReference().getValue();
@@ -339,12 +339,12 @@ export default function StreamOrchestrator(
           callbacks.needsDecipherabilityFlush({ position: observation.position.last,
                                                 autoPlay: shouldAutoPlay,
                                                 duration: observation.duration });
-          if (orchestratorCancelSignal.isCancelled) {
+          if (orchestratorCancelSignal.isCancelled()) {
             return ;
           }
         } else if (needsFlushingAfterClean(observation, rangesToRemove)) {
           callbacks.needsBufferFlush();
-          if (orchestratorCancelSignal.isCancelled) {
+          if (orchestratorCancelSignal.isCancelled()) {
             return ;
           }
         }

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -109,7 +109,7 @@ export default function PeriodStream(
   );
 
   callbacks.periodStreamReady({ type: bufferType, period, adaptationRef });
-  if (parentCancelSignal.isCancelled) {
+  if (parentCancelSignal.isCancelled()) {
     return;
   }
 
@@ -142,20 +142,20 @@ export default function PeriodStream(
               await segmentBufferStatus.value.removeBuffer(period.start,
                                                            periodEnd,
                                                            streamCanceller.signal);
-              if (streamCanceller.isUsed) {
+              if (streamCanceller.isUsed()) {
                 return; // The stream has been cancelled
               }
             }
           }
         } else if (segmentBufferStatus.type === "uninitialized") {
           segmentBuffersStore.disableSegmentBuffer(bufferType);
-          if (streamCanceller.isUsed) {
+          if (streamCanceller.isUsed()) {
             return; // The stream has been cancelled
           }
         }
 
         callbacks.adaptationChange({ type: bufferType, adaptation: null, period });
-        if (streamCanceller.isUsed) {
+        if (streamCanceller.isUsed()) {
           return; // Previous call has provoken Stream cancellation by side-effect
         }
 
@@ -193,7 +193,7 @@ export default function PeriodStream(
                `P: ${period.start}`);
 
       callbacks.adaptationChange({ type: bufferType, adaptation, period });
-      if (streamCanceller.isUsed) {
+      if (streamCanceller.isUsed()) {
         return; // Previous call has provoken cancellation by side-effect
       }
 
@@ -214,19 +214,19 @@ export default function PeriodStream(
       }
 
       await segmentBuffersStore.waitForUsableBuffers(streamCanceller.signal);
-      if (streamCanceller.isUsed) {
+      if (streamCanceller.isUsed()) {
         return; // The Stream has since been cancelled
       }
       if (strategy.type === "flush-buffer" || strategy.type === "clean-buffer") {
         for (const { start, end } of strategy.value) {
           await segmentBuffer.removeBuffer(start, end, streamCanceller.signal);
-          if (streamCanceller.isUsed) {
+          if (streamCanceller.isUsed()) {
             return; // The Stream has since been cancelled
           }
         }
         if (strategy.type === "flush-buffer") {
           callbacks.needsBufferFlush();
-          if (streamCanceller.isUsed) {
+          if (streamCanceller.isUsed()) {
             return ; // Previous callback cancelled the Stream by side-effect
           }
         }
@@ -282,7 +282,7 @@ export default function PeriodStream(
           defaultReason: "Unknown `AdaptationStream` error",
         });
         callbacks.warning(formattedError);
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return ; // Previous callback cancelled the Stream by side-effect
         }
 

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -122,7 +122,8 @@ export default function PeriodStream(
       if (adaptation === undefined) {
         return;
       }
-      const streamCanceller = new TaskCanceller({ cancelOn: parentCancelSignal });
+      const streamCanceller = new TaskCanceller();
+      streamCanceller.linkToSignal(parentCancelSignal);
       currentStreamCanceller?.cancel(); // Cancel oreviously created stream if one
       currentStreamCanceller = streamCanceller;
 

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -149,7 +149,7 @@ export default function RepresentationStream<TSegmentDataType>(
       callbacks.encryptionDataEncountered(
         encryptionData.map(d => objectAssign({ content }, d))
       );
-      if (globalCanceller.isUsed) {
+      if (globalCanceller.isUsed()) {
         return ; // previous callback has stopped everything by side-effect
       }
     }
@@ -161,7 +161,7 @@ export default function RepresentationStream<TSegmentDataType>(
                                                 segmentFetcher,
                                                 hasInitSegment);
   downloadingQueue.addEventListener("error", (err) => {
-    if (segmentsLoadingCanceller.signal.isCancelled) {
+    if (segmentsLoadingCanceller.signal.isCancelled()) {
       return; // ignore post requests-cancellation loading-related errors,
     }
     globalCanceller.cancel(); // Stop every operations
@@ -172,7 +172,7 @@ export default function RepresentationStream<TSegmentDataType>(
   downloadingQueue.addEventListener("emptyQueue", checkStatus);
   downloadingQueue.addEventListener("requestRetry", (payload) => {
     callbacks.warning(payload.error);
-    if (segmentsLoadingCanceller.signal.isCancelled) {
+    if (segmentsLoadingCanceller.signal.isCancelled()) {
       return; // If the previous callback led to loading operations being stopped, skip
     }
     const retriedSegment = payload.segment;
@@ -218,7 +218,7 @@ export default function RepresentationStream<TSegmentDataType>(
    * issues at the current time, calling the right callbacks if necessary.
    */
   function checkStatus() : void {
-    if (segmentsLoadingCanceller.isUsed) {
+    if (segmentsLoadingCanceller.isUsed()) {
       return ; // Stop all buffer status checking if load operations are stopped
     }
     const observation = playbackObserver.getReference().getValue();
@@ -305,7 +305,7 @@ export default function RepresentationStream<TSegmentDataType>(
                                    isEmptyStream: false,
                                    hasFinishedLoading: status.hasFinishedLoading,
                                    neededSegments: status.neededSegments });
-    if (segmentsLoadingCanceller.signal.isCancelled) {
+    if (segmentsLoadingCanceller.signal.isCancelled()) {
       return ; // previous callback has stopped loading operations by side-effect
     }
     const { UPTO_CURRENT_POSITION_CLEANUP } = config.getCurrent();
@@ -332,7 +332,7 @@ export default function RepresentationStream<TSegmentDataType>(
     evt : IParsedInitSegmentPayload<TSegmentDataType> |
           IParsedSegmentPayload<TSegmentDataType>
   ) : void {
-    if (globalCanceller.isUsed) {
+    if (globalCanceller.isUsed()) {
       // We should not do anything with segments if the `RepresentationStream`
       // is not running anymore.
       return ;
@@ -382,7 +382,7 @@ export default function RepresentationStream<TSegmentDataType>(
           callbacks.encryptionDataEncountered(
             allEncryptionData.map(p => objectAssign({ content }, p))
           );
-          if (globalCanceller.isUsed) {
+          if (globalCanceller.isUsed()) {
             return ; // previous callback has stopped everything by side-effect
           }
         }
@@ -390,13 +390,13 @@ export default function RepresentationStream<TSegmentDataType>(
 
       if (needsManifestRefresh === true) {
         callbacks.needsManifestRefresh();
-        if (globalCanceller.isUsed) {
+        if (globalCanceller.isUsed()) {
           return ; // previous callback has stopped everything by side-effect
         }
       }
       if (inbandEvents !== undefined && inbandEvents.length > 0) {
         callbacks.inbandEvent(inbandEvents);
-        if (globalCanceller.isUsed) {
+        if (globalCanceller.isUsed()) {
           return ; // previous callback has stopped everything by side-effect
         }
       }
@@ -425,7 +425,7 @@ export default function RepresentationStream<TSegmentDataType>(
    * @param {*} err
    */
   function onFatalBufferError(err : unknown) : void {
-    if (globalCanceller.isUsed && err instanceof CancellationError) {
+    if (globalCanceller.isUsed() && err instanceof CancellationError) {
       // The error is linked to cancellation AND we explicitely cancelled buffer
       // operations.
       // We can thus ignore it, it is very unlikely to lead to true buffer issues.

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -97,16 +97,16 @@ export default function RepresentationStream<TSegmentDataType>(
   const bufferType = adaptation.type;
 
   /** `TaskCanceller` stopping ALL operations performed by the `RepresentationStream` */
-  const globalCanceller = new TaskCanceller({ cancelOn: parentCancelSignal });
+  const globalCanceller = new TaskCanceller();
+  globalCanceller.linkToSignal(parentCancelSignal);
 
   /**
    * `TaskCanceller` allowing to only stop segment loading and checking operations.
    * This allows to stop only tasks linked to network resource usage, which is
    * often a limited resource, while still letting buffer operations to finish.
    */
-  const segmentsLoadingCanceller = new TaskCanceller({
-    cancelOn: globalCanceller.signal,
-  });
+  const segmentsLoadingCanceller = new TaskCanceller();
+  segmentsLoadingCanceller.linkToSignal(globalCanceller.signal);
 
   /** Saved initialization segment state for this representation. */
   const initSegmentState : IInitSegmentState<TSegmentDataType> = {

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -47,7 +47,7 @@ export default async function appendSegmentToBuffer<T>(
   try {
     await segmentBuffer.pushChunk(dataInfos, cancellationSignal);
   } catch (appendError : unknown) {
-    if (cancellationSignal.isCancelled && appendError instanceof CancellationError) {
+    if (cancellationSignal.isCancelled() && appendError instanceof CancellationError) {
       throw appendError;
     } else if (!(appendError instanceof Error) ||
                appendError.name !== "QuotaExceededError")

--- a/src/core/stream/representation/utils/downloading_queue.ts
+++ b/src/core/stream/representation/utils/downloading_queue.ts
@@ -28,6 +28,7 @@ import {
 } from "../../../../transports";
 import assert from "../../../../utils/assert";
 import EventEmitter from "../../../../utils/event_emitter";
+import noop from "../../../../utils/noop";
 import objectAssign from "../../../../utils/object_assign";
 import createSharedReference, {
   IReadOnlySharedReference,
@@ -255,7 +256,10 @@ export default class DownloadingQueue<T>
         this.trigger("emptyQueue", null);
         return;
       }
-      const canceller = new TaskCanceller({ cancelOn: this._currentCanceller?.signal });
+      const canceller = new TaskCanceller();
+      const unlinkCanceller = this._currentCanceller === null ?
+        noop :
+        canceller.linkToSignal(this._currentCanceller.signal);
 
       const { segment, priority } = startingSegment;
       const context = objectAssign({ segment }, this._content);
@@ -369,6 +373,7 @@ export default class DownloadingQueue<T>
          * requests are scheduled. It is used to schedule the next segment.
          */
         beforeEnded: () : void => {
+          unlinkCanceller();
           this._mediaSegmentRequest = null;
 
           if (isWaitingOnInitSegment) {
@@ -382,6 +387,7 @@ export default class DownloadingQueue<T>
       }, canceller.signal);
 
       request.catch((error : unknown) => {
+        unlinkCanceller();
         if (!isComplete) {
           isComplete = true;
           this.stop();
@@ -411,7 +417,10 @@ export default class DownloadingQueue<T>
       return ;
     }
 
-    const canceller = new TaskCanceller({ cancelOn: this._currentCanceller?.signal });
+    const canceller = new TaskCanceller();
+    const unlinkCanceller = this._currentCanceller === null ?
+      noop :
+      canceller.linkToSignal(this._currentCanceller.signal);
     const { segment, priority } = queuedInitSegment;
     const context = objectAssign({ segment }, this._content);
 
@@ -429,6 +438,7 @@ export default class DownloadingQueue<T>
         log.info("Stream: init segment request interrupted temporarly.", segment.id);
       },
       beforeEnded: () => {
+        unlinkCanceller();
         this._initSegmentRequest = null;
         isComplete = true;
       },
@@ -447,6 +457,7 @@ export default class DownloadingQueue<T>
     }, canceller.signal);
 
     request.catch((error : unknown) => {
+      unlinkCanceller();
       if (!isComplete) {
         isComplete = true;
         this.stop();

--- a/src/core/stream/representation/utils/downloading_queue.ts
+++ b/src/core/stream/representation/utils/downloading_queue.ts
@@ -231,6 +231,7 @@ export default class DownloadingQueue<T>
 
   public stop() {
     this._currentCanceller?.cancel();
+    this._currentCanceller = null;
   }
 
   /**
@@ -245,7 +246,7 @@ export default class DownloadingQueue<T>
     const recursivelyRequestSegments = (
       startingSegment : IQueuedSegment | undefined
     ) : void  => {
-      if (this._currentCanceller !== null && this._currentCanceller.isUsed) {
+      if (this._currentCanceller !== null && this._currentCanceller.isUsed()) {
         this._mediaSegmentRequest = null;
         return;
       }
@@ -400,7 +401,7 @@ export default class DownloadingQueue<T>
   private _restartInitSegmentDownloadingQueue(
     queuedInitSegment : IQueuedSegment | null
   ) : void {
-    if (this._currentCanceller !== null && this._currentCanceller.isUsed) {
+    if (this._currentCanceller !== null && this._currentCanceller.isUsed()) {
       return;
     }
     if (this._initSegmentRequest !== null) {

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -243,15 +243,16 @@ export default class VideoThumbnailLoader {
           if (pending !== undefined) {
             promises.push(pending.promise);
           } else {
-            const requestCanceller = new TaskCanceller({
-              cancelOn: lastRepInfo.cleaner.signal,
-            });
+            const requestCanceller = new TaskCanceller();
+            const unlinkSignal = requestCanceller
+              .linkToSignal(lastRepInfo.cleaner.signal);
             const segmentInfo = objectAssign({ segment },
                                              content);
             const prom = loadAndPushSegment(segmentInfo,
                                             segmentBuffer,
                                             lastRepInfo.segmentFetcher,
-                                            requestCanceller.signal);
+                                            requestCanceller.signal)
+              .finally(unlinkSignal);
             const newReq = {
               segmentId: segment.id,
               canceller: requestCanceller,

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -31,11 +31,9 @@ export default function addSegmentIntegrityChecks<T>(
 ) : ISegmentLoader<T> {
   return (url, content, loaderOptions, initialCancelSignal, callbacks) => {
     return new Promise((resolve, reject) => {
-      const requestCanceller = new TaskCanceller({ cancelOn: initialCancelSignal });
-
-      // Reject the `CancellationError` when `requestCanceller`'s signal emits
-      // `stopRejectingOnCancel` here is a function allowing to stop this mechanism
-      const stopRejectingOnCancel = requestCanceller.signal.register(reject);
+      const requestCanceller = new TaskCanceller();
+      const unlinkCanceller = requestCanceller.linkToSignal(initialCancelSignal);
+      requestCanceller.signal.register(reject);
 
       segmentLoader(url, content, loaderOptions, requestCanceller.signal, {
         ...callbacks,
@@ -45,18 +43,20 @@ export default function addSegmentIntegrityChecks<T>(
             callbacks.onNewChunk(data);
           } catch (err) {
             // Do not reject with a `CancellationError` after cancelling the request
-            stopRejectingOnCancel();
+            cleanUpCancellers();
+
             // Cancel the request
             requestCanceller.cancel();
+
             // Reject with thrown error
             reject(err);
           }
         },
       }).then((info) => {
+        cleanUpCancellers();
         if (requestCanceller.isUsed()) {
           return;
         }
-        stopRejectingOnCancel();
         if (info.resultType === "segment-loaded") {
           try {
             trowOnIntegrityError(info.resultData.responseData);
@@ -67,9 +67,14 @@ export default function addSegmentIntegrityChecks<T>(
         }
         resolve(info);
       }, (error : unknown) => {
-        stopRejectingOnCancel();
+        cleanUpCancellers();
         reject(error);
       });
+
+      function cleanUpCancellers() {
+        requestCanceller.signal.deregister(reject);
+        unlinkCanceller();
+      }
     });
 
     /**

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -53,7 +53,7 @@ export default function addSegmentIntegrityChecks<T>(
           }
         },
       }).then((info) => {
-        if (requestCanceller.isUsed) {
+        if (requestCanceller.isUsed()) {
           return;
         }
         stopRejectingOnCancel();

--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -65,14 +65,14 @@ export default function lowLatencySegmentLoader(
     partialChunk = res[1];
     for (let i = 0; i < completeChunks.length; i++) {
       callbacks.onNewChunk(completeChunks[i]);
-      if (cancelSignal.isCancelled) {
+      if (cancelSignal.isCancelled()) {
         return;
       }
     }
     callbacks.onProgress({ duration: info.duration,
                            size: info.size,
                            totalSize: info.totalSize });
-    if (cancelSignal.isCancelled) {
+    if (cancelSignal.isCancelled()) {
       return;
     }
   }

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -139,7 +139,7 @@ export default function generateManifestParser(
         if (parserResponse.value.warnings.length > 0) {
           onWarnings(parserResponse.value.warnings);
         }
-        if (cancelSignal.isCancelled) {
+        if (cancelSignal.isCancelled()) {
           return Promise.reject(cancelSignal.cancellationError);
         }
         const manifest = new Manifest(parserResponse.value.parsed, options);

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -156,7 +156,7 @@ export default function generateSegmentLoader(
                   size? : number | undefined;
                   duration? : number | undefined; }
       ) => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -172,7 +172,7 @@ export default function generateSegmentLoader(
        * @param {*} err - The corresponding error encountered
        */
       const reject = (err : unknown) : void => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -198,7 +198,7 @@ export default function generateSegmentLoader(
                   size : number;
                   totalSize? : number | undefined; }
       ) => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         callbacks.onProgress({ duration: _args.duration,
@@ -211,7 +211,7 @@ export default function generateSegmentLoader(
        * the "regular" implementation
        */
       const fallback = () => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;

--- a/src/transports/local/segment_loader.ts
+++ b/src/transports/local/segment_loader.ts
@@ -54,7 +54,7 @@ function loadInitSegment(
       size? : number;
       duration? : number;
     }) => {
-      if (hasFinished || cancelSignal.isCancelled) {
+      if (hasFinished || cancelSignal.isCancelled()) {
         return;
       }
       hasFinished = true;
@@ -70,7 +70,7 @@ function loadInitSegment(
      * @param {*} err - The corresponding error encountered
      */
     const reject = (err? : Error) => {
-      if (hasFinished || cancelSignal.isCancelled) {
+      if (hasFinished || cancelSignal.isCancelled()) {
         return;
       }
       hasFinished = true;
@@ -122,7 +122,7 @@ function loadSegment(
       size? : number;
       duration? : number;
     }) => {
-      if (hasFinished || cancelSignal.isCancelled) {
+      if (hasFinished || cancelSignal.isCancelled()) {
         return;
       }
       hasFinished = true;
@@ -138,7 +138,7 @@ function loadSegment(
      * @param {*} err - The corresponding error encountered
      */
     const reject = (err? : Error) => {
-      if (hasFinished || cancelSignal.isCancelled) {
+      if (hasFinished || cancelSignal.isCancelled()) {
         return;
       }
       hasFinished = true;

--- a/src/transports/smooth/segment_loader.ts
+++ b/src/transports/smooth/segment_loader.ts
@@ -185,7 +185,7 @@ const generateSegmentLoader = ({
         size? : number | undefined;
         duration? : number | undefined;
       }) => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -213,7 +213,7 @@ const generateSegmentLoader = ({
        * @param {*} err - The corresponding error encountered
        */
       const reject = (err : unknown) => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -239,7 +239,7 @@ const generateSegmentLoader = ({
                   size : number;
                   totalSize? : number | undefined; }
       ) => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         callbacks.onProgress({ duration: _args.duration,
@@ -248,7 +248,7 @@ const generateSegmentLoader = ({
       };
 
       const fallback = () => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -62,7 +62,7 @@ export default function callCustomManifestLoader(
                                  receivingTime? : number | undefined;
                                  sendingTime? : number | undefined; }) =>
       {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -87,7 +87,7 @@ export default function callCustomManifestLoader(
        * @param {*} err - The corresponding error encountered
        */
       const reject = (err : unknown) : void => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;
@@ -113,7 +113,7 @@ export default function callCustomManifestLoader(
        * the "regular" implementation
        */
       const fallback = () => {
-        if (hasFinished || cancelSignal.isCancelled) {
+        if (hasFinished || cancelSignal.isCancelled()) {
           return;
         }
         hasFinished = true;

--- a/src/utils/reference.ts
+++ b/src/utils/reference.ts
@@ -294,6 +294,9 @@ export default function createSharedReference<T>(
       options.clearSignal.register(unlisten);
 
       function unlisten() : void {
+        if (options?.clearSignal !== undefined) {
+          options.clearSignal.deregister(unlisten);
+        }
         if (cbObj.hasBeenCleared) {
           return;
         }
@@ -339,6 +342,9 @@ export default function createSharedReference<T>(
     finish,
   };
   function finish() {
+    if (cancelSignal !== undefined) {
+      cancelSignal.deregister(finish);
+    }
     isFinished = true;
     const clonedCbs = cbs.slice();
     for (const cbObj of clonedCbs) {

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -125,7 +125,7 @@ export default function request<T>(
           reject(err);
         });
 
-      if (cancelSignal.isCancelled) {
+      if (cancelSignal.isCancelled()) {
         return;
       }
     }

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -266,6 +266,7 @@ export class CancellationSignal {
     if (this.isCancelled) {
       assert(this.cancellationError !== null);
       fn(this.cancellationError);
+      return noop;
     }
     this._listeners.push(fn);
     return () => this.deregister(fn);


### PR DESCRIPTION
The `v3.30.0` pre-releases and the `v4.0.0-beta.0` beta release has a memory leak linked to the CancellationSignal abstraction - which is the new pattern to implement cancellation now that RxJS has been removed.

The idea is that callback to implement clean-up logic can be added to these `CancellationSignal` which will be triggered in case the corresponding task is cancelled, exactly like the browser native `AbortSignal`'s `"abort"` event if you know about it.

However, exactly like a classical event listener that callback is a closure which may keep unnecessarily in memory variables it contains, even when the cancellation logic become unneeded, as long as a reference is somewhere kept on its parent object.

For example, an ended task whose `CancellationSignal` has never been triggered may still keep alive the callback implementing the cancellation logic - because that `CancellationSignal` may technically still be triggered (and thus its logic can still be run) by the task's caller if it kept a reference to it.

Keeping the cancellation logic "runnable" even after the task has finished may seem nonsensical, but it has been left that way in some places in the code because it seemed there were no problem in the corresponding logic in doing so. Turned out there was, but still not in terms of logic, only in terms of memory being unnecessarily kept until the `CancellationSignal` was actually triggered (which generally happens, though might only be in the long future - for example when the content is stopped).

To fix these, I made sure to always clean-up cancellation logic when the task is actually finished and the cancellation logic has thus no utility anymore. I still have some checks to do to see if no memory leak remain.

This is actually an issue we prevented initially when using the `CancellationSignal`, but I apparently grew more lazy lately! This is a little sad still as it is an easy footgun.

---

What should be kept in mind and better communicated is that cancellation logic registered through a `CancellationSignal` has to be treated like an event listener on an element's whose lifecycle is not known by the code it is given to (it is linked to its parent `TaskCanceller` much like an `AbortSignal` is linked to its parent `AbortController`). Memory may be thus leaked as long as the `TaskCanceller` is alive.