### PR TITLE
Implement better messages for request errors

### DIFF
--- a/src/errors/__tests__/network_error.test.ts
+++ b/src/errors/__tests__/network_error.test.ts
@@ -21,36 +21,37 @@ describe("errors - NetworkError", () => {
   it("should be able to use a RequestError", () => {
     const xhr = new XMLHttpRequest();
     xhr.open("GET", "http://www.example.com");
-    const requestError = new RequestError("foo", 12, "TIMEOUT", xhr);
+    const requestError = new RequestError("foo", 0, "TIMEOUT", xhr);
     const networkError = new NetworkError("PIPELINE_LOAD_ERROR", requestError);
     expect(networkError).toBeInstanceOf(Error);
     expect(networkError.name).toBe("NetworkError");
     expect(networkError.type).toBe("NETWORK_ERROR");
     expect(networkError.xhr).toBe(requestError.xhr);
-    expect(networkError.status).toBe(12);
+    expect(networkError.status).toBe(0);
     expect(networkError.errorType).toBe(requestError.type);
     expect(networkError.code).toBe("PIPELINE_LOAD_ERROR");
     expect(networkError.fatal).toBe(false);
     expect(networkError.message)
-      .toBe("NetworkError (PIPELINE_LOAD_ERROR) TIMEOUT");
+      .toBe("NetworkError (PIPELINE_LOAD_ERROR) The request timed out");
   });
 
   it("should filter in a valid error code", () => {
     const xhr = new XMLHttpRequest();
     xhr.open("GET", "http://www.example.com");
-    const requestError = new RequestError("foo", 13, "ERROR_HTTP_CODE", xhr);
+    const requestError = new RequestError("foo", 403, "ERROR_HTTP_CODE", xhr);
     const networkError = new NetworkError("PIPELINE_LOAD_ERROR", requestError);
     networkError.fatal = true;
     expect(networkError).toBeInstanceOf(Error);
     expect(networkError.name).toBe("NetworkError");
     expect(networkError.type).toBe("NETWORK_ERROR");
     expect(networkError.xhr).toBe(requestError.xhr);
-    expect(networkError.status).toBe(13);
+    expect(networkError.status).toBe(403);
     expect(networkError.errorType).toBe(requestError.type);
     expect(networkError.code).toBe("PIPELINE_LOAD_ERROR");
     expect(networkError.fatal).toBe(true);
     expect(networkError.message)
-      .toBe("NetworkError (PIPELINE_LOAD_ERROR) ERROR_HTTP_CODE");
+      .toBe("NetworkError (PIPELINE_LOAD_ERROR) An HTTP status code " +
+            "indicating failure was received: 403");
   });
 
   it("should return false in isHttpError if not an HTTP error", () => {
@@ -66,7 +67,7 @@ describe("errors - NetworkError", () => {
   /* eslint-enable max-len */
     const xhr = new XMLHttpRequest();
     xhr.open("GET", "http://www.example.com");
-    const requestError = new RequestError("foo", 44, "ERROR_HTTP_CODE", xhr);
+    const requestError = new RequestError("foo", 500, "ERROR_HTTP_CODE", xhr);
     const networkError = new NetworkError("PIPELINE_LOAD_ERROR", requestError);
     expect(networkError.isHttpError(1)).toBe(false);
   });
@@ -76,8 +77,8 @@ describe("errors - NetworkError", () => {
   /* eslint-enable max-len */
     const xhr = new XMLHttpRequest();
     xhr.open("GET", "http://www.example.com");
-    const requestError = new RequestError("foo", 33, "ERROR_HTTP_CODE", xhr);
+    const requestError = new RequestError("foo", 418, "ERROR_HTTP_CODE", xhr);
     const networkError = new NetworkError("PIPELINE_LOAD_ERROR", requestError);
-    expect(networkError.isHttpError(33)).toBe(true);
+    expect(networkError.isHttpError(418)).toBe(true);
   });
 });

--- a/src/errors/__tests__/request_error.test.ts
+++ b/src/errors/__tests__/request_error.test.ts
@@ -27,17 +27,19 @@ describe("errors - RequestError", () => {
     expect(requestError.xhr).toBe(xhr);
     expect(requestError.status).toBe(355);
     expect(requestError.type).toBe("ERROR_EVENT");
-    expect(requestError.message).toBe("ERROR_EVENT");
+    expect(requestError.message).toBe(
+      "An error prevented the request to be performed successfully"
+    );
     xhr.abort();
   });
   it("should authorize no XHR", () => {
-    const requestError = new RequestError("foo", 355, "ERROR_EVENT");
+    const requestError = new RequestError("foo", 355, "TIMEOUT");
     expect(requestError).toBeInstanceOf(Error);
     expect(requestError.name).toBe("RequestError");
     expect(requestError.url).toBe("foo");
     expect(requestError.xhr).toBe(undefined);
     expect(requestError.status).toBe(355);
-    expect(requestError.type).toBe("ERROR_EVENT");
-    expect(requestError.message).toBe("ERROR_EVENT");
+    expect(requestError.type).toBe("TIMEOUT");
+    expect(requestError.message).toBe("The request timeouted");
   });
 });

--- a/src/errors/__tests__/request_error.test.ts
+++ b/src/errors/__tests__/request_error.test.ts
@@ -40,6 +40,6 @@ describe("errors - RequestError", () => {
     expect(requestError.xhr).toBe(undefined);
     expect(requestError.status).toBe(355);
     expect(requestError.type).toBe("TIMEOUT");
-    expect(requestError.message).toBe("The request timeouted");
+    expect(requestError.message).toBe("The request timed out");
   });
 });

--- a/src/errors/request_error.ts
+++ b/src/errors/request_error.ts
@@ -59,7 +59,7 @@ export default class RequestError extends Error {
 
     switch (type) {
       case "TIMEOUT":
-        this.message = "The request timeouted";
+        this.message = "The request timed out";
         break;
       case "ERROR_EVENT":
         this.message = "An error prevented the request to be performed successfully";

--- a/src/errors/request_error.ts
+++ b/src/errors/request_error.ts
@@ -56,6 +56,21 @@ export default class RequestError extends Error {
     }
     this.status = status;
     this.type = type;
-    this.message = type;
+
+    switch (type) {
+      case "TIMEOUT":
+        this.message = "The request timeouted";
+        break;
+      case "ERROR_EVENT":
+        this.message = "An error prevented the request to be performed successfully";
+        break;
+      case "PARSE_ERROR":
+        this.message = "An error happened while formatting the response data";
+        break;
+      case "ERROR_HTTP_CODE":
+        this.message = "An HTTP status code indicating failure was received: " +
+          String(this.status);
+        break;
+    }
   }
 }


### PR DESCRIPTION
While debugging some issues, we noticed that our network-related error messages could do with more verbosity. This is what this PR does.

It also adds the HTTP status code in the message when this is the source, of the network error. Today it is only present as a `status` property.