### PR TITLE
[WIP] Hotfix xbox seek initial

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -70,6 +70,9 @@ let isPanasonic = false;
 /** `true` for the PlayStation 5 game console. */
 let isPlayStation5 = false;
 
+/** `true` for the Xbox game consoles. */
+let isXbox = false;
+
 ((function findCurrentBrowser() : void {
   if (isNode) {
     return ;
@@ -135,6 +138,8 @@ let isPlayStation5 = false;
     }
   } else if (/[Pp]anasonic/.test(navigator.userAgent)) {
     isPanasonic = true;
+  } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
+    isXbox = true;
   }
 })());
 
@@ -145,6 +150,7 @@ export {
   isFirefox,
   isPanasonic,
   isPlayStation5,
+  isXbox,
   isSafariDesktop,
   isSafariMobile,
   isSamsungBrowser,

--- a/src/compat/should_prevent_seeking_at_0_initially.ts
+++ b/src/compat/should_prevent_seeking_at_0_initially.ts
@@ -1,0 +1,18 @@
+import { isXbox } from "./browser_detection";
+
+/**
+ * We noticed that on Xbox game consoles, the browser didn't send a "seeking"
+ * event if we were seeking at a 0 position initially.
+ *
+ * We could theoretically never seek at 0 initially as the initial position of
+ * an HTMLMediaElement should be at 0 anyway, but we still do it as a safe
+ * solution, as many devices have a buggy integration of HTML5 media API.
+ *
+ * This function returns `true` when we should avoid doing so, for now only for
+ * the non-standard behavior of XBox game consoles.
+ * @returns {number}
+ */
+export default function shouldPreventSeekingAt0Initially(
+): boolean {
+  return isXbox;
+}


### PR DESCRIPTION
We noticed that on Xbox game consoles, the browser didn't send a `"seeking"` event if we were seeking at a `0` position initially.

We could theoretically never seek at `0` initially as the initial position of an `HTMLMediaElement` should be at `0` anyway, but we still do it as a safe solution, as many devices have a buggy integration of HTML5 media API.

So here we just avoid doing so for xbox