### PR TITLE
fix: safari support audio lang "und" in audioTrack

### DIFF
--- a/src/main_thread/tracks_store/media_element_tracks_store.ts
+++ b/src/main_thread/tracks_store/media_element_tracks_store.ts
@@ -95,20 +95,14 @@ function createAudioTracks(audioTracks: ICompatAudioTrackList): Array<{
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < audioTracks.length; i++) {
     const audioTrack = audioTracks[i];
-    /**
-     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
-     * If a track is announced in the manifest with lang "und", Safari will
-     * incorrectly set `audioTrack.language` with an empty string instead of "und".
-     * To patch this, check if the label is "und".
-     */
-    const language = audioTrack.language || (audioTrack.label === "und" ? "und" : "");
+    const language = audioTrack.language === "" ? "nolang" : audioTrack.language;
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_audio_" + (language || "nolang") + "_" + occurences.toString();
+    const id = "gen_audio_" + language + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
     const track = {
-      language,
+      language: audioTrack.language,
       id,
-      normalized: normalizeLanguage(language),
+      normalized: normalizeLanguage(audioTrack.language),
       audioDescription:
         audioTrack.kind === "descriptions" ||
         // Safari seem to prefer the non-standard singular
@@ -133,15 +127,9 @@ function createTextTracks(
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < textTracks.length; i++) {
     const textTrack = textTracks[i];
-    /**
-     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
-     * If a track is announced in the manifest with lang "und", Safari will
-     * incorrectly set `textTrack.language` with an empty string instead of "und".
-     * To patch this, check if the label is "und".
-     */
-    const language = textTrack.language || (textTrack.label === "und" ? "und" : "");
+    const language = textTrack.language === "" ? "nolang" : textTrack.language;
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_text_" + (language || "nolang") + "_" + occurences.toString();
+    const id = "gen_text_" + language + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
 
     // Safari seems to be indicating that the subtitles track is a forced
@@ -150,11 +138,11 @@ function createTextTracks(
     // @see https://github.com/whatwg/html/issues/4472
     const forced = (textTrack.kind as string) === "forced" ? true : undefined;
     const track = {
-      language,
+      language: textTrack.language,
       forced,
       label: textTrack.label,
       id,
-      normalized: normalizeLanguage(language),
+      normalized: normalizeLanguage(textTrack.language),
       closedCaption: textTrack.kind === "captions",
     };
     newTextTracks.push({ track, nativeTrack: textTrack });
@@ -175,15 +163,9 @@ function createVideoTracks(videoTracks: ICompatVideoTrackList): Array<{
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < videoTracks.length; i++) {
     const videoTrack = videoTracks[i];
-    /**
-     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
-     * If a track is announced in the manifest with lang "und", Safari will
-     * incorrectly set `videoTrack.language` with an empty string instead of "und".
-     * To patch this, check if the label is "und".
-     */
-    const language = videoTrack.language || (videoTrack.label === "und" ? "und" : "");
+    const language = videoTrack.language === "" ? "nolang" : videoTrack.language;
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_video_" + (language || "nolang") + "_" + occurences.toString();
+    const id = "gen_video_" + language + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
     newVideoTracks.push({
       track: { id, representations: [] as IRepresentation[] },

--- a/src/main_thread/tracks_store/media_element_tracks_store.ts
+++ b/src/main_thread/tracks_store/media_element_tracks_store.ts
@@ -95,14 +95,20 @@ function createAudioTracks(audioTracks: ICompatAudioTrackList): Array<{
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < audioTracks.length; i++) {
     const audioTrack = audioTracks[i];
-    const language = audioTrack.language === "" ? "nolang" : audioTrack.language;
+    /**
+     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
+     * If a track is announced in the manifest with lang "und", Safari will
+     * incorrectly set `audioTrack.language` with an empty string instead of "und".
+     * To patch this, check if the label is "und".
+     */
+    const language = audioTrack.language || (audioTrack.label === "und" ? "und" : "");
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_audio_" + language + "_" + occurences.toString();
+    const id = "gen_audio_" + (language || "nolang") + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
     const track = {
-      language: audioTrack.language,
+      language,
       id,
-      normalized: normalizeLanguage(audioTrack.language),
+      normalized: normalizeLanguage(language),
       audioDescription:
         audioTrack.kind === "descriptions" ||
         // Safari seem to prefer the non-standard singular
@@ -127,9 +133,15 @@ function createTextTracks(
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < textTracks.length; i++) {
     const textTrack = textTracks[i];
-    const language = textTrack.language === "" ? "nolang" : textTrack.language;
+    /**
+     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
+     * If a track is announced in the manifest with lang "und", Safari will
+     * incorrectly set `textTrack.language` with an empty string instead of "und".
+     * To patch this, check if the label is "und".
+     */
+    const language = textTrack.language || (textTrack.label === "und" ? "und" : "");
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_text_" + language + "_" + occurences.toString();
+    const id = "gen_text_" + (language || "nolang") + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
 
     // Safari seems to be indicating that the subtitles track is a forced
@@ -138,11 +150,11 @@ function createTextTracks(
     // @see https://github.com/whatwg/html/issues/4472
     const forced = (textTrack.kind as string) === "forced" ? true : undefined;
     const track = {
-      language: textTrack.language,
+      language,
       forced,
       label: textTrack.label,
       id,
-      normalized: normalizeLanguage(textTrack.language),
+      normalized: normalizeLanguage(language),
       closedCaption: textTrack.kind === "captions",
     };
     newTextTracks.push({ track, nativeTrack: textTrack });
@@ -163,9 +175,15 @@ function createVideoTracks(videoTracks: ICompatVideoTrackList): Array<{
   const languagesOccurences: Partial<Record<string, number>> = {};
   for (let i = 0; i < videoTracks.length; i++) {
     const videoTrack = videoTracks[i];
-    const language = videoTrack.language === "" ? "nolang" : videoTrack.language;
+    /**
+     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
+     * If a track is announced in the manifest with lang "und", Safari will
+     * incorrectly set `videoTrack.language` with an empty string instead of "und".
+     * To patch this, check if the label is "und".
+     */
+    const language = videoTrack.language || (videoTrack.label === "und" ? "und" : "");
     const occurences = languagesOccurences[language] ?? 1;
-    const id = "gen_video_" + language + "_" + occurences.toString();
+    const id = "gen_video_" + (language || "nolang") + "_" + occurences.toString();
     languagesOccurences[language] = occurences + 1;
     newVideoTracks.push({
       track: { id, representations: [] as IRepresentation[] },

--- a/src/utils/languages/__tests__/normalize.test.ts
+++ b/src/utils/languages/__tests__/normalize.test.ts
@@ -17,8 +17,8 @@
 import normalizeLanguage, { normalizeAudioTrack, normalizeTextTrack } from "../normalize";
 
 describe("utils - normalizeLanguage", () => {
-  it("should translate an empty string to an empty string", () => {
-    expect(normalizeLanguage("")).toBe("");
+  it("should translate an empty string to an undertemined code", () => {
+    expect(normalizeLanguage("")).toBe("und");
   });
 
   it("should translate ISO639-1 to ISO639-3", () => {
@@ -58,7 +58,7 @@ describe("utils - normalizeAudioTrack", () => {
     expect(normalizeAudioTrack("")).toEqual({
       language: "",
       audioDescription: false,
-      normalized: "",
+      normalized: "und",
     });
   });
 
@@ -217,7 +217,7 @@ describe("utils - normalizeTextTrack", () => {
     expect(normalizeTextTrack("")).toEqual({
       language: "",
       closedCaption: false,
-      normalized: "",
+      normalized: "und",
     });
   });
 

--- a/src/utils/languages/__tests__/normalize.test.ts
+++ b/src/utils/languages/__tests__/normalize.test.ts
@@ -17,7 +17,7 @@
 import normalizeLanguage, { normalizeAudioTrack, normalizeTextTrack } from "../normalize";
 
 describe("utils - normalizeLanguage", () => {
-  it("should translate an empty string to an undertemined code", () => {
+  it("should translate an empty string to an undetermined code", () => {
     expect(normalizeLanguage("")).toBe("und");
   });
 

--- a/src/utils/languages/normalize.ts
+++ b/src/utils/languages/normalize.ts
@@ -51,7 +51,10 @@ interface INormalizedTextTrackObject extends IMinimalTextTrackObject {
  */
 function normalizeLanguage(_language: string): string {
   if (isNullOrUndefined(_language) || _language === "") {
-    return "";
+    /**
+     * "und" is a special value in ISO 639-3 that stands for "undetermined language".
+     */
+    return "und";
   }
   const fields = ("" + _language).toLowerCase().split("-");
   const base = fields[0];


### PR DESCRIPTION
`"und"` is a special value in ISO 639-3 that stands for "undetermined language"

In HLS with Safari, if the lang `"und"`  is provided in the HLS manifest
Safari will set `audioTrack.language` to `""` because `"und"` does not seems to be recognised as a lang for safari. 
This commit patch this behavior by changing lang to `"und"` if the lang is `""` and label is `"und"`.