### PR TITLE
[Proposal] On the PlayStation 4, update the tfdt instead of using timestampOffset

### DIFF
--- a/src/compat/append_buffer_with_offset.ts
+++ b/src/compat/append_buffer_with_offset.ts
@@ -1,0 +1,150 @@
+import log from "../log";
+import { getMDHDTimescale, hasInitSegment } from "../parsers/containers/isobmff";
+import {
+  getTrackFragmentDecodeTime,
+  setTrackFragmentDecodeTime,
+} from "../parsers/containers/isobmff/utils";
+import canRelyOnMseTimestampOffset from "./can_rely_on_mse_timestamp_offset";
+
+const sourceBufferInitTimescale = new WeakMap<SourceBuffer, number | undefined>();
+
+/**
+ * Append media or initialization segment (represented by `data`) to the given
+ * SourceBuffer (represented by `sourceBuffer`), with the given
+ * `timestampOffset` in seconds.
+ *
+ * Setting `timestampOffset` to `undefined`, means that we won't try to update
+ * one that may already (or may not) be present.
+ *
+ * @param {SourceBuffer} sourceBuffer
+ * @param {BufferSource} data
+ * @param {number|undefined} timestampOffset
+ */
+export default function appendBufferWithOffset(
+  sourceBuffer: SourceBuffer,
+  data: BufferSource,
+  timestampOffset: number | undefined,
+): void {
+  if (!canRelyOnMseTimestampOffset) {
+    return appendBufferWithoutTimestampOffsetCapabilities(
+      sourceBuffer,
+      data,
+      timestampOffset,
+    );
+  }
+  return appendBufferWithTimestampOffsetCapabilities(sourceBuffer, data, timestampOffset);
+}
+
+/**
+ * Append media or initialization segment (represented by `data`) to the given
+ * SourceBuffer (represented by `sourceBuffer`), with the given
+ * `timestampOffset` in seconds for devices where the MSE `timestampOffset`
+ * attribute **CAN** be used.
+ *
+ * @param {SourceBuffer} sourceBuffer
+ * @param {BufferSource} data
+ * @param {number|undefined} timestampOffset
+ */
+function appendBufferWithTimestampOffsetCapabilities(
+  sourceBuffer: SourceBuffer,
+  data: BufferSource,
+  timestampOffset: number | undefined,
+): void {
+  if (timestampOffset !== undefined && sourceBuffer.timestampOffset !== timestampOffset) {
+    const newTimestampOffset = timestampOffset;
+    log.debug(
+      "SBI: updating timestampOffset",
+      sourceBuffer.timestampOffset,
+      newTimestampOffset,
+    );
+    sourceBuffer.timestampOffset = newTimestampOffset;
+  }
+
+  sourceBuffer.appendBuffer(data);
+}
+
+/**
+ * Append media or initialization segment (represented by `data`) to the given
+ * SourceBuffer (represented by `sourceBuffer`), with the given
+ * `timestampOffset` in seconds for devices where the MSE `timestampOffset`
+ * attribute **CANNOT** be used.
+ *
+ * @param {SourceBuffer} sourceBuffer
+ * @param {BufferSource} data
+ * @param {number|undefined} timestampOffset
+ */
+function appendBufferWithoutTimestampOffsetCapabilities(
+  sourceBuffer: SourceBuffer,
+  data: BufferSource,
+  timestampOffset: number | undefined,
+): void {
+  const dataU8 = toUint8Array(data);
+
+  // TODO also for WebM
+  const isMp4InitSegment = hasInitSegment(dataU8);
+  if (isMp4InitSegment) {
+    const mdhdTimeScale = getMDHDTimescale(dataU8);
+    // TODO We're not resetting it when the SourceBuffer's `abort method is
+    // called, yet the browser IS forgetting about that init segment in that
+    // case, we may want to properly account for that.
+    //
+    // However, this should in all scenarios I can think of not be an issue
+    // because initialization segments should have to be pushed before mp4 media
+    // segments, so there's few actual chance that this value isn't synchronized
+    // with what it should be.
+    sourceBufferInitTimescale.set(sourceBuffer, mdhdTimeScale);
+  }
+
+  if (timestampOffset !== 0 && timestampOffset !== undefined) {
+    const initTimescale = sourceBufferInitTimescale.get(sourceBuffer);
+    if (initTimescale === undefined) {
+      log.warn("Compat: not able to mutate decode time due to unknown timescale");
+      return appendBufferWithTimestampOffsetCapabilities(
+        sourceBuffer,
+        data,
+        timestampOffset,
+      );
+    }
+    const oldTrackFragmentDecodeTime = getTrackFragmentDecodeTime(dataU8);
+    if (oldTrackFragmentDecodeTime === undefined) {
+      log.warn("Compat: not able to mutate decode time due to not found tfdt");
+      return appendBufferWithTimestampOffsetCapabilities(
+        sourceBuffer,
+        data,
+        timestampOffset,
+      );
+    }
+
+    const timescaledOffset = initTimescale * timestampOffset;
+    const newTrackFragmentDecodeTime = oldTrackFragmentDecodeTime + timescaledOffset;
+    log.debug(
+      "Compat: Trying to update decode time",
+      oldTrackFragmentDecodeTime,
+      newTrackFragmentDecodeTime,
+    );
+    if (!setTrackFragmentDecodeTime(dataU8, newTrackFragmentDecodeTime)) {
+      log.warn("Compat: not able to mutate decode time due to another reason");
+      return appendBufferWithTimestampOffsetCapabilities(
+        sourceBuffer,
+        data,
+        timestampOffset,
+      );
+    }
+  }
+  sourceBuffer.appendBuffer(dataU8);
+}
+
+/**
+ * Convert unknown BufferSource type value into an Uint8Array.
+ * @param {BufferSource} data
+ * @returns {Uint8Array}
+ */
+function toUint8Array(data: BufferSource): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
+  } else if (data instanceof ArrayBuffer) {
+    return new Uint8Array(data);
+  } else {
+    return new Uint8Array(data.buffer);
+  }
+}

