### PR TITLE
Set more standard mute/unMute behaviors

### DIFF
--- a/demo/full/scripts/controllers/VolumeBar.tsx
+++ b/demo/full/scripts/controllers/VolumeBar.tsx
@@ -16,7 +16,7 @@ function VolumeBar({
 }: {
   player: IPlayerModule
 }): JSX.Element {
-  const volume = useModuleState(player, "volume");
+  const { volume, muted } = useModuleState(player, "volumeInfo");
   const elementRef = React.useRef<HTMLDivElement>(null);
 
   const getMouseVolume = React.useCallback((event: React.MouseEvent) => {
@@ -36,7 +36,12 @@ function VolumeBar({
   const onVolumeClick = React.useCallback((evt: React.MouseEvent) => {
     const newVol = getMouseVolume(evt);
     if (newVol !== undefined) {
-      player.actions.setVolume(newVol);
+      if (newVol === 0) {
+        player.actions.mute();
+      } else {
+        player.actions.setVolume(newVol);
+        player.actions.unmute();
+      }
     }
   }, [player]);
 
@@ -48,7 +53,7 @@ function VolumeBar({
     >
       <div
         className="volume-bar-current"
-        style={{ "width": `${volume * 100}%` }}
+        style={{ "width": muted ? "0%" : `${volume * 100}%` }}
       />
     </div>
   );

--- a/demo/full/scripts/controllers/VolumeButton.tsx
+++ b/demo/full/scripts/controllers/VolumeButton.tsx
@@ -22,11 +22,11 @@ function VolumeButton({
   className?: string | undefined
   player: IPlayerModule;
 }) {
-  const volume = useModuleState(player, "volume");
+  const { muted, volume } = useModuleState(player, "volumeInfo");
 
   let volumeLevelClass;
   let charCode;
-  if (volume === 0) {
+  if (muted || volume === 0) {
     volumeLevelClass = "muted";
     charCode = 0xf026;
   } else if (volume <= 0.5) {
@@ -38,12 +38,17 @@ function VolumeButton({
   }
 
   const onClick = React.useCallback(() => {
-    if (volume === 0) {
+    if (muted) {
       player.actions.unmute();
     } else {
       player.actions.mute();
     }
-  }, [volume]);
+
+    if (volume === 0) {
+      player.actions.setVolume(0.3);
+    }
+  }, [volume, muted]);
+
   return (
     <Button
       ariaLabel="Mute/Unmute audio"

--- a/demo/full/scripts/modules/player/events.ts
+++ b/demo/full/scripts/modules/player/events.ts
@@ -28,7 +28,7 @@ function linkPlayerEventsToState(
   linkPlayerEventToState("videoRepresentationChange", "videoRepresentation");
   linkPlayerEventToState("audioRepresentationChange", "audioRepresentation");
   linkPlayerEventToState("error", "error");
-  linkPlayerEventToState("volumeChange", "volume");
+  linkPlayerEventToState("volumeChange", "volumeInfo");
   linkPlayerEventToState("audioTrackChange", "audioTrack");
   linkPlayerEventToState("videoTrackChange", "videoTrack");
   linkPlayerEventToState("availableAudioTracksChange", "availableAudioTracks");

--- a/demo/full/scripts/modules/player/index.ts
+++ b/demo/full/scripts/modules/player/index.ts
@@ -144,7 +144,10 @@ export interface IPlayerModuleState {
   videoRepresentation: IVideoRepresentation | undefined | null;
   videoRepresentationsLocked: boolean;
   videoTrack: IVideoTrack | undefined | null;
-  volume: number;
+  volumeInfo: {
+    volume: number;
+    muted: boolean;
+  };
   wallClockDiff: number | undefined;
   /**
    * If `true`, the currently set video track has a linked "trickmode" track.
@@ -195,7 +198,10 @@ const PlayerModule = declareModule(
     videoRepresentation: undefined,
     videoRepresentationsLocked: false,
     videoTrack: undefined,
-    volume: 1,
+    volumeInfo: {
+      volume: 1,
+      muted: false,
+    },
     wallClockDiff: undefined,
     videoTrackHasTrickMode: false,
     videoThumbnailsElement: null,

--- a/doc/Getting_Started/Migration_From_v3/Player_Events.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Events.md
@@ -136,3 +136,21 @@ All image related API, like the `imageTrackUpdate` event, have been removed.
 
 If you need to parse BIF file, you can use the
 [`parseBifThumbnails`](../../api/Tools/parseBifThumbnails.md) tool instead.
+
+
+### `volumeChange`
+
+Previously, this event only communicated about an audio volume as a number
+between `0` (silent) and `1` (loudest audio volume), with the `mute` RxPlayer
+method actually just setting that volume to `0` until the next `unMute` call.
+
+Now the `mute` RxPlayer method has been updated and this event accordingly send
+as a payload two properties:
+
+  - `volume` (`number`): The currently set audio volume from `0` to `1`, like
+    before.
+
+  - `muted` (`boolean`): If `true`, the media element is currently muted (e.g.
+    through the `mute` RxPlayer method), meaning that audio will be silent even
+    if a volume higher than `0` is set.
+    You can remove the `muted` status by calling the `unMute` RxPlayer method.

--- a/doc/Getting_Started/Migration_From_v3/Player_Methods.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Methods.md
@@ -283,3 +283,20 @@ The `bitrate` property that can be retrieved as a child property of the
 `representations` property, itself found in tracks returned by the
 `getAvailableAudioTracks` and `getAudioTrack` methods, can now be
 `undefined` if unknown.
+
+### `mute` / `unMute` / `getVolume`
+
+Previously, those two methods updated the `volume` property of an
+`HTMLMediaElement` by setting it to `0` and restoring its previous value.
+
+Now, it updates the `muted` property of that same `HTMLMediaElement` without
+actually updating the `volume`, meaning that:
+
+  - The volume returned by `getVolume` won't be affected anymore when muted
+    (it would previously be set to `0` in that case).
+
+  - Likewise the `volume` property of the `HTMLMediaElement` won't be affected
+
+Note that consequently the `volumeChange` also has been updated to indicates
+both an audio volume change (through a `volume` property) and/or a
+muting/un-muting of the volume (through a `muted` property).

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -891,3 +891,19 @@ was not entered, and will thus not be exited.
 This event is not sent in <i>DirectFile</i> mode (see
 <a href="./Loading_a_Content.md#transport">transport option</a>)
 </div>
+
+### volumeChange
+
+_payload type_: `Object`
+
+Notify about a change of audio volume and/or of muted status.
+
+The sent payload contains the following properties:
+
+  - `volume` (`number`): The currently set audio volume from `0` (silent) to
+    `1` (the loudest).
+
+  - `muted` (`boolean`): If `true`, the media element is currently muted (e.g.
+    through the `mute` RxPlayer method), meaning that audio will be silent even
+    if a volume higher than `0` is set.
+    You can remove the `muted` status by calling the `unMute` RxPlayer method.

--- a/doc/api/Volume_Control/mute.md
+++ b/doc/api/Volume_Control/mute.md
@@ -2,10 +2,9 @@
 
 ## Description
 
-Mute the volume.
+Mute the audio volume.
 
-Basically set the volume to 0 while keeping in memory the previous volume to
-reset it at the next `unMute` call.
+It can then be un-muted through [the unMute method](./unMute.md).
 
 As the volume is not dependent on a single content (it is persistent), this
 method can also be called when no content is playing.

--- a/doc/api/Volume_Control/unMute.md
+++ b/doc/api/Volume_Control/unMute.md
@@ -2,9 +2,7 @@
 
 ## Description
 
-When muted, restore the volume to the one previous to the last `mute` call.
-
-When the volume is already superior to `0`, this call won't do anything.
+Un-mute the audio volume if previously muted.
 
 As the volume is not dependent on a single content (it is persistent), this
 method can also be called when no content is playing.

--- a/src/core/api/__tests__/public_api.test.ts
+++ b/src/core/api/__tests__/public_api.test.ts
@@ -300,7 +300,7 @@ describe("API - Public API", () => {
         expect(player.isMute()).toBe(false);
       });
 
-      it("should not true in isMute if just the volume is equal to 0", () => {
+      it("should not return true in isMute if just the volume is equal to 0", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const player = new PublicAPI();
 

--- a/src/core/api/__tests__/public_api.test.ts
+++ b/src/core/api/__tests__/public_api.test.ts
@@ -236,7 +236,7 @@ describe("API - Public API", () => {
     });
 
     describe("mute/unMute/isMute", () => {
-      it("should set the volume to 0 in mute by default", () => {
+      it("should keep the volume yet mute the media element in mute by default", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const player = new PublicAPI();
         const videoElement = player.getVideoElement();
@@ -250,15 +250,18 @@ describe("API - Public API", () => {
         player.setVolume(1);
 
         player.mute();
-        expect(player.getVolume()).toBe(0);
-        expect(videoElement.volume).toBe(0);
-        expect(videoElement.muted).toBe(false);
+        expect(player.getVolume()).toBe(1);
+        expect(videoElement.volume).toBe(1);
+        expect(videoElement.muted).toBe(true);
         expect(player.isMute()).toBe(true);
         player.unMute();
         expect(player.isMute()).toBe(false);
+        expect(player.getVolume()).toBe(1);
+        expect(videoElement.volume).toBe(1);
+        expect(videoElement.muted).toBe(false);
       });
 
-      it("should unmute the volume at the previous value in unMute by default", () => {
+      it("should unmute without changing the volume in unMute by default", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const player = new PublicAPI();
         // back to a "normal" state.
@@ -280,13 +283,15 @@ describe("API - Public API", () => {
 
         player.mute();
         expect(player.isMute()).toBe(true);
-        expect(player.getVolume()).toBe(0);
-        expect(videoElement.volume).toBe(0);
+        expect(player.getVolume()).toBe(0.8);
+        expect(videoElement.volume).toBe(0.8);
+        expect(videoElement.muted).toBe(true);
 
         player.unMute();
         expect(player.isMute()).toBe(false);
         expect(player.getVolume()).toBe(0.8);
         expect(videoElement.volume).toBe(0.8);
+        expect(videoElement.muted).toBe(false);
       });
 
       it("should return false in isMute by default", () => {
@@ -295,31 +300,14 @@ describe("API - Public API", () => {
         expect(player.isMute()).toBe(false);
       });
 
-      it("should return true in isMute if the volume is equal to 0", () => {
+      it("should not true in isMute if just the volume is equal to 0", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const player = new PublicAPI();
-        const oldVolume = player.getVolume();
 
         expect(player.isMute()).toBe(false);
 
         player.setVolume(0);
-        expect(player.isMute()).toBe(true);
-        player.setVolume(oldVolume);
         expect(player.isMute()).toBe(false);
-
-        player.mute();
-        expect(player.isMute()).toBe(true);
-        player.unMute();
-        expect(player.isMute()).toBe(false);
-
-        player.mute();
-        expect(player.isMute()).toBe(true);
-        player.setVolume(oldVolume);
-        expect(player.isMute()).toBe(false);
-        player.unMute();
-        expect(player.isMute()).toBe(false);
-
-        player.setVolume(oldVolume);
       });
     });
 

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1406,7 +1406,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   /**
-   * Returns `true` if the audio volume is currently muted.
+   * Returns `true` if audio is currently muted.
    * @returns {Boolean}
    */
   isMute() : boolean {
@@ -1414,7 +1414,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   /**
-   * Mute the audio volume.
+   * Mute audio.
    */
   mute() : void {
     if (this.videoElement === null) {
@@ -1426,7 +1426,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   /**
-   * Unmute the audio volume.
+   * Unmute audio.
    */
   unMute() : void {
     if (this.videoElement === null) {

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -25,7 +25,6 @@ import {
 } from "../../compat";
 /* eslint-disable-next-line max-len */
 import canRelyOnVideoVisibilityAndSize from "../../compat/can_rely_on_video_visibility_and_size";
-import config from "../../config";
 import {
   ErrorCodes,
   ErrorTypes,
@@ -242,9 +241,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /** Store wanted configuration for the `throttleVideoBitrateWhenHidden` option. */
   private readonly _priv_throttleVideoBitrateWhenHidden : boolean;
 
-  /** Store volume when mute is called, to restore it on unmute. */
-  private _priv_mutedMemory : number;
-
   /**
    * Store last state of various values sent as events, to avoid re-triggering
    * them multiple times in a row.
@@ -341,7 +337,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             videoElement,
             wantedBufferAhead,
             maxVideoBufferSize } = parseConstructorOptions(options);
-    const { DEFAULT_UNMUTED_VOLUME } = config.getCurrent();
     // Workaround to support Firefox autoplay on FF 42.
     // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1194624
     videoElement.preload = "auto";
@@ -381,18 +376,28 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     this._priv_throttleVideoBitrateWhenHidden = throttleVideoBitrateWhenHidden;
     this._priv_videoResolutionLimit = videoResolutionLimit;
-    this._priv_mutedMemory = DEFAULT_UNMUTED_VOLUME;
 
     this._priv_currentError = null;
     this._priv_contentInfos = null;
 
     this._priv_contentEventsMemory = {};
 
-    this._priv_setPlayerState(PLAYER_STATES.STOPPED);
-
     this._priv_reloadingMetadata = {};
 
     this._priv_lastAutoPlay = false;
+
+    this.state = PLAYER_STATES.STOPPED;
+
+    const onVolumeChange = () => {
+      this.trigger("volumeChange", {
+        volume: videoElement.volume,
+        muted: videoElement.muted,
+      });
+    };
+    videoElement.addEventListener("volumechange", onVolumeChange);
+    destroyCanceller.signal.register(() => {
+      videoElement.removeEventListener("volumechange", onVolumeChange);
+    });
   }
 
   /**
@@ -1397,36 +1402,38 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const videoElement = this.videoElement;
     if (volume !== videoElement.volume) {
       videoElement.volume = volume;
-      this.trigger("volumeChange", volume);
     }
   }
 
   /**
-   * Returns true if the volume is set to 0. false otherwise.
+   * Returns `true` if the audio volume is currently muted.
    * @returns {Boolean}
    */
   isMute() : boolean {
-    return this.getVolume() === 0;
+    return this.videoElement?.muted === true;
   }
 
   /**
-   * Set the volume to 0 and save current one for when unmuted.
+   * Mute the audio volume.
    */
   mute() : void {
-    this._priv_mutedMemory = this.getVolume();
-    this.setVolume(0);
+    if (this.videoElement === null) {
+      throw new Error("Disposed player");
+    }
+    if (!this.videoElement.muted) {
+      this.videoElement.muted = true;
+    }
   }
 
   /**
-   * Set the volume back to when it was when mute was last called.
-   * If the volume was set to 0, set a default volume instead (see config).
+   * Unmute the audio volume.
    */
   unMute() : void {
-    const { DEFAULT_UNMUTED_VOLUME } = config.getCurrent();
-    const vol = this.getVolume();
-    if (vol === 0) {
-      this.setVolume(this._priv_mutedMemory === 0 ? DEFAULT_UNMUTED_VOLUME :
-                                                    this._priv_mutedMemory);
+    if (this.videoElement === null) {
+      throw new Error("Disposed player");
+    }
+    if (this.videoElement.muted) {
+      this.videoElement.muted = false;
     }
   }
 
@@ -2823,7 +2830,10 @@ interface IPublicAPIEvent {
   videoTrackChange : IVideoTrack | null;
   audioRepresentationChange : IVideoRepresentation | null;
   videoRepresentationChange : IAudioRepresentation | null;
-  volumeChange : number;
+  volumeChange : {
+    volume: number;
+    muted: boolean;
+  };
   error : IPlayerError | Error;
   warning : IPlayerError | Error;
   periodChange : IPeriodChangeEvent;

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -9,15 +9,6 @@
  */
 const DEFAULT_CONFIG = {
     /**
-     * Volume set on unMute if the volume is set to 0 and either:
-     *   - mute has never been called before
-     *   - mute has last been called while the volume was already set to 0 (either
-     *     via setVolume, or a previous mute call)
-     * @type {Number}
-     */
-  DEFAULT_UNMUTED_VOLUME: 0.1,
-
-    /**
      * Default time interval after which a request will timeout, in ms.
      * @type {Number}
      */

--- a/tests/integration/scenarios/idle.js
+++ b/tests/integration/scenarios/idle.js
@@ -191,7 +191,7 @@ describe("initial idle state", () => {
     });
 
     describe("mute/unMute/isMute", () => {
-      it("should set the volume to 0 in mute by default", () => {
+      it("should not update the volume when calling mute", () => {
         const videoElement = player.getVideoElement();
         if (videoElement.muted) {
           videoElement.muted = false;
@@ -210,7 +210,7 @@ describe("initial idle state", () => {
         expect(videoElement.muted).to.equal(false);
       });
 
-      it("should unmute the volume at the previous value in unMute by default", () => {
+      it("should unmute at the previous value in unMute by default", () => {
         // back to a "normal" state.
         player.unMute();
         const videoElement = player.getVideoElement();

--- a/tests/integration/scenarios/idle.js
+++ b/tests/integration/scenarios/idle.js
@@ -199,12 +199,15 @@ describe("initial idle state", () => {
         player.setVolume(1);
 
         expect(player.mute()).to.equal(undefined);
-        expect(player.getVolume()).to.equal(0);
-        expect(videoElement.volume).to.equal(0);
-        expect(videoElement.muted).to.equal(false);
+        expect(player.getVolume()).to.equal(1);
+        expect(videoElement.volume).to.equal(1);
+        expect(videoElement.muted).to.equal(true);
         expect(player.isMute()).to.equal(true);
         player.unMute();
         expect(player.isMute()).to.equal(false);
+        expect(player.getVolume()).to.equal(1);
+        expect(videoElement.volume).to.equal(1);
+        expect(videoElement.muted).to.equal(false);
       });
 
       it("should unmute the volume at the previous value in unMute by default", () => {
@@ -223,42 +226,28 @@ describe("initial idle state", () => {
 
         player.mute();
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(videoElement.volume).to.equal(0);
+        expect(player.getVolume()).to.equal(0.8);
+        expect(videoElement.volume).to.equal(0.8);
+        expect(videoElement.muted).to.equal(true);
 
         player.unMute();
         expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(0.8);
         expect(videoElement.volume).to.equal(0.8);
+        expect(videoElement.muted).to.equal(false);
       });
 
       it("should return false in isMute by default", () => {
         expect(player.isMute()).to.equal(false);
       });
 
-      it("should return true in isMute if the volume is equal to 0", () => {
-        const oldVolume = player.getVolume();
-
+      it("should not return true in isMute if the volume is equal to 0", () => {
         expect(player.isMute()).to.equal(false);
 
         player.setVolume(0);
-        expect(player.isMute()).to.equal(true);
-        player.setVolume(oldVolume);
         expect(player.isMute()).to.equal(false);
-
         player.mute();
         expect(player.isMute()).to.equal(true);
-        player.unMute();
-        expect(player.isMute()).to.equal(false);
-
-        player.mute();
-        expect(player.isMute()).to.equal(true);
-        player.setVolume(oldVolume);
-        expect(player.isMute()).to.equal(false);
-        player.unMute();
-        expect(player.isMute()).to.equal(false);
-
-        player.setVolume(oldVolume);
       });
     });
 

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1194,7 +1194,7 @@ export default function launchTestsForContent(manifestInfos) {
     });
 
     describe("getVolume", () => {
-      it("should return the current media elment volume", async () => {
+      it("should return the current media element volume", async () => {
         const initialVolume = player.getVideoElement().volume;
         expect(player.getVolume()).to.equal(initialVolume);
 
@@ -1230,11 +1230,11 @@ export default function launchTestsForContent(manifestInfos) {
         expect(player.getVolume()).to.equal(0.92);
       });
 
-      it("should return 0 if muted", async () => {
+      it("should still return the volume if muted", async () => {
         const initialVolume = player.getVideoElement().volume;
         expect(player.getVolume()).to.equal(initialVolume);
         player.mute();
-        expect(player.getVolume()).to.equal(0);
+        expect(player.getVolume()).to.equal(initialVolume);
         player.unMute();
         expect(player.getVolume()).to.equal(initialVolume);
         player.mute();
@@ -1245,7 +1245,7 @@ export default function launchTestsForContent(manifestInfos) {
           autoPlay: true,
         });
 
-        expect(player.getVolume()).to.equal(0);
+        expect(player.getVolume()).to.equal(initialVolume);
         player.setVolume(0.12);
         expect(player.getVolume()).to.equal(0.12);
         await waitForLoadedStateAfterLoadVideo(player);
@@ -1273,12 +1273,12 @@ export default function launchTestsForContent(manifestInfos) {
         expect(player.getVolume()).to.equal(0.17);
       });
 
-      it("should un-mute when muted", async () => {
+      it("should not un-mute when muted", async () => {
         player.mute();
         expect(player.isMute()).to.equal(true);
         player.setVolume(0.25);
         expect(player.getVolume()).to.equal(0.25);
-        expect(player.isMute()).to.equal(false);
+        expect(player.isMute()).to.equal(true);
 
         player.loadVideo({
           url: manifestInfos.url,
@@ -1286,21 +1286,19 @@ export default function launchTestsForContent(manifestInfos) {
           autoPlay: true,
         });
 
+        player.unMute();
         expect(player.isMute()).to.equal(false);
         player.mute();
         expect(player.isMute()).to.equal(true);
         player.setVolume(0.33);
         expect(player.getVolume()).to.equal(0.33);
-        expect(player.isMute()).to.equal(false);
+        expect(player.isMute()).to.equal(true);
 
         await waitForLoadedStateAfterLoadVideo(player);
 
-        expect(player.isMute()).to.equal(false);
-        player.mute();
-        expect(player.isMute()).to.equal(true);
         player.setVolume(0.45);
         expect(player.getVolume()).to.equal(0.45);
-        expect(player.isMute()).to.equal(false);
+        expect(player.isMute()).to.equal(true);
       });
     });
 
@@ -1338,17 +1336,19 @@ export default function launchTestsForContent(manifestInfos) {
         player.mute();
         expect(player.isMute()).to.equal(true);
         player.setVolume(1);
-        expect(player.isMute()).to.equal(false);
+        expect(player.isMute()).to.equal(true);
       });
     });
 
     describe("mute", () => {
-      it("should set the volume to 0", async () => {
+      it("should set the muted property", async () => {
         const initialVolume = player.getVideoElement().volume;
+        expect(player.getVideoElement().muted).to.equal(false);
         player.mute();
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
+        expect(player.getVolume()).to.equal(initialVolume);
+        expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(true);
 
         player.loadVideo({
           url: manifestInfos.url,
@@ -1357,25 +1357,30 @@ export default function launchTestsForContent(manifestInfos) {
         });
 
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
+        expect(player.getVideoElement().muted).to.equal(true);
+        expect(player.getVolume()).to.equal(initialVolume);
+        expect(player.getVideoElement().volume).to.equal(initialVolume);
         player.unMute();
         expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(initialVolume);
         expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(false);
         await waitForLoadedStateAfterLoadVideo(player);
         expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(initialVolume);
         expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(false);
 
         player.mute();
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
-        player.setVolume(1);
-        expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(initialVolume);
         expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(true);
+        player.setVolume(1);
+        expect(player.isMute()).to.equal(true);
+        expect(player.getVolume()).to.equal(initialVolume);
+        expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(true);
       });
     });
 
@@ -1384,8 +1389,9 @@ export default function launchTestsForContent(manifestInfos) {
         const initialVolume = player.getVideoElement().volume;
         player.mute();
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
+        expect(player.getVolume()).to.equal(initialVolume);
+        expect(player.getVideoElement().volume).to.equal(initialVolume);
+        expect(player.getVideoElement().muted).to.equal(true);
 
         player.loadVideo({
           url: manifestInfos.url,
@@ -1394,8 +1400,8 @@ export default function launchTestsForContent(manifestInfos) {
         });
 
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
+        expect(player.getVolume()).to.equal(initialVolume);
+        expect(player.getVideoElement().volume).to.equal(initialVolume);
         player.unMute();
         expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(initialVolume);
@@ -1407,12 +1413,12 @@ export default function launchTestsForContent(manifestInfos) {
 
         player.mute();
         expect(player.isMute()).to.equal(true);
-        expect(player.getVolume()).to.equal(0);
-        expect(player.getVideoElement().volume).to.equal(0);
-        player.setVolume(1);
-        expect(player.isMute()).to.equal(false);
         expect(player.getVolume()).to.equal(initialVolume);
         expect(player.getVideoElement().volume).to.equal(initialVolume);
+        player.setVolume(0.7);
+        expect(player.isMute()).to.equal(true);
+        expect(player.getVolume()).to.equal(0.7);
+        expect(player.getVideoElement().volume).to.equal(0.7);
       });
     });
 


### PR DESCRIPTION
Previous RxPlayer's `mute` and `unMute` method actually set the volume to `0` instead of changing the `muted` HTMLMediaElement property.

I here propose that we update their behavior to mutate the `muted` property instead as:
  1. It would seem more natural to an application I would guess
  2. It might integrate better with browsers built-in making use of the `HTMLMediaElement` properties directly (things like Picture-in-Picture and so on).

I also consequently updated that the `volumeChange` event to notify about both properties, and noticed it wasn't even documented in the API documentation.