### PR TITLE
Doc: Repeat some page groups name in h1

### DIFF
--- a/doc/Getting_Started/Migration_From_v3/Bitrate_Selection.md
+++ b/doc/Getting_Started/Migration_From_v3/Bitrate_Selection.md
@@ -1,4 +1,4 @@
-# Bitrate Selection
+# Migration from v3: Bitrate Selection
 
 ## Methods and options removed
 

--- a/doc/Getting_Started/Migration_From_v3/Constructor_Options.md
+++ b/doc/Getting_Started/Migration_From_v3/Constructor_Options.md
@@ -1,4 +1,4 @@
-# Constructor Options
+# Migration from v3: Constructor Options
 
 Constructor options are options given when instantiating a new RxPlayer.
 

--- a/doc/Getting_Started/Migration_From_v3/Player_Errors.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Errors.md
@@ -1,4 +1,4 @@
-# RxPlayer errors
+# Migration from v3: RxPlayer errors
 
 Errors are what are sent through the `"error"` event, the `"warning"` event and optionally
 returned by the `getPlayerError` method.

--- a/doc/Getting_Started/Migration_From_v3/Player_Events.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Events.md
@@ -1,4 +1,4 @@
-# RxPlayer events
+# Migration from v3: RxPlayer events
 
 RxPlayer events can be listened to thanks to the `addEventListener` method of the
 RxPlayer.

--- a/doc/Getting_Started/Migration_From_v3/Player_Methods.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Methods.md
@@ -1,4 +1,4 @@
-# RxPlayer methods
+# Migration from v3: RxPlayer methods
 
 Several RxPlayer methods have been removed, renamed or updated.
 

--- a/doc/Getting_Started/Migration_From_v3/Player_Types.md
+++ b/doc/Getting_Started/Migration_From_v3/Player_Types.md
@@ -1,4 +1,4 @@
-# RxPlayer types
+# Migration from v3: RxPlayer types
 
 Several of RxPlayer TypeScript types have been removed, renamed or updated.
 

--- a/doc/Getting_Started/Migration_From_v3/Preferences.md
+++ b/doc/Getting_Started/Migration_From_v3/Preferences.md
@@ -1,4 +1,4 @@
-# Removal of track preferences API
+# Migration from v3: Removal of track preferences API
 
 ## Methods and options removed
 

--- a/doc/Getting_Started/Migration_From_v3/loadVideo_Options.md
+++ b/doc/Getting_Started/Migration_From_v3/loadVideo_Options.md
@@ -1,4 +1,4 @@
-# `loadVideo` Options
+# Migration from v3: `loadVideo` Options
 
 Multiple options of the `loadVideo` have been changed or removed. They will all be listed
 in this page.

--- a/doc/Getting_Started/Tutorials/Quick_Start.md
+++ b/doc/Getting_Started/Tutorials/Quick_Start.md
@@ -1,4 +1,4 @@
-# Quick Start
+# Tutorial: Quick Start
 
 Because the RxPlayer exports a lot of functionnalities, you might want to quickly test
 basic use cases before you dive deep into the


### PR DESCRIPTION
I noticed that the "h1" title of some documentation pages wasn't clear enough on what the page was about when treated in isolation.

In particular, I think about the pages in our v3.x.x migration guide, which had generic titles like "Constructor Options" (instead of something like `v3 Migration guide: Constructor Options`).

Beside not giving a clear context as a title (which isn't that much problematic), search results also were poorer as the results only echoed the titles without providing the context in which that page appears (its parent or next and previous page).

E.g. when searching for `throttleWhenHidden`, a result could be found in a page that appeared through the search results as "Constructor Options" without making it clear that it is inside the migration guide - and as such that the `throttleWhenHidden` option does not exist anymore.

I think just making the `h1` always understandable as if it the page could be seen in a standalone way (not in the context of the next/previous/parent page) fixes the issue in a nice way.