### PR TITLE
fix: seeking to the last frame restart the video

### DIFF
--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -138,6 +138,16 @@ export default function performInitialSeekAndPlay(
       initialPlayPerformed.finish();
       deregisterCancellation();
       return resolveAutoPlay({ type: "skipped" as const });
+    } else if (mediaElement.ended) {
+      // the video has ended state to true, executing VideoElement.play() will
+      // restart the video from the start, which is not wanted in most cases.
+      // returning "skipped" prevents the call to play() and fix the issue
+      log.warn("Init: autoplay is enabled but the video is ended. " +
+        "Skipping autoplay to prevent video to start again");
+      initialPlayPerformed.setValue(true);
+      initialPlayPerformed.finish();
+      deregisterCancellation();
+      return resolveAutoPlay({ type: "skipped" as const });
     }
 
     let playResult : Promise<unknown>;


### PR DESCRIPTION
Seeking to the last frame of the video result in restarting the video from the beginning. This is because VideoElement.play() method restart the play from beginning if video is ended.
According to the spec:
> If the playback has ended and the direction of playback is forwards,
> seek to the earliest possible position of the media resource.

In this case checking if the video is ended and not call play() fixes the issue.