### PR TITLE
Demo Header: Add GitHubButton component to replace script in head

### DIFF
--- a/demo/full/index.html
+++ b/demo/full/index.html
@@ -8,7 +8,6 @@
 <link rel="stylesheet" href="styles/style.css" media="screen">
 <link rel="icon" type="image/x-icon" href="plus.ico" />
 <script type="text/javascript" src="./bundle.js" charset="utf-8"></script>
-<script async defer src="https://buttons.github.io/buttons.js"></script>
 <title>RxPlayer - CANAL+</title>
 </head>
 <body>

--- a/demo/full/scripts/components/GitHubButton.tsx
+++ b/demo/full/scripts/components/GitHubButton.tsx
@@ -13,7 +13,6 @@ const GitHubButton = ({
   dataIcon,
   dataShowCount,
   dataSize = "large",
-  dataText,
   title,
   children,
 }: {
@@ -23,7 +22,6 @@ const GitHubButton = ({
   dataIcon?: string;
   dataShowCount?: boolean | string;
   dataSize?: string;
-  dataText?: string;
   title?: string;
   children?: React.ReactNode;
 }): JSX.Element => {
@@ -49,7 +47,6 @@ const GitHubButton = ({
         data-color-scheme={dataColorScheme}
         data-show-count={dataShowCount}
         data-size={dataSize}
-        data-text={dataText}
         title={title}
       >
         {children}

--- a/demo/full/scripts/components/GitHubButton.tsx
+++ b/demo/full/scripts/components/GitHubButton.tsx
@@ -9,7 +9,7 @@ const {
 const GitHubButton = ({
   href,
   ariaLabel,
-  dataColorScheme = "no-preference: dark_high_contrast; light: dark_high_contrast; dark: dark_high_contrast;",
+  dataColorScheme = "dark_high_contrast",
   dataIcon,
   dataShowCount,
   dataSize = "large",
@@ -27,32 +27,20 @@ const GitHubButton = ({
   title?: string;
   children?: React.ReactNode;
 }): JSX.Element => {
-  const spanRef = useRef<HTMLSpanElement>(null);
   const aRef = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
-    // Apply github-buttons's render on a new span
-    if (spanRef.current && aRef.current) {
-      const newSpan = spanRef.current.appendChild(document.createElement("span"));
+    const aElement = aRef.current;
+    if (aElement !== null) {
       render(
-        newSpan.appendChild(aRef.current),
-        el => newSpan.parentNode?.replaceChild(el, newSpan),
+        aElement,
+        newA => aElement?.parentNode?.replaceChild(newA, aElement),
       );
     }
-
-    return () => {
-      // Reset
-      if (aRef.current && spanRef.current?.lastChild) {
-        spanRef.current.replaceChild(aRef.current, spanRef.current.lastChild);
-      }
-    };
   });
 
   return (
-    <span
-      ref={spanRef}
-      className="button-gh"
-    >
+    <span className="button-gh">
       <a
         ref={aRef}
         href={href}

--- a/demo/full/scripts/components/GitHubButton.tsx
+++ b/demo/full/scripts/components/GitHubButton.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+import { render } from "github-buttons";
+
+const {
+  useEffect,
+  useRef,
+} = React;
+
+const GitHubButton = ({
+  href,
+  ariaLabel,
+  dataColorScheme = "no-preference: dark_high_contrast; light: dark_high_contrast; dark: dark_high_contrast;",
+  dataIcon,
+  dataShowCount,
+  dataSize = "large",
+  dataText,
+  title,
+  children,
+}: {
+  href: string;
+  ariaLabel?: string;
+  dataColorScheme?: string;
+  dataIcon?: string;
+  dataShowCount?: boolean | string;
+  dataSize?: string;
+  dataText?: string;
+  title?: string;
+  children?: React.ReactNode;
+}): JSX.Element => {
+  const spanRef = useRef<HTMLSpanElement>(null);
+  const aRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    // Apply github-buttons's render on a new span
+    if (spanRef.current && aRef.current) {
+      const newSpan = spanRef.current.appendChild(document.createElement("span"));
+      render(
+        newSpan.appendChild(aRef.current),
+        el => newSpan.parentNode?.replaceChild(el, newSpan),
+      );
+    }
+
+    return () => {
+      // Reset
+      if (aRef.current && spanRef.current?.lastChild) {
+        spanRef.current.replaceChild(aRef.current, spanRef.current.lastChild);
+      }
+    };
+  });
+
+  return (
+    <span
+      ref={spanRef}
+      className="button-gh"
+    >
+      <a
+        ref={aRef}
+        href={href}
+        aria-label={ariaLabel}
+        data-icon={dataIcon}
+        data-color-scheme={dataColorScheme}
+        data-show-count={dataShowCount}
+        data-size={dataSize}
+        data-text={dataText}
+        title={title}
+      >
+        {children}
+      </a>
+    </span>
+  );
+};
+
+export default GitHubButton;

--- a/demo/full/scripts/components/GitHubButton.tsx
+++ b/demo/full/scripts/components/GitHubButton.tsx
@@ -13,6 +13,7 @@ const GitHubButton = ({
   dataIcon,
   dataShowCount,
   dataSize = "large",
+  dataText,
   title,
   children,
 }: {
@@ -22,6 +23,7 @@ const GitHubButton = ({
   dataIcon?: string;
   dataShowCount?: boolean | string;
   dataSize?: string;
+  dataText?: string;
   title?: string;
   children?: React.ReactNode;
 }): JSX.Element => {
@@ -47,6 +49,7 @@ const GitHubButton = ({
         data-color-scheme={dataColorScheme}
         data-show-count={dataShowCount}
         data-size={dataSize}
+        data-text={dataText}
         title={title}
       >
         {children}

--- a/demo/full/scripts/controllers/Main.tsx
+++ b/demo/full/scripts/controllers/Main.tsx
@@ -26,16 +26,14 @@ function MainComponent(): JSX.Element {
             ariaLabel="Star the RxPlayer on GitHub"
             dataIcon="octicon-star"
             dataShowCount="true"
-          >
-            Star
-          </GitHubButton>
+            dataText="Star"
+          />
           <GitHubButton
             href="https://github.com/canalplus/rx-player/fork"
             ariaLabel="Fork the RxPlayer on GitHub"
             dataIcon="octicon-repo-forked"
-          >
-            Fork
-          </GitHubButton>
+            dataText="Fork"
+          />
         </div>
       </div>
       <Player />

--- a/demo/full/scripts/controllers/Main.tsx
+++ b/demo/full/scripts/controllers/Main.tsx
@@ -26,14 +26,16 @@ function MainComponent(): JSX.Element {
             ariaLabel="Star the RxPlayer on GitHub"
             dataIcon="octicon-star"
             dataShowCount="true"
-            dataText="Star"
-          />
+          >
+            Star
+          </GitHubButton>
           <GitHubButton
             href="https://github.com/canalplus/rx-player/fork"
             ariaLabel="Fork the RxPlayer on GitHub"
             dataIcon="octicon-repo-forked"
-            dataText="Fork"
-          />
+          >
+            Fork
+          </GitHubButton>
         </div>
       </div>
       <Player />

--- a/demo/full/scripts/controllers/Main.tsx
+++ b/demo/full/scripts/controllers/Main.tsx
@@ -1,5 +1,6 @@
 import RxPlayer from "../../../../src/minimal";
 import * as React from "react";
+import GitHubButton from "../components/GitHubButton";
 import Player from "./Player";
 
 function MainComponent(): JSX.Element {
@@ -20,22 +21,19 @@ function MainComponent(): JSX.Element {
           <a aria-label="Go to Canal+ website" href="https://canalplus.com">
             <img className="title-logo" alt="CANAL+" src="./assets/canalp.svg"/>
           </a>
-          <span className="button-gh"><a
-            className="github-button"
+          <GitHubButton
             href="https://github.com/canalplus/rx-player"
-            data-size="large"
-            data-icon="octicon-star"
-            data-show-count="true"
-            aria-label="Star the RxPlayer on GitHub">
-            Star
-          </a></span>
-          <span className="button-gh"><a
-            className="github-button"
+            ariaLabel="Star the RxPlayer on GitHub"
+            dataIcon="octicon-star"
+            dataShowCount="true"
+            dataText="Star"
+          />
+          <GitHubButton
             href="https://github.com/canalplus/rx-player/fork"
-            data-size="large"
-            aria-label="Fork the RxPlayer on GitHub">
-            Fork
-          </a></span>
+            ariaLabel="Fork the RxPlayer on GitHub"
+            dataIcon="octicon-repo-forked"
+            dataText="Fork"
+          />
         </div>
       </div>
       <Player />

--- a/demo/full/styles/style.css
+++ b/demo/full/styles/style.css
@@ -1062,7 +1062,7 @@ input:checked + .slider:before {
 
 .header-links-buttons {
   display: flex;
-  align-items: baseline;
+  align-items: center;
 }
 
 .header-links-buttons > * {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "eslint-plugin-react": "7.32.2",
         "esm": "3.2.25",
         "express": "4.18.2",
+        "github-buttons": "2.27.0",
         "html-entities": "2.3.3",
         "jest": "29.5.0",
         "jest-environment-jsdom": "29.5.0",
@@ -7084,6 +7085,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-buttons": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.27.0.tgz",
+      "integrity": "sha512-PmfRMI2Rttg/2jDfKBeSl621sEznrsKF019SuoLdoNlO7qRUZaOyEI5Li4uW+79pVqnDtKfIEVuHTIJ5lgy64w==",
+      "dev": true
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -19062,6 +19069,12 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "github-buttons": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/github-buttons/-/github-buttons-2.27.0.tgz",
+      "integrity": "sha512-PmfRMI2Rttg/2jDfKBeSl621sEznrsKF019SuoLdoNlO7qRUZaOyEI5Li4uW+79pVqnDtKfIEVuHTIJ5lgy64w==",
+      "dev": true
     },
     "glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-react": "7.32.2",
     "esm": "3.2.25",
     "express": "4.18.2",
+    "github-buttons": "2.27.0",
     "html-entities": "2.3.3",
     "jest": "29.5.0",
     "jest-environment-jsdom": "29.5.0",


### PR DESCRIPTION
The demo page uses https://buttons.github.io/ for the `Star` and `Fork` buttons of the header, redirecting to the GitHub repo.

As the page is now built with React, the buttons are not present in the DOM when the script in the `<head/>` is executed, hence the buttons not being styled.
The issue is described [here](https://github.com/buttons/github-buttons/issues/66), and the recommendation is to use a React wrapper like the official [react-github-btn](https://github.com/buttons/react-github-btn). The component was working well but caused TSLint errors as it was probably incorrectly typed (Issue described [here](https://github.com/buttons/react-github-btn/issues/9)).

I implemented a similar wrapper as a React Functional Component, including our default values to lighten `Main.tsx`.
Its purpose is to create the styled `<span/>` element by calling the `render` function of the original `github-buttons` package.
