### PR TITLE
refactor: code in create persistent session was unreachable

### DIFF
--- a/src/core/decrypt/get_media_keys.ts
+++ b/src/core/decrypt/get_media_keys.ts
@@ -39,15 +39,9 @@ import ServerCertificateStore from "./utils/server_certificate_store";
 function createPersistentSessionsStorage(
   keySystemOptions : IKeySystemOption
 ) : PersistentSessionsStore|null {
-  if (isNullOrUndefined(keySystemOptions.persistentLicenseConfig)) {
-    return null;
-  }
-
   const { persistentLicenseConfig } = keySystemOptions;
-  if (persistentLicenseConfig == null) {
-    throw new EncryptedMediaError("INVALID_KEY_SYSTEM",
-                                  "No `persistentLicenseConfig` found for " +
-                                  "persistent license.");
+  if (isNullOrUndefined(persistentLicenseConfig)) {
+    return null;
   }
 
   log.debug("DRM: Set the given license storage");


### PR DESCRIPTION
The `throw new EncryptedMediaError` was never reached as the condition before
`isNullOrUndefined(keySystemOptions.persistentLicenseConfig)` was already catching the case where `persistentLicenseConfig` is `undefined`.

