### PR TITLE
Debug: update buffer graph maximum size so it becomes more readable for lengthy contents

### DIFF
--- a/src/core/api/debug/buffer_graph.ts
+++ b/src/core/api/debug/buffer_graph.ts
@@ -1,7 +1,7 @@
 import { Representation } from "../../../manifest";
 import { IBufferedChunk } from "../../segment_buffers";
 
-const BUFFER_WIDTH_IN_SECONDS = 10000;
+const BUFFER_WIDTH_IN_SECONDS = 30 * 60;
 
 const COLORS = [
   "#2ab7ca",
@@ -96,8 +96,8 @@ export default class SegmentBufferGraph {
     let maximumPosition;
     if (maximumPoint - minimumPoint > BUFFER_WIDTH_IN_SECONDS) {
       if (currentTime === undefined) {
-        minimumPosition = minimumPoint;
         maximumPosition = maximumPoint;
+        minimumPosition = maximumPoint - BUFFER_WIDTH_IN_SECONDS;
       } else if (maximumPoint - currentTime < BUFFER_WIDTH_IN_SECONDS / 2) {
         maximumPosition = maximumPoint;
         minimumPosition = maximumPoint - BUFFER_WIDTH_IN_SECONDS;

--- a/src/core/api/debug/buffer_graph.ts
+++ b/src/core/api/debug/buffer_graph.ts
@@ -95,10 +95,7 @@ export default class SegmentBufferGraph {
     let minimumPosition;
     let maximumPosition;
     if (maximumPoint - minimumPoint > BUFFER_WIDTH_IN_SECONDS) {
-      if (currentTime === undefined) {
-        maximumPosition = maximumPoint;
-        minimumPosition = maximumPoint - BUFFER_WIDTH_IN_SECONDS;
-      } else if (maximumPoint - currentTime < BUFFER_WIDTH_IN_SECONDS / 2) {
+      if (maximumPoint - currentTime < BUFFER_WIDTH_IN_SECONDS / 2) {
         maximumPosition = maximumPoint;
         minimumPosition = maximumPoint - BUFFER_WIDTH_IN_SECONDS;
       } else if (currentTime - minimumPoint < BUFFER_WIDTH_IN_SECONDS / 2) {


### PR DESCRIPTION
When displaying the RxPlayer's debug element, a graph describing the audio, video and text qualities in the various buffers might be displayed.

At maximum, that graph could display 10000 seconds of content, which made in that case the graph poorly readable.

I now chose to reduce it to maximum 30 minutes, as you rarely intend to see more when displaying debug information, making it much more readable.