### PR TITLE
[WIP] tests: perform exponential backoff in integration tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -94,4 +94,27 @@ jobs:
       # Firefox seems to have issue with integration tests on GitHub actions only
       # TODO to check
       - run: node tests/integration/run.mjs --bchromehl
+
+  memory_linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm install
+      # Firefox seems to have issue with integration tests on GitHub actions only
+      # TODO to check
       - run: npm run test:memory

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
   extends: "eslint:recommended",
 
   parserOptions: {
-    ecmaVersion: 2017,
+    ecmaVersion: 2020,
     ecmaFeatures: {
       jsx: true,
     },
@@ -62,29 +62,6 @@ module.exports = {
     curly: [1, "all"],
     "no-var": 1,
     "prefer-const": 1,
-    "max-len": [
-      1,
-      80,
-      2,
-      {
-        ignoreUrls: true,
-        ignoreStrings: true,
-        ignoreTemplateLiterals: true,
-        ignoreRegExpLiterals: true,
-      },
-    ],
-    indent: [
-      1,
-      2,
-      {
-        ArrayExpression: "first",
-        ObjectExpression: "first",
-        CallExpression: { arguments: "first" },
-        SwitchCase: 1,
-        ignoreComments: true,
-      },
-    ],
-    quotes: [1, "double"],
     "linebreak-style": [1, "unix"],
     semi: [1, "always"],
     "react/jsx-uses-vars": [2],

--- a/tests/integration/scenarios/dash_live_utc_timings.js
+++ b/tests/integration/scenarios/dash_live_utc_timings.js
@@ -6,7 +6,7 @@ import {
   WithHTTP,
   WithoutTimings,
 } from "../../contents/DASH_dynamic_UTCTimings";
-import sleep from "../../utils/sleep.js";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
 
 describe("DASH live - UTCTimings", () => {
   describe("DASH live content (SegmentTemplate + Direct UTCTiming)", function () {
@@ -26,9 +26,20 @@ describe("DASH live - UTCTimings", () => {
         url: manifestInfos.url,
         transport: manifestInfos.transport,
       });
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521448, 3);
-      expect(player.getMaximumPosition()).to.be.closeTo(1553521748, 3);
+
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521448, 3);
+            expect(player.getMaximumPosition()).to.be.closeTo(1553521748, 3);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
 
     it("should consider `serverSyncInfos` if provided", async () => {
@@ -41,9 +52,19 @@ describe("DASH live - UTCTimings", () => {
           clientTime: performance.now(),
         },
       });
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
-      expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
+            expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
   });
 
@@ -63,15 +84,24 @@ describe("DASH live - UTCTimings", () => {
       player.loadVideo({
         url: manifestInfos.url,
         transport: manifestInfos.transport,
-        manifestLoader(arg, cbs) {
+        manifestLoader(_arg, cbs) {
           cbs.fallback();
         },
         segmentLoader() {
           // noop
         },
       });
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1558791848, 3);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1558791848, 3);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+          },
+        },
+      );
     });
 
     it("should consider `serverSyncInfos` if provided", async () => {
@@ -85,9 +115,19 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
-      expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
+            expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
   });
 
@@ -108,14 +148,25 @@ describe("DASH live - UTCTimings", () => {
         url: manifestInfos.url,
         transport: manifestInfos.transport,
       });
-      await sleep(200);
 
-      const timeShiftBufferDepth = 5 * 60;
-      const maximumPosition = Date.now() / 1000 - manifestInfos.availabilityStartTime;
-      const minimumPosition = maximumPosition - timeShiftBufferDepth;
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            const timeShiftBufferDepth = 5 * 60;
+            const maximumPosition =
+              Date.now() / 1000 - manifestInfos.availabilityStartTime;
+            const minimumPosition = maximumPosition - timeShiftBufferDepth;
 
