### PR TITLE
Update how MINIMUM_SEGMENT_SIZE is used in the SegmentInventory

### DIFF
--- a/src/core/segment_sinks/inventory/segment_inventory.ts
+++ b/src/core/segment_sinks/inventory/segment_inventory.ts
@@ -335,7 +335,7 @@ export default class SegmentInventory {
           }
           if (
             nextRangeStart !== undefined &&
-            rangeEnd - thisSegmentStart >= thisSegmentEnd - nextRangeStart
+            rangeEnd - thisSegmentStart < thisSegmentEnd - nextRangeStart
           ) {
             // Ambiguous, but `thisSegment` has more chance to be part of the
             // next range than the current one

--- a/src/core/segment_sinks/inventory/segment_inventory.ts
+++ b/src/core/segment_sinks/inventory/segment_inventory.ts
@@ -221,6 +221,14 @@ export default class SegmentInventory {
     /** Type of buffer considered, used for logs */
     const bufferType: string | undefined = thisSegment?.infos.adaptation.type;
 
+    if (log.hasLevel("DEBUG")) {
+      const prettyPrintedRanges = ranges.map((r) => `${r.start}-${r.end}`).join(",");
+      log.debug(
+        `SI: synchronizing ${bufferType ?? "unknown"} buffered ranges:`,
+        prettyPrintedRanges,
+      );
+    }
+
     const rangesLength = ranges.length;
     for (let i = 0; i < rangesLength; i++) {
       if (thisSegment === undefined) {
@@ -312,12 +320,28 @@ export default class SegmentInventory {
         let thisSegmentStart = thisSegment.bufferedStart ?? thisSegment.start;
         let thisSegmentEnd = thisSegment.bufferedEnd ?? thisSegment.end;
         const nextRangeStart = i < rangesLength - 1 ? ranges[i + 1].start : undefined;
-        while (
-          thisSegment !== undefined &&
-          rangeEnd - thisSegmentStart >= MINIMUM_SEGMENT_SIZE &&
-          (nextRangeStart === undefined ||
-            rangeEnd - thisSegmentStart >= thisSegmentEnd - nextRangeStart)
-        ) {
+        while (thisSegment !== undefined) {
+          if (rangeEnd < thisSegmentStart) {
+            // `thisSegment` is part of the next range
+            break;
+          }
+          if (
+            rangeEnd - thisSegmentStart < MINIMUM_SEGMENT_SIZE &&
+            thisSegmentEnd - rangeEnd >= MINIMUM_SEGMENT_SIZE
+          ) {
+            // Ambiguous, but `thisSegment` seems more to come after the current
+            // range than during it.
+            break;
+          }
+          if (
+            nextRangeStart !== undefined &&
+            rangeEnd - thisSegmentStart >= thisSegmentEnd - nextRangeStart
+          ) {
+            // Ambiguous, but `thisSegment` has more chance to be part of the
+            // next range than the current one
+            break;
+          }
+
           const prevSegment = inventory[inventoryIndex - 1];
 
           // those segments are contiguous, we have no way to infer their real
@@ -353,20 +377,25 @@ export default class SegmentInventory {
     // if we still have segments left, they are not affiliated to any range.
     // They might have been garbage collected, delete them from here.
     if (!isNullOrUndefined(thisSegment)) {
-      log.debug(
-        "SI: last segments have been GCed",
-        bufferType,
-        inventoryIndex,
-        inventory.length,
-      );
-      const removed = inventory.splice(inventoryIndex, inventory.length - inventoryIndex);
-      for (const seg of removed) {
-        if (
-          seg.bufferedStart === undefined &&
-          seg.bufferedEnd === undefined &&
-          seg.status !== ChunkStatus.Failed
-        ) {
-          this._bufferedHistory.addBufferedSegment(seg.infos, null);
+      const { SEGMENT_SYNCHRONIZATION_DELAY } = config.getCurrent();
+      const now = getMonotonicTimeStamp();
+      for (let i = inventoryIndex; i < inventory.length; i++) {
+        const segmentInfo = inventory[i];
+        if (now - segmentInfo.insertionTs >= SEGMENT_SYNCHRONIZATION_DELAY) {
+          log.debug(
+            "SI: A segment at the end has been completely GCed",
+            bufferType,
+            `${segmentInfo.start}-${segmentInfo.end}`,
+          );
+          if (
+            segmentInfo.bufferedStart === undefined &&
+            segmentInfo.bufferedEnd === undefined &&
+            segmentInfo.status !== ChunkStatus.Failed
+          ) {
+            this._bufferedHistory.addBufferedSegment(segmentInfo.infos, null);
+          }
+          inventory.splice(i, 1);
+          i--;
         }
       }
     }

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -652,7 +652,7 @@ const DEFAULT_CONFIG = {
    * this logic could lead to bugs with the current code.
    * @type {Number}
    */
-  MINIMUM_SEGMENT_SIZE: 0.005,
+  MINIMUM_SEGMENT_SIZE: 0.001,
 
   /**
    * Append windows allow to filter media data from segments if they are outside


### PR DESCRIPTION
Fix a rebuffering issue seen since a fix proposed by #1416

The `MINIMUM_SEGMENT_SIZE`
--------------------------

Basically the `MINIMUM_SEGMENT_SIZE` value, which defined a minimum time duration a media segment can have to be considered by the RxPlayer (mainly to prevent some rounding errors in the RxPlayer, though this is far from the only mechanism for that) was also sometimes relied on for "chunks", which is the term the RxPlayer use for the units of media data that will be transmitted to media buffers.

The latter (chunks) can be smaller than the former (segments) in (and only in for now) low-latency scenarios.

Problem with chunks
-------------------

"Chunks" can be much much smaller than "segments" (the unit of media data we actually load from the network through a single HTTP(S) request) and it is very possible for a chunk to be smaller than 5 milliseconds, the original value (before this PR) for `MINIMUM_SEGMENT_SIZE`.

Before the fix proposed by #1416, multiple chunks were generally grouped together before being pushed at once to a buffer (though still as a smaller group than the whole segment) and it seemed those groups always were bigger than `MINIMUM_SEGMENT_SIZE`.

However, the #1416 fix now separates every one of those chunks (this is actually performed at its lowest level, by always considering carefully a `moof` and an `mdat` box for ISOBMFF-compatible containers) which leads to frequently obtaining chunks smaller than the `MINIMUM_SEGMENT_SIZE`.

In turn, due to some processing of the `SegmentInventory` (which lists the chunks believed to be currently buffered by the browser), the RxPlayer would then believe that some of those chunks have been garbage-collected.

For some reasons not yet explored (this gets messy very quickly from there sadly), the RxPlayer first seems to think that it cannot buffer those segments, then any of the following segment, and then enters a rebuffering status for around 20 seconds, before restarting playback as if nothing happened.

This would merit more investigation, but for now I mostly spent time fixing the original `MINIMUM_SEGMENT_SIZE` issue.

The fixes
---------

There's actually three fixes. It gets pretty technical so I guess only people knowing how the RxPlayer's `SegmentInventory` works could decipher this (even I, have issues explaining what I did :p):

  1. Before, we would have considered in the `SegmentInventory` that if a chunk only had less than `MINIMUM_SEGMENT_SIZE` (5 milliseconds originally) from its starting time to the end of the currently-considered contiguous buffered time range (so basically `range.end - chunk.start < MINIMUM_SEGMENT_SIZE`), then it was considered as part of the next range, unless there's no next range in which case it was considered garbage-collected (see fix 3).

     The fix here is to also check if there's more than `MINIMUM_SEGMENT_SIZE` after that same range's end in that scenario.

  2. `MINIMUM_SEGMENT_SIZE` has been updated from 5 milliseconds to 1 millisecond. This has risks but there's risks in both sides and I here noticed an issue due to its value being here "too high", so I chose to lower it for resiliency.

  3. We previously considered in the `SegmentInventory` that chunks that were not associated to any buffered time range (due to the fact that we already found the last chunk associated to the last buffered time range) must have since been garbage-collected.

     It theoretically makes sense, yet we didn't perform a check on their `insertionTs`, a property storing a timestamp of when the chunk has been pushed, and which protects against race condition where the browser wouldn't have yet updated its buffered time range, despite the chunk having been pushed.

     Now we do check that at least `SEGMENT_SYNCHRONIZATION_DELAY` milliseconds have elapsed since a chunk's `insertionTs` before defining if it has been garbage-collected or not.


Note that in the diff, `thisSegment` actually refers to a chunk and not a segment (it would have been too easy if we had the right variable name)