### PR TITLE
Remove `isSafariMobile` mention from `main_thread` code.

### DIFF
--- a/src/compat/can_seek_directly_after_loaded_metadata.ts
+++ b/src/compat/can_seek_directly_after_loaded_metadata.ts
@@ -1,0 +1,9 @@
+import { isSafariMobile } from "./browser_detection";
+
+/**
+ * On safari mobile (version 17.1.2) seeking too early cause the video to never buffer
+ * media data. Using delaying mechanisms such as `setTimeout(fn, 0)` defers the seek
+ * to a moment at which safari should be more able to handle a seek.
+ */
+const canSeekDirectlyAfterLoadedMetadata = !isSafariMobile;
+export default canSeekDirectlyAfterLoadedMetadata;

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isSafariMobile } from "../../../compat/browser_detection";
+import canSeekDirectlyAfterLoadedMetadata from "../../../compat/can_seek_directly_after_loaded_metadata";
 import shouldValidateMetadata from "../../../compat/should_validate_metadata";
 import { MediaError } from "../../../errors";
 import log from "../../../log";
@@ -118,15 +118,12 @@ export default function performInitialSeekAndPlay(
               const initiallySeekedTime =
                 typeof startTime === "number" ? startTime : startTime();
               if (initiallySeekedTime !== 0) {
-                if (isSafariMobile) {
-                  // On safari mobile (version 17.1.2) seeking too early cause the video
-                  // to never buffer media data. Using setTimeout 0 defers the seek
-                  // to a moment at which safari should be more able to handle a seek.
+                if (canSeekDirectlyAfterLoadedMetadata) {
+                  performInitialSeek(initiallySeekedTime);
+                } else {
                   setTimeout(() => {
                     performInitialSeek(initiallySeekedTime);
                   }, 0);
-                } else {
-                  performInitialSeek(initiallySeekedTime);
                 }
               }
               waitForSeekable();


### PR DESCRIPTION
When doing some hotfixes for our v4.0.0 version, we directly integrated a browser detection check in the main code of the RxPlayer.

The normal way for the RxPlayer of handling device compatibility, is to clearly list and document all differences in the `src/compat` directory, not directly in the main code.

This PR fixes that by giving a name to that work-around, documentating it and moving it in the `src/compat` directory.