### PR TITLE
Add maxBufferAhead exception for text garbage collection

### DIFF
--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -201,6 +201,23 @@ const DEFAULT_CONFIG = {
   } as Partial<Record<"audio"|"video"|"image"|"text", number>>,
     /* eslint-enable @typescript-eslint/consistent-type-assertions */
 
+  /* eslint-disable @typescript-eslint/consistent-type-assertions */
+  /**
+   * Minimum possible buffer ahead for each type of buffer, to avoid Garbage
+   * Collecting too much data when it would have adverse effects.
+   * Equal to `0` if not defined here.
+   * @type {Object}
+   */
+  MINIMUM_MAX_BUFFER_AHEAD: {
+    // Text segments are both much lighter on resources and might
+    // actually be much larger than other types of segments in terms
+    // of duration. Let's make an exception here by authorizing a
+    // larger text buffer ahead, to avoid unnecesarily reloading the
+    // same text track.
+    text: 2 * 60,
+  } as Partial<Record<"audio"|"video"|"image"|"text", number>>,
+  /* eslint-enable @typescript-eslint/consistent-type-assertions */
+
     /* eslint-disable @typescript-eslint/consistent-type-assertions */
     /**
      * Maximum possible buffer behind for each type of buffer, to avoid too much


### PR DESCRIPTION
The `maxBufferAhead` RxPlayer option allows to manually garbage collect media data that is too far ahead from the playing position.

It can be set to a number of seconds, and was previously applied to audio, video and text media segments.

For example when setting `maxBufferAhead` to `30`, and playing at position `20`, we would remove if present media data already buffered a position `50` or more (which could for example mostly happen when seeking back in the content).

We found out however that applying that same value to the text buffer may not always be sensible:
 - `maxBufferAhead` is most likely defined by an application to restrict memory usage. The space taken by the text cues have much less weight than audio and video
 - We encounter several contents where loaded text segments span for 1 minute, most likely because of how small those segments are. Here we risk progressively reloading the same segment as its end will be GCed multiple times.

Due to both of these situations, I decided for now to have a lower bound on the `maxBufferAhead` applied on the text buffer to 2 minutes. We also could have made the `maxBufferAhead` API more configurable by letting an application set a different setting per media type, but I thought that an application may not easily realize the issue.