### PR TITLE
Add `trackInfo` property to some `MediaError`

### DIFF
--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -64,7 +64,7 @@ all have a `type` property equal to `"NETWORK_ERROR"`.
 
 #### codes
 
-A NetworkError can only have the following code (`code` property):
+An error of `type` `NETWORK_ERROR` can only have the following code (`code` property):
 
 - `"PIPELINE_LOAD_ERROR"`: the
   [Manifest](../Getting_Started/Glossary.md#manifest) or
@@ -107,15 +107,29 @@ parsing) or from the browser itself (content playback).
 
 They all have a `type` property equal to `"MEDIA_ERROR"`.
 
+Depending on its `code` property (listed below), a `MEDIA_ERROR` may also have
+a supplementary `trackInfo` property, describing the track related to the issue.
+The format of that property is decribed in the chapter below listed codes, and
+the codes for which it is set are indicated in the corresponding code's
+description below.
+
 #### codes
 
-A MediaError can have the following codes (`code` property):
+An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
 
 - `"BUFFER_APPEND_ERROR"`: A media segment could not have been added to the
   corresponding media buffer. This often happens with malformed segments.
 
+  For those errors, you may be able to know the characteristics of the track
+  linked to that segment by inspecting the error's `trackInfo` property,
+  described below.
+
 - `"BUFFER_FULL_ERROR"`: The needed segment could not have been added
   because the corresponding media buffer was full.
+
+  For those errors, you may be able to know the characteristics of the track
+  linked to that segment by inspecting the error's `trackInfo` property,
+  described below.
 
 - `"BUFFER_TYPE_UNKNOWN"`: The type of buffer considered (e.g. "audio" /
   "video" / "text") has no media buffer implementation in your build.
