### PR TITLE
DASH_WASM: Update quick-xml (Rust) dependency and consequently update Rust code

### DIFF
--- a/src/parsers/manifest/dash/wasm-parser/Cargo.lock
+++ b/src/parsers/manifest/dash/wasm-parser/Cargo.lock
@@ -17,9 +17,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
  "memchr",
 ]

--- a/src/parsers/manifest/dash/wasm-parser/Cargo.toml
+++ b/src/parsers/manifest/dash/wasm-parser/Cargo.toml
@@ -13,4 +13,4 @@ lto = true
 opt-level = 3
 
 [dependencies]
-quick-xml = "0.22.0"
+quick-xml = "0.30.0"

--- a/src/parsers/manifest/dash/wasm-parser/rs/errors.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/errors.rs
@@ -1,5 +1,5 @@
-use crate::onCustomEvent;
 use crate::events::CustomEventType;
+use crate::onCustomEvent;
 
 pub type Result<T> = std::result::Result<T, ParsingError>;
 
@@ -21,8 +21,8 @@ impl ParsingError {
     }
 }
 
-impl<T : std::error::Error> From<T> for ParsingError {
-    fn from(err : T) -> ParsingError {
+impl<T: std::error::Error> From<T> for ParsingError {
+    fn from(err: T) -> ParsingError {
         ParsingError(err.to_string())
     }
 }

--- a/src/parsers/manifest/dash/wasm-parser/rs/events.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/events.rs
@@ -1,4 +1,4 @@
-use crate::{ParsingError, onTagClose, onTagOpen};
+use crate::{onTagClose, onTagOpen, ParsingError};
 
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -21,13 +21,13 @@ pub enum CustomEventType {
 /// the parser's implementation.
 #[derive(PartialEq, Clone, Copy)]
 #[repr(C)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum TagName {
     /// Indicate an <MPD> node
     /// These nodes are usually contained at the root of an MPD.
     MPD = 1,
 
     // -- Inside an <MPD> --
-
     /// Indicate a <Period> node
     Period = 2,
 
@@ -35,7 +35,6 @@ pub enum TagName {
     UtcTiming = 3,
 
     // -- Inside a <Period> --
-
     /// Indicate an <AdaptationSet> node
     AdaptationSet = 4,
 
@@ -47,7 +46,6 @@ pub enum TagName {
     EventStreamElt = 6,
 
     // -- Inside an <AdaptationSet> --
-
     /// Indicate a <Representation> node
     Representation = 7,
 
@@ -70,7 +68,6 @@ pub enum TagName {
     SupplementalProperty = 13,
 
     // -- Inside various elements --
-
     /// Indicate a <BaseURL> node
     BaseURL = 15,
 
@@ -87,7 +84,6 @@ pub enum TagName {
     InbandEventStream = 19,
 
     // -- Inside a <SegmentList> --
-
     /// Indicate a <SegmentURL> node
     SegmentUrl = 20,
 }
@@ -134,15 +130,15 @@ pub enum AttributeName {
     CodingDependency = 5,
     FrameRate = 6,
     Height = 7, // f64
-    Width = 8, // f64
+    Width = 8,  // f64
     MaxPlayoutRate = 9,
     MaxSAPPeriod = 10,
     MimeType = 11, // f64
     SegmentProfiles = 12,
 
     // ContentProtection
-    ContentProtectionValue = 13, // String
-    ContentProtectionKeyId = 14, // ArrayBuffer
+    ContentProtectionValue = 13,    // String
+    ContentProtectionKeyId = 14,    // ArrayBuffer
     ContentProtectionCencPSSH = 15, // ArrayBuffer
 
     // Various schemes (Accessibility) + EventStream + ContentProtection
@@ -162,8 +158,8 @@ pub enum AttributeName {
 
     // SegmentTemplate + SegmentBase
     AvailabilityTimeComplete = 22, // u8 (bool)
-    IndexRangeExact = 23, // u8 (bool)
-    PresentationTimeOffset = 24, // f64
+    IndexRangeExact = 23,          // u8 (bool)
+    PresentationTimeOffset = 24,   // f64
 
     // EventStream
     EventPresentationTime = 25, // f64
@@ -178,49 +174,48 @@ pub enum AttributeName {
     InitializationRange = 29, // [f64, f64]
 
     // SegmentURL + SegmentTemplate + SegmentBase + Initialization
-    Media = 30, // String
+    Media = 30,      // String
     IndexRange = 31, // [f64, f64]
 
     // Period + AdaptationSet + SegmentTemplate
     BitstreamSwitching = 32, // u8 (bool)
 
-
     // MPD
-    Type = 33, // String
-    AvailabilityStartTime = 34, // f64
-    AvailabilityEndTime = 35, // f64
-    PublishTime = 36, // f64
-    MinimumUpdatePeriod = 37, // f64
-    MinBufferTime = 38, // f64
-    TimeShiftBufferDepth = 39, // f64
+    Type = 33,                       // String
+    AvailabilityStartTime = 34,      // f64
+    AvailabilityEndTime = 35,        // f64
+    PublishTime = 36,                // f64
+    MinimumUpdatePeriod = 37,        // f64
+    MinBufferTime = 38,              // f64
+    TimeShiftBufferDepth = 39,       // f64
     SuggestedPresentationDelay = 40, // f64
-    MaxSegmentDuration = 41, // f64
-    MaxSubsegmentDuration = 42, // f64
+    MaxSegmentDuration = 41,         // f64
+    MaxSubsegmentDuration = 42,      // f64
 
     // BaseURL + SegmentTemplate
     AvailabilityTimeOffset = 43, // f64
 
     // Period
-    Start = 45, // f64
-    XLinkHref = 46, // String
+    Start = 45,        // f64
+    XLinkHref = 46,    // String
     XLinkActuate = 47, // String
 
     // AdaptationSet
     Group = 48,
     MaxBandwidth = 49, // f64
     MaxFrameRate = 50, // f64
-    MaxHeight = 51, // f64
-    MaxWidth = 52, // f64
+    MaxHeight = 51,    // f64
+    MaxWidth = 52,     // f64
     MinBandwidth = 53, // f64
     MinFrameRate = 54, // f64
-    MinHeight = 55, // f64
-    MinWidth = 56, // f64
+    MinHeight = 55,    // f64
+    MinWidth = 56,     // f64
     SelectionPriority = 57,
     SegmentAlignment = 58,
     SubsegmentAlignment = 59,
 
     // AdaptationSet + ContentComponent
-    Language = 60, // String
+    Language = 60,    // String
     ContentType = 61, // String
     Par = 62,
 
@@ -314,72 +309,49 @@ impl AttributeName {
         val.report_as_attr(self)
     }
 
-    pub fn try_report_as_string(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
-        match attr.unescaped_value() {
+    pub fn try_report_as_string(self, attr: &quick_xml::events::attributes::Attribute) {
+        match attr.unescape_value() {
             Ok(val) => self.report(val),
-            Err(_) =>
-                ParsingError("Could not escape original value".to_owned())
-                    .report_err(),
+            Err(_) => ParsingError("Could not escape original value".to_owned()).report_err(),
         }
     }
 
-    pub fn try_report_as_f64(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_f64(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_f64(&attr.value) {
             Ok(val) => self.report(val),
             Err(error) => error.report_err(),
         }
     }
 
-    pub fn try_report_as_iso_8601_duration(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_iso_8601_duration(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_iso_8601_duration(&attr.value) {
             Ok(val) => self.report(val),
             Err(error) => error.report_err(),
         }
     }
 
-    pub fn try_report_as_u64(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_u64(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_u64(&attr.value) {
             Ok(val) => self.report(val as f64),
             Err(error) => error.report_err(),
         }
     }
 
-    pub fn try_report_as_u64_or_bool(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_u64_or_bool(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_u64_or_bool(&attr.value) {
             Ok(val) => self.report(val),
             Err(error) => error.report_err(),
         }
     }
 
-    pub fn try_report_as_bool(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_bool(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_bool(&attr.value) {
             Ok(val) => self.report(val),
             Err(error) => error.report_err(),
         }
     }
 
-    pub fn try_report_as_range(
-        self,
-        attr : &quick_xml::events::attributes::Attribute
-    ) {
+    pub fn try_report_as_range(self, attr: &quick_xml::events::attributes::Attribute) {
         match utils::parse_byte_range(&attr.value) {
             Ok(val) => self.report(val),
             Err(error) => error.report_err(),
@@ -388,14 +360,12 @@ impl AttributeName {
 
     pub fn try_report_as_key_value(
         self,
-        key : &[u8],
-        value: &quick_xml::events::attributes::Attribute
+        key: &[u8],
+        value: &quick_xml::events::attributes::Attribute,
     ) {
-        match value.unescaped_value() {
+        match value.unescape_value() {
             Ok(val) => self.report((key, val)),
-            Err(_) =>
-                ParsingError("Could not escape original value".to_owned())
-                    .report_err(),
+            Err(_) => ParsingError("Could not escape original value".to_owned()).report_err(),
         }
     }
 }

--- a/src/parsers/manifest/dash/wasm-parser/rs/lib.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/lib.rs
@@ -1,8 +1,8 @@
 extern crate core;
 extern crate quick_xml;
 
-mod events;
 mod errors;
+mod events;
 mod processor;
 mod reader;
 mod reportable;
@@ -10,10 +10,10 @@ mod utils;
 
 pub use errors::{ParsingError, Result};
 
-use std::io::BufReader;
 use events::*;
 use processor::MPDProcessor;
 use reader::MPDReader;
+use std::io::BufReader;
 
 extern "C" {
     /// JS callback called each time a new known tag is encountered in the MPD.
@@ -24,7 +24,7 @@ extern "C" {
     /// # Arguments
     ///
     /// * `tag_name` - u8 describing the name of the tag encountered.
-    fn onTagOpen(tag_name : TagName);
+    fn onTagOpen(tag_name: TagName);
 
     /// JS callback called each time a previously-opened known tag is encountered in
     /// the MPD now closed.
@@ -32,7 +32,7 @@ extern "C" {
     /// # Arguments
     ///
     /// * `tag_name` - u8 describing the name of the tag which just closed.
-    fn onTagClose(tag_name : TagName);
+    fn onTagClose(tag_name: TagName);
 
     /// JS Callback called when a new attribute has been parsed in the last
     /// encountered element.
@@ -46,7 +46,7 @@ extern "C" {
     /// WebAssembly's linear memory.
     ///
     /// * `len` - Length of the data - starting at `ptr` - in bytes.
-    fn onAttribute(attr_name : AttributeName, ptr : *const u8, len : usize);
+    fn onAttribute(attr_name: AttributeName, ptr: *const u8, len: usize);
 
     /// JS callback for other specific operations, for example logging and warnings.
     ///
@@ -58,7 +58,7 @@ extern "C" {
     /// WebAssembly's linear memory.
     ///
     /// * `len` - Length of the data - starting at `ptr` - in bytes.
-    fn onCustomEvent(evt_type : CustomEventType, ptr: *const u8, len : usize);
+    fn onCustomEvent(evt_type: CustomEventType, ptr: *const u8, len: usize);
 
     /// JS callback allowing to read data from the MPD, which is stored in the
     /// JS-side.
@@ -74,7 +74,7 @@ extern "C" {
     /// * `size` - Optimal length of data that is wanted, in bytes.
     /// Less data (but not more) can be read. The true read length is returned
     /// by this function.
-    fn readNext(ptr : *const u8,  size : usize) -> usize;
+    fn readNext(ptr: *const u8, size: usize) -> usize;
 }
 
 #[no_mangle]

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/attributes.rs
@@ -1,30 +1,33 @@
 use crate::errors::ParsingError;
 use crate::events::AttributeName::*;
 
-pub fn report_mpd_attrs(e : &quick_xml::events::BytesStart) {
+pub fn report_mpd_attrs(e: &quick_xml::events::BytesStart) {
     for res_attr in e.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"id" => Id.try_report_as_string(&attr),
                 b"profiles" => Profiles.try_report_as_string(&attr),
                 b"type" => Type.try_report_as_string(&attr),
                 b"availabilityStartTime" => AvailabilityStartTime.try_report_as_string(&attr),
                 b"availabilityEndTime" => AvailabilityEndTime.try_report_as_string(&attr),
                 b"publishTime" => PublishTime.try_report_as_string(&attr),
-                b"mediaPresentationDuration" =>
-                    MediaPresentationDuration.try_report_as_iso_8601_duration(&attr),
-                b"minimumUpdatePeriod" =>
-                    MinimumUpdatePeriod.try_report_as_iso_8601_duration(&attr),
-                b"minBufferTime" =>
-                    MinBufferTime.try_report_as_iso_8601_duration(&attr),
-                b"timeShiftBufferDepth" =>
-                    TimeShiftBufferDepth.try_report_as_iso_8601_duration(&attr),
-                b"suggestedPresentationDelay" =>
-                    SuggestedPresentationDelay.try_report_as_iso_8601_duration(&attr),
-                b"maxSegmentDuration" =>
-                    MaxSegmentDuration.try_report_as_iso_8601_duration(&attr),
-                b"maxSubsegmentDuration" =>
-                    MaxSubsegmentDuration.try_report_as_iso_8601_duration(&attr),
+                b"mediaPresentationDuration" => {
+                    MediaPresentationDuration.try_report_as_iso_8601_duration(&attr)
+                }
+                b"minimumUpdatePeriod" => {
+                    MinimumUpdatePeriod.try_report_as_iso_8601_duration(&attr)
+                }
+                b"minBufferTime" => MinBufferTime.try_report_as_iso_8601_duration(&attr),
+                b"timeShiftBufferDepth" => {
+                    TimeShiftBufferDepth.try_report_as_iso_8601_duration(&attr)
+                }
+                b"suggestedPresentationDelay" => {
+                    SuggestedPresentationDelay.try_report_as_iso_8601_duration(&attr)
+                }
+                b"maxSegmentDuration" => MaxSegmentDuration.try_report_as_iso_8601_duration(&attr),
+                b"maxSubsegmentDuration" => {
+                    MaxSubsegmentDuration.try_report_as_iso_8601_duration(&attr)
+                }
                 x => {
                     if x.len() > 6 && &x[..6] == b"xmlns:" {
                         Namespace.try_report_as_key_value(&x[6..], &attr);
@@ -33,13 +36,13 @@ pub fn report_mpd_attrs(e : &quick_xml::events::BytesStart) {
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_period_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_period_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"id" => Id.try_report_as_string(&attr),
                 b"start" => Start.try_report_as_iso_8601_duration(&attr),
                 b"duration" => Duration.try_report_as_iso_8601_duration(&attr),
@@ -58,13 +61,13 @@ pub fn report_period_attrs(tag_bs : &quick_xml::events::BytesStart) {
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_adaptation_set_attrs(e : &quick_xml::events::BytesStart) {
+pub fn report_adaptation_set_attrs(e: &quick_xml::events::BytesStart) {
     for res_attr in e.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"id" => Id.try_report_as_string(&attr),
                 b"group" => Group.try_report_as_u64(&attr),
                 b"lang" => Language.try_report_as_string(&attr),
@@ -80,8 +83,7 @@ pub fn report_adaptation_set_attrs(e : &quick_xml::events::BytesStart) {
                 b"maxFrameRate" => MaxFrameRate.try_report_as_string(&attr),
                 b"selectionPriority" => SelectionPriority.try_report_as_u64(&attr),
                 b"segmentAlignment" => SegmentAlignment.try_report_as_u64_or_bool(&attr),
-                b"subsegmentAlignment" =>
-                    SubsegmentAlignment.try_report_as_u64_or_bool(&attr),
+                b"subsegmentAlignment" => SubsegmentAlignment.try_report_as_u64_or_bool(&attr),
                 b"bitstreamSwitching" => BitstreamSwitching.try_report_as_bool(&attr),
                 b"audioSamplingRate" => AudioSamplingRate.try_report_as_string(&attr),
                 b"codecs" => Codecs.try_report_as_string(&attr),
@@ -98,19 +100,18 @@ pub fn report_adaptation_set_attrs(e : &quick_xml::events::BytesStart) {
                     b"INF" => AvailabilityTimeOffset.report(f64::INFINITY),
                     _ => AvailabilityTimeOffset.try_report_as_u64(&attr),
                 },
-                b"availabilityTimeComplete" =>
-                    AvailabilityTimeComplete.try_report_as_bool(&attr),
-                _ => {},
+                b"availabilityTimeComplete" => AvailabilityTimeComplete.try_report_as_bool(&attr),
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_representation_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_representation_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"id" => Id.try_report_as_string(&attr),
                 b"audioSamplingRate" => AudioSamplingRate.try_report_as_string(&attr),
                 b"bandwidth" => Bitrate.try_report_as_u64(&attr),
@@ -129,132 +130,120 @@ pub fn report_representation_attrs(tag_bs : &quick_xml::events::BytesStart) {
                     b"INF" => AvailabilityTimeOffset.report(f64::INFINITY),
                     _ => AvailabilityTimeOffset.try_report_as_u64(&attr),
                 },
-                b"availabilityTimeComplete" =>
-                    AvailabilityTimeComplete.try_report_as_bool(&attr),
-                _ => {},
+                b"availabilityTimeComplete" => AvailabilityTimeComplete.try_report_as_bool(&attr),
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_base_url_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_base_url_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
-                b"serviceLocation" => ServiceLocation.try_report_as_string(&attr),
-                _ => {},
-            },
+            Ok(attr) => {
+                if let b"serviceLocation" = attr.key.as_ref() {
+                    ServiceLocation.try_report_as_string(&attr)
+                }
+            }
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_segment_template_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_segment_template_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"initialization" => InitializationMedia.try_report_as_string(&attr),
                 b"index" => Index.try_report_as_string(&attr),
                 b"timescale" => TimeScale.try_report_as_u64(&attr),
-                b"presentationTimeOffset" =>
-                    PresentationTimeOffset.try_report_as_f64(&attr),
-                b"indexRange" =>
-                    IndexRange.try_report_as_range(&attr),
-                b"IndexRangeExact" =>
-                    IndexRangeExact.try_report_as_bool(&attr),
+                b"presentationTimeOffset" => PresentationTimeOffset.try_report_as_f64(&attr),
+                b"indexRange" => IndexRange.try_report_as_range(&attr),
+                b"IndexRangeExact" => IndexRangeExact.try_report_as_bool(&attr),
                 b"availabilityTimeOffset" => match attr.value.as_ref() {
                     b"INF" => AvailabilityTimeOffset.report(f64::INFINITY),
                     _ => AvailabilityTimeOffset.try_report_as_u64(&attr),
                 },
-                b"availabilityTimeComplete" =>
-                    AvailabilityTimeComplete.try_report_as_bool(&attr),
-                b"duration" =>
-                    Duration.try_report_as_u64(&attr),
-                b"startNumber" =>
-                    StartNumber.try_report_as_u64(&attr),
-                b"endNumber" =>
-                    EndNumber.try_report_as_u64(&attr),
+                b"availabilityTimeComplete" => AvailabilityTimeComplete.try_report_as_bool(&attr),
+                b"duration" => Duration.try_report_as_u64(&attr),
+                b"startNumber" => StartNumber.try_report_as_u64(&attr),
+                b"endNumber" => EndNumber.try_report_as_u64(&attr),
                 b"media" => Media.try_report_as_string(&attr),
                 b"bitstreamSwitching" => BitstreamSwitching.try_report_as_bool(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_segment_base_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_segment_base_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"timescale" => TimeScale.try_report_as_u64(&attr),
-                b"presentationTimeOffset" =>
-                    PresentationTimeOffset.try_report_as_f64(&attr),
+                b"presentationTimeOffset" => PresentationTimeOffset.try_report_as_f64(&attr),
                 b"indexRange" => IndexRange.try_report_as_range(&attr),
                 b"indexRangeExact" => IndexRangeExact.try_report_as_bool(&attr),
                 b"availabilityTimeOffset" => match attr.value.as_ref() {
                     b"INF" => AvailabilityTimeOffset.report(f64::INFINITY),
                     _ => AvailabilityTimeOffset.try_report_as_u64(&attr),
                 },
-                b"availabilityTimeComplete" =>
-                    AvailabilityTimeComplete.try_report_as_bool(&attr),
-                b"duration" =>
-                    Duration.try_report_as_u64(&attr),
-                b"startNumber" =>
-                    StartNumber.try_report_as_u64(&attr),
-                b"endNumber" =>
-                    EndNumber.try_report_as_u64(&attr),
-                _ => {},
+                b"availabilityTimeComplete" => AvailabilityTimeComplete.try_report_as_bool(&attr),
+                b"duration" => Duration.try_report_as_u64(&attr),
+                b"startNumber" => StartNumber.try_report_as_u64(&attr),
+                b"endNumber" => EndNumber.try_report_as_u64(&attr),
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_content_component_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_content_component_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"id" => Id.try_report_as_string(&attr),
                 b"lang" => Language.try_report_as_string(&attr),
                 b"contentType" => ContentType.try_report_as_string(&attr),
                 b"par" => Par.try_report_as_string(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_content_protection_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_content_protection_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"schemeIdUri" => SchemeIdUri.try_report_as_string(&attr),
                 b"value" => ContentProtectionValue.try_report_as_string(&attr),
 
                 // TODO convert hex to bytes here?
                 b"cenc:default_KID" => ContentProtectionKeyId.try_report_as_string(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
 /// Report attributes encountered in an `<Initialization>` element.
-pub fn report_initialization_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_initialization_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"range" => InitializationRange.try_report_as_range(&attr),
                 b"sourceURL" => InitializationMedia.try_report_as_string(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
 /// Report attributes encountered in "Scheme-like" element.
@@ -263,38 +252,38 @@ pub fn report_initialization_attrs(tag_bs : &quick_xml::events::BytesStart) {
 /// a string form:
 ///   - "schemeIdUri"
 ///   - "value"
-pub fn report_scheme_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_scheme_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"schemeIdUri" => SchemeIdUri.try_report_as_string(&attr),
                 b"value" => SchemeValue.try_report_as_string(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_segment_url_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_segment_url_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"index" => Index.try_report_as_string(&attr),
                 b"indexRange" => IndexRange.try_report_as_range(&attr),
                 b"media" => Media.try_report_as_string(&attr),
                 b"mediaRange" => MediaRange.try_report_as_range(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_event_stream_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_event_stream_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"schemeIdUri" => SchemeIdUri.try_report_as_string(&attr),
                 b"value" => SchemeValue.try_report_as_string(&attr),
                 b"timescale" => TimeScale.try_report_as_u64(&attr),
@@ -306,21 +295,21 @@ pub fn report_event_stream_attrs(tag_bs : &quick_xml::events::BytesStart) {
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
-pub fn report_event_stream_event_attrs(tag_bs : &quick_xml::events::BytesStart) {
+pub fn report_event_stream_event_attrs(tag_bs: &quick_xml::events::BytesStart) {
     for res_attr in tag_bs.attributes() {
         match res_attr {
-            Ok(attr) => match attr.key {
+            Ok(attr) => match attr.key.as_ref() {
                 b"presentationTime" => EventPresentationTime.try_report_as_u64(&attr),
                 b"duration" => Duration.try_report_as_u64(&attr),
                 b"id" => Id.try_report_as_string(&attr),
-                _ => {},
+                _ => {}
             },
             Err(err) => ParsingError::from(err).report_err(),
         };
-    };
+    }
 }
 
 //use std::ffi::CString;
@@ -377,7 +366,7 @@ pub fn report_event_stream_event_attrs(tag_bs : &quick_xml::events::BytesStart) 
 //    let mut mpd_attrs = MpdAttributes::default();
 //    for res_attr in e.attributes() {
 //        match res_attr {
-//            Ok(attr) => match attr.key {
+//            Ok(attr) => match attr.key.as_ref() {
 //                b"id" => { mpd_attrs.id = extract_string_attr(&attr); },
 //                b"profiles" => { mpd_attrs.profiles = extract_string_attr(&attr); }
 //                b"type" => { mpd_attrs.mpd_type = extract_string_attr(&attr); }

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/s_element.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/s_element.rs
@@ -1,4 +1,4 @@
-use crate::errors::{ ParsingError, Result };
+use crate::errors::{ParsingError, Result};
 use crate::utils;
 
 /// Represents a parsed <S> node, itself in a <SegmentTimeline> node from an
@@ -9,24 +9,23 @@ use crate::utils;
 #[repr(C)] // Used in FFI
 #[derive(Debug, Clone, Copy, Default)]
 pub struct SegmentObject {
+    /// Starting timestamp for the segment, in the corresponding Timescale
+    ///
+    /// This is either equivalent to the `t` attribute of an `<S>` element, or to
+    /// the end of the previous one if no `t` attribute is found.
+    pub start: f64,
 
-  /// Starting timestamp for the segment, in the corresponding Timescale
-  ///
-  /// This is either equivalent to the `t` attribute of an `<S>` element, or to
-  /// the end of the previous one if no `t` attribute is found.
-  pub start : f64,
+    /// Duration of the segment, in the corresponding Timescale.
+    ///
+    /// This is the data contained in the `d` attribute of an `<S>` element.
+    /// If not found, it is set to `0`.
+    pub duration: f64,
 
-  /// Duration of the segment, in the corresponding Timescale.
-  ///
-  /// This is the data contained in the `d` attribute of an `<S>` element.
-  /// If not found, it is set to `0`.
-  pub duration : f64,
-
-  /// Amount of time contiguous segments of the duration are encountered.
-  ///
-  /// This is the data contained in the `r` attribute of an `<S>` element.
-  /// If not found, it is set to `0`.
-  pub repeat_count : f64
+    /// Amount of time contiguous segments of the duration are encountered.
+    ///
+    /// This is the data contained in the `r` attribute of an `<S>` element.
+    /// If not found, it is set to `0`.
+    pub repeat_count: f64,
 }
 
 impl SegmentObject {
@@ -37,8 +36,8 @@ impl SegmentObject {
     /// on a SegmentTimeline segment indexing scheme.
     #[inline(always)]
     pub fn from_s_element(
-        e : &quick_xml::events::BytesStart,
-        time_base : f64
+        e: &quick_xml::events::BytesStart,
+        time_base: f64,
     ) -> Result<SegmentObject> {
         let mut segment_obj = SegmentObject::default();
         let mut has_t = false;
@@ -47,21 +46,21 @@ impl SegmentObject {
             match res_attr {
                 Ok(attr) => {
                     let key = attr.key;
-                    match key {
+                    match key.as_ref() {
                         b"t" => {
                             segment_obj.start = utils::parse_u64(&attr.value)? as f64;
                             has_t = true;
-                        },
+                        }
                         b"d" => {
                             segment_obj.duration = utils::parse_u64(&attr.value)? as f64;
-                        },
+                        }
                         b"r" => {
                             // Note i64 instead of u64 as r can be equal to "-1"
                             segment_obj.repeat_count = utils::parse_i64(&attr.value)? as f64;
-                        },
-                        _ => {},
+                        }
+                        _ => {}
                     }
-                },
+                }
                 Err(err) => ParsingError::from(err).report_err(),
             };
         }
@@ -71,4 +70,3 @@ impl SegmentObject {
         Ok(segment_obj)
     }
 }
-

--- a/src/parsers/manifest/dash/wasm-parser/rs/reader.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/reader.rs
@@ -1,4 +1,4 @@
-use std::io::{ self, Read };
+use std::io::{self, Read};
 
 pub struct MPDReader {}
 
@@ -12,6 +12,6 @@ impl Read for MPDReader {
         unsafe {
             actual_size = super::readNext((*buf).as_ptr(), buf.len());
         }
-        Ok(actual_size as usize)
+        Ok(actual_size)
     }
 }


### PR DESCRIPTION
This commit updates the dependency in our Rust code, `quick-xml`, which allows to parse XML documents (which DASH MPD are) in our WASM MPD parser in a SAX-like manner.

The major change here is that the types for element names and attributes is now implemented by single-field structs whose field is the reference to the corresponding name whereas it was directly the reference initially.

Thankfully, there's no need to bring that new struct's name in all our pattern-matching cases (which would have been less readable), as calling the `as_ref` method implemented on that struct returns directly the reference we had before (we can thus pattern match on this instead, and keep the previous code for all matched patterns).
This is actually what is presented in quick-xml examples so it also seems like the idiomatic way to do it.

However the major part of that code is a formatting update, done thanks to the rust-official `rustfmt` tool and code updates based on clippy (official Rust linter) lints.

This branch was tested with success on various DASH contents.