### PR TITLE
Set `Infinity` as duration when playing live contents on the PS5

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -60,6 +60,9 @@ let isWebOs2022 = false;
 /** `true` for Panasonic devices. */
 let isPanasonic = false;
 
+/** `true` for the PlayStation 5 game console. */
+let isPlayStation5 = false;
+
 ((function findCurrentBrowser() : void {
   if (isNode) {
     return ;
@@ -101,7 +104,9 @@ let isPanasonic = false;
     isSamsungBrowser = true;
   }
 
-  if (/Tizen/.test(navigator.userAgent)) {
+  if (navigator.userAgent.indexOf("PlayStation 5") !== -1) {
+    isPlayStation5 = true;
+  } else if (navigator.userAgent.indexOf("Tizen") !== -1) {
     isTizen = true;
 
   // Inspired form: http://webostv.developer.lge.com/discover/specifications/web-engine/
@@ -136,6 +141,7 @@ export {
   isIEOrEdge,
   isFirefox,
   isPanasonic,
+  isPlayStation5,
   isSafariDesktop,
   isSafariMobile,
   isSamsungBrowser,

--- a/src/compat/get_live_content_duration.ts
+++ b/src/compat/get_live_content_duration.ts
@@ -1,0 +1,35 @@
+import { isPlayStation5 } from "./browser_detection";
+
+/** Number of seconds in a regular year. */
+const YEAR_IN_SECONDS = 365 * 24 * 3600;
+
+/**
+ * Get the duration to set on the MediaSource for a live content whose maximum
+ * position in seconds is the value given in argument.
+ *
+ * This needs to be its own compat utilitary function because different
+ * platforms have issues with different values.
+ *
+ * @param {number} currentContentMaximumPosition - The current maximum position
+ * reachable in the content, in seconds.
+ * @returns {number} - The actual `duration` to set on the `MediaSource`
+ * instance on which the content plays.
+ */
+export default function getLiveContentDuration(
+  currentContentMaximumPosition : number
+) : number {
+  // The PlayStation 5 has troubles with high numbers but not with the
+  // `Infinity` value, which is the advised value by the HTML5 living standard
+  // as of now (2023-03-02)
+  if (isPlayStation5) {
+    return Infinity;
+  }
+
+  // Some targets poorly support setting a very high number for durations.
+  // Yet, in dynamic contents, we would prefer setting a value as high as possible
+  // to still be able to seek anywhere we want to (even ahead of the Manifest if
+  // we want to). As such, we put it at a safe default value of 2^32 excepted
+  // when the maximum position is already relatively close to that value, where
+  // we authorize exceptionally going over it.
+  return Math.max(Math.pow(2, 32), currentContentMaximumPosition + YEAR_IN_SECONDS);
+}

--- a/src/core/init/utils/media_duration_updater.ts
+++ b/src/core/init/utils/media_duration_updater.ts
@@ -19,6 +19,7 @@ import {
   onSourceEnded,
   onSourceClose,
 } from "../../../compat/event_listeners";
+import getLiveContentDuration from "../../../compat/get_live_content_duration";
 import log from "../../../log";
 import Manifest from "../../../manifest";
 import createSharedReference, {
@@ -28,9 +29,6 @@ import createSharedReference, {
 import TaskCanceller, {
   CancellationSignal,
 } from "../../../utils/task_canceller";
-
-/** Number of seconds in a regular year. */
-const YEAR_IN_SECONDS = 365 * 24 * 3600;
 
 /**
  * Keep the MediaSource's duration up-to-date with what is being played.
@@ -183,13 +181,7 @@ function setMediaSourceDuration(
   }
 
   if (manifest.isDynamic) {
-    // Some targets poorly support setting a very high number for durations.
-    // Yet, in dynamic contents, we would prefer setting a value as high as possible
-    // to still be able to seek anywhere we want to (even ahead of the Manifest if
-    // we want to). As such, we put it at a safe default value of 2^32 excepted
-    // when the maximum position is already relatively close to that value, where
-    // we authorize exceptionally going over it.
-    newDuration =  Math.max(Math.pow(2, 32), newDuration + YEAR_IN_SECONDS);
+    newDuration =  getLiveContentDuration(newDuration);
   }
 
   let maxBufferedEnd : number = 0;


### PR DESCRIPTION
We recently noticed an issue on the PS5 which causes stuttering playback on live contents.

After exchanging with Sony, turns out the root cause is that their new WebKit version has performance troubles in its segment data eviction logic when the current `MediaSource`'s duration is set at a high value.

For live contents, we set in most cases (there are rare exceptions) the duration to 2^32, because higher values may cause issues on other platforms (most notably Tizen). To us, it didn't seem as a very high value but Sony actually advised us to use positive `Infinity` instead (a valid IEEE 754 value that can be set in JavaScript for a "Number"), as it seems to be handled specially by WebKit.

`Infinity` is also the actual value advised by the current HTML living standard for live contents, but I was still afraid that just changing to that special value would break other platforms - as we're used to random bugs when changing those types of properties. Because of this, and despite the fact that the issue seems rooted in a WebKit version, I chose to only set the `Infinity` duration on the PS5 for now as this is the only device where that issue has been seen for now.