### PR TITLE
demo: change removed property limitVideoWidth to videoResolutionLimit

### DIFF
--- a/demo/full/scripts/components/Options/VideoAdaptiveSettings.tsx
+++ b/demo/full/scripts/components/Options/VideoAdaptiveSettings.tsx
@@ -14,18 +14,20 @@ const { Fragment } = React;
 function VideoAdaptiveSettings({
   defaultVideoRepresentationsSwitchingMode,
   onDefaultVideoRepresentationsSwitchingModeChange,
-  limitVideoWidth,
+  videoResolutionLimit,
   throttleVideoBitrateWhenHidden,
-  onLimitVideoWidthChange,
+  onVideoResolutionLimitChange,
   onThrottleVideoBitrateWhenHiddenChange,
 }: {
   defaultVideoRepresentationsSwitchingMode: IVideoRepresentationsSwitchingMode;
   onDefaultVideoRepresentationsSwitchingModeChange: (
     mode: IVideoRepresentationsSwitchingMode
   ) => void;
-  limitVideoWidth: boolean;
+  videoResolutionLimit: "videoElement" | "screen" | "none";
   throttleVideoBitrateWhenHidden: boolean;
-  onLimitVideoWidthChange: (newVal: boolean) => void;
+  onVideoResolutionLimitChange: (
+    newVal: { index: number, value: string}
+  ) => void;
   onThrottleVideoBitrateWhenHiddenChange: (newVal: boolean) => void;
 }): JSX.Element {
   let defaultVideoRepresentationsSwitchingModeDescMsg;
@@ -49,6 +51,19 @@ function VideoAdaptiveSettings({
     default:
       defaultVideoRepresentationsSwitchingModeDescMsg =
         "Unknown value";
+      break;
+  }
+
+  let videoResolutionLimitDescMsg;
+  switch (videoResolutionLimit) {
+    case "none":
+      videoResolutionLimitDescMsg = "No limit on the video Representation’s resolution will be automatically applied.";
+      break;
+    case "screen":
+      videoResolutionLimitDescMsg = "The loaded video Representation will be throttled according to the screen’s dimensions.";
+      break;
+    case "videoElement":
+      videoResolutionLimitDescMsg = "The loaded video Representation will be throttled according to the given videoElement’s dimensions.";
       break;
   }
 
@@ -82,22 +97,23 @@ function VideoAdaptiveSettings({
         </span>
       </li>
       <li>
-        <div>
-          <Checkbox
-            className="playerOptionsCheckBox playerOptionsCheckBoxTitle"
-            name="limitVideoWidth"
-            ariaLabel="Limit video width option"
-            checked={limitVideoWidth}
-            onChange={onLimitVideoWidthChange}
-          >
-            Limit Video Width
-          </Checkbox>
-          <span className="option-desc">
-            {limitVideoWidth ?
-              "Limiting video width to the current <video> element's width" :
-              "Not limiting video width to the current <video> element's width"}
-          </span>
-        </div>
+        <Select
+          ariaLabel="Select the videoResolutionLimit"
+          className="playerOptionInput"
+          disabled={false}
+          name="videoResolutionLimit"
+          onChange={onVideoResolutionLimitChange}
+          selected={{
+            value: "none",
+            index: undefined,
+          }}
+          options={["videoElement", "screen", "none"]}
+        >
+            Limit Video Resolution
+        </Select>
+        <span className="option-desc">
+          {videoResolutionLimitDescMsg}
+        </span>
       </li>
       <li>
         <div className="playerOptionInput">

--- a/demo/full/scripts/controllers/Settings.tsx
+++ b/demo/full/scripts/controllers/Settings.tsx
@@ -48,7 +48,7 @@ function Settings({
   showOptions: boolean;
 }): JSX.Element | null {
   const {
-    limitVideoWidth,
+    videoResolutionLimit,
     maxBufferAhead,
     maxBufferBehind,
     maxVideoBufferSize,
@@ -84,14 +84,20 @@ function Settings({
     });
   }, [updateLoadVideoOptions]);
 
-  const onLimitVideoWidthChange = useCallback((limitVideoWidth: boolean) => {
-    updatePlayerOptions((prevOptions) => {
-      if (limitVideoWidth === prevOptions.limitVideoWidth) {
-        return prevOptions;
-      }
-      return Object.assign({}, prevOptions, { limitVideoWidth });
-    });
-  }, [updatePlayerOptions]);
+  const onVideoResolutionLimitChange = useCallback(
+    (videoResolutionLimitArg: { value: string}) => {
+      updatePlayerOptions((prevOptions) => {
+        if (videoResolutionLimitArg.value ===
+          prevOptions.videoResolutionLimit) {
+          return prevOptions;
+        }
+        return Object.assign(
+          {},
+          prevOptions,
+          { videoResolutionLimit: videoResolutionLimitArg.value }
+        );
+      });
+    }, [updatePlayerOptions]);
 
   const onThrottleVideoBitrateWhenHiddenChange = useCallback((
     value: boolean
@@ -285,12 +291,12 @@ function Settings({
             defaultVideoRepresentationsSwitchingMode={
               defaultVideoRepresentationsSwitchingMode
             }
-            limitVideoWidth={limitVideoWidth}
+            videoResolutionLimit={videoResolutionLimit}
             throttleVideoBitrateWhenHidden={throttleVideoBitrateWhenHidden}
             onDefaultVideoRepresentationsSwitchingModeChange={
               onDefaultVideoRepresentationsSwitchingModeChange
             }
-            onLimitVideoWidthChange={onLimitVideoWidthChange}
+            onVideoResolutionLimitChange={onVideoResolutionLimitChange}
             onThrottleVideoBitrateWhenHiddenChange={
               onThrottleVideoBitrateWhenHiddenChange
             }

--- a/demo/full/scripts/lib/defaultOptionsValues.ts
+++ b/demo/full/scripts/lib/defaultOptionsValues.ts
@@ -1,6 +1,8 @@
+import type { IConstructorOptions, ILoadVideoOptions } from "../../../../src/public_types";
+
 const defaultOptionsValues = {
   player: {
-    limitVideoWidth: false,
+    videoResolutionLimit: "none",
     maxBufferAhead: Infinity,
     maxBufferBehind: Infinity,
     maxVideoBufferSize: Infinity,
@@ -8,6 +10,7 @@ const defaultOptionsValues = {
     wantedBufferAhead: 30,
   },
   loadVideo: {
+    transport: "dash",
     autoPlay: true,
     defaultAudioTrackSwitchingMode: "reload",
     enableFastSwitching: true,
@@ -23,7 +26,7 @@ const defaultOptionsValues = {
     },
     onCodecSwitch: "continue",
   },
-};
+} satisfies { player: IConstructorOptions, loadVideo: ILoadVideoOptions };
 
 export type IConstructorSettings = typeof defaultOptionsValues.player;
 export type ILoadVideoSettings = typeof defaultOptionsValues.loadVideo;


### PR DESCRIPTION
Property `limitVideoWidth` has been removed in the API for v4.0.0 but the changes was not reflected in the demo.
This PR change this obsolete property by the new `videoResolutionLimit` in the demo.