### PR TITLE
[WIP] PoC for dummy media element and MSE API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,18 @@ module.exports = {
           Symbol: {
             message: "Avoid using the `Symbol` type. Did you mean `symbol`?",
           },
+          HTMLMediaElement: {
+            message:
+              "Avoid relying on `HTMLMediaElement` directly unless it is API-facing. Prefer our more restricted `IMediaElement` type",
+          },
+          MediaSource: {
+            message:
+              "Avoid relying on `MediaSource` directly unless it is API-facing. Prefer our more restricted `IMediaSource` type",
+          },
+          SourceBuffer: {
+            message:
+              "Avoid relying on `SourceBuffer` directly unless it is API-facing. Prefer our more restricted `ISourceBuffer` type",
+          },
         },
       },
     ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,6 +73,10 @@ module.exports = {
             message:
               "Avoid relying on `SourceBuffer` directly unless it is API-facing. Prefer our more restricted `ISourceBuffer` type",
           },
+          SourceBufferList: {
+            message:
+              "Avoid relying on `SourceBufferList` directly unless it is API-facing. Prefer our more restricted `ISourceBufferList` type",
+          },
         },
       },
     ],

--- a/a.js
+++ b/a.js
@@ -1,0 +1,43 @@
+import RxPlayer from "./src/index";
+import { DUMMY_MEDIA_ELEMENT } from "rx-player/experimental/features";
+
+const videoElement = document.querySelector("video");
+
+// Play current content on media element
+const player = new RxPlayer({ videoElement });
+player.addEventListener("newAvailablePeriods", selectTracks);
+// ... Other events handling
+
+player.loadVideo({
+  url: initialWantedContentUrl,
+  transport: "dash",
+  // ... Other options
+});
+
+// Pre-load future content without media element
+const preloadMediaElement = DUMMY_MEDIA_ELEMENT.create();
+const preloadPlayer = new RxPlayer({ videoElement: preloadMediaElement });
+
+// Heavily recommended: set limits on how much data is being loaded
+preloadPlayer.setWantedBufferAhead(10);
+preloadPlayer.setMaxVideoBufferSize(50_000);
+
+preloadPlayer.addEventListener("newAvailablePeriods", selectTracks);
+// ... Other track selection events handling
+
+preloadPlayer.loadVideo({
+  url: preloadedContentUrl,
+  transport: "dash",
+  // ...
+});
+
+// ... Wait until initially loaded content ended
+
+// stop `preloadPlayer` and play it on the real media element
+const preloadedData = preloadMediaElement.getLoadedData();
+preloadPlayer.stop();
+player.loadVideo({
+  url: preloadedContentUrl,
+  transport: "dash",
+  preloadedData,
+});

--- a/demo/full/scripts/modules/player/index.ts
+++ b/demo/full/scripts/modules/player/index.ts
@@ -19,7 +19,11 @@ import {
   HTML_VTT_PARSER,
   SMOOTH,
 } from "../../../../../src/features/list";
-import { METAPLAYLIST, MULTI_THREAD } from "../../../../../src/experimental/features";
+import {
+  METAPLAYLIST,
+  MULTI_THREAD,
+  DUMMY_MEDIA_ELEMENT,
+} from "../../../../../src/experimental/features";
 import RxPlayer from "../../../../../src/minimal";
 import { linkPlayerEventsToState } from "./events";
 import VideoThumbnailLoader, {
@@ -221,7 +225,10 @@ const PlayerModule = declareModule(
   ) => {
     let hasAttachedMultithread = false;
     const { debugElement, textTrackElement, ...constructorOpts } = initOpts;
-    const player = new RxPlayer(constructorOpts);
+    const player = new RxPlayer({
+      ...constructorOpts,
+      videoElement: DUMMY_MEDIA_ELEMENT.create(),
+    });
     let debugEltInstance: { dispose(): void } | undefined;
 
     // facilitate DEV mode

--- a/src/compat/__tests__/change_source_buffer_type.test.ts
+++ b/src/compat/__tests__/change_source_buffer_type.test.ts
@@ -15,12 +15,13 @@
  */
 
 import log from "../../log";
+import type { ISourceBuffer } from "../browser_compatibility_types";
 import tryToChangeSourceBufferType from "../change_source_buffer_type";
 
 describe("Compat - tryToChangeSourceBufferType", () => {
   it("should just return false if the SourceBuffer provided does not have a changeType method", () => {
     const spy = jest.spyOn(log, "warn");
-    const fakeSourceBuffer: SourceBuffer = {} as unknown as SourceBuffer;
+    const fakeSourceBuffer: ISourceBuffer = {} as unknown as ISourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto")).toBe(false);
     expect(spy).not.toHaveBeenCalled();
   });
@@ -30,7 +31,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
     const changeTypeFn = jest.fn();
     const fakeSourceBuffer = {
       changeType: changeTypeFn,
-    } as unknown as SourceBuffer;
+    } as unknown as ISourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto")).toBe(true);
     expect(spy).not.toHaveBeenCalled();
   });
@@ -43,7 +44,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
     });
     const fakeSourceBuffer = {
       changeType: changeTypeFn,
-    } as unknown as SourceBuffer;
+    } as unknown as ISourceBuffer;
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto")).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(

--- a/src/compat/add_text_track.ts
+++ b/src/compat/add_text_track.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ICompatTextTrack } from "./browser_compatibility_types";
+import type { ICompatTextTrack, IMediaElement } from "./browser_compatibility_types";
 import { isIEOrEdge } from "./browser_detection";
 
 /**
@@ -28,7 +28,7 @@ import { isIEOrEdge } from "./browser_detection";
  * @param {HTMLMediaElement} mediaElement
  * @returns {Object}
  */
