### PR TITLE
Fix ABR on old Edge browser

### DIFF
--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -188,26 +188,26 @@ function getDocumentVisibilityRef(
   let prefix : string|undefined;
 
   const doc = document as ICompatDocument;
-  if (doc.hidden != null) {
+  if (!isNullOrUndefined(doc.hidden)) {
     prefix = "";
-  } else if (doc.mozHidden != null) {
+  } else if (!isNullOrUndefined(doc.mozHidden)) {
     prefix = "moz";
-  } else if (doc.msHidden != null) {
+  } else if (!isNullOrUndefined(doc.msHidden)) {
     prefix = "ms";
-  } else if (doc.webkitHidden != null) {
+  } else if (!isNullOrUndefined(doc.webkitHidden)) {
     prefix = "webkit";
   }
 
-  const hidden = isNonEmptyString(prefix) ? prefix + "Hidden" :
+  const hidden = isNonEmptyString(prefix) ? (prefix + "Hidden" as "hidden") :
                                             "hidden";
   const visibilityChangeEvent = isNonEmptyString(prefix) ? prefix + "visibilitychange" :
                                                            "visibilitychange";
 
-  const isHidden = document[hidden as "hidden"];
+  const isHidden = document[hidden];
   const ref = new SharedReference(!isHidden, stopListening);
 
   addEventListener(document, visibilityChangeEvent, () => {
-    const isVisible = !(document[hidden as "hidden"]);
+    const isVisible = !(document[hidden]);
     ref.setValueIfChanged(isVisible);
   }, stopListening);
 

--- a/src/core/adaptive/__tests__/buffer_based_chooser.test.ts
+++ b/src/core/adaptive/__tests__/buffer_based_chooser.test.ts
@@ -92,7 +92,7 @@ describe("BufferBasedChooser", () => {
   /* eslint-disable max-len */
   it("should log an error and return the first bitrate if the given bitrate does not exist", () => {
   /* eslint-enable max-len */
-    const logger = { debug: jest.fn(), error: jest.fn() };
+    const logger = { debug: jest.fn(), info: jest.fn() };
     jest.mock("../../../log", () => ({ __esModule: true as const,
                                        default: logger }));
     const BufferBasedChooser = jest.requireActual("../buffer_based_chooser").default;
@@ -105,8 +105,8 @@ describe("BufferBasedChooser", () => {
       currentScore: undefined,
     });
     expect(bbc.getLastEstimate()).toEqual(10);
-    expect(logger.error).toHaveBeenCalledTimes(1);
-    expect(logger.error)
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info)
       .toHaveBeenCalledWith("ABR: Current Bitrate not found in the calculated levels");
   });
 

--- a/src/core/adaptive/buffer_based_chooser.ts
+++ b/src/core/adaptive/buffer_based_chooser.ts
@@ -153,7 +153,7 @@ export default class BufferBasedChooser {
     }
 
     if (currentBitrateIndex < 0 || bitrates.length !== bufferLevels.length) {
-      log.error("ABR: Current Bitrate not found in the calculated levels");
+      log.info("ABR: Current Bitrate not found in the calculated levels");
       this._currentEstimate = bitrates[0];
       return ;
     }

--- a/src/core/adaptive/network_analyzer.ts
+++ b/src/core/adaptive/network_analyzer.ts
@@ -18,6 +18,7 @@ import config from "../../config";
 import log from "../../log";
 import { Representation } from "../../manifest";
 import arrayFind from "../../utils/array_find";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import getMonotonicTimeStamp from "../../utils/monotonic_timestamp";
 import {
   IRepresentationEstimatorPlaybackObservation,
@@ -359,10 +360,10 @@ export default class NetworkAnalyzer {
                                                         this._lowLatencyMode,
                                                         lastEstimatedBitrate);
 
-      if (bandwidthEstimate != null) {
+      if (bandwidthEstimate !== undefined) {
         log.info("ABR: starvation mode emergency estimate:", bandwidthEstimate);
         bandwidthEstimator.reset();
-        newBitrateCeil = currentRepresentation == null ?
+        newBitrateCeil = isNullOrUndefined(currentRepresentation) ?
           bandwidthEstimate :
           Math.min(bandwidthEstimate, currentRepresentation.bitrate);
       }
@@ -372,11 +373,11 @@ export default class NetworkAnalyzer {
     if (newBitrateCeil == null) {
       bandwidthEstimate = bandwidthEstimator.getEstimate();
 
-      if (bandwidthEstimate != null) {
+      if (bandwidthEstimate !== undefined) {
         newBitrateCeil = bandwidthEstimate *
           (this._inStarvationMode ? localConf.starvationBitrateFactor :
                                     localConf.regularBitrateFactor);
-      } else if (lastEstimatedBitrate != null) {
+      } else if (lastEstimatedBitrate !== undefined) {
         newBitrateCeil = lastEstimatedBitrate *
           (this._inStarvationMode ? localConf.starvationBitrateFactor :
                                     localConf.regularBitrateFactor);

--- a/src/core/api/track_management/track_dispatcher.ts
+++ b/src/core/api/track_management/track_dispatcher.ts
@@ -209,7 +209,8 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
 
       // Check if Locked Representations have changed
       const oldRef = reference.getValue();
-      const sortedReps = playableRepresentations.slice().sort();
+      const sortedReps = playableRepresentations.slice()
+        .sort((ra, rb) => ra.bitrate - rb.bitrate);
       if (sortedReps.length !== oldRef.representations.length) {
         reference.setValue({ representations: sortedReps, switchingMode });
         return;


### PR DESCRIPTION
We noticed a strange issue on some older Edge browser versions (like the one used on some XBox or some other UWP applications) where the ABR (Adaptive BitRate, the code in charge of choosing the right audio and video quality) would make poor quality choices, even when the user had a high bandwidth, only in the future v4 version.

It turned out that the issue wasn't directly linked to ABR, but due to some other assumptions wrongly assumed by the RxPlayer (only in the future v4) which broke behavior only on older Edge browsers.

Basically:

  - The adaptive code assumed that all quality given to it were sorted from the lowest to the highest bitrate, as is almost convention in the RxPlayer code. Some of its algorithms were dependents on that assumption.

  - Although most of the code handling qualities respected that convention, the API code handling quality choices made by the application (or the absence of choice) broke it for an unrelated matter.

    Basically, to prevent sending the same quality choices consecutive times (purely for optimizations reasons), the API code sorted the array of qualities by calling the `sort` method on the array of objects directly.

    Not only was this totally unnecessary based on the rest of the code, it then used that newly sorted array to communicate it to the rest of the RxPlayer code and break the bitrate-sorted assumption for it. It turned out that Edge, surely for some cheeky reasons but in the right to do so :p, consistently set the first initial element last in the sorted array and letting the rest in order.

To fix this, I decided to stop with the bitrate-sorted assumption and to just explicitely sort by bitrate when sorting is needed: in the ABR or even in the API code (as sorting per bitrate is easier to think about than sorting whole objects).

I also did some minor ABR-related code updates so code is more explicit, as I encountered some legacy logic based on implicit double-equal JavaScript behavior that we try to avoid now.