@@ -124,6 +138,9 @@ A MediaError can have the following codes (`code` property):
   [Adaptation](../Getting_Started/Glossary.md#adaptation) (or track) has none of its
   [Representations](../Getting_Started/Glossary.md#representation) (read quality) in a supported
   codec.
+
+  For those errors, you may be able to know the characteristics of the track
+  linked to that codec by inspecting the error's `trackInfo` property, described below.
 
 - `"MANIFEST_PARSE_ERROR"`: Generic error to signal than the
   [Manifest](../Getting_Started/Glossary.md#structure_of_a_manifest_object) could not be parsed.
@@ -193,9 +210,13 @@ A MediaError can have the following codes (`code` property):
   This is rarely a problem and may be encountered at a very start of a content
   when the initial segment's start is much later than expected.
 
-- `"NO_PLAYABLE_REPRESENTATION"`: The currently chosen Adaptation does not
+- `"NO_PLAYABLE_REPRESENTATION"`: One of the currently chosen track does not
   contain any playable Representation. This usually happens when every
   Representation has been blacklisted due to encryption limitations.
+
+  For those errors, you may be able to know the characteristics of the
+  corresponding track by inspecting the error's `trackInfo` property, described
+  below.
 
 - `"MANIFEST_UPDATE_ERROR"`: This error should never be emitted as it is
   handled internally by the RxPlayer. Please open an issue if you encounter
@@ -211,16 +232,174 @@ A MediaError can have the following codes (`code` property):
   It is triggered when a time we initially thought to be in the bounds of the
   Manifest actually does not link to any "Period" of the Manifest.
 
+#### `trackInfo` property
+
+As described in the corresponding code's documentation, A aupplementary
+`trackInfo` property may be set on `MEDIA_ERROR` depending on its `code`
+property.
+
+That `trackInfo` describes, when it makes sense, the characteristics of the track
+linked to an error. For example, you may want to know which video track led to a
+`BUFFER_APPEND_ERROR` and thus might be linked to corrupted segments.
+
+The `trackInfo` property has itself two sub-properties:
+
+  - `type`: The type of track: `"audio"` for an audio track, `"text"` for a text
+    track, or `"video"` for a video track.
+
+  - `track`: Characteristics of the track. Its format depends on the
+    `trackInfo`'s `type` property and is described below.
+
+##### For video tracks
+
+When `trackInfo.type` is set to `"video"`, `track` describes a video track. It
+contains the following properties:
+
+  - `id` (`string`): The id used to identify this track. No other
+    video track for the same [Period](../Getting_Started/Glossary.md#period)
+    will have the same `id`.
+
+  - `label` (`string|undefined`): A human readable label that may be displayed in
+    the user interface providing a choice between video tracks.
+
+    This information is usually set only if the current Manifest contains one.
+
+  - `representations` (`Array.<Object>`):
+    [Representations](../Getting_Started/Glossary.md#representation) of this
+    video track, with attributes:
+
+    - `id` (`string`): The id used to identify this Representation.
+      No other Representation from this track will have the same `id`.
+
+    - `bitrate` (`Number`): The bitrate of this Representation, in bits per
+      seconds.
+
+    - `width` (`Number|undefined`): The width of video, in pixels.
+
+    - `height` (`Number|undefined`): The height of video, in pixels.
+
+    - `codec` (`string|undefined`): The video codec the Representation is
+      in, as announced in the corresponding Manifest.
+
+    - `frameRate` (`string|undefined`): The video frame rate.
+
+    - `hdrInfo` (`Object|undefined`) Information about the hdr
+      characteristics of the track.
+      (see [HDR support documentation](./Miscellaneous/hdr.md#hdrinfo))
+
+  - `signInterpreted` (`Boolean|undefined`): If set to `true`, this track is
+    known to contain an interpretation in sign language.
+    If set to `false`, the track is known to not contain that type of content.
+    If not set or set to undefined we don't know whether that video track
+    contains an interpretation in sign language.
+
+  - `isTrickModeTrack` (`Boolean|undefined`): If set to `true`, this track
+    is a trick mode track. This type of tracks proposes video content that is
+    often encoded with a very low framerate with the purpose to be played more
+    efficiently at a much higher speed.
+
+  - `trickModeTracks` (`Array.<Object> | undefined`): Trick mode video tracks
+    attached to this video track.
+
+    Each of those objects contain the same properties that a regular video track
+    (same properties than what is documented here).
+
+    It this property is either `undefined` or not set, then this track has no
+    linked trickmode video track.
+
+##### For audio tracks
+
+When `trackInfo.type` is set to `"audio"`, `track` describes an audio track. It
+contains the following properties:
+
+- `id` (`Number|string`): The id used to identify this track. No other
+  audio track for the same [Period](../Getting_Started/Glossary.md#period)
+  will have the same `id`.
+
+- `language` (`string`): The language the audio track is in, as set in the
+  [Manifest](../Getting_Started/Glossary.md#manifest).
+
+- `normalized` (`string`): An attempt to translate the `language`
+  property into an ISO 639-3 language code (for now only support translations
+  from ISO 639-1 and ISO 639-3 language codes). If the translation attempt
+  fails (no corresponding ISO 639-3 language code is found), it will equal the
+  value of `language`
+
+- `audioDescription` (`Boolean`): Whether the track is an audio
+  description of what is happening at the screen.
+
+- `dub` (`Boolean|undefined`): If set to `true`, this audio track is a
+  "dub", meaning it was recorded in another language than the original.
+  If set to `false`, we know that this audio track is in an original language.
+  This property is `undefined` if we do not known whether it is in an original
+  language.
+
+- `label` (`string|undefined`): A human readable label that may be displayed in
+  the user interface providing a choice between audio tracks.
+
+  This information is usually set only if the current Manifest contains one.
+
+- `representations` (`Array.<Object>`):
+  [Representations](../Getting_Started/Glossary.md#representation) of this video track, with
+  attributes:
+
+  - `id` (`string`): The id used to identify this Representation.
+    No other Representation from this track will have the same `id`.
+
+  - `bitrate` (`Number`): The bitrate of this Representation, in bits per
+    seconds.
+
+  - `codec` (`string|undefined`): The audio codec the Representation is
+    in, as announced in the corresponding Manifest.
+
+##### For text tracks
+
+When `trackInfo.type` is set to `"text"`, `track` describes a text track. It
+contains the following properties:
+
+- `id` (`string`): The id used to identify this track. No other
+  text track for the same [Period](../Getting_Started/Glossary.md#period)
+  will have the same `id`.
+
+- `language` (`string`): The language the text trac./../Basic_Methods/loadVideo.md#transport set in the
+  [Manifest](../Getting_Started/Glossary.md#manifest).
+
+- `normalized` (`string`): An attempt to translate the `language`
+  property into an ISO 639-3 language code (for now only support translations
+  from ISO 639-1 and ISO 639-3 language codes). If the translation attempt
+  fails (no corresponding ISO./../Basic_Methods/loadVideo.md#transport found), it will equal the
+  value of `language`
+
+- `label` (`string|undefined`): A human readable label that may be displayed in
+  the user interface providing a choice between text tracks.
+
+  This information is usually set only if the current Manifest contains one.
+
+- `closedCaption` (`Boolean`): Whether the track is specially adapted for
+  the hard of hearing or not.
+
+- `forced` (`Boolean`): If `true` this text track is meant to be displayed by
+  default if no other text track is selected.
+
+  It is often used to clarify dialogue, alternate languages, texted graphics or
+  location and person identification.
+
+
 ### ENCRYPTED_MEDIA_ERROR
 
-Those errors are linked to the Encrypted Media Extensions. They concern various
-DRM-related problems.
+Those errors are linked to the "Encrypted Media Extensions" API.
+They concern various DRM-related problems.
 
 They all have a `type` property equal to `"ENCRYPTED_MEDIA_ERROR"`.
 
+When its code is set to `KEY_STATUS_CHANGE_ERROR`, an ENCRYPTED_MEDIA_ERROR
+generally also have a `keyStatuses` property, which is documented in the
+corresponding `KEY_STATUS_CHANGE_ERROR` code explanation below.
+
 #### codes
 
-An EncryptedMediaError can have the following codes (`code` property):
+An error of `type` `ENCRYPTED_MEDIA_ERROR` can have the following codes (`code`
+property):
 
 - `"INCOMPATIBLE_KEYSYSTEMS"`: None of the provided key systems was
   compatible with the current browser.
@@ -295,7 +474,7 @@ They all have a `type` property equal to `"OTHER_ERROR"`.
 
 #### codes
 
-An OtherError can have the following codes (`code` property):
+An error of `type` `OTHER_ERROR` can have the following codes (`code` property):
 
 - `"PIPELINE_LOAD_ERROR"`: The
   [Manifest](../Getting_Started/Glossary.md#structure_of_a_manifest_object) or segment

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "babel-loader": "9.1.2",
         "chai": "4.3.7",
         "core-js": "3.30.0",
-        "docgen.ico": "0.1.2",
+        "docgen.ico": "^0.2.2",
         "esbuild": "0.17.15",
         "eslint": "8.37.0",
         "eslint-plugin-ban": "1.6.0",
@@ -5324,9 +5324,9 @@
       }
     },
     "node_modules/docgen.ico": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/docgen.ico/-/docgen.ico-0.1.2.tgz",
-      "integrity": "sha512-57pfNrW7yVCaKAjqs+PRoDs4CjBgqXpJpQSe+M9uIvWuLp1Yn18th9omVV5LkY8zv92JofSqWukvLpsJ7mC76Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/docgen.ico/-/docgen.ico-0.2.2.tgz",
+      "integrity": "sha512-vXOwHYuHR+l+/V7R22Ph2bmnG9+Km1CdxLGZ/chJF8sDz4dP/axNwyvmt6Mvy1vJUBMTa4HbNdO1JhLHLCjnvw==",
       "dev": true,
       "dependencies": {
         "cheerio": "1.0.0-rc.12",
@@ -5335,7 +5335,7 @@
         "markdown-it": "13.0.1"
       },
       "bin": {
-        "docgen.ico": "src/index.js"
+        "docgen.ico": "build/index.js"
       }
     },
     "node_modules/doctrine": {
@@ -17741,9 +17741,9 @@
       }
     },
     "docgen.ico": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/docgen.ico/-/docgen.ico-0.1.2.tgz",
-      "integrity": "sha512-57pfNrW7yVCaKAjqs+PRoDs4CjBgqXpJpQSe+M9uIvWuLp1Yn18th9omVV5LkY8zv92JofSqWukvLpsJ7mC76Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/docgen.ico/-/docgen.ico-0.2.2.tgz",
+      "integrity": "sha512-vXOwHYuHR+l+/V7R22Ph2bmnG9+Km1CdxLGZ/chJF8sDz4dP/axNwyvmt6Mvy1vJUBMTa4HbNdO1JhLHLCjnvw==",
       "dev": true,
       "requires": {
         "cheerio": "1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "babel-loader": "9.1.2",
     "chai": "4.3.7",
     "core-js": "3.30.0",
-    "docgen.ico": "0.1.2",
+    "docgen.ico": "^0.2.2",
     "esbuild": "0.17.15",
     "eslint": "8.37.0",
     "eslint-plugin-ban": "1.6.0",

--- a/src/core/api/debug/render.ts
+++ b/src/core/api/debug/render.ts
@@ -29,7 +29,7 @@ export default function renderDebugElement(
   debugWrapperElt.style.backgroundColor = "#00000099";
   debugWrapperElt.style.padding = "7px";
   debugWrapperElt.style.fontSize = "13px";
-  debugWrapperElt.style.fontFamily = "mono";
+  debugWrapperElt.style.fontFamily = "mono, monospace";
   debugWrapperElt.style.color = "white";
   debugWrapperElt.style.display = "inline-block";
   debugWrapperElt.style.bottom = "0px";

--- a/src/core/api/tracks_management/track_choice_manager.ts
+++ b/src/core/api/tracks_management/track_choice_manager.ts
@@ -24,9 +24,6 @@ import {
   Adaptation,
   Period,
   Representation,
-  toAudioTrack,
-  toTextTrack,
-  toVideoTrack,
 } from "../../../manifest";
 import {
   IAudioTrack,
@@ -620,7 +617,7 @@ export default class TrackChoiceManager {
     if (isNullOrUndefined(chosenTrack)) {
       return null;
     }
-    return toAudioTrack(chosenTrack);
+    return chosenTrack.toAudioTrack();
   }
 
   /**
@@ -645,7 +642,7 @@ export default class TrackChoiceManager {
     if (isNullOrUndefined(chosenTextAdaptation)) {
       return null;
     }
-    return toTextTrack(chosenTextAdaptation);
+    return chosenTextAdaptation.toTextTrack();
   }
 
   /**
@@ -671,7 +668,7 @@ export default class TrackChoiceManager {
       return null;
     }
     const currAdaptation = chosenVideoAdaptation.adaptation;
-    return toVideoTrack(currAdaptation);
+    return currAdaptation.toVideoTrack();
   }
 
   /**
@@ -697,7 +694,7 @@ export default class TrackChoiceManager {
       .map((adaptation) => {
         const active = currentId === null ? false :
                                             currentId === adaptation.id;
-        return objectAssign(toAudioTrack(adaptation), { active });
+        return objectAssign(adaptation.toAudioTrack(), { active });
       });
   }
 
@@ -725,7 +722,7 @@ export default class TrackChoiceManager {
       .map((adaptation) => {
         const active = currentId === null ? false :
                                             currentId === adaptation.id;
-        return objectAssign(toTextTrack(adaptation), { active });
+        return objectAssign(adaptation.toTextTrack(), { active });
       });
   }
 
@@ -752,7 +749,7 @@ export default class TrackChoiceManager {
       .map((adaptation) => {
         const active = currentId === null ? false :
                                             currentId === adaptation.id;
-        const track = toVideoTrack(adaptation);
+        const track = adaptation.toVideoTrack();
         const trickModeTracks = track.trickModeTracks !== undefined ?
           track.trickModeTracks.map((trickModeAdaptation) => {
             const isActive = currentId === null ? false :

--- a/src/core/api/tracks_management/track_choice_manager.ts
+++ b/src/core/api/tracks_management/track_choice_manager.ts
@@ -24,9 +24,11 @@ import {
   Adaptation,
   Period,
   Representation,
+  toAudioTrack,
+  toTextTrack,
+  toVideoTrack,
 } from "../../../manifest";
 import {
-  IAudioRepresentation,
   IAudioTrack,
   IAudioTrackPreference,
   IAvailableAudioTrack,
@@ -34,7 +36,6 @@ import {
   IAvailableVideoTrack,
   ITextTrack,
   ITextTrackPreference,
-  IVideoRepresentation,
   IVideoTrack,
   IVideoTrackPreference,
 } from "../../../public_types";
@@ -42,6 +43,7 @@ import arrayFind from "../../../utils/array_find";
 import arrayIncludes from "../../../utils/array_includes";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import normalizeLanguage from "../../../utils/languages";
+import objectAssign from "../../../utils/object_assign";
 import { ISharedReference } from "../../../utils/reference";
 import SortedList from "../../../utils/sorted_list";
 import takeFirstSet from "../../../utils/take_first_set";
@@ -618,19 +620,7 @@ export default class TrackChoiceManager {
     if (isNullOrUndefined(chosenTrack)) {
       return null;
     }
-
-    const audioTrack : IAudioTrack = {
-      language: takeFirstSet<string>(chosenTrack.language, ""),
-      normalized: takeFirstSet<string>(chosenTrack.normalizedLanguage, ""),
-      audioDescription: chosenTrack.isAudioDescription === true,
-      id: chosenTrack.id,
-      representations: chosenTrack.representations.map(parseAudioRepresentation),
-      label: chosenTrack.label,
-    };
-    if (chosenTrack.isDub === true) {
-      audioTrack.dub = true;
-    }
-    return audioTrack;
+    return toAudioTrack(chosenTrack);
   }
 
   /**
@@ -655,16 +645,7 @@ export default class TrackChoiceManager {
     if (isNullOrUndefined(chosenTextAdaptation)) {
       return null;
     }
-
-    const formatted : ITextTrack = {
-      language: takeFirstSet<string>(chosenTextAdaptation.language, ""),
-      normalized: takeFirstSet<string>(chosenTextAdaptation.normalizedLanguage, ""),
-      closedCaption: chosenTextAdaptation.isClosedCaption === true,
-      id: chosenTextAdaptation.id,
-      label: chosenTextAdaptation.label,
-      forced: chosenTextAdaptation.isForcedSubtitles,
-    };
-    return formatted;
+    return toTextTrack(chosenTextAdaptation);
   }
 
   /**
@@ -690,36 +671,7 @@ export default class TrackChoiceManager {
       return null;
     }
     const currAdaptation = chosenVideoAdaptation.adaptation;
-
-    const trickModeTracks = currAdaptation.trickModeTracks !== undefined ?
-      currAdaptation.trickModeTracks.map((trickModeAdaptation) => {
-        const representations = trickModeAdaptation.representations
-          .map(parseVideoRepresentation);
-        const trickMode : IVideoTrack = { id: trickModeAdaptation.id,
-                                          representations,
-                                          isTrickModeTrack: true };
-        if (trickModeAdaptation.isSignInterpreted === true) {
-          trickMode.signInterpreted = true;
-        }
-        return trickMode;
-      }) :
-      undefined;
-
-    const videoTrack: IVideoTrack = {
-      id: currAdaptation.id,
-      representations: currAdaptation.representations.map(parseVideoRepresentation),
-      label: currAdaptation.label,
-    };
-    if (currAdaptation.isSignInterpreted === true) {
-      videoTrack.signInterpreted = true;
-    }
-    if (currAdaptation.isTrickModeTrack === true) {
-      videoTrack.isTrickModeTrack = true;
-    }
-    if (trickModeTracks !== undefined) {
-      videoTrack.trickModeTracks = trickModeTracks;
-    }
-    return videoTrack;
+    return toVideoTrack(currAdaptation);
   }
 
   /**
@@ -743,20 +695,9 @@ export default class TrackChoiceManager {
 
     return audioInfos.adaptations
       .map((adaptation) => {
-        const formatted : IAvailableAudioTrack = {
-          language: takeFirstSet<string>(adaptation.language, ""),
-          normalized: takeFirstSet<string>(adaptation.normalizedLanguage, ""),
-          audioDescription: adaptation.isAudioDescription === true,
-          id: adaptation.id,
-          active: currentId === null ? false :
-                                       currentId === adaptation.id,
-          representations: adaptation.representations.map(parseAudioRepresentation),
-          label: adaptation.label,
-        };
-        if (adaptation.isDub === true) {
-          formatted.dub = true;
-        }
-        return formatted;
+        const active = currentId === null ? false :
+                                            currentId === adaptation.id;
+        return objectAssign(toAudioTrack(adaptation), { active });
       });
   }
 
@@ -782,17 +723,9 @@ export default class TrackChoiceManager {
 
     return textInfos.adaptations
       .map((adaptation) => {
-        const formatted : IAvailableTextTrack = {
-          language: takeFirstSet<string>(adaptation.language, ""),
-          normalized: takeFirstSet<string>(adaptation.normalizedLanguage, ""),
-          closedCaption: adaptation.isClosedCaption === true,
-          id: adaptation.id,
-          active: currentId === null ? false :
-                                       currentId === adaptation.id,
-          label: adaptation.label,
-          forced: adaptation.isForcedSubtitles,
-        };
-        return formatted;
+        const active = currentId === null ? false :
+                                            currentId === adaptation.id;
+        return objectAssign(toTextTrack(adaptation), { active });
       });
   }
 
@@ -817,37 +750,21 @@ export default class TrackChoiceManager {
 
     return videoInfos.adaptations
       .map((adaptation) => {
-        const trickModeTracks = adaptation.trickModeTracks !== undefined ?
-          adaptation.trickModeTracks.map((trickModeAdaptation) => {
+        const active = currentId === null ? false :
+                                            currentId === adaptation.id;
+        const track = toVideoTrack(adaptation);
+        const trickModeTracks = track.trickModeTracks !== undefined ?
+          track.trickModeTracks.map((trickModeAdaptation) => {
             const isActive = currentId === null ? false :
                                                   currentId === trickModeAdaptation.id;
-            const representations = trickModeAdaptation.representations
-              .map(parseVideoRepresentation);
-            const trickMode : IAvailableVideoTrack = { id: trickModeAdaptation.id,
-                                                       representations,
-                                                       isTrickModeTrack: true,
-                                                       active: isActive };
-            if (trickModeAdaptation.isSignInterpreted === true) {
-              trickMode.signInterpreted = true;
-            }
-            return trickMode;
+            return objectAssign(trickModeAdaptation, { active: isActive });
           }) :
-          undefined;
-
-        const formatted: IAvailableVideoTrack = {
-          id: adaptation.id,
-          active: currentId === null ? false :
-                                       currentId === adaptation.id,
-          representations: adaptation.representations.map(parseVideoRepresentation),
-          label: adaptation.label,
-        };
-        if (adaptation.isSignInterpreted === true) {
-          formatted.signInterpreted = true;
-        }
+          [];
+        const availableTrack = objectAssign(track, { active });
         if (trickModeTracks !== undefined) {
-          formatted.trickModeTracks = trickModeTracks;
+          availableTrack.trickModeTracks = trickModeTracks;
         }
-        return formatted;
+        return availableTrack;
       });
   }
 
@@ -1353,28 +1270,6 @@ function getPeriodItem(
       return periodI;
     }
   }
-}
-
-/**
- * Parse video Representation into a IVideoRepresentation.
- * @param {Object} representation
- * @returns {Object}
- */
-function parseVideoRepresentation(
-  { id, bitrate, frameRate, width, height, codec, hdrInfo } : Representation
-) : IVideoRepresentation {
-  return { id, bitrate, frameRate, width, height, codec, hdrInfo };
-}
-
-/**
- * Parse audio Representation into a ITMAudioRepresentation.
- * @param {Object} representation
- * @returns {Object}
- */
-function parseAudioRepresentation(
-  { id, bitrate, codec } : Representation
-)  : IAudioRepresentation {
-  return { id, bitrate, codec };
 }
 
 function getRightVideoTrack(

--- a/src/core/segment_buffers/index.ts
+++ b/src/core/segment_buffers/index.ts
@@ -30,6 +30,7 @@ import {
 import {
   IBufferedChunk,
   IChunkContext,
+  IInsertedChunkInfos,
 } from "./inventory";
 import SegmentBuffersStore, {
   ISegmentBufferOptions,
@@ -49,6 +50,7 @@ export {
 
   IBufferedChunk,
   IChunkContext,
+  IInsertedChunkInfos,
 
   IPushChunkInfos,
   IPushedChunkData,

--- a/src/core/stream/adaptation/utils/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/utils/create_representation_estimator.ts
@@ -87,8 +87,7 @@ export default function getRepresentationEstimate(
       const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                       "No Representation in the chosen " +
                                       adaptation.type + " Adaptation can be played",
-                                      { adaptationType: adaptation.type,
-                                        adaptation });
+                                      { adaptation });
       cleanUp();
       onFatalError(noRepErr);
       return;

--- a/src/core/stream/adaptation/utils/create_representation_estimator.ts
+++ b/src/core/stream/adaptation/utils/create_representation_estimator.ts
@@ -86,7 +86,9 @@ export default function getRepresentationEstimate(
     if (newRepr.length === 0) {
       const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                       "No Representation in the chosen " +
-                                      adaptation.type + " Adaptation can be played");
+                                      adaptation.type + " Adaptation can be played",
+                                      { adaptationType: adaptation.type,
+                                        adaptation });
       cleanUp();
       onFatalError(noRepErr);
       return;

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -381,8 +381,7 @@ function getFirstDeclaredMimeType(adaptation : Adaptation) : string {
     const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                     "No Representation in the chosen " +
                                     adaptation.type + " Adaptation can be played",
-                                    { adaptationType: adaptation.type,
-                                      adaptation });
+                                    { adaptation });
     throw noRepErr;
   }
   return representations[0].getMimeTypeString();

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -380,7 +380,9 @@ function getFirstDeclaredMimeType(adaptation : Adaptation) : string {
   if (representations.length === 0) {
     const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                     "No Representation in the chosen " +
-                                    adaptation.type + " Adaptation can be played");
+                                    adaptation.type + " Adaptation can be played",
+                                    { adaptationType: adaptation.type,
+                                      adaptation });
     throw noRepErr;
   }
   return representations[0].getMimeTypeString();

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -58,8 +58,7 @@ export default async function appendSegmentToBuffer<T>(
         "An unknown error happened when pushing content";
       throw new MediaError("BUFFER_APPEND_ERROR",
                            reason,
-                           { adaptationType: segmentBuffer.bufferType,
-                             adaptation: dataInfos.inventoryInfos.adaptation });
+                           { adaptation: dataInfos.inventoryInfos.adaptation });
     }
     const { position } = playbackObserver.getReference().getValue();
     const currentPos = position.pending ?? position.last;
@@ -72,8 +71,7 @@ export default async function appendSegmentToBuffer<T>(
 
       throw new MediaError("BUFFER_FULL_ERROR",
                            reason,
-                           { adaptationType: segmentBuffer.bufferType,
-                             adaptation: dataInfos.inventoryInfos.adaptation });
+                           { adaptation: dataInfos.inventoryInfos.adaptation });
     }
   }
 }

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -22,6 +22,7 @@ import { MediaError } from "../../../../errors";
 import { CancellationError, CancellationSignal } from "../../../../utils/task_canceller";
 import { IReadOnlyPlaybackObserver } from "../../../api";
 import {
+  IInsertedChunkInfos,
   IPushChunkInfos,
   SegmentBuffer,
 } from "../../../segment_buffers";
@@ -41,7 +42,7 @@ import forceGarbageCollection from "./force_garbage_collection";
 export default async function appendSegmentToBuffer<T>(
   playbackObserver : IReadOnlyPlaybackObserver<IRepresentationStreamPlaybackObservation>,
   segmentBuffer : SegmentBuffer,
-  dataInfos : IPushChunkInfos<T>,
+  dataInfos : IPushChunkInfos<T> & { inventoryInfos: IInsertedChunkInfos },
   cancellationSignal : CancellationSignal
 ) : Promise<void> {
   try {
@@ -55,7 +56,10 @@ export default async function appendSegmentToBuffer<T>(
       const reason = appendError instanceof Error ?
         appendError.toString() :
         "An unknown error happened when pushing content";
-      throw new MediaError("BUFFER_APPEND_ERROR", reason);
+      throw new MediaError("BUFFER_APPEND_ERROR",
+                           reason,
+                           { adaptationType: segmentBuffer.bufferType,
+                             adaptation: dataInfos.inventoryInfos.adaptation });
     }
     const { position } = playbackObserver.getReference().getValue();
     const currentPos = position.pending ?? position.last;
@@ -66,7 +70,10 @@ export default async function appendSegmentToBuffer<T>(
       const reason = err2 instanceof Error ? err2.toString() :
                                              "Could not clean the buffer";
 
-      throw new MediaError("BUFFER_FULL_ERROR", reason);
+      throw new MediaError("BUFFER_FULL_ERROR",
+                           reason,
+                           { adaptationType: segmentBuffer.bufferType,
+                             adaptation: dataInfos.inventoryInfos.adaptation });
     }
   }
 }

--- a/src/core/stream/representation/utils/push_init_segment.ts
+++ b/src/core/stream/representation/utils/push_init_segment.ts
@@ -20,6 +20,7 @@ import Manifest, {
   Period,
   Representation,
 } from "../../../../manifest";
+import objectAssign from "../../../../utils/object_assign";
 import { CancellationSignal } from "../../../../utils/task_canceller";
 import { IReadOnlyPlaybackObserver } from "../../../api";
 import {
@@ -71,9 +72,14 @@ export default async function pushInitSegment<T>(
                                        timestampOffset: 0,
                                        appendWindow: [ undefined, undefined ],
                                        codec };
+  const inventoryInfos = objectAssign({ segment,
+                                        chunkSize: undefined,
+                                        start: 0,
+                                        end: 0 },
+                                      content);
   await appendSegmentToBuffer(playbackObserver,
                               segmentBuffer,
-                              { data, inventoryInfos: null },
+                              { data, inventoryInfos },
                               cancelSignal);
   const buffered = segmentBuffer.getBufferedRanges();
   return { content, segment, buffered, segmentData };

--- a/src/errors/__tests__/media_error.test.ts
+++ b/src/errors/__tests__/media_error.test.ts
@@ -19,7 +19,7 @@ import MediaError from "../media_error";
 describe("errors - MediaError", () => {
   it("should format a MediaError", () => {
     const reason = "test";
-    const mediaError = new MediaError("BUFFER_FULL_ERROR", reason);
+    const mediaError = new MediaError("MEDIA_TIME_BEFORE_MANIFEST", reason);
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
     expect(mediaError.type).toBe("MEDIA_ERROR");
@@ -30,13 +30,14 @@ describe("errors - MediaError", () => {
 
   it("should be able to set it as fatal", () => {
     const reason = "test";
-    const mediaError = new MediaError("BUFFER_APPEND_ERROR", reason);
+    const mediaError = new MediaError("MEDIA_TIME_AFTER_MANIFEST", reason);
     mediaError.fatal = true;
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
     expect(mediaError.type).toBe("MEDIA_ERROR");
     expect(mediaError.code).toBe("BUFFER_APPEND_ERROR");
     expect(mediaError.fatal).toBe(true);
+    expect(mediaError.trackInfo?.type).toBe("video");
     expect(mediaError.message).toBe("MediaError (BUFFER_APPEND_ERROR) test");
   });
 

--- a/src/errors/__tests__/media_error.test.ts
+++ b/src/errors/__tests__/media_error.test.ts
@@ -37,7 +37,6 @@ describe("errors - MediaError", () => {
     expect(mediaError.type).toBe("MEDIA_ERROR");
     expect(mediaError.code).toBe("MEDIA_TIME_AFTER_MANIFEST");
     expect(mediaError.fatal).toBe(true);
-    expect(mediaError.trackInfo?.type).toBe("video");
     expect(mediaError.message).toBe("MediaError (MEDIA_TIME_AFTER_MANIFEST) test");
   });
 

--- a/src/errors/__tests__/media_error.test.ts
+++ b/src/errors/__tests__/media_error.test.ts
@@ -23,9 +23,9 @@ describe("errors - MediaError", () => {
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
     expect(mediaError.type).toBe("MEDIA_ERROR");
-    expect(mediaError.code).toBe("BUFFER_FULL_ERROR");
+    expect(mediaError.code).toBe("MEDIA_TIME_BEFORE_MANIFEST");
     expect(mediaError.fatal).toBe(false);
-    expect(mediaError.message).toBe("MediaError (BUFFER_FULL_ERROR) test");
+    expect(mediaError.message).toBe("MediaError (MEDIA_TIME_BEFORE_MANIFEST) test");
   });
 
   it("should be able to set it as fatal", () => {
@@ -35,10 +35,10 @@ describe("errors - MediaError", () => {
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
     expect(mediaError.type).toBe("MEDIA_ERROR");
-    expect(mediaError.code).toBe("BUFFER_APPEND_ERROR");
+    expect(mediaError.code).toBe("MEDIA_TIME_AFTER_MANIFEST");
     expect(mediaError.fatal).toBe(true);
     expect(mediaError.trackInfo?.type).toBe("video");
-    expect(mediaError.message).toBe("MediaError (BUFFER_APPEND_ERROR) test");
+    expect(mediaError.message).toBe("MediaError (MEDIA_TIME_AFTER_MANIFEST) test");
   });
 
   it("should filter in a valid error code", () => {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -26,7 +26,9 @@ import {
 } from "./error_codes";
 import formatError from "./format_error";
 import isKnownError from "./is_known_error";
-import MediaError from "./media_error";
+import MediaError, {
+  IMediaErrorTrackContext,
+} from "./media_error";
 import NetworkError from "./network_error";
 import OtherError from "./other_error";
 import RequestError from "./request_error";
@@ -39,6 +41,7 @@ export {
   ErrorTypes,
   IErrorCode,
   IErrorType,
+  IMediaErrorTrackContext,
   formatError,
   MediaError as MediaError,
   NetworkError,

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Adaptation,
-  toAudioTrack,
-  toTextTrack,
-  toVideoTrack,
-} from "../manifest";
+import { Adaptation } from "../manifest";
 import {
   IAudioTrack,
   ITextTrack,
@@ -107,15 +102,15 @@ export default class MediaError extends Error {
       switch (adaptation.type) {
         case "audio":
           this.trackInfo = { type: "audio",
-                             track: toAudioTrack(adaptation) };
+                             track: adaptation.toAudioTrack() };
           break;
         case "video":
           this.trackInfo = { type: "video",
-                             track: toVideoTrack(adaptation) };
+                             track: adaptation.toVideoTrack() };
           break;
         case "text":
           this.trackInfo = { type: "text",
-                             track: toTextTrack(adaptation) };
+                             track: adaptation.toTextTrack() };
           break;
       }
     }

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -15,10 +15,46 @@
  */
 
 import {
+  Adaptation,
+  IAdaptationType,
+  toAudioTrack,
+  toTextTrack,
+  toVideoTrack,
+} from "../manifest";
+import {
+  IAudioTrack,
+  ITextTrack,
+  IVideoTrack,
+} from "../public_types";
+import {
   ErrorTypes,
   IMediaErrorCode,
 } from "./error_codes";
 import errorMessage from "./error_message";
+
+interface IAudioTrackMediaErrorContext {
+  type : "audio";
+  track : IAudioTrack;
+}
+
+interface IVideoTrackMediaErrorContext {
+  type : "video";
+  track : IVideoTrack;
+}
+
+interface ITextTrackMediaErrorContext {
+  type : "text";
+  track : ITextTrack;
+}
+
+export type IMediaErrorTrackContext = IAudioTrackMediaErrorContext |
+                                      IVideoTrackMediaErrorContext |
+                                      ITextTrackMediaErrorContext;
+
+type ICodeWithAdaptationType = "BUFFER_APPEND_ERROR" |
+                               "BUFFER_FULL_ERROR" |
+                               "NO_PLAYABLE_REPRESENTATION" |
+                               "MANIFEST_INCOMPATIBLE_CODECS_ERROR";
 
 /**
  * Error linked to the media Playback.
@@ -31,13 +67,34 @@ export default class MediaError extends Error {
   public readonly type : "MEDIA_ERROR";
   public readonly message : string;
   public readonly code : IMediaErrorCode;
+  public readonly trackInfo : IMediaErrorTrackContext | undefined;
   public fatal : boolean;
 
   /**
    * @param {string} code
    * @param {string} reason
+   * @param {Object|undefined} [context]
    */
-  constructor(code : IMediaErrorCode, reason : string) {
+  constructor(
+    code : ICodeWithAdaptationType,
+    reason : string,
+    context: {
+      adaptationType : IAdaptationType;
+      adaptation : Adaptation;
+    }
+  );
+  constructor(
+    code : Exclude<IMediaErrorCode, ICodeWithAdaptationType>,
+    reason : string,
+  );
+  constructor(
+    code : IMediaErrorCode,
+    reason : string,
+    context? : {
+      adaptationType? : IAdaptationType | undefined;
+      adaptation? : Adaptation | undefined;
+    } | undefined
+  ) {
     super();
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, MediaError.prototype);
@@ -48,5 +105,22 @@ export default class MediaError extends Error {
     this.code = code;
     this.message = errorMessage(this.name, this.code, reason);
     this.fatal = false;
+    const adaptation = context?.adaptation;
+    if (adaptation !== undefined) {
+      switch (adaptation.type) {
+        case "audio":
+          this.trackInfo = { type: "audio",
+                             track: toAudioTrack(adaptation) };
+          break;
+        case "video":
+          this.trackInfo = { type: "video",
+                             track: toVideoTrack(adaptation) };
+          break;
+        case "text":
+          this.trackInfo = { type: "text",
+                             track: toTextTrack(adaptation) };
+          break;
+      }
+    }
   }
 }

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -16,7 +16,6 @@
 
 import {
   Adaptation,
-  IAdaptationType,
   toAudioTrack,
   toTextTrack,
   toVideoTrack,
@@ -79,7 +78,6 @@ export default class MediaError extends Error {
     code : ICodeWithAdaptationType,
     reason : string,
     context: {
-      adaptationType : IAdaptationType;
       adaptation : Adaptation;
     }
   );
@@ -91,7 +89,6 @@ export default class MediaError extends Error {
     code : IMediaErrorCode,
     reason : string,
     context? : {
-      adaptationType? : IAdaptationType | undefined;
       adaptation? : Adaptation | undefined;
     } | undefined
   ) {

--- a/src/manifest/__tests__/period.test.ts
+++ b/src/manifest/__tests__/period.test.ts
@@ -149,25 +149,30 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "56",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const videoAda3 = { type: "video",
                         id: "57",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda3; } };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
                         isSupported: true,
-                        representations: [] };
+                        representations: [],
+                        toAudioTrack() { return audioAda1; } };
     const audioAda2 = { type: "audio",
                         id: "59",
                         isSupported: true,
-                        representations: [] };
+                        representations: [],
+                        toAudioTrack() { return audioAda2; } };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
@@ -204,25 +209,30 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const videoAda3 = { type: "video",
                         id: "56",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda3; } };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "57",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audioAda2 = { type: "audio",
                         id: "58",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
@@ -259,25 +269,30 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [] };
+                        representations: [],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [] };
+                        representations: [],
+                        toVideoTrack() { return videoAda2; } };
     const videoAda3 = { type: "video",
                         id: "56",
                         isSupported: true,
-                        representations: [] };
+                        representations: [],
+                        toVideoTrack() { return videoAda3; } };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audioAda2 = { type: "audio",
                         id: "59",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda2; } };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
@@ -314,25 +329,30 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const videoAda3 = { type: "video",
                         id: "56",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda3; } };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "58",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audioAda2 = { type: "audio",
                         id: "59",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda2; } };
     const audio = [audioAda1, audioAda2];
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
@@ -372,12 +392,14 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const video = [videoAda1];
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video2 = [videoAda2];
     const args = { id: "12", adaptations: { video, video2 }, start: 0 };
     const period = new Period(args);
@@ -408,7 +430,8 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const video = [videoAda1];
     const bar = undefined;
     const args = { id: "12", adaptations: { bar, video }, start: 0 };
@@ -435,11 +458,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0 };
     const period = new Period(args, representationFilter);
@@ -467,11 +492,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: false,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const fooAda1 = { type: "foo",
                       id: "12",
                       isSupported: false,
@@ -503,11 +530,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: false,
-                        representations: [] };
+                        representations: [],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const fooAda1 = { type: "foo",
                       id: "12",
                       isSupported: false,
@@ -532,11 +561,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 72 };
     const period = new Period(args);
@@ -557,11 +588,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0, duration: 12 };
     const period = new Period(args);
@@ -582,11 +615,13 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 50, duration: 12 };
     const period = new Period(args);
@@ -607,17 +642,20 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
@@ -643,17 +681,20 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
 
     const audioAda1 = { type: "audio",
                         id: "56",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
@@ -686,21 +727,25 @@ describe("Manifest - Period", () => {
     const videoAda1 = { type: "video",
                         id: "54",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda1; } };
     const videoAda2 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda2; } };
     const videoAda3 = { type: "video",
                         id: "55",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toVideoTrack() { return videoAda3; } };
     const video = [videoAda1, videoAda2, videoAda3];
 
     const audioAda1 = { type: "audio",
                         id: "56",
                         isSupported: true,
-                        representations: [{}] };
+                        representations: [{}],
+                        toAudioTrack() { return audioAda1; } };
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -26,10 +26,7 @@ import arrayFind from "../utils/array_find";
 import isNullOrUndefined from "../utils/is_null_or_undefined";
 import normalizeLanguage from "../utils/languages";
 import uniq from "../utils/uniq";
-import Representation, {
-  parseAudioRepresentation,
-  parseVideoRepresentation,
-} from "./representation";
+import Representation from "./representation";
 import { IAdaptationType } from "./types";
 
 /** List in an array every possible value for the Adaptation's `type` property. */
@@ -224,83 +221,74 @@ export default class Adaptation {
   getRepresentation(wantedId : number|string) : Representation|undefined {
     return arrayFind(this.representations, ({ id }) => wantedId === id);
   }
-}
 
-/**
- * Format an `Adaptation`, generally of type `"audio"`, as an `IAudioTrack`.
- * @param {Object} audioAdaptation
- * @returns {Object}
- */
-export function toAudioTrack(
-  audioAdaptation: Adaptation
-) : IAudioTrack {
-  const formatted : IAudioTrack = {
-    language: audioAdaptation.language ?? "",
-    normalized: audioAdaptation.normalizedLanguage ?? "",
-    audioDescription: audioAdaptation.isAudioDescription === true,
-    id: audioAdaptation.id,
-    representations: audioAdaptation.representations.map(parseAudioRepresentation),
-    label: audioAdaptation.label,
-  };
-  if (audioAdaptation.isDub === true) {
-    formatted.dub = true;
+  /**
+   * Format an `Adaptation`, generally of type `"audio"`, as an `IAudioTrack`.
+   * @returns {Object}
+   */
+  public toAudioTrack() : IAudioTrack {
+    const formatted : IAudioTrack = {
+      language: this.language ?? "",
+      normalized: this.normalizedLanguage ?? "",
+      audioDescription: this.isAudioDescription === true,
+      id: this.id,
+      representations: this.representations.map(r => r.toAudioRepresentation()),
+      label: this.label,
+    };
+    if (this.isDub === true) {
+      formatted.dub = true;
+    }
+    return formatted;
   }
-  return formatted;
-}
 
-/**
- * Format an `Adaptation`, generally of type `"audio"`, as an `IAudioTrack`.
- * @param {Object} textAdaptation
- * @returns {Object}
- */
-export function toTextTrack(
-  textAdaptation: Adaptation
-) : ITextTrack {
-  return {
-    language: textAdaptation.language ?? "",
-    normalized: textAdaptation.normalizedLanguage ?? "",
-    closedCaption: textAdaptation.isClosedCaption === true,
-    id: textAdaptation.id,
-    label: textAdaptation.label,
-    forced: textAdaptation.isForcedSubtitles,
-  };
-}
+  /**
+   * Format an `Adaptation`, generally of type `"audio"`, as an `IAudioTrack`.
+   * @returns {Object}
+   */
+  public toTextTrack() : ITextTrack {
+    return {
+      language: this.language ?? "",
+      normalized: this.normalizedLanguage ?? "",
+      closedCaption: this.isClosedCaption === true,
+      id: this.id,
+      label: this.label,
+      forced: this.isForcedSubtitles,
+    };
+  }
 
-/**
- * Format an `Adaptation`, generally of type `"video"`, as an `IAudioTrack`.
- * @param {Object} videoAdaptation
- * @returns {Object}
- */
-export function toVideoTrack(
-  videoAdaptation: Adaptation
-) : IVideoTrack {
-  const trickModeTracks = videoAdaptation.trickModeTracks !== undefined ?
-    videoAdaptation.trickModeTracks.map((trickModeAdaptation) => {
-      const representations = trickModeAdaptation.representations
-        .map(parseVideoRepresentation);
-      const trickMode : IVideoTrack = { id: trickModeAdaptation.id,
-                                        representations,
-                                        isTrickModeTrack: true };
-      if (trickModeAdaptation.isSignInterpreted === true) {
-        trickMode.signInterpreted = true;
-      }
-      return trickMode;
-    }) :
-    undefined;
+  /**
+   * Format an `Adaptation`, generally of type `"video"`, as an `IAudioTrack`.
+   * @returns {Object}
+   */
+  public toVideoTrack() : IVideoTrack {
+    const trickModeTracks = this.trickModeTracks !== undefined ?
+      this.trickModeTracks.map((trickModeAdaptation) => {
+        const representations = trickModeAdaptation.representations
+          .map(r => r.toVideoRepresentation());
+        const trickMode : IVideoTrack = { id: trickModeAdaptation.id,
+                                          representations,
+                                          isTrickModeTrack: true };
+        if (trickModeAdaptation.isSignInterpreted === true) {
+          trickMode.signInterpreted = true;
+        }
+        return trickMode;
+      }) :
+      undefined;
 
-  const videoTrack: IVideoTrack = {
-    id: videoAdaptation.id,
-    representations: videoAdaptation.representations.map(parseVideoRepresentation),
-    label: videoAdaptation.label,
-  };
-  if (videoAdaptation.isSignInterpreted === true) {
-    videoTrack.signInterpreted = true;
+    const videoTrack: IVideoTrack = {
+      id: this.id,
+      representations: this.representations.map(r => r.toVideoRepresentation()),
+      label: this.label,
+    };
+    if (this.isSignInterpreted === true) {
+      videoTrack.signInterpreted = true;
+    }
+    if (this.isTrickModeTrack === true) {
+      videoTrack.isTrickModeTrack = true;
+    }
+    if (trickModeTracks !== undefined) {
+      videoTrack.trickModeTracks = trickModeTracks;
+    }
+    return videoTrack;
   }
-  if (videoAdaptation.isTrickModeTrack === true) {
-    videoTrack.isTrickModeTrack = true;
-  }
-  if (trickModeTracks !== undefined) {
-    videoTrack.trickModeTracks = trickModeTracks;
-  }
-  return videoTrack;
 }

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -16,9 +16,6 @@
 
 import Adaptation, {
   SUPPORTED_ADAPTATIONS_TYPE,
-  toAudioTrack,
-  toTextTrack,
-  toVideoTrack,
 } from "./adaptation";
 import Manifest, {
   IDecipherabilityUpdateElement,
@@ -49,9 +46,6 @@ export {
   areSameContent,
   getLoggableSegmentId,
   IBufferedChunkInfos,
-  toAudioTrack,
-  toTextTrack,
-  toVideoTrack,
 
   // classes
   Period,

--- a/src/manifest/index.ts
+++ b/src/manifest/index.ts
@@ -16,6 +16,9 @@
 
 import Adaptation, {
   SUPPORTED_ADAPTATIONS_TYPE,
+  toAudioTrack,
+  toTextTrack,
+  toVideoTrack,
 } from "./adaptation";
 import Manifest, {
   IDecipherabilityUpdateElement,
@@ -46,6 +49,9 @@ export {
   areSameContent,
   getLoggableSegmentId,
   IBufferedChunkInfos,
+  toAudioTrack,
+  toTextTrack,
+  toVideoTrack,
 
   // classes
   Period,

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -632,7 +632,9 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
       if (newAdaptation.representations.length > 0 && !newAdaptation.isSupported) {
         const error =
           new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-                         "An Adaptation contains only incompatible codecs.");
+                         "An Adaptation contains only incompatible codecs.",
+                         { adaptationType: "image",
+                           adaptation: newAdaptation });
         this.contentWarnings.push(error);
       }
       return newAdaptation;
@@ -694,7 +696,9 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
         if (newAdaptation.representations.length > 0 && !newAdaptation.isSupported) {
           const error =
             new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-                           "An Adaptation contains only incompatible codecs.");
+                           "An Adaptation contains only incompatible codecs.",
+                           { adaptationType: "text",
+                             adaptation: newAdaptation });
           this.contentWarnings.push(error);
         }
         return newAdaptation;

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -633,8 +633,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
         const error =
           new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                          "An Adaptation contains only incompatible codecs.",
-                         { adaptationType: "image",
-                           adaptation: newAdaptation });
+                         { adaptation: newAdaptation });
         this.contentWarnings.push(error);
       }
       return newAdaptation;
@@ -697,8 +696,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
           const error =
             new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                            "An Adaptation contains only incompatible codecs.",
-                           { adaptationType: "text",
-                             adaptation: newAdaptation });
+                           { adaptation: newAdaptation });
           this.contentWarnings.push(error);
         }
         return newAdaptation;
@@ -715,7 +713,7 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
 
   /**
    * @param {Object} newManifest
-   * @param {number} type
+   * @param {number} updateType
    */
   private _performUpdate(
     newManifest : Manifest,

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -89,7 +89,9 @@ export default class Period {
             if (newAdaptation.representations.length > 0 && !newAdaptation.isSupported) {
               const error =
                 new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-                               "An Adaptation contains only incompatible codecs.");
+                               "An Adaptation contains only incompatible codecs.",
+                               { adaptationType: adaptation.type,
+                                 adaptation: newAdaptation });
               this.contentWarnings.push(error);
             }
             return newAdaptation;

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -90,8 +90,7 @@ export default class Period {
               const error =
                 new MediaError("MANIFEST_INCOMPATIBLE_CODECS_ERROR",
                                "An Adaptation contains only incompatible codecs.",
-                               { adaptationType: adaptation.type,
-                                 adaptation: newAdaptation });
+                               { adaptation: newAdaptation });
               this.contentWarnings.push(error);
             }
             return newAdaptation;

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -21,7 +21,11 @@ import {
   IContentProtections,
   IParsedRepresentation,
 } from "../parsers/manifest";
