### PR TITLE
types: export type IcompatibleKeySystem to the public API

### DIFF
--- a/src/experimental/tools/mediaCapabilitiesProber/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/index.ts
@@ -15,4 +15,6 @@
  */
 
 import MediaCapabilitiesProber from "./api";
+import { ICompatibleKeySystem } from "./types";
+export { ICompatibleKeySystem };
 export default MediaCapabilitiesProber;


### PR DESCRIPTION
Some applicant might need type `ICompatibleKeySystem` and was therefore imported through 
`import { ICompatibleKeySystem } from 'rx-player/dist/es2017/experimental/tools/mediaCapabilitiesProber/types';`

This was not very robust has a change in the ES target changed the import path.
Exporting it will allow to import in a stabler way.

`import { mediaCapabilitiesProber } from 'rx-player/experimental/tools';`