### PR TITLE
Avoid using Promise.prototype.finally to better support older devices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,10 +16,18 @@ module.exports = {
   "plugins": [
     "eslint-plugin-import",
     "eslint-plugin-jsdoc",
+    "ban",
     "@typescript-eslint",
     "@typescript-eslint/tslint"
   ],
   "rules": {
+    "ban/ban": [
+      2,
+      {
+        "name": ["*", "finally"],
+        "message": "Promise.prototype.finally is forbidden due to poor support from older devices.\nNote that this linting rule just bans naively all \"finally\" method calls, if in this case it wasn't called on a Promise, you can safely ignore this error",
+      }
+    ],
     "@typescript-eslint/adjacent-overload-signatures": "error",
     "@typescript-eslint/array-type": [
       "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "core-js": "3.28.0",
         "esbuild": "0.17.10",
         "eslint": "8.34.0",
+        "eslint-plugin-ban": "1.6.0",
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-jsdoc": "40.0.0",
         "eslint-plugin-react": "7.32.2",
@@ -5853,6 +5854,18 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-ban": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.6.0.tgz",
+      "integrity": "sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==",
+      "dev": true,
+      "dependencies": {
+        "requireindex": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -11685,6 +11698,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.5"
       }
     },
     "node_modules/requires-port": {
@@ -18123,6 +18145,15 @@
         }
       }
     },
+    "eslint-plugin-ban": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.6.0.tgz",
+      "integrity": "sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.2.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.27.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
@@ -22316,6 +22347,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "requireindex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
+      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
     "requires-port": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "core-js": "3.28.0",
     "esbuild": "0.17.10",
     "eslint": "8.34.0",
+    "eslint-plugin-ban": "1.6.0",
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jsdoc": "40.0.0",
     "eslint-plugin-react": "7.32.2",

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -252,7 +252,10 @@ export default class VideoThumbnailLoader {
                                             segmentBuffer,
                                             lastRepInfo.segmentFetcher,
                                             requestCanceller.signal)
-              .finally(unlinkSignal);
+              .then(unlinkSignal, (err) => {
+                unlinkSignal();
+                throw err;
+              });
             const newReq = {
               segmentId: segment.id,
               canceller: requestCanceller,

--- a/src/transports/dash/add_segment_integrity_checks_to_loader.ts
+++ b/src/transports/dash/add_segment_integrity_checks_to_loader.ts
@@ -53,9 +53,9 @@ export default function addSegmentIntegrityChecks<T>(
           }
         },
       })
-        .finally(() =>  cleanUpCancellers())
         .then(
           (info) => {
+            cleanUpCancellers();
             if (requestCanceller.isUsed()) {
               return;
             }
@@ -69,7 +69,10 @@ export default function addSegmentIntegrityChecks<T>(
             }
             resolve(info);
           },
-          reject
+          (err : unknown) => {
+            cleanUpCancellers();
+            reject(err);
+          }
         );
 
       function cleanUpCancellers() {


### PR DESCRIPTION
Starting with the for-now-unreleased `v3.30.0` release, due to the fact that we completely removed RxJS from the code, we started relying much more on Promises and on its related methods.

After encountering a curious issue on Panasonic TVs while investigating #1219, we saw that the `finally` method on Promises was poorly supported on some devices, and to our surprise even if a Promise polyfill was added.

After evaluating what we could do, I decided to just ban the `finally` method from the RxPlayer code and replace it by duplicating its logic in Promises' resolve and failure handlers.
To ensure that those methods are not used on future developments, I also added an eslint rule (and plugin) to ban the `finally` method. Sadly, this plugin does not check if a `finally` method call is actually done on a Promise instance, so I had here to just ban the method altogether (to prevent future confusion, I clearly indicated in the error message that the linting rule was naively banning all `finally` method calls).

I also tried to override a Promise's finally method through TypeScript, but this solution appeared much more hacky than I first thought. I think a linting rule is a better solution for now.