-      expect(player.getMinimumPosition()).to.be.closeTo(minimumPosition, 3);
-      expect(player.getMaximumPosition()).to.be.closeTo(maximumPosition, 3);
+            expect(player.getMinimumPosition()).to.be.closeTo(minimumPosition, 3);
+            expect(player.getMaximumPosition()).to.be.closeTo(maximumPosition, 3);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
 
     it("should consider `serverSyncInfos` if provided", async () => {
@@ -129,9 +180,19 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
-      expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
+            expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
   });
 
@@ -153,8 +214,17 @@ describe("DASH live - UTCTimings", () => {
         transport: manifestInfos.transport,
       });
 
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521448, 3);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521448, 3);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+          },
+        },
+      );
     });
 
     it("should consider `serverSyncInfos` if provided", async () => {
@@ -168,9 +238,19 @@ describe("DASH live - UTCTimings", () => {
         },
       });
 
-      await sleep(200);
-      expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
-      expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+      await checkAfterSleepWithBackoff(
+        { maxTimeMs: 1000 },
+        {
+          resolveWhen() {
+            expect(player.getMinimumPosition()).to.be.closeTo(1553521748, 1);
+            expect(player.getMaximumPosition()).to.be.closeTo(1553522048, 1);
+          },
+          untilSuccess() {
+            expect(player.getMinimumPosition()).to.equal(null);
+            expect(player.getMaximumPosition()).to.equal(null);
+          },
+        },
+      );
     });
   });
 });

