### PR TITLE
demo: redirect to the demo page per version

### DIFF
--- a/demo/full/scripts/controllers/Main.tsx
+++ b/demo/full/scripts/controllers/Main.tsx
@@ -12,7 +12,10 @@ function MainComponent(): JSX.Element {
             <a href="https://github.com/canalplus/rx-player">
               <img className="logo" alt="RxPlayer" src="./assets/logo_white.png" />
             </a>
-            <a href="https://github.com/canalplus/rx-player/releases" className="version">
+            <a
+              href="https://developers.canal-plus.com/rx-player/demo_page_by_version.html"
+              className="version"
+            >
               {" v" + RxPlayer.version}
             </a>
           </h1>

--- a/scripts/generate_demo_list.mjs
+++ b/scripts/generate_demo_list.mjs
@@ -51,6 +51,22 @@ function isDirectory(source) {
   return lstatSync(source).isDirectory();
 }
 
+export function getUrlsForVersion(initialPath, version) {
+  const demoUrl = `${initialPath}/${version}/demo/index.html`;
+
+  // documentation homepage changed for the v3.26.1
+  const docUrl = semver.gte(version, "3.26.1")
+    ? `${initialPath}/${version}/doc/api/Overview.html`
+    : `${initialPath}/${version}/doc/pages/index.html`;
+
+  const releaseNoteUrl = `https://github.com/canalplus/rx-player/releases/tag/v${version}`;
+  return {
+    demoUrl,
+    docUrl,
+    releaseNoteUrl,
+  };
+}
+
 const style = `<style type="text/css">
 body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; color: #333; }
 ul { list-style-type: square; }
@@ -86,9 +102,20 @@ if (versions.length <= 0) {
   const sortedVersions = sortVersions(versions);
   for (let i = 0; i < sortedVersions.length; i++) {
     const version = sortedVersions[i];
-    // const versionAsNumber = +version.split(".").join();
-    const dirPath = join(INITIAL_PATH, version, "demo/index.html");
-    body += `<li><a href=${encode(dirPath)}>` + encode(version) + "</a></li>";
+    const { docUrl, demoUrl, releaseNoteUrl } = getUrlsForVersion(INITIAL_PATH, version);
+    const demoUrlAttr = demoUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const docUrlAttr = docUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const releaseNoteUrlAttr = releaseNoteUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    body +=
+      "<li>" +
+      `<a href="${demoUrlAttr}">` +
+      encode(version) +
+      "</a>" +
+      '<span style="font-size: 0.9em">' +
+      ` (see also: <i><a href="${releaseNoteUrlAttr}">Release Note</a></i>, ` +
+      `<i><a href="${docUrlAttr}">Documentation</a></i>)` +
+      "</span>" +
+      "</li>";
   }
   body += "</ul>";
 }

--- a/scripts/generate_documentation_list.mjs
+++ b/scripts/generate_documentation_list.mjs
@@ -38,6 +38,7 @@ import { lstatSync, readdirSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 import { encode } from "html-entities";
 import * as semver from "semver";
+import { getUrlsForVersion } from "./generate_demo_list.mjs";
 
 const INITIAL_PATH = "./versions";
 
@@ -86,13 +87,20 @@ if (versions.length <= 0) {
   const sortedVersions = sortVersions(versions);
   for (let i = 0; i < sortedVersions.length; i++) {
     const version = sortedVersions[i];
-
-    // documentation homepage changed for the v3.26.1
-    const dirPath = semver.gte(version, "3.26.1")
-      ? join(INITIAL_PATH, version, "doc/api/Overview.html")
-      : join(INITIAL_PATH, version, "doc/pages/index.html");
-
-    body += `<li><a href=${encode(dirPath)}>` + encode(version) + "</a></li>";
+    const { docUrl, demoUrl, releaseNoteUrl } = getUrlsForVersion(INITIAL_PATH, version);
+    const demoUrlAttr = demoUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const docUrlAttr = docUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const releaseNoteUrlAttr = releaseNoteUrl.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    body +=
+      "<li>" +
+      `<a href="${docUrlAttr}">` +
+      encode(version) +
+      "</a>" +
+      '<span style="font-size: 0.9em">' +
+      ` (see also: <i><a href="${releaseNoteUrlAttr}">Release Note</a></i>, ` +
+      `<i><a href="${demoUrlAttr}">Demo</a></i>)` +
+      "</span>" +
+      "</li>";
   }
   body += "</ul>";
 }


### PR DESCRIPTION
Aligning behavior of the demo to the behavior in the documentation: clicking the version number open a page listing all demo pages. 
This page was only referenced in the README so it's not easy to be aware of it.
The drawback is that it remove the link to the release on Github.
