### PR TITLE
Add unsupported and undecipherable bitrates to the debug element

### DIFF
--- a/doc/api/Miscellaneous/Debug_Element.md
+++ b/doc/api/Miscellaneous/Debug_Element.md
@@ -104,8 +104,20 @@ reflect exactly what's going on at a particular point in time.
     - **vt**: _Video tracks_. List of the video tracks' `id` property. The line begins with a number indicating the number of available video tracks, followed by `:`, followed by each video track's id separated by a space. The current video track is prepended by a `*` character.
     - **at**: _Audio tracks_. List of the audio tracks' `id` property. The line begins with a number indicating the number of available audio tracks, followed by `:`, followed by each audio track's id separated by a space. The current audio track is prepended by a `*` character.
     - **tt**: _Text tracks_. List of the text tracks' `id` property. The line begins with a number indicating the number of available text tracks, followed by `:`, followed by each text track's id separated by a space. The current text track is prepended by a `*` character.
-    - **vb**: _Video Bitrates_. The available video bitrates in the current video track, separated by a space.
-    - **ab**: _Audio Bitrates_. The available audio bitrates in the current audio track, separated by a space.
+    - **vb**: _Video Bitrates_. The available video bitrates in the current
+      video track, separated by a space.
+      Each bitrate value can optionally be followed by an "`U!`", in which case
+      the codec of the corresponding Representation is unsupported, and/or be
+      followed by an "`E!`", in which case it is undecipherable currently.
+      In both of those cases the corresponding video Representation won't be
+      played by the RxPlayer.
+    - **ab**: _Audio Bitrates_. The available audio bitrates in the current
+      audio track, separated by a space.
+      Each bitrate value can optionally be followed by an "`U!`", in which case
+      the codec of the corresponding Representation is unsupported, and/or be
+      followed by an "`E!`", in which case it is undecipherable currently.
+      In both of those cases the corresponding audio Representation won't be
+      played by the RxPlayer.
 
   - Buffer information
     - **vbuf**: _Graphical representation of the video buffer_. The red rectangle indicates the current position, the different colors indicate different video qualities in the buffer.

--- a/src/core/api/debug/modules/general_info.ts
+++ b/src/core/api/debug/modules/general_info.ts
@@ -181,19 +181,28 @@ export default function constructDebugGeneralInfo(
         ]);
         adaptationsElt.appendChild(textAdaps);
       }
-      const videoBitrates = instance.getAvailableVideoBitrates();
-      const audioBitrates = instance.getAvailableAudioBitrates();
+      const adaptations = instance.getCurrentAdaptations();
+      const videoBitratesStr = adaptations?.video?.representations.map((r) => {
+        return String(r.bitrate) +
+               (r.isSupported ? "" : " U!") +
+               (r.decipherable === false ? "" : " E!");
+      }) ?? [];
+      const audioBitratesStr = adaptations?.video?.representations.map((r) => {
+        return String(r.bitrate) +
+               (r.isSupported ? "" : " U!") +
+               (r.decipherable === false ? "" : " E!");
+      }) ?? [];
       representationsElt.innerHTML = "";
-      if (videoBitrates.length > 0) {
+      if (videoBitratesStr.length > 0) {
         representationsElt.appendChild(createMetricTitle("vb"));
         representationsElt.appendChild(createElement("span", {
-          textContent: videoBitrates.join(" ") + " ",
+          textContent: videoBitratesStr.join(" ") + " ",
         }));
       }
-      if (audioBitrates.length > 0) {
+      if (audioBitratesStr.length > 0) {
         representationsElt.appendChild(createMetricTitle("ab"));
         representationsElt.appendChild(createElement("span", {
-          textContent: audioBitrates.join(" ") + " ",
+          textContent: audioBitratesStr.join(" ") + " ",
         }));
       }
     } else {

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -313,6 +313,9 @@ export interface IRepresentation {
   /** If the track is HDR, gives the HDR characteristics of the content */
   hdrInfo? : IHDRInformation;
   index : IRepresentationIndex;
+
+  /** NOTE: not part of the API. */
+  isSupported: boolean;
 }
 
 export interface IHDRInformation {


### PR DESCRIPTION
The debug element that might be displayed with the `createDebugElement` method filtered from listed video and audio bitrates those that were not for decipherable or decodable Representation.

This makes sense, but it bothered us when debugging why some qualities were not advertised anymore through that window on some difficult-to-debug devices lately: was it an RxPlayer bug, a DRM policy not respected, or codecs that were unsupported.

This commit adds audio and video bitrates which are not actually playable, suffixing them by `E!` when it is because it's not decipherable, by `U!` when it's because the codec is not supported, or both (`U! E!`) when it's both.