### PR TITLE
[Proposal] [v4] Errors: Replace trackInfo prop by tracksInfo to group similar errors

### DIFF
--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -99,7 +99,8 @@ parsing) or from the browser itself (content playback).
 They all have a `type` property equal to `"MEDIA_ERROR"`.
 
 Depending on its `code` property (listed below), a `MEDIA_ERROR` may also have
-a supplementary `trackInfo` property, describing the track related to the issue.
+a supplementary `tracksInfo` property, describing the track(s) related to the
+issue.
 The format of that property is decribed in the chapter below listed codes, and
 the codes for which it is set are indicated in the corresponding code's
 description below.
@@ -111,27 +112,27 @@ An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
 - `"BUFFER_APPEND_ERROR"`: A media segment could not have been added to the
   corresponding media buffer. This often happens with malformed segments.
 
-  For those errors, you may be able to know the characteristics of the track
-  linked to that segment by inspecting the error's `trackInfo` property,
+  For those errors, you may be able to know the characteristics of the track(s)
+  linked to that segment by inspecting the error's `tracksInfo` property,
   described below.
 
 - `"BUFFER_FULL_ERROR"`: The needed segment could not have been added
   because the corresponding media buffer was full.
 
-  For those errors, you may be able to know the characteristics of the track
-  linked to that segment by inspecting the error's `trackInfo` property,
+  For those errors, you may be able to know the characteristics of the track(s)
+  linked to that segment by inspecting the error's `tracksInfo` property,
   described below.
 
 - `"BUFFER_TYPE_UNKNOWN"`: The type of buffer considered (e.g. "audio" /
   "video" / "text") has no media buffer implementation in your build.
 
