### PR TITLE
Detect forced subtitles on Safari in directfile (and label)

### DIFF
--- a/src/core/api/tracks_management/track_choice_manager.ts
+++ b/src/core/api/tracks_management/track_choice_manager.ts
@@ -662,10 +662,8 @@ export default class TrackChoiceManager {
       closedCaption: chosenTextAdaptation.isClosedCaption === true,
       id: chosenTextAdaptation.id,
       label: chosenTextAdaptation.label,
+      forced: chosenTextAdaptation.isForcedSubtitles,
     };
-    if (chosenTextAdaptation.isForcedSubtitles !== undefined) {
-      formatted.forced = chosenTextAdaptation.isForcedSubtitles;
-    }
     return formatted;
   }
 
@@ -792,10 +790,8 @@ export default class TrackChoiceManager {
           active: currentId === null ? false :
                                        currentId === adaptation.id,
           label: adaptation.label,
+          forced: adaptation.isForcedSubtitles,
         };
-        if (adaptation.isForcedSubtitles !== undefined) {
-          formatted.forced = adaptation.isForcedSubtitles;
-        }
         return formatted;
       });
   }

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -765,8 +765,8 @@ export interface IAudioTrack { language : string;
 export interface ITextTrack { language : string;
                               normalized : string;
                               closedCaption : boolean;
-                              forced? : boolean | undefined;
-                              label? : string | undefined;
+                              forced : boolean | undefined;
+                              label : string | undefined;
                               id : number|string; }
 
 /**


### PR DESCRIPTION
This update only concerns directfile contents, especially when playing HLS contents on safari.

---

As of now, no real standard exists to indicate through an HTML Text Track object whether that track represents "forced" subtitles.

There's been some proposal since 2013
(https://lists.whatwg.org/pipermail/whatwg-whatwg.org/2013-April/039374.html) to add the possibility to set the `kind` attribute of a `TextTrack` to `"forced"` but nothing has yet materialized in what is now the WHATWG HTML standard.

There's some very interesting discussion more "recently" in a whatwg Github issue here: https://github.com/whatwg/html/issues/4472 (note: I'm more aligned with Nigel Megitt opinions on those things) but again it did not really materialize into something yet.

Yet Webkit, and by extension Safari, decided to add support (maybe in 2013? https://bugs.webkit.org/show_bug.cgi?id=114460) relying on the `@kind` to `"forced"` proposal.

Because it exists and it's better than nothing, I decided to add support for directfile contents (as other types of content don't need this, we already know whether a forced track is forced thanks to the Manifest) to Safari's way of doing it, considering it shouldn't break anything else.

I also saw that the `label` of a `TextTrack` was not actually translated to its resulting "label" property through the `getAvailableTextTracks` and `getTextTrack` API. I fixed that.