### PR TITLE
Fix memory tests on Chrome 124

### DIFF
--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -73,7 +73,7 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(6 * 60 * 1000);
+    this.timeout(10 * 60 * 1000);
     player = new RxPlayer({
       initialVideoBitrate: Infinity,
       initialAudiobitrate: Infinity,
@@ -119,11 +119,10 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(5 * 60 * 1000);
+    this.timeout(10 * 60 * 1000);
     window.gc();
     await sleep(5000);
     const initialMemory = window.performance.memory;
-    this.timeout(5 * 60 * 1000);
     for (let i = 0; i < 100000; i++) {
       player = new RxPlayer({
         initialVideoBitrate: Infinity,

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -109,7 +109,7 @@ describe("Memory tests", () => {
     expect(heapDifference).to.be.below(7e6);
   });
 
-  it("should not have a sensible memory leak after 100000 instances of the RxPlayer", async function () {
+  it("should not have a sensible memory leak after 50000 instances of the RxPlayer", async function () {
     if (
       window.performance == null ||
       window.performance.memory == null ||
@@ -123,7 +123,7 @@ describe("Memory tests", () => {
     window.gc();
     await sleep(5000);
     const initialMemory = window.performance.memory;
-    for (let i = 0; i < 100000; i++) {
+    for (let i = 0; i < 50000; i++) {
       player = new RxPlayer({
         initialVideoBitrate: Infinity,
         initialAudiobitrate: Infinity,
@@ -150,7 +150,7 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-    expect(heapDifference).to.be.below(4e6);
+    expect(heapDifference).to.be.below(3e6);
   });
 
   it("should not have a sensible memory leak after many video quality switches", async function () {

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -139,7 +139,7 @@ describe("Memory tests", () => {
     }
     await sleep(5000);
     window.gc();
-    await sleep(15000);
+    await sleep(70000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -34,7 +34,7 @@ describe("Memory tests", () => {
       initialAudioBitrate: Infinity,
     });
     window.gc();
-    await sleep(1000);
+    await sleep(5000);
     const initialMemory = window.performance.memory;
 
     player.loadVideo({
@@ -48,7 +48,7 @@ describe("Memory tests", () => {
     player.stop();
     await sleep(100);
     window.gc();
-    await sleep(1000);
+    await sleep(5000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -72,13 +72,14 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(5 * 60 * 1000);
+    this.timeout(6 * 60 * 1000);
     player = new RxPlayer({
       initialVideoBitrate: Infinity,
       initialAudiobitrate: Infinity,
     });
-    window.gc();
     await sleep(1000);
+    window.gc();
+    await sleep(5000);
     const initialMemory = window.performance.memory;
 
     for (let i = 0; i < 1000; i++) {
@@ -91,9 +92,9 @@ describe("Memory tests", () => {
     }
     player.stop();
 
-    await sleep(100);
+    await sleep(5000);
     window.gc();
-    await sleep(1000);
+    await sleep(15000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -117,8 +118,9 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
+    this.timeout(5 * 60 * 1000);
     window.gc();
-    await sleep(1000);
+    await sleep(5000);
     const initialMemory = window.performance.memory;
     this.timeout(5 * 60 * 1000);
     for (let i = 0; i < 1000; i++) {
@@ -135,9 +137,9 @@ describe("Memory tests", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       player.dispose();
     }
-    await sleep(100);
-    window.gc();
     await sleep(1000);
+    window.gc();
+    await sleep(20000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -186,6 +188,7 @@ describe("Memory tests", () => {
     await sleep(1000);
 
     window.gc();
+    await sleep(5000);
     const initialMemory = window.performance.memory;
 
     // Allows to alternate between two positions
@@ -202,7 +205,7 @@ describe("Memory tests", () => {
       await sleep(1000);
     }
     window.gc();
-    await sleep(1000);
+    await sleep(5000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -234,8 +237,9 @@ describe("Memory tests", () => {
     const vtlVideoElement = document.createElement("video");
     VideoThumbnailLoader.addLoader(DASH_LOADER);
     const videoThumbnailLoader = new VideoThumbnailLoader(vtlVideoElement, player);
-
+    await sleep(1000);
     window.gc();
+    await sleep(10000);
     const initialMemory = window.performance.memory;
 
     player.loadVideo({
@@ -253,7 +257,7 @@ describe("Memory tests", () => {
     videoThumbnailLoader.dispose();
     await sleep(1000);
     window.gc();
-    await sleep(500);
+    await sleep(15000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -29,7 +29,7 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(5 * 60 * 1000);
+    this.timeout(15 * 60 * 1000);
     player = new RxPlayer({
       initialVideoBitrate: Infinity,
       initialAudioBitrate: Infinity,
@@ -119,7 +119,7 @@ describe("Memory tests", () => {
       console.warn("API not available. Skipping test.");
       return;
     }
-    this.timeout(10 * 60 * 1000);
+    this.timeout(15 * 60 * 1000);
     window.gc();
     await sleep(5000);
     const initialMemory = window.performance.memory;

--- a/tests/memory/index.js
+++ b/tests/memory/index.js
@@ -15,6 +15,7 @@ describe("Memory tests", () => {
   afterEach(() => {
     if (player != null) {
       player.dispose();
+      window.gc();
     }
   });
 
@@ -46,9 +47,9 @@ describe("Memory tests", () => {
     await waitForPlayerState(player, "ENDED");
 
     player.stop();
-    await sleep(100);
-    window.gc();
     await sleep(5000);
+    window.gc();
+    await sleep(10000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -59,10 +60,10 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-    expect(heapDifference).to.be.below(1.5e6);
+    expect(heapDifference).to.be.below(2e6);
   });
 
-  it("should not have a sensible memory leak after 1000 LOADED states and adaptive streaming", async function () {
+  it("should not have a sensible memory leak after 5000 LOADED states and adaptive streaming", async function () {
     if (
       window.performance == null ||
       window.performance.memory == null ||
@@ -82,7 +83,7 @@ describe("Memory tests", () => {
     await sleep(5000);
     const initialMemory = window.performance.memory;
 
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 5000; i++) {
       player.loadVideo({
         url: manifestInfos.url,
         transport: manifestInfos.transport,
@@ -105,10 +106,10 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-    expect(heapDifference).to.be.below(3e6);
+    expect(heapDifference).to.be.below(7e6);
   });
 
-  it("should not have a sensible memory leak after 1000 instances of the RxPlayer", async function () {
+  it("should not have a sensible memory leak after 100000 instances of the RxPlayer", async function () {
     if (
       window.performance == null ||
       window.performance.memory == null ||
@@ -123,7 +124,7 @@ describe("Memory tests", () => {
     await sleep(5000);
     const initialMemory = window.performance.memory;
     this.timeout(5 * 60 * 1000);
-    for (let i = 0; i < 1000; i++) {
+    for (let i = 0; i < 100000; i++) {
       player = new RxPlayer({
         initialVideoBitrate: Infinity,
         initialAudiobitrate: Infinity,
@@ -137,9 +138,9 @@ describe("Memory tests", () => {
       await waitForLoadedStateAfterLoadVideo(player);
       player.dispose();
     }
-    await sleep(1000);
+    await sleep(5000);
     window.gc();
-    await sleep(20000);
+    await sleep(15000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -185,7 +186,7 @@ describe("Memory tests", () => {
         "Not enough video Representations to perform sufficiently pertinent tests",
       );
     }
-    await sleep(1000);
+    await sleep(5000);
 
     window.gc();
     await sleep(5000);
@@ -204,8 +205,9 @@ describe("Memory tests", () => {
       player.lockVideoRepresentations([videoTrack.representations[repIdx].id]);
       await sleep(1000);
     }
-    window.gc();
     await sleep(5000);
+    window.gc();
+    await sleep(10000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 
@@ -255,9 +257,9 @@ describe("Memory tests", () => {
 
     player.stop();
     videoThumbnailLoader.dispose();
-    await sleep(1000);
+    await sleep(5000);
     window.gc();
-    await sleep(15000);
+    await sleep(10000);
     const newMemory = window.performance.memory;
     const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
 

--- a/tests/memory/run.mjs
+++ b/tests/memory/run.mjs
@@ -39,7 +39,7 @@ const webpackConfig = generateTestWebpackConfig({
 
 const karmaConf = {
   basePath: "",
-  browserNoActivityTimeout: 10 * 60 * 1000,
+  browserNoActivityTimeout: 30 * 60 * 1000,
   browsers,
   customLaunchers: {
     ChromeMemory: {


### PR DESCRIPTION
Our memory tests (which check for memory leaks) are failing since Chrome 124.

It seems that the issue is not memory leaks on our part but changes in the way Chrome performs its garbage collection, especially after the `gc` global function (it exposes it only if the `--js-flags="--expose-gc"` chrome flag is used when running) is called to manually trigger it.

Awaiting several seconds after that call seems to improve measures by a lot (tens of MB being collected), though not every tests seems to pass yet, so that may not be the only change we'll need to do.