### PR TITLE
Clean-up whole buffer in get_time_ranges_for_content.ts to be safe

### DIFF
--- a/src/core/stream/orchestrator/get_time_ranges_for_content.ts
+++ b/src/core/stream/orchestrator/get_time_ranges_for_content.ts
@@ -54,12 +54,7 @@ export default function getTimeRangesForContent(
       const { bufferedStart, bufferedEnd } = chunk;
       if (bufferedStart === undefined || bufferedEnd === undefined) {
         log.warn("SO: No buffered start or end found from a segment.");
-        const buffered = segmentBuffer.getBufferedRanges();
-        const len = buffered.length;
-        if (len === 0) {
-          return [];
-        }
-        return [{ start: buffered.start(0), end: buffered.end(len - 1) }];
+        return [{ start: 0, end: Number.MAX_VALUE }];
       }
 
       const previousLastElement = accumulator[accumulator.length - 1];


### PR DESCRIPTION
When content become undecipherable the RxPlayer first tries to remove the corresponding data from the buffer. When it is not known when the corresponding undecipherable data is in the buffer (a normally rare occurence, but can theoretically happen), it previously removed everything that is currently known to be buffered.

This code now removes the whole buffer and doesn't limit itself at "what is known to be buffered" at that particular point in time:
  - There may be unfinished push operations still going on (should be very rare) in which case the data may not be removed in the previous behavior.
  - It simplifies things, especially with the still-on-draft WebWorker branch (#1272) which may lead to the buffered data not obtainable synchronously (when MSE run in main thread, as that code would most likely run in the Worker).