### PR TITLE
fix(directfile): media with autoplay:false is infinitly in loading state

### DIFF
--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -60,6 +60,11 @@ export default function getLoadedReference(
           mediaElement.hasAttribute("playsinline"),
         )
       ) {
+        // The duration is NaN if no media data is available,
+        // which means media is not loaded yet.
+        if (isNaN(mediaElement.duration)) {
+          return;
+        }
         if (mediaElement.duration > 0) {
           isLoaded.setValue(true);
           listenCanceller.cancel();


### PR DESCRIPTION
Fixes https://github.com/canalplus/rx-player/issues/1390

When playing a directfile media on iOS with `autoplay: false`, the media state was stuck in "buffering".
On iOS, the ready state might never go above 1 when autoplay is blocked.
We already had a logic to change the state to `Loaded` on iOS if the ready state is 1 and  the `mediaElement.duration` is superior to 0.  
If attribute `duration` is a number, [that indicates that media data is available](https://html.spec.whatwg.org/multipage/media.html#dom-media-duration), and, therefore, the state can be set to `loaded`.
However in the case where duration is `NaN`, we fallback in the global logic, and the `loaded` state can be changed unexpectedly to `true`.

I have noticed that the PlaybackObserver emits an Observation with a state that reflects the status prior to the most recent `loadVideo()`, and,  in this state, the readyState may be 4. As a result, the state will be incorrectly set to `loaded`.
It's unclear to me why the Observation is "desync" from the actual state of the media. 

Anyway, in this PR I made a change to not fallback in the global logic if the duration is `NaN`.
