### PR TITLE
Update "list" npm script so it may actually execute commands

### DIFF
--- a/scripts/list-npm-scripts.js
+++ b/scripts/list-npm-scripts.js
@@ -12,20 +12,23 @@
 const fs = require("fs");
 const readline = require("readline");
 const path = require("path");
+const { spawn } = require("child_process");
+readline.emitKeypressEvents(process.stdin);
 
 run();
 
 async function run() {
   const pkg = getPackageJSONContent();
   if (!("scripts-list" in pkg)) {
-    console.log("No \"scripts-list\" key in the `package.json` file.");
+    console.log('No "scripts-list" key in the `package.json` file.');
     process.exit(0);
   }
 
+  // Display groups
   const scriptsList = pkg["scripts-list"];
   const groupNames = Object.keys(scriptsList);
   if (groupNames.length === 0) {
-    console.log("Nothing found in \"scripts-list\" in the `package.json` file.");
+    console.log('Nothing found in "scripts-list" in the `package.json` file.');
     process.exit(0);
   }
   console.log("\x1b[33m~~~~~~~~~~~~~~~~ RxPlayer scripts ~~~~~~~~~~~~~~~~\n");
@@ -34,18 +37,9 @@ async function run() {
     console.log(`\x1b[32m${groupIdx + 1}.\x1b[37m ${key}`);
   });
   console.log("");
-  const answer = await readInput("Your choice (leave empty to exit): ");
-  if (answer == null || answer === "") {
-    process.exit(0);
-  }
-  const groupNum = Number(answer);
-  if (isNaN(groupNum) || groupNum <= 0 || groupNum > groupNames.length) {
-    console.error("Invalid number given");
-    process.exit(1);
-  }
-
+  const groupChoiceNum = await getChoice(groupNames.length);
   console.log("");
-  const wantedGroupName = groupNames[groupNum - 1];
+  const wantedGroupName = groupNames[groupChoiceNum - 1];
   console.log(`\x1b[34m>>>> ${wantedGroupName}\x1b[37m`);
   console.log("");
   const subGroup = scriptsList[wantedGroupName];
@@ -55,45 +49,159 @@ async function run() {
     process.exit(0);
   }
 
-  displayGroupCommands(subGroupEntries);
+  // Display commands
+  {
+    let currCommandNb = 1;
+    const commandArray = [];
+    recusivelyDiplayGroupCommands(subGroupEntries);
+    const cmdChoiceNum = await getChoice(commandArray.length);
+    const wantedScript = commandArray[cmdChoiceNum - 1];
+    console.log("\n");
+    executeNpmScript(wantedScript);
 
-  process.exit(0);
-}
-
-function displayGroupCommands(
-  groupEntries,
-  indentation = ""
-) {
-  groupEntries.forEach(([name, val]) => {
-    if (typeof val === "string") {
-      console.log(`${indentation}[\x1b[32mnpm run ${name}\x1b[37m]:`);
-      console.log(`${indentation}  ${val}\n`);
-    } else if (typeof val === "object") {
-      console.log(`${indentation}\x1b[33m${name}\x1b[37m\n`);
-      const deeper = Object.entries(val);
-      displayGroupCommands(deeper, indentation + "  ");
-      console.log("");
+    function recusivelyDiplayGroupCommands(groupEntries, indentation = "") {
+      groupEntries.forEach(([name, val]) => {
+        if (typeof val === "string") {
+          commandArray.push(name);
+          console.log(
+            `${indentation}${emphasize(currCommandNb + ".")} [${emphasize(
+              `npm run ${name}`
+            )}]:`
+          );
+          console.log(`${indentation}   ${val}\n`);
+          currCommandNb++;
+        } else if (typeof val === "object") {
+          console.log(`${indentation}\x1b[33m${name}\x1b[37m\n`);
+          const deeper = Object.entries(val);
+          recusivelyDiplayGroupCommands(deeper, indentation + "  ");
+          console.log("");
+        }
+      });
     }
-  });
+  }
 }
 
