### PR TITLE
Add ugly `skipLog` parameter to the synchronizeInventory method

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2430,7 +2430,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const segmentBufferStatus = this._priv_contentInfos
       .segmentBuffersStore.getStatus(bufferType);
     if (segmentBufferStatus.type === "initialized") {
-      segmentBufferStatus.value.synchronizeInventory();
+      segmentBufferStatus.value.synchronizeInventory(true);
       return segmentBufferStatus.value.getInventory();
     }
     return null;

--- a/src/core/segment_buffers/implementations/types.ts
+++ b/src/core/segment_buffers/implementations/types.ts
@@ -169,10 +169,15 @@ export abstract class SegmentBuffer {
    * This methods allow to manually trigger a synchronization. It should be
    * called before retrieving Segment information from it (e.g. with
    * `getInventory`).
+   * @param {boolean} [skipLog] - This method may trigger a voluminous debug
+   * log once synchronization is finished if debug logs are enabled.
+   * As this method might be called very often in some specific debugging
+   * situations, setting this value to `true` allows to prevent the call from
+   * triggering a log.
    */
-  public synchronizeInventory() : void {
+  public synchronizeInventory(skipLog? : boolean) : void {
     // The default implementation just use the SegmentInventory
-    this._segmentInventory.synchronizeBuffered(this.getBufferedRanges());
+    this._segmentInventory.synchronizeBuffered(this.getBufferedRanges(), skipLog);
   }
 
   /**

--- a/src/core/segment_buffers/inventory/segment_inventory.ts
+++ b/src/core/segment_buffers/inventory/segment_inventory.ts
@@ -204,8 +204,13 @@ export default class SegmentInventory {
    * at a time, so each `synchronizeBuffered` call should be given a TimeRanges
    * coming from the same buffer.
    * @param {TimeRanges} buffered
+   * @param {boolean|undefined} [skipLog=false] - This method normally may
+   * trigger a voluminous debug log if debug logs are enabled.
+   * As this method might be called very often in some specific debugging
+   * situations, setting this value to `true` allows to prevent the call from
+   * triggering a log.
    */
-  public synchronizeBuffered(buffered : TimeRanges) : void {
+  public synchronizeBuffered(buffered : TimeRanges, skipLog : boolean = false) : void {
     const inventory = this._inventory;
     let inventoryIndex = 0; // Current index considered.
     let thisSegment = inventory[0]; // Current segmentInfos considered
@@ -348,7 +353,7 @@ export default class SegmentInventory {
         }
       }
     }
-    if (bufferType !== undefined && log.hasLevel("DEBUG")) {
+    if (!skipLog && bufferType !== undefined && log.hasLevel("DEBUG")) {
       log.debug(`SI: current ${bufferType} inventory timeline:\n` +
                 prettyPrintInventory(this._inventory));
     }


### PR DESCRIPTION
The `synchronizeInventory` method is an internal method of the RxPlayer allowing to synchronize our internal representation of media buffers (representing which segments are buffered where) with the anounced buffered TimeRanges of the media buffer as indicated by the web browser, which should be more up-to-date (e.g. take into consideration garbage collection).

As this internal representation of the buffer is very valuable when debugging, the `synchronizeInventory` produce logs each time it is called.

Yet that method is very often called when the debug element (under the `DEBUG_ELEMENT` feature) to be sure it is mostly up-to-date with the browser's buffer as the debug element is only shown in debugging contexts.

Calling that method in this context of visual debugging here has consequently the side-effect of producing a large ammount of debug logs, which isn't necessary.

Due to this, I decided to add an optional `skipLog` boolean parameter to the `synchronizeInventory` method. It is ugly, as it leaks debugging-related implementation details into the method signature, but it appears to me to be useful in that specific situation.