-- `"MANIFEST_INCOMPATIBLE_CODECS_ERROR"`: An
-  [Adaptation](../Getting_Started/Glossary.md#adaptation) (or track) has none of its
-  [Representations](../Getting_Started/Glossary.md#representation) (read quality) in a supported
-  codec.
+- `"MANIFEST_INCOMPATIBLE_CODECS_ERROR"`: One or multiple
+  [Adaptation](../Getting_Started/Glossary.md#adaptation) (or track) parsed from
+  the Manifest has none of its [Representations](../Getting_Started/Glossary.md#representation)
+  (read: quality) in a supported codec.
 
-  For those errors, you may be able to know the characteristics of the track
-  linked to that codec by inspecting the error's `trackInfo` property, described below.
+  For those errors, you may be able to know the characteristics of the track(s)
+  linked to that codec by inspecting the error's `tracksInfo` property, described below.
 
 - `"MANIFEST_PARSE_ERROR"`: Generic error to signal than the
   [Manifest](../Getting_Started/Glossary.md#structure_of_a_manifest_object) could not be parsed.
@@ -206,8 +207,8 @@ An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
   Representation has been blacklisted due to encryption limitations.
 
   For those errors, you may be able to know the characteristics of the
-  corresponding track by inspecting the error's `trackInfo` property, described
-  below.
+  corresponding track(s) by inspecting the error's `tracksInfo` property,
+  described below.
 
 - `"MANIFEST_UPDATE_ERROR"`: This error should never be emitted as it is
   handled internally by the RxPlayer. Please open an issue if you encounter
@@ -223,31 +224,37 @@ An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
   It is triggered when a time we initially thought to be in the bounds of the
   Manifest actually does not link to any "Period" of the Manifest.
 
-#### `trackInfo` property
+#### `tracksInfo` property
 
 As described in the corresponding code's documentation, A aupplementary
-`trackInfo` property may be set on `MEDIA_ERROR` depending on its `code`
+`tracksInfo` property may be set on `MEDIA_ERROR` depending on its `code`
 property.
 
-Note that even if the code may be linked to a `trackInfo` property, that
+Note that even if the code may be linked to a `tracksInfo` property, that
 property may well also be unset.
 
-That `trackInfo` describes, when it makes sense, the characteristics of the track
-linked to an error. For example, you may want to know which video track led to a
+That `tracksInfo` describes, when it makes sense, the characteristics of the
+track(s) linked to an error.
+
+For example, you may want to know which video track led to a
 `BUFFER_APPEND_ERROR` and thus might be linked to corrupted segments.
 
-The `trackInfo` property has itself two sub-properties:
+The `tracksInfo` property is an array of objects, each describing a track for
+which that error applies (in many case, the error only applies to one track and
+thus there is only one object inside that array).
+
+Each object has two sub-properties:
 
   - `type`: The type of track: `"audio"` for an audio track, `"text"` for a text
     track, or `"video"` for a video track.
 
   - `track`: Characteristics of the track. Its format depends on the
-    `trackInfo`'s `type` property and is described below.
+    `type` property and is described below.
 
 ##### For video tracks
 
-When `trackInfo.type` is set to `"video"`, `track` describes a video track. It
-contains the following properties:
+When `tracksInfo[].type` is set to `"video"`, `track` describes a video track.
+It contains the following properties:
 
   - `id` (`string`): The id used to identify this track. No other
     video track for the same [Period](../Getting_Started/Glossary.md#period)
@@ -312,8 +319,8 @@ contains the following properties:
 
 ##### For audio tracks
 
-When `trackInfo.type` is set to `"audio"`, `track` describes an audio track. It
-contains the following properties:
+When `tracksInfo[].type` is set to `"audio"`, `track` describes an audio track.
+It contains the following properties:
 
 - `id` (`Number|string`): The id used to identify this track. No other
   audio track for the same [Period](../Getting_Started/Glossary.md#period)
@@ -366,7 +373,7 @@ contains the following properties:
 
 ##### For text tracks
 
-When `trackInfo.type` is set to `"text"`, `track` describes a text track. It
+When `tracksInfo[].type` is set to `"text"`, `track` describes a text track. It
 contains the following properties:
 
 - `id` (`string`): The id used to identify this track. No other

--- a/src/core/api/track_management/tracks_store.ts
+++ b/src/core/api/track_management/tracks_store.ts
@@ -348,7 +348,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       if (nextAdaptation === undefined) {
         const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                         `No ${bufferType} Representation can be played`,
-                                        { adaptation: undefined });
+                                        { adaptations: undefined });
         this.trigger("error", noRepErr);
         this.dispose();
         return;

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -302,10 +302,10 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
                                                 cancelSignal,
                                                 scheduleRequest);
       if (!isPromise(res)) {
-        return finish(res.manifest);
+        return finish(res.manifest, res.warnings);
       } else {
-        const { manifest } = await res;
-        return finish(manifest);
+        const { manifest, warnings } = await res;
+        return finish(manifest, warnings);
       }
     } catch (err) {
       const formattedError = formatError(err, {
@@ -356,8 +356,11 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      * To call once the Manifest has been parsed.
      * @param {Object} manifest
      */
-    function finish(manifest : Manifest) : IManifestFetcherParsedResult {
-      onWarnings(manifest.contentWarnings);
+    function finish(
+      manifest : Manifest,
+      warnings: IPlayerError[]
+    ) : IManifestFetcherParsedResult {
+      onWarnings(warnings);
       const parsingTime = performance.now() - parsingTimeStart;
       log.info(`MF: Manifest parsed in ${parsingTime}ms`);
 

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -411,7 +411,7 @@ function getFirstDeclaredMimeType(adaptation : Adaptation) : string {
     const noRepErr = new MediaError("NO_PLAYABLE_REPRESENTATION",
                                     "No Representation in the chosen " +
                                     adaptation.type + " Adaptation can be played",
-                                    { adaptation });
+                                    { adaptations: [adaptation] });
     throw noRepErr;
   }
   return representations[0].getMimeTypeString();

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -58,7 +58,7 @@ export default async function appendSegmentToBuffer<T>(
         "An unknown error happened when pushing content";
       throw new MediaError("BUFFER_APPEND_ERROR",
                            reason,
-                           { adaptation: dataInfos.inventoryInfos.adaptation });
+                           { adaptations: [dataInfos.inventoryInfos.adaptation] });
     }
     const { position } = playbackObserver.getReference().getValue();
     const currentPos = position.pending ?? position.last;
@@ -71,7 +71,7 @@ export default async function appendSegmentToBuffer<T>(
 
       throw new MediaError("BUFFER_FULL_ERROR",
                            reason,
-                           { adaptation: dataInfos.inventoryInfos.adaptation });
+                           { adaptations: [dataInfos.inventoryInfos.adaptation] });
     }
   }
 }

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -61,7 +61,7 @@ export default class MediaError extends Error {
   public readonly type : "MEDIA_ERROR";
   public readonly message : string;
   public readonly code : IMediaErrorCode;
-  public readonly trackInfo : IMediaErrorTrackContext | undefined;
+  public readonly tracksInfo : IMediaErrorTrackContext[] | undefined;
   public fatal : boolean;
 
   /**
@@ -73,7 +73,7 @@ export default class MediaError extends Error {
     code : ICodeWithAdaptationType,
     reason : string,
     context: {
-      adaptation : Adaptation | undefined;
+      adaptations : Adaptation[] | undefined;
     }
   );
   constructor(
@@ -84,7 +84,7 @@ export default class MediaError extends Error {
     code : IMediaErrorCode,
     reason : string,
     context? : {
-      adaptation? : Adaptation | undefined;
+      adaptations? : Adaptation[] | undefined;
     } | undefined
   ) {
     super();
@@ -97,22 +97,28 @@ export default class MediaError extends Error {
     this.code = code;
     this.message = errorMessage(this.name, this.code, reason);
     this.fatal = false;
-    const adaptation = context?.adaptation;
-    if (adaptation !== undefined) {
-      switch (adaptation.type) {
-        case "audio":
-          this.trackInfo = { type: "audio",
-                             track: adaptation.toAudioTrack(false) };
-          break;
-        case "video":
-          this.trackInfo = { type: "video",
-                             track: adaptation.toVideoTrack(false) };
-          break;
-        case "text":
-          this.trackInfo = { type: "text",
-                             track: adaptation.toTextTrack() };
-          break;
-      }
+    const adaptations = context?.adaptations;
+    if (adaptations !== undefined && adaptations.length > 0) {
+      this.tracksInfo = adaptations.reduce((
+        acc: IMediaErrorTrackContext[],
+        adaptation: Adaptation
+      ) => {
+        switch (adaptation.type) {
+          case "audio":
+            acc.push({ type: "audio",
+                       track: adaptation.toAudioTrack(false) });
+            break;
+          case "video":
+            acc.push({ type: "video",
+                       track: adaptation.toVideoTrack(false) });
+            break;
+          case "text":
+            acc.push({ type: "text",
+                       track: adaptation.toTextTrack() });
+            break;
+        }
+        return acc;
+      }, []);
     }
   }
 }

--- a/src/manifest/__tests__/manifest.test.ts
+++ b/src/manifest/__tests__/manifest.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { IPlayerError } from "../../public_types";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -22,6 +24,41 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
+
+function generateParsedPeriod(
+  id: string,
+  start: number,
+  end: number | undefined
+) {
+  const adaptations = { audio: [generateParsedAudioAdaptation(id)] };
+  return { id, start, end, adaptations };
+}
+function generateParsedAudioAdaptation(id: string) {
+  return { id, type: "audio", representations: [generateParsedRepresentation(id)] };
+}
+function generateParsedRepresentation(id: string) {
+  return { id, bitrate: 100 };
+}
+
+// TODO we may want to refactor the Manifest structure's unit tests to avoid
+// weird subclasses implementations like the one below - which will probably be
+// a pain to maintain...
+function generateAdaptationInstance(
+  parsed: ReturnType<typeof generateParsedAudioAdaptation>
+) {
+  return {
+    id: parsed.id,
+    type: "audio",
+    representations: [],
+    toAudioTrack() {
+      return { language: "",
+               normalized: "",
+               audioDescription: false,
+               id: parsed.id,
+               representations: parsed.representations };
+    },
+  };
+}
 
 describe("Manifest - Manifest", () => {
   const fakeLogger = { warn: jest.fn(() => undefined),
@@ -57,7 +94,8 @@ describe("Manifest - Manifest", () => {
                                  periods: [] };
 
     const Manifest = jest.requireActual("../manifest").default;
-    const manifest = new Manifest(simpleFakeManifest, {});
+    const warnings: IPlayerError[] = [];
+    const manifest = new Manifest(simpleFakeManifest, {}, warnings);
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(undefined);
@@ -67,7 +105,7 @@ describe("Manifest - Manifest", () => {
     expect(manifest.lifetime).toEqual(undefined);
     expect(manifest.getMaximumSafePosition()).toEqual(10);
     expect(manifest.getMinimumSafePosition()).toEqual(0);
-    expect(manifest.contentWarnings).toEqual([]);
+    expect(warnings).toEqual([]);
     expect(manifest.periods).toEqual([]);
     expect(manifest.suggestedPresentationDelay).toEqual(undefined);
     expect(manifest.uris).toEqual([]);
@@ -79,8 +117,8 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should create a Period for each manifest.periods given", () => {
-    const period1 = { id: "0", start: 4, adaptations: {} };
-    const period2 = { id: "1", start: 12, adaptations: {} };
+    const period1 = generateParsedPeriod("0", 4, undefined);
+    const period2 = generateParsedPeriod("1", 12, undefined);
     const simpleFakeManifest = { id: "man",
                                  isDynamic: false,
                                  isLive: false,
@@ -95,24 +133,22 @@ describe("Manifest - Manifest", () => {
                                  periods: [period1, period2] };
 
     const fakePeriod = jest.fn((period) => {
-      return { id: `foo${period.id}`, adaptations: {}, contentWarnings: [] };
+      return { id: `foo${period.id}`, adaptations: period.adaptations };
     });
     jest.mock("../period", () =>  ({ __esModule: true as const,
                                      default: fakePeriod }));
 
     const Manifest = jest.requireActual("../manifest").default;
-    const manifest = new Manifest(simpleFakeManifest, {});
+    const manifest = new Manifest(simpleFakeManifest, {}, []);
     expect(fakePeriod).toHaveBeenCalledTimes(2);
-    expect(fakePeriod).toHaveBeenCalledWith(period1, undefined);
-    expect(fakePeriod).toHaveBeenCalledWith(period2, undefined);
+    expect(fakePeriod).toHaveBeenCalledWith(period1, [], undefined);
+    expect(fakePeriod).toHaveBeenCalledWith(period2, [], undefined);
 
     expect(manifest.periods).toEqual([ { id: "foo0",
-                                         adaptations: {},
-                                         contentWarnings: [] },
+                                         adaptations: period1.adaptations },
                                        { id: "foo1",
-                                         adaptations: {},
-                                         contentWarnings: [] } ]);
-    expect(manifest.adaptations).toEqual({});
+                                         adaptations: period2.adaptations } ]);
+    expect(manifest.adaptations).toEqual(period1.adaptations);
 
     expect(fakeIdGenerator).toHaveBeenCalled();
     expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
@@ -121,8 +157,8 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should pass a `representationFilter` to the Period if given", () => {
-    const period1 = { id: "0", start: 4, adaptations: {} };
-    const period2 = { id: "1", start: 12, adaptations: {} };
+    const period1 = generateParsedPeriod("0", 4, undefined);
+    const period2 = generateParsedPeriod("1", 12, undefined);
     const simpleFakeManifest = { id: "man",
                                  isDynamic: false,
                                  isLive: false,
@@ -139,19 +175,19 @@ describe("Manifest - Manifest", () => {
     const representationFilter = function() { return false; };
 
     const fakePeriod = jest.fn((period) => {
-      return { id: `foo${period.id}`, contentWarnings: [] };
+      return { id: `foo${period.id}` };
     });
     jest.mock("../period", () =>  ({ __esModule: true as const,
                                      default: fakePeriod }));
     const Manifest = jest.requireActual("../manifest").default;
 
     /* eslint-disable @typescript-eslint/no-unused-expressions */
-    new Manifest(simpleFakeManifest, { representationFilter });
+    new Manifest(simpleFakeManifest, { representationFilter }, []);
     /* eslint-enable @typescript-eslint/no-unused-expressions */
 
     expect(fakePeriod).toHaveBeenCalledTimes(2);
-    expect(fakePeriod).toHaveBeenCalledWith(period1, representationFilter);
-    expect(fakePeriod).toHaveBeenCalledWith(period2, representationFilter);
+    expect(fakePeriod).toHaveBeenCalledWith(period1, [], representationFilter);
+    expect(fakePeriod).toHaveBeenCalledWith(period2, [], representationFilter);
     expect(fakeIdGenerator).toHaveBeenCalled();
     expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
     expect(fakeLogger.info).not.toHaveBeenCalled();
@@ -177,20 +213,20 @@ describe("Manifest - Manifest", () => {
                                  periods: [period1, period2] };
 
     const fakePeriod = jest.fn((period) => {
-      return { ...period, id: `foo${period.id}`, contentWarnings: [] };
+      return { ...period, id: `foo${period.id}` };
     });
     jest.mock("../period", () =>  ({ __esModule: true as const,
                                      default: fakePeriod }));
     const Manifest = jest.requireActual("../manifest").default;
 
-    const manifest = new Manifest(simpleFakeManifest, {});
+    const manifest = new Manifest(simpleFakeManifest, {}, []);
     expect(fakePeriod).toHaveBeenCalledTimes(2);
-    expect(fakePeriod).toHaveBeenCalledWith(period1, undefined);
-    expect(fakePeriod).toHaveBeenCalledWith(period2, undefined);
+    expect(fakePeriod).toHaveBeenCalledWith(period1, [], undefined);
+    expect(fakePeriod).toHaveBeenCalledWith(period2, [], undefined);
 
     expect(manifest.periods).toEqual([
-      { id: "foo0", contentWarnings: [], start: 4, adaptations: adapP1 },
-      { id: "foo1", contentWarnings: [], start: 12, adaptations: adapP2 },
+      { id: "foo0", start: 4, adaptations: adapP1 },
+      { id: "foo1", start: 12, adaptations: adapP2 },
     ]);
     expect(manifest.adaptations).toBe(adapP1);
 
@@ -200,9 +236,9 @@ describe("Manifest - Manifest", () => {
     expect(fakeLogger.warn).not.toHaveBeenCalled();
   });
 
-  it("should push any parsing errors from the Period parsing", () => {
-    const period1 = { id: "0", start: 4, adaptations: {} };
-    const period2 = { id: "1", start: 12, adaptations: {} };
+  it("should push parsing errors if there are unsupported Adaptations", () => {
+    const period1 = generateParsedPeriod("0", 4, undefined);
+    const period2 = generateParsedPeriod("1", 12, undefined);
     const simpleFakeManifest = { id: "man",
                                  isDynamic: false,
                                  isLive: false,
@@ -216,10 +252,11 @@ describe("Manifest - Manifest", () => {
                                                } },
                                  periods: [period1, period2] };
 
-    const fakePeriod = jest.fn((period) => {
-      return { id: `foo${period.id}`,
-               contentWarnings: [ new Error(`a${period.id}`),
-                                  new Error(period.id) ] };
+    const fakePeriod = jest.fn((period, unsupportedAdaptations) => {
+      unsupportedAdaptations
+        .push(generateAdaptationInstance(period.adaptations.audio[0]));
+      return { ...period,
+               id: `foo${period.id}` };
     });
     jest.mock("../period", () =>  ({
       __esModule: true as const,
@@ -227,12 +264,21 @@ describe("Manifest - Manifest", () => {
     }));
     const Manifest = jest.requireActual("../manifest").default;
 
-    const manifest = new Manifest(simpleFakeManifest, {});
-    expect(manifest.contentWarnings).toHaveLength(4);
-    expect(manifest.contentWarnings).toContainEqual(new Error("a0"));
-    expect(manifest.contentWarnings).toContainEqual(new Error("a1"));
-    expect(manifest.contentWarnings).toContainEqual(new Error("0"));
-    expect(manifest.contentWarnings).toContainEqual(new Error("1"));
+    const warnings: IPlayerError[] = [];
+    new Manifest(simpleFakeManifest, {}, warnings);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].type).toEqual("MEDIA_ERROR");
+    expect(warnings[0].code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
+    expect((warnings[0] as unknown as { tracksInfo: unknown }).tracksInfo).toEqual([
+      {
+        track: generateAdaptationInstance(period1.adaptations.audio[0]).toAudioTrack(),
+        type: "audio",
+      },
+      {
+        track: generateAdaptationInstance(period2.adaptations.audio[0]).toAudioTrack(),
+        type: "audio",
+      },
+    ]);
 
     expect(fakeIdGenerator).toHaveBeenCalled();
     expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
@@ -241,8 +287,8 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should correctly parse every manifest information given", () => {
-    const oldPeriod1 = { id: "0", start: 4, adaptations: {} };
-    const oldPeriod2 = { id: "1", start: 12, adaptations: {} };
+    const oldPeriod1 = generateParsedPeriod("0", 4, undefined);
+    const oldPeriod2 = generateParsedPeriod("1", 12, undefined);
     const time = performance.now();
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
@@ -250,7 +296,6 @@ describe("Manifest - Manifest", () => {
                               isDynamic: false,
                               isLive: false,
                               lifetime: 13,
-                              contentWarnings: [new Error("a"), new Error("b")],
                               periods: [oldPeriod1, oldPeriod2],
                               timeBounds: { minimumSafePosition: 5,
                                             timeshiftDepth: null,
@@ -260,28 +305,34 @@ describe("Manifest - Manifest", () => {
                               suggestedPresentationDelay: 99,
                               uris: ["url1", "url2"] };
 
-    const fakePeriod = jest.fn((period) => {
+    const fakePeriod = jest.fn((period, unsupportedAdaptations) => {
+      unsupportedAdaptations
+        .push(generateAdaptationInstance(period.adaptations.audio[0]));
       return { ...period,
-               id: `foo${period.id}`,
-               contentWarnings: [new Error(period.id)] };
+               id: `foo${period.id}` };
     });
     jest.mock("../period", () =>  ({ __esModule: true as const,
                                      default: fakePeriod }));
     const Manifest = jest.requireActual("../manifest").default;
-    const manifest = new Manifest(oldManifestArgs, {});
+    const warnings: IPlayerError[] = [];
+    const manifest = new Manifest(oldManifestArgs, {}, warnings);
 
-    expect(manifest.adaptations).toEqual({});
+    expect(manifest.adaptations).toEqual(oldPeriod1.adaptations);
     expect(manifest.availabilityStartTime).toEqual(5);
     expect(manifest.id).toEqual("fakeId");
     expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(13);
-    expect(manifest.contentWarnings).toEqual([new Error("0"), new Error("1")]);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].type).toEqual("MEDIA_ERROR");
+    expect(warnings[0].code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
+
     expect(manifest.getMaximumSafePosition()).toEqual(10);
     expect(manifest.getMinimumSafePosition()).toEqual(5);
     expect(manifest.periods).toEqual([
-      { id: "foo0", contentWarnings: [new Error("0")], adaptations: {}, start: 4 },
-      { id: "foo1", contentWarnings: [new Error("1")], adaptations: {}, start: 12 },
+      { id: "foo0", adaptations: oldPeriod1.adaptations, start: 4 },
+      { id: "foo1", adaptations: oldPeriod2.adaptations, start: 12 },
     ]);
     expect(manifest.suggestedPresentationDelay).toEqual(99);
     expect(manifest.uris).toEqual(["url1", "url2"]);
@@ -292,12 +343,11 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should return all URLs given with `getContentUrls`", () => {
-    const fakePeriod = jest.fn((period) => {
-      return {
-        ...period,
-        id: `foo${period.id}`,
-        contentWarnings: [new Error(period.id)],
-      };
+    const fakePeriod = jest.fn((period, unsupportedAdaptations) => {
+      unsupportedAdaptations
+        .push(generateAdaptationInstance(period.adaptations.audio[0]));
+      return { ...period,
+               id: `foo${period.id}` };
     });
     jest.mock("../period", () =>  ({
       __esModule: true as const,
@@ -305,6 +355,8 @@ describe("Manifest - Manifest", () => {
     }));
     const Manifest = jest.requireActual("../manifest").default;
 
+    const oldPeriod1 = generateParsedPeriod("0", 4, undefined);
+    const oldPeriod2 = generateParsedPeriod("1", 12, undefined);
     const oldManifestArgs1 = { availabilityStartTime: 5,
                                duration: 12,
                                id: "man",
@@ -318,13 +370,11 @@ describe("Manifest - Manifest", () => {
                                                maximumSafePosition: 10,
                                                time: 10,
                                              } },
-                               contentWarnings: [new Error("a"), new Error("b")],
-                               periods: [ { id: "0", start: 4, adaptations: {} },
-                                          { id: "1", start: 12, adaptations: {} } ],
+                               periods: [oldPeriod1, oldPeriod2],
                                suggestedPresentationDelay: 99,
                                uris: ["url1", "url2"] };
 
-    const manifest1 = new Manifest(oldManifestArgs1, {});
+    const manifest1 = new Manifest(oldManifestArgs1, {}, []);
     expect(manifest1.getUrls()).toEqual(["url1", "url2"]);
 
     const oldManifestArgs2 = { availabilityStartTime: 5,
@@ -333,9 +383,12 @@ describe("Manifest - Manifest", () => {
                                isDynamic: false,
                                isLive: false,
                                lifetime: 13,
-                               contentWarnings: [new Error("a"), new Error("b")],
-                               periods: [ { id: "0", start: 4, adaptations: {} },
-                                          { id: "1", start: 12, adaptations: {} } ],
+                               periods: [ { id: "0",
+                                            start: 4,
+                                            adaptations: oldPeriod1.adaptations },
+                                          { id: "1",
+                                            start: 12,
+                                            adaptations: oldPeriod2.adaptations } ],
                                suggestedPresentationDelay: 99,
                                timeBounds: { minimumSafePosition: 0,
                                              timeshiftDepth: null,
@@ -345,14 +398,17 @@ describe("Manifest - Manifest", () => {
                                                time: 10,
                                              } },
                                uris: [] };
-    const manifest2 = new Manifest(oldManifestArgs2, {});
+    const manifest2 = new Manifest(oldManifestArgs2, {}, []);
     expect(manifest2.getUrls()).toEqual([]);
   });
 
   it("should replace with a new Manifest when calling `replace`", () => {
-    const fakePeriod = jest.fn((period) => ({ ...period,
-                                              id: `foo${period.id}`,
-                                              contentWarnings: [new Error(period.id)] }));
+    const fakePeriod = jest.fn((period, unsupportedAdaptations) => {
+      unsupportedAdaptations
+        .push(generateAdaptationInstance(period.adaptations.audio[0]));
+      return { ...period,
+               id: `foo${period.id}` };
+    });
     const fakeReplacePeriodsRes = {
       updatedPeriods: [],
       addedPeriods: [],
@@ -366,16 +422,15 @@ describe("Manifest - Manifest", () => {
       replacePeriods: fakeReplacePeriods,
     }));
 
+    const oldPeriod1 = generateParsedPeriod("0", 4, undefined);
+    const oldPeriod2 = generateParsedPeriod("1", 12, undefined);
     const oldManifestArgs = { availabilityStartTime: 5,
                               duration: 12,
                               id: "man",
                               isDynamic: false,
                               isLive: false,
                               lifetime: 13,
-                              contentWarnings: [ new Error("a"),
-                                                 new Error("b") ],
-                              periods: [ { id: "0", start: 4, adaptations: {} },
-                                         { id: "1", start: 12, adaptations: {} } ],
+                              periods: [oldPeriod1, oldPeriod2],
                               timeBounds: { minimumSafePosition: 7,
                                             timeshiftDepth: 10,
                                             maximumTimeData: {
@@ -387,20 +442,23 @@ describe("Manifest - Manifest", () => {
                               uris: ["url1", "url2"] };
 
     const Manifest = jest.requireActual("../manifest").default;
-    const manifest = new Manifest(oldManifestArgs, {});
+    const manifest = new Manifest(oldManifestArgs, {}, []);
 
     const mockTrigger = jest.spyOn(manifest, "trigger").mockImplementation(jest.fn());
 
     const newAdaptations = {};
-    const newPeriod1 = { id: "foo0", start: 4, adaptations: {} };
-    const newPeriod2 = { id: "foo1", start: 12, adaptations: {} };
+    const newPeriod1 = { id: "foo0",
+                         start: 4,
+                         adaptations: { audio: oldPeriod1.adaptations } };
+    const newPeriod2 = { id: "foo1",
+                         start: 12,
+                         adaptations: { audio: oldPeriod2.adaptations } };
     const newManifest = { adaptations: newAdaptations,
                           availabilityStartTime: 6,
                           id: "man2",
                           isDynamic: true,
                           isLive: true,
                           lifetime: 14,
-                          contentWarnings: [new Error("c"), new Error("d")],
                           suggestedPresentationDelay: 100,
                           timeShiftBufferDepth: 3,
                           _timeBounds: { minimumSafePosition: 7,

--- a/src/manifest/__tests__/period.test.ts
+++ b/src/manifest/__tests__/period.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import Adaptation from "../adaptation";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -27,7 +29,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no adaptation is given", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -38,12 +40,14 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: {}, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
 
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -59,7 +63,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no audio nor video adaptation is given", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -79,12 +83,14 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { foo }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
 
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -104,7 +110,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if only empty audio and/or video adaptations is given", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -115,12 +121,14 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { video: [], audio: [] }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
 
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -138,7 +146,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if we are left with no audio representation", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -177,12 +185,14 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
 
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -199,7 +209,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no audio Adaptation is supported", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -238,8 +248,9 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
@@ -247,6 +258,9 @@ describe("Manifest - Period", () => {
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
+    expect(unsupportedAdaptations).toHaveLength(2);
+    expect(unsupportedAdaptations[0].id).toEqual("57");
+    expect(unsupportedAdaptations[1].id).toEqual("58");
 
     // Impossible check to shut-up TypeScript
     if (!(errorReceived instanceof Error)) {
@@ -260,7 +274,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if we are left with no video representation", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -299,12 +313,14 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
 
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -321,7 +337,7 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no video adaptation is supported", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -360,8 +376,9 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: { video, audio }, start: 0 };
     let period = null;
     let errorReceived = null;
+    const unsupportedAdaptations: Adaptation[] = [];
     try {
-      period = new Period(args);
+      period = new Period(args, unsupportedAdaptations);
     } catch (e) {
       errorReceived = e;
     }
@@ -369,6 +386,7 @@ describe("Manifest - Period", () => {
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
+    expect(unsupportedAdaptations).toHaveLength(3);
 
     // Impossible check to shut-up TypeScript
     if (!(errorReceived instanceof Error)) {
@@ -406,8 +424,9 @@ describe("Manifest - Period", () => {
                         toVideoTrack() { return videoAda2; } };
     const video2 = [videoAda2];
     const args = { id: "12", adaptations: { video, video2 }, start: 0 };
-    const period = new Period(args);
-    expect(period.contentWarnings).toHaveLength(1);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(1);
 
     expect(mockAdaptation).toHaveBeenCalledTimes(2);
     expect(mockAdaptation).toHaveReturnedTimes(2);
@@ -415,14 +434,13 @@ describe("Manifest - Period", () => {
     expect(mockAdaptation).toHaveBeenCalledWith(videoAda2, {});
     expect(mockAdaptation).toHaveReturnedWith(period.adaptations.video[0]);
 
-    const [error] = period.contentWarnings;
-    expect(error).toBeInstanceOf(Error);
-    expect(error.code).toBe("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
-    expect(error.type).toBe("MEDIA_ERROR");
+    const [adap] = unsupportedAdaptations;
+    expect((adap as { id: string }).id).toBe("55");
+    expect((adap as { isSupported: boolean }).isSupported).toBe(false);
   });
 
   it("should not set a parsing error if an empty unsupported adaptation is given", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -439,18 +457,19 @@ describe("Manifest - Period", () => {
     const video = [videoAda1];
     const bar = undefined;
     const args = { id: "12", adaptations: { bar, video }, start: 0 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
     expect(period.adaptations).toEqual({
-      video: video.map(v => ({ ...v, contentWarnings: [] })),
+      video: video.map(v => ({ ...v })),
     });
-    expect(period.contentWarnings).toHaveLength(0);
+    expect(unsupportedAdaptations).toHaveLength(0);
 
     expect(mockAdaptation).toHaveBeenCalledTimes(1);
     expect(mockAdaptation).toHaveBeenCalledWith(videoAda1, {});
   });
 
   it("should give a representationFilter to the adaptation", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     const representationFilter = jest.fn();
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
@@ -471,9 +490,10 @@ describe("Manifest - Period", () => {
                         toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0 };
-    const period = new Period(args, representationFilter);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations, representationFilter);
 
-    expect(period.contentWarnings).toHaveLength(0);
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.adaptations.video).toHaveLength(2);
 
     expect(mockAdaptation).toHaveBeenCalledTimes(2);
@@ -484,7 +504,7 @@ describe("Manifest - Period", () => {
     expect(representationFilter).not.toHaveBeenCalled();
   });
 
-  it("should add contentWarnings if Adaptations are not supported", () => {
+  it("should report if Adaptations are not supported", () => {
     const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
@@ -510,19 +530,16 @@ describe("Manifest - Period", () => {
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    new Period(args, unsupportedAdaptations);
 
-    expect(period.contentWarnings).toHaveLength(2);
-    const error = period.contentWarnings[0];
-    expect(error.code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
-    expect(error.type).toEqual("MEDIA_ERROR");
-
-    const error2 = period.contentWarnings[1];
-    expect(error2.code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
-    expect(error2.type).toEqual("MEDIA_ERROR");
+    expect(unsupportedAdaptations).toHaveLength(2);
+    const [adap1, adap2] = unsupportedAdaptations;
+    expect((adap1 as { id: string }).id).toBe("54");
+    expect((adap2 as { id: string }).id).toBe("12");
   });
 
-  it("should not add contentWarnings if an Adaptation has no Representation", () => {
+  it("should not report if an Adaptation has no Representation", () => {
     const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
@@ -548,13 +565,13 @@ describe("Manifest - Period", () => {
     const video = [videoAda1, videoAda2];
     const foo = [fooAda1];
     const args = { id: "12", adaptations: { video, foo }, start: 0 };
-    const period = new Period(args);
-
-    expect(period.contentWarnings).toHaveLength(0);
+    const unsupportedAdaptations: Adaptation[] = [];
+    new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
   });
 
   it("should set the given start", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -574,14 +591,16 @@ describe("Manifest - Period", () => {
                         toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 72 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.start).toEqual(72);
     expect(period.duration).toEqual(undefined);
     expect(period.end).toEqual(undefined);
   });
 
   it("should set a given duration", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -601,14 +620,16 @@ describe("Manifest - Period", () => {
                         toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 0, duration: 12 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.start).toEqual(0);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(12);
   });
 
   it("should infer the end from the start and the duration", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -628,14 +649,16 @@ describe("Manifest - Period", () => {
                         toVideoTrack() { return videoAda2; } };
     const video = [videoAda1, videoAda2];
     const args = { id: "12", adaptations: { video }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.start).toEqual(50);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(62);
   });
 
   it("should return every Adaptations combined with `getAdaptations`", () => {
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -663,8 +686,9 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args);
-
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.getAdaptations()).toHaveLength(3);
     expect(period.getAdaptations()).toContain(period.adaptations.video[0]);
     expect(period.getAdaptations()).toContain(period.adaptations.video[1]);
@@ -674,7 +698,7 @@ describe("Manifest - Period", () => {
   /* eslint-disable max-len */
   it("should return every Adaptations from a given type with `getAdaptationsForType`", () => {
   /* eslint-enable max-len */
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -702,7 +726,9 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
-    const period = new Period(args);
+    const unsupportedAdaptations: Adaptation[] = [];
+    const period = new Period(args, unsupportedAdaptations);
+    expect(unsupportedAdaptations).toHaveLength(0);
 
     expect(period.getAdaptationsForType("video")).toHaveLength(2);
     expect(period.getAdaptationsForType("video"))
@@ -719,7 +745,7 @@ describe("Manifest - Period", () => {
   /* eslint-disable max-len */
   it("should return the first Adaptations with a given Id when calling `getAdaptation`", () => {
   /* eslint-enable max-len */
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,
@@ -752,8 +778,9 @@ describe("Manifest - Period", () => {
     const audio = [audioAda1];
 
     const args = { id: "12", adaptations: { video, audio }, start: 50, duration: 12 };
+    const unsupportedAdaptations: Adaptation[] = [];
     const period = new Period(args);
-
+    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.getAdaptation("54")).toEqual(period.adaptations.video[0]);
     expect(period.getAdaptation("55")).toEqual(period.adaptations.video[1]);
     expect(period.getAdaptation("56")).toEqual(period.adaptations.audio[0]);
@@ -762,7 +789,7 @@ describe("Manifest - Period", () => {
   /* eslint-disable max-len */
   it("should return undefind if no adaptation has the given Id when calling `getAdaptation`", () => {
   /* eslint-enable max-len */
-    const mockAdaptation = jest.fn(arg => ({ ...arg, contentWarnings: [] }));
+    const mockAdaptation = jest.fn(arg => ({ ...arg }));
     jest.mock("../adaptation", () => ({
       __esModule: true as const,
       default: mockAdaptation,

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -23,6 +23,7 @@ import {
   IDashParserResponse,
   ILoadedResource,
 } from "../../parsers/manifest/dash/parsers_types";
+import { IPlayerError } from "../../public_types";
 import objectAssign from "../../utils/object_assign";
 import request from "../../utils/request";
 import {
@@ -139,8 +140,9 @@ export default function generateManifestParser(
         if (cancelSignal.isCancelled()) {
           return Promise.reject(cancelSignal.cancellationError);
         }
-        const manifest = new Manifest(parserResponse.value.parsed, options);
-        return { manifest, url };
+        const warnings : IPlayerError[] = [];
+        const manifest = new Manifest(parserResponse.value.parsed, options, warnings);
+        return { manifest, url, warnings };
       }
 
       const { value } = parserResponse;

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -23,7 +23,7 @@ import Manifest from "../../manifest";
 import parseLocalManifest, {
   ILocalManifest,
 } from "../../parsers/manifest/local";
-import { ILoadedManifestFormat } from "../../public_types";
+import { ILoadedManifestFormat, IPlayerError } from "../../public_types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import { CancellationSignal } from "../../utils/task_canceller";
 import {
@@ -73,8 +73,9 @@ export default function getLocalManifestPipelines(
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const manifest = new Manifest(parsed, transportOptions);
-      return { manifest, url: undefined };
+      const warnings : IPlayerError[] = [];
+      const manifest = new Manifest(parsed, transportOptions, warnings);
+      return { manifest, url: undefined, warnings };
     },
   };
 

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -27,6 +27,7 @@ import {
   ICdnMetadata,
   IParsedManifest,
 } from "../../parsers/manifest/types";
+import { IPlayerError } from "../../public_types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
 import { CancellationSignal } from "../../utils/task_canceller";
@@ -153,8 +154,9 @@ export default function(options : ITransportOptions): ITransportPipelines {
         parsedResult : IMPLParserResponse<IParsedManifest>
       ) : Promise<IManifestParserResult> {
         if (parsedResult.type === "done") {
-          const manifest = new Manifest(parsedResult.value, options);
-          return Promise.resolve({ manifest });
+          const warnings : IPlayerError[] = [];
+          const manifest = new Manifest(parsedResult.value, options, warnings);
+          return Promise.resolve({ manifest, warnings });
         }
 
         const parsedValue = parsedResult.value;

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -19,6 +19,7 @@ import Manifest from "../../manifest";
 import { getMDAT } from "../../parsers/containers/isobmff";
 import { ICdnMetadata } from "../../parsers/manifest";
 import createSmoothManifestParser from "../../parsers/manifest/smooth";
+import { IPlayerError } from "../../public_types";
 import request from "../../utils/request";
 import {
   strToUtf8,
@@ -77,10 +78,11 @@ export default function(transportOptions : ITransportOptions) : ITransportPipeli
                                                 url,
                                                 manifestReceivedTime);
 
+      const warnings : IPlayerError[] = [];
       const manifest = new Manifest(parserResult, {
         representationFilter: transportOptions.representationFilter,
-      });
-      return { manifest, url };
+      }, warnings);
+      return { manifest, url, warnings };
     },
   };
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -26,6 +26,7 @@ import {
   IRepresentationFilter,
   ISegmentLoader as ICustomSegmentLoader,
   IServerSyncInfos,
+  IPlayerError,
 } from "../public_types";
 import TaskCanceller, {
   CancellationSignal,
@@ -352,6 +353,11 @@ export type IManifestParserRequestScheduler =
 export interface IManifestParserResult {
   /** The parsed Manifest Object itself. */
   manifest : Manifest;
+  /**
+   * Minor issues seen while constructing the Manifest object.
+   * Empty if no issue was seen.
+   */
+  warnings : IPlayerError[];
   /**
    * "Real" URL (post-redirection) at which the Manifest can be refreshed.
    *


### PR DESCRIPTION
After doing many tests, it seems that the strategy of sending a `MANIFEST_INCOMPATIBLE_CODECS_ERROR` warning each time we spot an audio or video AdaptationSet with no supported codec in the MPD is not optimal for very large MPD (or equivalent in smooth streaming / local Manifests / MetaPlaylists).

Specifically, MPD with a very large amount of unsupported AdaptationSet (multi-Period MPDs, MPDs with a large choice of AdaptationSet with multiple codecs, dynamic range, audio channels, or all of this together), might produce A LOT of warnings - even more for contents where the Manifest has to be updated.

In turn, those warnings produce a lot of uninteresting warning logs, and might have in some extreme cases a non-null impact on memory as parsing issues were until known stored as a property of the Manifest instance (still less than a MB in the current worst observed cases - so not THAT problematic either, but still).

This PR propose for the v4 the following changes:

  - All `MANIFEST_INCOMPATIBLE_CODECS_ERROR` warnings seen while parsing a Manifest are regrouped into one - even when talking about media of different types (i.e. "audio" and "video")

  - The `trackInfo` stored on some `MediaError`s is now renamed into `tracksInfo` (with an s) and is now an Array of tracks - to allow warnings for multiple tracks at once. This is sadly a breaking change - it is relatively minor as `trackInfo` was optional and a very recent addition - but still, we only authorize ourselves this on the v4 because it is still in beta.

  - A Manifest instance does not "store" the warnings as a property as this is not needed by anything and this is not in the API. This was mainly done because it was the simplest way to implement it - but grouping warnings together now need a more advanced solution anyway.