### PR TITLE
DASH/WASM: actually reject the DASH_WASM.initialize's Promise if it fails

### DIFF
--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -199,6 +199,7 @@ export default class DashWasmParser {
                                                "Unknown error";
         log.warn("DW: Could not create DASH-WASM parser:", message);
         this.status = "failure";
+        throw err;
       });
 
     return this._initProm;


### PR DESCRIPTION
I forgot to add a line on the implementation of the `DASH_WASM.initialize` API (which allows to "initialize", i.e. load and compile the linked WebAssembly file, the WASM-based DASH parser) which led to the Promise returned by this method still resolving even if the initialization failed.

The error was still logged and the internal status of the `DASH_WASM` feature was still updated to indicate failure, but that's not what the application is most likely listening to.