### PR TITLE
fix(test): fix flaky test get_license

### DIFF
--- a/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
@@ -44,23 +44,23 @@ describe("decrypt - global tests - getLicense", () => {
 
   it("should retry after an increased time at each retry", () => {
     /*
-    * The delay after each retry is multiplied by a factor 2.
-    * This delay is slightly modified to randomize the distribution.
-    * Following table display the expected delay for each retry, in the
-    * most pessimists and most optimistics scenarios.
-    * The last two columns show the minimum and maximum accumulated time
-    * waited since the first try.
-    *
-    * |Retry| base  |  max  |  min  |totalMax|totalMin |
-    * |-----|-------|-------|-------|--------|---------|
-    * | 1   |200    | 260   | 140   | 260    |  140    |
-    * | 2   |400    | 520   | 280   | 780    |  420    |
-    * | 3   |800    | 1040  | 560   | 1820   |  980    |
-    * | 4   |1600   | 2080  | 1120  | 3900   |  21OO   |
-    * | 5   |3000   | 3000  | 2100  | 7800   |  4200   |
-    * | 6   |3000   | 3000  | 2100  | 11700  |  6300   |
-    * | 7   |3000   | 3000  | 2100  | 15600  |  8400   |
-    */
+     * The delay after each retry is multiplied by a factor 2.
+     * This delay is slightly modified to randomize the distribution.
+     * Following table display the expected delay for each retry, in the
+     * most pessimists and most optimistics scenarios.
+     * The last two columns show the minimum and maximum accumulated time
+     * waited since the first try.
+     *
+     * |Retry| base  |  max  |  min  |totalMax|totalMin |
+     * |-----|-------|-------|-------|--------|---------|
+     * | 1   |200    | 260   | 140   | 260    |  140    |
+     * | 2   |400    | 520   | 280   | 780    |  420    |
+     * | 3   |800    | 1040  | 560   | 1820   |  980    |
+     * | 4   |1600   | 2080  | 1120  | 3900   |  21OO   |
+     * | 5   |3000   | 3000  | 2100  | 7800   |  4200   |
+     * | 6   |3000   | 3000  | 2100  | 11700  |  6300   |
+     * | 7   |3000   | 3000  | 2100  | 15600  |  8400   |
+     */
     const baseDelay = 200;
     const maxDelay = 3000;
     expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeGreaterThanOrEqual(140);
@@ -71,7 +71,7 @@ describe("decrypt - global tests - getLicense", () => {
 
     expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeGreaterThanOrEqual(2100);
     expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeLessThanOrEqual(3000);
-  })
+  });
 
   it("should update the session after getLicense resolves with a license", async () => {
     await checkGetLicense({
@@ -487,13 +487,19 @@ function checkGetLicense({
           timeout = 800;
           break;
         case 3:
-          timeout = 1200;
+          timeout = 2000;
           break;
         case 4:
-          timeout = 3000;
+          timeout = 4000;
+          break;
+        case 5:
+          timeout = 8000;
+          break;
+        case 6:
+          timeout = 12000;
           break;
         default:
-          timeout = 10000;
+          timeout = 16000;
       }
       setTimeout(() => {
         try {

--- a/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
@@ -25,6 +25,7 @@
 
 import type { IPlayerError } from "../../../../public_types";
 import { concat } from "../../../../utils/byte_parsing";
+import { getRetryDelay } from "../../../../utils/retry_promise_with_backoff";
 import {
   formatFakeChallengeFromInitData,
   MediaKeySessionImpl,
@@ -40,6 +41,37 @@ describe("decrypt - global tests - getLicense", () => {
     jest.resetModules();
     jest.restoreAllMocks();
   });
+
+  it("should retry after an increased time at each retry", () => {
+    /*
+    * The delay after each retry is multiplied by a factor 2.
+    * This delay is slightly modified to randomize the distribution.
+    * Following table display the expected delay for each retry, in the
+    * most pessimists and most optimistics scenarios.
+    * The last two columns show the minimum and maximum accumulated time
+    * waited since the first try.
+    *
+    * |Retry| base  |  max  |  min  |totalMax|totalMin |
+    * |-----|-------|-------|-------|--------|---------|
+    * | 1   |200    | 260   | 140   | 260    |  140    |
+    * | 2   |400    | 520   | 280   | 780    |  420    |
+    * | 3   |800    | 1040  | 560   | 1820   |  980    |
+    * | 4   |1600   | 2080  | 1120  | 3900   |  21OO   |
+    * | 5   |3000   | 3000  | 2100  | 7800   |  4200   |
+    * | 6   |3000   | 3000  | 2100  | 11700  |  6300   |
+    * | 7   |3000   | 3000  | 2100  | 15600  |  8400   |
+    */
+    const baseDelay = 200;
+    const maxDelay = 3000;
+    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeGreaterThanOrEqual(140);
+    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeLessThanOrEqual(260);
+
+    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeGreaterThanOrEqual(560);
+    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeLessThanOrEqual(1040);
+
+    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeGreaterThanOrEqual(2100);
+    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeLessThanOrEqual(3000);
+  })
 
   it("should update the session after getLicense resolves with a license", async () => {
     await checkGetLicense({

--- a/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
@@ -25,7 +25,6 @@
 
 import type { IPlayerError } from "../../../../public_types";
 import { concat } from "../../../../utils/byte_parsing";
-import { getRetryDelay } from "../../../../utils/retry_promise_with_backoff";
 import {
   formatFakeChallengeFromInitData,
   MediaKeySessionImpl,
@@ -40,37 +39,6 @@ describe("decrypt - global tests - getLicense", () => {
   afterEach(() => {
     jest.resetModules();
     jest.restoreAllMocks();
-  });
-
-  it("should retry after an increased time at each retry", () => {
-    /*
-     * The delay after each retry is multiplied by a factor 2.
-     * This delay is slightly modified to randomize the distribution.
-     * Following table display the expected delay for each retry, in the
-     * most pessimists and most optimistics scenarios.
-     * The last two columns show the minimum and maximum accumulated time
-     * waited since the first try.
-     *
-     * |Retry| base  |  max  |  min  |totalMax|totalMin |
-     * |-----|-------|-------|-------|--------|---------|
-     * | 1   |200    | 260   | 140   | 260    |  140    |
-     * | 2   |400    | 520   | 280   | 780    |  420    |
-     * | 3   |800    | 1040  | 560   | 1820   |  980    |
-     * | 4   |1600   | 2080  | 1120  | 3900   |  21OO   |
-     * | 5   |3000   | 3000  | 2100  | 7800   |  4200   |
-     * | 6   |3000   | 3000  | 2100  | 11700  |  6300   |
-     * | 7   |3000   | 3000  | 2100  | 15600  |  8400   |
-     */
-    const baseDelay = 200;
-    const maxDelay = 3000;
-    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeGreaterThanOrEqual(140);
-    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeLessThanOrEqual(260);
-
-    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeGreaterThanOrEqual(560);
-    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeLessThanOrEqual(1040);
-
-    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeGreaterThanOrEqual(2100);
-    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeLessThanOrEqual(3000);
   });
 
   it("should update the session after getLicense resolves with a license", async () => {

--- a/src/utils/__tests__/retry_promise_with_backoff.test.ts
+++ b/src/utils/__tests__/retry_promise_with_backoff.test.ts
@@ -1,0 +1,39 @@
+import { getRetryDelay } from "../retry_promise_with_backoff";
+
+describe("utils - RetryPromiseWithBackoff", () => {
+  it("retry delay should increase at each retry", () => {
+    /*
+     * The delay after each retry is multiplied by a factor 2.
+     * This delay is slightly modified to randomize the distribution.
+     * Following table display the expected delay for each retry, in the
+     * most pessimists and most optimistics scenarios.
+     * The last two columns show the minimum and maximum accumulated time
+     * waited since the first try.
+     *
+     * |Retry| base  |  max  |  min  |totalMax|totalMin |
+     * |-----|-------|-------|-------|--------|---------|
+     * | 1   |200    | 260   | 140   | 260    |  140    |
+     * | 2   |400    | 520   | 280   | 780    |  420    |
+     * | 3   |800    | 1040  | 560   | 1820   |  980    |
+     * | 4   |1600   | 2080  | 1120  | 3900   |  21OO   |
+     * | 5   |3000   | 3000  | 2100  | 7800   |  4200   |
+     * | 6   |3000   | 3000  | 2100  | 11700  |  6300   |
+     * | 7   |3000   | 3000  | 2100  | 15600  |  8400   |
+     */
+    const baseDelay = 200;
+    const maxDelay = 3000;
+    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeGreaterThanOrEqual(140);
+    expect(getRetryDelay(baseDelay, 1, maxDelay)).toBeLessThanOrEqual(260);
+
+    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeGreaterThanOrEqual(560);
+    expect(getRetryDelay(baseDelay, 3, maxDelay)).toBeLessThanOrEqual(1040);
+
+    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeGreaterThanOrEqual(2100);
+    expect(getRetryDelay(baseDelay, 6, maxDelay)).toBeLessThanOrEqual(3000);
+  });
+
+  it("retry delay should be capped by maximumDelay", () => {
+    const maxDelay = 1000;
+    expect(getRetryDelay(500, 6, maxDelay)).toBeLessThanOrEqual(maxDelay);
+  });
+});

--- a/src/utils/retry_promise_with_backoff.ts
+++ b/src/utils/retry_promise_with_backoff.ts
@@ -69,15 +69,25 @@ export default function retryPromiseWithBackoff<T>(
       if (typeof onRetry === "function") {
         onRetry(error, retryCount);
       }
-
-      const delay = Math.min(baseDelay * Math.pow(2, retryCount - 1), maxDelay);
-
-      const fuzzedDelay = getFuzzedDelay(delay);
-      await sleep(fuzzedDelay);
+      const delay = getRetryDelay(baseDelay, retryCount, maxDelay);
+      await sleep(delay);
       const res = iterate();
       return res;
     }
   }
+}
+/**
+ * Get the delay that should be applied to the following retry, it depends on the base delay
+ * and is increaser for with the retry count. The result is ceiled by the maxDelay.
+ * @param baseDelay delay after wich the first request is retried after a failure
+ * @param retryCount count of retries
+ * @param maxDelay maximum delay
+ * @returns the delay that should be applied to the following retry
+ */
+export function getRetryDelay(baseDelay: number, retryCount: number, maxDelay: number) {
+  const delay = baseDelay * Math.pow(2, retryCount - 1);
+  const fuzzedDelay = getFuzzedDelay(delay);
+  return Math.min(fuzzedDelay, maxDelay);
 }
 
 export interface IBackoffOptions {


### PR DESCRIPTION
Asserting after a `setTimeout()` is not highly reliable since device performance variations can lead to inconsistent outcomes.  That was highly noticeable on the CI where failures occurred frequently..

To address this issue, we ensure that the license has been received before performing the assertion.
Replace a `setTimeout` by the use of `setInterval` to periodically check the if the license has been received.

I was wondering if the condition is never met, will we infinitely get stuck in the setInterval ? But the test runner has his own timeout for every test case, so it does not feel necessary to add one in the code.