--- a/tests/integration/scenarios/dash_multi_periods.js
+++ b/tests/integration/scenarios/dash_multi_periods.js
@@ -11,6 +11,7 @@ import waitForPlayerState, {
 } from "../../utils/waitForPlayerState.js";
 import sleep from "../../utils/sleep.js";
 import { lockHighestBitrates } from "../../utils/bitrates";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
 
 describe("DASH non-linear multi-periods content (SegmentTemplate)", function () {
   launchTestsForContent(manifestInfos);
@@ -30,7 +31,7 @@ describe("DASH multi-Period with different choices", function () {
 
   async function goToFirstPeriod() {
     player.seekTo(5);
-    await sleep(500);
+    await sleep(50);
     if (player.getPlayerState() !== "PAUSED") {
       await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
@@ -39,7 +40,7 @@ describe("DASH multi-Period with different choices", function () {
 
   async function goToSecondPeriod() {
     player.seekTo(120);
-    await sleep(500);
+    await sleep(50);
     if (player.getPlayerState() !== "PAUSED") {
       await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING", "FREEZING"]);
     }
@@ -175,7 +176,7 @@ describe("DASH multi-Period with different choices", function () {
     // still first Period
     player.play();
     player.seekTo(100);
-    await sleep(100);
+    await sleep(50);
     if (player.getPlayerState() !== "PLAYING") {
       await waitForPlayerState(player, "PLAYING", ["SEEKING", "BUFFERING"]);
     }
@@ -187,22 +188,23 @@ describe("DASH multi-Period with different choices", function () {
     expect(videoTrackChangeEvents).to.have.length(1);
     expect(periodChangeEvents).to.have.length(1);
 
-    await sleep(4000);
-    expect(player.getPosition()).to.be.at.least(102);
+    await checkAfterSleepWithBackoff({}, () => {
+      expect(player.getPosition()).to.be.at.least(102);
 
-    expect(availableAudioTracksChange).to.have.length(2);
-    expect(availableAudioTracksChange[1]).to.have.length(5);
+      expect(availableAudioTracksChange).to.have.length(2);
+      expect(availableAudioTracksChange[1]).to.have.length(5);
 
-    expect(availableVideoTracksChange).to.have.length(2);
-    expect(availableVideoTracksChange[1]).to.have.length(2);
+      expect(availableVideoTracksChange).to.have.length(2);
+      expect(availableVideoTracksChange[1]).to.have.length(2);
 
-    expect(audioTrackChangeEvents).to.have.length(2);
-    expect(audioTrackChangeEvents[1].id).to.equal("audio-fr-audio-mp4a.40.2-audio/mp4");
+      expect(audioTrackChangeEvents).to.have.length(2);
+      expect(audioTrackChangeEvents[1].id).to.equal("audio-fr-audio-mp4a.40.2-audio/mp4");
 
-    expect(videoTrackChangeEvents).to.have.length(2);
-    expect(videoTrackChangeEvents[1].id).to.equal("video-si-video-video/mp4");
+      expect(videoTrackChangeEvents).to.have.length(2);
+      expect(videoTrackChangeEvents[1].id).to.equal("video-si-video-video/mp4");
 
-    expect(periodChangeEvents).to.have.length(2);
+      expect(periodChangeEvents).to.have.length(2);
+    });
   });
 });
 
@@ -219,7 +221,7 @@ describe("DASH multi-Period with same choices", function () {
 
   async function goToFirstPeriod() {
     player.seekTo(5);
-    await sleep(500);
+    await sleep(50);
     if (player.getPlayerState() !== "PAUSED") {
       await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
     }
@@ -228,7 +230,7 @@ describe("DASH multi-Period with same choices", function () {
 
   async function goToSecondPeriod() {
     player.seekTo(120);
-    await sleep(500);
+    await sleep(50);
     if (player.getPlayerState() !== "PAUSED") {
       await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
     }
@@ -364,7 +366,7 @@ describe("DASH multi-Period with same choices", function () {
     // still first Period
     player.play();
     player.seekTo(100);
-    await sleep(100);
+    await sleep(50);
     if (player.getPlayerState() !== "PLAYING") {
       await waitForPlayerState(player, "PLAYING", ["SEEKING", "BUFFERING"]);
     }
@@ -376,21 +378,22 @@ describe("DASH multi-Period with same choices", function () {
     expect(videoTrackChangeEvents).to.have.length(1);
     expect(periodChangeEvents).to.have.length(1);
 
-    await sleep(4000);
-    expect(player.getPosition()).to.be.at.least(102);
+    await checkAfterSleepWithBackoff({}, () => {
+      expect(player.getPosition()).to.be.at.least(102);
 
-    expect(availableAudioTracksChange).to.have.length(2);
-    expect(availableAudioTracksChange[1]).to.have.length(8);
+      expect(availableAudioTracksChange).to.have.length(2);
+      expect(availableAudioTracksChange[1]).to.have.length(8);
 
-    expect(availableVideoTracksChange).to.have.length(2);
-    expect(availableVideoTracksChange[1]).to.have.length(4);
+      expect(availableVideoTracksChange).to.have.length(2);
+      expect(availableVideoTracksChange[1]).to.have.length(4);
 
-    expect(audioTrackChangeEvents).to.have.length(2);
-    expect(audioTrackChangeEvents[1].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
+      expect(audioTrackChangeEvents).to.have.length(2);
+      expect(audioTrackChangeEvents[1].id).to.equal("audio-de-audio-mp4a.40.2-audio/mp4");
 
-    expect(videoTrackChangeEvents).to.have.length(2);
-    expect(videoTrackChangeEvents[1].id).to.equal("video-video-video/mp4-dup");
+      expect(videoTrackChangeEvents).to.have.length(2);
+      expect(videoTrackChangeEvents[1].id).to.equal("video-video-video/mp4-dup");
 
-    expect(periodChangeEvents).to.have.length(2);
+      expect(periodChangeEvents).to.have.length(2);
+    });
   });
 });

--- a/tests/integration/scenarios/discontinuities.js
+++ b/tests/integration/scenarios/discontinuities.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import RxPlayer from "../../../dist/es2017";
-import sleep from "../../utils/sleep.js";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
 import { waitForLoadedStateAfterLoadVideo } from "../../utils/waitForPlayerState";
 import {
   discontinuitiesBetweenPeriodsInfos,
@@ -41,10 +41,11 @@ describe("discontinuities handling", () => {
       });
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
-      await sleep(3000);
-      expect(player.getPosition()).to.be.above(131);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.equal(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 3000 }, () => {
+        expect(player.getPosition()).to.be.above(131);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.equal(1);
+      });
     });
 
     it("should seek to next Period when loading in discontinuity", async function () {
@@ -80,10 +81,11 @@ describe("discontinuities handling", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
       player.seekTo(122);
-      await sleep(1000);
-      expect(player.getPosition()).to.be.at.least(131);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.equal(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 1000 }, () => {
+        expect(player.getPosition()).to.be.at.least(131);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.equal(1);
+      });
     });
   });
 
@@ -106,10 +108,11 @@ describe("discontinuities handling", () => {
       });
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
-      await sleep(3000);
-      expect(player.getPosition()).to.be.above(131);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.equal(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 3000 }, () => {
+        expect(player.getPosition()).to.be.above(131);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.equal(1);
+      });
     });
 
     it("should seek to next Period when loading in discontinuity", async function () {
@@ -145,14 +148,15 @@ describe("discontinuities handling", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
       player.seekTo(122);
-      await sleep(1000);
-      expect(player.getPosition()).to.be.at.least(131);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.be.at.least(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 1000 }, () => {
+        expect(player.getPosition()).to.be.at.least(131);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.be.at.least(1);
 
-      // TODO this is a known very minor issue, investigate and fix in the
-      // RxPlayer's code?
-      expect(discontinuitiesWarningReceived).to.be.at.most(2);
+        // TODO this is a known very minor issue, investigate and fix in the
+        // RxPlayer's code?
+        expect(discontinuitiesWarningReceived).to.be.at.most(2);
+      });
     });
   });
 
@@ -175,10 +179,11 @@ describe("discontinuities handling", () => {
       });
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
-      await sleep(4000);
-      expect(player.getPosition()).to.be.above(28);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.equal(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 4000 }, () => {
+        expect(player.getPosition()).to.be.above(28);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.equal(1);
+      });
     });
 
     it("should seek over discontinuity when loading on one", async function () {
@@ -214,14 +219,15 @@ describe("discontinuities handling", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       expect(discontinuitiesWarningReceived).to.equal(0);
       player.seekTo(25);
-      await sleep(4000);
-      expect(player.getPosition()).to.be.at.least(28);
-      expect(player.getPlayerState()).to.equal("PLAYING");
-      expect(discontinuitiesWarningReceived).to.be.at.least(1);
+      await checkAfterSleepWithBackoff({ maxTimeMs: 4000 }, () => {
+        expect(player.getPosition()).to.be.at.least(28);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+        expect(discontinuitiesWarningReceived).to.be.at.least(1);
 
-      // Due to an issue seen in Firefox, the discontinuity might actually
-      // be seeked in two parts in it
-      expect(discontinuitiesWarningReceived).to.be.at.most(2);
+        // Due to an issue seen in Firefox, the discontinuity might actually
+        // be seeked in two parts in it
+        expect(discontinuitiesWarningReceived).to.be.at.most(2);
+      });
     });
   });
 
@@ -236,9 +242,10 @@ describe("discontinuities handling", () => {
         startAt: { position: 0 },
       });
       await waitForLoadedStateAfterLoadVideo(player);
-      await sleep(2000);
-      expect(player.getPosition()).to.be.above(12);
-      expect(player.getPlayerState()).to.equal("PLAYING");
+      await checkAfterSleepWithBackoff({ maxTimeMs: 2000 }, () => {
+        expect(player.getPosition()).to.be.above(12);
+        expect(player.getPlayerState()).to.equal("PLAYING");
+      });
     });
   });
 });

