### PR TITLE
Fix `representationListUpdate` event

### DIFF
--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -2466,7 +2466,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           acc,
           (x) => x[0].id === elt.period.id &&
                  x[1] === elt.adaptation.type
-        ) === undefined;
+        ) !== undefined;
 
         if (!isFound) {
           // Only consider the currently-selected tracks.


### PR DESCRIPTION
Turns out that because of a `===`/`!==` mix-up, the `representationListUpdate` event (new event in v4) was never sent.

Fortunately, this event was rarely useful.
Here it is developers of an application specifically purposed to inspect streams that noticed a difference between anounced video `Representation`s at `videoTrackChange`-time and what seemed to be available after some time (due to a DRM-related fallback since).