### PR TITLE
fix(types): remove IIFE to correctly export Player class type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,32 +38,25 @@ import {
 import logger from "./log";
 import Player from "./main_thread/api";
 
-// NOTE: We're here doing an IIFE to ensure those side-effects are performed
-// when this file's default export is imported while still respecting the
-// spirit of our `package.json`'s `sideEffects` attribute.
-export default (() => {
-  patchWebkitSourceBuffer();
+patchWebkitSourceBuffer();
 
-  Player.addFeatures([
-    SMOOTH,
-    DASH,
-    DIRECTFILE,
-    EME,
-    NATIVE_TTML_PARSER,
-    NATIVE_SAMI_PARSER,
-    NATIVE_VTT_PARSER,
-    NATIVE_SRT_PARSER,
-    HTML_TTML_PARSER,
-    HTML_SAMI_PARSER,
-    HTML_VTT_PARSER,
-    HTML_SRT_PARSER,
-  ]);
-  if (isDebugModeEnabled()) {
-    logger.setLevel("DEBUG");
-  } else if (
-    (__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)
-  ) {
-    logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
-  }
-  return Player;
-})();
+Player.addFeatures([
+  SMOOTH,
+  DASH,
+  DIRECTFILE,
+  EME,
+  NATIVE_TTML_PARSER,
+  NATIVE_SAMI_PARSER,
+  NATIVE_VTT_PARSER,
+  NATIVE_SRT_PARSER,
+  HTML_TTML_PARSER,
+  HTML_SAMI_PARSER,
+  HTML_VTT_PARSER,
+  HTML_SRT_PARSER,
+]);
+if (isDebugModeEnabled()) {
+  logger.setLevel("DEBUG");
+} else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
+  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
+}
+export default Player;

--- a/src/minimal.ts
+++ b/src/minimal.ts
@@ -28,27 +28,20 @@ import logger from "./log";
 import Player from "./main_thread/api";
 import MainCodecSupportProber from "./mse/main_codec_support_prober";
 
-// NOTE: We're here doing an IIFE to ensure those side-effects are performed
-// when this file's default export is imported while still respecting the
-// spirit of our `package.json`'s `sideEffects` attribute.
-export default (() => {
-  patchWebkitSourceBuffer();
+patchWebkitSourceBuffer();
 
-  // TODO this should be auto-imported when the various features that needs it
-  // are added.
-  // For now, I'm scare of breaking things so I'm not removing it yet.
-  features.codecSupportProber = MainCodecSupportProber;
+// TODO this should be auto-imported when the various features that needs it
+// are added.
+// For now, I'm scare of breaking things so I'm not removing it yet.
+features.codecSupportProber = MainCodecSupportProber;
 
-  if (isDebugModeEnabled()) {
-    logger.setLevel("DEBUG");
-  } else if (
-    (__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)
-  ) {
-    logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
-  }
+if (isDebugModeEnabled()) {
+  logger.setLevel("DEBUG");
+} else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
+  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
+}
 
-  /**
-   * Minimal Player which starts with no feature.
-   */
-  return Player;
-})();
+/**
+ * Minimal Player which starts with no feature.
+ */
+export default Player;


### PR DESCRIPTION
exporting a class with an IIFE change the exported type of the class from "RxPlayer" to "typeof RxPlayer". That will provoke typechecking errors for applications that used "RxPlayer" as a type. This does NOT mess-up with the sideEffects config because the global overrides, such as "patchWebkitSourceBuffer()" are executed at the entry point for RxPlayer class (src/index and src/minimal).