### PR TITLE
Add createCancellablePromise util

### DIFF
--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -358,10 +358,9 @@ export async function scheduleRequestWithCdns<T>(
       return requestCdn(nextWantedCdn);
     }
 
+    const canceller = new TaskCanceller();
+    const unlinkCanceller = canceller.linkToSignal(cancellationSignal);
     return new Promise<T>((res, rej) => {
-      const canceller = new TaskCanceller();
-      const unlinkCanceller = canceller.linkToSignal(cancellationSignal);
-
       /* eslint-disable-next-line @typescript-eslint/no-misused-promises */
       cdnPrioritizer?.addEventListener("priorityChange", () => {
         const updatedPrioritaryCdn = getCdnToRequest();
@@ -369,27 +368,18 @@ export async function scheduleRequestWithCdns<T>(
           throw cancellationSignal.cancellationError;
         }
         if (updatedPrioritaryCdn === undefined) {
-          return reject(prevRequestError);
+          return rej(prevRequestError);
         }
         if (updatedPrioritaryCdn !== nextWantedCdn) {
           canceller.cancel();
           waitPotentialBackoffAndRequest(updatedPrioritaryCdn, prevRequestError)
-            .then(resolve, reject);
+            .then(res, rej);
         }
       }, canceller.signal);
 
       cancellableSleep(blockedFor, canceller.signal)
-        .then(() => requestCdn(nextWantedCdn).then(resolve, reject), noop);
-
-      function resolve(val : T) {
-        unlinkCanceller();
-        res(val);
-      }
-      function reject(err : unknown) {
-        unlinkCanceller();
-        rej(err);
-      }
-    });
+        .then(() => requestCdn(nextWantedCdn).then(res, rej), noop);
+    }).finally(unlinkCanceller);
   }
 
   /**

--- a/src/core/init/utils/create_media_source.ts
+++ b/src/core/init/utils/create_media_source.ts
@@ -21,6 +21,7 @@ import {
 } from "../../../compat";
 import { MediaError } from "../../../errors";
 import log from "../../../log";
+import createCancellablePromise from "../../../utils/create_cancellable_promise";
 import isNonEmptyString from "../../../utils/is_non_empty_string";
 import { CancellationSignal } from "../../../utils/task_canceller";
 
@@ -126,12 +127,10 @@ export default function openMediaSource(
   mediaElement : HTMLMediaElement,
   unlinkSignal : CancellationSignal
 ) : Promise<MediaSource> {
-  return new Promise((resolve, reject) => {
+  return createCancellablePromise(unlinkSignal, (resolve) => {
     const mediaSource = createMediaSource(mediaElement, unlinkSignal);
     events.onSourceOpen(mediaSource, () => {
-      unlinkSignal.deregister(reject);
       resolve(mediaSource);
     }, unlinkSignal);
-    unlinkSignal.register(reject);
   });
 }

--- a/src/core/segment_buffers/segment_buffers_store.ts
+++ b/src/core/segment_buffers/segment_buffers_store.ts
@@ -17,10 +17,8 @@
 import { MediaError } from "../../errors";
 import features from "../../features";
 import log from "../../log";
-import {
-  CancellationError,
-  CancellationSignal,
-} from "../../utils/task_canceller";
+import createCancellablePromise from "../../utils/create_cancellable_promise";
+import { CancellationSignal } from "../../utils/task_canceller";
 import {
   AudioVideoSegmentBuffer,
   IBufferType,
@@ -194,7 +192,7 @@ export default class SegmentBuffersStore {
     if (this._areNativeBuffersUsable()) {
       return Promise.resolve();
     }
-    return new Promise((res, rej) => {
+    return createCancellablePromise(cancelWaitSignal, (res) => {
       /* eslint-disable-next-line prefer-const */
       let onAddedOrDisabled : () => void;
 
@@ -205,20 +203,15 @@ export default class SegmentBuffersStore {
         }
       };
 
-      const onCancellation = (error : CancellationError) => {
-        removeCallback();
-        rej(error);
-      };
       onAddedOrDisabled = () => {
         if (this._areNativeBuffersUsable()) {
           removeCallback();
-          cancelWaitSignal.deregister(onCancellation);
           res();
         }
       };
       this._onNativeBufferAddedOrDisabled.push(onAddedOrDisabled);
 
-      cancelWaitSignal.register(onCancellation);
+      return removeCallback;
     });
   }
 

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -52,24 +52,25 @@ export default function addSegmentIntegrityChecks<T>(
             reject(err);
           }
         },