--- a/tests/integration/scenarios/fast-switching.js
+++ b/tests/integration/scenarios/fast-switching.js
@@ -4,6 +4,7 @@ import { manifestInfos } from "../../contents/DASH_static_SegmentTimeline";
 import sleep from "../../utils/sleep.js";
 import { waitForLoadedStateAfterLoadVideo } from "../../utils/waitForPlayerState";
 import { lockHighestBitrates, lockLowestBitrates } from "../../utils/bitrates";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
 
 describe("Fast-switching", function () {
   let player;
@@ -24,23 +25,26 @@ describe("Fast-switching", function () {
     player.setWantedBufferAhead(10);
     player.loadVideo({ url, transport, autoPlay: false });
     await waitForLoadedStateAfterLoadVideo(player);
-    await sleep(1000);
+    await checkAfterSleepWithBackoff({}, () => {
+      expect(player.getCurrentBufferGap()).to.be.above(9);
+    });
 
     player.setWantedBufferAhead(30);
     lockHighestBitrates(player, "lazy");
-    await sleep(1000);
-    const videoSegmentBuffered = player
-      .__priv_getSegmentSinkContent("video")
-      .map(({ infos }) => {
-        return {
-          bitrate: infos.representation.bitrate,
-          time: infos.segment.time,
-          end: infos.segment.end,
-        };
-      });
-    expect(videoSegmentBuffered.length).to.be.at.least(3);
-    expect(videoSegmentBuffered[1].bitrate).to.equal(1996000);
-    expect(videoSegmentBuffered[2].bitrate).to.equal(1996000);
+    await checkAfterSleepWithBackoff({}, () => {
+      const videoSegmentBuffered = player
+        .__priv_getSegmentSinkContent("video")
+        .map(({ infos }) => {
+          return {
+            bitrate: infos.representation.bitrate,
+            time: infos.segment.time,
+            end: infos.segment.end,
+          };
+        });
+      expect(videoSegmentBuffered.length).to.be.at.least(3);
+      expect(videoSegmentBuffered[1].bitrate).to.equal(1996000);
+      expect(videoSegmentBuffered[2].bitrate).to.equal(1996000);
+    });
   });
 
   it("should enable fast-switching if explicitely enabled", async function () {
@@ -54,22 +58,26 @@ describe("Fast-switching", function () {
       enableFastSwitching: true,
     });
     await waitForLoadedStateAfterLoadVideo(player);
-    await sleep(1000);
+    await checkAfterSleepWithBackoff({}, () => {
+      expect(player.getCurrentBufferGap()).to.be.above(9);
+    });
+
     player.setWantedBufferAhead(30);
     lockHighestBitrates(player, "lazy");
-    await sleep(1000);
-    const videoSegmentBuffered = player
-      .__priv_getSegmentSinkContent("video")
-      .map(({ infos }) => {
-        return {
-          bitrate: infos.representation.bitrate,
-          time: infos.segment.time,
-          end: infos.segment.end,
-        };
-      });
-    expect(videoSegmentBuffered.length).to.be.at.least(3);
-    expect(videoSegmentBuffered[1].bitrate).to.equal(1996000);
-    expect(videoSegmentBuffered[2].bitrate).to.equal(1996000);
+    await checkAfterSleepWithBackoff({}, () => {
+      const videoSegmentBuffered = player
+        .__priv_getSegmentSinkContent("video")
+        .map(({ infos }) => {
+          return {
+            bitrate: infos.representation.bitrate,
+            time: infos.segment.time,
+            end: infos.segment.end,
+          };
+        });
+      expect(videoSegmentBuffered.length).to.be.at.least(3);
+      expect(videoSegmentBuffered[1].bitrate).to.equal(1996000);
+      expect(videoSegmentBuffered[2].bitrate).to.equal(1996000);
+    });
   });
 
   it("should disable fast-switching if explicitely disabled", async function () {
@@ -83,7 +91,9 @@ describe("Fast-switching", function () {
       enableFastSwitching: false,
     });
     await waitForLoadedStateAfterLoadVideo(player);
-    await sleep(1000);
+    await checkAfterSleepWithBackoff({}, () => {
+      expect(player.getCurrentBufferGap()).to.be.above(9);
+    });
     player.setWantedBufferAhead(30);
     lockHighestBitrates(player, "lazy");
     await sleep(1000);

--- a/tests/integration/scenarios/loadVideo_options.js
+++ b/tests/integration/scenarios/loadVideo_options.js
@@ -26,6 +26,7 @@ import sleep from "../../utils/sleep.js";
 import {
   /* waitForState, */ waitForLoadedStateAfterLoadVideo,
 } from "../../utils/waitForPlayerState";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
 
 runLoadVideoOptionsTests();
 runLoadVideoOptionsTests({ multithread: true });
@@ -73,14 +74,13 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
 
       it("should request the URL if one is given", async () => {
         let manifestLoaderCalledTimes = 0;
-        let segmentLoaderLoaderCalledTimes = 0;
         const manifestLoader = (man, callbacks) => {
           expect(manifestInfos.url).to.equal(man.url);
           manifestLoaderCalledTimes++;
           callbacks.fallback();
         };
         const segmentLoader = () => {
-          segmentLoaderLoaderCalledTimes++;
+          // noop
         };
         player.loadVideo({
           url: manifestInfos.url,
@@ -93,7 +93,6 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
         await sleep(0);
 
         expect(manifestLoaderCalledTimes).to.equal(1);
-        expect(segmentLoaderLoaderCalledTimes).to.equal(0);
       });
     });
 
@@ -148,8 +147,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
         await waitForLoadedStateAfterLoadVideo(player);
         expect(player.getPlayerState()).to.equal("PLAYING");
         expect(player.getPosition()).to.be.below(0.1);
-        await sleep(500);
-        expect(player.getPosition()).to.be.above(0.2);
+        await checkAfterSleepWithBackoff(null, () => {
+          expect(player.getPosition()).to.be.above(0.1);
+        });
       });
     });
 
