### PR TITLE
Better type Representation choice code in multithread mode

### DIFF
--- a/src/core/api/track_management/track_dispatcher.ts
+++ b/src/core/api/track_management/track_dispatcher.ts
@@ -45,7 +45,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
     /** "Switching mode" in which the track switch should happen. */
     switchingMode : ITrackSwitchingMode;
     /** Representations "locked" for this `Adaptation`. */
-    representations : SharedReference<IRepresentationsChoice>;
+    representations : IReadOnlySharedReference<IRepresentationsChoice>;
   } |
   null |
   undefined>;

--- a/src/core/stream/adaptation/types.ts
+++ b/src/core/stream/adaptation/types.ts
@@ -7,9 +7,7 @@ import {
   IAudioTrackSwitchingMode,
   IVideoTrackSwitchingMode,
 } from "../../../public_types";
-import SharedReference, {
-  IReadOnlySharedReference,
-} from "../../../utils/reference";
+import { IReadOnlySharedReference } from "../../../utils/reference";
 import { IRepresentationEstimator } from "../../adaptive";
 import { IReadOnlyPlaybackObserver } from "../../api";
 import { SegmentFetcherCreator } from "../../fetchers";
@@ -198,9 +196,8 @@ export interface IAdaptationChoice {
   /**
    * Shared reference allowing to indicate which Representations from
    * that Adaptation are allowed.
-   * TODO Read-only?
    */
-  representations : SharedReference<IRepresentationsChoice>;
+  representations : IReadOnlySharedReference<IRepresentationsChoice>;
 }
 
 export type ITrackSwitchingMode = IAudioTrackSwitchingMode |


### PR DESCRIPTION
During our work on making the RxPlayer use a WebWorker for most of its core logic, we encountered some issues that made declaring types (through TypeScript) more difficult.
One of the main issue was with the object emitting Representations (a.k.a. qualities) choices.

That object makes heavy use of TypeScript variance rules to enforce some type of read/write permissions on variables. This requires various TypeScript tricks (yet still sound).

When I made the initial worker code, I didn't think too much about that part, so I chose the easy way: to just remove that type-level permission checking where it bothered me.

This PR now brings back that security.