### PR TITLE
types: improve object assign type def

### DIFF
--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -1288,9 +1288,11 @@ function getInitialObservation(mediaElement: HTMLMediaElement) : IPlaybackObserv
   const mediaTimings = getMediaInfos(mediaElement);
   return objectAssign(mediaTimings,
                       { rebuffering: null,
-                        event: "init",
+                        event: "init" as const,
                         seeking: SeekingState.None,
-                        position: { last: mediaTimings.position,
-                                    pending: undefined },
-                        freezing: null });
+                        position: new ObservationPosition(mediaTimings.position, null),
+                        freezing: null,
+                        bufferGap: undefined,
+                        currentRange: null,
+                      });
 }

--- a/src/core/api/playback_observer.ts
+++ b/src/core/api/playback_observer.ts
@@ -1292,7 +1292,7 @@ function getInitialObservation(mediaElement: HTMLMediaElement) : IPlaybackObserv
                         seeking: SeekingState.None,
                         position: new ObservationPosition(mediaTimings.position, null),
                         freezing: null,
-                        bufferGap: undefined,
+                        bufferGap: 0,
                         currentRange: null,
                       });
 }

--- a/src/core/init/multithread/worker/content_preparer.ts
+++ b/src/core/init/multithread/worker/content_preparer.ts
@@ -206,7 +206,7 @@ export default class ContentPreparer {
           // Remove `periods` key to reduce cost of an unnecessary manifest
           // clone.
           const snapshot = objectAssign(manifest.getMetadataSnapshot(),
-                                        { periods: undefined });
+                                        { periods: [] });
           sendMessage({
             type: WorkerMessageType.ManifestUpdate,
             contentId,

--- a/src/core/init/multithread/worker/track_choice_setter.ts
+++ b/src/core/init/multithread/worker/track_choice_setter.ts
@@ -87,7 +87,7 @@ export default class TrackChoiceSetter {
       representations = new SharedReference<IRepresentationsChoice>(
         val.representations.getValue()
       );
-      ref.setValue(objectAssign({}, ref.getValue(), {
+      ref.setValue(objectAssign({}, val, {
         representations,
       }));
     }

--- a/src/utils/__tests__/object_assign.test.ts
+++ b/src/utils/__tests__/object_assign.test.ts
@@ -59,11 +59,13 @@ describe("utils - objectAssign", () => {
     interface Shape1 { a: number; b: number };
     interface Shape2 { a: string; b: number };
 
-    // @ts-expect-error type is incorrect, should be an error
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const mergedObj1: Shape1 = objectAssign(obj, { a: "foo" });
+    const mergedObj = objectAssign(obj, { a: "foo" });
+    // the intention in this test is to check typescript definitions
+    // the test would always pass in javascript, but it will show
+    // a typescript error if the typedefinition are incorrects.
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const mergedObj2: Shape2 = objectAssign(obj, { a: "foo" });
+    // @ts-expect-error result is not of Shape1, should show an error
+    expect(mergedObj).toMatchObject<Shape1>({ a: "foo", b: 5 });
+    expect(mergedObj).toMatchObject<Shape2>({ a: "foo", b: 5 });
   });
 });

--- a/src/utils/__tests__/object_assign.test.ts
+++ b/src/utils/__tests__/object_assign.test.ts
@@ -53,4 +53,17 @@ describe("utils - objectAssign", () => {
                         { c: { d: 85 } })).toBe(obj);
     expect(obj).toEqual({ a: 78, c: { d: 85 } });
   });
+
+  it("types definition should be correct", () => {
+    const obj = { a: 4, b: 5 };
+    interface Shape1 { a: number; b: number };
+    interface Shape2 { a: string; b: number };
+
+    // @ts-expect-error type is incorrect, should be an error
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const mergedObj1: Shape1 = objectAssign(obj, { a: "foo" });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const mergedObj2: Shape2 = objectAssign(obj, { a: "foo" });
+  });
 });

--- a/src/utils/object_assign.ts
+++ b/src/utils/object_assign.ts
@@ -14,25 +14,58 @@
  * limitations under the License.
  */
 
