### PR TITLE
fix(safari): V4 - no longer stuck in buffering on safari iOS when video has attribute "playsinline"

### DIFF
--- a/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
+++ b/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
@@ -36,7 +36,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
       "../should_wait_for_data_before_loaded",
     );
-    expect(shouldWaitForDataBeforeLoaded.default(false, true)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(false)).toBe(true);
   });
 
   it("should return true if we are not on Safari browser but in directfile mode", () => {
@@ -49,7 +49,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
       "../should_wait_for_data_before_loaded",
     );
-    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(true)).toBe(true);
   });
 
   it("should return true if we are on the Safari browser but not in directfile mode", () => {
@@ -62,10 +62,11 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
       "../should_wait_for_data_before_loaded",
     );
-    expect(shouldWaitForDataBeforeLoaded.default(false, false)).toBe(true);
+    expect(shouldWaitForDataBeforeLoaded.default(false)).toBe(true);
   });
 
-  it("should return false if we are on the Safari browser with no play inline and in directfile mode", () => {
+  // eslint-disable-next-line max-len
+  it("should return false if we are on the Safari browser and in directfile mode", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true as const,
@@ -75,47 +76,9 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
       "../should_wait_for_data_before_loaded",
     );
-    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(false);
+    expect(shouldWaitForDataBeforeLoaded.default(true)).toBe(false);
   });
 
-  it("should return true if we are on the Safari browser, we should play inline and in directfile mode", () => {
-    jest.mock("../browser_detection", () => {
-      return {
-        __esModule: true as const,
-        isSafariMobile: true,
-      };
-    });
-    const shouldWaitForDataBeforeLoaded = jest.requireActual(
-      "../should_wait_for_data_before_loaded",
-    );
-    expect(shouldWaitForDataBeforeLoaded.default(true, true)).toBe(true);
-  });
-
-  it("should return true if we are on the Safari browser, play inline but no directfile mode", () => {
-    jest.mock("../browser_detection", () => {
-      return {
-        __esModule: true as const,
-        isSafariMobile: true,
-      };
-    });
-    const shouldWaitForDataBeforeLoaded = jest.requireActual(
-      "../should_wait_for_data_before_loaded",
-    );
-    expect(shouldWaitForDataBeforeLoaded.default(false, true)).toBe(true);
-  });
-
-  it("should return true if we are not on the Safari browser, should not play inline and in directfile mode", () => {
-    jest.mock("../browser_detection", () => {
-      return {
-        __esModule: true as const,
-        isSafariMobile: false,
-      };
-    });
-    const shouldWaitForDataBeforeLoaded = jest.requireActual(
-      "../should_wait_for_data_before_loaded",
-    );
-    expect(shouldWaitForDataBeforeLoaded.default(true, false)).toBe(true);
-  });
   beforeEach(() => {
     jest.resetModules();
   });

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -24,12 +24,10 @@ import { isSafariMobile } from "./browser_detection";
  * @param {Boolean} isDirectfile
  * @returns {Boolean}
  */
-export default function shouldWaitForDataBeforeLoaded(
-  isDirectfile: boolean,
-  mustPlayInline: boolean,
-): boolean {
+export default function shouldWaitForDataBeforeLoaded(isDirectfile: boolean): boolean {
   if (isDirectfile && isSafariMobile) {
-    return mustPlayInline;
+    return false;
+  } else {
+    return true;
   }
-  return true;
 }

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -54,12 +54,7 @@ export default function getLoadedReference(
         return;
       }
 
-      if (
-        !shouldWaitForDataBeforeLoaded(
-          isDirectfile,
-          mediaElement.hasAttribute("playsinline"),
-        )
-      ) {
+      if (!shouldWaitForDataBeforeLoaded(isDirectfile)) {
         // The duration is NaN if no media data is available,
         // which means media is not loaded yet.
         if (isNaN(mediaElement.duration)) {


### PR DESCRIPTION
When playing a content with Safari mobile on iOS (17.3.1), it autoplay is false in loadVideoOptions, AND if the video element has attribute playsinline, the video will be stuck in buffering and never reach the LOADED state.

This PR fix the issue, and the content should be properly be LOADED. The LOADED attribute don't rely anymore on having or not attribute playsinline.

This PR target the V4 release.
relates to https://github.com/canalplus/rx-player/issues/1390 