### PR TITLE
Deprecate image buffer feature

### DIFF
--- a/doc/api/RxPlayer_Features.md
+++ b/doc/api/RxPlayer_Features.md
@@ -67,12 +67,14 @@ Here is the anotated exhaustive list (notes are at the bottom of the table):
 | `HTML_VTT_PARSER` [2]       | Parse VTT text tracks for the `"html"` `textTrackMode`    |
 | `HTML_TTML_PARSER` [2]      | Parse TTML text tracks for the `"html"` `textTrackMode`   |
 | `HTML_SAMI_PARSER` [2]      | Parse SAMI text tracks for the `"html"` `textTrackMode`   |
+| `BIF_PARSER`                | Parse BIF image tracks for the image buffer               |
 | `DEBUG_ELEMENT` [3]         | Allows to use the `createDebugElement` RxPlayer method    |
 | `DASH_WASM` [1] [4]         | Enable DASH playback using a WebAssembly-based MPD parser |
 | `LOCAL_MANIFEST` [4]        | Enable playback of "local" contents                       |
 | `METAPLAYLIST` [4]          | Enable playback of "metaplaylist" contents                |
 | `NATIVE_TEXT_BUFFER` [5]    | (Deprecated) Base for the `"native"` `textTrackMode`.     |
 | `HTML_TEXT_BUFFER` [5]      | (Deprecated) Base for the `"html"` `textTrackMode`.       |
+| `IMAGE_BUFFER` [5]          | Allow to display thumbnails through the image buffer      |
 
 ---
 
@@ -104,9 +106,10 @@ To help you choose between those two:
 **[4]**: The `DASH_WASM` feature has its own setup, detailed in the
 [corresponding documentation page](../api/Miscellaneous/DASH_WASM_Parser.md).
 
-**[5]**: Both the `NATIVE_TEXT_BUFFER` and `HTML_TEXT_BUFFER` features are
-deprecated. They are already implicitly imported when parsing any of the
-corresponding text parsers.
+**[5]**: The `NATIVE_TEXT_BUFFER`, `HTML_TEXT_BUFFER` and `IMAGE_BUFFER`
+features are deprecated.
+They are already implicitly imported when parsing any of the corresponding text
+or image parsers.
 
 ---
 

--- a/src/features/list/__tests__/bif_parser.test.ts
+++ b/src/features/list/__tests__/bif_parser.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import imageBuffer from "../../../core/segment_buffers/implementations/image";
 import bifParser from "../../../parsers/images/bif";
 import { IFeaturesObject } from "../../types";
 import addBIFParserFeature from "../bif_parser";
@@ -22,7 +23,8 @@ describe("Features list - BIF Parser", () => {
   it("should add the BIF Parser in the current features", () => {
     const featureObject = {} as unknown as IFeaturesObject;
     addBIFParserFeature(featureObject);
-    expect(featureObject).toEqual({ imageParser: bifParser });
+    expect(featureObject).toEqual({ imageParser: bifParser, imageBuffer });
     expect(featureObject.imageParser).toBe(bifParser);
+    expect(featureObject.imageBuffer).toBe(imageBuffer);
   });
 });

--- a/src/features/list/bif_parser.ts
+++ b/src/features/list/bif_parser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import imageBuffer from "../../core/segment_buffers/implementations/image";
 import bifParser from "../../parsers/images/bif";
 import { IFeaturesObject } from "../types";
 
@@ -23,6 +24,7 @@ import { IFeaturesObject } from "../types";
  */
 function addBIFParserFeature(features : IFeaturesObject) : void {
   features.imageParser = bifParser;
+  features.imageBuffer = imageBuffer;
 }
 
 export { addBIFParserFeature as BIF_PARSER };


### PR DESCRIPTION
In #1287, I deprecated the `NATIVE_TEXT_BUFFER` and `HTML_TEXT_BUFFER` as they already are automatically included when importing one of the corresponding text track parsers (so there's no point to have a separate import here, it can just be lazily added on any of those parser's injection to the RxPlayer).

Yet I forgot that the exact same situation was there for the `IMAGE_BUFFER` (and even completely forgot to re-document image-related features). This is now done.