### PR TITLE
Avoid destroying PeriodStream if one is re-created for the same period

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -466,7 +466,7 @@ export default function StreamOrchestrator(
           const nextPeriod = manifest.getPeriodAfter(basePeriod);
           if (nextPeriod !== null) {
             // current Stream is full, create the next one if not
-            createNextPeriodStream(nextPeriod);
+            checkOrCreateNextPeriodStream(nextPeriod);
           }
         } else if (nextStreamInfo !== null) {
           // current Stream is active, destroy next Stream if created
@@ -495,9 +495,13 @@ export default function StreamOrchestrator(
      * Create `PeriodStream` for the next Period, specified under `nextPeriod`.
      * @param {Object} nextPeriod
      */
-    function createNextPeriodStream(nextPeriod : Period) : void {
+    function checkOrCreateNextPeriodStream(nextPeriod : Period) : void {
       if (nextStreamInfo !== null) {
-        log.warn("Stream: Creating next `PeriodStream` while it was already created.");
+        if (nextStreamInfo.period.id === nextPeriod.id) {
+          return;
+        }
+        log.warn("Stream: Creating next `PeriodStream` while one was already created.",
+                 bufferType, nextPeriod.id, nextStreamInfo.period.id);
         consecutivePeriodStreamCb.periodStreamCleared({ type: bufferType,
                                                         period: nextStreamInfo.period });
         nextStreamInfo.canceller.cancel();


### PR DESCRIPTION
While doing some debugging on multi-Period contents, we saw some situations where at some Period's boundary, no segment would be loaded, since the `v3.30.0`.

Though we are still in the process of testing it, I relatedly found what seems like an issue where we could be in some kind of (slow) loop creating and destroying `PeriodStream`, which is the module allowing to load segment corresponding to a particular DASH period (or related in other `transport`s) when we approach from the end of the previous Period.

To try to fix this logic, I added a check to see if the next `PeriodStream` wanted was linked to the same `Period` than the next `PeriodStream` which was already created, in which case we won't be destroying it immediately, just to re-creating it like we did before.

For the source of this behavior, I think that re-checking that the right `PeriodStream` is created regularly (more specifically: each time the previous chronological `PeriodStream` signals that is has no segment to load) is not that bad of an idea, as a security, so I did not change it.