### PR TITLE
PS5: wait for a readyState of `4` before considering the content loaded

### DIFF
--- a/src/compat/__tests__/should_wait_for_have_enough_data.test.ts
+++ b/src/compat/__tests__/should_wait_for_have_enough_data.test.ts
@@ -1,0 +1,36 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+
+describe("compat - shouldWaitForHaveEnoughData", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("should return false if we are not on the Playstation 5", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isPlayStation5: false,
+      };
+    });
+    const shouldWaitForHaveEnoughData =
+      jest.requireActual("../should_wait_for_have_enough_data");
+    expect(shouldWaitForHaveEnoughData.default()).toBe(false);
+  });
+
+  it("should return true if we are on the Playstation 5", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isPlayStation5: true,
+      };
+    });
+    const shouldWaitForHaveEnoughData =
+      jest.requireActual("../should_wait_for_have_enough_data");
+    expect(shouldWaitForHaveEnoughData.default()).toBe(true);
+  });
+});

--- a/src/compat/index.ts
+++ b/src/compat/index.ts
@@ -61,6 +61,7 @@ import shouldRenewMediaKeySystemAccess from "./should_renew_media_key_system_acc
 import shouldUnsetMediaKeys from "./should_unset_media_keys";
 import shouldValidateMetadata from "./should_validate_metadata";
 import shouldWaitForDataBeforeLoaded from "./should_wait_for_data_before_loaded";
+import shouldWaitForHaveEnoughData from "./should_wait_for_have_enough_data";
 
 // TODO To remove. This seems to be the only side-effect done on import, which
 // we  would prefer to disallow (both for the understandability of the code and
@@ -105,5 +106,6 @@ export {
   shouldUnsetMediaKeys,
   shouldValidateMetadata,
   shouldWaitForDataBeforeLoaded,
+  shouldWaitForHaveEnoughData,
   tryToChangeSourceBufferType,
 };

--- a/src/compat/should_wait_for_have_enough_data.ts
+++ b/src/compat/should_wait_for_have_enough_data.ts
@@ -1,0 +1,17 @@
+import { isPlayStation5 } from "./browser_detection";
+
+/**
+ * An `HTMLMediaElement`'s readyState allows the browser to communicate whether
+ * it can play a content reliably.
+ * Usually, we may consider that a `HAVE_FUTURE_DATA` (readyState `3`) or even
+ * a `HAVE_CURRENT_DATA` (readyState `2`) is enough to begin playing the content
+ * and consider it as loaded.
+ *
+ * However some devices wrongly anounce those readyStates before being actually
+ * able to decode the content. For those devices we wait for the
+ * `HAVE_ENOUGH_DATA` readyState before considering the content as loaded.
+ * @returns {boolean}
+ */
+export default function shouldWaitForHaveEnoughData() : boolean {
+  return isPlayStation5;
+}

--- a/src/core/init/utils/get_loaded_reference.ts
+++ b/src/core/init/utils/get_loaded_reference.ts
@@ -18,6 +18,7 @@
 import {
   shouldValidateMetadata,
   shouldWaitForDataBeforeLoaded,
+  shouldWaitForHaveEnoughData,
 } from "../../../compat";
 import createSharedReference, {
   IReadOnlySharedReference,
@@ -64,7 +65,9 @@ export default function getLoadedReference(
       }
     }
 
-    if (observation.readyState >= 3 && observation.currentRange !== null) {
+    const minReadyState = shouldWaitForHaveEnoughData() ? 4 :
+                                                          3;
+    if (observation.readyState >= minReadyState && observation.currentRange !== null) {
       if (!shouldValidateMetadata() || mediaElement.duration > 0) {
         isLoaded.setValue(true);
         listenCanceller.cancel();


### PR DESCRIPTION
We noticed that on a PlayStation 5, an `HTMLMediaElement`'s [`readyState`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/readyState) property can switch to `3` even if the content is encrypted and its decryption key hasn't be obtained yet.

This is unusual (we usually encounters a `readyState` of `1` in that case) and perhaps not compliant to the WHATWG HTML5 standard. More importantly, it might cause the RxPlayer to switch to the `LOADED` state too soon, before switching to a `BUFFERING` state until the key is obtained (whereas it is expected that the RxPlayer can play immediately after reaching the `LOADED` state).

Thankfully, a simple work-around can be applied on this case: we know that on the PlayStation 5, we'll always reach a `readyState` of `4` as soon as we can play the content.

We thus rely, only on the PlayStation 5 for now, on the `readyState` being set to `4` before announcing the content as `LOADED`.