### PR TITLE
DASH: Fix track duplication when merging more than one switchable AdaptationSet

### DIFF
--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -467,6 +467,7 @@ export default function parseAdaptationSets(
                                 mergedInto[1].isMainAdaptation,
               indexInMpd: Math.min(adaptationIdx, mergedInto[1].indexInMpd),
             };
+            break;
           }
         }
       }


### PR DESCRIPTION
The RxPlayer merge together multiple DASH AdaptationSet with similar characteristics and a two-ways `"adaptation-set-switching"` SupplementalProperty into a single track, as this is a trick often used by packagers to make a single "track" linked to several key ids compliant with the DASH-IF IOP while still allowing navigating between the two freely through adaptive bitrate mechanisms.

I noticed that, because of a forgotten `break;` call, we could have duplicate tracks if at least 3 AdaptationSet where "switchable" (with the duplicate being the last one encountered each time).

This is not a huge deal, as the video track has in any case less priority, and is still a playable track, but it was still unwanted.

This is now fixed.