### PR TITLE
Debug: always synchronize SegmentInventory before reporting it through the API

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2429,9 +2429,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     const segmentBufferStatus = this._priv_contentInfos
       .segmentBuffersStore.getStatus(bufferType);
-    return segmentBufferStatus.type === "initialized" ?
-      segmentBufferStatus.value.getInventory() :
-      null;
+    if (segmentBufferStatus.type === "initialized") {
+      segmentBufferStatus.value.synchronizeInventory();
+      return segmentBufferStatus.value.getInventory();
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
We have a minor issue with an undocumented API letting applications know the content of the various buffers (audio, video and text), which may show in some rare cases to an unsynchronized view into one of those buffers.

As this API is not documented and put behind an unwelcoming method name, the only impact that unsynchronized status could have are:

  - information shown in the RxPlayer's debug element (through the `createDebugElement API`) could not reflect the exact reality.

    The only case I've seen now is that when enabling then disabling text tracks, we may still see a view making it seems that the since-remove text segments pushed were still here (it is in reality not, as should be expected).

  - Likewise, our demo page's buffer graph, which rely on the same API, could show an unsynchronized view into the buffer in the same situation.

The solution I found was just to make sure the `SegmentInventory`, the module actually storing that buffer information, is always synchronized to the buffer at the time that hidden API is called. This could mean unnecessary calls when the buffer is already synchronized, but we do not care much as that API is only called for debug anyway and not even performance-sensitive for the moment.