### PR TITLE
fix circular dependencies issues.

### DIFF
--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -16,27 +16,27 @@
 
 import { MediaError } from "../../errors";
 import log from "../../log";
-import type {
-  IAdaptationMetadata,
-  IManifestMetadata,
-  IPeriodMetadata,
-  IRepresentationMetadata,
-} from "../../manifest";
-import {
-  ManifestMetadataFormat,
-  getLivePosition,
-  getMaximumSafePosition,
-  getMinimumSafePosition,
-  getPeriodForTime,
-  getPeriodAfter,
-  toTaggedTrack,
-} from "../../manifest";
 import type { IParsedManifest } from "../../parsers/manifest";
 import type { ITrackType, IRepresentationFilter, IPlayerError } from "../../public_types";
 import arrayFind from "../../utils/array_find";
 import EventEmitter from "../../utils/event_emitter";
 import idGenerator from "../../utils/id_generator";
 import warnOnce from "../../utils/warn_once";
+import type {
+  IAdaptationMetadata,
+  IManifestMetadata,
+  IPeriodMetadata,
+  IRepresentationMetadata,
+} from "../types";
+import { ManifestMetadataFormat } from "../types";
+import {
+  getLivePosition,
+  getMaximumSafePosition,
+  getMinimumSafePosition,
+  getPeriodForTime,
+  getPeriodAfter,
+  toTaggedTrack,
+} from "../utils";
 import type Adaptation from "./adaptation";
 import type { IManifestAdaptations } from "./period";
 import Period from "./period";

--- a/src/manifest/classes/period.ts
+++ b/src/manifest/classes/period.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 import { MediaError } from "../../errors";
-import type { IAdaptationMetadata, IPeriodMetadata } from "../../manifest";
-import {
-  getAdaptations,
-  getSupportedAdaptations,
-  periodContainsTime,
-} from "../../manifest";
 import type { IManifestStreamEvent, IParsedPeriod } from "../../parsers/manifest";
 import type { ITrackType, IRepresentationFilter } from "../../public_types";
 import arrayFind from "../../utils/array_find";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
+import type { IAdaptationMetadata, IPeriodMetadata } from "../types";
+import { getAdaptations, getSupportedAdaptations, periodContainsTime } from "../utils";
 import Adaptation from "./adaptation";
 import type { ICodecSupportList } from "./representation";
 


### PR DESCRIPTION
Commit 2744e3332fc22e428cf115720cf823b022be2d36
Reorganized the repo and introduce circular dependencies:

```
../../../rx-player/dist/es2017/manifest/classes/index.js -> 
../../../rx-player/dist/es2017/manifest/classes/manifest.js -> 
../../../rx-player/dist/es2017/manifest/index.js -> 
../../../rx-player/dist/es2017/manifest/classes/index.js
```

This is fixed by importing from `utils` and `types` file directly