### PR TITLE
Centralize debug mode handling

### DIFF
--- a/src/compat/is_debug_mode_enabled.ts
+++ b/src/compat/is_debug_mode_enabled.ts
@@ -1,0 +1,12 @@
+/* eslint-disable-next-line @typescript-eslint/naming-convention */
+declare const __RX_PLAYER_DEBUG_MODE__ : boolean | undefined;
+
+/**
+ * Some external tools set that boolean, in which case, we should enable DEBUG
+ * logs and various tricks to make as much logs as available to those tools.
+ *
+ * @returns {boolean}
+ */
+export default function isDebugModeEnabled(): boolean {
+  return typeof __RX_PLAYER_DEBUG_MODE__ === "boolean" && __RX_PLAYER_DEBUG_MODE__;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@
  * This is the class used from a regular build.
  */
 
+import isDebugModeEnabled from "./compat/is_debug_mode_enabled";
 import Player from "./core/api";
 import initializeFeatures from "./features/initialize_features";
 import logger from "./log";
@@ -28,7 +29,7 @@ import logger from "./log";
 // set initial features according to environment variables
 initializeFeatures();
 
-if (typeof __RX_PLAYER_DEBUG_MODE__ === "boolean" && __RX_PLAYER_DEBUG_MODE__) {
+if (isDebugModeEnabled()) {
   logger.setLevel("DEBUG");
 } else if (__ENVIRONMENT__.CURRENT_ENV as number === __ENVIRONMENT__.DEV as number) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);

--- a/src/minimal.ts
+++ b/src/minimal.ts
@@ -21,6 +21,7 @@
  * import only features that is needed.
  */
 
+import isDebugModeEnabled from "./compat/is_debug_mode_enabled";
 import Player from "./core/api";
 import {
   addFeatures,
@@ -28,7 +29,7 @@ import {
 } from "./features";
 import logger from "./log";
 
-if (typeof __RX_PLAYER_DEBUG_MODE__ === "boolean" && __RX_PLAYER_DEBUG_MODE__) {
+if (isDebugModeEnabled()) {
   logger.setLevel("DEBUG");
 } else if (__ENVIRONMENT__.CURRENT_ENV as number === __ENVIRONMENT__.DEV as number) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);

--- a/src/typings/globals.d.ts
+++ b/src/typings/globals.d.ts
@@ -78,5 +78,3 @@ declare const enum ENVIRONMENT_ENUM {
 declare const __LOGGER_LEVEL__ : {
   CURRENT_LEVEL : string;
 };
-
-declare const __RX_PLAYER_DEBUG_MODE__ : boolean | undefined;


### PR DESCRIPTION
The RxPlayer has an hidden feature of setting automatically debug logs if a `__RX_PLAYER_DEBUG_MODE__` variable has been set to `true` in the globak scope. This allows to ease-up debugging work by preventing people to always having to manually set the log verbosity of the RxPlayer, and it is used by [RxPaired](https://github.com/peaBerberian/RxPaired), the RxPlayer-specialized remote debugger we routinely use and develop on.

Because in most scenarios, `__RX_PLAYER_DEBUG_MODE__` is not even defined as a global variable, just checking it that way will throw an error in JavaScript, so we have to be careful when relying on it: we HAVE TO rely on the `typeof` operator first, as it doesn't lead to an error if the variable given as argument does not exist.

However, TypeScript doesn't seem to have any mean to indicate that a global variable may or not be globally available (which is different from `| undefined`), so we just had to manually remind ourselves to call `typeof` on it before.

To be less error-prone, I chose to isolate debug-mode checking in its own util and to depend on it everywhere else.