-import { IHDRInformation } from "../public_types";
+import {
+  IAudioRepresentation,
+  IHDRInformation,
+  IVideoRepresentation,
+} from "../public_types";
 import areArraysOfNumbersEqual from "../utils/are_arrays_of_numbers_equal";
 import { IRepresentationIndex } from "./representation_index";
 import {
@@ -371,3 +375,25 @@ export interface IRepresentationProtectionData {
 }
 
 export default Representation;
+
+/**
+ * Parse audio Representation into a `IAudioRepresentation`.
+ * @param {Object} representation
+ * @returns {Object}
+ */
+export function parseAudioRepresentation(
+  { id, bitrate, codec } : Representation
+)  : IAudioRepresentation {
+  return { id, bitrate, codec };
+}
+
+/**
+ * Parse video Representation into a IVideoRepresentation.
+ * @param {Object} representation
+ * @returns {Object}
+ */
+export function parseVideoRepresentation(
+  { id, bitrate, frameRate, width, height, codec, hdrInfo } : Representation
+) : IVideoRepresentation {
+  return { id, bitrate, frameRate, width, height, codec, hdrInfo };
+}

--- a/src/manifest/representation.ts
+++ b/src/manifest/representation.ts
@@ -338,6 +338,24 @@ class Representation {
                                             values: data });
     return true;
   }
