### PR TITLE
Support Panasonic 2019 TVs

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -57,6 +57,9 @@ let isWebOs2021 = false;
 /** `true` specifically for WebOS 2022 version. */
 let isWebOs2022 = false;
 
+/** `true` for Panasonic devices. */
+let isPanasonic = false;
+
 ((function findCurrentBrowser() : void {
   if (isNode) {
     return ;
@@ -93,18 +96,18 @@ let isWebOs2022 = false;
 
   // 2 - Find out specific device/platform information
 
+  // Samsung browser e.g. on Android
   if (/SamsungBrowser/.test(navigator.userAgent)) {
     isSamsungBrowser = true;
   }
 
   if (/Tizen/.test(navigator.userAgent)) {
     isTizen = true;
-  }
 
   // Inspired form: http://webostv.developer.lge.com/discover/specifications/web-engine/
   // Note: even that page doesn't correspond to what we've actually seen in the
   // wild
-  if (/[Ww]eb[O0]S/.test(navigator.userAgent)) {
+  } else if (/[Ww]eb[O0]S/.test(navigator.userAgent)) {
     isWebOs = true;
 
     if (
@@ -118,6 +121,8 @@ let isWebOs2022 = false;
     ) {
       isWebOs2021 = true;
     }
+  } else if (/[Pp]anasonic/.test(navigator.userAgent)) {
+    isPanasonic = true;
   }
 })());
 
@@ -130,6 +135,7 @@ export {
   isIE11,
   isIEOrEdge,
   isFirefox,
+  isPanasonic,
   isSafariDesktop,
   isSafariMobile,
   isSamsungBrowser,

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -24,65 +24,106 @@ interface IIE11Document extends Document {
   documentMode? : unknown;
 }
 
-// true on IE11
-// false on Edge and other IEs/browsers.
-const isIE11 : boolean =
-  !isNode &&
-  typeof (window as IIE11WindowObject).MSInputMethodContext !== "undefined" &&
-  typeof (document as IIE11Document).documentMode !== "undefined";
+/** Edge Chromium, regardless of the device */
+let isEdgeChromium = false;
 
-// true for IE / Edge
-const isIEOrEdge : boolean = isNode ?
-  false :
-  navigator.appName === "Microsoft Internet Explorer" ||
-  navigator.appName === "Netscape" &&
-  /(Trident|Edge)\//.test(navigator.userAgent);
+/** IE11, regardless of the device */
+let isIE11 = false;
 
-const isEdgeChromium: boolean = !isNode &&
-                                navigator.userAgent.toLowerCase().indexOf("edg/") !== -1;
+/** IE11 or Edge __Legacy__ (not Edge Chromium), regardless of the device */
+let isIEOrEdge = false;
 
-const isFirefox : boolean = !isNode &&
-                            navigator.userAgent.toLowerCase().indexOf("firefox") !== -1;
+/** Firefox, regardless of the device */
+let isFirefox = false;
 
-const isSamsungBrowser : boolean = !isNode &&
-                                   /SamsungBrowser/.test(navigator.userAgent);
+/** `true` on Safari on a PC platform (i.e. not iPhone / iPad etc.) */
+let isSafariDesktop = false;
 
-const isTizen : boolean = !isNode &&
-                          /Tizen/.test(navigator.userAgent);
+/** `true` on Safari on an iPhone, iPad & iPod platform */
+let isSafariMobile = false;
 
-const isWebOs : boolean = !isNode &&
-                          navigator.userAgent.indexOf("Web0S") >= 0;
+/** Samsung's own browser application */
+let isSamsungBrowser = false;
 
-// Inspired form: http://webostv.developer.lge.com/discover/specifications/web-engine/
-// Note: even that page doesn't correspond to what we've actually seen in the
-// wild
-const isWebOs2021 : boolean = isWebOs &&
-                              (
-                                /[Ww]eb[O0]S.TV-2021/.test(navigator.userAgent) ||
-                                /[Cc]hr[o0]me\/79/.test(navigator.userAgent)
-                              );
-const isWebOs2022 : boolean = isWebOs &&
-                              (
-                                /[Ww]eb[O0]S.TV-2022/.test(navigator.userAgent) ||
-                                /[Cc]hr[o0]me\/87/.test(navigator.userAgent)
-                              );
+/** `true` on devices where Tizen is the OS (e.g. Samsung TVs). */
+let isTizen = false;
+
+/** `true` on devices where WebOS is the OS (e.g. LG TVs). */
+let isWebOs = false;
+
+/** `true` specifically for WebOS 2021 version. */
+let isWebOs2021 = false;
+
+/** `true` specifically for WebOS 2022 version. */
+let isWebOs2022 = false;
+
+((function findCurrentBrowser() : void {
+  if (isNode) {
+    return ;
+  }
+
+  // 1 - Find out browser between IE/Edge Legacy/Edge Chromium/Firefox/Safari
+
+  if (typeof (window as IIE11WindowObject).MSInputMethodContext !== "undefined" &&
+      typeof (document as IIE11Document).documentMode !== "undefined")
+  {
+    isIE11 = true;
+    isIEOrEdge = true;
+  } else if (
+    navigator.appName === "Microsoft Internet Explorer" ||
+    navigator.appName === "Netscape" &&
+    /(Trident|Edge)\//.test(navigator.userAgent)
+  ) {
+    isIEOrEdge = true;
+  } else if (navigator.userAgent.toLowerCase().indexOf("edg/") !== -1) {
+    isEdgeChromium = true;
+  } else if (navigator.userAgent.toLowerCase().indexOf("firefox") !== -1) {
+    isFirefox = true;
+  } else if (typeof navigator.platform === "string" &&
+             /iPad|iPhone|iPod/.test(navigator.platform))
+  {
+    isSafariMobile = true;
+  } else if (
+    Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") >= 0 ||
+    (window as ISafariWindowObject).safari?.pushNotification?.toString() ===
+      "[object SafariRemoteNotification]"
+  ) {
+    isSafariDesktop = true;
+  }
+
+  // 2 - Find out specific device/platform information
+
+  if (/SamsungBrowser/.test(navigator.userAgent)) {
+    isSamsungBrowser = true;
+  }
+
+  if (/Tizen/.test(navigator.userAgent)) {
+    isTizen = true;
+  }
+
+  // Inspired form: http://webostv.developer.lge.com/discover/specifications/web-engine/
+  // Note: even that page doesn't correspond to what we've actually seen in the
+  // wild
+  if (/[Ww]eb[O0]S/.test(navigator.userAgent)) {
+    isWebOs = true;
+
+    if (
+      /[Ww]eb[O0]S.TV-2022/.test(navigator.userAgent) ||
+      /[Cc]hr[o0]me\/87/.test(navigator.userAgent)
+    ) {
+      isWebOs2022 = true;
+    } else if (
+      /[Ww]eb[O0]S.TV-2021/.test(navigator.userAgent) ||
+      /[Cc]hr[o0]me\/79/.test(navigator.userAgent)
+    ) {
+      isWebOs2021 = true;
+    }
+  }
+})());
 
 interface ISafariWindowObject extends Window {
   safari? : { pushNotification? : { toString() : string } };
 }
-
-/** `true` on Safari on a PC platform (i.e. not iPhone / iPad etc.) */
-const isSafariDesktop : boolean =
-  !isNode && (
-    Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") >= 0 ||
-    (window as ISafariWindowObject).safari?.pushNotification?.toString() ===
-      "[object SafariRemoteNotification]"
-  );
-
-/** `true` on Safari on an iPhone, iPad & iPod platform */
-const isSafariMobile : boolean = !isNode &&
-                                 typeof navigator.platform === "string" &&
-                                 /iPad|iPhone|iPod/.test(navigator.platform);
 
 export {
   isEdgeChromium,

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,5 +1,3 @@
-import { isWebOs } from "./browser_detection";
-
 /**
  * Returns `true` if a `MediaKeys` instance (the  `Encrypted Media Extension`
  * concept) can be reused between contents.
@@ -13,5 +11,5 @@ import { isWebOs } from "./browser_detection";
  * @returns {boolean}
  */
 export default function canReuseMediaKeys() : boolean {
-  return !isWebOs;
+  return false;
 }

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,3 +1,8 @@
+import {
+  isPanasonic,
+  isWebOs,
+} from "./browser_detection";
+
 /**
  * Returns `true` if a `MediaKeys` instance (the  `Encrypted Media Extension`
  * concept) can be reused between contents.
@@ -11,5 +16,5 @@
  * @returns {boolean}
  */
 export default function canReuseMediaKeys() : boolean {
-  return false;
+  return !isWebOs && !isPanasonic;
 }

--- a/src/core/decrypt/__tests__/__global__/utils.ts
+++ b/src/core/decrypt/__tests__/__global__/utils.ts
@@ -40,48 +40,68 @@ import {
 import { CancellationSignal } from "../../../../utils/task_canceller";
 
 /** Default MediaKeySystemAccess configuration used by the RxPlayer. */
-export const defaultKSConfig = [{
-  audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
-                       { contentType: "audio/webm;codecs=opus" } ],
-  distinctiveIdentifier: "optional" as const,
-  initDataTypes: ["cenc"] as const,
-  persistentState: "optional" as const,
-  sessionTypes: ["temporary"] as const,
-  videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
-                       { contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
-                       { contentType: "video/webm;codecs=\"vp8\"" } ],
-}];
+export const defaultKSConfig = [
+  {
+    audioCapabilities: [ { contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                         { contentType: "audio/webm;codecs=opus" } ],
+    distinctiveIdentifier: "optional" as const,
+    initDataTypes: ["cenc"] as const,
+    persistentState: "optional" as const,
+    sessionTypes: ["temporary"] as const,
+    videoCapabilities: [ { contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                         { contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                         { contentType: "video/webm;codecs=\"vp8\"" } ],
+  },
+  {
+    audioCapabilities: undefined,
+    distinctiveIdentifier: "optional" as const,
+    initDataTypes: ["cenc"] as const,
+    persistentState: "optional" as const,
+    sessionTypes: ["temporary"] as const,
+    videoCapabilities: undefined,
+  },
+];
 
 /**
  * Default "com.microsoft.playready.recommendation" MediaKeySystemAccess
  * configuration used by the RxPlayer.
  */
-export const defaultPRRecommendationKSConfig = [{
-  audioCapabilities: [ { robustness: "3000",
-                         contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
-                       { robustness: "3000",
-                         contentType: "audio/webm;codecs=opus" },
-                       { robustness: "2000",
-                         contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
-                       { robustness: "2000",
-                         contentType: "audio/webm;codecs=opus" } ],
-  distinctiveIdentifier: "optional" as const,
-  initDataTypes: ["cenc"] as const,
-  persistentState: "optional" as const,
-  sessionTypes: ["temporary"] as const,
-  videoCapabilities: [ { robustness: "3000",
-                         contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
-                       { robustness: "3000",
-                         contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
-                       { robustness: "3000",
-                         contentType: "video/webm;codecs=\"vp8\"" },
-                       { robustness: "2000",
-                         contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
-                       { robustness: "2000",
-                         contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
-                       { robustness: "2000",
-                         contentType: "video/webm;codecs=\"vp8\"" } ],
-}];
+export const defaultPRRecommendationKSConfig = [
+  {
+    audioCapabilities: [ { robustness: "3000",
+                           contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                         { robustness: "3000",
+                           contentType: "audio/webm;codecs=opus" },
+                         { robustness: "2000",
+                           contentType: "audio/mp4;codecs=\"mp4a.40.2\"" },
+                         { robustness: "2000",
+                           contentType: "audio/webm;codecs=opus" } ],
+    distinctiveIdentifier: "optional" as const,
+    initDataTypes: ["cenc"] as const,
+    persistentState: "optional" as const,
+    sessionTypes: ["temporary"] as const,
+    videoCapabilities: [ { robustness: "3000",
+                           contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                         { robustness: "3000",
+                           contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                         { robustness: "3000",
+                           contentType: "video/webm;codecs=\"vp8\"" },
+                         { robustness: "2000",
+                           contentType: "video/mp4;codecs=\"avc1.4d401e\"" },
+                         { robustness: "2000",
+                           contentType: "video/mp4;codecs=\"avc1.42e01e\"" },
+                         { robustness: "2000",
+                           contentType: "video/webm;codecs=\"vp8\"" } ],
+  },
+  {
+    audioCapabilities: undefined,
+    distinctiveIdentifier: "optional" as const,
+    initDataTypes: ["cenc"] as const,
+    persistentState: "optional" as const,
+    sessionTypes: ["temporary"] as const,
+    videoCapabilities: undefined,
+  },
+];
 
 /** Default Widevine MediaKeySystemAccess configuration used by the RxPlayer. */
 export const defaultWidevineConfig = (() => {
@@ -104,9 +124,10 @@ export const defaultWidevineConfig = (() => {
             { contentType: "audio/webm;codecs=opus",
               robustness } ];
   });
-  return defaultKSConfig.map(conf => {
-    return { ...conf,  audioCapabilities, videoCapabilities };
-  });
+  return [
+    { ...defaultKSConfig[0],  audioCapabilities, videoCapabilities },
+    defaultKSConfig[1],
+  ];
 })();
 
 /**

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -923,21 +923,41 @@ const DEFAULT_CONFIG = {
      */
   MIN_CANCELABLE_PRIORITY: 3, // priority number 3 onward can be cancelled
 
-    /**
-     * Robustnesses used in the {audio,video}Capabilities of the
-     * MediaKeySystemConfiguration (DRM).
-     *
-     * Only used for widevine keysystems.
-     *
-     * Defined in order of importance (first will be tested first etc.)
-     * @type {Array.<string>}
-     */
+  /**
+   * Codecs used in the videoCapabilities of the MediaKeySystemConfiguration
+   * (DRM).
+   *
+   * Defined in order of importance (first will be tested first etc.)
+   * @type {Array.<string>}
+   */
+  EME_DEFAULT_VIDEO_CODECS: [ "video/mp4;codecs=\"avc1.4d401e\"",
+                              "video/mp4;codecs=\"avc1.42e01e\"",
+                              "video/webm;codecs=\"vp8\"" ],
+
+  /**
+   * Codecs used in the audioCapabilities of the MediaKeySystemConfiguration
+   * (DRM).
+   *
+   * Defined in order of importance (first will be tested first etc.)
+   * @type {Array.<string>}
+   */
+  EME_DEFAULT_AUDIO_CODECS: [ "audio/mp4;codecs=\"mp4a.40.2\"",
+                              "audio/webm;codecs=opus" ],
+
+  /**
+   * Robustnesses used in the {audio,video}Capabilities of the
+   * MediaKeySystemConfiguration (DRM).
+   *
+   * Only used for widevine keysystems.
+   *
+   * Defined in order of importance (first will be tested first etc.)
+   * @type {Array.<string>}
+   */
   EME_DEFAULT_WIDEVINE_ROBUSTNESSES: [ "HW_SECURE_ALL",
                                        "HW_SECURE_DECODE",
                                        "HW_SECURE_CRYPTO",
                                        "SW_SECURE_DECODE",
-                                       "SW_SECURE_CRYPTO",
-                                       undefined ],
+                                       "SW_SECURE_CRYPTO" ],
 
   /**
    * Robustnesses used in the {audio,video}Capabilities of the
@@ -948,7 +968,7 @@ const DEFAULT_CONFIG = {
    * Defined in order of importance (first will be tested first etc.)
    * @type {Array.<string>}
    */
-  EME_DEFAULT_PLAYREADY_ROBUSTNESSES: [ "3000", "2000", undefined ],
+  EME_DEFAULT_PLAYREADY_ROBUSTNESSES: [ "3000", "2000" ],
 
     /**
      * Link canonical key systems names to their respective reverse domain name,

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -936,7 +936,8 @@ const DEFAULT_CONFIG = {
                                        "HW_SECURE_DECODE",
                                        "HW_SECURE_CRYPTO",
                                        "SW_SECURE_DECODE",
-                                       "SW_SECURE_CRYPTO" ],
+                                       "SW_SECURE_CRYPTO",
+                                       undefined ],
 
   /**
    * Robustnesses used in the {audio,video}Capabilities of the
@@ -947,7 +948,7 @@ const DEFAULT_CONFIG = {
    * Defined in order of importance (first will be tested first etc.)
    * @type {Array.<string>}
    */
-  EME_DEFAULT_PLAYREADY_ROBUSTNESSES: [ "3000", "2000" ],
+  EME_DEFAULT_PLAYREADY_ROBUSTNESSES: [ "3000", "2000", undefined ],
 
     /**
      * Link canonical key systems names to their respective reverse domain name,


### PR DESCRIPTION
An issue, #1219, noticed several problems preventing from playing encrypted content on Panasonic 2019 TVs:

  - Though it advertises for widevine L1 support, it does not support any {video,audio}Capabilities' robustness.
 
     To fix this, I chose to re-bring the legacy work-around of adding a supplementary MediaKeySystemConfiguration without any {audio,video}Capabilities

  - Playing multiple encrypted contents through the same RxPlayer instance causes playback issues.
    
     This seems similar to issue we have on LG TVs. The work-around of re-doing EME negotiation from MediaKeys creation for each content also works here.

To implement the second work-around, I updated the browser detection code (using an IIFE). To detect Panasonic devices, I've been voluntarily large - only spotting a "panasonic" substring in the user-agent.