### PR TITLE
Fix error in improbable case where content is already ready on load

### DIFF
--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -86,14 +86,15 @@ export default function performInitialSeekAndPlay(
   const initialPlayPerformed = createSharedReference(false, cancelSignal);
 
   mediaElement.addEventListener("loadedmetadata", onLoadedMetadata);
-  if (mediaElement.readyState >= READY_STATES.HAVE_METADATA) {
-    onLoadedMetadata();
-  }
 
   const deregisterCancellation = cancelSignal.register((err : CancellationError) => {
     mediaElement.removeEventListener("loadedmetadata", onLoadedMetadata);
     rejectAutoPlay(err);
   });
+
+  if (mediaElement.readyState >= READY_STATES.HAVE_METADATA) {
+    onLoadedMetadata();
+  }
 
   return { autoPlayResult, initialPlayPerformed, initialSeekPerformed };
 


### PR DESCRIPTION
The code implementing the initial seek (e.g. to play the initial position of a live content, or to implement the `startAt` option) and play (e.g. to implement `autoPlay`) could lead to an error in the for-now improbable (impossible?) scenario where the HTMLMediaElement already has at least the `HAVE_METADATA` `readyState` before that function is called, due to a callback using a variable before it was defined.

I don't know of any current issue that may be triggered by this, but some future work triggered it, so let's just fix that future issue.