### PR TITLE
When listing segments needed, stop filtering the current range

### DIFF
--- a/src/core/stream/representation/utils/get_buffer_status.ts
+++ b/src/core/stream/representation/utils/get_buffer_status.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import config from "../../../../config";
 import type {
   IManifest,
   IAdaptation,
@@ -24,14 +23,10 @@ import type {
 import type { IReadOnlyPlaybackObserver } from "../../../../playback_observer";
 import isNullOrUndefined from "../../../../utils/is_null_or_undefined";
 import type {
-  IBufferedChunk,
   ISignalCompleteSegmentOperation,
   SegmentSink,
 } from "../../../segment_sinks";
-import SegmentSinksStore, {
-  ChunkStatus,
-  SegmentSinkOperation,
-} from "../../../segment_sinks";
+import SegmentSinksStore, { SegmentSinkOperation } from "../../../segment_sinks";
 import type {
   IBufferDiscontinuity,
   IRepresentationStreamPlaybackObservation,
@@ -140,10 +135,7 @@ export default function getBufferStatus(
     .map((operation) => operation.value);
 
   /** Data on every segments buffered around `neededRange`. */
-  const bufferedSegments = getPlayableBufferedSegments(
-    { start: Math.max(neededRange.start - 0.5, 0), end: neededRange.end + 0.5 },
-    segmentSink.getLastKnownInventory(),
-  );
+  const bufferedSegments = segmentSink.getLastKnownInventory();
   let currentPlaybackTime = playbackObserver.getCurrentTime();
   if (currentPlaybackTime === undefined) {
     // We're in a WebWorker, just consider the last known position
@@ -312,47 +304,4 @@ function isPeriodTheCurrentAndLastOne(
     manifest.isLastPeriodKnown &&
     period.id === manifest.periods[manifest.periods.length - 1]?.id
   );
-}
-
-/**
- * From the given SegmentInventory, filters the "playable" (in a supported codec
- * and not known to be undecipherable) buffered Segment Objects which overlap
- * with the given range.
- * @param {Object} neededRange
- * @param {Array.<Object>} segmentInventory
- * @returns {Array.<Object>}
- */
-function getPlayableBufferedSegments(
-  neededRange: { start: number; end: number },
-  segmentInventory: IBufferedChunk[],
-): IBufferedChunk[] {
-  const { MINIMUM_SEGMENT_SIZE } = config.getCurrent();
-  const segmentRoundingError = Math.max(1 / 60, MINIMUM_SEGMENT_SIZE);
-  const minEnd = neededRange.start + segmentRoundingError;
-  const maxStart = neededRange.end - segmentRoundingError;
-
-  const overlappingChunks: IBufferedChunk[] = [];
-  for (let i = segmentInventory.length - 1; i >= 0; i--) {
-    const eltInventory = segmentInventory[i];
-
-    const { representation } = eltInventory.infos;
-    if (
-      eltInventory.status === ChunkStatus.Complete &&
-      representation.decipherable !== false &&
-      representation.isSupported !== false
-    ) {
-      const inventorySegment = eltInventory.infos.segment;
-      const eltInventoryStart = inventorySegment.time / inventorySegment.timescale;
-      const eltInventoryEnd = !inventorySegment.complete
-        ? eltInventory.end
-        : eltInventoryStart + inventorySegment.duration / inventorySegment.timescale;
-      if (
-        (eltInventoryEnd > minEnd && eltInventoryStart < maxStart) ||
-        (eltInventory.end > minEnd && eltInventory.start < maxStart)
-      ) {
-        overlappingChunks.unshift(eltInventory);
-      }
-    }
-  }
-  return overlappingChunks;
 }

--- a/src/core/stream/representation/utils/get_needed_segments.ts
+++ b/src/core/stream/representation/utils/get_needed_segments.ts
@@ -31,6 +31,7 @@ import type {
   IBufferedHistoryEntry,
   IChunkContext,
 } from "../../../segment_sinks";
+import { ChunkStatus } from "../../../segment_sinks/inventory/segment_inventory";
 
 interface IContentContext {
   adaptation: IAdaptation;
@@ -243,7 +244,7 @@ export default function getNeededSegments({
       // periods, we should consider a segment as already downloaded if
       // it is from same period (but can be from different adaptation or
       // representation)
-      if (areFromSamePeriod) {
+      if (completeSeg.status === ChunkStatus.Complete && areFromSamePeriod) {
         const completeSegInfos = completeSeg.infos.segment;
         if (
           time - completeSegInfos.time > -ROUNDING_ERROR &&


### PR DESCRIPTION
While debugging an issue, I noticed that for optimization purposes we filtered already-loaded segments' metadata so we only considered those of the currently-needed time range before giving it to both the `getNeededSegments` function, which lists the segments the RxPlayer needs to download, and the `checkForDiscontinuity` function, which checks if a discontinuity is imminent.

This is problematic since we added the `maxVideoBufferSize` option (so a long time ago!), as that option is also exploited in `getNeededSegments` yet needs to know **ALL** of the buffered segments so it can estimate the amount of video data currently retained by the browser's video buffer - and not just those in the currently-needed range. So it seems that the `maxVideoBufferSize`-linked estimate could have been inexact most of the time here.