-      }).then((info) => {
-        cleanUpCancellers();
-        if (requestCanceller.isUsed()) {
-          return;
-        }
-        if (info.resultType === "segment-loaded") {
-          try {
-            trowOnIntegrityError(info.resultData.responseData);
-          } catch (err) {
-            reject(err);
-            return;
-          }
-        }
-        resolve(info);
-      }, (error : unknown) => {
-        cleanUpCancellers();
-        reject(error);
-      });
+      })
+        .finally(() =>  cleanUpCancellers())
+        .then(
+          (info) => {
+            if (requestCanceller.isUsed()) {
+              return;
+            }
+            if (info.resultType === "segment-loaded") {
+              try {
+                trowOnIntegrityError(info.resultData.responseData);
+              } catch (err) {
+                reject(err);
+                return;
+              }
+            }
+            resolve(info);
+          },
+          reject
+        );
 
       function cleanUpCancellers() {
         requestCanceller.signal.deregister(reject);

--- a/src/utils/cancellable_sleep.ts
+++ b/src/utils/cancellable_sleep.ts
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-import {
-  CancellationError,
-  CancellationSignal,
-} from "./task_canceller";
+import createCancellablePromise from "./create_cancellable_promise";
+import { CancellationSignal } from "./task_canceller";
 
 /**
  * Wait the given `delay`, resolving the Promise when finished.
@@ -36,15 +34,8 @@ export default function cancellableSleep(
   delay: number,
   cancellationSignal: CancellationSignal
 ) : Promise<void> {
-  return new Promise((res, rej) => {
-    const timeout = setTimeout(() => {
-      unregisterCancelSignal();
-      res();
-    }, delay);
-    const unregisterCancelSignal = cancellationSignal
-      .register(function onCancel(cancellationError : CancellationError) {
-        clearTimeout(timeout);
-        rej(cancellationError);
-      });
+  return createCancellablePromise(cancellationSignal, (res) => {
+    const timeout = setTimeout(() => res(), delay);
+    return () => clearTimeout(timeout);
   });
 }

--- a/src/utils/create_cancellable_promise.ts
+++ b/src/utils/create_cancellable_promise.ts
@@ -1,0 +1,69 @@
+import {
+  CancellationError,
+  CancellationSignal,
+} from "./task_canceller";
+
+/**
+ * Returns a Promise linked to a `CancellationSignal`, which will reject the
+ * corresponding `CancellationError` if that signal emits before the wanted
+ * task finishes (either on success or on error).
+ *
+ * The given callback mimicks the Promise interface with the added possibility
+ * of returning a callback which will be called when and if the task is
+ * cancelled before being either resolved or rejected.
+ * In that case, that logic will be called just before the Promise is rejected
+ * with the corresponding `CancellationError`.
+ * The point of this callback is to implement aborting logic, such as for
+ * example aborting a request.
+ *
+ * @param {Object} cancellationSignal - The `CancellationSignal` the returned
+ * Promise will be linked to.
+ * @param {Function} cb - The function implementing the cancellable Promise. Its
+ * arguments follow Promise's semantics but it can also return a function which
+ * will be called when and if `cancellationSignal` emits before either arguments
+ * are called.
+ * @returns {Promise} - The created Promise, which will resolve when and if the
+ * first argument to `cb` is called first and reject either if the second
+ * argument to `cb` is called first or if the given `CancellationSignal` emits
+ * before either of the two previous conditions.
+ */
+export default function createCancellablePromise<T>(
+  cancellationSignal : CancellationSignal,
+  cb : (
+    resolve : (val : T) => void,
+    reject : (err : unknown) => void,
+  ) => (() => void) | void
+) : Promise<T> {
+  let abortingLogic : (() => void) | void;
+  return new Promise((res, rej) => {
+    if (cancellationSignal.cancellationError !== null) {
+      // If the signal was already triggered before, do not even call `cb`
+      return rej(cancellationSignal.cancellationError);
+    }
+
+    let hasUnregistered = false;
+    abortingLogic = cb(
+      function onCancellablePromiseSuccess(val : T) {
+        cancellationSignal.deregister(onCancellablePromiseCancellation);
+        hasUnregistered = true;
+        res(val);
+      },
+      function onCancellablePromiseFailure(err : unknown) {
+        cancellationSignal.deregister(onCancellablePromiseCancellation);
+        hasUnregistered = true;
+        rej(err);
+      }
+    );
+
+    if (!hasUnregistered) {
+      cancellationSignal.register(onCancellablePromiseCancellation);
+    }
+
+    function onCancellablePromiseCancellation(error : CancellationError) {
+      if (abortingLogic !== undefined) {
+        abortingLogic();
+      }
+      rej(error);
+    }
+  });
+}


### PR DESCRIPTION
In #1213, I fixed a memory leak by making sure that cancellation logic was unregistered as soon as possible. Without that work, cancellation-linked callbacks were most of the time kept in-memory until the corresponding `CancellationSignal` actually emits, which was sometimes only after a very-long-lived task (for example when the corresponding `TaskCanceller` was linked to the playback of the whole content).

Turned out the most frequent case where we want to unregister cancellation logic was when using Promises (other cases are very often long-lived task which don't actually finish until cancellation - those do not need such clean-up).

When relying on Promises, the cancellation architecture is most of the time very similar: we generally want to reject if a `CancellationSignal` emits before the Promise fulfilled, optionally running some cancellation logic just before doing that, and in cases where the Promise actually fullfills first, we might want to unallocate the cancellation logic to free now unnecessary memory.

To facilitate that work and prevent future issues, I added the `createCancellablePromise` util that does just that, and replaced parts of the code where it made sense to have it.