### PR TITLE
fix: subtitles blinking in low-latency mode

### DIFF
--- a/src/main_thread/text_displayer/html/__tests__/text_track_cues_store.test.ts
+++ b/src/main_thread/text_displayer/html/__tests__/text_track_cues_store.test.ts
@@ -1,0 +1,309 @@
+import TextTrackCuesStore from "../text_track_cues_store";
+import type { ICuesGroup } from "../utils";
+
+/**
+ * Mocks document.createElement to simplify comparison of cuesElement by returning
+ * a plain object with innerText property instead of an HTMLElement.
+ * @param text innerText
+ * @returns
+ */
+function mockCreateElementFn() {
+  jest
+    .spyOn(document, "createElement")
+    .mockImplementation((n: string) => ({ innerText: n }) as HTMLElement);
+
+  return (text: string) => document.createElement(text);
+}
+
+describe("TextTrackCuesStore - insert()", () => {
+  const createCueElement = mockCreateElementFn();
+
+  it("test the mock function, a and b should be considered different", () => {
+    const a = createCueElement("hello");
+    const b = createCueElement("bye");
+    expect(a).not.toEqual(b);
+    expect(a.innerText).toEqual("hello");
+  });
+
+  it("inserting strictly after previous one", () => {
+    //   ours:                  |AAAAA|
+    //   the current one: |BBBBB|
+    //   Result:          |BBBBB|AAAAA|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("bye"), start: 1, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+    ];
+
+    // small hack to access class private property with bracket notation without having ts errors
+    /* eslint-disable @typescript-eslint/dot-notation */
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("bye"), start: 1, end: 2 }],
+      1,
+      2,
+    );
+
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("inserting strictly before existing cue", () => {
+    //   ours:            |AAAAA|
+    //   the current one:       |BBBBB|
+    //   Result:          |AAAAA|BBBBB|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("bye"), start: 1, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("bye"), start: 1, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("hello"), start: 0, end: 1 }],
+      0,
+      1,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("inserting between two cues", () => {
+    //   ours:                  |AAAAA|
+    //   the current one: |BBBBB|     |BBBBB|
+    //   Result:          |BBBBB|AAAAA|BBBBB|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("hello again"), start: 2, end: 3 }],
+        start: 2,
+        end: 3,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("bye"), start: 1, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+      {
+        cues: [{ element: createCueElement("hello again"), start: 2, end: 3 }],
+        start: 2,
+        end: 3,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("bye"), start: 1, end: 2 }],
+      1,
+      2,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("replacing current cues", () => {
+    //   ours:            |AAAAA|
+    //   the current one: |BBBBB|
+    //   Result:          |AAAAA|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hello"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("hi"), start: 0, end: 1 }],
+      0,
+      1,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("inserting cues that partially replace existing cues", () => {
+    //   ours:            |AAAAA|
+    //   the current one: |BBBBBBBB|
+    //   Result:          |AAAAABBB|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("how are you?"), start: 0, end: 2 }],
+        start: 0,
+        end: 2,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("how are you?"), start: 0, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("hi"), start: 0, end: 1 }],
+      0,
+      1,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+  it("inserting cues that replace existing cues and go beyond", () => {
+    //   ours:            |AAAAAAA|
+    //   the current one: |BBBB|...
+    //   Result:          |AAAAAAA|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 0, end: 1 }],
+        start: 0,
+        end: 1,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("how are you?"), start: 0, end: 2 }],
+        start: 0,
+        end: 2,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("how are you?"), start: 0, end: 2 }],
+      0,
+      2,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("inserting after previous one with parsing approximation", () => {
+    //   ours:                  |AAAAA|
+    //   the current one: |BBBBB|
+    //   Result:          |BBBBB|AAAAA|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 0, end: 1.0001 }],
+        start: 0,
+        end: 1.0001,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 0, end: 1.0001 }],
+        start: 0,
+        end: 1,
+      },
+      {
+        cues: [{ element: createCueElement("how are you?"), start: 1, end: 2 }],
+        start: 1,
+        end: 2,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("how are you?"), start: 1, end: 2 }],
+      1,
+      2,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+
+  it("inserting cues that replace existing cues and go beyond with parsing approximation", () => {
+    //   ours:            |AAAAAAA|
+    //   the current one: |BBBB|...
+    //   Result:          |AAAAAAA|
+    const textTrackCuesStore = new TextTrackCuesStore();
+    const currentCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 9.8, end: 10.001 }],
+        start: 9.8,
+        end: 10.001,
+      },
+    ];
+
+    const expectedCues: ICuesGroup[] = [
+      {
+        cues: [{ element: createCueElement("hi"), start: 9.8, end: 10.001 }],
+        start: 9.8,
+        end: 10,
+      },
+      {
+        cues: [{ element: createCueElement("hi"), start: 10, end: 12 }],
+        start: 10,
+        end: 12,
+      },
+    ];
+
+    textTrackCuesStore["_cuesBuffer"] = currentCues;
+    textTrackCuesStore.insert(
+      [{ element: createCueElement("hi"), start: 10, end: 12 }],
+      10,
+      12,
+    );
+    expect(textTrackCuesStore["_cuesBuffer"]).toEqual(expectedCues);
+  });
+});

