### PR TITLE
[Proposal] Solution 2: PlaybackObserver utils moved to `src/core/common`

### DIFF
--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -17,7 +17,7 @@
 import config from "../../config";
 import log from "../../log";
 import type {
-  IObservationPosition,
+  ObservationPosition,
   IReadOnlyPlaybackObserver,
 } from "../../main_thread/types";
 import type {
@@ -604,7 +604,7 @@ export interface IRepresentationEstimatorPlaybackObservation {
    * Information on the current media position in seconds at the time of a
    * Playback Observation.
    */
-  position : IObservationPosition;
+  position : ObservationPosition;
   /**
    * Last "playback rate" set by the user. This is the ideal "playback rate" at
    * which the media should play.

--- a/src/core/main/common/generate_read_only_observer.ts
+++ b/src/core/main/common/generate_read_only_observer.ts
@@ -1,0 +1,153 @@
+import type { IReadOnlySharedReference } from "../../../utils/reference";
+import type { CancellationSignal } from "../../../utils/task_canceller";
+
+/**
+ * Interface providing a generic and read-only version of a `PlaybackObserver`.
+ *
+ * This interface allows to provide regular and specific playback information
+ * without allowing any effect on playback like seeking.
+ *
+ * This can be very useful to give specific playback information to modules you
+ * don't want to be able to update playback.
+ *
+ * Note that a `PlaybackObserver` is compatible and can thus be upcasted to a
+ * `IReadOnlyPlaybackObserver` to "remove" its right to update playback.
+ */
+export interface IReadOnlyPlaybackObserver<TObservationType> {
+  /**
+   * Get the current playing position, in seconds.
+   * Returns `undefined` when this cannot be known, such as when the playback
+   * observer is running in a WebWorker.
+   * @returns {number|undefined}
+   */
+  getCurrentTime() : number | undefined;
+  /**
+   * Returns the current playback rate advertised by the `HTMLMediaElement`.
+   * Returns `undefined` when this cannot be known, such as when the playback
+   * observer is running in a WebWorker.
+   * @returns {number|undefined}
+   */
+  getPlaybackRate() : number | undefined;
+  /**
+   * Get the HTMLMediaElement's current `readyState`.
+   * Returns `undefined` when this cannot be known, such as when the playback
+   * observer is running in a WebWorker.
+   * @returns {number|undefined}
+   */
+  getReadyState() : number | undefined;
+  /**
+   * Returns the current `paused` status advertised by the `HTMLMediaElement`.
+   *
+   * Use this instead of the same status emitted on an observation when you want
+   * to be sure you're using the current value.
+   *
+   * Returns `undefined` when this cannot be known, such as when the playback
+   * observer is running in a WebWorker.
+   * @returns {boolean|undefined}
+   */
+  getIsPaused() : boolean | undefined;
+  /**
+   * Returns an `IReadOnlySharedReference` storing the last playback observation
+   * produced by the `IReadOnlyPlaybackObserver` and updated each time a new one
+   * is produced.
+   *
+   * This value can then be for example listened to to be notified of future
+   * playback observations.
+   *
+   * @returns {Object}
+   */
+  getReference() : IReadOnlySharedReference<TObservationType>;
+  /**
+   * Register a callback so it regularly receives playback observations.
+   * @param {Function} cb
+   * @param {Object} options - Configuration options:
+   *   - `includeLastObservation`: If set to `true` the last observation will
+   *     be first emitted synchronously.
+   *   - `clearSignal`: If set, the callback will be unregistered when this
+   *     CancellationSignal emits.
+   * @returns {Function} - Allows to easily unregister the callback
+   */
+  listen(
+    cb : (
+      observation : TObservationType,
+      stopListening : () => void
+    ) => void,
+    options? : { includeLastObservation? : boolean | undefined;
+                 clearSignal? : CancellationSignal | undefined; }
+  ) : void;
+  /**
+   * Generate a new `IReadOnlyPlaybackObserver` from this one.
+   *
+   * As argument, this method takes a function which will allow to produce
+   * the new set of properties to be present on each observation.
+   * @param {Function} transform
+   * @returns {Object}
+   */
+  deriveReadOnlyObserver<TDest>(
+    transform : (
+      observationRef : IReadOnlySharedReference<TObservationType>,
+      cancellationSignal : CancellationSignal
+    ) => IReadOnlySharedReference<TDest>
+  ) : IReadOnlyPlaybackObserver<TDest>;
+}
+
+/**
+ * Create `IReadOnlyPlaybackObserver` from a source `IReadOnlyPlaybackObserver`
+ * and a mapping function.
+ * @param {Object} src
+ * @param {Function} transform
+ * @returns {Object}
+ */
+export default function generateReadOnlyObserver<TSource, TDest>(
+  src : IReadOnlyPlaybackObserver<TSource>,
+  transform : (
+    observationRef : IReadOnlySharedReference<TSource>,
+    cancellationSignal : CancellationSignal
+  ) => IReadOnlySharedReference<TDest>,
+  cancellationSignal : CancellationSignal
+) : IReadOnlyPlaybackObserver<TDest> {
+  const mappedRef = transform(src.getReference(), cancellationSignal);
+  return {
+    getCurrentTime() {
+      return src.getCurrentTime();
+    },
+    getReadyState() {
+      return src.getReadyState();
+    },
+    getPlaybackRate() {
+      return src.getPlaybackRate();
+    },
+    getIsPaused() {
+      return src.getIsPaused();
+    },
+    getReference() : IReadOnlySharedReference<TDest> {
+      return mappedRef;
+    },
+    listen(
+      cb : (
+        observation : TDest,
+        stopListening : () => void
+      ) => void,
+      options? : { includeLastObservation? : boolean | undefined;
+                   clearSignal? : CancellationSignal | undefined; }
+    ) : void {
+      if (cancellationSignal.isCancelled() ||
+          options?.clearSignal?.isCancelled() === true)
+      {
+        return ;
+      }
+      mappedRef.onUpdate(cb, {
+        clearSignal: options?.clearSignal,
+        emitCurrentValue: options?.includeLastObservation,
+      });
+    },
+    deriveReadOnlyObserver<TNext>(
+      newTransformFn : (
+        observationRef : IReadOnlySharedReference<TDest>,
+        signal : CancellationSignal
+      ) => IReadOnlySharedReference<TNext>
+    ) : IReadOnlyPlaybackObserver<TNext> {
+      return generateReadOnlyObserver(this, newTransformFn, cancellationSignal);
+    },
+  };
+}

--- a/src/core/main/common/observation_position.ts
+++ b/src/core/main/common/observation_position.ts
@@ -1,0 +1,105 @@
+export default class ObservationPosition {
+  /**
+   * Known position at the time the Observation was emitted, in seconds.
+   *
+   * Note that it might have changed since. If you want truly precize
+   * information, you should recuperate it from the HTMLMediaElement directly
+   * through another mean.
+   */
+  private _last: number;
+  /**
+   * Actually wanted position in seconds that is not yet reached.
+   *
+   * This might for example be set to the initial position when the content is
+   * loading (and thus potentially at a `0` position) but which will be seeked
+   * to a given position once possible. It may also be the position of a seek
+   * that has not been properly accounted for by the current device.
+   */
+  private _wanted: number | null;
+  constructor(last: number, wanted: number | null) {
+    this._last = last;
+    this._wanted = wanted;
+  }
+
+  /**
+   * Obtain arguments allowing to instanciate the same ObservationPosition.
+   *
+   * This can be used to create a new `ObservationPosition` across JS realms,
+   * generally to communicate its data between the main thread and a WebWorker.
+   * @returns {Array.<number>}
+   */
+  public serialize(): [number, number | null] {
+    return [this._last, this._wanted];
+  }
+
+  /**
+   * Returns the playback position actually observed on the media element at
+   * the time the playback observation was made.
+   *
+   * Note that it may be different than the position for which media data is
+   * wanted in rare scenarios where the goal position is not yet set on the
+   * media element.
+   *
+   * You should use this value when you want to obtain the actual position set
+   * on the media element for browser compatibility purposes. Note that this
+   * position was calculated at observation time, it might thus not be
+   * up-to-date if what you want is milliseconds-accuracy.
+   *
+   * If what you want is the actual position which the player is intended to
+   * play, you should rely on `getWanted` instead`.
+   * @returns {number}
+   */
+  public getPolled(): number {
+    return this._last;
+  }
+
+  /**
+   * Returns the position which the player should consider to load media data
+   * at the time the observation was made.
+   *
+   * It can be different than the value returned by `getPolled` in rare
+   * scenarios:
+   *
+   *   - When the initial position has not been set yet.
+   *
+   *   - When the current device do not let the RxPlayer peform precize seeks,
+   *     usually for perfomance reasons by seeking to a previous IDR frame
+   *     instead (for now only Tizen may be like this), in which case we
+   *     prefer to generally rely on the position wanted by the player (this
+   *     e.g. prevents issues where the RxPlayer logic and the device are
+   *     seeking back and forth in a loop).
+   *
+   *   - When a wanted position has been "forced" (@see forceWantedPosition).
+   * @returns {number}
+   */
+  public getWanted(): number {
+    return this._wanted ?? this._last;
+  }
+
+  /**
+   * Method to call if you want to overwrite the currently wanted position.
+   * @param {number} pos
+   */
+  public forceWantedPosition(pos: number): void {
+    this._wanted = pos;
+  }
+
+  /**
+   * Returns `true` when the position wanted returned by `getWanted` and the
+   * actual position returned by `getPolled` may be different, meaning that
+   * we're currently not at the position we want to reach.
+   *
+   * This is a relatively rare situation which only happens when either the
+   * initial seek has not yet been performed. on specific targets where the
+   * seeking behavior is a little broken (@see getWanted) or when the wanted
+   * position has been forced (@see forceWantedPosition).
+   *
+   * In those situations, you might temporarily refrain from acting upon the
+   * actual current media position, as it may change soon.
+   *
+   * @returns {boolean}
+   */
+  public isAwaitingFuturePosition(): boolean {
+    return this._wanted !== null;
+  }
+}

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -5,8 +5,6 @@ import {
 } from "../../../errors";
 import features from "../../../features";
 import log from "../../../log";
-// XXX TODO
-import { ObservationPosition } from "../../../main_thread/api/playback_observer";
 import Manifest, {
   Adaptation,
   Period,
@@ -48,6 +46,7 @@ import StreamOrchestrator from "../../stream";
 /* eslint-disable-next-line max-len */
 import createContentTimeBoundariesObserver from "../common/create_content_time_boundaries_observer";
 import getBufferedDataPerMediaBuffer from "../common/get_buffered_data_per_media_buffer";
+import ObservationPosition from "../common/observation_position";
 import ContentPreparer from "./content_preparer";
 import {
   limitVideoResolution,

--- a/src/core/main/worker/worker_playback_observer.ts
+++ b/src/core/main/worker/worker_playback_observer.ts
@@ -1,5 +1,3 @@
-// XXX TODO
-import { generateReadOnlyObserver } from "../../../main_thread/api/playback_observer";
 import type {
   IFreezingStatus,
   IReadOnlyPlaybackObserver,
@@ -9,6 +7,7 @@ import { WorkerMessageType } from "../../../multithread_types";
 import type { IReadOnlySharedReference } from "../../../utils/reference";
 import type { CancellationSignal } from "../../../utils/task_canceller";
 import type { IStreamOrchestratorPlaybackObservation } from "../../stream";
+import generateReadOnlyObserver from "../common/generate_read_only_observer";
 import sendMessage from "./send_message";
 
 export type ICorePlaybackObservation = IStreamOrchestratorPlaybackObservation & {

--- a/src/core/stream/period/types.ts
+++ b/src/core/stream/period/types.ts
@@ -1,5 +1,5 @@
 import type {
-  IObservationPosition,
+  ObservationPosition,
   IReadOnlyPlaybackObserver,
 } from "../../../main_thread/types";
 import type {
@@ -94,7 +94,7 @@ export interface IPeriodStreamPlaybackObservation {
    * Information on the current media position in seconds at the time of the
    * Observation.
    */
-  position : IObservationPosition;
+  position : ObservationPosition;
   /** `duration` property of the HTMLMediaElement. */
   duration : number;
   /** `readyState` property of the HTMLMediaElement. */

--- a/src/core/stream/representation/types.ts
+++ b/src/core/stream/representation/types.ts
@@ -1,6 +1,6 @@
 import type {
   IContentProtection,
-  IObservationPosition,
+  ObservationPosition,
   IReadOnlyPlaybackObserver,
 } from "../../../main_thread/types";
 import type {
@@ -185,7 +185,7 @@ export interface IRepresentationStreamPlaybackObservation {
    * Information on the current media position in seconds at the time of a
    * Playback Observation.
    */
-  position : IObservationPosition;
+  position : ObservationPosition;
   /**
    * Information on whether the media element was paused at the time of the
    * Observation.

--- a/src/main_thread/api/index.ts
+++ b/src/main_thread/api/index.ts
@@ -18,10 +18,10 @@ import PlaybackObserver from "./playback_observer";
 import Player from "./public_api";
 export { PlaybackObserver };
 export {
-  IObservationPosition,
   IPlaybackObservation,
   IPlaybackObserverEventType,
   IReadOnlyPlaybackObserver,
+  ObservationPosition,
   IFreezingStatus,
   IRebufferingStatus,
 } from "./playback_observer";

--- a/src/main_thread/types.ts
+++ b/src/main_thread/types.ts
@@ -2,7 +2,7 @@ import type RxPlayer from "./api";
 import type {
   IFreezingStatus,
   IRebufferingStatus,
-  IObservationPosition,
+  ObservationPosition,
   IReadOnlyPlaybackObserver,
 } from "./api";
 import type {
@@ -18,8 +18,8 @@ export type IRxPlayer = RxPlayer;
 
 export type {
   // Playback Observation Metadata
-  IObservationPosition,
   IReadOnlyPlaybackObserver,
+  ObservationPosition,
   IFreezingStatus,
   IRebufferingStatus,
 


### PR DESCRIPTION
Root issue
----------

See #1366 for the root issue.

Solution 2
----------

This is the second solution (after #1366), which only moves utils common to both the WebWorker's PlaybackObserver and the main thread's PlaybackObserver into the `src/core/main/common/` directory - just like `ContentInitializer` utils in monothreaded mode.

In a way, this solution repeats the same solution found for `ContentInitializer` utils - which are in a different place when ran in monothreaded mode (where the utils is imported by the `src/main_thread/init` logic) or ran in multithreaded mode (where the utils are imported by the `src/core/main/worker` logic).

Result
------

I will admit that I'm less a fan of this solution than #1366, as the `src/core/main/common` directory feels like a hack in any scenario it is used.

There is also the fact that types exported through that path need to be re-exported through a more accessible path (usually src/main_thread/types`) to simplify import paths in the project.

Thoughts?