### PR TITLE
add log to provide hint in debugging if serverCertificate was unintentionally omitted.

### DIFF
--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -105,6 +105,10 @@ export default function SessionEventsListener(
         : "license-request";
 
       log.info(`DRM: Received message event, type ${messageType}`, session.sessionId);
+      if(message.byteLength <= 4) {
+        log.warn(`DRM: License challenge seems anormaly short, length is: ${message.byteLength}.
+        MediaKeySession should probably have added a certificate with "setServerCertificate".`)
+      }
 
       const backoffOptions = getLicenseBackoffOptions(getLicenseConfig.retry);
       retryPromiseWithBackoff(


### PR DESCRIPTION
…

When using a keySystem that needs a serverCertificate, if by mistake user forgot to set the `serverCertificate` options, the CDM is still able to create a challenge but such a challenge will be too short (2 bytes on widevine) and the license request will be refused by the license server upon received that unsuitable challenge.

Usually theses challenge are much longer.
This commit add a log warning if the challenged is considered too short to be suitable. This log warning intent is to help debugging someone that has unintentionally omitted to set the `serverCertficate` options.