### PR TITLE
fix(demo): fix ts error in global declaration

### DIFF
--- a/demo/full/tsconfig.json
+++ b/demo/full/tsconfig.json
@@ -21,6 +21,7 @@
     ]
   },
   "include": [
+    "../../src/globals.prod.d.ts",
     "./scripts/**/*"
   ]
 }


### PR DESCRIPTION
using global import, ex: `__ENVIRONMENT__` in the `demo/full` folder didn't work because there is a `demo/full/tsconfig` file that has more priority than `src/tsconfig` in the `demo/full` folder. The fix was to add the global import file in the `demo/full/tsconfig`