### PR TITLE
Generate TypeScript declaration maps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,8 @@
 /doc
 /.github
 /scripts
+# rust build artifacts
+/src/parsers/manifest/dash/wasm-parser/target
 
 /FILES.md
 /CONTRIBUTING.md

--- a/.npmignore
+++ b/.npmignore
@@ -13,7 +13,6 @@
 /tests
 
 /doc
-/src
 /.github
 /scripts
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "./dist/es2017",
     "declaration": true,
+    "declarationMap": true,
     "target": "es2017",
     "lib": ["es2017", "dom"],
     "types": ["jest"],


### PR DESCRIPTION
In IDEs such as Visual Studio Code and WebStorm, when you command-click (or control-click) on an imported identifier from another package (e.g. `rx-player`), it does one of the following:

1. In packages without type definitions, the IDE takes you to the identifier's declaration in the relevant (transpiled) JavaScript file.
2. In packages that contain type definitions, the IDE takes you to the identifier's type definition.
3. In packages that contain type definitions, declaration maps and the source files that the declaration maps refer to, the IDE takes you to the declaration in the source.

Currently, `rx-player` is a type 2 package. This pull request makes it type 3.

The trade-off is the package now includes source, making the package larger. The package size (when packed) is

* 5.29 MB with source
* 2.77 MB without source

Personally, I don't mind trading off a few MB for being able to navigate directly to the source.

Before this change:
![rx-player-before](https://github.com/canalplus/rx-player/assets/1135589/fe76b24c-8b54-44a6-a36a-2fd585df3c33)

After this change:
![rx-player-after](https://github.com/canalplus/rx-player/assets/1135589/d3ce5719-23e0-4a10-9d8c-6c162052336a)