### PR TITLE
fix(safari): check seeking event type in addition to the videoElement state "seeking"

### DIFF
--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -150,7 +150,12 @@ export default function performInitialSeekAndPlay(
         let hasStartedSeeking = false;
         playbackObserver.listen(
           (obs, stopListening) => {
-            if (!hasStartedSeeking && obs.seeking !== SeekingState.None) {
+            if (
+              !hasStartedSeeking &&
+              (obs.seeking !== SeekingState.None ||
+                obs.event === "seeking" ||
+                obs.event === "internal-seeking")
+            ) {
               hasStartedSeeking = true;
             }
             if ((hasAskedForInitialSeek && !hasStartedSeeking) || obs.readyState === 0) {


### PR DESCRIPTION
equivalent of https://github.com/canalplus/rx-player/pull/1404 for v4

This didn't cause a bug in v4 but for safety and code robustness I propose to back-port the fix from the v3 to the v4.