### PR TITLE
On safari Mobile, don't await for data before switching to the LOADED state

### DIFF
--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -22,14 +22,12 @@ import { isSafariMobile } from "./browser_detection";
  * We might go into BUFFERING just after that state, but that's a small price to
  * pay.
  * @param {Boolean} isDirectfile
+ * @param {HTMLMediaElement} mediaElement
  * @returns {Boolean}
  */
 export default function shouldWaitForDataBeforeLoaded(
   isDirectfile: boolean,
-  mustPlayInline: boolean,
+  mediaElement: HTMLMediaElement,
 ): boolean {
-  if (isDirectfile && isSafariMobile) {
-    return mustPlayInline;
-  }
-  return true;
+  return !(isSafariMobile && isDirectfile && mediaElement.paused);
 }

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -54,12 +54,7 @@ export default function getLoadedReference(
         return;
       }
 
-      if (
-        !shouldWaitForDataBeforeLoaded(
-          isDirectfile,
-          mediaElement.hasAttribute("playsinline"),
-        )
-      ) {
+      if (!shouldWaitForDataBeforeLoaded(isDirectfile, mediaElement)) {
         if (mediaElement.duration > 0) {
           isLoaded.setValue(true);
           listenCanceller.cancel();


### PR DESCRIPTION
Fixes #1390

We previously had a work-around specific to safari mobile when the media element had the `playsinline` attribute where the browser would never switch to the `LOADED` state if the media element was still in a `paused` state.

From a recent issue (#1390), it seems to now even happen when `playsinline` is not set.

We also add a check for whether the media element is `paused` (if not paused, such as when autoplay was started, there doesn't seem to be any issue).

It shouldn't break the previous seen case if we are to believe the comment on top of the work-around.