### PR TITLE
Do not rely on performance.now if unavailable

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -260,7 +260,7 @@ module.exports = {
         object: "performance",
         property: "now",
         message:
-          "Avoid using `performance.now` directly as timestamps may be different in the worker and the main thread. Please use the `getMonotonicTimeStamp` util instead.",
+          "Avoid using `performance.now` directly as timestamps may be different in the worker and the main thread and some platforms don't have it in a Worker environment. Please use the `getMonotonicTimeStamp` util instead.",
       },
       {
         object: "window",

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -22,7 +22,7 @@ import createDashPipelines from "../../../transports/dash";
 import arrayFind from "../../../utils/array_find";
 import assert, { assertUnreachable } from "../../../utils/assert";
 import type { ILoggerLevel } from "../../../utils/logger";
-import { mainThreadTimestampDiff } from "../../../utils/monotonic_timestamp";
+import { scaleTimestamp } from "../../../utils/monotonic_timestamp";
 import objectAssign from "../../../utils/object_assign";
 import type { IReadOnlySharedReference } from "../../../utils/reference";
 import SharedReference from "../../../utils/reference";
@@ -90,11 +90,7 @@ export default function initializeWorkerMain() {
       case MainThreadMessageType.Init:
         assert(!isInitialized);
         isInitialized = true;
-
-        const diffMain = msg.value.date - msg.value.timestamp;
-        /* eslint-disable-next-line no-restricted-properties */
-        const diffWorker = Date.now() - performance.now();
-        mainThreadTimestampDiff.setValueIfChanged(diffWorker - diffMain);
+        scaleTimestamp(msg.value);
         updateLoggerLevel(msg.value.logLevel, msg.value.sendBackLogs);
         if (msg.value.dashWasmUrl !== undefined && dashWasmParser.isCompatible()) {
           dashWasmParser.initialize({ wasmUrl: msg.value.dashWasmUrl }).catch((err) => {

--- a/src/utils/monotonic_timestamp.ts
+++ b/src/utils/monotonic_timestamp.ts
@@ -7,7 +7,16 @@ import SharedReference from "./reference";
  */
 const mainThreadTimestampDiff = new SharedReference(0);
 
-export { mainThreadTimestampDiff };
+export function scaleTimestamp({ date, timestamp }: { date: number; timestamp: number }) {
+  const delta = date - timestamp;
+
+  const diffCurrentEnv =
+    typeof performance !== "undefined"
+      ? /* eslint-disable-next-line no-restricted-properties */
+        Date.now() - performance.now()
+      : 0;
+  mainThreadTimestampDiff.setValueIfChanged(diffCurrentEnv - delta);
+}
 
 /**
  * Provide a "monotonically-raising timestamp". That is, a timestamp that is
@@ -25,7 +34,10 @@ export { mainThreadTimestampDiff };
  * provide a monotonic timestamp synchronized with the main thread.
  * @returns {number}
  */
-export default function getMonotonicTimeStamp(): number {
-  /* eslint-disable-next-line no-restricted-properties */
-  return performance.now() + mainThreadTimestampDiff.getValue();
-}
+const getMonotonicTimeStamp =
+  typeof performance !== "undefined"
+    ? /* eslint-disable-next-line no-restricted-properties */
+      () => performance.now() + mainThreadTimestampDiff.getValue()
+    : () => Date.now() + mainThreadTimestampDiff.getValue();
+
+export default getMonotonicTimeStamp;


### PR DESCRIPTION
After #1401 (fix about the fact that `typeof Worker === "object"` on the PlayStation 4 for some reason), I finally succeeded to run the `MULTI_THREAD` experimental feature on a PlayStation 4 by adding one supplementary fix.

Turns out that the `performance.now` web API, that we use to measure time differences (Date.now() being clock-related, it's not always appropriate for that) was not available in a Worker environment on the PlayStation 4.

I have no idea why, as it is available in main thread, a random guess would be that this is a remnant of mitigations against something like spectre/meltdown but all I could find is that [they reduced its precision](https://trac.webkit.org/changeset/226495/webkit), not removed it from workers.

Anyway, we thankfully only relied on this API at two places, as we voluntarily reduced those places previously to allow a synchronization mechanism between main thread and worker.

This means that we can now easily use `Date.now()` in its place when `performance.now()` is unavailable without much fear of the issue coming back again in the future (our linter already ensure the API isn't used elsewhere).

The main issue would be that timing measures would now become time-dependant on the PlayStation 4 and thus may be affected by clock changes, or subtle unix timestamp quirks. This should very rarely be problematic though, and it will just happen when the experimental `MULTI_THREAD` feature is explicitely relied on on the PlayStation 4 for now.