--- a/src/main_thread/text_displayer/html/__tests__/utils.test.ts
+++ b/src/main_thread/text_displayer/html/__tests__/utils.test.ts
@@ -20,6 +20,7 @@ import {
   getCuesAfter,
   getCuesBefore,
   removeCuesInfosBetween,
+  areCuesStartNearlyEqual,
 } from "../utils";
 
 describe("HTML Text buffer utils - getCuesBefore", () => {
@@ -333,3 +334,61 @@ describe("HTML Text buffer utils - removeCuesInfosBetween", () => {
     ]);
   });
 });
+
+describe("HTML areCuesStartNearlyEqual", () => {
+  it("Case 1: should be false", () => {
+    // * [0, 2] and [2, 4] start are NOT equals
+    const element = document.createElement("div");
+    const cues = [
+      { start: 1, end: 2, element },
+    ];
+    const cueInfo1 = { start: 0, end: 2, cues };
+    const cueInfo2 = { start: 2, end: 4, cues };
+  
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
+  })
+  it("Case 2: should be true", () => {
+    // * [0, 2] and [0, 4]  start are equals
+    const element = document.createElement("div");
+    const cues = [
+      { start: 1, end: 2, element },
+    ];
+    const cueInfo1 = { start: 0, end: 2, cues };
+    const cueInfo2 = { start: 0, end: 4, cues };
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(true);
+  });
+
+
+  it("Case 3: should be false", () => {
+    // * [0, 0.1] and [0.101, 2] start are NOT equals
+    const element = document.createElement("div");
+    const cues = [
+      { start: 1, end: 2, element },
+    ];
+    const cueInfo1 = { start: 0, end: 0.1, cues };
+    const cueInfo2 = { start: 0.101, end: 2, cues };
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
+  })
+
+  it("Case 4: should be true", () => {
+    // * [0, 2] and [0.01, 4]  start are equals
+    const element = document.createElement("div");
+    const cues = [
+      { start: 1, end: 2, element },
+    ];
+    const cueInfo1 = { start: 0, end: 2, cues };
+    const cueInfo2 = { start: 0.01, end: 4, cues };
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(true);
+  })
+
+  it("Case 5: should be false", () => {
+    // * [0, 100] and [1, 200]  start are NOT equals
+    const element = document.createElement("div");
+    const cues = [
+      { start: 1, end: 2, element },
+    ];
+    const cueInfo1 = { start: 0, end: 100, cues };
+    const cueInfo2 = { start: 2, end: 200, cues };
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
+  })
+})

