### PR TITLE
api: throw an error if an application use a video element in multiple instance of the RxPlayer

### DIFF
--- a/demo/full/scripts/controllers/Player.tsx
+++ b/demo/full/scripts/controllers/Player.tsx
@@ -153,6 +153,9 @@ function Player(): JSX.Element {
     ) {
       return;
     }
+    if (playerModule) {
+      playerModule.destroy();
+    }
     const playerMod = new PlayerModule(
       Object.assign(
         {},
@@ -166,7 +169,7 @@ function Player(): JSX.Element {
     );
     setPlayerModule(playerMod);
     return playerMod;
-  }, [playerOpts]);
+  }, [playerOpts, playerModule]);
 
   const onVideoClick = useCallback(() => {
     if (playerModule === null) {

--- a/src/main_thread/api/__tests__/public_api.test.ts
+++ b/src/main_thread/api/__tests__/public_api.test.ts
@@ -442,7 +442,7 @@ describe("API - Public API", () => {
     });
 
     describe("Player instantiation", () => {
-      it("should throw an error if creating two players attached to the same video element", () => {
+      it("should log a warning if creating two players attached to the same video element", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
         const videoElement = document.createElement("video");
@@ -469,7 +469,7 @@ describe("API - Public API", () => {
          */
       });
 
-      it(`should not throw an error if creating a player attached to 
+      it(`should not log a warning if creating a player attached to 
         the same video element after the previous one was disposed`, () => {
         const PublicAPI = jest.requireActual("../public_api").default;
         const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());

--- a/src/main_thread/api/__tests__/public_api.test.ts
+++ b/src/main_thread/api/__tests__/public_api.test.ts
@@ -440,5 +440,56 @@ describe("API - Public API", () => {
         expect(player.getMinimumPosition()).toBe(null);
       });
     });
+
+    describe("Player instantiation", () => {
+      it("should throw an error if creating two players attached to the same video element", () => {
+        const PublicAPI = jest.requireActual("../public_api").default;
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const videoElement = document.createElement("video");
+        const player1 = new PublicAPI({ videoElement });
+        expect(player1.getVideoElement()).toBe(videoElement);
+
+        const errorMessage =
+          "The video element is already attached to another RxPlayer instance." +
+          "\nMake sure to dispose the previous instance with player.dispose() before creating" +
+          " a new player instance attaching that video element.";
+
+        new PublicAPI({ videoElement });
+        expect(warn).toHaveBeenCalledWith(errorMessage);
+        expect(warn).toHaveBeenCalledTimes(1);
+
+        warn.mockClear();
+        /*
+         * TODO: for next major version 5.0: this need to throw an error instead of just logging
+         * this was not done for minor version as it could be considerated a breaking change
+         *
+         * expect(() => {
+         *    new PublicAPI({ videoElement });
+         * }).toThrow(errorMessage);
+         */
+      });
+
+      it(`should not throw an error if creating a player attached to 
+        the same video element after the previous one was disposed`, () => {
+        const PublicAPI = jest.requireActual("../public_api").default;
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const videoElement = document.createElement("video");
+        const player1 = new PublicAPI({ videoElement });
+        expect(player1.getVideoElement()).toBe(videoElement);
+
+        player1.dispose();
+        expect(warn).not.toHaveBeenCalled();
+        /*
+         * TODO: for next major version 5.0: this need to throw an error instead of just logging
+         * this was not done for minor version as it could be considerated a breaking change.
+         *
+         * expect(() => {
+         *   new PublicAPI({ videoElement });
+         * }).not.toThrow();
+         *
+         */
+        warn.mockClear();
+      });
+    });
   });
 });

--- a/src/main_thread/api/__tests__/public_api.test.ts
+++ b/src/main_thread/api/__tests__/public_api.test.ts
@@ -444,7 +444,7 @@ describe("API - Public API", () => {
     describe("Player instantiation", () => {
       it("should throw an error if creating two players attached to the same video element", () => {
         const PublicAPI = jest.requireActual("../public_api").default;
-        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
         const videoElement = document.createElement("video");
         const player1 = new PublicAPI({ videoElement });
         expect(player1.getVideoElement()).toBe(videoElement);
@@ -472,7 +472,7 @@ describe("API - Public API", () => {
       it(`should not throw an error if creating a player attached to 
         the same video element after the previous one was disposed`, () => {
         const PublicAPI = jest.requireActual("../public_api").default;
-        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
         const videoElement = document.createElement("video");
         const player1 = new PublicAPI({ videoElement });
         expect(player1.getVideoElement()).toBe(videoElement);

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -339,11 +339,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @throws Error - Throws if the element is already used by another player instance.
    */
   private static _priv_registerVideoElement(videoElement: HTMLMediaElement) {
-    const errorMessage =
+    if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
+      const errorMessage =
       "The video element is already attached to another RxPlayer instance." +
       "\nMake sure to dispose the previous instance with player.dispose() before creating" +
       " a new player instance attaching that video element.";
-    if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
       // eslint-disable-next-line no-console
       console.warn(errorMessage);
       /*

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -341,9 +341,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private static _priv_registerVideoElement(videoElement: HTMLMediaElement) {
     if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
       const errorMessage =
-      "The video element is already attached to another RxPlayer instance." +
-      "\nMake sure to dispose the previous instance with player.dispose() before creating" +
-      " a new player instance attaching that video element.";
+        "The video element is already attached to another RxPlayer instance." +
+        "\nMake sure to dispose the previous instance with player.dispose() before creating" +
+        " a new player instance attaching that video element.";
       // eslint-disable-next-line no-console
       console.warn(errorMessage);
       /*

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -344,6 +344,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       "\nMake sure to dispose the previous instance with player.dispose() before creating" +
       " a new player instance attaching that video element.";
     if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
+      // eslint-disable-next-line no-console
       console.warn(errorMessage);
       /*
        * TODO: for next major version 5.0: this need to throw an error instead of just logging

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -339,12 +339,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @throws Error - Throws if the element is already used by another player instance.
    */
   private static _priv_registerVideoElement(videoElement: HTMLMediaElement) {
+    const errorMessage =
+      "The video element is already attached to another RxPlayer instance." +
+      "\nMake sure to dispose the previous instance with player.dispose() before creating" +
+      " a new player instance attaching that video element.";
     if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
-      throw new Error(
-        "The video element is already attached to another RxPlayer instance." +
-          "\nMake sure to dispose the previous instance with player.dispose() before creating" +
-          " a new player instance attaching that video element.",
-      );
+      console.warn(errorMessage);
+      /*
+       * TODO: for next major version 5.0: this need to throw an error instead of just logging
+       * this was not done for minor version as it could be considerated a breaking change.
+       *
+       * throw new Error(errorMessage);
+       */
     }
     Player._priv_currentlyUsedVideoElements.add(videoElement);
   }

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -163,6 +163,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   public readonly version: string;
 
   /**
+   * Store all video elements currently in use by an RxPlayer instance.
+   * This is used to check that a video element is not shared between multiple instances.
+   * Use of a WeakSet ensure the object is garbage collected if it's not used anymore.
+   */
+  private static _priv_currentlyUsedVideoElements = new WeakSet<HTMLMediaElement>();
+
+  /**
    * Media element attached to the RxPlayer.
    * Set to `null` when the RxPlayer is disposed.
    */
@@ -327,6 +334,32 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   }
 
   /**
+   * Register the video element to the set of elements currently in use.
+   * @param videoElement the video element to register.
+   * @throws Error - Throws if the element is already used by another player instance.
+   */
+  private static _priv_registerVideoElement(videoElement: HTMLMediaElement) {
+    if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
+      throw new Error(
+        "The video element is already attached to another RxPlayer instance." +
+          "\nMake sure to dispose the previous instance with player.dispose() before creating" +
+          " a new player instance attaching that video element.",
+      );
+    }
+    Player._priv_currentlyUsedVideoElements.add(videoElement);
+  }
+
+  /**
+   * Deregister the video element of the set of elements currently in use.
+   * @param videoElement the video element to deregister.
+   */
+  static _priv_deregisterVideoElement(videoElement: HTMLMediaElement) {
+    if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
+      Player._priv_currentlyUsedVideoElements.delete(videoElement);
+    }
+  }
+
+  /**
    * @constructor
    * @param {Object} options
    */
@@ -350,7 +383,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this.log = log;
     this.state = "STOPPED";
     this.videoElement = videoElement;
-
+    Player._priv_registerVideoElement(this.videoElement);
     const destroyCanceller = new TaskCanceller();
     this._destroyCanceller = destroyCanceller;
 
@@ -567,6 +600,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this.stop();
 
     if (this.videoElement !== null) {
+      Player._priv_deregisterVideoElement(this.videoElement);
       // free resources used for decryption management
       disposeDecryptionResources(this.videoElement).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : "Unknown error";


### PR DESCRIPTION
The RxPlayer was not designed to run multiple instance of RxPlayer with the same videoElement. Having multiple instance sharing the same video element would result in various issues and unexpected behavior.

This commit adds a check to throw an error if a videoElement is shared between RxPlayer instances. This will provide better guidance to application developers regarding any errors in their implementation.

Relates to https://github.com/canalplus/rx-player/issues/1390