### PR TITLE
Rename codec to codecs in the representationFilter for the v4

### DIFF
--- a/doc/Getting_Started/Migration_From_v3/loadVideo_Options.md
+++ b/doc/Getting_Started/Migration_From_v3/loadVideo_Options.md
@@ -473,6 +473,8 @@ argument updated:
     `undefined`, instead of a string.
   - `bitrate` can now be `undefined` or just not be defined as a property at
     all.
+  - `codec` has been renamed to `codecs` and is now potentially an array of
+    multiple codec strings in very rare situations.
   - The `decipherable` property has been removed.
   - The `index` property has been removed.
   - A new `contentProtections` property has been added, describing protections

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -549,6 +549,7 @@ rxPlayer.loadVideo({
 });
 ```
 
+More information on it can be found [here](../api/Miscellaneous/plugins.md#representationfilter).
 
 ### segmentLoader
 

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -381,7 +381,33 @@ The representationFilter will be called each time we load a
    - `height` (`Number|undefined`): If the `Representation` is from a video
      track and if its height is known, this is the height of video, in pixels.
 
-   - `codec` (`string|undefined`): The codec the Representation is in.
+   - `codecs` (`Array.<string>|undefined`): Codec(s) relied on by the media
+     segments of that Representation.
+
+     For the great majority of cases, this value will be set to either
+     `undefined` (meaning the codec is unknown) or to an array with a
+     single element which will be the actual codec relied on when the
+     corresponding Representation will be played.
+
+     However in some very rare scenarios, this value might be set to an array
+     with multiple codecs, itself being a list of its candidate codecs from the
+     most wanted to the most compatible.
+     The conditions for this more complex format are very specific:
+
+       - It can only happen if the `representationFilter` callback is called in
+         an environment where it hasn't yet been possible for the RxPlayer to
+         check for codec support (mainly when running through the RxPlayer's
+         `MULTI_THREAD` feature in a browser without MSE-in-worker
+         capabilities).
+
+       - The corresponding Representation is compatible to a restrictive codec
+         yet also retro-compatible to a less restrictive one.
+
+         The main example being Dolby Vision Representations which are
+         retro-compatible to HDR10 HEVC codecs.
+         In that very specific case, we could have an array with two elements:
+           1. The Dolby Vision codec
+           2. The base HDR10 codec
 
    - `frameRate` (`Number|undefined`): If the `Representation` is from a video
      track and if its frame rate is known, this is the frame rate of video, in

--- a/src/manifest/adaptation.ts
+++ b/src/manifest/adaptation.ts
@@ -157,7 +157,8 @@ export default class Adaptation {
         const reprObject : IRepresentationFilterRepresentation = {
           id: representation.id,
           bitrate: representation.bitrate,
-          codec: representation.codec,
+          codecs: representation.codec === undefined ? [] :
+                                                       [representation.codec],
           height: representation.height,
           width: representation.width,
           frameRate: representation.frameRate,

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -186,8 +186,35 @@ export interface IRepresentationFilterRepresentation {
   /** String identifying the Representation, unique per Adaptation. */
   id : string;
   bitrate? : number | undefined;
-  /** Codec used by the media segments of that Representation. */
-  codec? : string | undefined;
+  /**
+   * Codec(s) relied on by the media segments of that Representation.
+   *
+   * For the great majority of cases, this value will be set to either
+   * `undefined` (meaning the codec is unknown) or to an array with a
+   * single element which will be the actual codec relied on when the
+   * corresponding Representation will be played.
+   *
+   * However in some very rare scenarios, this value might be set to an array
+   * with multiple codecs, itself being a list of its candidate codecs from the
+   * most wanted to the most compatible.
+   * The conditions for this more complex format are very specific:
+   *
+   *   - It can only happen if the `representationFilter` callback is called in
+   *     an environment where it hasn't yet been possible for the RxPlayer to
+   *     check for codec support (mainly when running through the RxPlayer's
+   *     `MULTI_THREAD` feature in a browser without MSE-in-worker
+   *     capabilities).
+   *
+   *   - The corresponding Representation is compatible to a restrictive codec
+   *     yet also retro-compatible to a less restrictive one.
+   *
+   *     The main example being Dolby Vision Representations which are
+   *     retro-compatible to HDR10 HEVC codecs.
+   *     In that very specific case, we could have an array with two elements:
+   *       1. The Dolby Vision codec
+   *       2. The base HDR10 codec
+   */
+  codecs? : string[] | undefined;
   /**
    * This property makes the most sense for video Representations.
    * It defines the height of the video, in pixels.


### PR DESCRIPTION
## Problem 

When porting supplementalCodec support (allowing today to better support retro-compatible Dolby Vision codecs when playing DASH contents, planned for the incoming v3.33.0) to the `MULTI_THREAD` branch (#1272, allowing to run the RxPlayer in a WebWorker optionally, even using MSE-in-worker API when available, to improve performance and ABR stability - this is a huge work we're pretty confident will be released, surely in a `v4.1.0` so still not for today), we found out that the feature was incompatible with that branch because of a subtle reason.

Basically, the supplementalCodec work on v3.x.x branches only expose as a codec the codec that will actually be used on the device (e.g. the Dolby Vision codec on compatible devices, or the retro-compatible more supported codec on others). The idea is that an application should probably only need to know which codec is actually relied on, and not what it could have been on another device (there may be exceptions, but it appeared to us to be the more sensible choice).

In the `MULTI_THREAD` branch however, a specific API callback which needs to communicate that `codec` property, the `representationFilter` `loadVideo` option, might be called on a WebWorker at a point where the codec currently supported might not yet be known (the main browser API to check for codec support is related to the MSE API, so it won't be available in platforms where the MSE-in-worker feature is not available).

## Potential solutions

Here we would have three choices:
  - change the `representationFilter` API
  - make a round-trip in problematic scenarios to the main thread to check for codec support before calling that callback
  - choose a codec between the "supplementalCodec" one or the "codec" one to indicate through the `representationFilter`

We profited from the fact that the `v4.0.0` is not yet released and from the fact that the `codec` property of a `representationFilter` does not seem to be much used in the wild (though it's not complicated to update the code if it is), to go with the first solution (changing the `representationFilter` API).

## Solution in this PR 

The idea is here the following: `codec` was previously a simple optional string property representing the codec of the corresponding `Representation`. It is now an optional array of strings.

For the great majority of cases, this value will be set to either `undefined` (meaning the codec is unknown) or to an array with a single element which will be the actual codec relied on when the corresponding Representation will be played.

However in the very rare scenarios, when you're:
  - playing in "multithreading mode"
  - do not have MSE-in-worker available on the current platform
  - have a `supplementalCodec` attribute and a `codec` attribute linked to the Representation in your MPD (for DASH only)

You'll here have an array of two codec strings, defined as a list of the Representation's candidate codecs from the most wanted to the most compatible. So basically in our example it would first be the Dolby Vision codec indicated as a "supplementalCodec" in the MPD, then the base, more compatible, codec indicated as a "codec" property in the MPD.