### PR TITLE
doc: remove duplicate warning for maxvideoBufferSize

### DIFF
--- a/doc/api/Creating_a_Player.md
+++ b/doc/api/Creating_a_Player.md
@@ -105,11 +105,6 @@ is currently buffered and an estimation of the size of the next segments.
 </div>
 
 <div class="warning">
-In <i>DirectFile</i> mode (see <a href="./Loading_a_Content.md#transport">loadVideo options</a>),
-this method has no effect.
-</div>
-
-<div class="warning">
 This option will have no effects if we didn't buffer at least <b>MIN_BUFFER_LENGTH</b>
 <i>( defaults at 5sec )</i>
 </div>


### PR DESCRIPTION
API Documentation warn 2 times that the maxvideoBufferSize options has no effect when in DirectFile mode.
(and the second statement use the term "method" which is not exact as it should be "option" or "property")
So I propose to keep the first warn statement only.

> This option will have no effect for contents loaded in Directfile mode (see [loadVideo options](https://developers.canal-plus.com/rx-player/versions/4.0.0-beta.3/doc//api/Loading_a_Content.html#transport)).


> In DirectFile mode (see [loadVideo options](https://developers.canal-plus.com/rx-player/versions/4.0.0-beta.3/doc//api/Loading_a_Content.html#transport)), this method has no effect.`