--- a/src/main_thread/text_displayer/html/__tests__/utils.test.ts
+++ b/src/main_thread/text_displayer/html/__tests__/utils.test.ts
@@ -339,56 +339,45 @@ describe("HTML areCuesStartNearlyEqual", () => {
   it("Case 1: should be false", () => {
     // * [0, 2] and [2, 4] start are NOT equals
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-    ];
+    const cues = [{ start: 1, end: 2, element }];
     const cueInfo1 = { start: 0, end: 2, cues };
     const cueInfo2 = { start: 2, end: 4, cues };
-  
+
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
-  })
+  });
   it("Case 2: should be true", () => {
     // * [0, 2] and [0, 4]  start are equals
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-    ];
+    const cues = [{ start: 1, end: 2, element }];
     const cueInfo1 = { start: 0, end: 2, cues };
     const cueInfo2 = { start: 0, end: 4, cues };
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(true);
   });
 
-
   it("Case 3: should be false", () => {
     // * [0, 0.1] and [0.101, 2] start are NOT equals
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-    ];
+    const cues = [{ start: 1, end: 2, element }];
     const cueInfo1 = { start: 0, end: 0.1, cues };
     const cueInfo2 = { start: 0.101, end: 2, cues };
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
-  })
+  });
 
   it("Case 4: should be true", () => {
     // * [0, 2] and [0.01, 4]  start are equals
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-    ];
+    const cues = [{ start: 1, end: 2, element }];
     const cueInfo1 = { start: 0, end: 2, cues };
     const cueInfo2 = { start: 0.01, end: 4, cues };
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(true);
-  })
+  });
 
   it("Case 5: should be false", () => {
     // * [0, 100] and [1, 200]  start are NOT equals
     const element = document.createElement("div");
-    const cues = [
-      { start: 1, end: 2, element },
-    ];
+    const cues = [{ start: 1, end: 2, element }];
     const cueInfo1 = { start: 0, end: 100, cues };
     const cueInfo2 = { start: 2, end: 200, cues };
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
-  })
-})
+  });
+});

--- a/src/main_thread/text_displayer/html/__tests__/utils.test.ts
+++ b/src/main_thread/text_displayer/html/__tests__/utils.test.ts
@@ -380,4 +380,13 @@ describe("HTML areCuesStartNearlyEqual", () => {
     const cueInfo2 = { start: 2, end: 200, cues };
     expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(false);
   });
+
+  it("Case 6: should be true", () => {
+    // * [0, 4] and [0.01, 3.99]  start should be equals
+    const element = document.createElement("div");
+    const cues = [{ start: 0, end: 4, element }];
+    const cueInfo1 = { start: 0, end: 4, cues };
+    const cueInfo2 = { start: 0.01, end: 3.99, cues };
+    expect(areCuesStartNearlyEqual(cueInfo1, cueInfo2)).toBe(true);
+  });
 });