--- a/src/compat/can_rely_on_mse_timestamp_offset.ts
+++ b/src/compat/can_rely_on_mse_timestamp_offset.ts
@@ -1,0 +1,17 @@
+import { isPlayStation4 } from "./browser_detection";
+
+/**
+ * Some devices do not support the `timestampOffset` SourceBuffer attribute
+ * properly:
+ *
+ *   - On the PlayStation 4, at least at date 2024-04-10, mutating the
+ *     `timestampOffset` seems to properly append the media data at the right
+ *     timestamp when interrogating both the `SourceBuffer`s and the
+ *     `HTMLMediaElement`'s `buffered` property, but playback is not able to
+ *     start.
+ *
+ * When this value is false, we may want to use another trick to offset media
+ * segments such as updating it their metadata at the container level.
+ */
+const canRelyOnMseTimestampOffset = !isPlayStation4;
+export default canRelyOnMseTimestampOffset;

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -1,3 +1,4 @@
+import appendBufferWithOffset from "../compat/append_buffer_with_offset";
 import { MediaSource_ } from "../compat/browser_compatibility_types";
 import tryToChangeSourceBufferType from "../compat/change_source_buffer_type";
 import { onSourceClose, onSourceEnded, onSourceOpen } from "../compat/event_listeners";
@@ -500,20 +501,6 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       }
     }
 
-    if (
-      timestampOffset !== undefined &&
-      sourceBuffer.timestampOffset !== timestampOffset
-    ) {
-      const newTimestampOffset = timestampOffset;
-      log.debug(
-        "SBI: updating timestampOffset",
-        codec,
-        sourceBuffer.timestampOffset,
-        newTimestampOffset,
-      );
-      sourceBuffer.timestampOffset = newTimestampOffset;
-    }
-
     if (appendWindow[0] === undefined) {
       if (sourceBuffer.appendWindowStart > 0) {
         log.debug("SBI: re-setting `appendWindowStart` to `0`");
@@ -539,7 +526,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       sourceBuffer.appendWindowEnd = appendWindow[1];
     }
     log.debug("SBI: pushing segment", this.type);
-    sourceBuffer.appendBuffer(data);
+    appendBufferWithOffset(sourceBuffer, data, timestampOffset);
   }
 }
 

