### PR TITLE
Don't re-load a Manifest's optional external resource each time if initial failed

### DIFF
--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -622,6 +622,7 @@ export default class Manifest
     this.isLive = newManifest.isLive;
     this.isLastPeriodKnown = newManifest.isLastPeriodKnown;
     this.lifetime = newManifest.lifetime;
+    this.clockOffset = newManifest.clockOffset;
     this.suggestedPresentationDelay = newManifest.suggestedPresentationDelay;
     this.transport = newManifest.transport;
     this.publishTime = newManifest.publishTime;


### PR DESCRIPTION
While doing some testing on `<UTCTiming>` elements in a DASH MPD, it has been brought to us that if all attempts to load its linked URL failed for the initial fetch of the Manifest (in which case we fallback to a mode where we don't rely on that element) and if the Manifest has to be refreshed multiple times, then the URL will be accessed every time the Manifest is refreshed, even if just one sucessful attempt would have been enough.

The issue was very simple to fix, as it was just that a newly obtained `clockOffset` - the actual metadata derived from parsing an `<UTCTiming>` element, was not actually copied when updating the base Manifest by its new parsed version.

Once that `clockOffset` is set to the base Manifest, that information will be communicated to our Manifest parser when the Manifest is refreshed, so it won't retry to load the clock and continue relying on the one fetched before.