### PR TITLE
Fix duplicate segment requests for low-latency contents

### DIFF
--- a/src/core/segment_sinks/inventory/segment_inventory.ts
+++ b/src/core/segment_sinks/inventory/segment_inventory.ts
@@ -33,11 +33,11 @@ export const enum ChunkStatus {
    * fully-loaded and pushed.
    *
    * Once and if the corresponding segment is fully-pushed, its `ChunkStatus`
-   * switches to `Complete`.
+   * switches to `FullyLoaded`.
    */
   PartiallyPushed = 0,
   /** This chunk corresponds to a fully-loaded segment. */
-  Complete = 1,
+  FullyLoaded = 1,
   /**
    * This chunk's push operation failed, in this scenario there is no certitude
    * about the presence of that chunk in the buffer: it may not be present,
@@ -323,9 +323,17 @@ export default class SegmentInventory {
           // those segments are contiguous, we have no way to infer their real
           // end
           if (prevSegment.bufferedEnd === undefined) {
-            prevSegment.bufferedEnd = thisSegment.precizeStart
-              ? thisSegment.start
-              : prevSegment.end;
+            if (thisSegment.precizeStart) {
+              prevSegment.bufferedEnd = thisSegment.start;
+            } else if (prevSegment.infos.segment.complete) {
+              prevSegment.bufferedEnd = prevSegment.end;
+            } else {
+              // We cannot truly trust the anounced end here as the segment was
+              // potentially not complete at its time of announce.
+              // Just assume the next's segment announced start is right - as
+              // `start` is in that scenario more "trustable" than `end`.
+              prevSegment.bufferedEnd = thisSegment.start;
+            }
             log.debug(
               "SI: calculating buffered end of contiguous segment",
               bufferType,
@@ -836,7 +844,8 @@ export default class SegmentInventory {
   }
 
   /**
-   * Indicate that inserted chunks can now be considered as a complete segment.
+   * Indicate that inserted chunks can now be considered as a fully-loaded
+   * segment.
    * Take in argument the same content than what was given to `insertChunk` for
    * the corresponding chunks.
    * @param {Object} content
@@ -890,7 +899,7 @@ export default class SegmentInventory {
           i -= length;
         }
         if (this._inventory[firstI].status === ChunkStatus.PartiallyPushed) {
-          this._inventory[firstI].status = ChunkStatus.Complete;
+          this._inventory[firstI].status = ChunkStatus.FullyLoaded;
         }
         this._inventory[firstI].chunkSize = segmentSize;
         this._inventory[firstI].end = lastEnd;
@@ -966,7 +975,7 @@ export default class SegmentInventory {
 function bufferedStartLooksCoherent(thisSegment: IBufferedChunk): boolean {
   if (
     thisSegment.bufferedStart === undefined ||
-    thisSegment.status !== ChunkStatus.Complete
+    thisSegment.status !== ChunkStatus.FullyLoaded
   ) {
     return false;
   }
@@ -995,7 +1004,8 @@ function bufferedStartLooksCoherent(thisSegment: IBufferedChunk): boolean {
 function bufferedEndLooksCoherent(thisSegment: IBufferedChunk): boolean {
   if (
     thisSegment.bufferedEnd === undefined ||
-    thisSegment.status !== ChunkStatus.Complete
+    !thisSegment.infos.segment.complete ||
+    thisSegment.status !== ChunkStatus.FullyLoaded
   ) {
     return false;
   }
@@ -1177,8 +1187,8 @@ function guessBufferedEndFromRangeEnd(
     log.debug("SI: buffered end is precize end", bufferType, lastSegmentInRange.end);
     lastSegmentInRange.bufferedEnd = lastSegmentInRange.end;
   } else if (
-    rangeEnd - lastSegmentInRange.end <=
-    MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE
+    rangeEnd - lastSegmentInRange.end <= MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE ||
+    !lastSegmentInRange.infos.segment.complete
   ) {
     const now = getMonotonicTimeStamp();
     if (

--- a/src/core/stream/representation/utils/get_needed_segments.ts
+++ b/src/core/stream/representation/utils/get_needed_segments.ts
@@ -182,6 +182,7 @@ export default function getNeededSegments({
   const ROUNDING_ERROR = Math.min(1 / 60, MINIMUM_SEGMENT_SIZE);
   let isBufferFull = false;
   const segmentsOnHold: ISegment[] = [];
+
   const segmentsToLoad = availableSegmentsForRange.filter((segment) => {
     const contentObject = objectAssign({ segment }, content);
 
@@ -221,7 +222,11 @@ export default function getNeededSegments({
         if (oldSegment.time - ROUNDING_ERROR > time) {
           return false;
         }
-        if (oldSegment.end + ROUNDING_ERROR < end) {
+        if (oldSegment.complete) {
+          if (oldSegment.end + ROUNDING_ERROR < end) {
+            return false;
+          }
+        } else if (Math.abs(time - oldSegment.time) > time) {
           return false;
         }
         return !shouldContentBeReplaced(
@@ -244,13 +249,17 @@ export default function getNeededSegments({
       // periods, we should consider a segment as already downloaded if
       // it is from same period (but can be from different adaptation or
       // representation)
-      if (completeSeg.status === ChunkStatus.Complete && areFromSamePeriod) {
+      if (completeSeg.status === ChunkStatus.FullyLoaded && areFromSamePeriod) {
         const completeSegInfos = completeSeg.infos.segment;
-        if (
-          time - completeSegInfos.time > -ROUNDING_ERROR &&
-          completeSegInfos.end - end > -ROUNDING_ERROR
-        ) {
-          return false; // already downloaded
+        if (time - completeSegInfos.time > -ROUNDING_ERROR) {
+          if (completeSegInfos.complete) {
+            if (completeSegInfos.end - end > -ROUNDING_ERROR) {
+              return false; // Same segment's characteristics: already downloaded
+            }
+          } else if (Math.abs(time - completeSegInfos.time) < ROUNDING_ERROR) {
+            // same start (special case for non-complete segments): already downloaded
+            return false;
+          }
         }
       }
     }

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -402,25 +402,8 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
     if (this._index.timeline === null) {
       this._index.timeline = this._getTimeline();
     }
-
-    // destructuring to please TypeScript
-    const {
-      segmentUrlTemplate,
-      startNumber,
-      endNumber,
-      timeline,
-      timescale,
-      indexTimeOffset,
-    } = this._index;
     return getSegmentsFromTimeline(
-      {
-        segmentUrlTemplate,
-        startNumber,
-        endNumber,
-        timeline,
-        timescale,
-        indexTimeOffset,
-      },
+      this._index as typeof this._index & { timeline: IIndexSegment[] },
       from,
       duration,
       this._manifestBoundsCalculator,

--- a/src/parsers/manifest/dash/common/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/common/parse_representation_index.ts
@@ -118,6 +118,14 @@ export default function parseRepresentationIndex(
         (context.availabilityTimeOffset ?? 0);
     }
 
+    if (
+      segmentTemplate.availabilityTimeComplete !== undefined ||
+      context.availabilityTimeComplete !== undefined
+    ) {
+      reprIndexCtxt.availabilityTimeComplete =
+        segmentTemplate.availabilityTimeComplete ?? context.availabilityTimeComplete;
+    }
+
     representationIndex = TimelineRepresentationIndex.isTimelineIndexArgument(
       segmentTemplate,
     )


### PR DESCRIPTION
Based on #1421

## Multiple requests for the same segments for some low-latency contents

This fixes a complex issue that may arise for DASH low-latency contents where the RxPlayer could load multiple times the same segment (usually two times at most and only for the last segment).

In low-latency contents, segments might be anounced in an MPD through `<S>` elements with their duration (`d` attribute) not set to their final value (less than it, e.g. an estimate of what is currently encoded).

Here, the RxPlayer would load that segment, and it would internally announce through its `SegmentSink` module that a segment with the corresponding shorter duration should be pushed to a media buffer.

That `SegmentSink` keeps a `SegmentInventory` listing all segments it thinks are currently buffered by the browser (for various purposes, including detection of segment's automatic garbage-collection). It will here associate the shorter duration to that segment at first (from that point on, it is difficult to determine if that shorter end will be considered as the true segment's end by the `SegmentInventory` or if it will put more trust into the presumably bigger announced buffered time range coming from the buffer, as the algorithm gets quite complex).

Then the RxPlayer will at some point update the MPD, potentially now see the true duration of the segment and either:

  - See that the same segment is already being pushed or has already been loaded and not try to re-load it (scenario 1).

    This is the scenario we always want to follow here.

  - That due to the differences between segment durations before/after the MPD update, we are now considering a different segment than before (scenario 2).

    It seems that this scenario was the most frequent.

  - The `SegmentInventory` could announce that a shorter segment is buffered. The RxPlayer would then think that the older version has been garbage collected (scenario 3).

    This one is only theoretically possible. I fixed it at the same time than the scenario 2 which is the only one I actually observed, so I cannot confirm that this scenario 3 happens.

Here there's multiple fixes to prevent those two last scenarios from happening.

## Parsing issue

First, there was an issue where our parser ignored the `availabilityTimeComplete` attribute when it was on a `<SegmentTemplate>` element at the `<AdaptationSet>` level.
This is the attribute announcing that segments might not be fully available right away - a scenario which was already specifically-handled in the RxPlayer.
This is now fixed.

## Consider non-complete segments of different durations as the same

A second issue was that we still may have relied on the original segment's duration at multiple places for such segments, especially in the `getNeededSegments` function, which is the function listing segments we need to request.
As the duration could have changed in-between MPD updates, that code would think that we're encountering another segment.

To fix it, I now just consider the segment's start (and Representation) to check if this is the same segment - though only if the segment could be considered as non-complete (which is true for the last segment of a `SegmentTimeline` associated to a `availabilityTimeComplete` attribute set to `false`). In other cases, the older logic of checking both the start and duration still stands.

## Better buffered end estimation

Another fix, was to just better evaluate in the `SegmentInventory` the end of non-complete segments, by assuming that they may have a much further end in the buffer than expected. Here also, this update is only set for such non-complete segments.