### PR TITLE
fix(demo): text for limit video resolution updates when selecting another options

### DIFF
--- a/demo/full/scripts/components/Options/VideoAdaptiveSettings.tsx
+++ b/demo/full/scripts/components/Options/VideoAdaptiveSettings.tsx
@@ -102,7 +102,7 @@ function VideoAdaptiveSettings({
           name="videoResolutionLimit"
           onChange={onVideoResolutionLimitChange}
           selected={{
-            value: "none",
+            value: videoResolutionLimit,
             index: undefined,
           }}
           options={["videoElement", "screen", "none"]}


### PR DESCRIPTION
In the demo, changing video resolution from "videoElement" to "screen" didn't change the  text displayed on the <select>.
The settings was still correctly applied.