### PR TITLE
Clean dist directory when calling build:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
   "scripts": {
     "build": "./scripts/generate_build.mjs",
     "build:dev": "./scripts/generate_build.mjs --dev-mode",
-    "build:all": "npm run build:wasm:release && npm run bundle && npm run bundle:min && npm run build",
+    "build:all": "npm run clean:build && npm run build:wasm:release && npm run bundle && npm run bundle:min && npm run build",
     "build:wasm:debug": "mkdir -p dist && cd ./src/parsers/manifest/dash/wasm-parser && cargo build --target wasm32-unknown-unknown && cp target/wasm32-unknown-unknown/debug/mpd_node_parser.wasm ../../../../../dist/mpd-parser.wasm",
     "build:wasm:release": "./scripts/build_wasm_release.sh",
     "bundle": "webpack --progress --config webpack.config.mjs --env production",
@@ -170,6 +170,7 @@
     "check:types:watch": "tsc --noEmit --watch --project .",
     "check:demo": "npm run check:demo:types && npm run lint:demo",
     "check:demo:types": "tsc --noEmit --project demo/full",
+    "clean:build": "rimraf dist",
     "demo": "node ./scripts/build_demo.mjs --production-mode",
     "demo:min": "node ./scripts/build_demo.mjs --production-mode --minify",
     "demo:watch": "node ./scripts/build_demo.mjs --watch --production-mode",


### PR DESCRIPTION
@Florent-Bouisset  noticed that some release published in the v4 had a `dist` directory with unnecessary v3-related artefacts inside.

This is due to the fact that `/dist` was added to our `.gitignore` file (so it isn't tracked by git) and back-and-forth between v3 and v4 code means that the dist directory might end up having potentially v3 stuff.

We could be adding those in the `.npmignore` to prevent them to be published to npm, but I guess it makes more sense to just clean-up the `dist` directory each time we redo the `build:all` script which re-build every files and directories inside that that directory (and which is the script we do before every release).