### PR TITLE
fix(demo): live content had wrong values on the progress bar

### DIFF
--- a/demo/full/scripts/controllers/ProgressBar.tsx
+++ b/demo/full/scripts/controllers/ProgressBar.tsx
@@ -57,7 +57,7 @@ function ProgressBar({
     setTimeIndicatorVisible(true);
     setTimeIndicatorPosition(clientX);
     setTimeIndicatorText(currentReadableTime);
-  }, []);
+  }, [isLive]);
 
   const hideTimeIndicator = React.useCallback((): void => {
     setTimeIndicatorVisible(false);


### PR DESCRIPTION
Fix a bug in the demo of the Rx-Player : 
Playing a live content in the demo resulted in wrong values in the progress bar.
The content was unexpectedly interpreted as non-live content, because `isLive` was not tracked as a dependency in the react callback.

<img width="564" alt="image" src="https://github.com/canalplus/rx-player/assets/58945185/b05c8422-5541-4a71-8aa0-cdf06ce62641">
