### PR TITLE
DASH: Fix Period overlap resolution logic for when the first Period is removed

### DIFF
--- a/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
@@ -139,4 +139,24 @@ describe("flattenOverlappingPeriods", function() {
     expect(mockLog).toHaveBeenCalledTimes(99);
     mockLog.mockRestore();
   });
+
+  //      [ Period 1 ][ Period 2 ]       ------>  [  Period 3  ]
+  //  [            Period 3           ]
+  it("should handle when a Period overlaps all previous periods", () => {
+    const mockLog = jest.spyOn(log, "warn").mockImplementation(jest.fn());
+
+    const periods = [
+      { id: "1", start: 40, duration: 20, adaptations: {} },
+      { id: "2", start: 60, duration: 20, adaptations: {} },
+      { id: "3", start: 20, duration: 100, adaptations: {} },
+    ];
+
+    const flattenPeriods = flattenOverlappingPeriods(periods);
+    expect(flattenPeriods.length).toBe(1);
+    expect(flattenPeriods[0].start).toBe(20);
+    expect(flattenPeriods[0].duration).toBe(100);
+    expect(flattenPeriods[0].id).toBe("3");
+    expect(mockLog).toHaveBeenCalledTimes(2);
+    mockLog.mockRestore();
+  });
 });

--- a/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
+++ b/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
@@ -73,6 +73,11 @@ export default function flattenOverlappingPeriods(
         // `lastFlattenedPeriod` has now a negative or `0` duration.
         // Remove it, consider the next Period in its place, and re-start the loop.
         flattenedPeriods.pop();
+        if (flattenedPeriods.length === 0) {
+          // There's no remaining Period to compare to `parsedPeriod`
+          break;
+        }
+        // Take the previous Period as reference and compare it now to `parsedPeriod`
         lastFlattenedPeriod = flattenedPeriods[flattenedPeriods.length - 1];
       }
     }


### PR DESCRIPTION
Some streaming technologies/protocols such as DASH have a concept of `Period`, which is a temporal subpart of the content with its own tracks, qualities and other characteristics. You can think of it for example as various programs in a contents, some having multiple audio languages and subtitles, other not.

In the RxPlayer, Period are meant to be non-overlapping, to always rely on a single known list of available tracks (for audio, video and text) and available qualities at any given position.
This means that you may have a Period from the position `10` (let's say seconds) to `20`, then from `20` to `30`, but never something like from position `10` to `25` then from `20` to `30`, as the `20-25` interval would be ambiguous regarding its available tracks and qualities: the two Periods are competing for it, which one should the RxPlayer consider at e.g. position `22`?

Because the RxPlayer does not control the server providing the content, it has safe guards ensuring that Periods do not overlap, and in the rare cases where they do, has an algorithm to resolve such overlaps.

Usually we give in that algorithm more priority to the later Periods (for example it makes sense for a live content, where a later Period most likely has been produced later and might thus be an updated version of the content if conflicting at some timecodes with a previous Period).

We found out however that there was a bug in that code for when the initial Period was removed due to a later Period completely overlapping it (meaning: the later Period starts at the same time or before the initial Period).

This PR fixes this, and adds a test for it.

This may be seen as a very rare situation, and it is as we just encountered for the first time lately, and most likely indicative of an issue at the back-end-side: why would a Period scheduled for later begins before (or at) a previous Period's start?

It turns out that this is a trick made by some packagers in some ad-switching scenarios, to dynamically remove an ad from a content once it has been completely watched and replace it with the original content - which may even begin before the start of the now removed ad.