### PR TITLE
fix(DRM): keys missing in the license marked as decipherable

### DIFF
--- a/src/main_thread/decrypt/__tests__/__global__/content_decryptor.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/content_decryptor.test.ts
@@ -1,5 +1,7 @@
 import { describe, beforeEach, it, expect, vi } from "vitest";
-import { getMissingKeyIds } from "../../content_decryptor";
+import { getKeyIdsLinkedToSession, getMissingKeyIds } from "../../content_decryptor";
+import InitDataValuesContainer from "../../utils/init_data_values_container";
+import KeySessionRecord from "../../utils/key_session_record";
 
 describe("content_decryptor - blacklist missing key Ids", () => {
   beforeEach(() => {
@@ -41,5 +43,64 @@ describe("content_decryptor - blacklist missing key Ids", () => {
     const actualKeyIds = [new Uint8Array([1]), new Uint8Array([3])]; // Missing [2] and [4]
     const result = getMissingKeyIds(expectedKeyIds, actualKeyIds);
     expect(result).toEqual([new Uint8Array([2]), new Uint8Array([4])]);
+  });
+});
+
+describe("content_decryptor - getKeyIdsLinkedToSession", () => {
+  it("should return the whitelisted and blacklisted depending if keys are usable or not", () => {
+    const initDataValues = new InitDataValuesContainer([
+      {
+        systemId: "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" /* Widevine */,
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ]);
+
+    const keySessionRecord = new KeySessionRecord({
+      type: "cenc",
+      values: initDataValues,
+    });
+    const { whitelisted, blacklisted } = getKeyIdsLinkedToSession(
+      /* InitData */ {
+        type: "cenc",
+        values: initDataValues,
+      },
+      /* KeySessionRecord */ keySessionRecord,
+      /* SingleLicensePer */ "init-data",
+      /* isCurrentLicense */ true,
+      /* usableKeys */ [new Uint8Array([1]), new Uint8Array([2])],
+      /* unusableKeys */ [new Uint8Array([3])],
+    );
+
+    expect(whitelisted).toStrictEqual([new Uint8Array([1]), new Uint8Array([2])]);
+    expect(blacklisted).toStrictEqual([new Uint8Array([3])]);
+  });
+
+  it("should have 1 blacklisted keyIds because it's in the initData but it's not in the usableKeys list", () => {
+    const initDataValues = new InitDataValuesContainer([
+      {
+        systemId: "edef8ba9-79d6-4ace-a3c8-27dcd51d21ed" /* Widevine */,
+        data: new Uint8Array([1, 2, 3]),
+      },
+    ]);
+
+    const keySessionRecord = new KeySessionRecord({
+      type: "cenc",
+      values: initDataValues,
+    });
+    const { whitelisted, blacklisted } = getKeyIdsLinkedToSession(
+      /* InitData */ {
+        type: "cenc",
+        values: initDataValues,
+        keyIds: [new Uint8Array([1]), new Uint8Array([2]), new Uint8Array([3])],
+      },
+      /* KeySessionRecord */ keySessionRecord,
+      /* SingleLicensePer */ "init-data",
+      /* isCurrentLicense */ true,
+      /* usableKeys */ [new Uint8Array([1]), new Uint8Array([2])],
+      /* unusableKeys */ [],
+    );
+
+    expect(whitelisted).toStrictEqual([new Uint8Array([1]), new Uint8Array([2])]);
+    expect(blacklisted).toStrictEqual([new Uint8Array([3])]); // KeyId 3 is not in usableKeys list
   });
 });

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -1015,26 +1015,15 @@ function getKeyIdsLinkedToSession(
   const missingKnownKeyIds = getMissingKnownKeyIds(keySessionRecord, keyIdsInLicense);
   const associatedKeyIds = keyIdsInLicense.concat(missingKnownKeyIds);
 
-  if (singleLicensePer !== undefined && singleLicensePer !== "init-data") {
-    // We want to add the current key ids in the blacklist if it is
-    // not already there.
-    //
-    // We only do that when `singleLicensePer` is set to something
-    // else than the default `"init-data"` because this logic:
-    //   1. might result in a quality fallback, which is a v3.x.x
-    //      breaking change if some APIs (like `singleLicensePer`)
-    //      aren't used.
-    //   2. Rely on the EME spec regarding key statuses being well
-    //      implemented on all supported devices, which we're not
-    //      sure yet. Because in any other `singleLicensePer`, we
-    //      need a good implementation anyway, it doesn't matter
-    //      there.
-    const missingInitDataKeyIds = getMissingInitDataKeyIds(
-      initializationData,
-      associatedKeyIds,
-    );
-    associatedKeyIds.push(...missingInitDataKeyIds);
+  // key that are missing from the license but present on the init data are
+  // considered as non-usable and are blacklisted.
+  const missingInitDataKeyIds = getMissingInitDataKeyIds(
+    initializationData,
+    associatedKeyIds,
+  );
+  associatedKeyIds.push(...missingInitDataKeyIds);
 
+  if (singleLicensePer !== undefined && singleLicensePer !== "init-data") {
     const { content } = initializationData;
     if (isCurrentLicense && content !== undefined) {
       if (singleLicensePer === "content") {

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -998,7 +998,7 @@ export function getMissingInitDataKeyIds(
  *   - `blacklisted`: Array of key ids for keys that are considered unusable.
  *     The qualities linked to those keys should not be played.
  */
-function getKeyIdsLinkedToSession(
+export function getKeyIdsLinkedToSession(
   initializationData: IProcessedProtectionData,
   keySessionRecord: KeySessionRecord,
   singleLicensePer: undefined | "init-data" | "content" | "periods",


### PR DESCRIPTION
Previously, even if certain keys were missing from a license, the representation was still marked as decipherable. This commit change this behavior to require explicit inclusion of keys in the license for the representation to be considered decipherable.

Relates to https://github.com/canalplus/rx-player/issues/1427