### PR TITLE
Add `"play"` and `"pause"` events

### DIFF
--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -94,6 +94,33 @@ The object emitted as the following properties:
   That is the real live position (and not the position as announced by the
   video element).
 
+### play
+
+Emitted when the `RxPlayer`'s `videoElement` is no longer considered paused.
+
+This event is triggered when and if the [`play`](./Basic_Methods/play.md) method
+has succeeded or when auto-play succeeded if the `autoPlay` `loadVideo` option has
+been set to `true`.
+
+Note that this event can be sent even if the [player's state](./Player_States.md)
+doesn't currently allow playback, for example when in the `"LOADING"` or
+`"BUFFERING"` states, among other.
+It shouldn't be sent however when the player's state is `"STOPPED"` which is
+when no content is loading nor loaded.
+
+### pause
+
+Emitted when the `RxPlayer`'s `videoElement` is now considered paused.
+
+This event is triggered when and if the [`pause`](./Basic_Methods/play.md) method
+has succeeded or when the content has ended.
+
+Note that this event can be sent even if the [player's state](./Player_States.md)
+doesn't currently allow playback, for example when in the `"LOADING"` or
+`"BUFFERING"` states, among other.
+It shouldn't be sent however when the player's state is `"STOPPED"` which is
+when no content is loading nor loaded.
+
 ### seeking
 
 Emitted when a "seek" operation (to "move"/"skip" to another position) begins

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -98,9 +98,8 @@ The object emitted as the following properties:
 
 Emitted when the `RxPlayer`'s `videoElement` is no longer considered paused.
 
-This event is triggered when and if the [`play`](./Basic_Methods/play.md) method
-has succeeded or when auto-play succeeded if the `autoPlay` `loadVideo` option has
-been set to `true`.
+This event is generally triggered when and if the
+[`play`](./Basic_Methods/play.md) method has succeeded.
 
 Note that this event can be sent even if the [player's state](./Player_States.md)
 doesn't currently allow playback, for example when in the `"LOADING"` or
@@ -113,7 +112,9 @@ when no content is loading nor loaded.
 Emitted when the `RxPlayer`'s `videoElement` is now considered paused.
 
 This event is triggered when and if the [`pause`](./Basic_Methods/play.md) method
-has succeeded or when the content has ended.
+has succeeded, when the content has ended or due to other rare occurences: for
+example if we could not automatically play after a `"LOADING"` or `"RELOADING"`
+state due to [the browser's autoplay policies](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide).
 
 Note that this event can be sent even if the [player's state](./Player_States.md)
 doesn't currently allow playback, for example when in the `"LOADING"` or

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -122,9 +122,9 @@ import MediaElementTrackChoiceManager from "./tracks_management/media_element_tr
 import TrackChoiceManager from "./tracks_management/track_choice_manager";
 import {
   constructPlayerStateReference,
+  emitPlayPauseEvents,
   emitSeekEvents,
   isLoadedState,
-  // emitSeekEvents,
   PLAYER_STATES,
 } from "./utils";
 
@@ -955,6 +955,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           break;
       }
     };
+
+    emitPlayPauseEvents(videoElement,
+                        () => this.trigger("play", null),
+                        () => this.trigger("pause", null),
+                        currentContentCanceller.signal);
 
     /**
      * `TaskCanceller` allowing to stop emitting `"seeking"` and `"seeked"`
@@ -3066,6 +3071,8 @@ interface IPublicAPIEvent {
   availableTextTracksChange : IAvailableTextTrack[];
   availableVideoTracksChange : IAvailableVideoTrack[];
   decipherabilityUpdate : IDecipherabilityUpdateContent[];
+  play: null;
+  pause: null;
   seeking : null;
   seeked : null;
   streamEvent : IStreamEvent;

--- a/src/core/api/utils.ts
+++ b/src/core/api/utils.ts
@@ -70,6 +70,32 @@ export function emitSeekEvents(
   }, { includeLastObservation: true, clearSignal: cancelSignal });
 }
 
+/**
+ * @param {HTMLMediaElement} mediaElement
+ * @param {function} onPlay - Callback called when a play operation has started
+ * on `mediaElement`.
+ * @param {function} onPause - Callback called when a pause operation has
+ * started on `mediaElement`.
+ * @param {Object} cancelSignal - When triggered, stop calling callbacks and
+ * remove all listeners this function has registered.
+ */
+export function emitPlayPauseEvents(
+  mediaElement : HTMLMediaElement | null,
+  onPlay: () => void,
+  onPause: () => void,
+  cancelSignal : CancellationSignal
+) : void {
+  if (cancelSignal.isCancelled() || mediaElement === null) {
+    return ;
+  }
+  mediaElement.addEventListener("play", onPlay);
+  mediaElement.addEventListener("pause", onPause);
+  cancelSignal.register(() => {
+    mediaElement.removeEventListener("play", onPlay);
+    mediaElement.removeEventListener("pause", onPause);
+  });
+}
+
 /** Player state dictionnary. */
 export const enum PLAYER_STATES {
   STOPPED = "STOPPED",

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1375,6 +1375,22 @@ export default function launchTestsForContent(manifestInfos) {
     });
 
     describe("play", () => {
+      let pauseEventsSent = 0;
+      let playEventsSent = 0;
+      beforeEach(() => {
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+      });
+
+      afterEach(() => {
+        pauseEventsSent = 0;
+        playEventsSent = 0;
+      });
+
       it("should begin to play if LOADED", async () => {
         player.loadVideo({
           url: manifestInfos.url,
@@ -1382,9 +1398,13 @@ export default function launchTestsForContent(manifestInfos) {
         });
         await waitForLoadedStateAfterLoadVideo(player);
         expect(player.getPlayerState()).to.equal("LOADED");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(0);
         player.play();
         await sleep(10);
         expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(1);
       });
 
       it("should resume if paused", async () => {
@@ -1396,16 +1416,38 @@ export default function launchTestsForContent(manifestInfos) {
         await waitForLoadedStateAfterLoadVideo(player);
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(0);
         player.pause();
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PAUSED");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(0);
         player.play();
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(1);
       });
     });
 
     describe("pause", () => {
+      let pauseEventsSent = 0;
+      let playEventsSent = 0;
+      beforeEach(() => {
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+      });
+
+      afterEach(() => {
+        pauseEventsSent = 0;
+        playEventsSent = 0;
+      });
+
       it("should have no effect when LOADED", async () => {
         await tryTestMultipleTimes(
           async function runTest(cancelTest) {
@@ -1432,6 +1474,8 @@ export default function launchTestsForContent(manifestInfos) {
             await sleep(10);
 
             expect(player.getPlayerState()).to.equal("LOADED");
+            expect(pauseEventsSent).to.equal(0);
+            expect(playEventsSent).to.equal(0);
           },
           3,
           function cleanUp() {
@@ -1448,9 +1492,12 @@ export default function launchTestsForContent(manifestInfos) {
         });
         await waitForLoadedStateAfterLoadVideo(player);
         expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(pauseEventsSent).to.equal(0);
         player.pause();
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PAUSED");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(0);
       });
 
       it("should do nothing if already paused", async () => {
@@ -1461,12 +1508,17 @@ export default function launchTestsForContent(manifestInfos) {
         });
         await waitForLoadedStateAfterLoadVideo(player);
         expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(pauseEventsSent).to.equal(0);
         player.pause();
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PAUSED");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(0);
         player.pause();
         await sleep(100);
         expect(player.getPlayerState()).to.equal("PAUSED");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(0);
       });
     });
 
@@ -1482,6 +1534,113 @@ export default function launchTestsForContent(manifestInfos) {
         expect(player.getPosition()).to.be.below(minimumPosition + 0.1);
         player.seekTo(minimumPosition + 50);
         expect(player.getPosition()).to.be.closeTo(minimumPosition + 50, 0.5);
+      });
+
+      it("should conserve pause if previously paused", async () => {
+        let pauseEventsSent = 0;
+        let playEventsSent = 0;
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        player.seekTo(minimumPosition + 50);
+        await waitForState(player, "PAUSED");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(0);
+      });
+
+      it("should still play if previously playing", async () => {
+        let pauseEventsSent = 0;
+        let playEventsSent = 0;
+        let nbPausedStates = 0;
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+        player.addEventListener("playerStateChange", (state) => {
+          if (state === "PAUSED") {
+            nbPausedStates++;
+          }
+        });
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          autoPlay: true,
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        player.seekTo(minimumPosition + 50);
+        await waitForState(player, "PLAYING");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(0);
+        expect(nbPausedStates).to.equal(0);
+      });
+
+      it("should be able to pause while seeking", async () => {
+        let pauseEventsSent = 0;
+        let playEventsSent = 0;
+        let nbPausedStates = 0;
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+        player.addEventListener("playerStateChange", (state) => {
+          if (state === "PAUSED") {
+            nbPausedStates++;
+          }
+        });
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+          autoPlay: true,
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        player.seekTo(minimumPosition + 50);
+        await sleep(0);
+        player.pause();
+        await waitForState(player, "PAUSED");
+        expect(pauseEventsSent).to.equal(1);
+        expect(playEventsSent).to.equal(0);
+        expect(nbPausedStates).to.equal(1);
+      });
+
+      it("should be able to play while seeking", async () => {
+        let pauseEventsSent = 0;
+        let playEventsSent = 0;
+        let nbPlayingStates = 0;
+        player.addEventListener("pause", () => {
+          pauseEventsSent++;
+        });
+        player.addEventListener("play", () => {
+          playEventsSent++;
+        });
+        player.addEventListener("playerStateChange", (state) => {
+          if (state === "PLAYING") {
+            nbPlayingStates++;
+          }
+        });
+        player.loadVideo({
+          url: manifestInfos.url,
+          transport,
+        });
+        await waitForLoadedStateAfterLoadVideo(player);
+        player.seekTo(minimumPosition + 50);
+        await sleep(0);
+        player.play();
+        await waitForState(player, "PLAYING");
+        expect(pauseEventsSent).to.equal(0);
+        expect(playEventsSent).to.equal(1);
+        expect(nbPlayingStates).to.equal(1);
       });
     });
 


### PR DESCRIPTION
As I've been working a lot more with application code (media player UIs) lately, I saw that a real concept of whether playback was playing or paused was missing in the RxPlayer API.

You could approximate it by getting the player's state, but some states, like `"BUFFERING"` or `"LOADING"`, even if they indicate that playback is not happening right now, do not indicate whether we're actually paused or not.

For example, once the buffering period is over, will we play directly or still be paused? Or, after `"LOADING"`, will we play or just be paused on the first loaded frame?

One area where this concept is central to an application is for example to know whether the "play/pause" button should currently play or pause, which also dictates what the button should look like: if we're playing, this is a pause button which will pause playback, if we're paused, it will be a play button starting playback - and this, regardless of the current player's state.

---

That's the reason the `isPaused` method (#1248) is planned for the future `v3.31.0`. While writing the beginning of that release's release note, I however noticed that the API wouldn't be complete without `"play"` and `"pause"` events, indicating respectively when the player exits a pause and when it enters it.

This PR adds those two events. 