### PR TITLE
DRM/Stream: do not needlessly restart Streams when Representations become known to be decipherable

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -324,8 +324,16 @@ export default function StreamOrchestrator(
       const segmentBufferStatus = segmentBuffersStore.getStatus(bufferType);
       const ofCurrentType = updates
         .filter(update => update.adaptation.type === bufferType);
-      if (ofCurrentType.length === 0 || segmentBufferStatus.type !== "initialized") {
-        return EMPTY; // no need to stop the current Streams.
+      if (
+        // No update concerns the current type of data
+        ofCurrentType.length === 0 ||
+        segmentBufferStatus.type !== "initialized" ||
+        // The update only notifies of now-decipherable streams
+        ofCurrentType.every(x => x.representation.decipherable === true)
+      ) {
+        // Data won't have to be removed from the buffers, no need to stop the
+        // current Streams.
+        return EMPTY;
       }
 
       const segmentBuffer = segmentBufferStatus.value;


### PR DESCRIPTION
There is no need to do that (there's nothing to fallback from for example) and it may lead to request being needlessly restarted.