### PR TITLE
Fix path resolve not works correct

### DIFF
--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -27,19 +27,19 @@ describe("utils - resolveURL", () => {
     expect(resolveURL("http://toto.com/a"))
       .toBe("http://toto.com/a");
     expect(resolveURL("http://toto.com/a", "b/c/d/", "g.a"))
-      .toBe("http://toto.com/a/b/c/d/g.a");
+      .toBe("http://toto.com/b/c/d/g.a");
   });
 
   it("should ignore empty strings when concatenating multiple URLs", () => {
     expect(resolveURL("", "http://toto.com/a", ""))
       .toBe("http://toto.com/a");
     expect(resolveURL("http://toto.com/a", "b/c/d/", "", "g.a"))
-      .toBe("http://toto.com/a/b/c/d/g.a");
+      .toBe("http://toto.com/b/c/d/g.a");
   });
 
   it("should remove a leading slash if one", () => {
     expect(resolveURL("http://toto.com/a", "/b/c/d/", "/", "/g.a"))
-      .toBe("http://toto.com/a/b/c/d/g.a");
+      .toBe("http://toto.com/g.a");
   });
 
   it("should reset the concatenation if a given string contains a scheme", () => {
@@ -49,20 +49,20 @@ describe("utils - resolveURL", () => {
 
   it("should have a - fairly simple - algorithm to simplify parent directories", () => {
     expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../a"))
-      .toBe("torrent://g.a/b/c/a");
+      .toBe("torrent://g.a/b/a");
     expect(
       resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/../../a")
-    ).toBe("torrent://g.a/b/a");
+    ).toBe("torrent://g.a/a");
   });
 
   /* eslint-disable max-len */
   it("should have a - fairly simple - algorithm to simplify the current directory", () => {
   /* eslint-enable max-len */
     expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "./a"))
-      .toBe("torrent://g.a/b/c/d/a");
+      .toBe("torrent://g.a/b/c/a");
     expect(
       resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/.././a")
-    ).toBe("torrent://g.a/b/c/a");
+    ).toBe("torrent://g.a/b/a");
   });
 });
 

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -27,14 +27,14 @@ describe("utils - resolveURL", () => {
     expect(resolveURL("http://toto.com/a"))
       .toBe("http://toto.com/a");
     expect(resolveURL("http://toto.com/a", "b/c/d/", "g.a"))
-      .toBe("http://toto.com/b/c/d/g.a");
+      .toBe("http://toto.com/a/b/c/d/g.a");
   });
 
   it("should ignore empty strings when concatenating multiple URLs", () => {
     expect(resolveURL("", "http://toto.com/a", ""))
       .toBe("http://toto.com/a");
     expect(resolveURL("http://toto.com/a", "b/c/d/", "", "g.a"))
-      .toBe("http://toto.com/b/c/d/g.a");
+      .toBe("http://toto.com/a/b/c/d/g.a");
   });
 
   it("should remove a leading slash if one", () => {
@@ -49,20 +49,20 @@ describe("utils - resolveURL", () => {
 
   it("should have a - fairly simple - algorithm to simplify parent directories", () => {
     expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../a"))
-      .toBe("torrent://g.a/b/a");
+      .toBe("torrent://g.a/b/c/a");
     expect(
       resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/../../a")
-    ).toBe("torrent://g.a/a");
+    ).toBe("torrent://g.a/b/a");
   });
 
   /* eslint-disable max-len */
   it("should have a - fairly simple - algorithm to simplify the current directory", () => {
   /* eslint-enable max-len */
     expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "./a"))
-      .toBe("torrent://g.a/b/c/a");
+      .toBe("torrent://g.a/b/c/d/a");
     expect(
       resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/.././a")
-    ).toBe("torrent://g.a/b/a");
+    ).toBe("torrent://g.a/b/c/a");
   });
 });
 

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -75,6 +75,16 @@ export default function resolveURL(...args : Array<string|undefined>) : string {
     else {
       try {
         // try use window.URL first
+        if (base) {
+          const baseUrl = new URL(base);
+
+          if (!baseUrl.pathname.endsWith("/")) {
+            baseUrl.pathname += "/";
+          }
+
+          base = baseUrl.toString();
+        }
+
         base = new URL(part, base).toString();
       } catch {
         // trim if begins with "/"

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -73,17 +73,22 @@ export default function resolveURL(...args : Array<string|undefined>) : string {
       base = part;
     }
     else {
-      // trim if begins with "/"
-      if (part[0] === "/") {
-        part = part.substring(1);
-      }
+      try {
+        // try use window.URL first
+        base = new URL(part, base).toString();
+      } catch {
+        // trim if begins with "/"
+        if (part[0] === "/") {
+          part = part.substring(1);
+        }
 
-      // trim if ends with "/"
-      if (base[base.length - 1] === "/") {
-        base = base.substring(0, base.length - 1);
-      }
+        // trim if ends with "/"
+        if (base[base.length - 1] === "/") {
+          base = base.substring(0, base.length - 1);
+        }
 
-      base = base + "/" + part;
+        base = base + "/" + part;
+      }
     }
   }
 


### PR DESCRIPTION
This PR is the fix of this issue: https://github.com/canalplus/rx-player/issues/1440.

From what I'm understanding, for path resolve: `'/a/b/c'` and `https://a.b/c` result should be `https://a.b/a/b/c` not `https://a.b/c/a/b/c`.