### PR TITLE
On the PlayStation 5, set Infinity MediaSource duration for live contents

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -60,6 +60,9 @@ let isWebOs2022 = false;
 /** `true` for Panasonic devices. */
 let isPanasonic = false;
 
+/** `true` for the PlayStation 5 game console. */
+let isPlayStation5 = false;
+
 ((function findCurrentBrowser() : void {
   if (isNode) {
     return ;
@@ -101,7 +104,9 @@ let isPanasonic = false;
     isSamsungBrowser = true;
   }
 
-  if (/Tizen/.test(navigator.userAgent)) {
+  if (navigator.userAgent.indexOf("PlayStation 5") !== -1) {
+    isPlayStation5 = true;
+  } else if (/Tizen/.test(navigator.userAgent)) {
     isTizen = true;
 
   // Inspired form: http://webostv.developer.lge.com/discover/specifications/web-engine/
@@ -136,6 +141,7 @@ export {
   isIEOrEdge,
   isFirefox,
   isPanasonic,
+  isPlayStation5,
   isSafariDesktop,
   isSafariMobile,
   isSamsungBrowser,

--- a/src/compat/has_issues_with_high_media_source_duration.ts
+++ b/src/compat/has_issues_with_high_media_source_duration.ts
@@ -1,0 +1,27 @@
+import { isPlayStation5 } from "./browser_detection";
+
+/**
+ * Some platforms have issues when the `MediaSource`'s `duration` property
+ * is set to a very high value (playback freezes) but not when setting it
+ * to `Infinity`, which is what the HTML spec as of now (2023-05-15) recommends
+ * for live contents.
+ *
+ * However setting the `MediaSource`'s `duration` property to `Infinity` seems
+ * more risky, considering all platforms we now support, than setting it at a
+ * relatively high ~2**32 value which is what we do generally.
+ *
+ * Moreover, setting it to `Infinity` require us to use another MSE API,
+ * `setLiveSeekableRange` to properly allow seeking. We're used to MSE issues so
+ * I'm not too confident of using another MSE API for all platforms directly.
+ *
+ * So this methods just return `true` based on a whitelist of platform for which
+ * it has been detected that high `duration` values cause issues but setting it
+ * to Infinity AND playing with `setLiveSeekableRange` does not.
+ *
+ * @returns {boolean}
+ */
+export default function hasIssuesWithHighMediaSourceDuration(): boolean {
+  // For now only seen on the Webkit present in the PlayStation 5, for which the
+  // alternative is known to work.
+  return isPlayStation5;
+}

--- a/src/core/init/media_source_content_initializer.ts
+++ b/src/core/init/media_source_content_initializer.ts
@@ -664,7 +664,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       this.trigger("activePeriodChanged", { period });
     });
     contentTimeBoundariesObserver.addEventListener("durationUpdate", (newDuration) => {
-      mediaSourceDurationUpdater.updateDuration(newDuration.duration, !newDuration.isEnd);
+      mediaSourceDurationUpdater.updateDuration(newDuration.duration, newDuration.isEnd);
     });
     contentTimeBoundariesObserver.addEventListener("endOfStream", () => {
       if (endOfStreamCanceller === null) {
@@ -683,7 +683,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     });
     const currentDuration = contentTimeBoundariesObserver.getCurrentDuration();
     mediaSourceDurationUpdater.updateDuration(currentDuration.duration,
-                                              !currentDuration.isEnd);
+                                              currentDuration.isEnd);
     return contentTimeBoundariesObserver;
   }
 


### PR DESCRIPTION
 The Playstation 5 have issues when the `MediaSource`'s `duration` property is set to a very high value (playback freezes) but not when setting it to `Infinity`, which is what the HTML spec as of now recommends for live contents.
 
 However setting the `MediaSource`'s `duration` property to `Infinity` seems more risky, considering all platforms we now support,  than setting it at a relatively high 2^32 value which is what we do generally.
 
 Moreover, setting it to `Infinity` require us to use another MSE API, `setLiveSeekableRange` to properly allow seeking. We're used to MSE issues so I'm not too confident of using another MSE API for all platforms directly.
 
 So I added a new method in `compat`, returning `true` based on a whitelist of platform for which
 it has been detected that high `duration` values cause issues but setting it to Infinity AND playing with `setLiveSeekableRange` does not. It only returns `true` for now on the PlayStation 5.

I then rely on that method return value for performing those work-arounds. Also because now the ~2^32 work-around may appear in two places (either on the MediaSource's duration like before, or on the `setLiveSeekableRange` API on the PlayStation 5 to stay close to other platforms' implementation), I also factorized the function and its inner comment.
