### PR TITLE
StreamEventsEmitter is now a class

### DIFF
--- a/src/core/init/utils/stream_events_emitter/refresh_scheduled_events_list.ts
+++ b/src/core/init/utils/stream_events_emitter/refresh_scheduled_events_list.ts
@@ -45,21 +45,24 @@ function refreshScheduledEventsList(
         }
       }
 
+      const element = data.value.element;
+      const actualData = { type: data.type,
+                           value: { ...data.value, element } };
       if (end === undefined) {
         const newScheduledEvent = { start,
                                     id,
-                                    data,
+                                    data: actualData,
                                     publicEvent: { start,
-                                                   data } };
+                                                   data: actualData } };
         scheduledEvents.push(newScheduledEvent);
       } else {
         const newScheduledEvent = { start,
                                     end,
                                     id,
-                                    data,
+                                    data: actualData,
                                     publicEvent: { start,
                                                    end,
-                                                   data } };
+                                                   data: actualData } };
         scheduledEvents.push(newScheduledEvent);
       }
 


### PR DESCRIPTION
The `StreamEventsEmitter` is the RxPlayer module storing events found in the Manifest (for now only DASH' `EventStream` elements) and emitting `streamEvent`/`streamEventSkip` RxPlayer events when they are encountered.

In the WebWorker work (#1272), I had to refacto the `StreamEventsEmitter` from being a long-lived function to being a class, to make it possible to be communicated manifest updates less awkwardly and more idiomatically, through an `onManifestUpdate` method.

However, I liked the result and find it much more easy to understand than the previous one, which bears the mark of having been previously an RxJS-based logic. The new has some more lines, but it just seems much more idiomatic and easy-to-understand with a regular event-emitter-based logic, than with callbacks parameters.

This refactoes the `StreamEventsEmitter` into a class without adding the supplementary worker-linked logic handlin manifest updates differently.

Basically, it's just now a class emitting events with `start` and `stop` methods.