### PR TITLE
Add forgotten bufferedStart setting in SegmentInventory

### DIFF
--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -921,6 +921,7 @@ function guessBufferedStartFromRangeStart(
   } else if (rangeStart < firstSegmentInRange.start) {
     log.debug("SI: range start too far from expected start",
               bufferType, rangeStart, firstSegmentInRange.start);
+    firstSegmentInRange.bufferedStart = firstSegmentInRange.start;
   } else {
     log.debug("SI: Segment appears immediately garbage collected at the start",
               bufferType, firstSegmentInRange.bufferedStart, rangeStart);


### PR DESCRIPTION
The RxPlayer maintains an inventory of which segments should be right now in browser buffers and at which position, through the `SegmentInventory` structure.

This is a complex part of the code which has to be frequently re-synchronized with the browser's buffer yet it allows a LOT of optimizations (preventing reloads when not needed, allowing to not re-load segments on seek, allowing fast-switching, allowing to implement in-JS buffer-memory limitations, allowing more efficient buffer-based adaptive algorithms, allowing to advertise the current played quality...).

I recently found out that `bufferedStart` - a mechanism to indicate the probable start time in seconds of a segment in the browser's buffer in that structure, was not set if the browser's buffer had a large time range of un-categorized buffered data before that segment. This is just something that I forgot to add and its mirror "end" value `bufferedEnd` is actually set in similar conditions.

Consequence of not setting this is a little unclear, as the RxPlayer has a lot of resilience in that area, but setting it should normally improve things...!