### PR TITLE
fix(safari): check seeking event type in addition to the videoElement state "seeking"

### DIFF
--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -156,7 +156,10 @@ export default function performInitialSeekAndPlay(
      */
     let isAwaitingSeek = hasAskedForInitialSeek;
     playbackObserver.listen((observation, stopListening) => {
-      if (hasAskedForInitialSeek && observation.seeking) {
+      if (hasAskedForInitialSeek &&
+        (observation.seeking ||
+          observation.event === "seeking" ||
+          observation.event === "internal-seeking")) {
         isAwaitingSeek = false;
         return;
       }


### PR DESCRIPTION
When seeking on the current position the video element trigger the
`seeking` event, but the seeking attribute of the video element itself
is either not updated or is already reset to `false` at the moment the
event "seeking" is received.
    
```js
video.onseeking = () => {
        // video.seeking attribute can be false
        console.log("on seeking!", video.seeking)
}
```
    
Due to a recent change we are waiting for the attribute `video.seeking`
to be true. Checking that the event type correspond to a seeking event
fix the issue.

Bug introduces with [06ecb150a1b6758fd26992011d618710b6c7c66c]
Report as part of https://github.com/canalplus/rx-player/issues/1390