-export default function addTextTrack(mediaElement: HTMLMediaElement): {
+export default function addTextTrack(mediaElement: IMediaElement): {
   track: ICompatTextTrack;
   trackElement: HTMLTrackElement | undefined;
 } {
@@ -42,7 +42,7 @@ export default function addTextTrack(mediaElement: HTMLMediaElement): {
     track = (
       tracksLength > 0
         ? mediaElement.textTracks[tracksLength - 1]
-        : mediaElement.addTextTrack(kind)
+        : mediaElement.addTextTrack?.(kind)
     ) as ICompatTextTrack;
     track.mode = track.SHOWING ?? "showing";
   } else {

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -300,30 +300,30 @@ export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
 /* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types */
 // @ts-expect-error unused function, just used for compile-time typechecking
 function testMediaElement(x: HTMLMediaElement) {
-  assetCompatibleIMediaElement(x);
+  assertCompatibleIMediaElement(x);
 }
-function assetCompatibleIMediaElement(_x: IMediaElement) {
+function assertCompatibleIMediaElement(_x: IMediaElement) {
   // Noop
 }
 // @ts-expect-error unused function, just used for compile-time typechecking
 function testMediaSource(x: MediaSource) {
-  assetCompatibleIMediaSource(x);
+  assertCompatibleIMediaSource(x);
 }
-function assetCompatibleIMediaSource(_x: IMediaSource) {
+function assertCompatibleIMediaSource(_x: IMediaSource) {
   // Noop
 }
 // @ts-expect-error unused function, just used for compile-time typechecking
 function testSourceBuffer(x: SourceBuffer) {
-  assetCompatibleISourceBuffer(x);
+  assertCompatibleISourceBuffer(x);
 }
-function assetCompatibleISourceBuffer(_x: ISourceBuffer) {
+function assertCompatibleISourceBuffer(_x: ISourceBuffer) {
   // Noop
 }
 // @ts-expect-error unused function, just used for compile-time typechecking
 function testSourceBufferList(x: SourceBufferList) {
-  assetCompatibleISourceBufferList(x);
+  assertCompatibleISourceBufferList(x);
 }
-function assetCompatibleISourceBufferList(_x: ISourceBufferList) {
+function assertCompatibleISourceBufferList(_x: ISourceBufferList) {
   // Noop
 }
 /* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types */

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -230,12 +230,6 @@ export interface IMediaElementEventMap {
  *     implement it.
  */
 export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
-  /**
-   * Optional property allowing to force a specific MSE Implementation when
-   * relying on a given `IMediaElement`.
-   */
-  FORCED_MEDIA_SOURCE?: new () => IMediaSource;
-
   /* From `HTMLMediaElement`: */
   autoplay: boolean;
   buffered: TimeRanges;

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -242,7 +242,7 @@ export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
   nodeName: string;
   paused: boolean;
   playbackRate: number;
-  preload: string;
+  preload: "none" | "metadata" | "auto" | "";
   readyState: number;
   seekable: TimeRanges;
   seeking: boolean;

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IListener } from "../utils/event_emitter";
 import globalScope from "../utils/global_scope";
 import isNullOrUndefined from "../utils/is_null_or_undefined";
 
@@ -70,17 +71,199 @@ interface ICompatDocument extends Document {
 }
 
 /**
- * HTMLMediaElement with added optional vendored functions used by "old"
- * browsers.
- * And TypeScript forgot to add assiociated AudioTrackList and VideoTrackList
- * (and yes apparently a HTMLAudioElement can have an assiociated
- * VideoTrackList).
- *
- * Note: I prefer to define my own `ICompatHTMLMediaElement` rather to extend
- * the original definition to better detect which types have been extended and
- * are not actually valid TypeScript types.
+ * Simpler re-definition of an `EventTarget`, allowing more straightforward
+ * TypeScript exploitation in the RxPlayer.
  */
-interface ICompatHTMLMediaElement extends HTMLMediaElement {
+export interface IEventTarget<TEventMap> {
+  addEventListener<TEventName extends keyof TEventMap>(
+    evt: TEventName,
+    fn: IListener<TEventMap, TEventName>,
+  ): void;
+  removeEventListener<TEventName extends keyof TEventMap>(
+    evt?: TEventName,
+    fn?: IListener<TEventMap, TEventName>,
+  ): void;
+}
+
+/** Events potentially dispatched by an `IMediaSource` */
+export interface IMediaSourceEventMap {
+  sourceopen: Event;
+  sourceended: Event;
+  sourceclose: Event;
+}
+
+/**
+ * More restrictive and type-compatible with the `MediaSource` type (i.e. a
+ * `MediaSource` is a valid `IMediaSource`), the `IMediaSource` type allows to:
+ *
+ *   - re-define some attributes or methods in cases where we detected that some
+ *     platforms have a different implementation.
+ *
+ *   - list all `MediaSource` attributes, methods and events that are relied on
+ *     by the RxPlayer.
+ *
+ *   - Allow an easier re-definition of that API for tests or for platforms
+ *     which do not implement it.
+ */
+export interface IMediaSource extends IEventTarget<IMediaSourceEventMap> {
+  activeSourceBuffers: ISourceBuffer[] | SourceBufferList;
+  duration: number;
+  handle?: MediaProvider | IMediaSource | undefined;
+  readyState: "closed" | "open" | "ended";
+  sourceBuffers: ISourceBuffer[] | SourceBufferList;
+
+  addSourceBuffer(type: string): ISourceBuffer;
+  clearLiveSeekableRange(): void;
+  endOfStream(): void;
+  removeSourceBuffer(sb: ISourceBuffer): void;
+  setLiveSeekableRange(start: number, end: number): void;
+
+  onsourceopen: ((evt: Event) => void) | null;
+  onsourceended: ((evt: Event) => void) | null;
+  onsourceclose: ((evt: Event) => void) | null;
+}
+
+/** Events potentially dispatched by an `ISourceBuffer` */
+export interface ISourceBufferEventMap {
+  abort: Event;
+  error: Event;
+  update: Event;
+  updateend: Event;
+  updatestart: Event;
+}
+
+/**
+ * More restrictive and type-compatible with the `SourceBuffer` type (i.e. a
+ * `SourceBuffer` is a valid `ISourceBuffer`), the `ISourceBuffer` type allows
+ * to:
+ *
+ *   - re-define some attributes or methods in cases where we detected that some
+ *     platforms have a different implementation.
+ *
+ *   - list all `SourceBuffer` attributes, methods and events that are relied on
+ *     by the RxPlayer.
+ *
+ *   - Allow an easier re-definition of that API for tests or for platforms
+ *     which do not implement it.
+ */
+export interface ISourceBuffer extends IEventTarget<ISourceBufferEventMap> {
+  appendWindowEnd: number;
+  appendWindowStart: number;
+  buffered: TimeRanges;
+  timestampOffset: number;
+  updating: boolean;
+
+  abort(): void;
+  appendBuffer(data: BufferSource): void;
+  changeType(type: string): void;
+  remove(start: number, end: number): void;
+
+  onabort: ((evt: Event) => void) | null;
+  onerror: ((evt: Event) => void) | null;
+  onupdate: ((evt: Event) => void) | null;
+  onupdateend: ((evt: Event) => void) | null;
+  onupdatestart: ((evt: Event) => void) | null;
+}
+
+/** Events potentially dispatched by an `IMediaElement` */
+export interface IMediaElementEventMap {
+  canplay: Event;
+  canplaythrough: Event;
+  encrypted: MediaEncryptedEvent;
+  ended: Event;
+  enterpictureinpicture: Event;
+  error: Event;
+  leavepictureinpicture: Event;
+  loadeddata: Event;
+  loadedmetadata: Event;
+  pause: Event;
+  play: Event;
+  playing: Event;
+  ratechange: Event;
+  seeked: Event;
+  seeking: Event;
+  stalled: Event;
+  timeupdate: Event;
+  visibilitychange: Event;
+  volumechange: Event;
+  waiting: Event;
+}
+
+/**
+ * More restrictive and type-compatible with the `HTMLMediaElement` type (i.e. a
+ * `HTMLMediaElement` is a valid `IMediaElement`), the `IMediaElement` type
+ * allows to:
+ *
+ *   - re-define some attributes or methods in cases where we detected that some
+ *     platforms have a different implementation.
+ *
+ *   - list all `HTMLMediaElement` attributes, methods and events that are
+ *     relied on by the RxPlayer.
+ *
+ *   - Allow a re-definition of that API for tests or for platforms which do not
+ *     implement it.
+ */
+export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
+  /**
+   * Optional property allowing to force a specific MSE Implementation when
+   * relying on a given `IMediaElement`.
+   */
+  FORCED_MEDIA_SOURCE?: new () => IMediaSource;
+
+  /* From `HTMLMediaElement`: */
+  autoplay: boolean;
+  buffered: TimeRanges;
+  childNodes: NodeList | never[];
+  clientHeight: number | undefined;
+  clientWidth: number | undefined;
+  currentTime: number;
+  duration: number;
+  ended: boolean;
+  error: MediaError | null;
+  mediaKeys: null | MediaKeys;
+  muted: boolean;
+  nodeName: string;
+  paused: boolean;
+  playbackRate: number;
+  preload: string;
+  readyState: number;
+  seekable: TimeRanges;
+  seeking: boolean;
+  src: string;
+  srcObject?: undefined | null | MediaProvider;
+  textTracks: TextTrackList | never[];
+  volume: number;
+
+  addTextTrack?: (kind: TextTrackKind) => TextTrack;
+  appendChild<T extends Node>(x: T): void;
+  hasAttribute(attr: string): boolean;
+  hasChildNodes(): boolean;
+  pause(): void;
+  play(): Promise<void>;
+  removeAttribute(attr: string): void;
+  removeChild(x: unknown): void;
+  setMediaKeys(x: MediaKeys | null): Promise<void>;
+
+  onencrypted: ((evt: MediaEncryptedEvent) => void) | null;
+  oncanplay: ((evt: Event) => void) | null;
+  oncanplaythrough: ((evt: Event) => void) | null;
+  onended: ((evt: Event) => void) | null;
+  onenterpictureinpicture?: ((evt: Event) => void) | null;
+  onleavepictureinpicture?: ((evt: Event) => void) | null;
+  onerror: ((evt: Event) => void) | null;
+  onloadeddata: ((evt: Event) => void) | null;
+  onloadedmetadata: ((evt: Event) => void) | null;
+  onpause: ((evt: Event) => void) | null;
+  onplay: ((evt: Event) => void) | null;
+  onplaying: ((evt: Event) => void) | null;
+  onratechange: ((evt: Event) => void) | null;
+  onseeked: ((evt: Event) => void) | null;
+  onseeking: ((evt: Event) => void) | null;
+  onstalled: ((evt: Event) => void) | null;
+  ontimeupdate: ((evt: Event) => void) | null;
+  onvolumechange: ((evt: Event) => void) | null;
+  onwaiting: ((evt: Event) => void) | null;
+
   mozRequestFullScreen?: () => void;
   msRequestFullscreen?: () => void;
   webkitRequestFullscreen?: () => void;
@@ -96,6 +279,30 @@ interface ICompatHTMLMediaElement extends HTMLMediaElement {
   readonly audioTracks?: ICompatAudioTrackList;
   readonly videoTracks?: ICompatVideoTrackList;
 }
+
+/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types */
+// @ts-expect-error unused function, just used for compile-time typechecking
+function testMediaElement(x: HTMLMediaElement) {
+  assetCompatibleIMediaElement(x);
+}
+function assetCompatibleIMediaElement(_x: IMediaElement) {
+  // Noop
+}
+// @ts-expect-error unused function, just used for compile-time typechecking
+function testMediaSource(x: MediaSource) {
+  assetCompatibleIMediaSource(x);
+}
+function assetCompatibleIMediaSource(_x: IMediaSource) {
+  // Noop
+}
+// @ts-expect-error unused function, just used for compile-time typechecking
+function testSourceBuffer(x: SourceBuffer) {
+  assetCompatibleISourceBuffer(x);
+}
+function assetCompatibleISourceBuffer(_x: ISourceBuffer) {
+  // Noop
+}
+/* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types */
 
 /**
  * AudioTrackList implementation (that TS forgot).
@@ -169,7 +376,9 @@ export interface ICompatPictureInPictureWindow extends EventTarget {
 /* eslint-disable */
 /** MediaSource implementation, including vendored implementations. */
 const gs = globalScope as any;
-const MediaSource_: typeof MediaSource | undefined =
+const MediaSource_:
+  | { new (): IMediaSource; isTypeSupported(type: string): boolean }
+  | undefined =
   gs === undefined
     ? undefined
     : !isNullOrUndefined(gs.MediaSource)
@@ -202,7 +411,6 @@ export interface ICompatTextTrackList extends TextTrackList {
 
 export {
   ICompatDocument,
-  ICompatHTMLMediaElement,
   ICompatAudioTrackList,
   ICompatVideoTrackList,
   ICompatAudioTrack,

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -92,9 +92,8 @@ export interface ISourceBufferListEventMap {
 }
 
 /**
- * More restrictive and type-compatible with the `SourceBufferList` type (i.e. a
- * `SourceBufferList` is a valid `ISourceBufferList`), the `ISourceBufferList`
- * type allows to:
+ * Type-compatible with the `SourceBufferList` type (i.e. a `SourceBufferList`
+ * is a valid `ISourceBufferList`), the `ISourceBufferList` type allows to:
  *
  *   - re-define some attributes or methods in cases where we detected that some
  *     platforms have a different implementation.
@@ -120,8 +119,8 @@ export interface IMediaSourceEventMap {
 }
 
 /**
- * More restrictive and type-compatible with the `MediaSource` type (i.e. a
- * `MediaSource` is a valid `IMediaSource`), the `IMediaSource` type allows to:
+ * Type-compatible with the `MediaSource` type (i.e. a `MediaSource` is a valid
+ * `IMediaSource`), the `IMediaSource` type allows to:
  *
  *   - re-define some attributes or methods in cases where we detected that some
  *     platforms have a different implementation.
@@ -159,9 +158,8 @@ export interface ISourceBufferEventMap {
 }
 
 /**
- * More restrictive and type-compatible with the `SourceBuffer` type (i.e. a
- * `SourceBuffer` is a valid `ISourceBuffer`), the `ISourceBuffer` type allows
- * to:
+ * Type-compatible with the `SourceBuffer` type (i.e. a `SourceBuffer` is a valid
+ * `ISourceBuffer`), the `ISourceBuffer` type allows to:
  *
  *   - re-define some attributes or methods in cases where we detected that some
  *     platforms have a different implementation.
@@ -216,9 +214,8 @@ export interface IMediaElementEventMap {
 }
 
 /**
- * More restrictive and type-compatible with the `HTMLMediaElement` type (i.e. a
- * `HTMLMediaElement` is a valid `IMediaElement`), the `IMediaElement` type
- * allows to:
+ * Type-compatible with the `HTMLMediaElement` type (i.e. a `HTMLMediaElement` is
+ * a valid `IMediaElement`), the `IMediaElement` type allows to:
  *
  *   - re-define some attributes or methods in cases where we detected that some
  *     platforms have a different implementation.

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -85,6 +85,33 @@ export interface IEventTarget<TEventMap> {
   ): void;
 }
 
+/** Events potentially dispatched by an `ISourceBufferList` */
+export interface ISourceBufferListEventMap {
+  addsourcebuffer: Event;
+  removesourcebuffer: Event;
+}
+
+/**
+ * More restrictive and type-compatible with the `SourceBufferList` type (i.e. a
+ * `SourceBufferList` is a valid `ISourceBufferList`), the `ISourceBufferList`
+ * type allows to:
+ *
+ *   - re-define some attributes or methods in cases where we detected that some
+ *     platforms have a different implementation.
+ *
+ *   - list all `SourceBufferList` attributes, methods and events that are
+ *     relied on by the RxPlayer.
+ *
+ *   - Allow an easier re-definition of that API for tests or for platforms
+ *     which do not implement it.
+ */
+export interface ISourceBufferList extends IEventTarget<ISourceBufferListEventMap> {
+  readonly length: number;
+  onaddsourcebuffer: ((evt: Event) => void) | null;
+  onremovesourcebuffer: ((evt: Event) => void) | null;
+  [index: number]: ISourceBuffer;
+}
+
 /** Events potentially dispatched by an `IMediaSource` */
 export interface IMediaSourceEventMap {
   sourceopen: Event;
@@ -106,11 +133,10 @@ export interface IMediaSourceEventMap {
  *     which do not implement it.
  */
 export interface IMediaSource extends IEventTarget<IMediaSourceEventMap> {
-  activeSourceBuffers: ISourceBuffer[] | SourceBufferList;
   duration: number;
   handle?: MediaProvider | IMediaSource | undefined;
   readyState: "closed" | "open" | "ended";
-  sourceBuffers: ISourceBuffer[] | SourceBufferList;
+  sourceBuffers: ISourceBuffer[] | ISourceBufferList;
 
   addSourceBuffer(type: string): ISourceBuffer;
   clearLiveSeekableRange(): void;
@@ -300,6 +326,13 @@ function testSourceBuffer(x: SourceBuffer) {
   assetCompatibleISourceBuffer(x);
 }
 function assetCompatibleISourceBuffer(_x: ISourceBuffer) {
+  // Noop
+}
+// @ts-expect-error unused function, just used for compile-time typechecking
+function testSourceBufferList(x: SourceBufferList) {
+  assetCompatibleISourceBufferList(x);
+}
+function assetCompatibleISourceBufferList(_x: ISourceBufferList) {
   // Noop
 }
 /* eslint-enable @typescript-eslint/no-unused-vars, @typescript-eslint/ban-types */

--- a/src/compat/clear_element_src.ts
+++ b/src/compat/clear_element_src.ts
@@ -16,12 +16,13 @@
 
 import log from "../log";
 import isNullOrUndefined from "../utils/is_null_or_undefined";
+import type { IMediaElement } from "./browser_compatibility_types";
 
 /**
  * Clear element's src attribute.
  * @param {HTMLMediaElement} element
  */
-export default function clearElementSrc(element: HTMLMediaElement): void {
+export default function clearElementSrc(element: IMediaElement): void {
   // On some browsers, we first have to make sure the textTracks elements are
   // both disabled and removed from the DOM.
   // If we do not do that, we may be left with displayed text tracks on the

--- a/src/compat/dummy_media_element.ts
+++ b/src/compat/dummy_media_element.ts
@@ -1,0 +1,1103 @@
+import ManualTimeRanges from "../main_thread/text_displayer/manual_time_ranges";
+import {
+  findCompleteBox,
+  getDurationFromTrun,
+  getMDHDTimescale,
+  getTrackFragmentDecodeTime,
+  extractCompleteChunks,
+} from "../parsers/containers/isobmff";
+import arrayIncludes from "../utils/array_includes";
+import EventEmitter from "../utils/event_emitter";
+import noop from "../utils/noop";
+import type { IRange } from "../utils/ranges";
+import { convertToRanges, isTimeInRanges, keepRangeIntersection } from "../utils/ranges";
+import type { CancellationSignal } from "../utils/task_canceller";
+import TaskCanceller from "../utils/task_canceller";
+import type {
+  IMediaElement,
+  IMediaElementEventMap,
+  IMediaSource,
+  IMediaSourceEventMap,
+  ISourceBuffer,
+  ISourceBufferEventMap,
+} from "./browser_compatibility_types";
+
+export interface IStoredMediaSourceInfo {
+  sourceBuffers: IStoredSourceBufferInfo[];
+}
+
+export const enum SourceBufferOperation {
+  Append = 0,
+  Remove,
+}
+
+export interface ISourceBufferAppendOperation {
+  type: SourceBufferOperation.Append;
+  segment: BufferSource;
+  timestampOffset: number;
+  appendWindowStart: number;
+  appendWindowEnd: number;
+  mimeType: string;
+}
+
+export interface ISourceBufferRemoveOperation {
+  type: SourceBufferOperation.Remove;
+  start: number;
+  end: number;
+}
+
+export type ISourceBufferOperation =
+  | ISourceBufferRemoveOperation
+  | ISourceBufferAppendOperation;
+
+export interface IStoredSourceBufferInfo {
+  type: string;
+  operations: ISourceBufferOperation[];
+}
+
+interface IDummyMediaSourceCallbacks {
+  hasMediaElementErrored: () => boolean;
+  onBufferedUpdate: () => void;
+  updateMediaElementDuration: (duration: number) => void;
+}
+
+export class DummyMediaSource
+  extends EventEmitter<IMediaSourceEventMap>
+  implements IMediaSource
+{
+  public readonly isDummy: true;
+  public handle: DummyMediaSource;
+  public sourceBuffers: ISourceBuffer[];
+  public activeSourceBuffers: ISourceBuffer[];
+  public readyState: "closed" | "open" | "ended";
+  public destroyed: boolean;
+  private _duration: number;
+  public liveSeekableRange: ManualTimeRanges;
+
+  public onsourceopen: ((evt: Event) => void) | null;
+  public onsourceended: ((evt: Event) => void) | null;
+  public onsourceclose: ((evt: Event) => void) | null;
+
+  public eventScheduler: EventScheduler;
+  private _stored: IStoredMediaSourceInfo;
+  private _callbacks: IDummyMediaSourceCallbacks;
+
+  constructor() {
+    super();
+    this.isDummy = true;
+    this.sourceBuffers = [];
+    this.activeSourceBuffers = [];
+    this.readyState = "closed";
+    this.handle = this;
+    this.onsourceopen = null;
+    this.onsourceended = null;
+    this.onsourceclose = null;
+    this.destroyed = false;
+    this._stored = { sourceBuffers: [] };
+    this._callbacks = {
+      hasMediaElementErrored: () => false,
+      onBufferedUpdate: noop,
+      updateMediaElementDuration: noop,
+    };
+    this._duration = NaN;
+    this.liveSeekableRange = new ManualTimeRanges();
+    this.eventScheduler = new EventScheduler();
+  }
+
+  public get duration(): number {
+    if (this.readyState === "closed") {
+      return NaN;
+    }
+    return this._duration;
+  }
+
+  public set duration(givenDuration: number) {
+    const duration = Number(givenDuration);
+    if (isNaN(duration) || duration < 0) {
+      throw new TypeError("Invalid duration");
+    }
+    if (this.readyState !== "open") {
+      const err = new Error("`duration` updated on a non-open DummyMediaSource");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    if (this.sourceBuffers.some((s) => s.updating)) {
+      const err = new Error("`duration` updated on an updating DummyMediaSource");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (duration === this.duration) {
+      return;
+    }
+
+    const highestBuffered = this.sourceBuffers.reduce((acc, sb) => {
+      if (sb.buffered.length === 0) {
+        return acc;
+      }
+      return Math.max(sb.buffered.end(sb.buffered.length - 1), acc);
+    }, 0);
+
+    if (duration < highestBuffered) {
+      const err = new Error("`duration` update lower than latest buffered coded frame");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    this._duration = duration;
+
+    this._callbacks.updateMediaElementDuration(duration);
+  }
+
+  public addSourceBuffer(givenType: string): ISourceBuffer {
+    const type = String(givenType);
+    if (type === "") {
+      throw new TypeError("`addSourceBuffer` error: empty string");
+    }
+    if (this.readyState !== "open") {
+      const err = new Error("`addSourceBuffer` called on a non-open DummyMediaSource");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    const operations: ISourceBufferOperation[] = [];
+    const sb = new DummySourceBuffer(type, operations, {
+      hasMediaElementErrored: () => {
+        return this._callbacks.hasMediaElementErrored();
+      },
+      getMediaSourceDuration: () => {
+        return this.duration;
+      },
+      getMediaSourceReadyState: () => {
+        return this.readyState;
+      },
+      openMediaSource: () => {
+        this.readyState = "open";
+        this.eventScheduler.schedule(this, "sourceopen", null).catch(noop);
+      },
+      onBufferedUpdate: () => {
+        this._callbacks.onBufferedUpdate();
+      },
+    });
+    this._stored.sourceBuffers.push({ type, operations });
+    this.sourceBuffers.push(sb);
+    this.activeSourceBuffers.push(sb);
+    return sb;
+  }
+
+  public removeSourceBuffer(sb: ISourceBuffer): void {
+    if (!arrayIncludes(this.sourceBuffers, sb)) {
+      const err = new Error("`removeSourceBuffer` called on an unknown SourceBuffer");
+      err.name = "NotFoundError";
+      throw err;
+    }
+
+    if (sb.updating) {
+      sb.updating = false;
+      if (sb instanceof DummySourceBuffer) {
+        if (sb.currentAppendCanceller !== null) {
+          sb.currentAppendCanceller.cancel();
+          sb.currentAppendCanceller = null;
+          sb.eventScheduler
+            .schedule(sb, "abort", null)
+            .then(() => sb.eventScheduler.schedule(sb, "updateend", null))
+            .catch(noop);
+        }
+        sb.canceller.cancel();
+        sb.removed = true;
+      }
+    }
+
+    const indexOfActive = this.activeSourceBuffers.indexOf(sb);
+    if (indexOfActive >= 0) {
+      this.activeSourceBuffers.splice(indexOfActive, 1);
+    }
+
+    const index = this.sourceBuffers.indexOf(sb);
+    if (index >= 0) {
+      this.sourceBuffers.splice(index, 1);
+    }
+  }
+
+  public destroy(): void {
+    this.readyState = "closed";
+    this._duration = NaN;
+    this.activeSourceBuffers.forEach((sb) => this.removeSourceBuffer(sb));
+    this.sourceBuffers.forEach((sb) => this.removeSourceBuffer(sb));
+    this.destroyed = true;
+    this.eventScheduler.schedule(this, "sourceclose", null).catch(noop);
+  }
+
+  public endOfStream(): void {
+    if (this.readyState !== "open") {
+      const err = new Error("`endOfStream` called on a non-open DummyMediaSource");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.sourceBuffers.some((s) => s.updating)) {
+      const err = new Error("`endOfStream` called on an updating DummyMediaSource");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    this.readyState = "ended";
+    const end = this.sourceBuffers.reduce((acc, sb) => {
+      if (sb.buffered.length === 0) {
+        return acc;
+      }
+      const lastPos = sb.buffered.end(sb.buffered.length - 1);
+      return Math.max(lastPos, acc);
+    }, 0);
+    this.duration = end;
+    this.eventScheduler.schedule(this, "sourceended", null).catch(noop);
+  }
+
+  public updateCallbacks(cb: IDummyMediaSourceCallbacks): void {
+    this._callbacks = cb;
+  }
+
+  public setLiveSeekableRange(start: number, end: number): void {
+    if (this.readyState !== "open") {
+      const err = new Error(
+        "`setLiveSeekableRange` called on a non-open DummyMediaSource",
+      );
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    if (start < 0 || start > end) {
+      const err = new Error("Invalid arguments given to `setLiveSeekableRange`");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    this.liveSeekableRange = new ManualTimeRanges();
+    this.liveSeekableRange.insert(start, end);
+  }
+
+  public clearLiveSeekableRange(): void {
+    if (this.readyState !== "open") {
+      const err = new Error(
+        "`setLiveSeekableRange` called on a non-open DummyMediaSource",
+      );
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    this.liveSeekableRange = new ManualTimeRanges();
+  }
+}
+
+interface IDummySourceBufferInternalCallbacks {
+  hasMediaElementErrored: () => boolean;
+  getMediaSourceDuration: () => number;
+  getMediaSourceReadyState: () => "open" | "ended" | "closed";
+  openMediaSource: () => void;
+  onBufferedUpdate: () => void;
+}
+
+export class DummySourceBuffer
+  extends EventEmitter<ISourceBufferEventMap>
+  implements ISourceBuffer
+{
+  public updating: boolean;
+  public removed: boolean;
+  public canceller: TaskCanceller;
+  public currentAppendCanceller: TaskCanceller | null;
+  public eventScheduler: EventScheduler;
+
+  public onupdatestart: ((evt: Event) => void) | null;
+  public onupdate: ((evt: Event) => void) | null;
+  public onupdateend: ((evt: Event) => void) | null;
+  public onerror: ((evt: Event) => void) | null;
+  public onabort: ((evt: Event) => void) | null;
+
+  private _timestampOffset: number;
+  private _buffered: ManualTimeRanges;
+  private _appendWindowStart: number;
+  private _appendWindowEnd: number;
+  private _operations: ISourceBufferOperation[];
+  private _currentType: string;
+  private _isRemoving: boolean;
+  private _callbacks: IDummySourceBufferInternalCallbacks;
+  private _lastInitTimescale: number | null;
+
+  constructor(
+    type: string,
+    operations: ISourceBufferOperation[],
+    callbacks: IDummySourceBufferInternalCallbacks,
+  ) {
+    super();
+    this.updating = false;
+    this.removed = false;
+
+    this.onupdatestart = null;
+    this.onupdate = null;
+    this.onupdateend = null;
+    this.onerror = null;
+    this.onabort = null;
+    this.canceller = new TaskCanceller();
+    this.currentAppendCanceller = null;
+    this._callbacks = callbacks;
+    this._buffered = new ManualTimeRanges();
+    this._appendWindowStart = 0;
+    this._appendWindowEnd = Infinity;
+    this._timestampOffset = 0;
+    this._operations = operations;
+    this._currentType = type;
+    this._isRemoving = false;
+    this._lastInitTimescale = null;
+    this.eventScheduler = new EventScheduler();
+  }
+
+  public set mode(mode: "segments" | "sequence" | "dummy") {
+    this._checkProp("mode", true);
+    if (mode === "sequence") {
+      throw new Error("Trying to update mode of DummySourceBuffer");
+    }
+  }
+
+  public get mode(): "dummy" {
+    return "dummy";
+  }
+
+  public set timestampOffset(timestampOffset: number) {
+    this._checkProp("timestampOffset", true);
+    this._timestampOffset = timestampOffset;
+  }
+
+  public get timestampOffset(): number {
+    return this._timestampOffset;
+  }
+
+  public set appendWindowStart(appendWindowStart: number) {
+    this._checkProp("appendWindowStart", false);
+    if (appendWindowStart < 0 || appendWindowStart >= this._appendWindowEnd) {
+      const err = new TypeError("Invalid `appendWindowStart` set");
+      throw err;
+    }
+    this._appendWindowStart = appendWindowStart;
+  }
+
+  public get appendWindowStart(): number {
+    return this._appendWindowStart;
+  }
+
+  public set appendWindowEnd(appendWindowEnd: number) {
+    this._checkProp("appendWindowEnd", false);
+    if (isNaN(appendWindowEnd) || appendWindowEnd <= this._appendWindowStart) {
+      const err = new TypeError("Invalid `appendWindowStart` set");
+      throw err;
+    }
+    this._appendWindowEnd = appendWindowEnd;
+  }
+
+  public get appendWindowEnd(): number {
+    return this._appendWindowEnd;
+  }
+
+  public get buffered(): ManualTimeRanges {
+    if (this.removed) {
+      const err = new Error("buffered updated on a removed DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+    return this._buffered;
+  }
+
+  public appendBuffer(data: BufferSource): void {
+    if (this.removed) {
+      const err = new Error("`appendBuffer` called on a removed DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.updating) {
+      const err = new Error("`appendBuffer` called on an updating DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this._callbacks.hasMediaElementErrored()) {
+      const err = new Error("`appendBuffer` called on an errored HTMLMediaElement");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this._callbacks.getMediaSourceReadyState() === "ended") {
+      this._callbacks.openMediaSource();
+    }
+
+    // TODO replace and/or evict?
+    // if (bufferFull) {
+    //   const err = new Error("`appendBuffer` called on a full DummySourceBuffer");
+    //   err.name = "QuotaExceededError";
+    //   throw err;
+    // }
+
+    this._operations.push({
+      type: SourceBufferOperation.Append,
+      segment: data,
+      timestampOffset: this.timestampOffset,
+      appendWindowStart: this.appendWindowStart,
+      appendWindowEnd: this.appendWindowEnd,
+      mimeType: this._currentType,
+    });
+
+    this.updating = true;
+
+    const canceller = new TaskCanceller();
+    canceller.linkToSignal(this.canceller.signal);
+    this.currentAppendCanceller = canceller;
+    this.eventScheduler
+      .schedule(this, "updatestart", canceller.signal)
+      .then(() => {
+        let u8data;
+        if (data instanceof Uint8Array) {
+          u8data = data;
+        } else if (data instanceof ArrayBuffer) {
+          u8data = new Uint8Array(data);
+        } else {
+          u8data = new Uint8Array(data.buffer);
+        }
+
+        const segmentRanges: IRange[] = [];
+        const chunks = extractCompleteChunks(u8data);
+        if (chunks[0] === null) {
+          this.updating = false;
+          return this.eventScheduler.schedule(this, "error", null);
+        }
+        for (const chunk of chunks[0]) {
+          const moovIndex = findCompleteBox(chunk, 0x6d6f6f76);
+          if (moovIndex >= 0) {
+            this._lastInitTimescale = getMDHDTimescale(chunk) ?? null;
+          } else {
+            const trackFragmentDecodeTime = getTrackFragmentDecodeTime(chunk);
+            let trunDuration = getDurationFromTrun(chunk);
+            if (
+              trackFragmentDecodeTime !== undefined &&
+              trunDuration !== undefined &&
+              this._lastInitTimescale !== null
+            ) {
+              let startTime =
+                this._timestampOffset + trackFragmentDecodeTime / this._lastInitTimescale;
+              trunDuration = trunDuration / this._lastInitTimescale;
+              if (startTime < 0) {
+                if (trunDuration !== undefined) {
+                  trunDuration += startTime; // remove from duration what comes before `0`
+                }
+                startTime = 0;
+              }
+              segmentRanges.push({ start: startTime, end: startTime + trunDuration });
+            }
+          }
+        }
+
+        for (const { start, end } of segmentRanges) {
+          this.buffered.insert(start, end);
+        }
+        this._callbacks.onBufferedUpdate();
+        this.updating = false;
+        return this.eventScheduler.schedule(this, "update", canceller.signal);
+      })
+      .then(() => this.eventScheduler.schedule(this, "updateend", canceller.signal))
+      .then(() => {
+        this.currentAppendCanceller = null;
+      })
+      .catch(() => {
+        this.currentAppendCanceller = null;
+      });
+  }
+
+  public remove(start: number, end: number): void {
+    if (this.removed) {
+      const err = new Error("`remove` called on a removed DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.updating) {
+      const err = new Error("`remove` called on an updating DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    const duration = this._callbacks.getMediaSourceDuration();
+    if (isNaN(duration)) {
+      const err = new TypeError(
+        "Cannot remove data from DummySourceBuffer: NaN duration",
+      );
+      throw err;
+    }
+    if (start < 0 || start > duration) {
+      throw new TypeError("Invalid start given to `remove`");
+    }
+
+    if (isNaN(end) || start > end) {
+      throw new TypeError("Invalid arguments given to `remove`");
+    }
+
+    if (this._callbacks.getMediaSourceReadyState() === "ended") {
+      this._callbacks.openMediaSource();
+    }
+
+    this._operations.push({
+      type: SourceBufferOperation.Remove,
+      start,
+      end,
+    });
+
+    this.updating = true;
+    this._isRemoving = true;
+
+    this.eventScheduler
+      .schedule(this, "updatestart", this.canceller.signal)
+      .then(() => {
+        this.buffered.remove(start, end);
+        this._callbacks.onBufferedUpdate();
+        this.updating = false;
+        return this.eventScheduler.schedule(this, "update", this.canceller.signal);
+      })
+      .then(() => this.eventScheduler.schedule(this, "updateend", this.canceller.signal))
+      .catch(noop);
+  }
+
+  public abort(): void {
+    if (this.removed) {
+      const err = new Error("`abort` called on a removed DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this._isRemoving) {
+      const err = new Error("`abort` called as a DummySourceBuffer is removing");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.updating) {
+      this.currentAppendCanceller?.cancel();
+      this.currentAppendCanceller = null;
+      this.updating = false;
+      this.eventScheduler
+        .schedule(this, "abort", this.canceller.signal)
+        .then(() =>
+          this.eventScheduler.schedule(this, "updateend", this.canceller.signal),
+        )
+        .catch(noop);
+    }
+
+    this._lastInitTimescale = null;
+    this.appendWindowStart = 0;
+    this.appendWindowEnd = Infinity;
+  }
+
+  public changeType(givenType: string): void {
+    const type = String(givenType);
+    if (type === "") {
+      throw new TypeError("`changeType` error: empty string");
+    }
+
+    if (this.removed) {
+      const err = new Error("`changeType` called on a removed DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.updating) {
+      const err = new Error("`changeType` called on an updating DummySourceBuffer");
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this._callbacks.getMediaSourceReadyState() === "ended") {
+      this._callbacks.openMediaSource();
+    }
+
+    this._currentType = type;
+  }
+
+  private _checkProp(propName: string, openMediaSource: boolean): void {
+    if (this.removed) {
+      const err = new Error(`${propName} updated on a removed DummySourceBuffer`);
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (this.updating) {
+      const err = new Error(`${propName} updated on an updating DummySourceBuffer`);
+      err.name = "InvalidStateError";
+      throw err;
+    }
+
+    if (openMediaSource) {
+      if (this._callbacks.getMediaSourceReadyState() === "ended") {
+        this._callbacks.openMediaSource();
+      }
+    }
+  }
+}
+
+export interface IDummyMediaElementOptions {
+  nodeName?: "AUDIO" | "VIDEO" | undefined | null;
+}
+
+export class DummyMediaElement
+  extends EventEmitter<IMediaElementEventMap>
+  implements IMediaElement
+{
+  public readonly FORCED_MEDIA_SOURCE: new () => IMediaSource;
+
+  public readonly autoplay: false;
+  public readonly childNodes: [];
+  public readonly ended: boolean;
+  public readonly isDummy: true;
+  public readonly nodeName: "AUDIO" | "VIDEO";
+  public readonly src: "";
+  public readonly textTracks: never[];
+
+  public buffered: ManualTimeRanges;
+  public clientHeight: undefined;
+  public clientWidth: undefined;
+  public error: MediaError | null;
+  public mediaKeys: null;
+  public muted: boolean;
+  public paused: boolean;
+  public preload: "auto";
+  public readyState: number;
+  public seekable: ManualTimeRanges;
+  public seeking: boolean;
+  public volume: number;
+
+  // events
+  public onencrypted: ((evt: MediaEncryptedEvent) => void) | null;
+  public oncanplay: ((evt: Event) => void) | null;
+  public oncanplaythrough: ((evt: Event) => void) | null;
+  public onenterpictureinpicture: ((evt: Event) => void) | null;
+  public onleavepictureinpicture: ((evt: Event) => void) | null;
+  public onended: ((evt: Event) => void) | null;
+  public onerror: ((evt: Event) => void) | null;
+  public onloadeddata: ((evt: Event) => void) | null;
+  public onloadedmetadata: ((evt: Event) => void) | null;
+  public onpause: ((evt: Event) => void) | null;
+  public onplay: ((evt: Event) => void) | null;
+  public onplaying: ((evt: Event) => void) | null;
+  public onratechange: ((evt: Event) => void) | null;
+  public onseeked: ((evt: Event) => void) | null;
+  public onseeking: ((evt: Event) => void) | null;
+  public onstalled: ((evt: Event) => void) | null;
+  public ontimeupdate: ((evt: Event) => void) | null;
+  public onvolumechange: ((evt: Event) => void) | null;
+  public onwaiting: ((evt: Event) => void) | null;
+
+  private _attachedMediaSource: null | DummyMediaSource;
+  private _currentContentCanceller: TaskCanceller | null;
+  private _duration: number;
+  private _eventScheduler: EventScheduler;
+  private _lastPosition: number;
+  private _playbackRate: number;
+  // private _allowedToPlay: boolean;
+  // private _canAutoPlay: boolean;
+  // private _pendingPlayPromises: Array<{
+  //   resolve: () => void;
+  //   reject: (err: Error) => void;
+  // }>;
+
+  constructor(opts: IDummyMediaElementOptions = {}) {
+    super();
+
+    this.FORCED_MEDIA_SOURCE = DummyMediaSource;
+
+    this.autoplay = false;
+    this.buffered = new ManualTimeRanges();
+    this.childNodes = [];
+    this.ended = false;
+    this.error = null;
+    this.isDummy = true;
+    this.mediaKeys = null;
+    this.muted = false;
+    this.nodeName = opts.nodeName ?? "VIDEO";
+    this.paused = true;
+    this.preload = "auto";
+    this.readyState = 0;
+    this.seekable = new ManualTimeRanges();
+    this.seeking = false;
+    this.src = "";
+    this.textTracks = [];
+    this.volume = 1;
+
+    this._attachedMediaSource = null;
+    this._attachedMediaSource = null;
+    this._currentContentCanceller = null;
+    this._duration = NaN;
+    this._eventScheduler = new EventScheduler();
+    this._lastPosition = 0;
+    this._playbackRate = 1;
+    // this._allowedToPlay = true;
+    // this._canAutoPlay = true;
+    // this._pendingPlayPromises = [];
+
+    this.onencrypted = null;
+    this.oncanplay = null;
+    this.oncanplaythrough = null;
+    this.onended = null;
+    this.onerror = null;
+    this.onloadeddata = null;
+    this.onloadedmetadata = null;
+    this.onpause = null;
+    this.onplay = null;
+    this.onplaying = null;
+    this.onratechange = null;
+    this.onseeked = null;
+    this.onseeking = null;
+    this.onstalled = null;
+    this.ontimeupdate = null;
+    this.onenterpictureinpicture = null;
+    this.onleavepictureinpicture = null;
+    this.onvolumechange = null;
+    this.onwaiting = null;
+  }
+
+  public get duration(): number {
+    // TODO liveSeekableRange etc.
+
+    return this._duration;
+  }
+
+  // TODO
+  // private _resolvePendingPlayPromises() {
+  //   while (true) {
+  //     const next = this._pendingPlayPromises.shift();
+  //     if (next === undefined) {
+  //       return;
+  //     }
+  //     next.resolve();
+  //   }
+  // }
+
+  public set srcObject(val: MediaProvider | null) {
+    if (!(val instanceof DummyMediaSource)) {
+      throw new Error("A DummyMediaElement can only be linked to a DummyMediaSource");
+    }
+    const prev = this._attachedMediaSource;
+    this._attachedMediaSource = val;
+    if (val !== null) {
+      this.buffered = new ManualTimeRanges();
+      this._currentContentCanceller = new TaskCanceller();
+      this._attachMediaSource(val);
+    } else if (prev !== null) {
+      prev.destroy();
+      this.buffered = new ManualTimeRanges();
+      this._lastPosition = 0;
+      this._duration = NaN;
+      this.error = null;
+      this._attachedMediaSource = null;
+      this.seeking = false;
+      this.readyState = 0;
+    }
+  }
+
+  public get srcObject(): MediaProvider | null {
+    return this._attachedMediaSource as unknown as MediaProvider;
+  }
+
+  public appendChild<T extends Node>(_child: T): void {
+    throw new Error("Unimplemented");
+  }
+
+  public setMediaKeys(_mk: MediaKeys | null): Promise<void> {
+    return Promise.reject("EME not implemented on dummy media element.");
+  }
+
+  public set currentTime(val: number) {
+    const canceller = this._currentContentCanceller;
+    if (canceller === null || this.readyState === 0) {
+      return;
+    }
+
+    let seekingPos = val;
+
+    this.seeking = true;
+    if (seekingPos > this._duration) {
+      seekingPos = this._duration;
+    }
+
+    let distance: [number, number | undefined] = [Infinity, undefined];
+    for (let i = 0; i < this.seekable.length; i++) {
+      if (seekingPos >= this.seekable.start(i) && seekingPos <= this.seekable.end(i)) {
+        distance = [0, i];
+        break;
+      } else {
+        const rangeDistance = Math.min(
+          Math.abs(this.seekable.end(i) - seekingPos),
+          Math.abs(this.seekable.start(i) - seekingPos),
+        );
+        if (rangeDistance < distance[0]) {
+          distance = [rangeDistance, i];
+        } else if (rangeDistance === distance[0]) {
+          // TODO
+        }
+      }
+    }
+
+    if (distance[0] === Infinity) {
+      seekingPos = 0;
+    }
+
+    this._lastPosition = val;
+    this._eventScheduler
+      .schedule(this, "seeking", canceller.signal)
+      .then(() => {
+        this.seeking = false;
+        return Promise.all([
+          this._eventScheduler.schedule(this, "timeupdate", canceller.signal),
+          this._eventScheduler.schedule(this, "seeked", canceller.signal),
+        ]);
+      })
+      .catch(noop);
+  }
+
+  public get currentTime(): number {
+    return this._lastPosition;
+  }
+
+  public set playbackRate(val: number) {
+    this._playbackRate = val;
+    this._eventScheduler.schedule(this, "ratechange", null).catch(noop);
+  }
+
+  public get playbackRate(): number {
+    return this._playbackRate;
+  }
+
+  public play(): Promise<void> {
+    const error = new Error("Dummy media element cannot play");
+    error.name = "NotAllowedError";
+    return Promise.reject(error);
+
+    // TODO
+    // if (!this._allowedToPlay) {
+    //   const error = new Error("Dummy media element cannot play");
+    //   error.name = "NotAllowedError";
+    //   return Promise.reject(error);
+    // }
+    // if (this.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
+    //   const error = new Error("`play` call on not supported content");
+    //   error.name = "NotSupportedError";
+    //   return Promise.reject(error);
+    // }
+    // if (this.ended) {
+    //   this.currentTime =
+    //     this.seekable.length > 0 ? this.seekable.start(0) : this.currentTime;
+    // }
+    // if (this._currentContentCanceller !== null && this.paused) {
+    //   this.paused = false;
+    //   this._eventScheduler.schedule(this, "play", this._currentContentCanceller.signal)
+    //     .catch(noop);
+    //   if (this.readyState <= 2) {
+    //     this._eventScheduler.schedule(this, "waiting", this._currentContentCanceller.signal)
+    //       .catch(noop);
+    //   } else {
+    //     this._eventScheduler.schedule(this, "playing", this._currentContentCanceller.signal)
+    //       .catch(noop);
+    //   }
+    // } else if (this.readyState >= 3) {
+    // }
+    // this._pendingPlayPromise.push(res);
+    // this._canAutoPlay = false;
+  }
+
+  public pause(): void {
+    // TODO
+  }
+
+  public hasAttribute(_attr: string): boolean {
+    return false;
+  }
+
+  public removeAttribute(_attr: string): void {
+    return;
+  }
+
+  public hasChildNodes(): false {
+    return false;
+  }
+
+  public removeChild(x: unknown): never {
+    if (x === null) {
+      throw new TypeError("Asked to remove null child");
+    }
+    const notFoundErr = new Error("DummyMediaElement has no child");
+    notFoundErr.name = "NotFoundError";
+    throw notFoundErr;
+  }
+
+  private _attachMediaSource(dummyMs: DummyMediaSource): void {
+    dummyMs.updateCallbacks({
+      hasMediaElementErrored: () => {
+        return this.error !== null;
+      },
+
+      onBufferedUpdate: () => {
+        const allBuffered = dummyMs.sourceBuffers.reduce((acc: IRange[] | null, sb) => {
+          if (acc === null) {
+            return convertToRanges(sb.buffered);
+          }
+          return keepRangeIntersection(acc, convertToRanges(sb.buffered));
+        }, null);
+        if (allBuffered !== null) {
+          for (const range of allBuffered) {
+            this.buffered.insert(range.start, range.end);
+          }
+          if (this.readyState === 0) {
+            const canceller = this._currentContentCanceller;
+            if (canceller === null) {
+              return;
+            }
+            this.readyState = 1;
+            this.seekable.insert(0, Infinity);
+            this._eventScheduler
+              .schedule(this, "loadedmetadata", canceller.signal)
+              .catch(noop);
+          } else if (
+            this.readyState === 1 &&
+            isTimeInRanges(allBuffered, this.currentTime)
+          ) {
+            const canceller = this._currentContentCanceller;
+            if (canceller === null) {
+              return;
+            }
+            this.readyState = 3;
+            this._eventScheduler
+              .schedule(this, "loadeddata", canceller.signal)
+              .then(() => {
+                return this._eventScheduler.schedule(this, "canplay", canceller.signal);
+              })
+              .then(() => {
+                this.readyState = 4;
+                return this._eventScheduler.schedule(
+                  this,
+                  "canplaythrough",
+                  canceller.signal,
+                );
+              })
+              .catch(noop);
+          }
+        }
+      },
+
+      updateMediaElementDuration: (duration: number) => {
+        // TODO check
+        this._duration = duration;
+        if (this.currentTime > this._duration) {
+          this.currentTime = this._duration;
+        }
+      },
+    });
+    dummyMs.readyState = "open";
+    dummyMs.eventScheduler.schedule(dummyMs, "sourceopen", null).catch(noop);
+  }
+}
+
+// TODO this should be better typed, might leave some brain cells behind though
+interface IDummySourceBufferEventObject {
+  resolve: () => void;
+  reject: (e: unknown) => void;
+  obj: DummySourceBuffer;
+  evtName: keyof ISourceBufferEventMap;
+  cancelSignal: CancellationSignal | null;
+}
+interface IDummyMediaSourceEventObject {
+  resolve: () => void;
+  reject: (e: unknown) => void;
+  obj: DummyMediaSource;
+  evtName: keyof IMediaSourceEventMap;
+  cancelSignal: CancellationSignal | null;
+}
+export class EventScheduler {
+  private _scheduled: Array<IDummySourceBufferEventObject | IDummyMediaSourceEventObject>;
+  constructor() {
+    this._scheduled = [];
+  }
+
+  public schedule(
+    obj: DummyMediaElement,
+    evtName: keyof IMediaElementEventMap,
+    cancelSignal: CancellationSignal | null,
+  ): Promise<void>;
+  public schedule(
+    obj: DummyMediaSource,
+    evtName: keyof IMediaSourceEventMap,
+    cancelSignal: CancellationSignal | null,
+  ): Promise<void>;
+  public schedule(
+    obj: DummySourceBuffer,
+    evtName: keyof ISourceBufferEventMap,
+    cancelSignal: CancellationSignal | null,
+  ): Promise<void>;
+  public schedule(
+    obj: DummyMediaElement | DummyMediaSource | DummySourceBuffer,
+    evtName:
+      | keyof IMediaElementEventMap
+      | keyof IMediaSourceEventMap
+      | keyof ISourceBufferEventMap,
+    cancelSignal: CancellationSignal | null,
+  ): Promise<void> {
+    return new Promise<void>((res, rej) => {
+      /* eslint-disable */
+      this._scheduled.push({
+        resolve: res,
+        reject: rej,
+        obj: obj as any,
+        evtName: evtName as any,
+        cancelSignal,
+      });
+      /* eslint-enable */
+      if (this._scheduled.length === 1) {
+        this._start();
+      }
+    });
+  }
+
+  private _start() {
+    const elt = this._scheduled[0];
+    if (elt === undefined) {
+      return;
+    }
+    /* eslint-disable */
+    let timeout: number | null;
+    timeout = setTimeout(() => {
+      const { evtName, obj } = elt;
+      timeout = null;
+      const event = new Event(evtName);
+      const handlerFnName = `on${evtName}` as any;
+      if ((obj as any)[handlerFnName] !== null) {
+        try {
+          (obj as any)[handlerFnName](event);
+        } catch (e) {
+          // nothing
+        }
+      }
+      timeout = setTimeout(() => {
+        timeout = null;
+        (obj as any).trigger(evtName as any, event);
+        const index = this._scheduled.indexOf(elt);
+        if (index >= 0) {
+          this._scheduled.splice(index, 1);
+        }
+        elt.resolve();
+        this._start();
+      }, 0);
+    }, 0);
+    /* eslint-enable */
+    elt.cancelSignal?.register((err) => {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+        timeout = null;
+      }
+      const index = this._scheduled.indexOf(elt);
+      if (index >= 0) {
+        this._scheduled.splice(index, 1);
+      }
+      elt.reject(err);
+      this._start();
+    });
+  }
+}

--- a/src/compat/eme/custom_media_keys/ie11_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/ie11_media_keys.ts
@@ -18,7 +18,7 @@ import EventEmitter from "../../../utils/event_emitter";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import TaskCanceller from "../../../utils/task_canceller";
 import wrapInPromise from "../../../utils/wrapInPromise";
-import type { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
+import type { IMediaElement } from "../../browser_compatibility_types";
 import * as events from "../../event_listeners";
 import type { MSMediaKeys, MSMediaKeySession } from "./ms_media_keys_constructor";
 import { MSMediaKeysConstructor } from "./ms_media_keys_constructor";
@@ -124,7 +124,7 @@ class IE11MediaKeySession
 }
 
 class IE11CustomMediaKeys implements ICustomMediaKeys {
-  private _videoElement?: ICompatHTMLMediaElement;
+  private _videoElement?: IMediaElement;
   private _mediaKeys?: MSMediaKeys;
 
   constructor(keyType: string) {
@@ -134,9 +134,9 @@ class IE11CustomMediaKeys implements ICustomMediaKeys {
     this._mediaKeys = new MSMediaKeysConstructor(keyType);
   }
 
-  _setVideo(videoElement: HTMLMediaElement): Promise<unknown> {
+  _setVideo(videoElement: IMediaElement): Promise<unknown> {
     return wrapInPromise(() => {
-      this._videoElement = videoElement as ICompatHTMLMediaElement;
+      this._videoElement = videoElement;
       if (this._videoElement.msSetMediaKeys !== undefined) {
         this._videoElement.msSetMediaKeys(this._mediaKeys);
       }
@@ -159,7 +159,7 @@ export default function getIE11MediaKeysCallbacks(): {
   isTypeSupported: (keyType: string) => boolean;
   createCustomMediaKeys: (keyType: string) => IE11CustomMediaKeys;
   setMediaKeys: (
-    elt: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ) => Promise<unknown>;
 } {
@@ -174,7 +174,7 @@ export default function getIE11MediaKeysCallbacks(): {
   };
   const createCustomMediaKeys = (keyType: string) => new IE11CustomMediaKeys(keyType);
   const setMediaKeys = (
-    elt: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ): Promise<unknown> => {
     if (mediaKeys === null) {

--- a/src/compat/eme/custom_media_keys/moz_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/moz_media_keys_constructor.ts
@@ -16,7 +16,7 @@
 
 import globalScope from "../../../utils/global_scope";
 import wrapInPromise from "../../../utils/wrapInPromise";
-import type { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
+import type { IMediaElement } from "../../browser_compatibility_types";
 import type { ICustomMediaKeys } from "./types";
 
 interface IMozMediaKeysConstructor {
@@ -44,7 +44,7 @@ export default function getMozMediaKeysCallbacks(): {
   isTypeSupported: (keyType: string) => boolean;
   createCustomMediaKeys: (keyType: string) => ICustomMediaKeys;
   setMediaKeys: (
-    elt: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ) => Promise<unknown>;
 } {
@@ -64,11 +64,10 @@ export default function getMozMediaKeysCallbacks(): {
     return new MozMediaKeysConstructor(keyType);
   };
   const setMediaKeys = (
-    mediaElement: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ): Promise<unknown> => {
     return wrapInPromise(() => {
-      const elt: ICompatHTMLMediaElement = mediaElement;
       if (
         elt.mozSetMediaKeys === undefined ||
         typeof elt.mozSetMediaKeys !== "function"

--- a/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/old_webkit_media_keys.ts
@@ -20,6 +20,7 @@ import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import noop from "../../../utils/noop";
 import { utf8ToStr } from "../../../utils/string_parsing";
 import wrapInPromise from "../../../utils/wrapInPromise";
+import type { IMediaElement } from "../../browser_compatibility_types";
 import type {
   ICustomMediaKeys,
   ICustomMediaKeySession,
@@ -165,9 +166,7 @@ class OldWebKitCustomMediaKeys implements ICustomMediaKeys {
     this._keySystem = keySystem;
   }
 
-  _setVideo(
-    videoElement: IOldWebkitHTMLMediaElement | HTMLMediaElement,
-  ): Promise<unknown> {
+  _setVideo(videoElement: IOldWebkitHTMLMediaElement | IMediaElement): Promise<unknown> {
     return wrapInPromise(() => {
       if (!isOldWebkitMediaElement(videoElement)) {
         throw new Error("Video not attached to the MediaKeys");
@@ -192,7 +191,7 @@ export default function getOldWebKitMediaKeysCallbacks(): {
   isTypeSupported: (keyType: string) => boolean;
   createCustomMediaKeys: (keyType: string) => OldWebKitCustomMediaKeys;
   setMediaKeys: (
-    elt: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ) => Promise<unknown>;
 } {
@@ -220,7 +219,7 @@ export default function getOldWebKitMediaKeysCallbacks(): {
   const createCustomMediaKeys = (keyType: string) =>
     new OldWebKitCustomMediaKeys(keyType);
   const setMediaKeys = (
-    elt: HTMLMediaElement,
+    elt: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ): Promise<unknown> => {
     if (mediaKeys === null) {

--- a/src/compat/eme/custom_media_keys/types.ts
+++ b/src/compat/eme/custom_media_keys/types.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IEventEmitter } from "../../../utils/event_emitter";
+import type { IMediaElement } from "../../browser_compatibility_types";
 
 export interface ICustomMediaKeySession extends IEventEmitter<IMediaKeySessionEvents> {
   // Attributes
@@ -38,7 +39,7 @@ export interface ICustomMediaKeySession extends IEventEmitter<IMediaKeySessionEv
 }
 
 export interface ICustomMediaKeys {
-  _setVideo: (vid: HTMLMediaElement) => Promise<unknown>;
+  _setVideo: (vid: IMediaElement) => Promise<unknown>;
   createSession(sessionType?: MediaKeySessionType): ICustomMediaKeySession;
   setServerCertificate(setServerCertificate: BufferSource): Promise<void>;
 }

--- a/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
+++ b/src/compat/eme/custom_media_keys/webkit_media_keys_constructor.ts
@@ -15,7 +15,7 @@
  */
 
 import globalScope from "../../../utils/global_scope";
-import type { ICompatHTMLMediaElement } from "../../browser_compatibility_types";
+import type { IMediaElement } from "../../browser_compatibility_types";
 
 type IWebKitMediaKeys = unknown;
 
@@ -36,8 +36,7 @@ if (
   WebKitMediaKeys !== undefined &&
   typeof WebKitMediaKeys.isTypeSupported === "function" &&
   typeof WebKitMediaKeys.prototype.createSession === "function" &&
-  typeof (HTMLMediaElement.prototype as ICompatHTMLMediaElement).webkitSetMediaKeys ===
-    "function"
+  typeof (HTMLMediaElement.prototype as IMediaElement).webkitSetMediaKeys === "function"
 ) {
   WebKitMediaKeysConstructor = WebKitMediaKeys;
 }

--- a/src/compat/eme/eme-api-implementation.ts
+++ b/src/compat/eme/eme-api-implementation.ts
@@ -4,7 +4,7 @@ import globalScope from "../../utils/global_scope";
 import isNode from "../../utils/is_node";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { CancellationSignal } from "../../utils/task_canceller";
-import type { ICompatHTMLMediaElement } from "../browser_compatibility_types";
+import type { IMediaElement } from "../browser_compatibility_types";
 import { isIE11 } from "../browser_detection";
 import type { IEventTargetLike } from "../event_listeners";
 import { createCompatibleEventListener } from "../event_listeners";
@@ -77,7 +77,7 @@ export interface IEmeApiImplementation {
    * scenario.
    */
   setMediaKeys: (
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     mediaKeys: MediaKeys | ICustomMediaKeys | null,
   ) => Promise<unknown>;
 
@@ -278,17 +278,16 @@ function getEmeApiImplementation(
 /**
  * Set the given MediaKeys on the given HTMLMediaElement.
  * Emits null when done then complete.
- * @param {HTMLMediaElement} mediaElement
+ * @param {HTMLMediaElement} elt
  * @param {Object} mediaKeys
  * @returns {Promise}
  */
 function defaultSetMediaKeys(
-  mediaElement: HTMLMediaElement,
+  elt: IMediaElement,
   mediaKeys: MediaKeys | ICustomMediaKeys | null,
 ): Promise<unknown> {
   try {
     let ret: unknown;
-    const elt: ICompatHTMLMediaElement = mediaElement;
     /* eslint-disable @typescript-eslint/unbound-method */
     if (typeof elt.setMediaKeys === "function") {
       ret = elt.setMediaKeys(mediaKeys as MediaKeys);

--- a/src/compat/eme/set_media_keys.ts
+++ b/src/compat/eme/set_media_keys.ts
@@ -1,5 +1,6 @@
 import log from "../../log";
 import sleep from "../../utils/sleep";
+import type { IMediaElement } from "../browser_compatibility_types";
 import shouldAwaitSetMediaKeys from "../should_await_set_media_keys";
 import type { ICustomMediaKeys } from "./custom_media_keys";
 import type { IEmeApiImplementation } from "./eme-api-implementation";
@@ -12,7 +13,7 @@ import type { IEmeApiImplementation } from "./eme-api-implementation";
  */
 export function setMediaKeys(
   emeImplementation: IEmeApiImplementation,
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   mediaKeys: MediaKeys | ICustomMediaKeys | null,
 ): Promise<unknown> {
   const prom = emeImplementation

--- a/src/compat/get_start_date.ts
+++ b/src/compat/get_start_date.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "./browser_compatibility_types";
+
 /**
  * Calculating a live-offseted media position necessitate to obtain first an
  * offset, and then adding that offset to the wanted position.
@@ -28,8 +30,8 @@
  * @param {HTMLMediaElement} mediaElement
  * @returns {number|undefined}
  */
-export default function getStartDate(mediaElement: HTMLMediaElement): number | undefined {
-  const _mediaElement: HTMLMediaElement & {
+export default function getStartDate(mediaElement: IMediaElement): number | undefined {
+  const _mediaElement: IMediaElement & {
     getStartDate?: () => number | Date | null | undefined;
   } = mediaElement;
   if (typeof _mediaElement.getStartDate === "function") {

--- a/src/experimental/features/dummy_media_element.ts
+++ b/src/experimental/features/dummy_media_element.ts
@@ -1,0 +1,10 @@
+import { DummyMediaElement } from "../../compat/dummy_media_element";
+
+const dummyMediaElementFeature = {
+  create(): DummyMediaElement {
+    return new DummyMediaElement();
+  },
+};
+
+export { dummyMediaElementFeature as DUMMY_MEDIA_ELEMENT };
+export default dummyMediaElementFeature;

--- a/src/experimental/features/index.ts
+++ b/src/experimental/features/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+export { DUMMY_MEDIA_ELEMENT } from "./dummy_media_element";
 export { METAPLAYLIST } from "./metaplaylist";
 export { LOCAL_MANIFEST } from "./local";
 export { MULTI_THREAD } from "./multi_thread";

--- a/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
@@ -15,6 +15,7 @@
  */
 
 import { MediaSource_ } from "../../../compat/browser_compatibility_types";
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import log from "../../../log";
 import { resetMediaElement } from "../../../main_thread/init/utils/create_media_source";
 import { SourceBufferType } from "../../../mse";
@@ -36,7 +37,7 @@ const generateMediaSourceId = idGenerator();
  * @returns {Promise.<Object>}
  */
 export default function prepareSourceBuffer(
-  videoElement: HTMLVideoElement,
+  videoElement: IMediaElement,
   codec: string,
   cleanUpSignal: CancellationSignal,
 ): Promise<MainSourceBufferInterface> {

--- a/src/experimental/tools/VideoThumbnailLoader/remove_buffer_around_time.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/remove_buffer_around_time.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import type { MainSourceBufferInterface } from "../../../mse/main_media_source_interface";
 
 /**
@@ -28,7 +29,7 @@ import type { MainSourceBufferInterface } from "../../../mse/main_media_source_i
  * @returns {Promise}
  */
 export default function removeBufferAroundTime(
-  videoElement: HTMLMediaElement,
+  videoElement: IMediaElement,
   sourceBufferInterface: MainSourceBufferInterface,
   time: number,
   margin: number | undefined,

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../compat/browser_compatibility_types";
 import type { SegmentSink } from "../core/segment_sinks";
 import type ContentDecryptor from "../main_thread/decrypt";
 import type DirectFileContentInitializer from "../main_thread/init/directfile_content_initializer";
@@ -46,7 +47,7 @@ import type { CancellationSignal } from "../utils/task_canceller";
  * @returns {Object} - `SegmentSink` implementation.
  */
 export type IHTMLTextTracksBuffer = new (
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   textTrackElement: HTMLElement,
 ) => SegmentSink;
 
@@ -59,7 +60,7 @@ export type IHTMLTextTracksBuffer = new (
  * tracks will be displayed will also be linked to this `HTMLMediaElement`.
  * @returns {Object} - `SegmentSink` implementation.
  */
-export type INativeTextTracksBuffer = new (mediaElement: HTMLMediaElement) => SegmentSink;
+export type INativeTextTracksBuffer = new (mediaElement: IMediaElement) => SegmentSink;
 
 export type IDashNativeParser = (
   dom: Document,

--- a/src/main_thread/api/__tests__/utils.test.ts
+++ b/src/main_thread/api/__tests__/utils.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import config from "../../../config";
 import { getLoadedContentState } from "../utils";
 
@@ -25,7 +26,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 0,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
 
     // we can just do every possibility here
     expect(getLoadedContentState(mediaElement, null)).toBe("ENDED");
@@ -49,7 +50,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 10, // worst case -> currentTime === duration
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, null)).toBe("PLAYING");
   });
 
@@ -60,7 +61,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 10, // worst case -> currentTime === duration
       paused: true,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, null)).toBe("PAUSED");
   });
 
@@ -71,7 +72,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 5,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
     fakeProps.paused = true;
     expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
@@ -84,7 +85,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 5,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "freezing")).toBe("FREEZING");
     fakeProps.paused = true;
     expect(getLoadedContentState(mediaElement, "freezing")).toBe("FREEZING");
@@ -97,7 +98,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 5,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
     fakeProps.paused = true;
     expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
@@ -110,7 +111,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 5,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
     fakeProps.paused = true;
     expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
@@ -123,7 +124,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 10,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
@@ -142,7 +143,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 10 - config.getCurrent().FORCED_ENDED_THRESHOLD,
       paused: false,
     };
-    const mediaElement = fakeProps as HTMLMediaElement;
+    const mediaElement = fakeProps as IMediaElement;
     expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
@@ -160,7 +161,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: 10 - config.getCurrent().FORCED_ENDED_THRESHOLD,
       paused: false,
     };
-    const mediaElement1 = fakeProps1 as HTMLMediaElement;
+    const mediaElement1 = fakeProps1 as IMediaElement;
     expect(getLoadedContentState(mediaElement1, "seeking")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement1, "buffering")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement1, "not-ready")).toBe("ENDED");
@@ -177,7 +178,7 @@ describe("API - getLoadedContentState", () => {
       currentTime: config.getCurrent().FORCED_ENDED_THRESHOLD + 10,
       paused: false,
     };
-    const mediaElement2 = fakeProps2 as HTMLMediaElement;
+    const mediaElement2 = fakeProps2 as IMediaElement;
     expect(getLoadedContentState(mediaElement2, "seeking")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement2, "buffering")).toBe("ENDED");
     expect(getLoadedContentState(mediaElement2, "not-ready")).toBe("ENDED");

--- a/src/main_thread/api/option_utils.ts
+++ b/src/main_thread/api/option_utils.ts
@@ -19,6 +19,7 @@
  * throw if something is wrong, and return a normalized option object.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import config from "../../config";
 import log from "../../log";
 import type {
@@ -56,7 +57,7 @@ export interface IParsedConstructorOptions {
   videoResolutionLimit: "videoElement" | "screen" | "none";
   throttleVideoBitrateWhenHidden: boolean;
 
-  videoElement: HTMLMediaElement;
+  videoElement: IMediaElement;
   baseBandwidth: number;
 }
 
@@ -130,7 +131,7 @@ function parseConstructorOptions(
   let wantedBufferAhead: number;
   let maxVideoBufferSize: number;
 
-  let videoElement: HTMLMediaElement;
+  let videoElement: IMediaElement;
   let baseBandwidth: number;
 
   const {
@@ -191,7 +192,10 @@ function parseConstructorOptions(
 
   if (isNullOrUndefined(options.videoElement)) {
     videoElement = document.createElement("video");
-  } else if (options.videoElement instanceof HTMLMediaElement) {
+  } else if (
+    options.videoElement.nodeName.toLowerCase() === "video" ||
+    options.videoElement.nodeName.toLowerCase() === "audio"
+  ) {
     videoElement = options.videoElement;
   } else {
     throw new Error("Invalid videoElement parameter. Should be a HTMLMediaElement.");

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -19,6 +19,7 @@
  * It also starts the different sub-parts of the player on various API calls.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import canRelyOnVideoVisibilityAndSize from "../../compat/can_rely_on_video_visibility_and_size";
 import type { IPictureInPictureEvent } from "../../compat/event_listeners";
 import {
@@ -104,7 +105,7 @@ import arrayFind from "../../utils/array_find";
 import arrayIncludes from "../../utils/array_includes";
 import assert, { assertUnreachable } from "../../utils/assert";
 import type { IEventPayload, IListener } from "../../utils/event_emitter";
-import EventEmitter from "../../utils/event_emitter";
+import EventEmitter, { addEventListener } from "../../utils/event_emitter";
 import idGenerator from "../../utils/id_generator";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type Logger from "../../utils/logger";
@@ -168,13 +169,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * This is used to check that a video element is not shared between multiple instances.
    * Use of a WeakSet ensure the object is garbage collected if it's not used anymore.
    */
-  private static _priv_currentlyUsedVideoElements = new WeakSet<HTMLMediaElement>();
+  private static _priv_currentlyUsedVideoElements = new WeakSet<IMediaElement>();
 
   /**
    * Media element attached to the RxPlayer.
    * Set to `null` when the RxPlayer is disposed.
    */
-  public videoElement: HTMLMediaElement | null; // null on dispose
+  public videoElement: IMediaElement | null; // null on dispose
 
   /** Logger the RxPlayer uses.  */
   public readonly log: Logger;
@@ -339,7 +340,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @param videoElement the video element to register.
    * @throws Error - Throws if the element is already used by another player instance.
    */
-  private static _priv_registerVideoElement(videoElement: HTMLMediaElement) {
+  private static _priv_registerVideoElement(videoElement: IMediaElement) {
     if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
       const errorMessage =
         "The video element is already attached to another RxPlayer instance." +
@@ -361,7 +362,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * Deregister the video element of the set of elements currently in use.
    * @param videoElement the video element to deregister.
    */
-  static _priv_deregisterVideoElement(videoElement: HTMLMediaElement) {
+  static _priv_deregisterVideoElement(videoElement: IMediaElement) {
     if (Player._priv_currentlyUsedVideoElements.has(videoElement)) {
       Player._priv_currentlyUsedVideoElements.delete(videoElement);
     }
@@ -449,10 +450,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         muted: videoElement.muted,
       });
     };
-    videoElement.addEventListener("volumechange", onVolumeChange);
-    destroyCanceller.signal.register(() => {
-      videoElement.removeEventListener("volumechange", onVolumeChange);
-    });
+    addEventListener(
+      videoElement,
+      "volumechange",
+      onVolumeChange,
+      destroyCanceller.signal,
+    );
   }
 
   /**
@@ -1241,9 +1244,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * @returns {HTMLMediaElement|null} - The HTMLMediaElement used (`null` when
    * disposed)
    */
+  /* eslint-disable @typescript-eslint/ban-types */
   getVideoElement(): HTMLMediaElement | null {
-    return this.videoElement;
+    return this.videoElement as HTMLMediaElement;
   }
+  /* eslint-enable @typescript-eslint/ban-types */
 
   /**
    * Returns the player's current state.

--- a/src/main_thread/api/utils.ts
+++ b/src/main_thread/api/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import config from "../../config";
 import type {
   IPlaybackObservation,
@@ -22,6 +23,7 @@ import type {
 import { SeekingState } from "../../playback_observer";
 import type { IPlayerState } from "../../public_types";
 import arrayIncludes from "../../utils/array_includes";
+import { addEventListener } from "../../utils/event_emitter";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { IReadOnlySharedReference } from "../../utils/reference";
 import SharedReference from "../../utils/reference";
@@ -40,7 +42,7 @@ import type { ContentInitializer, IStallingSituation } from "../init";
  * remove all listeners this function has registered.
  */
 export function emitSeekEvents(
-  mediaElement: HTMLMediaElement | null,
+  mediaElement: IMediaElement | null,
   playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
   onSeeking: () => void,
   onSeeked: () => void,
@@ -82,7 +84,7 @@ export function emitSeekEvents(
  * remove all listeners this function has registered.
  */
 export function emitPlayPauseEvents(
-  mediaElement: HTMLMediaElement | null,
+  mediaElement: IMediaElement | null,
   onPlay: () => void,
   onPause: () => void,
   cancelSignal: CancellationSignal,
@@ -90,12 +92,8 @@ export function emitPlayPauseEvents(
   if (cancelSignal.isCancelled() || mediaElement === null) {
     return;
   }
-  mediaElement.addEventListener("play", onPlay);
-  mediaElement.addEventListener("pause", onPause);
-  cancelSignal.register(() => {
-    mediaElement.removeEventListener("play", onPlay);
-    mediaElement.removeEventListener("pause", onPause);
-  });
+  addEventListener(mediaElement, "play", onPlay, cancelSignal);
+  addEventListener(mediaElement, "pause", onPause, cancelSignal);
 }
 
 /** Player state dictionnary. */
@@ -114,7 +112,7 @@ export const enum PLAYER_STATES {
 
 export function constructPlayerStateReference(
   initializer: ContentInitializer,
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<IPlayerState> {
@@ -212,7 +210,7 @@ export function constructPlayerStateReference(
  * @returns {string}
  */
 export function getLoadedContentState(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   stalledStatus: IStallingSituation | null,
 ): IPlayerState {
   const { FORCED_ENDED_THRESHOLD } = config.getCurrent();

--- a/src/main_thread/decrypt/__tests__/__global__/utils.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/utils.ts
@@ -26,6 +26,7 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable no-restricted-properties */
 
+import type { IMediaElement } from "../../../../compat/browser_compatibility_types";
 import type { IEmeApiImplementation, IEncryptedEventData } from "../../../../compat/eme";
 import { base64ToBytes, bytesToBase64 } from "../../../../utils/base64";
 import EventEmitter from "../../../../utils/event_emitter";
@@ -288,12 +289,12 @@ export function requestMediaKeySystemAccessImpl(
 }
 
 class MockedDecryptorEventEmitter extends EventEmitter<{
-  encrypted: { elt: HTMLMediaElement; value: unknown };
+  encrypted: { elt: IMediaElement; value: unknown };
   keymessage: { session: MediaKeySessionImpl; value: unknown };
   keyerror: { session: MediaKeySessionImpl; value: unknown };
   keystatuseschange: { session: MediaKeySessionImpl; value: unknown };
 }> {
-  public triggerEncrypted(elt: HTMLMediaElement, value: unknown) {
+  public triggerEncrypted(elt: IMediaElement, value: unknown) {
     this.trigger("encrypted", { elt, value });
   }
   public triggerKeyError(session: MediaKeySessionImpl, value: unknown) {
@@ -324,7 +325,7 @@ export function mockCompat(
   const onEncrypted =
     presets.onEncrypted ??
     jest.fn(
-      (elt: HTMLMediaElement, fn: (x: unknown) => void, signal: CancellationSignal) => {
+      (elt: IMediaElement, fn: (x: unknown) => void, signal: CancellationSignal) => {
         elt.addEventListener("encrypted", fn);
         signal.register(() => {
           elt.removeEventListener("encrypted", fn);
@@ -442,7 +443,7 @@ export function mockCompat(
   return {
     mockEvents,
     eventTriggers: {
-      triggerEncrypted(elt: HTMLMediaElement, value: unknown) {
+      triggerEncrypted(elt: IMediaElement, value: unknown) {
         ee.triggerEncrypted(elt, value);
       },
       triggerKeyMessage(session: MediaKeySessionImpl, value: unknown) {
@@ -473,7 +474,7 @@ export function mockCompat(
  */
 export function testContentDecryptorError(
   ContentDecryptor: any,
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   keySystemsConfigs: unknown[],
 ): Promise<unknown> {
   return new Promise((res, rej) => {

--- a/src/main_thread/decrypt/attach_media_keys.ts
+++ b/src/main_thread/decrypt/attach_media_keys.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import type {
   ICustomMediaKeys,
   ICustomMediaKeySystemAccess,
@@ -34,7 +35,7 @@ import MediaKeysInfosStore from "./utils/media_keys_infos_store";
  * @param {Object} mediaElement
  * @returns {Promise}
  */
-export function disableMediaKeys(mediaElement: HTMLMediaElement): Promise<unknown> {
+export function disableMediaKeys(mediaElement: IMediaElement): Promise<unknown> {
   const previousState = MediaKeysInfosStore.getState(mediaElement);
   MediaKeysInfosStore.setState(mediaElement, null);
   return setMediaKeys(previousState?.emeImplementation ?? eme, mediaElement, null);
@@ -50,7 +51,7 @@ export function disableMediaKeys(mediaElement: HTMLMediaElement): Promise<unknow
  * @returns {Promise}
  */
 export default async function attachMediaKeys(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   {
     emeImplementation,
     keySystemOptions,

--- a/src/main_thread/decrypt/clear_on_stop.ts
+++ b/src/main_thread/decrypt/clear_on_stop.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import shouldUnsetMediaKeys from "../../compat/should_unset_media_keys";
 import log from "../../log";
 import disposeDecryptionResources from "./dispose_decryption_resources";
@@ -25,7 +26,7 @@ import MediaKeysInfosStore from "./utils/media_keys_infos_store";
  * @param {HTMLMediaElement} mediaElement
  * @returns {Promise}
  */
-export default function clearOnStop(mediaElement: HTMLMediaElement): Promise<unknown> {
+export default function clearOnStop(mediaElement: IMediaElement): Promise<unknown> {
   log.info("DRM: Clearing-up DRM session.");
   if (shouldUnsetMediaKeys()) {
     log.info("DRM: disposing current MediaKeys.");

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import type { ICustomMediaKeys, ICustomMediaKeySystemAccess } from "../../compat/eme";
 import eme, { getInitData } from "../../compat/eme";
 import config from "../../config";
@@ -147,7 +148,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * configurations. It will choose the appropriate one depending on user
    * settings and browser support.
    */
-  constructor(mediaElement: HTMLMediaElement, ksOptions: IKeySystemOption[]) {
+  constructor(mediaElement: IMediaElement, ksOptions: IKeySystemOption[]) {
     super();
 
     log.debug("DRM: Starting ContentDecryptor logic.");
@@ -1154,7 +1155,7 @@ type IWaitingForAttachmentStateData = IContentDecryptorStateBase<
   true, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.NotAttached, // isMediaKeysAttached
   // data
-  { mediaKeysInfo: IMediaKeysInfos; mediaElement: HTMLMediaElement }
+  { mediaKeysInfo: IMediaKeysInfos; mediaElement: IMediaElement }
 >;
 
 /**
@@ -1165,7 +1166,7 @@ type IReadyForContentStateDataUnattached = IContentDecryptorStateBase<
   ContentDecryptorState.ReadyForContent,
   true, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.NotAttached | MediaKeyAttachmentStatus.Pending, // isMediaKeysAttached
-  { mediaKeysInfo: IMediaKeysInfos; mediaElement: HTMLMediaElement } // data
+  { mediaKeysInfo: IMediaKeysInfos; mediaElement: IMediaElement } // data
 >;
 
 /**

--- a/src/main_thread/decrypt/dispose_decryption_resources.ts
+++ b/src/main_thread/decrypt/dispose_decryption_resources.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import { setMediaKeys } from "../../compat/eme/set_media_keys";
 import log from "../../log";
 import MediaKeysInfosStore from "./utils/media_keys_infos_store";
@@ -24,7 +25,7 @@ import MediaKeysInfosStore from "./utils/media_keys_infos_store";
  * @returns {Promise}
  */
 export default async function disposeDecryptionResources(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
 ): Promise<unknown> {
   const currentState = MediaKeysInfosStore.getState(mediaElement);
   if (currentState === null) {

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import type { ICustomMediaKeySystemAccess } from "../../compat/eme";
 import eme from "../../compat/eme";
 import shouldRenewMediaKeySystemAccess from "../../compat/should_renew_media_key_system_access";
@@ -278,7 +279,7 @@ function buildKeySystemConfigurations(
  * @returns {Promise.<Object>}
  */
 export default function getMediaKeySystemAccess(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   keySystemsConfigs: IKeySystemOption[],
   cancelSignal: CancellationSignal,
 ): Promise<IFoundMediaKeySystemAccessEvent> {

--- a/src/main_thread/decrypt/get_key_system_configuration.ts
+++ b/src/main_thread/decrypt/get_key_system_configuration.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import MediaKeysInfosStore from "./utils/media_keys_infos_store";
 
 /**
@@ -23,7 +24,7 @@ import MediaKeysInfosStore from "./utils/media_keys_infos_store";
  * @returns {Array|null}
  */
 export default function getKeySystemConfiguration(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
 ): [string, MediaKeySystemConfiguration] | null {
   const currentState = MediaKeysInfosStore.getState(mediaElement);
   if (currentState === null) {

--- a/src/main_thread/decrypt/get_media_keys.ts
+++ b/src/main_thread/decrypt/get_media_keys.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import canReuseMediaKeys from "../../compat/can_reuse_media_keys";
 import type { ICustomMediaKeys, ICustomMediaKeySystemAccess } from "../../compat/eme";
 import { EncryptedMediaError } from "../../errors";
@@ -71,7 +72,7 @@ export interface IMediaKeysInfos {
  * @returns {Promise.<Object>}
  */
 export default async function getMediaKeysInfos(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   keySystemsConfigs: IKeySystemOption[],
   cancelSignal: CancellationSignal,
 ): Promise<IMediaKeysInfos> {

--- a/src/main_thread/decrypt/init_media_keys.ts
+++ b/src/main_thread/decrypt/init_media_keys.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import log from "../../log";
 import type { IKeySystemOption } from "../../public_types";
 import type { CancellationSignal } from "../../utils/task_canceller";
@@ -29,7 +30,7 @@ import getMediaKeysInfos from "./get_media_keys";
  * @returns {Promise.<Object>}
  */
 export default async function initMediaKeys(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   keySystemsConfigs: IKeySystemOption[],
   cancelSignal: CancellationSignal,
 ): Promise<IMediaKeysInfos> {

--- a/src/main_thread/decrypt/utils/media_keys_infos_store.ts
+++ b/src/main_thread/decrypt/utils/media_keys_infos_store.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import type {
   ICustomMediaKeys,
   ICustomMediaKeySystemAccess,
@@ -47,7 +48,7 @@ export interface IMediaElementMediaKeysInfos {
 
 // Store the MediaKeys infos attached to a media element.
 const currentMediaState = new WeakMap<
-  HTMLMediaElement,
+  IMediaElement,
   IMediaElementMediaKeysInfos | null
 >();
 
@@ -57,10 +58,7 @@ export default {
    * @param {HTMLMediaElement} mediaElement
    * @param {Object} state
    */
-  setState(
-    mediaElement: HTMLMediaElement,
-    state: IMediaElementMediaKeysInfos | null,
-  ): void {
+  setState(mediaElement: IMediaElement, state: IMediaElementMediaKeysInfos | null): void {
     currentMediaState.set(mediaElement, state);
   },
 
@@ -69,7 +67,7 @@ export default {
    * @param {HTMLMediaElement} mediaElement
    * @returns {Object}
    */
-  getState(mediaElement: HTMLMediaElement): IMediaElementMediaKeysInfos | null {
+  getState(mediaElement: IMediaElement): IMediaElementMediaKeysInfos | null {
     const currentState = currentMediaState.get(mediaElement);
     return currentState === undefined ? null : currentState;
   },
@@ -78,7 +76,7 @@ export default {
    * Remove MediaKeys infos currently set on a HMTLMediaElement
    * @param {HTMLMediaElement} mediaElement
    */
-  clearState(mediaElement: HTMLMediaElement): void {
+  clearState(mediaElement: IMediaElement): void {
     currentMediaState.set(mediaElement, null);
   },
 };

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -19,6 +19,7 @@
  * It always should be imported through the `features` object.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import clearElementSrc from "../../compat/clear_element_src";
 import type { MediaError } from "../../errors";
 import log from "../../log";
@@ -85,7 +86,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
    * information.
    */
   public start(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
     const cancelSignal = this._initCanceller.signal;
@@ -210,7 +211,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
    * @param {Object} playbackObserver
    */
   private _seekAndPlay(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
     const cancelSignal = this._initCanceller.signal;
@@ -258,7 +259,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
  * @returns {number}
  */
 function getDirectFileInitialTime(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   startAt?: IInitialTimeOptions,
 ): number {
   if (isNullOrUndefined(startAt)) {

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import config from "../../config";
@@ -150,7 +151,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
    * @param {Object} playbackObserver
    */
   public start(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
     this.prepare(); // Load Manifest if not already done
@@ -208,7 +209,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   private _initializeMediaSourceAndDecryption(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     protectionRef: IReadOnlySharedReference<IContentProtection | null>,
   ): Promise<{
     mediaSource: MainMediaSourceInterface;
@@ -308,7 +309,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   private async _onInitialMediaSourceReady(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     initialMediaSource: MainMediaSourceInterface,
     playbackObserver: IMediaElementPlaybackObserver,
     drmSystemId: string | undefined,
@@ -1026,7 +1027,7 @@ interface IBufferingMediaSettings {
   /* Manifest of the content we want to play. */
   manifest: IManifest;
   /** Media Element on which the content will be played. */
-  mediaElement: HTMLMediaElement;
+  mediaElement: IMediaElement;
   /** Emit playback conditions regularly. */
   playbackObserver: IMediaElementPlaybackObserver;
   /** Estimate the right Representation. */

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,3 +1,4 @@
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import isCodecSupported from "../../compat/is_codec_supported";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
@@ -207,7 +208,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
    * @param {Object} playbackObserver
    */
   public start(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
     this.prepare(); // Load Manifest if not already done
@@ -1099,7 +1100,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
   }
 
   private _initializeContentDecryption(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     lastContentProtection: IReadOnlySharedReference<null | IContentProtection>,
     mediaSourceStatus: SharedReference<MediaSourceInitializationStatus>,
     reloadMediaSource: () => void,
@@ -1264,7 +1265,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
   }
 
   private _reload(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     textDisplayer: ITextDisplayer | null,
     playbackObserver: IMediaElementPlaybackObserver,
     mediaSourceStatus: SharedReference<MediaSourceInitializationStatus>,
@@ -1342,7 +1343,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     parameters: {
       initialTime: number;
       autoPlay: boolean;
-      mediaElement: HTMLMediaElement;
+      mediaElement: IMediaElement;
       textDisplayer: ITextDisplayer | null;
       playbackObserver: IMediaElementPlaybackObserver;
     },
@@ -1498,7 +1499,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
    * playback start.
    */
   private _startPlaybackIfReady(parameters: {
-    mediaElement: HTMLMediaElement;
+    mediaElement: IMediaElement;
     textDisplayer: ITextDisplayer | null;
     playbackObserver: IMediaElementPlaybackObserver;
     drmInitializationStatus: IReadOnlySharedReference<IDrmInitializationStatus>;
@@ -1582,7 +1583,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
    */
   private _onCreateMediaSourceMessage(
     msg: ICreateMediaSourceWorkerMessage,
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     mediaSourceStatus: SharedReference<MediaSourceInitializationStatus>,
     worker: Worker,
   ): void {

--- a/src/main_thread/init/types.ts
+++ b/src/main_thread/init/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import type {
   ISegmentSinksStore,
   IBufferType,
@@ -83,7 +84,7 @@ export abstract class ContentInitializer extends EventEmitter<IContentInitialize
    * intervals.
    */
   public abstract start(
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void;
 

--- a/src/main_thread/init/utils/create_media_source.ts
+++ b/src/main_thread/init/utils/create_media_source.ts
@@ -79,10 +79,7 @@ function createMediaSource(
   // make sure the media has been correctly reset
   const oldSrc = isNonEmptyString(mediaElement.src) ? mediaElement.src : null;
   resetMediaElement(mediaElement, oldSrc);
-  const mediaSource = new MainMediaSourceInterface(
-    generateMediaSourceId(),
-    "FORCED_MEDIA_SOURCE" in mediaElement ? mediaElement.FORCED_MEDIA_SOURCE : undefined,
-  );
+  const mediaSource = new MainMediaSourceInterface(generateMediaSourceId());
   unlinkSignal.register(() => {
     mediaSource.dispose();
   });

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import shouldValidateMetadata from "../../../compat/should_validate_metadata";
 import shouldWaitForDataBeforeLoaded from "../../../compat/should_wait_for_data_before_loaded";
 import shouldWaitForHaveEnoughData from "../../../compat/should_wait_for_have_enough_data";
@@ -37,7 +38,7 @@ import TaskCanceller from "../../../utils/task_canceller";
  */
 export default function getLoadedReference(
   playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   isDirectfile: boolean,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import canSeekDirectlyAfterLoadedMetadata from "../../../compat/can_seek_directly_after_loaded_metadata";
 import shouldValidateMetadata from "../../../compat/should_validate_metadata";
 import { MediaError } from "../../../errors";
@@ -68,7 +69,7 @@ export default function performInitialSeekAndPlay(
     isDirectfile,
     onWarning,
   }: {
-    mediaElement: HTMLMediaElement;
+    mediaElement: IMediaElement;
     playbackObserver: IMediaElementPlaybackObserver;
     startTime: number | (() => number);
     mustAutoPlay: boolean;

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -1,3 +1,4 @@
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import { EncryptedMediaError } from "../../../errors";
 import features from "../../../features";
 import log from "../../../log";
@@ -33,7 +34,7 @@ import type { IContentProtection, IProcessedProtectionData } from "../../decrypt
  * initialization.
  */
 export default function initializeContentDecryption(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   keySystems: IKeySystemOption[],
   protectionRef: IReadOnlySharedReference<null | IContentProtection>,
   callbacks: {

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../../compat/browser_compatibility_types";
 import config from "../../../../config";
 import type { IManifestMetadata } from "../../../../manifest";
 import { SeekingState } from "../../../../playback_observer";
@@ -43,7 +44,7 @@ interface IStreamEventsEmitterEvent {
  */
 export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitterEvent> {
   private _manifest: IManifestMetadata;
-  private _mediaElement: HTMLMediaElement;
+  private _mediaElement: IMediaElement;
   private _playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>;
   private _scheduledEventsRef: SharedReference<
     Array<IStreamEventPayload | INonFiniteStreamEventPayload>
@@ -61,7 +62,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
    */
   constructor(
     manifest: IManifestMetadata,
-    mediaElement: HTMLMediaElement,
+    mediaElement: IMediaElement,
     playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
   ) {
     super();

--- a/src/main_thread/init/utils/throw_on_media_error.ts
+++ b/src/main_thread/init/utils/throw_on_media_error.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import { MediaError } from "../../../errors";
+import { addEventListener } from "../../../utils/event_emitter";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import type { CancellationSignal } from "../../../utils/task_canceller";
 
@@ -24,7 +26,7 @@ import type { CancellationSignal } from "../../../utils/task_canceller";
  * @param {Object} cancelSignal
  */
 export default function listenToMediaError(
-  mediaElement: HTMLMediaElement,
+  mediaElement: IMediaElement,
   onError: (error: MediaError) => void,
   cancelSignal: CancellationSignal,
 ): void {
@@ -32,11 +34,7 @@ export default function listenToMediaError(
     return;
   }
 
-  mediaElement.addEventListener("error", onMediaError);
-
-  cancelSignal.register(() => {
-    mediaElement.removeEventListener("error", onMediaError);
-  });
+  addEventListener(mediaElement, "error", onMediaError, cancelSignal);
 
   function onMediaError(): void {
     const mediaError = mediaElement.error;

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -1,3 +1,4 @@
+import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import { onEnded, onSeeked, onSeeking } from "../../../compat/event_listeners";
 import onHeightWidthChange from "../../../compat/on_height_width_change";
 import config from "../../../config";
@@ -55,7 +56,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
    * The video element the cues refer to.
    * Used to know when the user is seeking, for example.
    */
-  private readonly _videoElement: HTMLMediaElement;
+  private readonly _videoElement: IMediaElement;
 
   /** Allows to cancel the interval at which subtitles are updated. */
   private _subtitlesIntervalCanceller: TaskCanceller;
@@ -100,7 +101,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
    * @param {HTMLMediaElement} videoElement
    * @param {HTMLElement} textTrackElement
    */
-  constructor(videoElement: HTMLMediaElement, textTrackElement: HTMLElement) {
+  constructor(videoElement: IMediaElement, textTrackElement: HTMLElement) {
     log.debug("HTD: Creating HTMLTextDisplayer");
     this._buffered = new ManualTimeRanges();
 

--- a/src/main_thread/text_displayer/native/native_text_displayer.ts
+++ b/src/main_thread/text_displayer/native/native_text_displayer.ts
@@ -1,5 +1,8 @@
 import addTextTrack from "../../../compat/add_text_track";
-import type { ICompatTextTrack } from "../../../compat/browser_compatibility_types";
+import type {
+  ICompatTextTrack,
+  IMediaElement,
+} from "../../../compat/browser_compatibility_types";
 import removeCue from "../../../compat/remove_cue";
 import log from "../../../log";
 import type { ITextTrackSegmentData } from "../../../transports";
@@ -16,7 +19,7 @@ import parseTextTrackToCues from "./native_parsers";
  * @class NativeTextDisplayer
  */
 export default class NativeTextDisplayer implements ITextDisplayer {
-  private readonly _videoElement: HTMLMediaElement;
+  private readonly _videoElement: IMediaElement;
   private readonly _track: ICompatTextTrack;
   private readonly _trackElement: HTMLTrackElement | undefined;
 
@@ -25,7 +28,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
   /**
    * @param {HTMLMediaElement} videoElement
    */
-  constructor(videoElement: HTMLMediaElement) {
+  constructor(videoElement: IMediaElement) {
     log.debug("NTD: Creating NativeTextDisplayer");
     const { track, trackElement } = addTextTrack(videoElement);
     this._buffered = new ManualTimeRanges();

--- a/src/main_thread/tracks_store/media_element_tracks_store.ts
+++ b/src/main_thread/tracks_store/media_element_tracks_store.ts
@@ -22,10 +22,10 @@
 import type {
   ICompatAudioTrack,
   ICompatAudioTrackList,
-  ICompatHTMLMediaElement,
   ICompatTextTrackList,
   ICompatVideoTrack,
   ICompatVideoTrackList,
+  IMediaElement,
 } from "../../compat/browser_compatibility_types";
 import enableAudioTrack from "../../compat/enable_audio_track";
 import type { IRepresentation } from "../../manifest";
@@ -236,13 +236,13 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
    */
   private _videoTrackLockedOn: ICompatVideoTrack | undefined | null;
 
-  constructor(mediaElement: HTMLMediaElement) {
+  constructor(mediaElement: IMediaElement) {
     super();
     // TODO In practice, the audio/video/text tracks API are not always implemented on
     // the media element, although Typescript HTMLMediaElement types tend to mean
     // that can't be undefined.
-    this._nativeAudioTracks = (mediaElement as ICompatHTMLMediaElement).audioTracks;
-    this._nativeVideoTracks = (mediaElement as ICompatHTMLMediaElement).videoTracks;
+    this._nativeAudioTracks = mediaElement.audioTracks;
+    this._nativeVideoTracks = mediaElement.videoTracks;
     this._nativeTextTracks = mediaElement.textTracks as ICompatTextTrackList | undefined;
 
     this._audioTracks =

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -1,10 +1,11 @@
+import type { IMediaSource, ISourceBuffer } from "../compat/browser_compatibility_types";
 import { MediaSource_ } from "../compat/browser_compatibility_types";
 import tryToChangeSourceBufferType from "../compat/change_source_buffer_type";
 import { onSourceClose, onSourceEnded, onSourceOpen } from "../compat/event_listeners";
 import { MediaError, SourceBufferError } from "../errors";
 import log from "../log";
 import { concat } from "../utils/byte_parsing";
-import EventEmitter from "../utils/event_emitter";
+import EventEmitter, { addEventListener } from "../utils/event_emitter";
 import isNullOrUndefined from "../utils/is_null_or_undefined";
 import objectAssign from "../utils/object_assign";
 import type { IRange } from "../utils/ranges";
@@ -44,7 +45,7 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public readyState: ReadyState;
   /** The MSE `MediaSource` instance linked to that `IMediaSourceInterface`. */
-  private _mediaSource: MediaSource;
+  private _mediaSource: IMediaSource;
   /**
    * Abstraction allowing to set and update the MediaSource's duration.
    */
@@ -68,7 +69,7 @@ export default class MainMediaSourceInterface
    * You can then obtain a link to that `MediaSource`, for example to link it
    * to an `HTMLMediaElement`, through the `handle` property.
    */
-  constructor(id: string) {
+  constructor(id: string, forcedMediaSource?: new () => IMediaSource) {
     super();
     this.id = id;
     this.sourceBuffers = [];
@@ -82,13 +83,15 @@ export default class MainMediaSourceInterface
     }
 
     log.info("Init: Creating MediaSource");
-    const mediaSource = new MediaSource_();
-    this.readyState = mediaSource.readyState;
+    const mediaSource =
+      forcedMediaSource !== undefined ? new forcedMediaSource() : new MediaSource_();
     const handle = (mediaSource as unknown as { handle: MediaProvider }).handle;
     this.handle = isNullOrUndefined(handle)
-      ? { type: "media-source", value: mediaSource }
+      ? /* eslint-disable-next-line @typescript-eslint/ban-types */
+        { type: "media-source", value: mediaSource as unknown as MediaSource }
       : { type: "handle", value: handle };
     this._mediaSource = mediaSource;
+    this.readyState = mediaSource.readyState;
     this._durationUpdater = new MediaSourceDurationUpdater(mediaSource);
     this._endOfStreamCanceller = null;
     onSourceOpen(
@@ -181,7 +184,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
    */
   private _canceller: TaskCanceller;
   /** The MSE `SourceBuffer` instance linked to that `ISourceBufferInterface`. */
-  private _sourceBuffer: SourceBuffer;
+  private _sourceBuffer: ISourceBuffer;
   /**
    * Queue of operations, from the most to the least urgent, currently waiting
    * their turn to be performed on the `SourceBuffer`.
@@ -202,7 +205,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
    * @param {string} codec
    * @param {SourceBuffer} sourceBuffer
    */
-  constructor(sbType: SourceBufferType, codec: string, sourceBuffer: SourceBuffer) {
+  constructor(sbType: SourceBufferType, codec: string, sourceBuffer: ISourceBuffer) {
     this.type = sbType;
     this.codec = codec;
     this._canceller = new TaskCanceller();
@@ -255,12 +258,9 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       }
       this._performNextOperation();
     };
-    sourceBuffer.addEventListener("error", onError);
-    sourceBuffer.addEventListener("updateend", onUpdateEnd);
-    this._canceller.signal.register(() => {
-      sourceBuffer.removeEventListener("error", onError);
-      sourceBuffer.removeEventListener("updateend", onUpdateEnd);
-    });
+
+    addEventListener(sourceBuffer, "updateend", onUpdateEnd, this._canceller.signal);
+    addEventListener(sourceBuffer, "error", onError, this._canceller.signal);
   }
 
   /** @see ISourceBufferInterface */
@@ -543,7 +543,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   }
 }
 
-function resetMediaSource(mediaSource: MediaSource): void {
+function resetMediaSource(mediaSource: IMediaSource): void {
   if (mediaSource.readyState !== "closed") {
     const { readyState, sourceBuffers } = mediaSource;
     for (let i = sourceBuffers.length - 1; i >= 0; i--) {

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -69,7 +69,7 @@ export default class MainMediaSourceInterface
    * You can then obtain a link to that `MediaSource`, for example to link it
    * to an `HTMLMediaElement`, through the `handle` property.
    */
-  constructor(id: string, forcedMediaSource?: new () => IMediaSource) {
+  constructor(id: string) {
     super();
     this.id = id;
     this.sourceBuffers = [];
@@ -83,8 +83,7 @@ export default class MainMediaSourceInterface
     }
 
     log.info("Init: Creating MediaSource");
-    const mediaSource =
-      forcedMediaSource !== undefined ? new forcedMediaSource() : new MediaSource_();
+    const mediaSource = new MediaSource_();
     const handle = (mediaSource as unknown as { handle: MediaProvider }).handle;
     this.handle = isNullOrUndefined(handle)
       ? /* eslint-disable-next-line @typescript-eslint/ban-types */

--- a/src/mse/types.ts
+++ b/src/mse/types.ts
@@ -163,6 +163,7 @@ export type IMediaSourceHandle =
        * Do not forget to revoke such URL (e.g. through `URL.revokeObjectURL`) when
        * you're done.
        */
+      /* eslint-disable-next-line @typescript-eslint/ban-types */
       value: MediaSource;
     };
 

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+import type {
+  IMediaSource,
+  ISourceBuffer,
+} from "../../compat/browser_compatibility_types";
 import {
   onRemoveSourceBuffers,
   onSourceOpen,
   onSourceBufferUpdate,
 } from "../../compat/event_listeners";
 import log from "../../log";
+import { addEventListener } from "../../utils/event_emitter";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import TaskCanceller from "../../utils/task_canceller";
 
@@ -28,8 +33,10 @@ import TaskCanceller from "../../utils/task_canceller";
  * @param {SourceBufferList} sourceBuffers
  * @returns {Array.<SourceBuffer>}
  */
-function getUpdatingSourceBuffers(sourceBuffers: SourceBufferList): SourceBuffer[] {
-  const updatingSourceBuffers: SourceBuffer[] = [];
+function getUpdatingSourceBuffers(
+  sourceBuffers: SourceBufferList | ISourceBuffer[],
+): ISourceBuffer[] {
+  const updatingSourceBuffers: ISourceBuffer[] = [];
   for (let i = 0; i < sourceBuffers.length; i++) {
     const SourceBuffer = sourceBuffers[i];
     if (SourceBuffer.updating) {
@@ -49,7 +56,7 @@ function getUpdatingSourceBuffers(sourceBuffers: SourceBufferList): SourceBuffer
  * @param {Object} cancelSignal
  */
 export default function triggerEndOfStream(
-  mediaSource: MediaSource,
+  mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): void {
   log.debug("Init: Trying to call endOfStream");
@@ -82,6 +89,21 @@ export default function triggerEndOfStream(
     );
   }
 
+  if (Array.isArray(sourceBuffers)) {
+    sourceBuffers.forEach((sb) => {
+      addEventListener(
+        sb,
+        "updateend",
+        () => {
+          innerCanceller.cancel();
+          triggerEndOfStream(mediaSource, cancelSignal);
+        },
+        innerCanceller.signal,
+      );
+    });
+    return;
+  }
+
   onRemoveSourceBuffers(
     sourceBuffers,
     () => {
@@ -99,7 +121,7 @@ export default function triggerEndOfStream(
  * @param {Object} cancelSignal
  */
 export function maintainEndOfStream(
-  mediaSource: MediaSource,
+  mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): void {
   let endOfStreamCanceller = new TaskCanceller();

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -17,6 +17,7 @@
 import type {
   IMediaSource,
   ISourceBuffer,
+  ISourceBufferList,
 } from "../../compat/browser_compatibility_types";
 import {
   onRemoveSourceBuffers,
@@ -34,7 +35,7 @@ import TaskCanceller from "../../utils/task_canceller";
  * @returns {Array.<SourceBuffer>}
  */
 function getUpdatingSourceBuffers(
-  sourceBuffers: SourceBufferList | ISourceBuffer[],
+  sourceBuffers: ISourceBufferList | ISourceBuffer[],
 ): ISourceBuffer[] {
   const updatingSourceBuffers: ISourceBuffer[] = [];
   for (let i = 0; i < sourceBuffers.length; i++) {

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -17,6 +17,7 @@
 import type {
   IMediaSource,
   ISourceBuffer,
+  ISourceBufferList,
 } from "../../compat/browser_compatibility_types";
 import { onSourceOpen, onSourceEnded, onSourceClose } from "../../compat/event_listeners";
 import hasIssuesWithHighMediaSourceDuration from "../../compat/has_issues_with_high_media_source_duration";
@@ -249,7 +250,7 @@ const enum MediaSourceDurationUpdateStatus {
  * @returns {Object}
  */
 function createSourceBuffersUpdatingReference(
-  sourceBuffers: SourceBufferList | ISourceBuffer[],
+  sourceBuffers: ISourceBufferList | ISourceBuffer[],
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {
   if (sourceBuffers.length === 0) {

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+import type {
+  IMediaSource,
+  ISourceBuffer,
+} from "../../compat/browser_compatibility_types";
 import { onSourceOpen, onSourceEnded, onSourceClose } from "../../compat/event_listeners";
 import hasIssuesWithHighMediaSourceDuration from "../../compat/has_issues_with_high_media_source_duration";
 import log from "../../log";
@@ -34,7 +38,7 @@ export default class MediaSourceDurationUpdater {
   /**
    * `MediaSource` on which we're going to update the `duration` attribute.
    */
-  private _mediaSource: MediaSource;
+  private _mediaSource: IMediaSource;
 
   /**
    * Abort the current duration-setting logic.
@@ -47,7 +51,7 @@ export default class MediaSourceDurationUpdater {
    * @param {MediaSource} mediaSource - The MediaSource on which the content is
    * played.
    */
-  constructor(mediaSource: MediaSource) {
+  constructor(mediaSource: IMediaSource) {
     this._mediaSource = mediaSource;
     this._currentMediaSourceDurationUpdateCanceller = null;
   }
@@ -150,7 +154,7 @@ export default class MediaSourceDurationUpdater {
  * @returns {string}
  */
 function setMediaSourceDuration(
-  mediaSource: MediaSource,
+  mediaSource: IMediaSource,
   duration: number,
   isRealEndKnown: boolean,
 ): MediaSourceDurationUpdateStatus {
@@ -245,7 +249,7 @@ const enum MediaSourceDurationUpdateStatus {
  * @returns {Object}
  */
 function createSourceBuffersUpdatingReference(
-  sourceBuffers: SourceBufferList,
+  sourceBuffers: SourceBufferList | ISourceBuffer[],
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {
   if (sourceBuffers.length === 0) {
@@ -289,7 +293,7 @@ function createSourceBuffersUpdatingReference(
  * @returns {Object}
  */
 function createMediaSourceOpenReference(
-  mediaSource: MediaSource,
+  mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {
   const isMediaSourceOpen = new SharedReference(
@@ -335,7 +339,7 @@ function createMediaSourceOpenReference(
  * @param {Object} cancelSignal
  */
 function recursivelyForceDurationUpdate(
-  mediaSource: MediaSource,
+  mediaSource: IMediaSource,
   duration: number,
   isRealEndKnown: boolean,
   cancelSignal: CancellationSignal,

--- a/src/parsers/containers/isobmff/index.ts
+++ b/src/parsers/containers/isobmff/index.ts
@@ -38,4 +38,9 @@ export {
   patchPssh,
   updateBoxLength,
 } from "./utils";
-export { extractCompleteChunks, findCompleteBox, getPsshSystemID, takePSSHOut };
+export {
+  extractCompleteChunks,
+  findCompleteBox,
+  getPsshSystemID,
+  takePSSHOut,
+};

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -3,6 +3,7 @@
  * Those types are considered as part of the API.
  */
 
+import type { IMediaElement } from "./compat/browser_compatibility_types";
 import type { IPreferredEmeApiType } from "./compat/eme";
 import type { EncryptedMediaError, MediaError, NetworkError, OtherError } from "./errors";
 import type {
@@ -38,7 +39,7 @@ export interface IConstructorOptions {
   videoResolutionLimit?: "videoElement" | "screen" | "none";
   throttleVideoBitrateWhenHidden?: boolean;
 
-  videoElement?: HTMLMediaElement;
+  videoElement?: IMediaElement;
   baseBandwidth?: number;
 }
 

--- a/src/tools/TextTrackRenderer/text_track_renderer.ts
+++ b/src/tools/TextTrackRenderer/text_track_renderer.ts
@@ -60,6 +60,7 @@ export default class TextTrackRenderer {
     videoElement,
     textTrackElement,
   }: {
+    /* eslint-disable-next-line @typescript-eslint/ban-types */
     videoElement: HTMLMediaElement;
     textTrackElement: HTMLElement;
   }) {

--- a/src/utils/event_emitter.ts
+++ b/src/utils/event_emitter.ts
@@ -17,6 +17,78 @@
 import isNullOrUndefined from "./is_null_or_undefined";
 import type { CancellationSignal } from "./task_canceller";
 
+// After making way too many attempts, I'm just listing cases here
+/* eslint-disable @typescript-eslint/ban-types */
+export function addEventListener(
+  target: Window,
+  eventType: keyof WindowEventMap,
+  eventFn: (evt: Event) => void,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener(
+  target: Document,
+  eventType: keyof DocumentEventMap,
+  eventFn: (evt: Event) => void,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener(
+  target: SourceBuffer,
+  eventType: keyof SourceBufferEventMap,
+  eventFn: (evt: Event) => void,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener(
+  target: MediaSource,
+  eventType: keyof MediaSourceEventMap,
+  eventFn: (evt: Event) => void,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener(
+  target: HTMLVideoElement,
+  eventType: keyof HTMLVideoElementEventMap,
+  eventFn: (evt: Event) => void,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener<T, TEventName extends keyof T>(
+  target: IEventEmitter<T>,
+  eventType: TEventName,
+  eventFn: IListener<T, TEventName>,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener<T, TEventName extends keyof T>(
+  target: IEventEmitter<T>,
+  eventType: TEventName,
+  eventFn: IListener<T, TEventName>,
+  cancelSignal?: CancellationSignal | undefined,
+): void;
+export function addEventListener<T, TEventName extends keyof T>(
+  target:
+    | SourceBuffer
+    | MediaSource
+    | HTMLMediaElement
+    | HTMLVideoElement
+    | Document
+    | Window
+    | IEventEmitter<T>,
+  eventType: string,
+  eventFn: IListener<T, TEventName> | ((evt: Event) => void),
+  cancelSignal?: CancellationSignal | undefined,
+): void {
+  /* eslint-disable @typescript-eslint/no-unsafe-call */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+  (target as any).addEventListener(eventType, eventFn);
+  if (cancelSignal !== undefined) {
+    cancelSignal.register(() => {
+      (target as any).removeEventListener(eventType, eventFn);
+    });
+  }
+  /* eslint-enable @typescript-eslint/no-unsafe-call */
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+  /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  /* eslint-enable @typescript-eslint/ban-types */
+}
+
 export interface IEventEmitter<T> {
   addEventListener<TEventName extends keyof T>(
     evt: TEventName,


### PR DESCRIPTION
This is a proof-of-concept to see if adding a mock implementation of the video HTML5 API and MSE API subset used by the RxPlayer inside the code of the RxPlayer seems useful and maintainable.

Motivation
----------

Initially, the idea was to implement one of the several solutions we have in mind to pre-load a future content when another content is already loaded on the media element. This was the most far-fetched solution, but I thought that it could still make enough sense to be tried.
In this solution, the application would create two player instances:

  1. One linked to the true media element on the page, as usual

  2. The other linked to our own provided dummy media element which would preload and store locally (in memory? through storage APIs when available?) future contents.

     Note that here nothing will change in the RxPlayer API, it is just that the application will have provided to that instance our mocked media element exported separately - which would implement all that storage logic in its implementation of MSE API - instead of a regular media element instance. This is to ensure a very minimal modification of the core RxPlayer code.

When the application judged that playback should begin, it can get the preloaded data through an API of that dummy media element, call `stop` on the RxPlayer instance with that dummy element and give the preloaded data as a supplementary `loadVideo` option (`preloadedData`?) to the RxPlayer instance with the real media element.

There are several complexities that are not yet handled here: most of all we need to be careful as segments on that dummy implementation will for now be stored in memory. Also, we will also need to provide segment-identification metadata alongside the preloaded data so the "real" RxPlayer is able to recognize which Adaptation/Representation has already been loaded so that instance doesn't try to replace it.

Also a potential use case asked by applications is to preload a content while another one is already loading. With how this solution is currently implemented, this wouldn't be efficient, as both instances could be loading media data at the same time without priorization mechanisms (e.g. we would imagine that the currently-loaded content is more important) - though I imagine this could be implemented in some way.

Other uses
----------

While doing a skeleton of it, I've realized that the MSE API outside of segment parsing and decoding was relatively straightforward: throw when the state or arguments is not right, send the right events etc., so I thought that a second use case (which may well in final be our first use case!) would be for testing.

Thanks to this implementation:

  1. we could just push fake generated content to facilitate writing tests (no need to generate a real content linked to the wanted behavior for each test)

  2. we could more easily replicate and test MSE implementation bugs seen on other devices and ensure they keep being tested.

Another nice use of it is that it implement a good chunk of the API used by the RxPlayer that are only found in browser environments, which may simplify PoCs in more restricted environments which can still run JS.