### PR TITLE
Deprecate manifestUpdateUrl loadVideo option in the v3

### DIFF
--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -367,45 +367,6 @@ considered stable:
   contents if its request was done immediately before the `loadVideo`
   call.
 
-- **manifestUpdateUrl** (`string|undefined`):
-
-  Set a custom Manifest URL for Manifest updates.
-  This URL can point to another version of the Manifest with a shorter
-  timeshift window, to lighten the CPU, memory and bandwidth impact of
-  Manifest updates.
-
-  Example:
-
-  ```js
-  rxPlayer.loadVideo({
-    transport: "dash",
-    url: "https://example.com/full-content.mpd",
-    transportOptions: {
-      manifestUpdateUrl: "https://example.com/content-with-shorter-window.mpd",
-    },
-  });
-  ```
-
-  When the RxPlayer plays a live content, it may have to refresh frequently
-  the Manifest to be aware of where to find new media segments.
-  It generally uses the regular Manifest URL when doing so, meaning that the
-  information about the whole content is downloaded again.
-
-  This is generally not a problem though: The Manifest is generally short
-  enough meaning that this process won't waste much bandwidth memory or
-  parsing time.
-  However, we found that for huge Manifests (multiple MB uncompressed), this
-  behavior could be a problem on some low-end devices (some set-top-boxes,
-  chromecasts) where slowdowns can be observed when Manifest refresh are
-  taking place.
-
-  The `manifestUpdateUrl` will thus allow an application to provide a second
-  URL, specifically used for Manifest updates, which can represent the same
-  content with a shorter timeshift window (e.g. using only 5 minutes of
-  timeshift window instead of 10 hours for the full Manifest). The content
-  will keep its original timeshift window and the RxPlayer will be able to get
-  information about new segments at a lower cost.
-
 - **representationFilter** (`Function|undefined`):
 
   Allows to filter out `Representation`s (i.e. media qualities) from the
@@ -531,6 +492,31 @@ considered stable:
   a complete explanation, you can look at the [corresponding chapter of the
   low-latency documentation](./Miscellaneous/Low_Latency.md#note-time-sync).
 
+- **referenceDateTime** (`number|undefined`):
+
+  Only useful for live contents. This is the default amount of time, in
+  seconds, to add as an offset to a given media content's time, to obtain the
+  real live time.
+
+  For example, if the media has it's `0` time corresponding to the 30th of
+  January 2010 at midnight, you can set the `referenceDateTime` to `new Date(2010-01-30) / 1000`. This value is useful to communicate back to you
+  the "live time", for example through the `getWallClockTime` method.
+
+  This will only be taken into account for live contents, and if the Manifest
+  / MPD does not already contain an offset (example: an
+  "availabilityStartTime" attribute in a DASH MPD).
+
+  Example:
+
+  ```js
+  rxPlayer.loadVideo({
+    // ...
+    transportOptions: {
+      referenceDateTime: new Date(2015 - 05 - 29) / 1000,
+    },
+  });
+  ```
+
 - **aggressiveMode** (`boolean|undefined`):
 
 <div class="warning">
@@ -563,30 +549,51 @@ APIs</a>).
   });
   ```
 
-- **referenceDateTime** (`number|undefined`):
+- **manifestUpdateUrl** (`string|undefined`):
 
-  Only useful for live contents. This is the default amount of time, in
-  seconds, to add as an offset to a given media content's time, to obtain the
-  real live time.
+<div class="warning">
+This option is deprecated, it will disappear in the next major release
+`v4.0.0` (see <a href="./Miscellaneous/Deprecated_APIs.md">Deprecated
+APIs</a>).
+</div>
 
-  For example, if the media has it's `0` time corresponding to the 30th of
-  January 2010 at midnight, you can set the `referenceDateTime` to `new Date(2010-01-30) / 1000`. This value is useful to communicate back to you
-  the "live time", for example through the `getWallClockTime` method.
-
-  This will only be taken into account for live contents, and if the Manifest
-  / MPD does not already contain an offset (example: an
-  "availabilityStartTime" attribute in a DASH MPD).
+  Set a custom Manifest URL for Manifest updates.
+  This URL can point to another version of the Manifest with a shorter
+  timeshift window, to lighten the CPU, memory and bandwidth impact of
+  Manifest updates.
 
   Example:
 
   ```js
   rxPlayer.loadVideo({
-    // ...
+    transport: "dash",
+    url: "https://example.com/full-content.mpd",
     transportOptions: {
-      referenceDateTime: new Date(2015 - 05 - 29) / 1000,
+      manifestUpdateUrl: "https://example.com/content-with-shorter-window.mpd",
     },
   });
   ```
+
+  When the RxPlayer plays a live content, it may have to refresh frequently
+  the Manifest to be aware of where to find new media segments.
+  It generally uses the regular Manifest URL when doing so, meaning that the
+  information about the whole content is downloaded again.
+
+  This is generally not a problem though: The Manifest is generally short
+  enough meaning that this process won't waste much bandwidth memory or
+  parsing time.
+  However, we found that for huge Manifests (multiple MB uncompressed), this
+  behavior could be a problem on some low-end devices (some set-top-boxes,
+  chromecasts) where slowdowns can be observed when Manifest refresh are
+  taking place.
+
+  The `manifestUpdateUrl` will thus allow an application to provide a second
+  URL, specifically used for Manifest updates, which can represent the same
+  content with a shorter timeshift window (e.g. using only 5 minutes of
+  timeshift window instead of 10 hours for the full Manifest). The content
+  will keep its original timeshift window and the RxPlayer will be able to get
+  information about new segments at a lower cost.
+
 
 ### textTrackMode
 

--- a/src/core/api/option_utils.ts
+++ b/src/core/api/option_utils.ts
@@ -63,12 +63,12 @@ export interface IParsedTransportOptions {
   checkMediaSegmentIntegrity? : boolean | undefined;
   lowLatencyMode : boolean;
   manifestLoader?: IManifestLoader | undefined;
-  manifestUpdateUrl? : string | undefined;
   referenceDateTime? : number | undefined;
   representationFilter? : IRepresentationFilter | undefined;
   segmentLoader? : ISegmentLoader | undefined;
   serverSyncInfos? : IServerSyncInfos | undefined;
   /* eslint-disable import/no-deprecated */
+  manifestUpdateUrl? : string | undefined;
   supplementaryImageTracks? : ISupplementaryImageTrack[] | undefined;
   supplementaryTextTracks? : ISupplementaryTextTrack[] | undefined;
   /* eslint-enable import/no-deprecated */
@@ -587,6 +587,11 @@ function parseLoadVideoOptions(
       }
     }
     transportOptions.supplementaryImageTracks = supplementaryImageTracks;
+  }
+
+  if (!isNullOrUndefined(options.transportOptions?.manifestUpdateUrl)) {
+    warnOnce("`manifestUpdateUrl` API is deprecated, please open an issue if you" +
+             " still rely on this.");
   }
 
   if (isNullOrUndefined(options.textTrackMode)) {


### PR DESCRIPTION
As we're going to probably remove it from the v4 (#1276), it makes sense to prepare its removal by first deprecating in the v3.