### PR TITLE
Refacto current position handling again just to work-around tizen mischievous seek-backs

### DIFF
--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -30,7 +30,7 @@ import SharedReference, {
 import TaskCanceller, {
   CancellationSignal,
 } from "../../utils/task_canceller";
-import { IReadOnlyPlaybackObserver } from "../api";
+import { IObservationPosition, IReadOnlyPlaybackObserver } from "../api";
 import { IBufferType } from "../segment_buffers";
 import BufferBasedChooser from "./buffer_based_chooser";
 import GuessBasedChooser from "./guess_based_chooser";
@@ -272,7 +272,7 @@ function getEstimateReference(
       }
       const { position, speed } = lastPlaybackObservation;
       const timeRanges = val.buffered;
-      const bufferGap = getLeftSizeOfBufferedTimeRange(timeRanges, position.last);
+      const bufferGap = getLeftSizeOfBufferedTimeRange(timeRanges, position.getWanted());
       const { representation } = val.content;
       const currentScore = scoreCalculator.getEstimate(representation);
       const currentBitrate = representation.bitrate;
@@ -389,7 +389,7 @@ function getEstimateReference(
       if (lowLatencyMode &&
           currentRepresentationVal !== null &&
           context.manifest.isDynamic &&
-          maximumPosition - position.last < 40)
+          maximumPosition - position.getWanted() < 40)
       {
         chosenRepFromGuessMode = guessBasedChooser
           .getGuess(sortedRepresentations,
@@ -595,24 +595,7 @@ export interface IRepresentationEstimatorPlaybackObservation {
    * Information on the current media position in seconds at the time of a
    * Playback Observation.
    */
-  position : {
-    /**
-     * Known position at the time the Observation was emitted, in seconds.
-     *
-     * Note that it might have changed since. If you want truly precize
-     * information, you should recuperate it from the HTMLMediaElement directly
-     * through another mean.
-     */
-    last : number;
-    /**
-     * Actually wanted position in seconds that is not yet reached.
-     *
-     * This might for example be set to the initial position when the content is
-     * loading (and thus potentially at a `0` position) but which will be seeked
-     * to a given position once possible.
-     */
-    pending : number | undefined;
-  };
+  position : IObservationPosition;
   /**
    * Last "playback rate" set by the user. This is the ideal "playback rate" at
    * which the media should play.

--- a/src/core/adaptive/network_analyzer.ts
+++ b/src/core/adaptive/network_analyzer.ts
@@ -154,7 +154,7 @@ function estimateStarvationModeBitrate(
   const { bufferGap, speed, position } = playbackInfo;
   const realBufferGap = isFinite(bufferGap) ? bufferGap :
                                               0;
-  const nextNeededPosition = position.last + realBufferGap;
+  const nextNeededPosition = position.getWanted() + realBufferGap;
   const concernedRequests = getConcernedRequests(pendingRequests, nextNeededPosition);
 
   if (concernedRequests.length !== 1) { // 0  == no request
@@ -238,7 +238,7 @@ function shouldDirectlySwitchToLowBitrate(
   }
   const realBufferGap = isFinite(playbackInfo.bufferGap) ? playbackInfo.bufferGap :
                                                            0;
-  const nextNeededPosition = playbackInfo.position.last + realBufferGap;
+  const nextNeededPosition = playbackInfo.position.getWanted() + realBufferGap;
   const nextRequest = arrayFind(requests, ({ content }) =>
     content.segment.duration > 0 &&
     (content.segment.time + content.segment.duration) > nextNeededPosition);
@@ -334,7 +334,7 @@ export default class NetworkAnalyzer {
     const { ABR_STARVATION_DURATION_DELTA } = config.getCurrent();
     // check if should get in/out of starvation mode
     if (isNaN(duration) ||
-        realBufferGap + position.last < duration - ABR_STARVATION_DURATION_DELTA)
+        realBufferGap + position.getWanted() < duration - ABR_STARVATION_DURATION_DELTA)
     {
       if (!this._inStarvationMode && realBufferGap <= localConf.starvationGap) {
         log.info("ABR: enter starvation mode.");

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -18,6 +18,7 @@ import PlaybackObserver from "./playback_observer";
 import Player from "./public_api";
 export { PlaybackObserver };
 export {
+  IObservationPosition,
   IPlaybackObservation,
   IPlaybackObserverEventType,
   IReadOnlyPlaybackObserver,

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -814,12 +814,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         case "ENDED":
           this._priv_reloadingMetadata.reloadInPause = true;
           this._priv_reloadingMetadata.reloadPosition =
-            playbackObserver.getReference().getValue().position;
+            playbackObserver.getReference().getValue().position.last;
           break;
         default:
           const o = playbackObserver.getReference().getValue();
           this._priv_reloadingMetadata.reloadInPause = o.paused;
-          this._priv_reloadingMetadata.reloadPosition = o.position;
+          this._priv_reloadingMetadata.reloadPosition = o.position.pending ??
+                                                        o.position.last;
           break;
       }
     };
@@ -2590,7 +2591,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const maximumPosition = manifest !== null ? manifest.getMaximumSafePosition() :
                                                 undefined;
     const positionData : IPositionUpdate = {
-      position: observation.position,
+      position: observation.position.last,
       duration: observation.duration,
       playbackRate: observation.playbackRate,
       maximumPosition,
@@ -2604,18 +2605,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     if (manifest !== null &&
         manifest.isLive &&
-        observation.position > 0
+        observation.position.last > 0
     ) {
       const ast = manifest.availabilityStartTime ?? 0;
-      positionData.wallClockTime = observation.position + ast;
+      positionData.wallClockTime = observation.position.last + ast;
       const livePosition = manifest.getLivePosition();
       if (livePosition !== undefined) {
-        positionData.liveGap = livePosition - observation.position;
+        positionData.liveGap = livePosition - observation.position.last;
       }
     } else if (isDirectFile && this.videoElement !== null) {
       const startDate = getStartDate(this.videoElement);
       if (startDate !== undefined) {
-        positionData.wallClockTime = startDate + observation.position;
+        positionData.wallClockTime = startDate + observation.position.last;
       }
     }
     this.trigger("positionUpdate", positionData);

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -814,13 +814,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         case "ENDED":
           this._priv_reloadingMetadata.reloadInPause = true;
           this._priv_reloadingMetadata.reloadPosition =
-            playbackObserver.getReference().getValue().position.last;
+            playbackObserver.getReference().getValue().position.getPolled();
           break;
         default:
           const o = playbackObserver.getReference().getValue();
           this._priv_reloadingMetadata.reloadInPause = o.paused;
-          this._priv_reloadingMetadata.reloadPosition = o.position.pending ??
-                                                        o.position.last;
+          this._priv_reloadingMetadata.reloadPosition = o.position.getWanted();
           break;
       }
     };
@@ -2591,7 +2590,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const maximumPosition = manifest !== null ? manifest.getMaximumSafePosition() :
                                                 undefined;
     const positionData : IPositionUpdate = {
-      position: observation.position.last,
+      position: observation.position.getPolled(),
       duration: observation.duration,
       playbackRate: observation.playbackRate,
       maximumPosition,
@@ -2605,18 +2604,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     if (manifest !== null &&
         manifest.isLive &&
-        observation.position.last > 0
+        observation.position.getPolled() > 0
     ) {
       const ast = manifest.availabilityStartTime ?? 0;
-      positionData.wallClockTime = observation.position.last + ast;
+      positionData.wallClockTime = observation.position.getPolled() + ast;
       const livePosition = manifest.getLivePosition();
       if (livePosition !== undefined) {
-        positionData.liveGap = livePosition - observation.position.last;
+        positionData.liveGap = livePosition - observation.position.getPolled();
       }
     } else if (isDirectFile && this.videoElement !== null) {
       const startDate = getStartDate(this.videoElement);
       if (startDate !== undefined) {
-        positionData.wallClockTime = startDate + observation.position.last;
+        positionData.wallClockTime = startDate + observation.position.getPolled();
       }
     }
     this.trigger("positionUpdate", positionData);

--- a/src/core/api/utils.ts
+++ b/src/core/api/utils.ts
@@ -28,6 +28,7 @@ import {
 import {
   IPlaybackObservation,
   IReadOnlyPlaybackObserver,
+  SeekingState,
 } from "./playback_observer";
 
 /**
@@ -52,7 +53,8 @@ export function emitSeekEvents(
     return ;
   }
 
-  let wasSeeking = playbackObserver.getReference().getValue().seeking;
+  let wasSeeking =
+    playbackObserver.getReference().getValue().seeking === SeekingState.External;
   if (wasSeeking) {
     onSeeking();
     if (cancelSignal.isCancelled()) {

--- a/src/core/init/directfile_content_initializer.ts
+++ b/src/core/init/directfile_content_initializer.ts
@@ -208,14 +208,14 @@ export default class DirectFileContentInitializer extends ContentInitializer {
       log.debug("Init: Initial time calculated:", initTime);
       return initTime;
     };
-    performInitialSeekAndPlay(
-      mediaElement,
-      playbackObserver,
-      initialTime,
-      autoPlay,
-      (err) => this.trigger("warning", err),
-      cancelSignal
-    ).autoPlayResult
+    performInitialSeekAndPlay({ mediaElement,
+                                playbackObserver,
+                                startTime: initialTime,
+                                mustAutoPlay: autoPlay,
+                                onWarning: (err) => this.trigger("warning", err),
+                                isDirectfile: true },
+                              cancelSignal)
+      .autoPlayResult
       .then(() =>
         getLoadedReference(playbackObserver, mediaElement, true, cancelSignal)
           .onUpdate((isLoaded, stopListening) => {

--- a/src/core/init/media_source_content_initializer.ts
+++ b/src/core/init/media_source_content_initializer.ts
@@ -416,12 +416,13 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       segmentBuffersStore.disposeAll();
     });
 
-    const { autoPlayResult, initialPlayPerformed, initialSeekPerformed } =
-      performInitialSeekAndPlay(mediaElement,
-                                playbackObserver,
-                                initialTime,
-                                autoPlay,
-                                (err) => this.trigger("warning", err),
+    const { autoPlayResult, initialPlayPerformed } =
+      performInitialSeekAndPlay({ mediaElement,
+                                  playbackObserver,
+                                  startTime: initialTime,
+                                  mustAutoPlay: autoPlay,
+                                  onWarning: (err) => { this.trigger("warning", err); },
+                                  isDirectfile: false },
                                 cancelSignal);
 
     if (cancelSignal.isCancelled()) {
@@ -451,9 +452,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                                                         { autoPlay,
                                                           manifest,
                                                           initialPlayPerformed,
-                                                          initialSeekPerformed,
-                                                          speed,
-                                                          startTime: initialTime },
+                                                          speed },
                                                         cancelSignal);
 
     const rebufferingController = this._createRebufferingController(playbackObserver,
@@ -463,13 +462,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                                                                     cancelSignal);
     rebufferingController.addEventListener("needsReload", () => {
       let position: number;
-      const pendingPosition = playbackObserver.getReference().getValue().position.pending;
-      if (pendingPosition !== undefined) {
-        position = pendingPosition;
-      } else if (initialSeekPerformed.getValue()) {
-        position = playbackObserver.getCurrentTime2();
+      const lastObservation = playbackObserver.getReference().getValue();
+      if (lastObservation.position.isAwaitingFuturePosition()) {
+        position = lastObservation.position.getWanted();
       } else {
-        position = initialTime;
+        position = playbackObserver.getCurrentTime();
       }
 
       // NOTE couldn't both be always calculated at event destination?
@@ -549,11 +546,10 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               // Data is buffered around the current position
               obs.currentRange !== null ||
               // Or, for whatever reason, we have no buffer but we're already advancing
-              obs.position.last > seekedTime + 0.1
+              obs.position.getPolled() > seekedTime + 0.1
             ) {
               stopListening();
-              playbackObserver
-                .setCurrentTime(obs.position.pending ?? obs.position.last + 0.001);
+              playbackObserver.setCurrentTime(obs.position.getWanted() + 0.001);
             }
           }, { includeLastObservation: false, clearSignal: cancelSignal });
         },
@@ -643,8 +639,9 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
         needsMediaSourceReload: (payload) => {
           const lastObservation = streamObserver.getReference().getValue();
-          const currentPosition = lastObservation.position.pending ??
-                                  streamObserver.getCurrentTime2();
+          const currentPosition = lastObservation.position.isAwaitingFuturePosition() ?
+            lastObservation.position.getWanted() :
+            streamObserver.getCurrentTime();
           const isPaused = lastObservation.paused.pending ??
                            streamObserver.getIsPaused();
           let position = currentPosition + payload.timeOffset;
@@ -661,15 +658,17 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           const keySystem = getKeySystemConfiguration(mediaElement);
           if (shouldReloadMediaSourceOnDecipherabilityUpdate(keySystem?.[0])) {
             const lastObservation = streamObserver.getReference().getValue();
-            const position = lastObservation.position.pending ??
-                             streamObserver.getCurrentTime2();
+            const position = lastObservation.position.isAwaitingFuturePosition() ?
+              lastObservation.position.getWanted() :
+              streamObserver.getCurrentTime();
             const isPaused = lastObservation.paused.pending ??
                              streamObserver.getIsPaused();
             onReloadOrder({ position, autoPlay: !isPaused });
           } else {
             const lastObservation = streamObserver.getReference().getValue();
-            const position = lastObservation.position.pending ??
-                             streamObserver.getCurrentTime2();
+            const position = lastObservation.position.isAwaitingFuturePosition() ?
+              lastObservation.position.getWanted() :
+              streamObserver.getCurrentTime();
             // simple seek close to the current position
             // to flush the buffers
             if (position + 0.001 < lastObservation.duration) {

--- a/src/core/init/utils/content_time_boundaries_observer.ts
+++ b/src/core/init/utils/content_time_boundaries_observer.ts
@@ -94,7 +94,7 @@ export default class ContentTimeBoundariesObserver
 
     const cancelSignal = this._canceller.signal;
     playbackObserver.listen(({ position }) => {
-      const wantedPosition = position.pending ?? position.last;
+      const wantedPosition = position.getWanted();
       if (wantedPosition < manifest.getMinimumSafePosition()) {
         const warning = new MediaError("MEDIA_TIME_BEFORE_MANIFEST",
                                        "The current position is behind the " +

--- a/src/core/init/utils/create_stream_playback_observer.ts
+++ b/src/core/init/utils/create_stream_playback_observer.ts
@@ -36,12 +36,8 @@ export interface IStreamPlaybackObserverArguments {
   manifest : Manifest;
   /** Becomes `true` after the initial play has been taken care of. */
   initialPlayPerformed : IReadOnlySharedReference<boolean>;
-  /** Becomes `true` after the initial seek has been taken care of. */
-  initialSeekPerformed : IReadOnlySharedReference<boolean>;
   /** The last speed requested by the user. */
   speed : IReadOnlySharedReference<number>;
-  /** The time the player will seek when `initialSeekPerformed` becomes `true`. */
-  startTime : number;
 }
 
 /**
@@ -57,10 +53,8 @@ export default function createStreamPlaybackObserver(
   srcPlaybackObserver : PlaybackObserver,
   { autoPlay,
     initialPlayPerformed,
-    initialSeekPerformed,
     manifest,
-    speed,
-    startTime } : IStreamPlaybackObserverArguments,
+    speed } : IStreamPlaybackObserverArguments,
   fnCancelSignal : CancellationSignal
 ) : IReadOnlyPlaybackObserver<IStreamOrchestratorPlaybackObservation> {
   return srcPlaybackObserver.deriveReadOnlyObserver(function transform(
@@ -87,10 +81,8 @@ export default function createStreamPlaybackObserver(
     function constructStreamPlaybackObservation() {
       const observation = observationRef.getValue();
       const lastSpeed = speed.getValue();
-      let pendingPosition : number | undefined = observation.position.pending;
-      if (!initialSeekPerformed.getValue()) {
-        pendingPosition = startTime;
-      } else if (!manifest.isDynamic || manifest.isLastPeriodKnown) {
+
+      if (!manifest.isDynamic || manifest.isLastPeriodKnown) {
         // HACK: When the position is actually further than the maximum
         // position for a finished content, we actually want to be loading
         // the last segment before ending.
@@ -99,12 +91,19 @@ export default function createStreamPlaybackObserver(
         // doing it).
         const lastPeriod = manifest.periods[manifest.periods.length - 1];
         if (lastPeriod !== undefined && lastPeriod.end !== undefined) {
-          if (observation.position.pending !== undefined) {
-            if (observation.position.pending > lastPeriod.end) {
-              pendingPosition = lastPeriod.end - 1;
+          const wantedPosition = observation.position.getWanted();
+          if (wantedPosition >= lastPeriod.start &&
+              wantedPosition >= lastPeriod.end - 1)
+          {
+            // We're after the end of the last Period, check if `buffered`
+            // indicates that the last segment is probably not loaded, in which
+            // case act as if we want to load one second before the end.
+            const buffered = observation.buffered;
+            if (buffered.length === 0 ||
+                buffered.end(buffered.length - 1) < observation.duration - 1)
+            {
+              observation.position.forceWantedPosition(lastPeriod.end - 1);
             }
-          } else if (observation.position.last > lastPeriod.end) {
-            pendingPosition = lastPeriod.end - 1;
           }
         }
       }
@@ -112,10 +111,7 @@ export default function createStreamPlaybackObserver(
       return {
         // TODO more exact according to the current Adaptation chosen?
         maximumPosition: manifest.getMaximumSafePosition(),
-        position: {
-          last: observation.position.last,
-          pending: pendingPosition,
-        },
+        position: observation.position,
         duration: observation.duration,
         paused: {
           last: observation.paused,

--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -24,6 +24,7 @@ import SharedReference, {
 } from "../../../utils/reference";
 import { CancellationError, CancellationSignal } from "../../../utils/task_canceller";
 import { PlaybackObserver } from "../../api";
+import { SeekingState } from "../../api/playback_observer";
 
 /** Event emitted when trying to perform the initial `play`. */
 export type IInitialPlayEvent =
@@ -117,7 +118,7 @@ export default function performInitialSeekAndPlay(
     }
 
     playbackObserver.listen((observation, stopListening) => {
-      if (!observation.seeking &&
+      if (observation.seeking !== SeekingState.None &&
           observation.rebuffering === null &&
           observation.readyState >= 1)
       {

--- a/src/core/init/utils/rebuffering_controller.ts
+++ b/src/core/init/utils/rebuffering_controller.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import isSeekingApproximate from "../../../compat/is_seeking_approximate";
 import config from "../../../config";
 import { MediaError } from "../../../errors";
 import log from "../../../log";
@@ -31,6 +30,7 @@ import {
   IPlaybackObservation,
   PlaybackObserver,
 } from "../../api";
+import { SeekingState } from "../../api/playback_observer";
 import SegmentBuffersStore, { IBufferType } from "../../segment_buffers";
 import { IStallingSituation } from "../types";
 
@@ -107,33 +107,6 @@ export default class RebufferingController
     }
     this._isStarted = true;
 
-    /**
-     * On some devices (right now only seen on Tizen), seeking through the
-     * `currentTime` property can lead to the browser re-seeking once the
-     * segments have been loaded to improve seeking performances (for
-     * example, by seeking right to an intra video frame).
-     * In that case, we risk being in a conflict with that behavior: if for
-     * example we encounter a small discontinuity at the position the browser
-     * seeks to, we will seek over it, the browser would seek back and so on.
-     *
-     * This variable allows to store the last known position we were seeking to
-     * so we can detect when the browser seeked back (to avoid performing another
-     * seek after that). When browsers seek back to a position behind a
-     * discontinuity, they are usually able to skip them without our help.
-     */
-    let lastSeekingPosition : number | null;
-
-    /**
-     * In some conditions (see `lastSeekingPosition`), we might want to not
-     * automatically seek over discontinuities because the browser might do it
-     * itself instead.
-     * In that case, we still want to perform the seek ourselves if the browser
-     * doesn't do it after sufficient time.
-     * This variable allows to store the timestamp at which a discontinuity began
-     * to be ignored.
-     */
-    let ignoredStallTimeStamp : number | null = null;
-
     const playbackRateUpdater = new PlaybackRateUpdater(this._playbackObserver,
                                                         this._speed);
     this._canceller.signal.register(() => {
@@ -151,25 +124,9 @@ export default class RebufferingController
               freezing } = observation;
 
       const { BUFFER_DISCONTINUITY_THRESHOLD,
-              FORCE_DISCONTINUITY_SEEK_DELAY,
               FREEZING_STALLED_DELAY,
               UNFREEZING_SEEK_DELAY,
               UNFREEZING_DELTA_POSITION } = config.getCurrent();
-
-      if (
-        !observation.seeking &&
-        isSeekingApproximate &&
-        ignoredStallTimeStamp === null &&
-        lastSeekingPosition !== null && observation.position < lastSeekingPosition)
-      {
-        log.debug("Init: the device appeared to have seeked back by itself.");
-        const now = getMonotonicTimeStamp();
-        ignoredStallTimeStamp = now;
-      }
-
-      lastSeekingPosition = observation.seeking ?
-        Math.max(observation.pendingInternalSeek ?? 0, observation.position) :
-        null;
 
       if (this._checkDecipherabilityFreeze(observation)) {
         return ;
@@ -185,12 +142,12 @@ export default class RebufferingController
         if (now - referenceTimestamp > UNFREEZING_SEEK_DELAY) {
           log.warn("Init: trying to seek to un-freeze player");
           this._playbackObserver.setCurrentTime(
-            this._playbackObserver.getCurrentTime() + UNFREEZING_DELTA_POSITION);
+            this._playbackObserver.getCurrentTime2() + UNFREEZING_DELTA_POSITION);
           prevFreezingState = { attemptTimestamp: now };
         }
 
         if (now - freezing.timestamp > FREEZING_STALLED_DELAY) {
-          if (rebuffering === null || ignoredStallTimeStamp !== null) {
+          if (rebuffering === null) {
             playbackRateUpdater.stopRebuffering();
           } else {
             playbackRateUpdater.startRebuffering();
@@ -208,9 +165,10 @@ export default class RebufferingController
           // With a readyState set to 1, we should still not be able to play:
           // Return that we're stalled
           let reason : IStallingSituation;
-          if (observation.seeking) {
-            reason = observation.pendingInternalSeek !== null ? "internal-seek" :
-                                                                "seeking";
+          if (observation.seeking !== SeekingState.None) {
+            reason = observation.seeking === SeekingState.Internal ?
+              "internal-seek" :
+              "seeking";
           } else {
             reason = "not-ready";
           }
@@ -228,20 +186,13 @@ export default class RebufferingController
         "internal-seek" as const :
         rebuffering.reason;
 
-      if (ignoredStallTimeStamp !== null) {
-        const now = getMonotonicTimeStamp();
-        if (now - ignoredStallTimeStamp < FORCE_DISCONTINUITY_SEEK_DELAY) {
-          playbackRateUpdater.stopRebuffering();
-          log.debug("Init: letting the device get out of a stall by itself");
-          this.trigger("stalled", stalledReason);
-          return ;
-        } else {
-          log.warn("Init: ignored stall for too long, considering it",
-                   now - ignoredStallTimeStamp);
-        }
+      if (position.pending !== undefined) {
+        playbackRateUpdater.stopRebuffering();
+        log.debug("Init: letting the device get out of a stall by itself");
+        this.trigger("stalled", stalledReason);
+        return ;
       }
 
-      ignoredStallTimeStamp = null;
       playbackRateUpdater.startRebuffering();
 
       if (this._manifest === null) {
@@ -261,12 +212,12 @@ export default class RebufferingController
                                                                  stalledPosition);
         if (skippableDiscontinuity !== null) {
           const realSeekTime = skippableDiscontinuity + 0.001;
-          if (realSeekTime <= this._playbackObserver.getCurrentTime()) {
+          if (realSeekTime <= this._playbackObserver.getCurrentTime2()) {
             log.info("Init: position to seek already reached, no seeking",
-                     this._playbackObserver.getCurrentTime(), realSeekTime);
-          } else {
+                     this._playbackObserver.getCurrentTime2(), realSeekTime);
+          } else if (position.pending === undefined) {
             log.warn("SA: skippable discontinuity found in the stream",
-                     position, realSeekTime);
+                     position.last, realSeekTime);
             this._playbackObserver.setCurrentTime(realSeekTime);
             this.trigger("warning", generateDiscontinuityError(stalledPosition,
                                                                realSeekTime));
@@ -275,7 +226,7 @@ export default class RebufferingController
         }
       }
 
-      const freezePosition = stalledPosition ?? position;
+      const freezePosition = stalledPosition ?? position.last;
 
       // Is it a very short discontinuity in buffer ? -> Seek at the beginning of the
       //                                                 next range
@@ -290,7 +241,7 @@ export default class RebufferingController
         nextBufferRangeGap < BUFFER_DISCONTINUITY_THRESHOLD
       ) {
         const seekTo = (freezePosition + nextBufferRangeGap + EPSILON);
-        if (this._playbackObserver.getCurrentTime() < seekTo) {
+        if (this._playbackObserver.getCurrentTime2() < seekTo) {
           log.warn("Init: discontinuity encountered inferior to the threshold",
                    freezePosition, seekTo, BUFFER_DISCONTINUITY_THRESHOLD);
           this._playbackObserver.setCurrentTime(seekTo);
@@ -306,7 +257,7 @@ export default class RebufferingController
         if (period.end !== undefined && period.end <= freezePosition) {
           if (this._manifest.periods[i + 1].start > freezePosition &&
               this._manifest.periods[i + 1].start >
-                this._playbackObserver.getCurrentTime())
+                this._playbackObserver.getCurrentTime2())
           {
             const nextPeriod = this._manifest.periods[i + 1];
             this._playbackObserver.setCurrentTime(nextPeriod.start);
@@ -360,7 +311,7 @@ export default class RebufferingController
     ) {
       return;
     }
-    const currPos = observation.position;
+    const currPos = observation.position.pending ?? observation.position.last;
     const rebufferingPos = observation.rebuffering.position ?? currPos;
     const lockedPeriodStart = period.start;
     if (currPos < lockedPeriodStart &&
@@ -555,10 +506,14 @@ function updateDiscontinuitiesStore(
   evt : IDiscontinuityEvent,
   observation : IPlaybackObservation
 ) : void {
+  const gcTime = observation.position.pending !== undefined ?
+    Math.min(observation.position.last, observation.position.pending) :
+    observation.position.last;
+
   // First, perform clean-up of old discontinuities
   while (discontinuitiesStore.length > 0 &&
          discontinuitiesStore[0].period.end !== undefined &&
-         discontinuitiesStore[0].period.end + 10 < observation.position)
+         discontinuitiesStore[0].period.end + 10 < gcTime)
   {
     discontinuitiesStore.shift();
   }

--- a/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -20,6 +20,7 @@ import EventEmitter from "../../../../utils/event_emitter";
 import SharedReference from "../../../../utils/reference";
 import TaskCanceller, { CancellationSignal } from "../../../../utils/task_canceller";
 import { IPlaybackObservation, IReadOnlyPlaybackObserver } from "../../../api";
+import { SeekingState } from "../../../api/playback_observer";
 import refreshScheduledEventsList from "./refresh_scheduled_events_list";
 import {
   INonFiniteStreamEventPayload,
@@ -127,7 +128,8 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
       });
 
       function constructObservation() {
-        const isSeeking = playbackObserver.getReference().getValue().seeking;
+        const isSeeking =
+          playbackObserver.getReference().getValue().seeking !== SeekingState.None;
         return { currentTime: mediaElement.currentTime,
                  isSeeking };
       }

--- a/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/core/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -128,9 +128,10 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
       });
 
       function constructObservation() {
-        const isSeeking =
-          playbackObserver.getReference().getValue().seeking !== SeekingState.None;
-        return { currentTime: mediaElement.currentTime,
+        const lastObservation = playbackObserver.getReference().getValue();
+        const currentTime = mediaElement.currentTime;
+        const isSeeking = lastObservation.seeking !== SeekingState.None;
+        return { currentTime,
                  isSeeking };
       }
     }, { emitCurrentValue: true, clearSignal: cancelSignal });

--- a/src/core/segment_buffers/garbage_collector.ts
+++ b/src/core/segment_buffers/garbage_collector.ts
@@ -54,7 +54,7 @@ export default function BufferGarbageCollector(
 ) : void {
   let lastPosition : number;
   playbackObserver.listen((o) => {
-    lastPosition = o.position.pending ?? o.position.last;
+    lastPosition = o.position.getWanted();
     clean();
   }, { includeLastObservation: true, clearSignal: cancellationSignal });
   function clean() {

--- a/src/core/stream/adaptation/get_representations_switch_strategy.ts
+++ b/src/core/stream/adaptation/get_representations_switch_strategy.ts
@@ -87,12 +87,12 @@ export default function getRepresentationsSwitchingStrategy(
   const readyState = playbackObserver.getReadyState();
   if (settings.switchingMode === "reload" && readyState > 1) {
     const lastObservation = playbackObserver.getReference().getValue();
-    if (lastObservation.position.pending !== undefined) {
+    if (lastObservation.position.isAwaitingFuturePosition()) {
       // We are not at the position we want to reach (e.g. initial seek, tizen
       // seek-back...), just reload as checks here would be too complex
       return { type: "needs-reload", value: undefined };
     } else {
-      const currentTime = playbackObserver.getCurrentTime2();
+      const currentTime = playbackObserver.getCurrentTime();
       if (isTimeInRange({ start, end }, currentTime) &&
           // We're not playing the current wanted video Adaptation
           !isTimeInRanges(rangesWithReps, currentTime))
@@ -136,7 +136,7 @@ export default function getRepresentationsSwitchingStrategy(
     if (paddingAfter == null) {
       paddingAfter = 0;
     }
-    const currentTime = playbackObserver.getCurrentTime2();
+    const currentTime = playbackObserver.getCurrentTime();
     rangesToExclude.push({ start: currentTime - paddingBefore,
                            end: currentTime + paddingAfter });
   }

--- a/src/core/stream/adaptation/get_representations_switch_strategy.ts
+++ b/src/core/stream/adaptation/get_representations_switch_strategy.ts
@@ -35,14 +35,17 @@ import {
   IBufferedChunk,
   SegmentBuffer,
 } from "../../segment_buffers";
-import { IRepresentationsChoice } from "../representation";
+import {
+  IRepresentationStreamPlaybackObservation,
+  IRepresentationsChoice,
+} from "../representation";
 
 export default function getRepresentationsSwitchingStrategy(
   period : Period,
   adaptation : Adaptation,
   settings : IRepresentationsChoice,
   segmentBuffer : SegmentBuffer,
-  playbackObserver : IReadOnlyPlaybackObserver<unknown>
+  playbackObserver : IReadOnlyPlaybackObserver<IRepresentationStreamPlaybackObservation>
 ) : IRepresentationSwitchStrategy {
   if (settings.switchingMode === "lazy") {
     return { type: "continue", value: undefined };
@@ -81,17 +84,22 @@ export default function getRepresentationsSwitchingStrategy(
     return { type: "continue", value: undefined };
   }
 
-  const currentTime = playbackObserver.getCurrentTime();
   const readyState = playbackObserver.getReadyState();
-  if (settings.switchingMode === "reload" &&
-      // We're playing the current Period
-      isTimeInRange({ start, end }, currentTime) &&
-      // There is data for the current position
-      readyState > 1 &&
-      // We're not playing the current wanted video Adaptation
-      !isTimeInRanges(rangesWithReps, currentTime))
-  {
-    return { type: "needs-reload", value: undefined };
+  if (settings.switchingMode === "reload" && readyState > 1) {
+    const lastObservation = playbackObserver.getReference().getValue();
+    if (lastObservation.position.pending !== undefined) {
+      // We are not at the position we want to reach (e.g. initial seek, tizen
+      // seek-back...), just reload as checks here would be too complex
+      return { type: "needs-reload", value: undefined };
+    } else {
+      const currentTime = playbackObserver.getCurrentTime2();
+      if (isTimeInRange({ start, end }, currentTime) &&
+          // We're not playing the current wanted video Adaptation
+          !isTimeInRanges(rangesWithReps, currentTime))
+      {
+        return { type: "needs-reload", value: undefined };
+      }
+    }
   }
 
   // From here, clean-up data from the previous Adaptation, if one
@@ -128,6 +136,7 @@ export default function getRepresentationsSwitchingStrategy(
     if (paddingAfter == null) {
       paddingAfter = 0;
     }
+    const currentTime = playbackObserver.getCurrentTime2();
     rangesToExclude.push({ start: currentTime - paddingBefore,
                            end: currentTime + paddingAfter });
   }

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -173,7 +173,7 @@ export default function StreamOrchestrator(
     // Restart the current Stream when the wanted time is in another period
     // than the ones already considered
     playbackObserver.listen(({ position }) => {
-      const time = position.pending ?? position.last;
+      const time = position.getWanted();
       if (!enableOutOfBoundsCheck || !isOutOfPeriodList(time)) {
         return ;
       }
@@ -370,8 +370,7 @@ export default function StreamOrchestrator(
           }
         }
 
-        const lastPosition = observation.position.pending ??
-                             observation.position.last;
+        const lastPosition = observation.position.getWanted();
         const newInitialPeriod = manifest.getPeriodForTime(lastPosition);
         if (newInitialPeriod == null) {
           callbacks.error(
@@ -444,13 +443,11 @@ export default function StreamOrchestrator(
     // Stop current PeriodStream when the current position goes over the end of
     // that Period.
     playbackObserver.listen(({ position }, stopListeningObservations) => {
-      if (basePeriod.end !== undefined &&
-          (position.pending ?? position.last) >= basePeriod.end)
-      {
+      if (basePeriod.end !== undefined && position.getWanted() >= basePeriod.end) {
         log.info("Stream: Destroying PeriodStream as the current playhead moved above it",
                  bufferType,
                  basePeriod.start,
-                 position.pending ?? position.last,
+                 position.getWanted(),
                  basePeriod.end);
         stopListeningObservations();
         consecutivePeriodStreamCb.periodStreamCleared({ type: bufferType,
@@ -719,7 +716,7 @@ function needsFlushingAfterClean(
   if (cleanedRanges.length === 0) {
     return false;
   }
-  const curPos = observation.position.last;
+  const curPos = observation.position.getPolled();
 
   // Based on the playback direction, we just check whether we may encounter
   // the corresponding ranges, without seeking or re-switching playback

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -441,8 +441,10 @@ function createAdaptationStreamPlaybackObserver(
     ) : IAdaptationStreamPlaybackObservation {
       const baseObservation = observationRef.getValue();
       const buffered = segmentBuffer.getBufferedRanges();
-      const bufferGap = getLeftSizeOfBufferedTimeRange(buffered,
-                                                       baseObservation.position.last);
+      const bufferGap = getLeftSizeOfBufferedTimeRange(
+        buffered,
+        baseObservation.position.getWanted()
+      );
       return objectAssign({}, baseObservation, { bufferGap });
     }
 
@@ -483,15 +485,15 @@ function createEmptyAdaptationStream(
   function sendStatus() : void {
     const observation = playbackObserver.getReference().getValue();
     const wba = wantedBufferAhead.getValue();
-    const position = observation.position.last;
+    const position = observation.position.getWanted();
     if (period.end !== undefined && position + wba >= period.end) {
       log.debug("Stream: full \"empty\" AdaptationStream", bufferType);
       hasFinishedLoading = true;
     }
     callbacks.streamStatusUpdate({ period,
                                    bufferType,
-                                   position,
                                    imminentDiscontinuity: null,
+                                   position,
                                    isEmptyStream: true,
                                    hasFinishedLoading,
                                    neededSegments: [] });

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -221,18 +221,15 @@ export default function PeriodStream(
         return; // Previous call has provoken cancellation by side-effect
       }
 
-      const readyState = playbackObserver.getReadyState();
       const segmentBuffer = createOrReuseSegmentBuffer(segmentBuffersStore,
                                                        bufferType,
                                                        adaptation,
                                                        options);
-      const playbackInfos = { currentTime: playbackObserver.getCurrentTime(),
-                              readyState };
       const strategy = getAdaptationSwitchStrategy(segmentBuffer,
                                                    period,
                                                    adaptation,
                                                    choice.switchingMode,
-                                                   playbackInfos,
+                                                   playbackObserver,
                                                    options);
       if (strategy.type === "needs-reload") {
         return askForMediaSourceReload(relativePosAfterSwitch,

--- a/src/core/stream/period/types.ts
+++ b/src/core/stream/period/types.ts
@@ -8,7 +8,7 @@ import SharedReference, {
 import { CancellationSignal } from "../../../utils/task_canceller";
 import WeakMapMemory from "../../../utils/weak_map_memory";
 import { IRepresentationEstimator } from "../../adaptive";
-import { IReadOnlyPlaybackObserver } from "../../api";
+import { IObservationPosition, IReadOnlyPlaybackObserver } from "../../api";
 import { SegmentFetcherCreator } from "../../fetchers";
 import SegmentBuffersStore, {
   IBufferType,
@@ -21,7 +21,6 @@ import {
   IAdaptationStreamOptions,
   IPausedPlaybackObservation,
 } from "../adaptation";
-import { IPositionPlaybackObservation } from "../representation";
 
 /** Callbacks called by the `AdaptationStream` on various events. */
 export interface IPeriodStreamCallbacks extends
@@ -86,7 +85,7 @@ export interface IPeriodStreamPlaybackObservation {
    * Information on the current media position in seconds at the time of the
    * Observation.
    */
-  position : IPositionPlaybackObservation;
+  position : IObservationPosition;
   /** `duration` property of the HTMLMediaElement. */
   duration : number;
   /** `readyState` property of the HTMLMediaElement. */

--- a/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
@@ -123,11 +123,11 @@ export default function getAdaptationSwitchStrategy(
     return { type: "continue", value: undefined };
   }
 
-  const currentTime = playbackObserver.getCurrentTime2();
+  const currentTime = playbackObserver.getCurrentTime();
   const readyState = playbackObserver.getReadyState();
   if (switchingMode === "reload" && readyState > 1) {
     const lastObservation = playbackObserver.getReference().getValue();
-    if (lastObservation.position.pending !== undefined) {
+    if (lastObservation.position.isAwaitingFuturePosition()) {
       // We are not at the position we want to reach (e.g. initial seek, tizen
       // seek-back...), just reload as checks here would be too complex
       return { type: "needs-reload", value: undefined };

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -230,8 +230,7 @@ export default function RepresentationStream<TSegmentDataType>(
       return ; // Stop all buffer status checking if load operations are stopped
     }
     const observation = playbackObserver.getReference().getValue();
-    const initialWantedTime = observation.position.pending ??
-                              observation.position.last;
+    const initialWantedTime = observation.position.getWanted();
     const status = getBufferStatus(content,
                                    initialWantedTime,
                                    playbackObserver,
@@ -251,8 +250,7 @@ export default function RepresentationStream<TSegmentDataType>(
         log.warn("Stream: Uninitialized index with an already loaded " +
                  "initialization segment");
       } else {
-        const wantedStart = observation.position.pending ??
-                            observation.position.last;
+        const wantedStart = observation.position.getWanted();
         neededInitSegment = { segment: initSegmentState.segment,
                               priority: getSegmentPriority(period.start,
                                                            wantedStart) };
@@ -307,7 +305,7 @@ export default function RepresentationStream<TSegmentDataType>(
     }
 
     callbacks.streamStatusUpdate({ period,
-                                   position: observation.position.last,
+                                   position: observation.position.getWanted(),
                                    bufferType,
                                    imminentDiscontinuity: status.imminentDiscontinuity,
                                    isEmptyStream: false,

--- a/src/core/stream/representation/types.ts
+++ b/src/core/stream/representation/types.ts
@@ -11,7 +11,7 @@ import {
   IVideoRepresentationsSwitchingMode,
 } from "../../../public_types";
 import { IReadOnlySharedReference } from "../../../utils/reference";
-import { IReadOnlyPlaybackObserver } from "../../api";
+import { IObservationPosition, IReadOnlyPlaybackObserver } from "../../api";
 import { IContentProtection } from "../../decrypt";
 import { IPrioritizedSegmentFetcher } from "../../fetchers";
 import {
@@ -180,7 +180,7 @@ export interface IRepresentationStreamPlaybackObservation {
    * Information on the current media position in seconds at the time of a
    * Playback Observation.
    */
-  position : IPositionPlaybackObservation;
+  position : IObservationPosition;
 }
 
 /** Position-related information linked to an emitted Playback observation. */

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -61,7 +61,7 @@ export default async function appendSegmentToBuffer<T>(
                            { adaptations: [dataInfos.inventoryInfos.adaptation] });
     }
     const { position } = playbackObserver.getReference().getValue();
-    const currentPos = position.pending ?? position.last;
+    const currentPos = position.getWanted();
     try {
       await forceGarbageCollection(currentPos, segmentBuffer, cancellationSignal);
       await segmentBuffer.pushChunk(dataInfos, cancellationSignal);

--- a/src/core/stream/representation/utils/get_buffer_status.ts
+++ b/src/core/stream/representation/utils/get_buffer_status.ts
@@ -124,7 +124,7 @@ export default function getBufferStatus(
     getPlayableBufferedSegments({ start: Math.max(neededRange.start - 0.5, 0),
                                   end: neededRange.end + 0.5 },
                                 segmentBuffer.getInventory());
-  const currentPlaybackTime = playbackObserver.getCurrentTime();
+  const currentPlaybackTime = playbackObserver.getCurrentTime2();
 
   /** Callback allowing to retrieve a segment's history in the buffer. */
   const getBufferedHistory = segmentBuffer.getSegmentHistory.bind(segmentBuffer);

--- a/src/core/stream/representation/utils/get_buffer_status.ts
+++ b/src/core/stream/representation/utils/get_buffer_status.ts
@@ -124,7 +124,7 @@ export default function getBufferStatus(
     getPlayableBufferedSegments({ start: Math.max(neededRange.start - 0.5, 0),
                                   end: neededRange.end + 0.5 },
                                 segmentBuffer.getInventory());
-  const currentPlaybackTime = playbackObserver.getCurrentTime2();
+  const currentPlaybackTime = playbackObserver.getCurrentTime();
 
   /** Callback allowing to retrieve a segment's history in the buffer. */
   const getBufferedHistory = segmentBuffer.getSegmentHistory.bind(segmentBuffer);

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -237,23 +237,6 @@ const DEFAULT_CONFIG = {
   BUFFER_DISCONTINUITY_THRESHOLD: 0.2,
 
     /**
-     * When encountering small discontinuities, the RxPlayer may want, in specific
-     * conditions, ignore those and let the browser seek over them iself (this
-     * allows for example to avoid conflicts when both the browser and the
-     * RxPlayer want to seek at a different position, sometimes leading to a
-     * seeking loop).
-     * In this case, we however still want to seek it ourselves if the browser
-     * doesn't take the opportunity soon enough.
-     *
-     * This value specifies a delay after which a discontinuity ignored by the
-     * RxPlayer is finally considered.
-     * We want to maintain high enough to be sure the browser will not seek yet
-     * small enough so this (arguably rare) situation won't lead to too much
-     * waiting time.
-     */
-  FORCE_DISCONTINUITY_SEEK_DELAY: 5000,
-
-    /**
      * Ratio used to know if an already loaded segment should be re-buffered.
      * We re-load the given segment if the current one times that ratio is
      * inferior to the new one.

--- a/tests/contents/DASH_static_SegmentTimeline/media/discontinuity.mpd
+++ b/tests/contents/DASH_static_SegmentTimeline/media/discontinuity.mpd
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Created with Unified Streaming Platform(version=1.7.32) -->
 <MPD
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="urn:mpeg:dash:schema:mpd:2011"

--- a/tests/integration/scenarios/dash_live.js
+++ b/tests/integration/scenarios/dash_live.js
@@ -243,7 +243,7 @@ describe("DASH live content (SegmentTimeline)", function () {
                          segmentLoader });
 
       expect(manifestLoaderCalledTimes).to.equal(1);
-      await sleep(50);
+      await sleep(100);
       expect(player.getMinimumPosition()).to.be
         .closeTo(1527507768, 1);
     });
@@ -268,7 +268,7 @@ describe("DASH live content (SegmentTimeline)", function () {
       });
 
       expect(manifestLoaderCalledTimes).to.equal(1);
-      await sleep(50);
+      await sleep(100);
       expect(player.getMaximumPosition()).to.be
         .closeTo(1527508062, 1);
     });

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1156,6 +1156,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(0);
         player.pause();
         await waitForState(player, "PAUSED");
+        await sleep(0);
         expect(pauseEventsSent).to.equal(1);
         expect(playEventsSent).to.equal(0);
         expect(nbPausedStates).to.equal(1);
@@ -1185,6 +1186,7 @@ export default function launchTestsForContent(manifestInfos) {
         await sleep(0);
         player.play();
         await waitForState(player, "PLAYING");
+        await sleep(0);
         expect(pauseEventsSent).to.equal(0);
         expect(playEventsSent).to.equal(1);
         expect(nbPlayingStates).to.equal(1);


### PR DESCRIPTION
## Tizen "seek-backs"

Tizen devices (mainly samsung TVs) are the only devices on which seek operations is not precize.

On those devices for example, you might want to seek at a given position, let's say `51` seconds, and tizen could actually after media segments are loaded decide to finally play at an earlier position instead, let's say `50` seconds.
The choice actually made by tizen seems to correspond to the closest IDR video frame instead of what the RxPlayer wants, we guess because of performance reasons.

This caused many problems in the RxPlayer as we generally want to seek at a very specific position for very valid reasons, for example it could be because we need the position to be within a specific Period's boundaries or because we need to make sure the current position is after a known audio discontinuity to ensure smooth playback.

The fact that tizen may re-seek back in the past, what we now call "seek-backs", can lead to very problematic player  behaviors, such as seeking loops (tizen seeking back, RxPlayer seeking forth) or worse in the recently-seen case, content reloading loops.

The previous strategy was to directly make exceptions, just for Tizen devices, at each place in the code where this seek-back behavior led to problems. After 5 or 6 patches, we thought for many years that we had no remaining issues.

## The newly seen issue

However we very recently found out a new rare and subtle issue linked to those same pesky seek-backs, this time when:
  1. We're on a Samsung TV
  2. The `onCodecSwitch` `loadVideo` option is set to `reload`
  3. We're currently playing the very end of a Period with a given codec "A"
  4. The very close next Period has an incompatible codec "B"
  5. The RxPlayer, seek on the Period with the codec "B", also triggering a reload for the new codec
  6. Tizen decides to seek back at the very end of the previous Period with the codec "A"
  7. The RxPlayer sees that again, we're at the very end of Period "A", seeks to the very beginning of Period "B", and we're in an infinite loop, yay!

We finally decided to try a general solution which is the point of this PR.

## New way of dealing with it

What I decided to do here, was to reinforce a difference between:
 1. the `HTMLMediaElement`'s `currentTime` attribute, which is the position we're actually playing on the media element, and
 2. The actual position we want to load the media at

Simply written in the Tizen case, the former will actually be affected by seek-backs and might thus not always reflect what the RxPlayer wants the position to be, but the second will only indicate the position the RxPlayer actually wants to play at.

Then the rest of the RxPlayer code will use one or the other, depending on what it wants to do:
  - If the corresponding code has to do with HTML implementation details (e.g. detecting browser playback issues), it will rely on the true `currentTime`, which may have been affected by Tizen seek-backs
  - For the great majority of the code where what we want to do is just knowing which position we want to load and play at, we'll actually rely on the latter. 

I've been able to reuse the same 2-positions concept to also simplify the handling of the initial seek performed by the RxPlayer:
  - Until it is actually performed (we need the media element to reach a specific `readyState` before being able to seek), the `currentTime` is set to `0`
  - However, the wanted position will be set to the initially-wanted position in that case, as that's the position for which we actually want to load segments.

## Why only for the v4?

This is the first bug fix we've implemented only for the v4. We may backport it for the `v3` but the code update was big enough and the bug rare enough for me to prefer targeting the v4 first.