### PR TITLE
Fix issue arising when using track APIs at the exact last possible position of a Period with no consecutive Period

### DIFF
--- a/src/core/stream/representation/utils/get_buffer_status.ts
+++ b/src/core/stream/representation/utils/get_buffer_status.ts
@@ -273,7 +273,8 @@ function isPeriodTheCurrentAndLastOne(
   period : Period,
   time : number
 ) : boolean {
-  return period.containsTime(time) &&
+  const nextPeriod = manifest.getPeriodAfter(period);
+  return period.containsTime(time, nextPeriod) &&
          manifest.isLastPeriodKnown &&
          period.id === manifest.periods[manifest.periods.length - 1]?.id;
 }

--- a/src/manifest/manifest.ts
+++ b/src/manifest/manifest.ts
@@ -410,10 +410,14 @@ export default class Manifest extends EventEmitter<IManifestEvents> {
    * @returns {Object|undefined}
    */
   public getPeriodForTime(time : number) : Period | undefined {
-    return arrayFind(this.periods, (period) => {
-      return time >= period.start &&
-             (period.end === undefined || period.end > time);
-    });
+    let nextPeriod = null;
+    for (let i = this.periods.length - 1; i >= 0; i--) {
+      const period = this.periods[i];
+      if (period.containsTime(time, nextPeriod)) {
+        return period;
+      }
+      nextPeriod = period;
+    }
   }
 
   /**

--- a/src/manifest/period.ts
+++ b/src/manifest/period.ts
@@ -189,10 +189,23 @@ export default class Period {
   /**
    * Returns true if the give time is in the time boundaries of this `Period`.
    * @param {number} time
+   * @param {object|null} nextPeriod - Period coming chronologically just
+   * after in the same Manifest. `null` if this instance is the last `Period`.
    * @returns {boolean}
    */
-  containsTime(time : number) : boolean {
-    return time >= this.start && (this.end === undefined ||
-                                  time < this.end);
+  containsTime(time : number, nextPeriod : Period | null) : boolean {
+    if (time >= this.start && (this.end === undefined || time < this.end)) {
+      return true;
+    } else if (time === this.end && (nextPeriod === null ||
+                                     nextPeriod.start > this.end))
+    {
+      // The last possible timed position of a Period is ambiguous as it is
+      // frequently in common with the start of the next one: is it part of
+      // the current or of the next Period?
+      // Here we only consider it part of the current Period if it is the
+      // only one with that position.
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
We found out that an issue prevented from switching the track when the current position was exactly at the position indicated by a Period's `end` property if there was no immediately consecutive Period.

For example if a content had, as a last Period, one starting at position `10` (seconds) and ending at `30`, and if the player was currently paused at position `30` a `setAudioTrack` or any track switching call wouldn't have any effect.

This is because the logic handling which Period should currently be handled decides that a Period finishes as soon as we reached the position indicated by its `end` property. Because under that logic we're not playing the last Period anymore when we reached it, API updating tracks of the current Period do not have any effect.

It actually makes perfect sense for the frequent usecase of having consecutive Periods, where the `end` of one is equal to the `start` of the following one (in which case the following one has priority, so finishing the previous Period is wanted here), but it begins to show weird behaviors like the one described here when a Period's `end` is not shared with a consecutive Period, in which case we could (and probably should) consider that `end` position as part of that Period instead as there's no such ambiguity.

So this PR actually explicitely handles that case, which fixes the issue.