### PR TITLE
RepresentationStream: Also check segments after a Manifest update

### DIFF
--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -197,6 +197,9 @@ export default function RepresentationStream<TSegmentDataType>(
     includeLastObservation: false,
     clearSignal: segmentsLoadingCanceller.signal,
   });
+  content.manifest.addEventListener("manifestUpdate",
+                                    checkStatus,
+                                    segmentsLoadingCanceller.signal);
   bufferGoal.onUpdate(checkStatus, {
     emitCurrentValue: false,
     clearSignal: segmentsLoadingCanceller.signal ,


### PR DESCRIPTION
The mechanism to check for new segment to request is done on several events but was not done on a Manifest update.

Even if for complex reasons, there are small advantages to not check for new segments directly after a Manifest update, it also seems in most cases more logical and efficient.

I decided to add it.