### PR TITLE
Improve `NO_PLAYABLE_REPRESENTATION` behavior for the v4

### DIFF
--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -624,6 +624,10 @@ The payload for this event is an object with the following properties:
       - `"missing"` the previously-chosen track was missing from the content's
         refreshed Manifest.
 
+      - `"no-playable-representation"`: the previously-chosen track had none of
+        its `Representation` playable, most likely because of decipherability
+        issues and thus the RxPlayer decided to switch to a new track.
+
     Though other reasons may be added in the future (for future reasons not
     covered by those values), so you should expect this possibility in your
     application's logic.

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -683,26 +683,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     // Bind events
     initializer.addEventListener("error", (error) => {
-      const formattedError = formatError(error, {
-        defaultCode: "NONE",
-        defaultReason: "An unknown error stopped content playback.",
-      });
-      formattedError.fatal = true;
-
-      contentInfos.currentContentCanceller.cancel();
-      this._priv_cleanUpCurrentContentState();
-      this._priv_currentError = formattedError;
-      log.error("API: The player stopped because of an error",
-                error instanceof Error ? error : "");
-      this._priv_setPlayerState(PLAYER_STATES.STOPPED);
-
-      // TODO This condition is here because the eventual callback called when the
-      // player state is updated can launch a new content, thus the error will not
-      // be here anymore, in which case triggering the "error" event is unwanted.
-      // This is very ugly though, and we should probable have a better solution
-      if (this._priv_currentError === formattedError) {
-        this.trigger("error", formattedError);
-      }
+      this._priv_onFatalError(error, contentInfos);
     });
     initializer.addEventListener("warning", (error) => {
       const formattedError = formatError(error, {
@@ -2002,21 +1983,34 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return; // Event for another content
     }
     contentInfos.manifest = manifest;
-    const cancelSignal = contentInfos.currentContentCanceller.signal;
     this._priv_reloadingMetadata.manifest = manifest;
 
-    contentInfos.tracksStore = new TracksStore({
+    const tracksStore = new TracksStore({
       preferTrickModeTracks: this._priv_preferTrickModeTracks,
       defaultAudioTrackSwitchingMode: contentInfos.defaultAudioTrackSwitchingMode,
     });
-    contentInfos.tracksStore.addEventListener("newAvailablePeriods", (p) => {
+    contentInfos.tracksStore = tracksStore;
+    tracksStore.addEventListener("newAvailablePeriods", (p) => {
       this.trigger("newAvailablePeriods", p);
     });
-    contentInfos.tracksStore.addEventListener("brokenRepresentationsLock", (e) => {
+    tracksStore.addEventListener("brokenRepresentationsLock", (e) => {
       this.trigger("brokenRepresentationsLock", e);
     });
-    contentInfos.tracksStore.addEventListener("trackUpdate", (e) => {
+    tracksStore.addEventListener("trackUpdate", (e) => {
       this.trigger("trackUpdate", e);
+
+      const currentPeriod = this._priv_contentInfos?.currentPeriod ?? undefined;
+      if (e.reason === "no-playable-representation" &&
+          e.period.id === currentPeriod?.id)
+      {
+        this._priv_onAvailableTracksMayHaveChanged(e.trackType);
+      }
+    });
+    contentInfos.tracksStore.addEventListener("warning", (err) => {
+      this.trigger("warning", err);
+    });
+    contentInfos.tracksStore.addEventListener("error", (err) => {
+      this._priv_onFatalError(err, contentInfos);
     });
 
     contentInfos.tracksStore.updatePeriodList(manifest);
@@ -2027,8 +2021,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         contentInfos.tracksStore.updatePeriodList(manifest);
       }
       const currentPeriod = this._priv_contentInfos?.currentPeriod ?? undefined;
-      const tracksStore = this._priv_contentInfos?.tracksStore;
-      if (currentPeriod === undefined || isNullOrUndefined(tracksStore)) {
+      const currTracksStore = this._priv_contentInfos?.tracksStore;
+      if (currentPeriod === undefined || isNullOrUndefined(currTracksStore)) {
         return;
       }
       for (const update of updates.updatedPeriods) {
@@ -2037,22 +2031,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
               update.result.removedAdaptations.length > 0)
           {
             // We might have new (or less) tracks, send events just to be sure
-            const periodRef = tracksStore.getPeriodObjectFromPeriod(currentPeriod);
+            const periodRef = currTracksStore.getPeriodObjectFromPeriod(currentPeriod);
             if (periodRef === undefined) {
               return;
             }
-            const audioTracks = tracksStore.getAvailableAudioTracks(periodRef);
-            this._priv_triggerEventIfNotStopped("availableAudioTracksChange",
-                                                audioTracks ?? [],
-                                                cancelSignal);
-            const textTracks = tracksStore.getAvailableTextTracks(periodRef);
-            this._priv_triggerEventIfNotStopped("availableTextTracksChange",
-                                                textTracks ?? [],
-                                                cancelSignal);
-            const videoTracks = tracksStore.getAvailableVideoTracks(periodRef);
-            this._priv_triggerEventIfNotStopped("availableVideoTracksChange",
-                                                videoTracks ?? [],
-                                                cancelSignal);
+            this._priv_onAvailableTracksMayHaveChanged("audio");
+            this._priv_onAvailableTracksMayHaveChanged("text");
+            this._priv_onAvailableTracksMayHaveChanged("video");
           }
         }
         return;
@@ -2525,6 +2510,91 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       return defaultValue;
     }
     return cb(tracksStore, periodRef);
+  }
+
+  /**
+   * Method to call when some event lead to a high for possibility that the
+   * available tracks for the given type have changed.
+   * Send the corresponding `available*Tracks` change event with the last
+   * available tracks.
+   *
+   * @param {string} trackType
+   * @param {Object|undefined} [oPeriodRef] - optional period object used by the
+   * `tracksStore` API, allows to optimize the method by bypassing this step.
+   */
+  private _priv_onAvailableTracksMayHaveChanged(
+    trackType : IBufferType,
+    oPeriodRef? : ITMPeriodObject
+  ): void {
+    const contentInfos = this._priv_contentInfos;
+    if (contentInfos === null) {
+      return;
+    }
+    const { currentPeriod,
+            tracksStore,
+            currentContentCanceller } = contentInfos;
+    const cancelSignal = currentContentCanceller.signal;
+    if (isNullOrUndefined(currentPeriod) || tracksStore === null) {
+      return;
+    }
+    const periodRef = oPeriodRef ?? tracksStore.getPeriodObjectFromPeriod(currentPeriod);
+    if (periodRef === undefined) {
+      return;
+    }
+    switch (trackType) {
+      case "video":
+        const videoTracks = tracksStore.getAvailableVideoTracks(periodRef);
+        this._priv_triggerEventIfNotStopped("availableVideoTracksChange",
+                                            videoTracks ?? [],
+                                            cancelSignal);
+        break;
+      case "audio":
+        const audioTracks = tracksStore.getAvailableAudioTracks(periodRef);
+        this._priv_triggerEventIfNotStopped("availableAudioTracksChange",
+                                            audioTracks ?? [],
+                                            cancelSignal);
+        break;
+      case "text":
+        const textTracks = tracksStore.getAvailableTextTracks(periodRef);
+        this._priv_triggerEventIfNotStopped("availableTextTracksChange",
+                                            textTracks ?? [],
+                                            cancelSignal);
+        break;
+      default:
+        assertUnreachable(trackType);
+    }
+  }
+
+  /**
+   * Method to call when a fatal error lead to the stopping of the current
+   * content.
+   *
+   * @param {*} err - The error encountered.
+   * @param {Object} contentInfos - The `IPublicApiContentInfos` object linked
+   * to the content for which the error was received.
+   */
+  private _priv_onFatalError(
+    err : unknown,
+    contentInfos : IPublicApiContentInfos
+  ): void {
+    const formattedError = formatError(err, {
+      defaultCode: "NONE",
+      defaultReason: "An unknown error stopped content playback.",
+    });
+    formattedError.fatal = true;
+    contentInfos.currentContentCanceller.cancel();
+    this._priv_cleanUpCurrentContentState();
+    this._priv_currentError = formattedError;
+    log.error("API: The player stopped because of an error", formattedError);
+    this._priv_setPlayerState(PLAYER_STATES.STOPPED);
+
+    // TODO This condition is here because the eventual callback called when the
+    // player state is updated can launch a new content, thus the error will not
+    // be here anymore, in which case triggering the "error" event is unwanted.
+    // This is very ugly though, and we should probable have a better solution
+    if (this._priv_currentError === formattedError) {
+      this.trigger("error", formattedError);
+    }
   }
 }
 Player.version = /* PLAYER_VERSION */"4.0.0-beta.1";

--- a/src/core/api/track_management/track_dispatcher.ts
+++ b/src/core/api/track_management/track_dispatcher.ts
@@ -1,4 +1,3 @@
-import { MediaError } from "../../../errors";
 import Manifest, {
   Adaptation,
   Representation,
@@ -64,36 +63,55 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
   private _canceller : TaskCanceller;
 
   /**
+   * Boolean set to `true` when a track-updating method is called and to `false`
+   * just before it performs the actual track change to allow checking for
+   * re-entrancy: if the token is already reset to `false` before the
+   * track change is officialized, then another track update has already been
+   * performed in the meantime.
+   */
+  private _updateToken: boolean;
+
+  /**
    * Create a new `TrackDispatcher` by giving its Reference and an initial track
    * setting.
    * This constructor will update the Reference with the right preferences
    * synchronously.
    * @param {Object} manifest
    * @param {Object} adaptationRef
-   * @param {Object|null} initialTrackInfo
    */
   constructor(
     manifest : Manifest,
-    adaptationRef : ISharedReference<IAdaptationChoice | null | undefined>,
-    initialTrackInfo : ITrackSetting | null
+    adaptationRef : ISharedReference<IAdaptationChoice | null | undefined>
   ) {
     super();
     this._canceller = new TaskCanceller();
     this._manifest = manifest;
     this._adaptationRef = adaptationRef;
+    this._updateToken = false;
+  }
 
+  /**
+   * @param {Object|null} initialTrackInfo
+   */
+  public start(initialTrackInfo : ITrackSetting | null) : void {
+    this._updateToken = true;
     if (initialTrackInfo === null) {
-      this._lastEmitted = initialTrackInfo;
-      adaptationRef.setValue(null);
+      this._lastEmitted = null;
+      this._updateToken = false;
+      this._adaptationRef.setValue(null);
       return;
     }
     const reference = this._constructLockedRepresentationsReference(initialTrackInfo);
+    if (!this._updateToken) {
+      return;
+    }
     this._lastEmitted = { adaptation: initialTrackInfo.adaptation,
                           switchingMode: initialTrackInfo.switchingMode,
                           lockedRepresentations: null };
-    adaptationRef.setValue({ adaptation: initialTrackInfo.adaptation,
-                             switchingMode: initialTrackInfo.switchingMode,
-                             representations: reference });
+    this._updateToken = false;
+    this._adaptationRef.setValue({ adaptation: initialTrackInfo.adaptation,
+                                   switchingMode: initialTrackInfo.switchingMode,
+                                   representations: reference });
   }
 
   /**
@@ -101,10 +119,12 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
    * @param {Object|null} newTrackInfo
    */
   public updateTrack(newTrackInfo : ITrackSetting | null) : void {
+    this._updateToken = true;
     if (newTrackInfo === null) {
       if (this._lastEmitted === null) {
         return;
       }
+      this._updateToken = false;
       this._canceller.cancel();
 
       // has no point but let's still create one for simplicity sake
@@ -117,7 +137,11 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
     this._canceller.cancel();
     this._canceller = new TaskCanceller();
     const reference = this._constructLockedRepresentationsReference(newTrackInfo);
+    if (!this._updateToken) {
+      return;
+    }
     this._lastEmitted = { adaptation, switchingMode, lockedRepresentations: null };
+    this._updateToken = false;
     this._adaptationRef.setValue({ adaptation,
                                    switchingMode,
                                    representations: reference });
@@ -176,11 +200,9 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
         }
       }
       if (playableRepresentations.length <= 0) {
-        const adaptationType = trackInfo.adaptation.type;
-        const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
-                                        "No Representation in the chosen " +
-                                        adaptationType + " Adaptation can be played");
-        throw noRepErr;
+        trackInfo.adaptation.isSupported = false;
+        self.trigger("noPlayableRepresentation", null);
+        return;
       }
 
       // Check if Locked Representations have changed
@@ -221,6 +243,7 @@ export interface ITrackDispatcherEvent {
    * none of them are currently "playable".
    */
   noPlayableLockedRepresentation : null;
+  noPlayableRepresentation: null;
 }
 
 /** Define a new Track preference given to the `TrackDispatcher`. */

--- a/src/core/api/track_management/tracks_store.ts
+++ b/src/core/api/track_management/tracks_store.ts
@@ -20,6 +20,7 @@
  */
 
 import config from "../../../config";
+import { MediaError } from "../../../errors";
 import log from "../../../log";
 import Manifest, {
   Adaptation,
@@ -42,10 +43,12 @@ import {
   IVideoRepresentationsSwitchingMode,
   IVideoTrack,
   IVideoTrackSwitchingMode,
+  IPlayerError,
 } from "../../../public_types";
 import arrayFind from "../../../utils/array_find";
 import assert from "../../../utils/assert";
 import EventEmitter from "../../../utils/event_emitter";
+import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import createSharedReference, {
   ISharedReference,
 } from "../../../utils/reference";
@@ -156,7 +159,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           const stillHere = textAdaptations
             .some(a => a.id === curWantedTextTrack.adaptation.id);
           if (!stillHere) {
-            log.warn("TracksStore: Chosen text Adaptation not available anymore");
+            log.warn("TS: Chosen text Adaptation not available anymore");
             const periodInfo =  this._storedPeriodInfo[i];
             periodInfo.text.storedSettings = null;
             this.trigger("trackUpdate", { period: toExposedPeriod(newPeriod),
@@ -182,7 +185,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           const stillHere = videoAdaptations
             .some(a => a.id === curWantedVideoTrack.adaptation.id);
           if (!stillHere) {
-            log.warn("TracksStore: Chosen video Adaptation not available anymore");
+            log.warn("TS: Chosen video Adaptation not available anymore");
             const periodItem = this._storedPeriodInfo[i];
             let storedSettings : IVideoStoredSettings;
             if (videoAdaptations.length === 0) {
@@ -224,7 +227,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           const stillHere = audioAdaptations
             .some(a => a.id === curWantedAudioTrack.adaptation.id);
           if (!stillHere) {
-            log.warn("TracksStore: Chosen audio Adaptation not available anymore");
+            log.warn("TS: Chosen audio Adaptation not available anymore");
             const periodItem = this._storedPeriodInfo[i];
             const storedSettings = audioAdaptations.length === 0 ?
               null :
@@ -323,20 +326,61 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     }
 
     if (periodObj[bufferType].dispatcher !== null) {
-      log.error(`TracksStore: Subject already added for ${bufferType} ` +
+      log.error(`TS: Subject already added for ${bufferType} ` +
                 `and Period ${period.start}`);
       return;
     }
     const trackSetting = periodObj[bufferType].storedSettings;
-    const dispatcher = new TrackDispatcher(manifest, adaptationRef, trackSetting);
+    const dispatcher = new TrackDispatcher(manifest, adaptationRef);
     periodObj[bufferType].dispatcher = dispatcher;
+    dispatcher.addEventListener("noPlayableRepresentation", () => {
+      const nextAdaptation = arrayFind(period.getAdaptationsForType(bufferType), (a) => {
+        const playableRepresentations = a.getPlayableRepresentations();
+        return playableRepresentations.length > 0;
+      });
+      if (nextAdaptation === undefined) {
+        const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
+                                        `No ${bufferType} Representation can be played`);
+        this.trigger("error", noRepErr);
+        this.dispose();
+        return;
+      }
+      let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[bufferType];
+      if (isNullOrUndefined(typeInfo)) {
+        return;
+      }
+      const switchingMode = bufferType === "audio" ?
+        this._defaultAudioTrackSwitchingMode :
+        "reload";
+      const storedSettings = { adaptation: nextAdaptation,
+                               switchingMode,
+                               lockedRepresentations: createSharedReference(null) };
+      typeInfo.storedSettings = storedSettings;
+      this.trigger("trackUpdate", { period: toExposedPeriod(period),
+                                    trackType: bufferType,
+                                    reason: "no-playable-representation" });
+
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+      typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[bufferType];
+      if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
+        return;
+      }
+      typeInfo.dispatcher?.updateTrack(storedSettings);
+    });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
+      // TODO check that it doesn't already lead to segment loading or MediaSource
+      // reloading
       trackSetting?.lockedRepresentations.setValue(null);
       this.trigger("brokenRepresentationsLock", { period: { id: period.id,
                                                             start: period.start,
                                                             end: period.end },
                                                   trackType: bufferType });
     });
+    dispatcher.start(trackSetting);
   }
 
   /**
@@ -351,7 +395,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   ) : void {
     const periodIndex = findPeriodIndex(this._storedPeriodInfo, period);
     if (periodIndex === undefined) {
-      log.warn(`TracksStore: ${bufferType} not found for period`,
+      log.warn(`TS: ${bufferType} not found for period`,
                period.start);
       return;
     }
@@ -359,7 +403,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const periodObj = this._storedPeriodInfo[periodIndex];
     const choiceItem = periodObj[bufferType];
     if (choiceItem?.dispatcher === null) {
-      log.warn(`TracksStore: TrackDispatcher already removed for ${bufferType} ` +
+      log.warn(`TS: TrackDispatcher already removed for ${bufferType} ` +
                `and Period ${period.start}`);
       return;
     }
@@ -1431,6 +1475,8 @@ interface ITracksStoreEvents {
   newAvailablePeriods : IPeriod[];
   brokenRepresentationsLock : IBrokenRepresentationsLockContext;
   trackUpdate : ITrackUpdateEventPayload;
+  error : unknown;
+  warning : IPlayerError;
 }
 
 export interface IAudioRepresentationsLockSettings {

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -916,6 +916,7 @@ export interface ITrackUpdateEventPayload {
            "manual" | // Manually and explicitely updated
            "trickmode-enabled" | // Video trickmode tracks being enabled
            "trickmode-disabled" | // Video trickmode tracks being disabled
+           "no-playable-representation" | // Previous track had no playable Representation
            string;
 }
 


### PR DESCRIPTION
In the v3.x.x, the impossibility to play any `Representation` from a chosen track due to non-usable keys, lead to an error with the `NO_PLAYABLE_REPRESENTATION` error code .

This seemed sensible at the time, but we're now encountering use cases where it would be more sensible to change the current track instead, to one that perhaps has decipherable Representation(s).

The main example would be to have a separate video track linked to to another dynamic range (e.g. an HDR and a SDR track) each with different security policies (tracks with higher dynamic range would have more drastic security policies for example). Here, I would guess that an application would prefer that by default we switch to the SDR video track if no
`Representation` in the HDR one is decipherable, instead of just stopping playback with a 
`NO_PLAYABLE_REPRESENTATION` error.

This is sadly not something we can do easilty in a `v3.x.x` because it would imply breaking changes (such as switching to the `RELOADING` state during the track change without a supplementary API), but that's definitely something we would want to implement in the v4.

Because an application might still want to be notified or even stop playback by itself when the chosen track has no playable Representation, I added the `no-playable-Representation` `reason` to the `trackUpdate` event, which indicates that the current track for any Period of the current content was updated due to this situation.

The `NO_PLAYABLE_REPRESENTATION` error is still thrown, only now it is when no `Representation` of all tracks for the given type are decipherable.
