### PR TITLE
Fix setVideoBitrate and setAudioBitrate in seamless manualBitrateSwitchingMode

### DIFF
--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -323,6 +323,9 @@ function getEstimateReference(
       currentBufferBasedEstimate = bufferBasedChooser.getEstimate(observation);
       updateEstimate();
     };
+    innerCancellationSignal.register(() => {
+      onAddedSegment = noop;
+    });
 
     minAutoBitrate.onUpdate(updateEstimate, { clearSignal: innerCancellationSignal });
     maxAutoBitrate.onUpdate(updateEstimate, { clearSignal: innerCancellationSignal });


### PR DESCRIPTION
I just found out an issue that may be here for some time when calling `setVideoBitrate` and `setAudioBitrate` in `"seamless"` `manualBitrateSwitchingMode` (which sadly is the mode by default - though not the one by default in the demo page).

Calling it work for a time but after some time, we may still raise in quality if the buffer grows.
Turns out, the buffer-based algorithm still has an influence over the choice of Representation when a bitrate is forced manually because I forgot to cancel it (no risk of leak though - it only happen in this scenario).

I tried a first simple solution which is to just resetting the `onAddedSegment` callback to a noop function when we cancel the auto mode (such as when bitrate choice switches to manual), though this means that when bitrate choice is back to auto, the buffer-based algorithm will only provide a choice when the next segment is pushed, not right away.

This is not a huge issue, but I'm looking if we cannot fix this.