### PR TITLE
fix bug: subtitle no longer blink in low latency

### DIFF
--- a/src/core/segment_buffers/implementations/text/html/__tests__/utils.test.ts
+++ b/src/core/segment_buffers/implementations/text/html/__tests__/utils.test.ts
@@ -261,6 +261,21 @@ describe("HTML Text buffer utils - areNearlyEqual", () => {
   it("should return true if input number are equals", () => {
     expect(areNearlyEqual(5, 5)).toBe(true);
   });
+  it(
+    "should return false if input number are not nearly equals with delta parameter",
+    () => {
+      expect(areNearlyEqual(5, 5.1, 0.02)).toBe(false);
+    });
+  it(
+    "should return true if input number are nearly equals with delta parameter",
+    () => {
+      expect(areNearlyEqual(5, 5.01, 0.02)).toBe(true);
+    });
+  it(
+    "should return true if input number are equals with delta parameter",
+    () => {
+      expect(areNearlyEqual(5, 5, 0.02)).toBe(true);
+    });
 });
 
 describe("HTML Text buffer utils - removeCuesInfosBetween", () => {

--- a/src/core/segment_buffers/implementations/text/html/text_track_cues_store.ts
+++ b/src/core/segment_buffers/implementations/text/html/text_track_cues_store.ts
@@ -93,11 +93,13 @@ export default class TextTrackCuesStore {
         // or end time than the start or end time of the ICuesGroup due to parsing
         // approximation.
         // Add a tolerance of 1ms to fix this issue
-        if (ret.length === 0 && cues.length) {
-          if (areNearlyEqual(time, cues[0].start, DELTA_CUES_GROUP)) {
-            ret.push(cues[0].element);
-          } else if (areNearlyEqual(time, cues[cues.length - 1].end, DELTA_CUES_GROUP)) {
-            ret.push(cues[cues.length - 1].element);
+        if (ret.length === 0 && cues.length > 0) {
+          for (let j = 0; j < cues.length; j++) {
+            if (areNearlyEqual(time, cues[j].start, DELTA_CUES_GROUP)
+            || areNearlyEqual(time, cues[j].end, DELTA_CUES_GROUP)
+            ) {
+              ret.push(cues[j].element);
+            }
           }
         }
         return ret;

--- a/src/core/segment_buffers/implementations/text/html/text_track_cues_store.ts
+++ b/src/core/segment_buffers/implementations/text/html/text_track_cues_store.ts
@@ -26,10 +26,22 @@ import {
   removeCuesInfosBetween,
 } from "./utils";
 
-const DELTA_CUES_GROUP = 1e-3; // 1ms
+/**
+ * first or last IHTMLCue in a group can have a slighlty different start
+ * or end time than the start or end time of the ICuesGroup due to parsing
+ * approximation.
+ * DELTA_CUES_GROUP defines the tolerance level when comparing the start/end
+ * of a IHTMLCue to the start/end of a ICuesGroup.
+ * Having this value too high may lead to have unwanted subtitle displayed
+ * Having this value too low may lead to have subtitles not displayed
+ */
+const DELTA_CUES_GROUP = 1e-3;
 
-// segment_duration / RELATIVE_DELTA_RATIO = relative_delta
-// relative_delta is the tolerance to determine if two segements are the same
+/**
+ * segment_duration / RELATIVE_DELTA_RATIO = relative_delta
+ *
+ * relative_delta is the tolerance to determine if two segements are the same
+ */
 const RELATIVE_DELTA_RATIO = 5;
 /**
  * Manage the buffer of the HTMLTextSegmentBuffer.
@@ -358,11 +370,15 @@ export default class TextTrackCuesStore {
     if (cuesBuffer.length) {
       const lastCue = cuesBuffer[cuesBuffer.length - 1];
       if (areNearlyEqual(lastCue.end, start, relativeDelta)) {
-           // Match the end of the previous cue to the start of
-           // the following one if they are close enough
-           //   ours:                   |AAAAA|
-           //   the current one: |BBBBB|...
-           //   Result:          |BBBBBBBAAAAA|
+        // Match the end of the previous cue to the start of the following one
+        // if they are close enough. If there is a small gap between two segments
+        // it can lead to having no subtitles for a short time, this is noticeable when
+        // two successive segments displays the same text, making it diseappear
+        // and reappear quickly, which gives the impression of blinking
+        //
+        //   ours:                   |AAAAA|
+        //   the current one: |BBBBB|...
+        //   Result:          |BBBBBBBAAAAA|
         lastCue.end  = start;
       }
     }

--- a/src/core/segment_buffers/implementations/text/html/utils.ts
+++ b/src/core/segment_buffers/implementations/text/html/utils.ts
@@ -50,6 +50,21 @@ import {
  * Setting a value too high might lead to two segments targeting different times
  * to be wrongly believed to target the same time. In worst case scenarios, this
  * could lead to wanted text tracks being removed.
+ *
+ * When comparing 2 segments s1 and s2, you may want to take into account the duration
+ * of the segments:
+ *   - if s1 is [0, 2] and s2 is [0, 2.1] s1 and s2 can be considered as nearly equal as
+ *     there is a relative difference of: (2.1-2) / 2 = 5%;
+ *     Formula: (end_s1 - end_s2) / duration_s2 = relative_difference
+ *   - if s1 is [0, 0.04] and s2 is [0.04, 0.08] s1 and s2 may not considered as nearly
+ *     equal as there is a relative difference of: (0.04-0.08) / 0.04 = 100%
+ *
+ * To compare relatively to the duration of a segment you can provide and additional
+ * parameter "delta" that remplace MAX_DELTA_BUFFER_TIME.
+ * If parameter "delta" is higher than MAX_DELTA_BUFFER_TIME, MAX_DELTA_BUFFER_TIME
+ * is used instead of delta. This ensure that segments are nearly equal when comparing
+ * relatively AND absolutely.
+ *
  * @type Number
  */
 const MAX_DELTA_BUFFER_TIME = 0.2;
@@ -58,10 +73,12 @@ const MAX_DELTA_BUFFER_TIME = 0.2;
  * @see MAX_DELTA_BUFFER_TIME
  * @param {Number} a
  * @param {Number} b
+ * @param {Number} delta
  * @returns {Boolean}
  */
-export function areNearlyEqual(a : number, b : number) : boolean {
-  return Math.abs(a - b) <= MAX_DELTA_BUFFER_TIME;
+export function areNearlyEqual(
+  a : number, b : number, delta: number = MAX_DELTA_BUFFER_TIME) : boolean {
+  return Math.abs(a - b) <= Math.min(delta, MAX_DELTA_BUFFER_TIME);
 }
 
 /**


### PR DESCRIPTION
### The bug
When playing a video in low-latency mode with subtitle, the subtitle were disappearing and reappear very quickly making the subtitles "blink".
This was only experienced in low-latency mode.


--------
#### Explanations

It was due to the size of the subtitles segments that differs in normal mode vs low-latency: 
- Normal mode: around 2 seconds
- Low latency: around 2 seconds with chunks of 40 milliseconds

When sorting segments in the buffer, there is a logic that compare which segments should come first, and it determines if there are segments that are the "same" or if they overlap.

The logic that compute if two segments are the "same" were relying on a constant `MAX_DELTA_BUFFER_TIME` equals to 200ms.
200ms of tolerance is fine for segments that lasts 2s, but for segments of 40ms in low-latency it's way too high, and segments of 40ms that were different were considered "same".

As a correction, the tolerance is variable and depends on the segment duration that is being inserted. It's equal to one fifth of the duration of the segment.



-------
Additionally, there was another issue on parsing of the cues: 
the `end: 278946541.9999333` of the cuesGroup has more precision than the `end: 278946542.039` of the cuesElement.
In very specific case, there can be `time < cuesGroup.end` and `time > cuesElement.end`.
In such case the `cuesElement` is not displayed. 
Again adding a small tolerance fix the issue

```json
{
    "start": 278946541.9999333,
    "end": 278946542.0399333,
    "cues": [
        {
            "start": 278946541.999,
            "end": 278946542.039,
            "element": {}
        }
    ]
}
```