-function readInput(query) {
+/**
+ * Ask for a numbered input between `1` and the `maxNb` given.
+ *
+ * Directly exits script in case of invalid input or in cases where the user
+ * asked to exit.
+ *
+ * The returned number is guaranteed to be between `1` and `maxNb` included.
+ * @param {number} maxNb
+ * @returns {Promise.<number>}
+ */
+async function getChoice(maxNb) {
+  const answer =
+    maxNb <= 9 ? await getSingleCharChoice() : await readAnyLengthChoice();
+  if (
+    answer == null ||
+    answer == "" ||
+    (answer.length === 1 &&
+      [
+        3, // ^C
+        4, // ^D
+        13, // enter
+        32, // space
+      ].includes(answer.charCodeAt(0)))
+  ) {
+    process.exit(0);
+  }
+  const val = Number(answer);
+  if (isNaN(val) || val <= 0 || val > maxNb) {
+    console.error("Invalid number given");
+    process.exit(1);
+  }
+  return val;
+}
+
+/**
+ * Execute the given npm script.
+ *
+ * Redirect its stdin and stdout to ours, communicate signals, and exit when
+ * the script exits.
+ *
+ * @param {string} cmd
+ */
+function executeNpmScript(script) {
+  const emphasizedCmdStr = emphasize(`npm run ${script}`);
+  console.log(`Executing: ${emphasizedCmdStr}`);
+  const cmd = spawn("npm", ["run", script], {
+    stdio: "inherit",
+    stderr: "inherit",
+  });
+  process.on("SIGINT", function () {
+    cmd.kill("SIGINT");
+  });
+  process.on("SIGTERM", function () {
+    cmd.kill("SIGTERM");
+  });
+  cmd.on("error", (d) => {
+    process.stderr.write(`Error while executing command: ${d}`);
+  });
+  cmd.on("exit", (c) => process.exit(c));
+}
+
+/**
+ * Emphasize the given string with ANSI escape codes for the console.
+ * @param {string} str
+ * @returns {string}
+ */
+function emphasize(str) {
+  return `\x1b[32m${str}\x1b[37m`;
+}
+
+/**
+ * Read input string of any length.
+ * @returns {Promise.<string>}
+ */
+function readAnyLengthChoice() {
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
   });
-
-  return new Promise(resolve => rl.question(query, ans => {
-    rl.close();
-    resolve(ans);
-  }));
+  return new Promise((resolve) =>
+    rl.question("Your choice (leave empty to exit): ", (ans) => {
+      rl.close();
+      resolve(ans);
+    })
+  );
 }
 
+/**
+ * Read single-character input.
+ *
+ * The advantage of this function when compared to `readAnyLengthChoice` is that
+ * you won't need to enter a newline to validate your choice.
+ * @returns {Promise.<string>}
+ */
+function getSingleCharChoice() {
+  return new Promise((res) => {
+    process.stdin.setRawMode(true);
+    process.stdout.write("Your choice (leave empty to exit): ");
+    process.stdin.on("keypress", onKeyPress);
+    function onKeyPress(char) {
+      process.stdin.setRawMode(false);
+      process.stdin.off("keypress", onKeyPress);
+      res(char);
+    }
+  });
+}
+
+/**
+ * Read the content of the `package.json` file in the current directory and
+ * parses its input into a JS Object.
+ *
+ * Throws if no `package.json` exists in the current directory.
+ *
+ * @returns {Object}
+ */
 function getPackageJSONContent() {
-  const filename = path.join(process.cwd(), 'package.json');
+  const filename = path.join(process.cwd(), "package.json");
   if (!fs.existsSync(filename)) {
-    throw new Error('`package.json` was not found in the current working directory.');
+    throw new Error(
+      "`package.json` was not found in the current working directory."
+    );
   }
-  return JSON.parse(fs.readFileSync(filename, 'utf8'));
+  return JSON.parse(fs.readFileSync(filename, "utf8"));
 }
-


### PR DESCRIPTION
This is an update of the "list" npm script, which brings two things to improve its usefulness:
  - if less than 10 numbered inputs are possible, the script won't wait for the enter key to be entered for validating your choice.
  - Listed commands are now choosable, and choosing one will execute it.

This is to allow new RxPlayer developpers to more easily familiarize themselves to the high number of scripts there are in the RxPlayer (to build, build a demo, build the doc, doing the various kinds of tests - unit, integration, memory & performance -, doing the various kinds of code checks - linting, typechecking -, doing some maintenance, updating the version, updating the served demo and documentation pages and so on...).

Here the idea is to just use a single script at the beginning, `npm run list`, which in two steps asks you:
  1. what you want to do (e.g. build a demo, run tests etc.)
  2. list all script variants to do just that and let you directly run that script.

Once a developper becomes familiar enough with the various scripts, he/she may start using them directly instead.