### PR TITLE
On the playstation 5, reload ASAP if a key become unusable

### DIFF
--- a/src/compat/may_media_element_fail_on_undecipherable_data.ts
+++ b/src/compat/may_media_element_fail_on_undecipherable_data.ts
@@ -1,0 +1,18 @@
+import { isPlayStation5 } from "./browser_detection";
+
+/**
+ * We noticed that the PlayStation 5 may have the HTMLMediaElement on which the
+ * content is played stop on a `MEDIA_ERR_DECODE` error if it encounters
+ * encrypted media data whose key is not usable due to policy restrictions (the
+ * most usual issue being non-respect of HDCP restrictions).
+ *
+ * This is not an usual behavior, other platforms just do not attempt to decode
+ * the encrypted media data and stall the playback instead (which is a much
+ * preferable behavior for us as we have some advanced mechanism to restart
+ * playback when this happens).
+ *
+ * Consequently, we have to specifically consider platforms with that
+ * fail-on-undecipherable-data issue, to perform a work-around in that case.
+ */
+const mayMediaElementFailOnUndecipherableData = isPlayStation5;
+export default mayMediaElementFailOnUndecipherableData;

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import config from "../../config";
 import type {
@@ -596,6 +597,19 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       segmentSinksStore,
     );
 
+    if (mayMediaElementFailOnUndecipherableData) {
+      // On some devices, just reload immediately when data become undecipherable
+      manifest.addEventListener(
+        "decipherabilityUpdate",
+        (elts) => {
+          if (elts.some((e) => e.representation.decipherable !== true)) {
+            reloadMediaSource(0, undefined, undefined);
+          }
+        },
+        cancelSignal,
+      );
+    }
+
     playbackObserver.listen(
       (observation) => {
         if (decipherabilityFreezeDetector.needToReload(observation)) {
@@ -820,22 +834,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         bitrateEstimateChange: (value) => self.trigger("bitrateEstimateChange", value),
 
         needsMediaSourceReload: (payload) => {
-          const lastObservation = coreObserver.getReference().getValue();
-          const currentPosition = lastObservation.position.isAwaitingFuturePosition()
-            ? lastObservation.position.getWanted()
-            : coreObserver.getCurrentTime() ?? lastObservation.position.getPolled();
-          const isPaused =
-            lastObservation.paused.pending ??
-            coreObserver.getIsPaused() ??
-            lastObservation.paused.last;
-          let position = currentPosition + payload.timeOffset;
-          if (payload.minimumPosition !== undefined) {
-            position = Math.max(payload.minimumPosition, position);
-          }
-          if (payload.maximumPosition !== undefined) {
-            position = Math.min(payload.maximumPosition, position);
-          }
-          onReloadOrder({ position, autoPlay: !isPaused });
+          reloadMediaSource(
+            payload.timeOffset,
+            payload.minimumPosition,
+            payload.maximumPosition,
+          );
         },
 
         needsDecipherabilityFlush() {
@@ -876,6 +879,38 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
         error: (err) => self._onFatalError(err),
       };
+    }
+
+    /**
+     * Callback allowing to reload the current content.
+     * @param {number} deltaPosition - Position you want to seek to after
+     * reloading, as a delta in seconds from the last polled playing position.
+     * @param {number|undefined} minimumPosition - If set, minimum time bound
+     * in seconds after `deltaPosition` has been applied.
+     * @param {number|undefined} maximumPosition - If set, minimum time bound
+     * in seconds after `deltaPosition` has been applied.
+     */
+    function reloadMediaSource(
+      deltaPosition: number,
+      minimumPosition: number | undefined,
+      maximumPosition: number | undefined,
+    ): void {
+      const lastObservation = coreObserver.getReference().getValue();
+      const currentPosition = lastObservation.position.isAwaitingFuturePosition()
+        ? lastObservation.position.getWanted()
+        : coreObserver.getCurrentTime() ?? lastObservation.position.getPolled();
+      const isPaused =
+        lastObservation.paused.pending ??
+        coreObserver.getIsPaused() ??
+        lastObservation.paused.last;
+      let position = currentPosition + deltaPosition;
+      if (minimumPosition !== undefined) {
+        position = Math.max(minimumPosition, position);
+      }
+      if (maximumPosition !== undefined) {
+        position = Math.min(maximumPosition, position);
+      }
+      onReloadOrder({ position, autoPlay: !isPaused });
     }
   }
 


### PR DESCRIPTION
Issue
-----

We noticed that the PlayStation 5 may have the HTMLMediaElement on which the content is played stop on a `MEDIA_ERR_DECODE` error if it encounters encrypted media data whose key is not usable due to policy restrictions (the most usual issue being non-respect of HDCP restrictions).

This is not an usual behavior, other platforms just do not attempt to decode the encrypted media data and stall the playback instead (which is a much preferable behavior for us as we have some advanced mechanism to restart playback when this happens).

To complexify even more, the RxPlayer learn of that error (through an `"error"` event) much later than after receiving the information that a key became undecipherable. The RxPlayer could thus already have performed several operations such as `SourceBuffer.remove` calls BEFORE it is aware that the media element is on error. Such operations will throw - at that time without any understood reason - which lead to a miscategorized fatal error by the RxPlayer.

Consequently, we have to specifically consider platforms with that fail-on-undecipherable-data issue, to perform a work-around in that case.

Work-around
-----------

The work-around found for now is to just directly cancel all streaming logic linked to a `MediaSource` as soon as the RxPlayer's `ContentDecryptor` (its module handling content decryption) signals about unusable keys, which should normally happen synchronously after the corresponding event is triggered by the browser.

To ensure this is done as soon as possible (because this is a race with the browser), this is performed in the `ContentInitializer` RxPlayer module, which is the module directly interfacing with the `ContentDecryptor`, with media element errors, and with the logic of creating `MediaSource` instances.
If we handled this in the `StreamOrchestrator` for example (which is better able to handle this scenario because it knows which segments have been buffered and are going to be buffered), we would have much more risk to "lose" the race with the browser here, as more RxPlayer modules will be involved as well as two threads and message-passing in a multithreaded scenario.

I'm not that satisfied with this solution though. Because a race is still going on between the browser and the RxPlayer, it may break in the future if we bring an asynchronicity (e.g. a round trip to the event loop) between the moment a decryption key becomes unusable and the moment we're reloading the `MediaSource`.

Perhaps a better solution would be to just let the corresponding `MEDIA_ERR_DECODE` happen, then determine heuristically if it had a good chance to happen due to the aforementioned decryption issue and reload in that case, but this is also difficult to implement.