--- a/src/parsers/containers/isobmff/index.ts
+++ b/src/parsers/containers/isobmff/index.ts
@@ -33,6 +33,7 @@ export {
   getTrackFragmentDecodeTime,
   getDurationFromTrun,
   getSegmentsFromSidx,
+  hasInitSegment,
   IEMSG,
   ISidxSegment,
   patchPssh,

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -30,6 +30,7 @@ import { hexToBytes, readNullTerminatedString } from "../../../utils/string_pars
 import { MAX_32_BIT_INT } from "./constants";
 import { createBox } from "./create_box";
 import { getPlayReadyKIDFromPrivateData } from "./drm";
+import findCompleteBox from "./find_complete_box";
 import { getBoxContent, getBoxOffsets, getChildBox } from "./get_box";
 import { getEMSG, getMDIA, getTRAF, getTRAFs } from "./read";
 
@@ -192,6 +193,46 @@ function getTrackFragmentDecodeTime(buffer: Uint8Array): number | undefined {
     return be4toi(tfdt, 4);
   }
   return undefined;
+}
+
+/**
+ * Update track Fragment Decode Time of a segment, if found.
+ * Returns `true` if it could have been updated and `false` if not.
+ * @param {Uint8Array} buffer
+ * @param {number} time
+ * @returns {boolean}
+ */
+function setTrackFragmentDecodeTime(buffer: Uint8Array, time: number): boolean {
+  const traf = getTRAF(buffer);
+  if (traf === null) {
+    return false;
+  }
+  const tfdt = getBoxContent(traf, 0x74666474 /* tfdt */);
+  if (tfdt === null) {
+    return false;
+  }
+  const version = tfdt[0];
+  if (version === 1) {
+    const newTfdt = itobe8(time);
+    tfdt[4] = newTfdt[0];
+    tfdt[5] = newTfdt[1];
+    tfdt[6] = newTfdt[2];
+    tfdt[7] = newTfdt[3];
+    tfdt[8] = newTfdt[4];
+    tfdt[9] = newTfdt[5];
+    tfdt[10] = newTfdt[6];
+    tfdt[11] = newTfdt[7];
+    return true;
+  }
+  if (version === 0) {
+    const newTfdt = itobe4(time);
+    tfdt[4] = newTfdt[0];
+    tfdt[5] = newTfdt[1];
+    tfdt[6] = newTfdt[2];
+    tfdt[7] = newTfdt[3];
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -561,6 +602,26 @@ function getKeyIdFromInitSegment(segment: Uint8Array): Uint8Array | null {
   return tenc.subarray(8, 24);
 }
 
+/**
+ * Returns `true` if the given `buffer` probably contains an initialization
+ * segment in the ISOBMFF format.
+ * Returns `false` otherwise.
+ *
+ * @param {Uint8Array} buffer
+ * @returns {boolean}
+ */
+function hasInitSegment(buffer: Uint8Array): boolean {
+  const ftypIndex = findCompleteBox(buffer, 0x66747970 /* ftyp */);
+  if (ftypIndex < 0) {
+    return false;
+  }
+  const moovIndex = findCompleteBox(buffer, 0x6d6f6f76 /* moov */);
+  if (moovIndex < 0) {
+    return false;
+  }
+  return true;
+}
+
 export {
   getKeyIdFromInitSegment,
   getMDHDTimescale,
@@ -568,7 +629,9 @@ export {
   getTrackFragmentDecodeTime,
   getDurationFromTrun,
   getSegmentsFromSidx,
+  hasInitSegment,
   patchPssh,
+  setTrackFragmentDecodeTime,
   updateBoxLength,
   parseEmsgBoxes,
 };


### PR DESCRIPTION
The issue
---------

We recently noticed that the PlayStation 4's browser had issues with the MSE `timestampOffset` `SourceBuffer` attribute, which allows to add an offset to pushed media segments relative to their "regular" starting timestamp.

More specifically, it seemed to properly append the media data at the right timestamp when interrogating both the `SourceBuffer`s and the `HTMLMediaElement`'s `buffered` property, but playback was not able to start.

To work-around it, we noticed that updating instead the starting timestamp at the container level (e.g. on the pushed mp4 files directly) did have the expected result.

This proposal
-------------

Here I propose to add compatibility code at the level of the `SourceBuffer.appendBuffer` MSE API, which allows to push segments.

Here, a new `appendBufferWithOffset` function would be able to check, based on device-detection (usually through the user agent), whether the timestamp should be added by relying on the `timestampOffset` attribute (on all devices except the PlayStation 4, and even on the PlayStation 4 if the container file is not recognized, see below) or by patching the container file (only on the PlayStation 4 on recognized container formats).

This is not as straightforward as it first may seem, because to patch mp4 media segments, we need to rely on a timescale value (as the corresponding `trackFragmentDecodeTime` is always stored as an integer in ISOBMFF) which is announced in the initialization segment - meaning there's the need for some state. It could be done in several ways (a class, a value stored by the caller etc.), but for now I opted for a WeakMap-based solution (which maps each `SourceBuffer` to its corresponding timescale).

This solution isn't the simplest one to understand as is but allows to just isolate the complexity to the compat files, which I judged more readable.

Limitations
-----------

There are several limitations with the current implementation:

  - Theoretically, it is possible in MSE to tell the browser to basically "forget" about the last initialization segment pushed, through the `SourceBuffer.abort` method.

    If we wanted to be thorough, we should probably also remove all memory about the last init segment's timescale stored on that SourceBuffer.

    I However didn't do that because it wasn't easy to do so, and in all real scenarios I could think of there was none where this could be an issue (famous last words).

  - For now in that proposal, I only parse ISOBMFF files (basically MP4 files).

    We may be able to do the same thing for webm/mkv files with few efforts, to check.

    For all scenarios where we don't recognize the container, we fallback to using the MSE `SourceBuffer.timestampOffset` attribute as a last resort.

  - There may be rounding error at some point, or even when factoring in the timescale. In observed scenarios, this did not lead to problematic scenarios on devices for now.

  - It adds a lot of code.

    Note that we also have a SourceBuffer patch specific to old webkit devices (among which maybe the PlayStation 4 :D, I did not check that but it would be kind of funny), that actually monkey-patches the `WebkitSourceBuffer` native class (this is the only ugly instance of a monkey patch in the RxPlayer codebase).

    I though about merging the two into a single cleaner work-around but I was both too lazy for now and afraid to break things for only a proposal, so I did not do so yet.