--- a/src/main_thread/text_displayer/html/text_track_cues_store.ts
+++ b/src/main_thread/text_displayer/html/text_track_cues_store.ts
@@ -5,6 +5,7 @@ import {
   getCuesAfter,
   getCuesBefore,
   removeCuesInfosBetween,
+  areCuesStartNearlyEqual,
 } from "./utils";
 
 /**
@@ -234,7 +235,7 @@ export default class TextTrackCuesStore {
     for (let cueIdx = 0; cueIdx < cuesBuffer.length; cueIdx++) {
       let cuesInfos = cuesBuffer[cueIdx];
       if (start + DELTA_CUES_GROUP < cuesInfos.end) {
-        if (areNearlyEqual(start, cuesInfos.start, relativeDelta)) {
+        if (areCuesStartNearlyEqual(cuesInfosToInsert, cuesInfos)) {
           if (areNearlyEqual(end, cuesInfos.end, relativeDelta)) {
             // exact same segment
             //   ours:            |AAAAA|

--- a/src/main_thread/text_displayer/html/text_track_cues_store.ts
+++ b/src/main_thread/text_displayer/html/text_track_cues_store.ts
@@ -233,7 +233,7 @@ export default class TextTrackCuesStore {
 
     for (let cueIdx = 0; cueIdx < cuesBuffer.length; cueIdx++) {
       let cuesInfos = cuesBuffer[cueIdx];
-      if (start < cuesInfos.end) {
+      if (start + DELTA_CUES_GROUP < cuesInfos.end) {
         if (areNearlyEqual(start, cuesInfos.start, relativeDelta)) {
           if (areNearlyEqual(end, cuesInfos.end, relativeDelta)) {
             // exact same segment

--- a/src/main_thread/text_displayer/html/text_track_cues_store.ts
+++ b/src/main_thread/text_displayer/html/text_track_cues_store.ts
@@ -234,7 +234,7 @@ export default class TextTrackCuesStore {
 
     for (let cueIdx = 0; cueIdx < cuesBuffer.length; cueIdx++) {
       let cuesInfos = cuesBuffer[cueIdx];
-      if (start + DELTA_CUES_GROUP < cuesInfos.end) {
+      if (start < cuesInfos.end) {
         if (areCuesStartNearlyEqual(cuesInfosToInsert, cuesInfos)) {
           if (areNearlyEqual(end, cuesInfos.end, relativeDelta)) {
             // exact same segment

--- a/src/main_thread/text_displayer/html/utils.ts
+++ b/src/main_thread/text_displayer/html/utils.ts
@@ -74,11 +74,11 @@ export function areNearlyEqual(
   return Math.abs(a - b) <= Math.min(delta, MAX_DELTA_BUFFER_TIME);
 }
 
-const EPSILON = 5e-2;  // 5%
+const EPSILON = 5e-2; // 5%
 /**
  * Check if two cues start are almost the same.
  * It should depend on there relative length:
- * 
+ *
  * [0, 2] and [2, 4] start are NOT equals
  * [0, 2] and [0, 4]  start are equals
  * [0, 0.1] and [0.101, 2] start are NOT equals
@@ -96,8 +96,12 @@ export function areCuesStartNearlyEqual(
   const firstCueDuration = Math.abs(firstCue.end - firstCue.start);
   const secondCueDuration = Math.abs(secondCue.end - secondCue.start);
   const diffBetweenStart = Math.abs(firstCue.start - secondCue.start);
-  const minDuration = Math.min(firstCueDuration, secondCueDuration, MAX_DELTA_BUFFER_TIME);
-  return (diffBetweenStart / minDuration) <= EPSILON; // ratio diff/ minduration is bellow 5% 
+  const minDuration = Math.min(
+    firstCueDuration,
+    secondCueDuration,
+    MAX_DELTA_BUFFER_TIME,
+  );
+  return diffBetweenStart / minDuration <= EPSILON; // ratio diff/ minduration is bellow 5%
 }
 
 /**

--- a/src/main_thread/text_displayer/html/utils.ts
+++ b/src/main_thread/text_displayer/html/utils.ts
@@ -93,8 +93,8 @@ export function areCuesStartNearlyEqual(
   firstCue: ICuesGroup,
   secondCue: ICuesGroup,
 ): boolean {
-  const firstCueDuration = Math.abs(firstCue.end - firstCue.start);
-  const secondCueDuration = Math.abs(secondCue.end - secondCue.start);
+  const firstCueDuration = firstCue.end - firstCue.start;
+  const secondCueDuration = secondCue.end - secondCue.start;
   const diffBetweenStart = Math.abs(firstCue.start - secondCue.start);
   const minDuration = Math.min(
     firstCueDuration,

--- a/src/main_thread/text_displayer/html/utils.ts
+++ b/src/main_thread/text_displayer/html/utils.ts
@@ -74,6 +74,32 @@ export function areNearlyEqual(
   return Math.abs(a - b) <= Math.min(delta, MAX_DELTA_BUFFER_TIME);
 }
 
+const EPSILON = 5e-2;  // 5%
+/**
+ * Check if two cues start are almost the same.
+ * It should depend on there relative length:
+ * 
+ * [0, 2] and [2, 4] start are NOT equals
+ * [0, 2] and [0, 4]  start are equals
+ * [0, 0.1] and [0.101, 2] start are NOT equals
+ * [0, 2] and [0.01, 4]  start are equals
+ * [0, 100] and [1, 200]  start are NOT equals
+ * @see MAX_DELTA_BUFFER_TIME
+ * @param {Number} firstCue the existing cue
+ * @param {Number} secondCue the cue that we test if it follow firstCue
+ * @returns {Boolean}
+ */
+export function areCuesStartNearlyEqual(
+  firstCue: ICuesGroup,
+  secondCue: ICuesGroup,
+): boolean {
+  const firstCueDuration = Math.abs(firstCue.end - firstCue.start);
+  const secondCueDuration = Math.abs(secondCue.end - secondCue.start);
+  const diffBetweenStart = Math.abs(firstCue.start - secondCue.start);
+  const minDuration = Math.min(firstCueDuration, secondCueDuration, MAX_DELTA_BUFFER_TIME);
+  return (diffBetweenStart / minDuration) <= EPSILON; // ratio diff/ minduration is bellow 5% 
+}
+
 /**
  * Get all cues which have data before the given time.
  * @param {Object} cues

--- a/src/parsers/containers/isobmff/extract_complete_chunks.ts
+++ b/src/parsers/containers/isobmff/extract_complete_chunks.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { be4toi, concat } from "../../../utils/byte_parsing";
+import { be4toi } from "../../../utils/byte_parsing";
 import findCompleteBox from "./find_complete_box";
 
 /**
@@ -27,7 +27,7 @@ import findCompleteBox from "./find_complete_box";
  */
 export default function extractCompleteChunks(
   buffer: Uint8Array,
-): [Uint8Array | null, Uint8Array | null] {
+): [Uint8Array[] | null, Uint8Array | null] {
   let _position = 0;
   const chunks: Uint8Array[] = [];
   let currentBuffer = null;
@@ -70,5 +70,5 @@ export default function extractCompleteChunks(
   if (chunks.length === 0) {
     return [null, currentBuffer];
   }
-  return [concat(...chunks), currentBuffer];
+  return [chunks, currentBuffer];
 }

--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -62,13 +62,9 @@ export default function lowLatencySegmentLoader(
     const completeChunks = res[0];
     partialChunk = res[1];
     if (completeChunks !== null) {
-      if (content.type === "text") {
-        completeChunks.forEach((completedChunk) => {
-          callbacks.onNewChunk(completedChunk);
-        });
-      } else {
-        callbacks.onNewChunk(concat(...completeChunks));
-      }
+      completeChunks.forEach((completedChunk) => {
+        callbacks.onNewChunk(completedChunk);
+      });
       if (cancelSignal.isCancelled()) {
         return;
       }

--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -62,7 +62,13 @@ export default function lowLatencySegmentLoader(
     const completeChunks = res[0];
     partialChunk = res[1];
     if (completeChunks !== null) {
-      callbacks.onNewChunk(completeChunks);
+      if (content.type === "text") {
+        completeChunks.forEach((completedChunk) => {
+          callbacks.onNewChunk(completedChunk);
+        });
+      } else {
+        callbacks.onNewChunk(concat(...completeChunks));
+      }
       if (cancelSignal.isCancelled()) {
         return;
       }


### PR DESCRIPTION
This PR add 2 fixes that cause subtitles to blink in low latency mode.

The first one concern  `TextTrackCuesStore.insert()` method, that remove subtitles due to parsing approximations.
The bug and the fix can be observed by the unit tests I added.


The second one is a bug on the parsing of fragmented MP4. Those files have several moof and mdat box, but only the first moof and mdat were parsed into subtitles. The fix is to extract the complete chunks and to NOT merge them together, instead we are passing them individually to the parser, so each one of them has a single moof and mdat.