@@ -167,8 +167,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("LOADED");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(startAt, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position if startAt.wallClockTime is set", async function () {
@@ -183,8 +184,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("LOADED");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(startAt, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position if startAt.fromFirstPosition is set", async function () {
@@ -202,8 +204,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMinimumPosition() + startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position if startAt.fromLastPosition is set", async function () {
@@ -221,8 +224,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMaximumPosition() - startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position if startAt.fromLivePosition is set", async function () {
@@ -240,8 +244,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMaximumPosition() - startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position if startAt.percentage is set", async function () {
@@ -255,8 +260,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("LOADED");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(player.getMaximumPosition() * 0.3, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.equal(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.equal(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.position and autoPlay is set", async function () {
@@ -271,8 +277,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("PLAYING");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(startAt, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.wallClockTime and autoPlay is set", async function () {
@@ -287,8 +294,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("PLAYING");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(startAt, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.fromFirstPosition and autoPlay is set", async function () {
@@ -306,8 +314,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMinimumPosition() + startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.fromLastPosition and autoPlay is set", async function () {
@@ -325,8 +334,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMaximumPosition() - startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.fromLivePosition and autoPlay is set", async function () {
@@ -344,8 +354,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
             player.getMaximumPosition() - startAt,
             0.5,
           );
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
 
         it("should seek at the right position then play if startAt.percentage and autoPlay is set", async function () {
@@ -359,8 +370,9 @@ function runLoadVideoOptionsTests({ multithread } = {}) {
           expect(player.getPlayerState()).to.equal("PLAYING");
           const initialPosition = player.getPosition();
           expect(initialPosition).to.be.closeTo(player.getMaximumPosition() * 0.3, 0.5);
-          await sleep(500);
-          expect(player.getPosition()).to.be.above(initialPosition);
+          await checkAfterSleepWithBackoff(null, () => {
+            expect(player.getPosition()).to.be.above(initialPosition);
+          });
         });
       });
     });

--- a/tests/utils/checkAfterSleepWithBackoff.js
+++ b/tests/utils/checkAfterSleepWithBackoff.js
@@ -1,0 +1,68 @@
+import sleep from "./sleep";
+
+/**
+ * Performs a check after a given delay (starting at either `minTimeMs`
+ * milliseconds or just after a `setTimeout` of `0` if not set).
+ * If that check fails, re-wait two times the previous delay (or less if/when
+ * we reached `maxTimeMs`).
+ *
+ * Once `maxTimeMs` milliseconds have passed (or 4 seconds if not set) since
+ * this function was called and if the check still fails, throw the
+ * corresponding failure.
+ *
+ * This util is useful for asynchronous tests which pass after some delay but
+ * how much is not certain. Instead of setting a very high delay which will
+ * lead to your test taking too much time, you may use this util instead to give
+ * a range from a short to a longer delay.
+ *
+ * @param {Object|null|undefined} [configuration]
+ * @param {number|null|undefined} [configuration.minTimeMs]
+ * @param {number|null|undefined} [configuration.maxTimeMs]
+ * @param {number|null|undefined} [configuration.stepMs]
+ * @param {function|Object} checks
+ * @returns {Promise}
+ */
+export async function checkAfterSleepWithBackoff(configuration, checks) {
+  const minTimeMs = configuration?.minTimeMs;
+  const maxTimeMs = configuration?.maxTimeMs;
+  const stepMs = configuration?.stepMs;
+  const checkFn = typeof checks === "function" ? checks : checks.resolveWhen;
+  const onFailure =
+    typeof checks === "function"
+      ? () => {
+          /* noop */
+        }
+      : checks.untilSuccess;
+  let sleepTime = minTimeMs ?? 0;
+  try {
+    await sleep(sleepTime);
+    checkFn();
+  } catch (err) {
+    onFailure();
+    const usedMax = maxTimeMs ?? 4000;
+    const remainingMax = usedMax - sleepTime;
+    if (remainingMax <= 0) {
+      throw err;
+    }
+
+    if (sleepTime === 0) {
+      return checkAfterSleepWithBackoff(
+        {
+          minTimeMs: Math.min(5, maxTimeMs),
+          maxTimeMs,
+        },
+        checks,
+      );
+    } else {
+      const step = stepMs ?? sleepTime;
+      sleepTime += step;
+      if (sleepTime > remainingMax) {
+        sleepTime = remainingMax;
+      }
+      return checkAfterSleepWithBackoff(
+        { minTimeMs: sleepTime, maxTimeMs: remainingMax },
+        checks,
+      );
+    }
+  }
+}


### PR DESCRIPTION
This is an implementation of an idea we had in the past to speed up asynchronous tests.

Those often depend on some timeout, with a timeout set very high (hundreds of milliseconds, sometimes seconds) to ensure a test pass even on the slowest machine running our tests.

This results in our integration tests taking a lot of time to finish (more than 30 minutes), even more considering that those are not parallelized, unlike our unit tests (and doing so is not straightforward because we rely on a dependency, mocha, as a test runner and on another, karma, as a browser launcher).

To make it less long, we wondered if we could not rely on another strategy:
  1. Perform the check almost immediately, on fast computers it has a chance of very quickly passing
  2. If the check fails, wait some amount of time and re-perform the check.
  3. If the check fails multiple times, it surely means that the current device is slow, so we'll wait a longer and longer delay before re-performing the check.
  4. If the check still fails after some set time (or 4 seconds by default), fail the test.

This is basically another implementation of an "exponential backoff" algorithm in the player (we already use this type of algorithm at several places in the player, like for media requests for example).

This commit does not yet transition everything to that new way, because I didn't have the time yet.


TODO:
  - [x] tests/integration/scenarios/dash_live.js
  - [x] tests/integration/scenarios/dash_live_utc_timings.js
  - [x] tests/integration/scenarios/dash_multi_periods.js
  - [x] tests/integration/scenarios/dash_multi-track.js
  - [x] tests/integration/scenarios/dash_static.js
  - [x] tests/integration/scenarios/dash_stream-events.js
  - [x] tests/integration/scenarios/directfile.js
  - [x] tests/integration/scenarios/discontinuities.js
  - [x] tests/integration/scenarios/fast-switching.js
  - [x] tests/integration/scenarios/initial_playback.js
  - [x] tests/integration/scenarios/manifest_error.js
  - [x] tests/integration/scenarios/end_number.js
  - [x] tests/integration/scenarios/dash_live_SegmentTemplate.js
  - [x] tests/integration/scenarios/loadVideo_options.js
  - [x] tests/integration/scenarios/video_thumbnail_loader.js
  - [x] tests/integration/utils/launch_tests_for_content.js