+
+  /**
+   * Format Representation as an `IAudioRepresentation`.
+   * @returns {Object}
+   */
+  public toAudioRepresentation(): IAudioRepresentation {
+    const { id, bitrate, codec } = this;
+    return { id, bitrate, codec };
+  }
+
+  /**
+   * Format Representation as an `IVideoRepresentation`.
+   * @returns {Object}
+   */
+  public toVideoRepresentation(): IVideoRepresentation {
+    const { id, bitrate, frameRate, width, height, codec, hdrInfo } = this;
+    return { id, bitrate, frameRate, width, height, codec, hdrInfo };
+  }
 }
 
 /** Protection data as returned by a Representation. */
@@ -375,25 +393,3 @@ export interface IRepresentationProtectionData {
 }
 
 export default Representation;
-
-/**
- * Parse audio Representation into a `IAudioRepresentation`.
- * @param {Object} representation
- * @returns {Object}
- */
-export function parseAudioRepresentation(
-  { id, bitrate, codec } : Representation
-)  : IAudioRepresentation {
-  return { id, bitrate, codec };
-}
-
-/**
- * Parse video Representation into a IVideoRepresentation.
- * @param {Object} representation
- * @returns {Object}
- */
-export function parseVideoRepresentation(
-  { id, bitrate, frameRate, width, height, codec, hdrInfo } : Representation
-) : IVideoRepresentation {
-  return { id, bitrate, frameRate, width, height, codec, hdrInfo };
-}

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -24,6 +24,7 @@ import {
 } from "./core/decrypt";
 import { IBufferType } from "./core/segment_buffers";
 import {
+  IMediaErrorTrackContext,
   EncryptedMediaError,
   MediaError,
   NetworkError,
@@ -32,6 +33,8 @@ import {
 import Manifest from "./manifest";
 import { ILocalManifest } from "./parsers/manifest/local";
 import { IMetaPlaylist } from "./parsers/manifest/metaplaylist/metaplaylist_parser";
+
+export { IMediaErrorTrackContext };
 
 /**
  * This file defines and exports types we want to expose to library users.
@@ -235,11 +238,13 @@ export interface IPeriod {
                   image? : IAdaptation[]; };
 }
 
+export type IAdaptationType = "video" | "audio" | "text" | "image";
+
 /** Adaptation (represents a track), as documented in the API documentation. */
 export interface IAdaptation {
   /** String identifying the Adaptation, unique per Period. */
   id : string;
-  type : "video" | "audio" | "text" | "image";
+  type : IAdaptationType;
   language? : string | undefined;
   normalizedLanguage? : string | undefined;
   isAudioDescription? : boolean | undefined;

--- a/src/transports/smooth/isobmff/create_boxes.ts
+++ b/src/transports/smooth/isobmff/create_boxes.ts
@@ -33,7 +33,7 @@ import {
  * @param {Number} height
  * @param {Number} hRes - horizontal resolution, eg 72
  * @param {Number} vRes - vertical resolution, eg 72
- * @param {string} encDepth
+ * @param {string} encName
  * @param {Number} colorDepth - eg 24
  * @param {Uint8Array} avcc - Uint8Array representing the avcC atom
  * @returns {Uint8Array}
@@ -68,7 +68,7 @@ function createAVC1Box(
  * @param {Number} height
  * @param {Number} hRes - horizontal resolution, eg 72
  * @param {Number} vRes - vertical resolution, eg 72
- * @param {string} encDepth
+ * @param {string} encName
  * @param {Number} colorDepth - eg 24
  * @param {Uint8Array} avcc - Uint8Array representing the avcC atom
  * @param {Uint8Array} sinf - Uint8Array representing the sinf atom
@@ -108,8 +108,6 @@ function createENCVBox(
  * @param {Number} packetSize
  * @param {Number} sampleRate
  * @param {Uint8Array} esds - Uint8Array representing the esds atom
- * @param {Uint8Array} [sinf] - Uint8Array representing the sinf atom,
- * only if name == "enca"
  * @returns {Uint8Array}
  */
 function createMP4ABox(
@@ -164,7 +162,7 @@ function createENCABox(
 }
 
 /**
- * @param {url} Uint8Array
+ * @param {Uint8Array} url
  * @returns {Uint8Array}
  */
 function createDREFBox(url : Uint8Array) : Uint8Array {
@@ -415,7 +413,7 @@ function createSMHDBox() : Uint8Array {
 }
 
 /**
- * @param {Array.<Uint8Array>} representations - arrays of Uint8Array,
+ * @param {Array.<Uint8Array>} reps - arrays of Uint8Array,
  * typically [avc1] or [encv, avc1]
  * @returns {Uint8Array}
  */


### PR DESCRIPTION
This PR adds a `trackInfo` property to `MediaError` errors when its `code` property is set to either:

  - `"NO_PLAYABLE_REPRESENTATION"` (unplayable track based on DRM policy non-compliance),

  - `"MANIFEST_INCOMPATIBLE_CODECS_ERROR"` (track with unsupported codec),

  - `"BUFFER_APPEND_ERROR"` (error while pushing a segment)

  - `"BUFFER_FULL_ERROR"` (error while pushing a segment which seems specifically linked to that buffer not having enough memory space left) 

 That `trackInfo` property provides characteristics about the track linked to the error. For example, the video track's characteristics when a `BUFFER_APPEND_ERROR` is linked to a video segment.

---

The idea here mainly is  to allow applications to develop much more powerful error management logic:

  - allowing logs of better errors. For example by knowing if an error was linked to a video or audio track and which one.

  - letting the application add resilience in the context of rare issues it empirically observed, that are most of the time linked to both device issues and the contents being played.

    For example, if an application observes that a device's low level bug lead to the impossibility to play for some contents a video track under the PlayReady SL3000 key system, but that playing another video track do work, the application may want to reload the content after the error was received, this time filtering the problematic video track (if this example looks VERY specific, it's because it's one of the situation we did actually encounter! Issues encountered are multiple and for the most part only linked to some device, contents and DRM policies combinations).

     We also thought about handling all those cases on the RxPlayer-side, but some of those appear to be very specific to the contents being played. We thus decided to also let the application develop its own code if it wants to, allowing much more flexibility and reactivity.