### PR TITLE
chore: replace demo manifest that is no longer available

### DIFF
--- a/demo/full/scripts/contents.ts
+++ b/demo/full/scripts/contents.ts
@@ -114,7 +114,7 @@ const DEFAULT_CONTENTS: IDefaultContent[] = [
   },
   {
     "name": "Multi Video Tracks",
-    "url": "https://utils.ssl.cdn.cra.cz/dash/1/manifest.mpd",
+    "url": "https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd",
     "transport": "dash",
     "live": false,
   },


### PR DESCRIPTION
Change the URL that was no longer working