+
+type MergeRecursively<T extends object, S extends object[]> =
+    S extends [infer First, ...infer Rest] ?
+      MergeRecursively<MergeObjects<T, First extends object ? First : never>,
+       Rest extends object[] ? Rest: never>
+    : T;
+;
+
+type MergeObjects<T extends object, S extends object> = {
+  [K in (OptionalPropertyOfTNotInS<T, S> | OptionalProperty<T>)]?:
+        K extends keyof S ? S[K]
+        : K extends keyof T ? T[K]
+        : never;
+} & {
+  [K in Exclude<
+    (keyof T | keyof S),
+    OptionalPropertyOfTNotInS<T, S> | OptionalProperty<T>
+    >]:
+        K extends keyof S ? S[K]
+        : K extends keyof T ? T[K]
+        : never;
+};
+
+type OptionalProperty<T> = Exclude<{
+  [K in keyof T]: T extends Record<K, T[K]>
+  ? never
+  : K
+}[keyof T], undefined>;
+
+type OptionalPropertyOfTNotInS<T, S> = Exclude<{
+  [K in keyof T]: T extends Record<K, T[K]>
+      ? never
+      : K
+}[keyof T], undefined | {[K in keyof S]: S extends Record<K, S[K]>
+  ? K
+  : never
+}[keyof S]>;
+
+
 /**
  * Very simple implementation of Object.assign.
  * Should be sufficient for all use-cases here.
  *
  * Does not support symbols, but this should not be a problem as browsers
- * supporting symbols generally support Object.asign;
+ * supporting symbols generally support Object.assign;
  *
  * @param {Object} target
  * @param {Array.<Object>} ...sources
  * @returns {Object}
  */
-function objectAssign<T, U>(target : T, source : U) : T & U;
-function objectAssign<T, U, V>(target : T, source1 : U, source2 : V) : T & U & V;
-function objectAssign<T, U, V, W>(
-  target : T,
-  source1 : U,
-  source2 : V,
-  source3 : W) : T & U & V & W;
-function objectAssign<T, U>(target : T, ...sources : U[]) : T & U {
+function objectAssign<T extends object, U extends object[]>(target : T, ...sources : U) :
+MergeRecursively<T, U> {
   if (target === null || target === undefined) {
     throw new TypeError("Cannot convert undefined or null to object");
   }
@@ -42,14 +75,13 @@ function objectAssign<T, U>(target : T, ...sources : U[]) : T & U {
     const source = sources[i];
     for (const key in source) {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
-        /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        to[key] = source[key];
-        /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+        // eslint-disable-next-line max-len
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+        to[key] = source[key as (keyof typeof source)];
       }
     }
   }
-  return to as T & U;
+  return to as MergeRecursively<T, U>;
 }
 
 // eslint-disable-next-line @typescript-eslint/unbound-method, no-restricted-properties


### PR DESCRIPTION
## Why ?

Out of the box type definition of `Object.assign` is confusing and wrong: 
```ts
const myObj = { a: "a"};
let merged = Object.assign({a: "a"}, {a: 1})
typeof merged.a // "never"       but it should be "number" !
```
Return type of `object.assign(a: U, b: T)`  is  intersection `U & T`.
However intersecting two object that share some property but with different types will result in no overlapping and it's then typed as `never`.

```ts
type A = { a: string };
type B = { a : number };
type C = A & B 
// ^? { a : never }

```
https://www.typescriptlang.org/play?#code/C4TwDgpgBA8gRgKwgY2AQQM4YJYHMB2UAvFKJAPYBmsiKwAdAIZZ74DcAUB8ufhsFAC2IeAmJQA3lEYAuKACJG8gL6cOAGwgDBEAE64IAE3Gi6TFgQAUE5QBpJshUrsO5ARmUBKLmQhUhegaGTFAA9KFQ+BAAbnoAhFBwAK4C2AIYABbkSerGcNDy+EmC+bryQA


## Solution
The solution is to change the return type from the built-in to a self-made.

The base is to iterate through the keys of two objects Target and Source and:
- if property is present in source and  in target, take the source definition for the merge
- if property is present in source but not in target, take the source definition for the merge
- if property is present in target but not in source, take the target definition for the merge

Additionally to preserve optional properties e.g. `{foo?: string}`, we need to merge both required and optional properties separately and then do an intersection (which doesn't overlap).

