### PR TITLE
Improve global scope situation with util and lint update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -329,6 +329,10 @@ module.exports = {
     "no-restricted-properties": [
       "error",
       {
+        "object": "window",
+        "message": "`window` doesn't work in Node.JS and only works when JavaScript is running in the main thread. Please import `globalScope` instead.",
+      },
+      {
         "object": "Object",
         "property": "assign",
         "message": "Not available in IE11, use `objectAssign` utils instead.",

--- a/src/compat/__tests__/browser_compatibility_types.test.ts
+++ b/src/compat/__tests__/browser_compatibility_types.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../global_scope";
+
 // Needed for calling require (which itself is needed to mock properly) because
 // it is not type-checked:
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -30,123 +32,100 @@ describe("compat - browser compatibility types", () => {
     WebKitMediaSource? : unknown;
     MSMediaSource? : unknown;
   }
-  const win = window as IFakeWindow;
+  const gs = globalScope as IFakeWindow;
   beforeEach(() => {
     jest.resetModules();
-  });
-
-  it("should set the MediaSource to `undefined` when running nodejs", () => {
-    jest.mock("../is_node", () => ({ __esModule: true as const,
-                                     default: true }));
-
-    const origMediaSource = win.MediaSource;
-    const origMozMediaSource = win.MozMediaSource;
-    const origWebKitMediaSource = win.WebKitMediaSource;
-    const origMSMediaSource = win.MSMediaSource;
-
-    win.MediaSource = { a: 1 };
-    win.MozMediaSource = { a: 2 };
-    win.WebKitMediaSource = { a: 3 };
-    win.MSMediaSource = { a: 4 };
-
-    const { MediaSource_ } = jest.requireActual("../browser_compatibility_types");
-    expect(MediaSource_).toEqual(undefined);
-
-    win.MediaSource = origMediaSource;
-    win.MozMediaSource = origMozMediaSource;
-    win.WebKitMediaSource = origWebKitMediaSource;
-    win.MSMediaSource = origMSMediaSource;
   });
 
   it("should use the native MediaSource if defined", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = win.MediaSource;
-    const origMozMediaSource = win.MozMediaSource;
-    const origWebKitMediaSource = win.WebKitMediaSource;
-    const origMSMediaSource = win.MSMediaSource;
+    const origMediaSource = gs.MediaSource;
+    const origMozMediaSource = gs.MozMediaSource;
+    const origWebKitMediaSource = gs.WebKitMediaSource;
+    const origMSMediaSource = gs.MSMediaSource;
 
-    win.MediaSource = { a: 1 };
-    win.MozMediaSource = { a: 2 };
-    win.WebKitMediaSource = { a: 3 };
-    win.MSMediaSource = { a: 4 };
+    gs.MediaSource = { a: 1 };
+    gs.MozMediaSource = { a: 2 };
+    gs.WebKitMediaSource = { a: 3 };
+    gs.MSMediaSource = { a: 4 };
 
     const { MediaSource_ } = jest.requireActual("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 1 });
 
-    win.MediaSource = origMediaSource;
-    win.MozMediaSource = origMozMediaSource;
-    win.WebKitMediaSource = origWebKitMediaSource;
-    win.MSMediaSource = origMSMediaSource;
+    gs.MediaSource = origMediaSource;
+    gs.MozMediaSource = origMozMediaSource;
+    gs.WebKitMediaSource = origWebKitMediaSource;
+    gs.MSMediaSource = origMSMediaSource;
   });
 
   it("should use MozMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = win.MediaSource;
-    const origMozMediaSource = win.MozMediaSource;
-    const origWebKitMediaSource = win.WebKitMediaSource;
-    const origMSMediaSource = win.MSMediaSource;
+    const origMediaSource = gs.MediaSource;
+    const origMozMediaSource = gs.MozMediaSource;
+    const origWebKitMediaSource = gs.WebKitMediaSource;
+    const origMSMediaSource = gs.MSMediaSource;
 
-    win.MediaSource = undefined;
-    win.MozMediaSource = { a: 2 };
-    win.WebKitMediaSource = undefined;
-    win.MSMediaSource = undefined;
+    gs.MediaSource = undefined;
+    gs.MozMediaSource = { a: 2 };
+    gs.WebKitMediaSource = undefined;
+    gs.MSMediaSource = undefined;
 
     const { MediaSource_ } = jest.requireActual("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 2 });
 
-    win.MediaSource = origMediaSource;
-    win.MozMediaSource = origMozMediaSource;
-    win.WebKitMediaSource = origWebKitMediaSource;
-    win.MSMediaSource = origMSMediaSource;
+    gs.MediaSource = origMediaSource;
+    gs.MozMediaSource = origMozMediaSource;
+    gs.WebKitMediaSource = origWebKitMediaSource;
+    gs.MSMediaSource = origMSMediaSource;
   });
 
   it("should use WebKitMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = win.MediaSource;
-    const origMozMediaSource = win.MozMediaSource;
-    const origWebKitMediaSource = win.WebKitMediaSource;
-    const origMSMediaSource = win.MSMediaSource;
+    const origMediaSource = gs.MediaSource;
+    const origMozMediaSource = gs.MozMediaSource;
+    const origWebKitMediaSource = gs.WebKitMediaSource;
+    const origMSMediaSource = gs.MSMediaSource;
 
-    win.MediaSource = undefined;
-    win.MozMediaSource = undefined;
-    win.WebKitMediaSource = { a: 3 };
-    win.MSMediaSource = undefined;
+    gs.MediaSource = undefined;
+    gs.MozMediaSource = undefined;
+    gs.WebKitMediaSource = { a: 3 };
+    gs.MSMediaSource = undefined;
 
     const { MediaSource_ } = jest.requireActual("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 3 });
 
-    win.MediaSource = origMediaSource;
-    win.MozMediaSource = origMozMediaSource;
-    win.WebKitMediaSource = origWebKitMediaSource;
-    win.MSMediaSource = origMSMediaSource;
+    gs.MediaSource = origMediaSource;
+    gs.MozMediaSource = origMozMediaSource;
+    gs.WebKitMediaSource = origWebKitMediaSource;
+    gs.MSMediaSource = origMSMediaSource;
   });
 
   it("should use MSMediaSource if defined and MediaSource is not", () => {
     jest.mock("../is_node", () => ({ __esModule: true as const,
                                      default: false }));
 
-    const origMediaSource = win.MediaSource;
-    const origMozMediaSource = win.MozMediaSource;
-    const origWebKitMediaSource = win.WebKitMediaSource;
-    const origMSMediaSource = win.MSMediaSource;
+    const origMediaSource = gs.MediaSource;
+    const origMozMediaSource = gs.MozMediaSource;
+    const origWebKitMediaSource = gs.WebKitMediaSource;
+    const origMSMediaSource = gs.MSMediaSource;
 
-    win.MediaSource = undefined;
-    win.MozMediaSource = undefined;
-    win.WebKitMediaSource = undefined;
-    win.MSMediaSource = { a: 4 };
+    gs.MediaSource = undefined;
+    gs.MozMediaSource = undefined;
+    gs.WebKitMediaSource = undefined;
+    gs.MSMediaSource = { a: 4 };
 
     const { MediaSource_ } = jest.requireActual("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 4 });
 
-    win.MediaSource = origMediaSource;
-    win.MozMediaSource = origMozMediaSource;
-    win.WebKitMediaSource = origWebKitMediaSource;
-    win.MSMediaSource = origMSMediaSource;
+    gs.MediaSource = origMediaSource;
+    gs.MozMediaSource = origMozMediaSource;
+    gs.WebKitMediaSource = origWebKitMediaSource;
+    gs.MSMediaSource = origMSMediaSource;
   });
 });

--- a/src/compat/__tests__/is_vtt_cue.test.ts
+++ b/src/compat/__tests__/is_vtt_cue.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -35,20 +37,20 @@ describe("Compat - isVTTCue", () => {
       this.text = text;
     }
   }
-  const win = window as IFakeWindow;
+  const gs = globalScope as IFakeWindow;
 
   it("should return true if the given cue is an instance of a vtt cue", () => {
-    const originalVTTCue = window.VTTCue;
-    win.VTTCue = MockVTTCue;
+    const originalVTTCue = globalScope.VTTCue;
+    gs.VTTCue = MockVTTCue;
     const cue = new VTTCue(0, 10, "");
     const isVTTCue = jest.requireActual("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(true);
-    window.VTTCue = originalVTTCue;
+    globalScope.VTTCue = originalVTTCue;
   });
 
   it("should return false if the given cue is not an instance of a vtt cue", () => {
-    const originalVTTCue = window.VTTCue;
-    win.VTTCue = MockVTTCue;
+    const originalVTTCue = globalScope.VTTCue;
+    gs.VTTCue = MockVTTCue;
     const cue = {
       startTime: 0,
       endTime: 10,
@@ -56,16 +58,18 @@ describe("Compat - isVTTCue", () => {
     };
     const isVTTCue = jest.requireActual("../is_vtt_cue").default;
     expect(isVTTCue(cue)).toEqual(false);
-    window.VTTCue = originalVTTCue;
+    globalScope.VTTCue = originalVTTCue;
   });
 
-  it("should return false in any case if window does not define a VTTCue", () => {
-    const originalVTTCue = window.VTTCue;
-    win.VTTCue = MockVTTCue;
-    const cue = new VTTCue(0, 10, "");
-    delete win.VTTCue;
-    const isVTTCue = jest.requireActual("../is_vtt_cue").default;
-    expect(isVTTCue(cue)).toEqual(false);
-    window.VTTCue = originalVTTCue;
-  });
+  it(
+    "should return false in any case if the global scope does not define a VTTCue",
+    () => {
+      const originalVTTCue = globalScope.VTTCue;
+      gs.VTTCue = MockVTTCue;
+      const cue = new VTTCue(0, 10, "");
+      delete gs.VTTCue;
+      const isVTTCue = jest.requireActual("../is_vtt_cue").default;
+      expect(isVTTCue(cue)).toEqual(false);
+      globalScope.VTTCue = originalVTTCue;
+    });
 });

--- a/src/compat/__tests__/make_vtt_cue.test.ts
+++ b/src/compat/__tests__/make_vtt_cue.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -33,23 +35,23 @@ describe("Compat - makeVTTCue", () => {
     }
   }
 
-  const win = window as {
+  const gs = globalScope as {
     VTTCue? : unknown;
     TextTrackCue? : unknown;
   };
 
-  const ogVTTuCue = win.VTTCue;
-  const ogTextTrackCue = win.TextTrackCue;
+  const ogVTTuCue = gs.VTTCue;
+  const ogTextTrackCue = gs.TextTrackCue;
   beforeEach(() => {
     jest.resetModules();
-    win.VTTCue = ogVTTuCue;
-    win.TextTrackCue = ogTextTrackCue;
+    gs.VTTCue = ogVTTuCue;
+    gs.TextTrackCue = ogTextTrackCue;
   });
 
   it("should throw if nor VTTCue nor TextTrackCue is available", () => {
     const mockLog = { warn: jest.fn() };
-    win.VTTCue = undefined;
-    win.TextTrackCue = undefined;
+    gs.VTTCue = undefined;
+    gs.TextTrackCue = undefined;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: mockLog,
@@ -70,7 +72,7 @@ describe("Compat - makeVTTCue", () => {
 
   it("should warn and not create anything if start time is after end time", () => {
     const mockLog = { warn: jest.fn() };
-    win.VTTCue = MockVTTCue;
+    gs.VTTCue = MockVTTCue;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: mockLog,
@@ -84,7 +86,7 @@ describe("Compat - makeVTTCue", () => {
 
   it("should create a new VTT Cue in other cases", () => {
     const mockLog = { warn: jest.fn() };
-    win.VTTCue = MockVTTCue;
+    gs.VTTCue = MockVTTCue;
     jest.mock("../../log", () => ({
       __esModule: true as const,
       default: mockLog,

--- a/src/compat/__tests__/patch_webkit_source_buffer.test.ts
+++ b/src/compat/__tests__/patch_webkit_source_buffer.test.ts
@@ -22,35 +22,36 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import EventEmitter from "../../utils/event_emitter";
+import globalScope from "../global_scope";
 import patchWebkitSourceBuffer from "../patch_webkit_source_buffer";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const win = window as any;
+const gs = globalScope as any;
 
 describe("compat - parseWebkitSourceBuffer", () => {
   it("should do nothing if no WebkitSourceBuffer", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
-    win.WebKitSourceBuffer = undefined;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
+    gs.WebKitSourceBuffer = undefined;
     patchWebkitSourceBuffer();
-    expect(win.WebKitSourceBuffer).toBe(undefined);
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    expect(gs.WebKitSourceBuffer).toBe(undefined);
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
   });
 
   it("should do nothing if has WebkitSourceBuffer with addEventListener", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
     const mockWebKitSourceBuffer = {
       prototype: {
         addEventListener: () => null,
       },
     };
-    win.WebKitSourceBuffer = mockWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = mockWebKitSourceBuffer;
     patchWebkitSourceBuffer();
-    expect(win.WebKitSourceBuffer).toEqual(mockWebKitSourceBuffer);
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    expect(gs.WebKitSourceBuffer).toEqual(mockWebKitSourceBuffer);
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
   });
 
   it("should assign EventEmitter funcs to WebKitSourceBuffer", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
     const mockWebKitSourceBuffer = {
       prototype: {},
     };
@@ -65,29 +66,29 @@ describe("compat - parseWebkitSourceBuffer", () => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (EventEmitter as any) = mockEventEmitter;
-    win.WebKitSourceBuffer = mockWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = mockWebKitSourceBuffer;
     patchWebkitSourceBuffer();
-    const protoWebkitSourceBuffer = win.WebKitSourceBuffer.prototype;
+    const protoWebkitSourceBuffer = gs.WebKitSourceBuffer.prototype;
     expect(protoWebkitSourceBuffer.test1).not.toBeUndefined();
     expect(protoWebkitSourceBuffer.test2).not.toBeUndefined();
     expect(protoWebkitSourceBuffer.addEventListener).not.toBeUndefined();
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (EventEmitter as any) = origEventEmitter;
   });
 
   it("(appendBuffer) should update buffer", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
     const mockWebKitSourceBuffer = { prototype: {} };
 
     const mockTrigger = jest.fn(() => ({}));
     const _mockEmitUpdate = jest.fn(() => ({}));
     const mockAppend = jest.fn(() => ({}));
 
-    win.WebKitSourceBuffer = mockWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = mockWebKitSourceBuffer;
     patchWebkitSourceBuffer();
 
-    win.WebKitSourceBuffer.prototype.appendBuffer.call(
+    gs.WebKitSourceBuffer.prototype.appendBuffer.call(
       {
         updating: false,
         trigger: mockTrigger,
@@ -100,20 +101,20 @@ describe("compat - parseWebkitSourceBuffer", () => {
     expect(mockTrigger).toHaveBeenCalledWith("updatestart");
     expect(_mockEmitUpdate).toHaveBeenCalledTimes(1);
     expect(_mockEmitUpdate).toHaveBeenCalledWith("update");
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
   });
 
   it("(appendBuffer) should fail to update buffer if no append function", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
     const mockWebKitSourceBuffer = { prototype: {} };
 
     const mockTrigger = jest.fn(() => ({}));
     const _mockEmitUpdate = jest.fn(() => ({}));
 
-    win.WebKitSourceBuffer = mockWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = mockWebKitSourceBuffer;
     patchWebkitSourceBuffer();
 
-    win.WebKitSourceBuffer.prototype.appendBuffer.call(
+    gs.WebKitSourceBuffer.prototype.appendBuffer.call(
       {
         updating: false,
         trigger: mockTrigger,
@@ -127,18 +128,18 @@ describe("compat - parseWebkitSourceBuffer", () => {
 
     const err = new TypeError("this.append is not a function");
     expect(_mockEmitUpdate).toHaveBeenCalledWith("error", err);
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
   });
 
   it("(appendBuffer) should fail to update buffer if updating", () => {
-    const origWebKitSourceBuffer = win.WebKitSourceBuffer;
+    const origWebKitSourceBuffer = gs.WebKitSourceBuffer;
     const mockWebKitSourceBuffer = { prototype: {} };
-    win.WebKitSourceBuffer = mockWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = mockWebKitSourceBuffer;
     patchWebkitSourceBuffer();
 
-    expect(() => win.WebKitSourceBuffer.prototype.appendBuffer.call(
+    expect(() => gs.WebKitSourceBuffer.prototype.appendBuffer.call(
       { updating: true }
     )).toThrowError("updating");
-    win.WebKitSourceBuffer = origWebKitSourceBuffer;
+    gs.WebKitSourceBuffer = origWebKitSourceBuffer;
   });
 });

--- a/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
+++ b/src/compat/__tests__/should_favour_custom_safari_EME.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -22,19 +24,19 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
 describe("compat - shouldFavourSafariMediaKeys", () => {
-  const win = window as unknown as Window & {
+  const gs = globalScope as unknown as typeof globalThis & {
     WebKitMediaKeys? : unknown;
     HTMLMediaElement : typeof HTMLMediaElement;
   };
 
-  const originalWebKitMediaKeys = win.WebKitMediaKeys;
+  const originalWebKitMediaKeys = gs.WebKitMediaKeys;
 
   beforeEach(() => {
     jest.resetModules();
   });
 
   afterEach(() => {
-    win.WebKitMediaKeys = originalWebKitMediaKeys;
+    gs.WebKitMediaKeys = originalWebKitMediaKeys;
   });
 
   it("should return false if we are not on Safari", () => {
@@ -52,7 +54,7 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return false if we are on Safari Desktop but WekitMediaKeys is not available", () => {
   /* eslint-enable max-len */
 
-    win.WebKitMediaKeys = undefined;
+    gs.WebKitMediaKeys = undefined;
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isSafariDesktop: true,
@@ -67,7 +69,7 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return false if we are on Safari Mobile but WekitMediaKeys is not available", () => {
   /* eslint-enable max-len */
 
-    win.WebKitMediaKeys = undefined;
+    gs.WebKitMediaKeys = undefined;
     jest.mock("../browser_detection", () => {
       return { __esModule: true as const,
                isSafariDesktop: false,
@@ -82,13 +84,13 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return true if we are on Safari Desktop and a WebKitMediaKeys implementation is available", () => {
   /* eslint-enable max-len */
 
-    win.WebKitMediaKeys = {
+    gs.WebKitMediaKeys = {
       isTypeSupported: () => ({}),
       prototype: {
         createSession: () => ({}),
       },
     };
-    const proto = win.HTMLMediaElement.prototype as unknown as {
+    const proto = gs.HTMLMediaElement.prototype as unknown as {
       webkitSetMediaKeys : () => Record<string, never>;
     };
     proto.webkitSetMediaKeys = () => ({});
@@ -106,13 +108,13 @@ describe("compat - shouldFavourSafariMediaKeys", () => {
   it("should return true if we are on Safari Mobile and a WebKitMediaKeys implementation is available", () => {
   /* eslint-enable max-len */
 
-    win.WebKitMediaKeys = {
+    gs.WebKitMediaKeys = {
       isTypeSupported: () => ({}),
       prototype: {
         createSession: () => ({}),
       },
     };
-    const proto = win.HTMLMediaElement.prototype as unknown as {
+    const proto = gs.HTMLMediaElement.prototype as unknown as {
       webkitSetMediaKeys : () => Record<string, never>;
     };
     proto.webkitSetMediaKeys = () => ({});

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -15,7 +15,7 @@
  */
 
 import isNullOrUndefined from "../utils/is_null_or_undefined";
-import isNode from "./is_node";
+import globalScope from "./global_scope";
 
 /** Regular MediaKeys type + optional functions present in IE11. */
 interface ICompatMediaKeysConstructor {
@@ -164,23 +164,16 @@ export interface ICompatPictureInPictureWindow
   extends EventTarget { width: number;
                         height: number; }
 
-interface WindowsWithMediaSourceImplems extends Window {
-  MediaSource? : typeof MediaSource;
-  MozMediaSource? : typeof MediaSource;
-  WebKitMediaSource? : typeof MediaSource;
-  MSMediaSource? : typeof MediaSource;
-}
-
-const win : WindowsWithMediaSourceImplems | undefined = isNode ? undefined :
-                                                                 window;
-
+/* eslint-disable */
 /** MediaSource implementation, including vendored implementations. */
+const gs = globalScope as any;
 const MediaSource_ : typeof MediaSource | undefined =
-  win === undefined                            ? undefined :
-  !isNullOrUndefined(win.MediaSource)          ? win.MediaSource :
-  !isNullOrUndefined(win.MozMediaSource)       ? win.MozMediaSource :
-  !isNullOrUndefined(win.WebKitMediaSource)    ? win.WebKitMediaSource :
-                                                 win.MSMediaSource;
+  gs === undefined                            ? undefined :
+  !isNullOrUndefined(gs.MediaSource)          ? gs.MediaSource :
+  !isNullOrUndefined(gs.MozMediaSource)       ? gs.MozMediaSource :
+  !isNullOrUndefined(gs.WebKitMediaSource)    ? gs.WebKitMediaSource :
+                                                gs.MSMediaSource;
+/* eslint-enable */
 
 /** List an HTMLMediaElement's possible values for its readyState property. */
 const READY_STATES = { HAVE_NOTHING: 0,

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
+import globalScope from "./global_scope";
 import isNode from "./is_node";
 
-interface IIE11WindowObject extends Window {
+type GlobalScope = typeof globalScope;
+
+interface IIE11WindowObject extends GlobalScope {
   MSInputMethodContext? : unknown;
 }
 
 interface IIE11Document extends Document {
   documentMode? : unknown;
+}
+
+interface ISafariWindowObject extends GlobalScope {
+  safari? : { pushNotification? : { toString() : string } };
 }
 
 /** Edge Chromium, regardless of the device */
@@ -70,7 +77,7 @@ let isPlayStation5 = false;
 
   // 1 - Find out browser between IE/Edge Legacy/Edge Chromium/Firefox/Safari
 
-  if (typeof (window as IIE11WindowObject).MSInputMethodContext !== "undefined" &&
+  if (typeof (globalScope as IIE11WindowObject).MSInputMethodContext !== "undefined" &&
       typeof (document as IIE11Document).documentMode !== "undefined")
   {
     isIE11 = true;
@@ -90,8 +97,8 @@ let isPlayStation5 = false;
   {
     isSafariMobile = true;
   } else if (
-    Object.prototype.toString.call(window.HTMLElement).indexOf("Constructor") >= 0 ||
-    (window as ISafariWindowObject).safari?.pushNotification?.toString() ===
+    Object.prototype.toString.call(globalScope.HTMLElement).indexOf("Constructor") >= 0 ||
+    (globalScope as ISafariWindowObject).safari?.pushNotification?.toString() ===
       "[object SafariRemoteNotification]"
   ) {
     isSafariDesktop = true;
@@ -130,10 +137,6 @@ let isPlayStation5 = false;
     isPanasonic = true;
   }
 })());
-
-interface ISafariWindowObject extends Window {
-  safari? : { pushNotification? : { toString() : string } };
-}
 
 export {
   isEdgeChromium,

--- a/src/compat/eme/custom_media_keys/moz_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/moz_media_keys_constructor.ts
@@ -16,7 +16,7 @@
 
 import wrapInPromise from "../../../utils/wrapInPromise";
 import { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
-import isNode from "../../is_node";
+import globalScope from "../../global_scope";
 import { ICustomMediaKeys } from "./types";
 
 interface IMozMediaKeysConstructor {
@@ -25,20 +25,18 @@ interface IMozMediaKeysConstructor {
 }
 
 let MozMediaKeysConstructor: IMozMediaKeysConstructor|undefined;
-if (!isNode) {
-  const { MozMediaKeys } = (window as Window & {
-    MozMediaKeys? : IMozMediaKeysConstructor;
-  });
-  if (
-    MozMediaKeys !== undefined &&
-    MozMediaKeys.prototype !== undefined &&
-    typeof MozMediaKeys.isTypeSupported === "function" &&
-    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    typeof MozMediaKeys.prototype.createSession === "function"
-    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  ) {
-    MozMediaKeysConstructor = MozMediaKeys;
-  }
+const { MozMediaKeys } = (globalScope as typeof globalThis & {
+  MozMediaKeys? : IMozMediaKeysConstructor;
+});
+if (
+  MozMediaKeys !== undefined &&
+  MozMediaKeys.prototype !== undefined &&
+  typeof MozMediaKeys.isTypeSupported === "function" &&
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  typeof MozMediaKeys.prototype.createSession === "function"
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+) {
+  MozMediaKeysConstructor = MozMediaKeys;
 }
 export { MozMediaKeysConstructor };
 

--- a/src/compat/eme/custom_media_keys/ms_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/ms_media_keys_constructor.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import isNode from "../../is_node";
+import globalScope from "../../global_scope";
 
 export interface MSMediaKeyError {
     readonly code: number;
@@ -51,19 +51,17 @@ interface IMSMediaKeysConstructor {
 }
 
 let MSMediaKeysConstructor: IMSMediaKeysConstructor|undefined;
-if (!isNode) {
-  const { MSMediaKeys } = (window as Window & {
-    MSMediaKeys? : IMSMediaKeysConstructor;
-  });
-  if (
-    MSMediaKeys !== undefined &&
-    MSMediaKeys.prototype !== undefined &&
-    typeof MSMediaKeys.isTypeSupported === "function" &&
-    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    typeof MSMediaKeys.prototype.createSession === "function"
-    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  ) {
-    MSMediaKeysConstructor = MSMediaKeys;
-  }
+const { MSMediaKeys } = (globalScope as typeof globalThis & {
+  MSMediaKeys? : IMSMediaKeysConstructor;
+});
+if (
+  MSMediaKeys !== undefined &&
+  MSMediaKeys.prototype !== undefined &&
+  typeof MSMediaKeys.isTypeSupported === "function" &&
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  typeof MSMediaKeys.prototype.createSession === "function"
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+) {
+  MSMediaKeysConstructor = MSMediaKeys;
 }
 export { MSMediaKeysConstructor };

--- a/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
@@ -15,7 +15,7 @@
  */
 
 import { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
-import isNode from "../../is_node";
+import globalScope from "../../global_scope";
 
 type IWebKitMediaKeys = unknown;
 
@@ -26,23 +26,21 @@ interface IWebKitMediaKeysConstructor {
 
 let WebKitMediaKeysConstructor: undefined|IWebKitMediaKeysConstructor;
 
-if (!isNode) {
-  /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  const { WebKitMediaKeys } = (window as Window & {
-    WebKitMediaKeys? : IWebKitMediaKeysConstructor;
-  });
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+const { WebKitMediaKeys } = (globalScope as typeof globalThis & {
+  WebKitMediaKeys? : IWebKitMediaKeysConstructor;
+});
 
-  if (WebKitMediaKeys !== undefined &&
-      typeof WebKitMediaKeys.isTypeSupported === "function" &&
-      typeof WebKitMediaKeys.prototype.createSession === "function" &&
-      typeof (HTMLMediaElement.prototype as ICompatHTMLMediaElement)
-        .webkitSetMediaKeys === "function") {
-    WebKitMediaKeysConstructor = WebKitMediaKeys;
-  }
-  /* eslint-enable @typescript-eslint/no-unsafe-assignment */
-  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+if (WebKitMediaKeys !== undefined &&
+    typeof WebKitMediaKeys.isTypeSupported === "function" &&
+    typeof WebKitMediaKeys.prototype.createSession === "function" &&
+    typeof (HTMLMediaElement.prototype as ICompatHTMLMediaElement)
+      .webkitSetMediaKeys === "function") {
+  WebKitMediaKeysConstructor = WebKitMediaKeys;
 }
+/* eslint-enable @typescript-eslint/no-unsafe-assignment */
+/* eslint-enable @typescript-eslint/no-unsafe-member-access */
 
 export {
   WebKitMediaKeysConstructor,

--- a/src/compat/eme/eme-api-implementation.ts
+++ b/src/compat/eme/eme-api-implementation.ts
@@ -5,6 +5,7 @@ import { CancellationSignal } from "../../utils/task_canceller";
 import { ICompatHTMLMediaElement } from "../browser_compatibility_types";
 import { isIE11 } from "../browser_detection";
 import { createCompatibleEventListener, IEventTargetLike } from "../event_listeners";
+import globalScope from "../global_scope";
 import isNode from "../is_node";
 import shouldFavourCustomSafariEME from "../should_favour_custom_safari_EME";
 import CustomMediaKeySystemAccess from "./custom_key_system_access";
@@ -188,7 +189,7 @@ function getEmeApiImplementation(
         implementation = "moz";
       } else {
         onEncrypted = createCompatibleEventListener(["encrypted", "needkey"]);
-        const MK = window.MediaKeys as unknown as typeof MediaKeys & {
+        const MK = globalScope.MediaKeys as unknown as typeof MediaKeys & {
           isTypeSupported? : (keyType : string) => boolean;
           new(keyType? : string) : ICustomMediaKeys;
         };

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -29,6 +29,7 @@ import {
   ICompatHTMLMediaElement,
   ICompatPictureInPictureWindow,
 } from "./browser_compatibility_types";
+import globalScope from "./global_scope";
 
 const BROWSER_PREFIXES = ["", "webkit", "moz", "ms"];
 
@@ -124,7 +125,7 @@ function createCompatibleEventListener(
 
     // if the element is a HTMLElement we can detect
     // the supported event, and memoize it in `mem`
-    if (element instanceof HTMLElement) {
+    if (typeof HTMLElement !== "undefined" && element instanceof HTMLElement) {
       if (typeof mem === "undefined") {
         mem = findSupportedEvent(element, prefixedEvents);
       }
@@ -286,7 +287,7 @@ function getVideoVisibilityRef(
   stopListening : CancellationSignal
 ) : IReadOnlySharedReference<boolean> {
   const isDocVisibleRef = getDocumentVisibilityRef(stopListening);
-  let currentTimeout : number | undefined;
+  let currentTimeout : number | NodeJS.Timeout | undefined;
   const ref = createSharedReference(true, stopListening);
   stopListening.register(() => {
     clearTimeout(currentTimeout);
@@ -307,7 +308,7 @@ function getVideoVisibilityRef(
       ref.setValueIfChanged(true);
     } else {
       const { INACTIVITY_DELAY } = config.getCurrent();
-      currentTimeout = window.setTimeout(() => {
+      currentTimeout = setTimeout(() => {
         ref.setValueIfChanged(false);
       }, INACTIVITY_DELAY);
     }
@@ -324,18 +325,18 @@ function getScreenResolutionRef(
 ) : IReadOnlySharedReference<{ width : number | undefined;
                                height : number | undefined;
                                pixelRatio : number; }> {
-  const pixelRatio = window.devicePixelRatio == null ||
-                     window.devicePixelRatio === 0 ? 1 :
-                                                     window.devicePixelRatio;
+  const pixelRatio = globalScope.devicePixelRatio == null ||
+                     globalScope.devicePixelRatio === 0 ? 1 :
+                                                          globalScope.devicePixelRatio;
   const ref = createSharedReference<{
     width : number | undefined;
     height : number | undefined;
     pixelRatio : number;
-  }>({ width: window.screen.width,
-       height: window.screen.height,
+  }>({ width: globalScope.screen?.width,
+       height: globalScope.screen?.height,
        pixelRatio },
      stopListening);
-  const interval = window.setInterval(checkScreenResolution, 20000);
+  const interval = setInterval(checkScreenResolution, 20000);
   stopListening.register(function stopUpdating() {
     clearInterval(interval);
   });
@@ -369,9 +370,9 @@ function getElementResolutionRef(
                                height : number | undefined;
                                pixelRatio : number; }> {
 
-  const pixelRatio = window.devicePixelRatio == null ||
-                     window.devicePixelRatio === 0 ? 1 :
-                                                     window.devicePixelRatio;
+  const pixelRatio = globalScope.devicePixelRatio == null ||
+                     globalScope.devicePixelRatio === 0 ? 1 :
+                                                          globalScope.devicePixelRatio;
   const ref = createSharedReference<{
     width : number | undefined;
     height : number | undefined;
@@ -382,7 +383,7 @@ function getElementResolutionRef(
      stopListening);
   let clearPreviousEventListener = noop;
   pipStatusRef.onUpdate(checkElementResolution, { clearSignal: stopListening });
-  addEventListener(window, "resize", checkElementResolution, stopListening);
+  addEventListener(globalScope, "resize", checkElementResolution, stopListening);
   addEventListener(mediaElement,
                    "enterpictureinpicture",
                    checkElementResolution,
@@ -391,7 +392,7 @@ function getElementResolutionRef(
                    "leavepictureinpicture",
                    checkElementResolution,
                    stopListening);
-  const interval = window.setInterval(checkElementResolution, 20000);
+  const interval = setInterval(checkElementResolution, 20000);
 
   checkElementResolution();
 

--- a/src/compat/global_scope.ts
+++ b/src/compat/global_scope.ts
@@ -1,0 +1,16 @@
+import isNode from "./is_node";
+import isWorker from "./is_worker";
+
+/**
+ * The current environment's global object, written in such a way to maximize
+ * compatibility.
+ *
+ * Though the RxPlayer should theoretically not be runnable in NodeJS, we still
+ * had to support it for some applications implementing server-side rendering.
+ */
+const globalScope : typeof globalThis =
+  isWorker ? self :
+  isNode   ? global :
+             window;
+
+export default globalScope;

--- a/src/compat/is_node.ts
+++ b/src/compat/is_node.ts
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 
-const isNode = typeof window === "undefined";
+import isWorker from "./is_worker";
+
+/** `true` if we're currently in a Node.JS environment. */
+const isNode = typeof window === "undefined" && !isWorker;
 export default isNode;

--- a/src/compat/is_vtt_cue.ts
+++ b/src/compat/is_vtt_cue.ts
@@ -15,6 +15,7 @@
  */
 
 import { ICompatVTTCue } from "./browser_compatibility_types";
+import globalScope from "./global_scope";
 
 /**
  * Returns true if the given cue is an instance of a VTTCue.
@@ -25,6 +26,6 @@ export default function isVTTCue(
   cue : ICompatVTTCue|TextTrackCue
 ) : cue is ICompatVTTCue {
   /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-  return typeof window.VTTCue === "function" && cue instanceof window.VTTCue;
+  return typeof globalScope.VTTCue === "function" && cue instanceof globalScope.VTTCue;
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }

--- a/src/compat/is_worker.ts
+++ b/src/compat/is_worker.ts
@@ -1,0 +1,9 @@
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+declare const WorkerGlobalScope : any | undefined;
+
+/**
+ * `true` if the current code is running in a WebWorker.
+ */
+export default  typeof WorkerGlobalScope !== "undefined" &&
+  self instanceof WorkerGlobalScope;
+

--- a/src/compat/make_vtt_cue.ts
+++ b/src/compat/make_vtt_cue.ts
@@ -17,6 +17,7 @@
 import log from "../log";
 import isNullOrUndefined from "../utils/is_null_or_undefined";
 import { ICompatVTTCue } from "./browser_compatibility_types";
+import globalScope from "./global_scope";
 
 /**
  * Creates a cue using the best platform-specific interface available.
@@ -40,8 +41,8 @@ export default function makeCue(
     return null;
   }
 
-  if (isNullOrUndefined(window.VTTCue)) {
-    if (isNullOrUndefined(window.TextTrackCue)) {
+  if (isNullOrUndefined(globalScope.VTTCue)) {
+    if (isNullOrUndefined(globalScope.TextTrackCue)) {
       throw new Error("VTT cues not supported in your target");
     }
     return new (TextTrackCue as unknown as typeof VTTCue)(startTime, endTime, payload);

--- a/src/compat/on_height_width_change.ts
+++ b/src/compat/on_height_width_change.ts
@@ -19,7 +19,7 @@ import createSharedReference, {
   IReadOnlySharedReference,
 } from "../utils/reference";
 import { CancellationSignal } from "../utils/task_canceller";
-import isNode from "./is_node";
+import globalScope from "./global_scope";
 
 export interface IResolution { width : number;
                                height : number; }
@@ -49,13 +49,8 @@ interface IDOMRectReadOnly { readonly x: number;
                              readonly bottom: number;
                              readonly left: number; }
 
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 const _ResizeObserver : IResizeObserverConstructor |
-                        undefined = isNode ? undefined :
-                                             window.ResizeObserver;
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */
+                        undefined = globalScope.ResizeObserver;
 
 /**
  * Emit the current height and width of the given `element` each time it

--- a/src/compat/patch_webkit_source_buffer.ts
+++ b/src/compat/patch_webkit_source_buffer.ts
@@ -16,6 +16,7 @@
 
 import nextTick from "next-tick";
 import EventEmitter from "../utils/event_emitter";
+import globalScope from "./global_scope";
 import isNode from "./is_node";
 
 type IWebKitSourceBufferConstructor = new() => IWebKitSourceBuffer;
@@ -32,14 +33,14 @@ export default function patchWebkitSourceBuffer() : void {
   // old WebKit SourceBuffer implementation,
   // where a synchronous append is used instead of appendBuffer
   if (
-    !isNode && (window as any).WebKitSourceBuffer != null &&
-    (window as any).WebKitSourceBuffer.prototype.addEventListener === undefined)
+    !isNode && (globalScope as any).WebKitSourceBuffer != null &&
+    (globalScope as any).WebKitSourceBuffer.prototype.addEventListener === undefined)
   {
   /* eslint-enable @typescript-eslint/no-explicit-any */
 
     /* eslint-disable @typescript-eslint/no-unsafe-assignment */
     const sourceBufferWebkitRef : IWebKitSourceBufferConstructor =
-      (window as unknown as {
+      (globalScope as unknown as {
         WebKitSourceBuffer : IWebKitSourceBufferConstructor;
       }).WebKitSourceBuffer;
     const sourceBufferWebkitProto = sourceBufferWebkitRef.prototype;

--- a/src/core/fetchers/cdn_prioritizer.ts
+++ b/src/core/fetchers/cdn_prioritizer.ts
@@ -56,7 +56,7 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
      * `metadata` array which is used considerably more than the `timeouts`
      * array.
      */
-    timeouts : number[];
+    timeouts : Array<number | NodeJS.Timeout>;
   };
 
   /**
@@ -121,7 +121,7 @@ export default class CdnPrioritizer extends EventEmitter<ICdnPrioritizerEvents> 
     const { DEFAULT_CDN_DOWNGRADE_TIME } = config.getCurrent();
     const downgradeTime = DEFAULT_CDN_DOWNGRADE_TIME;
     this._downgradedCdnList.metadata.push(metadata);
-    const timeout = window.setTimeout(() => {
+    const timeout = setTimeout(() => {
       const newIndex = indexOfMetadata(this._downgradedCdnList.metadata, metadata);
       if (newIndex >= 0) {
         this._removeIndexFromDowngradeList(newIndex);

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
@@ -23,29 +23,30 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 
+import globalScope from "../../../../../compat/global_scope";
 import { ProberStatus } from "../../types";
 
 describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
   it("should throw if matchMedia is undefined", () => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
-    (window as any).matchMedia = undefined;
+    (globalScope as any).matchMedia = undefined;
     const probeMediaDisplayInfos =
       jest.requireActual("../../probers/mediaDisplayInfos").default;
     /* eslint-disable @typescript-eslint/no-floating-promises */
     expect(probeMediaDisplayInfos({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: matchMedia not available");
     /* eslint-enable @typescript-eslint/no-floating-promises */
-    (window as any).matchMedia  = origWindowMatchMedia;
+    (globalScope as any).matchMedia  = origMatchMedia;
   });
 
   it("should throw if no colorSpace in display configuration", (done) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
     const mockMatchMedia = jest.fn(() => true);
-    (window as any).matchMedia = mockMatchMedia;
+    (globalScope as any).matchMedia = mockMatchMedia;
     const config = {
       display: {},
     };
@@ -56,23 +57,23 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
     expect.assertions(1);
     probeMediaDisplayInfos(config)
       .then(() => {
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       })
       .catch(({ message }: { message: string }) => {
         expect(message).toBe("MediaCapabilitiesProber >>> API_CALL: " +
           "Not enough arguments for calling matchMedia.");
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       });
   });
 
   it("should throw if no display in configuration", (done) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
     const mockMatchMedia = jest.fn(() => true);
-    (window as any).matchMedia = mockMatchMedia;
+    (globalScope as any).matchMedia = mockMatchMedia;
     const config = {};
 
     const probeMediaDisplayInfos =
@@ -81,25 +82,25 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
     expect.assertions(1);
     probeMediaDisplayInfos(config)
       .then(() => {
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       })
       .catch(({ message }: { message: string }) => {
         expect(message).toBe("MediaCapabilitiesProber >>> API_CALL: " +
           "Not enough arguments for calling matchMedia.");
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       });
   });
 
   it("should throw if mediaMatch called with bad arguments", (done) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
     const mockMatchMedia = jest.fn(() => ({
       media: "not all",
     }));
-    (window as any).matchMedia = mockMatchMedia;
+    (globalScope as any).matchMedia = mockMatchMedia;
     const config = {
       display: {
         colorSpace: "srgb",
@@ -112,26 +113,26 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
     expect.assertions(2);
     probeMediaDisplayInfos(config)
       .then(() => {
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       })
       .catch(({ message }: { message: string }) => {
         expect(message).toBe("MediaCapabilitiesProber >>> API_CALL: " +
           "Bad arguments for calling matchMedia.");
         expect(mockMatchMedia).toHaveBeenCalledTimes(1);
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       });
   });
 
   it("should resolves with `Supported` if color space is supported", (done) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
     const mockMatchMedia = jest.fn(() => ({
       matches: true,
     }));
-    (window as any).matchMedia = mockMatchMedia;
+    (globalScope as any).matchMedia = mockMatchMedia;
     const config = {
       display: {
         colorSpace: "srgb",
@@ -146,23 +147,23 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
       .then(([res]: [any]) => {
         expect(res).toEqual(ProberStatus.Supported);
         expect(mockMatchMedia).toHaveBeenCalledTimes(1);
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       })
       .catch(() => {
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       });
   });
 
   it("should resolves with `NotSupported` if color space is not supported", (done) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    const origWindowMatchMedia = window.matchMedia;
+    const origMatchMedia = globalScope.matchMedia;
     /* eslint-enable @typescript-eslint/unbound-method */
     const mockMatchMedia = jest.fn(() => ({
       matches: false,
     }));
-    (window as any).matchMedia = mockMatchMedia;
+    (globalScope as any).matchMedia = mockMatchMedia;
     const config = {
       display: {
         colorSpace: "p5",
@@ -177,11 +178,11 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
       .then(([res]: [any]) => {
         expect(res).toEqual(ProberStatus.NotSupported);
         expect(mockMatchMedia).toHaveBeenCalledTimes(1);
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       })
       .catch(() => {
-        (window as any).matchMedia = origWindowMatchMedia;
+        (globalScope as any).matchMedia = origMatchMedia;
         done();
       });
   });

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/mediaContentTypeWithFeatures/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/mediaContentTypeWithFeatures/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import globalScope from "../../../../../compat/global_scope";
 import {
   IMediaConfiguration,
   ProberStatus,
@@ -33,13 +34,13 @@ export type ISupportWithFeatures = ""|"Maybe"|"Not Supported"|"Probably";
  */
 function isTypeSupportedWithFeaturesAPIAvailable(): Promise<void> {
   return new Promise((resolve) => {
-    if (!("MSMediaKeys" in window)) {
+    if (!("MSMediaKeys" in globalScope)) {
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "MSMediaKeys API not available");
     }
     /* eslint-disable @typescript-eslint/no-explicit-any */
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-    if (!("isTypeSupportedWithFeatures" in (window as any).MSMediaKeys)) {
+    if (!("isTypeSupportedWithFeatures" in (globalScope as any).MSMediaKeys)) {
     /* eslint-enable @typescript-eslint/no-explicit-any */
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
@@ -76,7 +77,7 @@ export default function probeTypeWithFeatures(
     /* eslint-disable @typescript-eslint/no-unsafe-call */
     /* eslint-disable @typescript-eslint/no-explicit-any */
     const result: ISupportWithFeatures =
-      (window as any).MSMediaKeys.isTypeSupportedWithFeatures(type, features);
+      (globalScope as any).MSMediaKeys.isTypeSupportedWithFeatures(type, features);
     /* eslint-enable @typescript-eslint/no-explicit-any */
     /* eslint-enable @typescript-eslint/no-unsafe-assignment */
     /* eslint-enable @typescript-eslint/no-unsafe-member-access */

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/mediaDisplayInfos.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/mediaDisplayInfos.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import globalScope from "../../../../compat/global_scope";
 import {
   IMediaConfiguration,
   ProberStatus,
@@ -28,7 +29,7 @@ export default function probeMatchMedia(
 ): Promise<[ProberStatus]> {
   return new Promise((resolve) => {
     /* eslint-disable @typescript-eslint/unbound-method */
-    if (typeof window.matchMedia !== "function") {
+    if (typeof globalScope.matchMedia !== "function") {
     /* eslint-enable @typescript-eslint/unbound-method */
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "matchMedia not available");
@@ -40,7 +41,7 @@ export default function probeMatchMedia(
         "Not enough arguments for calling matchMedia.");
     }
 
-    const match = window.matchMedia(`(color-gamut: ${config.display.colorSpace})`);
+    const match = globalScope.matchMedia(`(color-gamut: ${config.display.colorSpace})`);
     if (match.media === "not all") {
       throw new Error("MediaCapabilitiesProber >>> API_CALL: " +
         "Bad arguments for calling matchMedia.");

--- a/src/features/__tests__/initialize_features.test.ts
+++ b/src/features/__tests__/initialize_features.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../../compat/global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -28,13 +30,13 @@ describe("Features - initializeFeaturesObject", () => {
   });
 
   /* eslint-disable @typescript-eslint/naming-convention */
-  const win = window as unknown as {
+  const gs = globalScope as unknown as {
     __FEATURES__: unknown;
   };
   /* eslint-enable @typescript-eslint/naming-convention */
 
   it("should set no feature if nothing is enabled", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -60,11 +62,11 @@ describe("Features - initializeFeaturesObject", () => {
     const initializeFeaturesObject = jest.requireActual("../initialize_features").default;
     initializeFeaturesObject();
     expect<unknown>(feat).toEqual({});
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should set the right features when everything is enabled", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -136,11 +138,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the html text buffer if the html vtt parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -178,11 +180,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the html text buffer if the html sami parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -220,11 +222,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the html text buffer if the html ttml parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -262,11 +264,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the html text buffer if the html srt parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -304,11 +306,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the native text buffer if the native vtt parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -346,11 +348,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the native text buffer if the native sami parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -388,11 +390,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the native text buffer if the native ttml parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -430,11 +432,11 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 
   it("should add the native text buffer if the native srt parser is added", () => {
-    win.__FEATURES__ = {
+    gs.__FEATURES__ = {
       IS_DISABLED: 0,
       IS_ENABLED: 1,
 
@@ -472,6 +474,6 @@ describe("Features - initializeFeaturesObject", () => {
       },
     });
 
-    delete win.__FEATURES__;
+    delete gs.__FEATURES__;
   });
 });

--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import globalScope from "../../../../../compat/global_scope";
 import log from "../../../../../log";
 import assertUnreachable from "../../../../../utils/assert_unreachable";
 import noop from "../../../../../utils/noop";
@@ -318,7 +319,7 @@ export default class DashWasmParser {
   public isCompatible() : boolean {
     return typeof WebAssembly === "object" &&
            typeof WebAssembly.instantiate === "function" &&
-           typeof window.TextDecoder === "function";
+           typeof globalScope.TextDecoder === "function";
   }
 
   private _parseMpd(

--- a/src/parsers/texttracks/ttml/html/__tests__/__global__/html_ttml_parser.test.test.ts
+++ b/src/parsers/texttracks/ttml/html/__tests__/__global__/html_ttml_parser.test.test.ts
@@ -15,6 +15,7 @@
  */
 
 import parseTTMLToDiv from "../../";
+import globalScope from "../../../../../../compat/global_scope";
 
 const testingText = `<?xml version="1.0" encoding="UTF-8"?>
 <tt xmlns="http://www.w3.org/ns/ttml">
@@ -181,7 +182,7 @@ describe("Global TTML HTML parsing tests", () => {
     for (let i = 0; i < textNodes.length; i++) {
       const parentElement = textNodes[i].parentElement;
       if (parentElement !== null) {
-        expect(window.getComputedStyle(parentElement).color).toEqual("yellow");
+        expect(globalScope.getComputedStyle(parentElement).color).toEqual("yellow");
         nbTextNodes++;
       }
     }

--- a/src/parsers/texttracks/webvtt/html/__tests__/convert_payload_to_html.test.ts
+++ b/src/parsers/texttracks/webvtt/html/__tests__/convert_payload_to_html.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../../../../../compat/global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -26,7 +28,7 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     jest.resetModules();
   });
 
-  const win = window as {
+  const gs = globalScope as {
     DOMParser : unknown;
   };
   it("should return empty payload when input text is empty", () => {
@@ -38,8 +40,8 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
       };
     });
 
-    const origDOMParser = win.DOMParser;
-    win.DOMParser = class MockDOMParser {
+    const origDOMParser = gs.DOMParser;
+    gs.DOMParser = class MockDOMParser {
       constructor() {
         // Useless constructor in mock
       }
@@ -58,7 +60,7 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     expect(convertPayloadToHTML("", {})).toEqual([]);
     expect(spyParseFromString).toHaveBeenCalledTimes(1);
     expect(spy).not.toHaveBeenCalled();
-    win.DOMParser = origDOMParser;
+    gs.DOMParser = origDOMParser;
   });
 
   it("should convert normal input text with no style", () => {
@@ -87,8 +89,8 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
       default: spyCreateStyledElement,
     }));
 
-    const origDOMParser = win.DOMParser;
-    win.DOMParser = class MockDOMParser {
+    const origDOMParser = gs.DOMParser;
+    gs.DOMParser = class MockDOMParser {
       constructor() {
         // Useless constructor in mock
       }
@@ -101,6 +103,6 @@ describe("parsers - webvtt - convertPayloadToHTML", () => {
     expect(convertPayloadToHTML(innerText, {})).toEqual([bNode, span]);
     expect(spyParseFromString).toHaveBeenCalledTimes(1);
     expect(spyCreateStyledElement).toHaveBeenCalledTimes(2);
-    win.DOMParser = origDOMParser;
+    gs.DOMParser = origDOMParser;
   });
 });

--- a/src/utils/__tests__/base64.test.ts
+++ b/src/utils/__tests__/base64.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import globalScope from "../../compat/global_scope";
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
@@ -67,7 +69,7 @@ describe("base64ToBytes", () => {
       .toEqual(new Uint8Array([ 36, 101, 120, 112, 101, 99, 116, 40, 98, 97,
                                 115, 101, 54, 52, 84, 111, 85, 105, 110, 116,
                                 56, 65, 114, 114, 97, 121, 40, 34, 34, 41 ]));
-    expect(base64ToBytes(window.btoa("toto")))
+    expect(base64ToBytes(globalScope.btoa("toto")))
       .toEqual(new Uint8Array([ 116, 111, 116, 111 ]));
     expect(logWarn).not.toHaveBeenCalled();
 
@@ -141,7 +143,7 @@ describe("bytesToBase64", () => {
                                           56, 65, 114, 114, 97, 121, 40, 34, 34, 41 ])))
       .toEqual("JGV4cGVjdChiYXNlNjRUb1VpbnQ4QXJyYXkoIiIp");
     expect(bytesToBase64(new Uint8Array([ 116, 111, 116, 111 ])))
-      .toEqual(window.btoa("toto"));
+      .toEqual(globalScope.btoa("toto"));
     expect(logWarn).not.toHaveBeenCalled();
   });
 });

--- a/src/utils/__tests__/id_generator.test.ts
+++ b/src/utils/__tests__/id_generator.test.ts
@@ -16,14 +16,15 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
+import globalScope from "../../compat/global_scope";
 import idGenerator from "../id_generator";
 
-const oldNumberDef = window.Number;
+const oldNumberDef = globalScope.Number;
 
 describe("utils - idGenerator", () => {
   afterEach(() => {
     // There's an ugly test in here that changes the Number object
-    window.Number = oldNumberDef;
+    globalScope.Number = oldNumberDef;
   });
 
   it("should increment an ID", () => {
@@ -54,8 +55,10 @@ describe("utils - idGenerator", () => {
   });
   it ("should preprend a 0 after A LOT of ID generation", () => {
     // Ugly but I don't care
-    window.Number = { MAX_SAFE_INTEGER: 3,
-                      isSafeInteger: (x : number) => x <= 3 } as typeof window.Number;
+    globalScope.Number = {
+      MAX_SAFE_INTEGER: 3,
+      isSafeInteger: (x : number) => x <= 3,
+    } as typeof globalScope.Number;
     const generateNewID1 = idGenerator();
     const generateNewID2 = idGenerator();
     const generateNewID3 = idGenerator();

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import globalScope from "../../compat/global_scope";
 import {
   NetworkErrorTypes,
   RequestError,
@@ -144,9 +145,9 @@ export default function fetchRequest(
     abortController.abort();
   }
 
-  let timeout : number | undefined;
+  let timeout : number | NodeJS.Timeout | undefined;
   if (options.timeout !== undefined) {
-    timeout = window.setTimeout(() => {
+    timeout = setTimeout(() => {
       timeouted = true;
       abortFetch();
     }, options.timeout);
@@ -244,7 +245,7 @@ export default function fetchRequest(
  * @return {boolean}
  */
 export function fetchIsSupported() : boolean {
-  return (typeof window.fetch === "function" &&
+  return (typeof globalScope.fetch === "function" &&
           !isNullOrUndefined(_AbortController) &&
           !isNullOrUndefined(_Headers));
 }

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -80,7 +80,7 @@ export default function request<T>(
     const xhr = new XMLHttpRequest();
     xhr.open("GET", url, true);
 
-    let timeoutId : undefined | number;
+    let timeoutId : undefined | number | NodeJS.Timeout;
     if (timeout !== undefined) {
       xhr.timeout = timeout;
 
@@ -90,7 +90,7 @@ export default function request<T>(
       // That's why we also start a manual timeout. We do this a little later
       // than the "native one" performed on the xhr assuming that the latter
       // is more precise, it might also be more efficient.
-      timeoutId = window.setTimeout(() => {
+      timeoutId = setTimeout(() => {
         clearCancellingProcess();
         reject(new RequestError(url, xhr.status, "TIMEOUT"));
       }, timeout + 3000);

--- a/src/utils/string_parsing.ts
+++ b/src/utils/string_parsing.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+import globalScope from "../compat/global_scope";
 import log from "../log";
 import assert from "./assert";
 
-const hasTextDecoder = typeof window === "object" &&
-                       typeof window.TextDecoder === "function";
+const hasTextDecoder = typeof globalScope === "object" &&
+                       typeof globalScope.TextDecoder === "function";
 
-const hasTextEncoder = typeof window === "object" &&
-                       typeof window.TextEncoder === "function";
+const hasTextEncoder = typeof globalScope === "object" &&
+                       typeof globalScope.TextEncoder === "function";
 
 /**
  * Convert a string to an Uint8Array containing the corresponding UTF-16 code


### PR DESCRIPTION
Some years back, we were notified of an issue when the RxPlayer was imported in a Node.JS environment - which has mostly no chance to bring any result unless that environment implements MSE, EME and DOM API - but which was still done due to some application logic linked to server-side-rendering.

That issue lead to an error, and was due to the RxPlayer refering to the `window` (the global scope accessible in JavaScript in a main thread environment) at the top level (generally done there to check once at script evaluation if various browser API are present), because `window` does not exist in Node.JS environments.

What we did at the time is just to check (poorly) if we were in a Node.js environment, and to not rely on `window` if that was the case at those various places. However that was error-prone (we could forget that check) and the only thing preventing mistakes was a script in `scripts/check_nodejs_import_compatibility.js` which wouldn't be able to catch all cases.

---

Because this became again a problem when PoCing worker environments, I profited from this project to work on a better solution.

Now the global scope is directly provided by an util function of our compat code, which works for NodeJS, JS main thread and JS WebWorker environments, and its usage is enforced by a linter rule which should hopefully catch most `window` usage in the code.

I also chose to erase all usage of the term `window` or the shortened `win` alias in code to better communicate the point that we're specifically mean the global scope, regardless of how it is referred to in the current environment.