### PR TITLE
fix a bug in the demo: changing video/audio switching mode had no effect

### DIFF
--- a/demo/full/scripts/controllers/Player.tsx
+++ b/demo/full/scripts/controllers/Player.tsx
@@ -224,6 +224,7 @@ function Player(): JSX.Element {
     (mod: IAudioRepresentationsSwitchingMode) => {
       if (playerModule === null) {
         setDefaultAudioRepresentationsSwitchingMode(mod);
+        setHasUpdatedPlayerOptions(true);
         return;
       }
       playerModule.actions.setDefaultAudioRepresentationSwitchingMode(mod);
@@ -235,6 +236,7 @@ function Player(): JSX.Element {
     (mod: IVideoRepresentationsSwitchingMode) => {
       if (playerModule === null) {
         setDefaultVideoRepresentationsSwitchingMode(mod);
+        setHasUpdatedPlayerOptions(true);
         return;
       }
       playerModule.actions.setDefaultVideoRepresentationSwitchingMode(mod);


### PR DESCRIPTION
Changing the video/audio switching mode in the demo was not taken into account when you update it more than 1 time:

- Load a video
- Set Default Audio Representations switching mode to "direct"
- Reload the video
- Set Default Audio Representations switching mode to "lazy"  --> The switching mode will be stuck on "direct"

