### PR TITLE
Fix Worker usage on PS4 browser

### DIFF
--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -67,6 +67,9 @@ let isWebOs2022 = false;
 /** `true` for Panasonic devices. */
 let isPanasonic = false;
 
+/** `true` for the PlayStation 4 game console. */
+let isPlayStation4 = false;
+
 /** `true` for the PlayStation 5 game console. */
 let isPlayStation5 = false;
 
@@ -128,7 +131,9 @@ let isXbox = false;
     isSamsungBrowser = true;
   }
 
-  if (navigator.userAgent.indexOf("PlayStation 5") !== -1) {
+  if (navigator.userAgent.indexOf("PlayStation 4") !== -1) {
+    isPlayStation4 = true;
+  } else if (navigator.userAgent.indexOf("PlayStation 5") !== -1) {
     isPlayStation5 = true;
   } else if (/Tizen/.test(navigator.userAgent)) {
     isTizen = true;
@@ -163,6 +168,7 @@ export {
   isIEOrEdge,
   isFirefox,
   isPanasonic,
+  isPlayStation4,
   isPlayStation5,
   isXbox,
   isSafariDesktop,

--- a/src/compat/has_worker_api.ts
+++ b/src/compat/has_worker_api.ts
@@ -1,0 +1,15 @@
+import { isPlayStation4 } from "./browser_detection";
+
+/**
+ * Return `true` if the current device is compatible with the Worker API.
+ *
+ * Some old webkit devices, such as the PlayStation 4, returns weird results
+ * when doing the most straightforward check. We have to check if other Webkit
+ * devices have the same issue.
+ * @returns {boolean}
+ */
+export default function hasWorkerApi(): boolean {
+  return isPlayStation4
+    ? typeof Worker === "object" || typeof Worker === "function"
+    : typeof Worker === "function";
+}

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -29,6 +29,7 @@ import {
 } from "../../compat/event_listeners";
 import getStartDate from "../../compat/get_start_date";
 import hasMseInWorker from "../../compat/has_mse_in_worker";
+import hasWorkerApi from "../../compat/has_worker_api";
 import isDebugModeEnabled from "../../compat/is_debug_mode_enabled";
 import type {
   IAdaptationChoice,
@@ -420,7 +421,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   public attachWorker(workerSettings: IWorkerSettings): Promise<void> {
     return new Promise((res, rej) => {
-      if (typeof Worker !== "function") {
+      if (!hasWorkerApi()) {
         log.warn("API: Cannot rely on a WebWorker: Worker API unavailable");
         return rej(
           new WorkerInitializationError("INCOMPATIBLE_ERROR", "Worker unavailable"),


### PR DESCRIPTION
We noticed that ps4 applications were not relying on the `MULTI_THREAD` despite being theoretically compatible with it.

Turns out that `typeof Worker` does not return `"function"` as expected with such objects but `"object"` instead on that browser. Thus, the RxPlayer believes that it hasn't access to the Worker API, the necessary requirement for the `MULTI_THREAD` feature.

I suppose that this may also be true for other old Webkit-based browsers, though it isn't for recent-ish webkitgtk-based browsers on my PC, so for now I only enforce it for the PlayStation 4.