### PR TITLE
feature: support absolute path in URL resolution with RFC 3986 implementation.

### DIFF
--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -131,6 +131,18 @@ describe(`utils - resolveURL ${resolveURL.name}`, () => {
       expect(resolveURL(baseURL, example.input)).toBe(example.output);
     });
   });
+
+  it("should work with URL with a port number in the URL", () => {
+    const baseURL = "http://example.com:8090/foo/";
+    const relative = "bar";
+    expect(resolveURL(baseURL, relative)).toBe("http://example.com:8090/foo/bar")
+  })
+
+  it("should work with credentials in the URL", () => {
+    const baseURL = "http://username:password@example.com/";
+    const relative = "bar";
+    expect(resolveURL(baseURL, relative)).toBe("http://username:password@example.com/bar")
+  })
 });
 
 describe("utils - getFilenameIndexInUrl", () => {

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -89,65 +89,64 @@ resolveURLImplementation.forEach((resolveURL) => {
       expect(resolveURL("http://a/b/c/d;p?q", "/g")).toBe("http://a/g");
     });
 
-    it("should conform to RFC 3986 normal examples", () => {
-      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
-      const baseURL: string = "http://a/b/c/d;p?q";
-      const normalExamples = [
-        { input: "g:h", output: "g:h" },
-        { input: "g", output: "http://a/b/c/g" },
-        { input: "./g", output: "http://a/b/c/g" },
-        { input: "g/", output: "http://a/b/c/g/" },
-        { input: "/g", output: "http://a/g" },
-        { input: "//g", output: "http://g" },
-        { input: "?y", output: "http://a/b/c/d;p?y" },
-        { input: "g?y", output: "http://a/b/c/g?y" },
-        { input: "#s", output: "http://a/b/c/d;p?q#s" },
-        { input: "g#s", output: "http://a/b/c/g#s" },
-        { input: "g?y#s", output: "http://a/b/c/g?y#s" },
-        { input: ";x", output: "http://a/b/c/;x" },
-        { input: "g;x", output: "http://a/b/c/g;x" },
-        { input: "g;x?y#s", output: "http://a/b/c/g;x?y#s" },
-        { input: "", output: "http://a/b/c/d;p?q" },
-        { input: ".", output: "http://a/b/c/" },
-        { input: "./", output: "http://a/b/c/" },
-        { input: "..", output: "http://a/b/" },
-        { input: "../", output: "http://a/b/" },
-        { input: "../g", output: "http://a/b/g" },
-        { input: "../..", output: "http://a/" },
-        { input: "../../", output: "http://a/" },
-        { input: "../../g", output: "http://a/g" },
-      ];
-      normalExamples.forEach((example) => {
+    const normalExamples = [
+      { input: "g:h", output: "g:h" },
+      { input: "g", output: "http://a/b/c/g" },
+      { input: "./g", output: "http://a/b/c/g" },
+      { input: "g/", output: "http://a/b/c/g/" },
+      { input: "/g", output: "http://a/g" },
+      { input: "//g", output: "http://g" },
+      { input: "?y", output: "http://a/b/c/d;p?y" },
+      { input: "g?y", output: "http://a/b/c/g?y" },
+      { input: "#s", output: "http://a/b/c/d;p?q#s" },
+      { input: "g#s", output: "http://a/b/c/g#s" },
+      { input: "g?y#s", output: "http://a/b/c/g?y#s" },
+      { input: ";x", output: "http://a/b/c/;x" },
+      { input: "g;x", output: "http://a/b/c/g;x" },
+      { input: "g;x?y#s", output: "http://a/b/c/g;x?y#s" },
+      { input: "", output: "http://a/b/c/d;p?q" },
+      { input: ".", output: "http://a/b/c/" },
+      { input: "./", output: "http://a/b/c/" },
+      { input: "..", output: "http://a/b/" },
+      { input: "../", output: "http://a/b/" },
+      { input: "../g", output: "http://a/b/g" },
+      { input: "../..", output: "http://a/" },
+      { input: "../../", output: "http://a/" },
+      { input: "../../g", output: "http://a/g" },
+    ];
+    normalExamples.forEach((example) => {
+      it("should conform to RFC 3986 normal examples - case: " + example.input, () => {
+        const baseURL: string = "http://a/b/c/d;p?q";
+        // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
         expect(resolveURL(baseURL, example.input)).toBe(example.output);
       });
     });
-
-    it("should conform to RFC 3986 abnormal examples", () => {
+  });
+  const abnormalExamples = [
+    { input: "../../../g", output: "http://a/g" },
+    { input: "../../../../g", output: "http://a/g" },
+    { input: "/./g", output: "http://a/g" },
+    { input: "/../g", output: "http://a/g" },
+    { input: "g.", output: "http://a/b/c/g." },
+    { input: ".g", output: "http://a/b/c/.g" },
+    { input: "g..", output: "http://a/b/c/g.." },
+    { input: "..g", output: "http://a/b/c/..g" },
+    { input: "./../g", output: "http://a/b/g" },
+    { input: "./g/.", output: "http://a/b/c/g/" },
+    { input: "g/./h", output: "http://a/b/c/g/h" },
+    { input: "g/../h", output: "http://a/b/c/h" },
+    { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
+    { input: "g;x=1/../y", output: "http://a/b/c/y" },
+    { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
+    { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
+    { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
+    { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
+  ];
+  abnormalExamples.forEach((example) => {
+    it("should conform to RFC 3986 abnormal examples - case: " + example.input, () => {
       // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
       const baseURL: string = "http://a/b/c/d;p?q";
-      const abnormalExamples = [
-        { input: "../../../g", output: "http://a/g" },
-        { input: "../../../../g", output: "http://a/g" },
-        { input: "/./g", output: "http://a/g" },
-        { input: "/../g", output: "http://a/g" },
-        { input: "g.", output: "http://a/b/c/g." },
-        { input: ".g", output: "http://a/b/c/.g" },
-        { input: "g..", output: "http://a/b/c/g.." },
-        { input: "..g", output: "http://a/b/c/..g" },
-        { input: "./../g", output: "http://a/b/g" },
-        { input: "./g/.", output: "http://a/b/c/g/" },
-        { input: "g/./h", output: "http://a/b/c/g/h" },
-        { input: "g/../h", output: "http://a/b/c/h" },
-        { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
-        { input: "g;x=1/../y", output: "http://a/b/c/y" },
-        { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
-        { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
-        { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
-        { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
-      ];
-      abnormalExamples.forEach((example) => {
-        expect(resolveURL(baseURL, example.input)).toBe(example.output);
-      });
+      expect(resolveURL(baseURL, example.input)).toBe(example.output);
     });
   });
 });

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -104,32 +104,32 @@ describe(`utils - resolveURL ${resolveURL.name}`, () => {
       expect(resolveURL(baseURL, example.input)).toBe(example.output);
     });
   });
-});
-const abnormalExamples = [
-  { input: "../../../g", output: "http://a/g" },
-  { input: "../../../../g", output: "http://a/g" },
-  { input: "/./g", output: "http://a/g" },
-  { input: "/../g", output: "http://a/g" },
-  { input: "g.", output: "http://a/b/c/g." },
-  { input: ".g", output: "http://a/b/c/.g" },
-  { input: "g..", output: "http://a/b/c/g.." },
-  { input: "..g", output: "http://a/b/c/..g" },
-  { input: "./../g", output: "http://a/b/g" },
-  { input: "./g/.", output: "http://a/b/c/g/" },
-  { input: "g/./h", output: "http://a/b/c/g/h" },
-  { input: "g/../h", output: "http://a/b/c/h" },
-  { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
-  { input: "g;x=1/../y", output: "http://a/b/c/y" },
-  { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
-  { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
-  { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
-  { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
-];
-abnormalExamples.forEach((example) => {
-  it("should conform to RFC 3986 abnormal examples - case: " + example.input, () => {
-    // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
-    const baseURL: string = "http://a/b/c/d;p?q";
-    expect(resolveURL(baseURL, example.input)).toBe(example.output);
+  const abnormalExamples = [
+    { input: "../../../g", output: "http://a/g" },
+    { input: "../../../../g", output: "http://a/g" },
+    { input: "/./g", output: "http://a/g" },
+    { input: "/../g", output: "http://a/g" },
+    { input: "g.", output: "http://a/b/c/g." },
+    { input: ".g", output: "http://a/b/c/.g" },
+    { input: "g..", output: "http://a/b/c/g.." },
+    { input: "..g", output: "http://a/b/c/..g" },
+    { input: "./../g", output: "http://a/b/g" },
+    { input: "./g/.", output: "http://a/b/c/g/" },
+    { input: "g/./h", output: "http://a/b/c/g/h" },
+    { input: "g/../h", output: "http://a/b/c/h" },
+    { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
+    { input: "g;x=1/../y", output: "http://a/b/c/y" },
+    { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
+    { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
+    { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
+    { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
+  ];
+  abnormalExamples.forEach((example) => {
+    it("should conform to RFC 3986 abnormal examples - case: " + example.input, () => {
+      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
+      const baseURL: string = "http://a/b/c/d;p?q";
+      expect(resolveURL(baseURL, example.input)).toBe(example.output);
+    });
   });
 });
 

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -135,14 +135,16 @@ describe(`utils - resolveURL ${resolveURL.name}`, () => {
   it("should work with URL with a port number in the URL", () => {
     const baseURL = "http://example.com:8090/foo/";
     const relative = "bar";
-    expect(resolveURL(baseURL, relative)).toBe("http://example.com:8090/foo/bar")
-  })
+    expect(resolveURL(baseURL, relative)).toBe("http://example.com:8090/foo/bar");
+  });
 
   it("should work with credentials in the URL", () => {
     const baseURL = "http://username:password@example.com/";
     const relative = "bar";
-    expect(resolveURL(baseURL, relative)).toBe("http://username:password@example.com/bar")
-  })
+    expect(resolveURL(baseURL, relative)).toBe(
+      "http://username:password@example.com/bar",
+    );
+  });
 });
 
 describe("utils - getFilenameIndexInUrl", () => {

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -14,55 +14,141 @@
  * limitations under the License.
  */
 
-import resolveURL, { getFilenameIndexInUrl } from "../resolve_url";
+import {
+  getFilenameIndexInUrl,
+  resolveURLWhatWcURL,
+  resolveURLegacy,
+  resolveURLwithRFC3689Algo,
+} from "../resolve_url";
 
-describe("utils - resolveURL", () => {
-  it("should return an empty string if no argument is given", () => {
-    expect(resolveURL()).toBe("");
-  });
+const resolveURLImplementation = [
+  resolveURLWhatWcURL,
+  resolveURLegacy,
+  resolveURLwithRFC3689Algo,
+];
 
-  it("should concatenate multiple URLs", () => {
-    expect(resolveURL("http://toto.com/a")).toBe("http://toto.com/a");
-    expect(resolveURL("http://toto.com/a", "b/c/d/", "g.a")).toBe(
-      "http://toto.com/a/b/c/d/g.a",
-    );
-  });
+resolveURLImplementation.forEach((resolveURL) => {
+  describe(`utils - resolveURL ${resolveURL.name}`, () => {
+    it("should return an empty string if no argument is given", () => {
+      expect(resolveURL()).toBe("");
+    });
 
-  it("should ignore empty strings when concatenating multiple URLs", () => {
-    expect(resolveURL("", "http://toto.com/a", "")).toBe("http://toto.com/a");
-    expect(resolveURL("http://toto.com/a", "b/c/d/", "", "g.a")).toBe(
-      "http://toto.com/a/b/c/d/g.a",
-    );
-  });
+    it("should concatenate multiple URLs", () => {
+      expect(resolveURL("http://toto.com/a")).toBe("http://toto.com/a");
+      expect(
+        resolveURL("http://toto.com/a" /** Trailling slash missing */, "b/c/d/", "g.a"),
+      ).toBe("http://toto.com/b/c/d/g.a");
+      expect(
+        resolveURL("http://toto.com/a/" /** With a trailling slash */, "b/c/d/", "g.a"),
+      ).toBe("http://toto.com/a/b/c/d/g.a");
+    });
 
-  it("should remove a leading slash if one", () => {
-    expect(resolveURL("http://toto.com/a", "/b/c/d/", "/", "/g.a")).toBe(
-      "http://toto.com/a/b/c/d/g.a",
-    );
-  });
+    it("should ignore empty strings when concatenating multiple URLs", () => {
+      expect(resolveURL("", "http://toto.com/a", "")).toBe("http://toto.com/a");
+      expect(resolveURL("http://toto.com/a/", "b/c/d/", "", "g.a")).toBe(
+        "http://toto.com/a/b/c/d/g.a",
+      );
+    });
 
-  it("should reset the concatenation if a given string contains a scheme", () => {
-    expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a", "b")).toBe(
-      "torrent://g.a/b",
-    );
-  });
+    it("should handle absolute path and keep the last one only", () => {
+      expect(resolveURL("http://toto.com/a", "/b/c/d/", "/", "/g.a")).toBe(
+        "http://toto.com/g.a",
+      );
+    });
 
-  it("should have a - fairly simple - algorithm to simplify parent directories", () => {
-    expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../a")).toBe(
-      "torrent://g.a/b/c/a",
-    );
-    expect(
-      resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/../../a"),
-    ).toBe("torrent://g.a/b/a");
-  });
+    it("should reset the concatenation if a given string contains a scheme", () => {
+      expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a", "b")).toBe(
+        "torrent://g.a/b",
+      );
+    });
 
-  it("should have a - fairly simple - algorithm to simplify the current directory", () => {
-    expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "./a")).toBe(
-      "torrent://g.a/b/c/d/a",
-    );
-    expect(
-      resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a/b/c/d", "../c/.././a"),
-    ).toBe("torrent://g.a/b/c/a");
+    it("should have a - fairly simple - algorithm to simplify parent directories", () => {
+      expect(
+        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../a"),
+      ).toBe("torrent://g.a/b/c/a");
+      expect(
+        resolveURL(
+          "http://toto.com/a/",
+          "b/c/d/",
+          "torrent://g.a/b/c/d/",
+          "../c/../../a",
+        ),
+      ).toBe("torrent://g.a/b/a");
+    });
+
+    it("should have a - fairly simple - algorithm to simplify the current directory", () => {
+      expect(
+        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "./a"),
+      ).toBe("torrent://g.a/b/c/d/a");
+      expect(
+        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../c/.././a"),
+      ).toBe("torrent://g.a/b/c/a");
+    });
+
+    it("should resolve absolute urls with overriding baseURL path", () => {
+      expect(resolveURL("http://a/b/c/d;p?q", "/g")).toBe("http://a/g");
+    });
+
+    it("should conform to RFC 3986 normal examples", () => {
+      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
+      const baseURL: string = "http://a/b/c/d;p?q";
+      const normalExamples = [
+        { input: "g:h", output: "g:h" },
+        { input: "g", output: "http://a/b/c/g" },
+        { input: "./g", output: "http://a/b/c/g" },
+        { input: "g/", output: "http://a/b/c/g/" },
+        { input: "/g", output: "http://a/g" },
+        { input: "//g", output: "http://g" },
+        { input: "?y", output: "http://a/b/c/d;p?y" },
+        { input: "g?y", output: "http://a/b/c/g?y" },
+        { input: "#s", output: "http://a/b/c/d;p?q#s" },
+        { input: "g#s", output: "http://a/b/c/g#s" },
+        { input: "g?y#s", output: "http://a/b/c/g?y#s" },
+        { input: ";x", output: "http://a/b/c/;x" },
+        { input: "g;x", output: "http://a/b/c/g;x" },
+        { input: "g;x?y#s", output: "http://a/b/c/g;x?y#s" },
+        { input: "", output: "http://a/b/c/d;p?q" },
+        { input: ".", output: "http://a/b/c/" },
+        { input: "./", output: "http://a/b/c/" },
+        { input: "..", output: "http://a/b/" },
+        { input: "../", output: "http://a/b/" },
+        { input: "../g", output: "http://a/b/g" },
+        { input: "../..", output: "http://a/" },
+        { input: "../../", output: "http://a/" },
+        { input: "../../g", output: "http://a/g" },
+      ];
+      normalExamples.forEach((example) => {
+        expect(resolveURL(baseURL, example.input)).toBe(example.output);
+      });
+    });
+
+    it("should conform to RFC 3986 abnormal examples", () => {
+      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
+      const baseURL: string = "http://a/b/c/d;p?q";
+      const abnormalExamples = [
+        { input: "../../../g", output: "http://a/g" },
+        { input: "../../../../g", output: "http://a/g" },
+        { input: "/./g", output: "http://a/g" },
+        { input: "/../g", output: "http://a/g" },
+        { input: "g.", output: "http://a/b/c/g." },
+        { input: ".g", output: "http://a/b/c/.g" },
+        { input: "g..", output: "http://a/b/c/g.." },
+        { input: "..g", output: "http://a/b/c/..g" },
+        { input: "./../g", output: "http://a/b/g" },
+        { input: "./g/.", output: "http://a/b/c/g/" },
+        { input: "g/./h", output: "http://a/b/c/g/h" },
+        { input: "g/../h", output: "http://a/b/c/h" },
+        { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
+        { input: "g;x=1/../y", output: "http://a/b/c/y" },
+        { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
+        { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
+        { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
+        { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
+      ];
+      abnormalExamples.forEach((example) => {
+        expect(resolveURL(baseURL, example.input)).toBe(example.output);
+      });
+    });
   });
 });
 

--- a/src/utils/__tests__/resolve_url.test.ts
+++ b/src/utils/__tests__/resolve_url.test.ts
@@ -14,140 +14,122 @@
  * limitations under the License.
  */
 
-import {
-  getFilenameIndexInUrl,
-  resolveURLWhatWcURL,
-  resolveURLegacy,
-  resolveURLwithRFC3689Algo,
-} from "../resolve_url";
+import resolveURL, { getFilenameIndexInUrl } from "../resolve_url";
 
-const resolveURLImplementation = [
-  resolveURLWhatWcURL,
-  resolveURLegacy,
-  resolveURLwithRFC3689Algo,
-];
-
-resolveURLImplementation.forEach((resolveURL) => {
-  describe(`utils - resolveURL ${resolveURL.name}`, () => {
-    it("should return an empty string if no argument is given", () => {
-      expect(resolveURL()).toBe("");
-    });
-
-    it("should concatenate multiple URLs", () => {
-      expect(resolveURL("http://toto.com/a")).toBe("http://toto.com/a");
-      expect(
-        resolveURL("http://toto.com/a" /** Trailling slash missing */, "b/c/d/", "g.a"),
-      ).toBe("http://toto.com/b/c/d/g.a");
-      expect(
-        resolveURL("http://toto.com/a/" /** With a trailling slash */, "b/c/d/", "g.a"),
-      ).toBe("http://toto.com/a/b/c/d/g.a");
-    });
-
-    it("should ignore empty strings when concatenating multiple URLs", () => {
-      expect(resolveURL("", "http://toto.com/a", "")).toBe("http://toto.com/a");
-      expect(resolveURL("http://toto.com/a/", "b/c/d/", "", "g.a")).toBe(
-        "http://toto.com/a/b/c/d/g.a",
-      );
-    });
-
-    it("should handle absolute path and keep the last one only", () => {
-      expect(resolveURL("http://toto.com/a", "/b/c/d/", "/", "/g.a")).toBe(
-        "http://toto.com/g.a",
-      );
-    });
-
-    it("should reset the concatenation if a given string contains a scheme", () => {
-      expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a", "b")).toBe(
-        "torrent://g.a/b",
-      );
-    });
-
-    it("should have a - fairly simple - algorithm to simplify parent directories", () => {
-      expect(
-        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../a"),
-      ).toBe("torrent://g.a/b/c/a");
-      expect(
-        resolveURL(
-          "http://toto.com/a/",
-          "b/c/d/",
-          "torrent://g.a/b/c/d/",
-          "../c/../../a",
-        ),
-      ).toBe("torrent://g.a/b/a");
-    });
-
-    it("should have a - fairly simple - algorithm to simplify the current directory", () => {
-      expect(
-        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "./a"),
-      ).toBe("torrent://g.a/b/c/d/a");
-      expect(
-        resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../c/.././a"),
-      ).toBe("torrent://g.a/b/c/a");
-    });
-
-    it("should resolve absolute urls with overriding baseURL path", () => {
-      expect(resolveURL("http://a/b/c/d;p?q", "/g")).toBe("http://a/g");
-    });
-
-    const normalExamples = [
-      { input: "g:h", output: "g:h" },
-      { input: "g", output: "http://a/b/c/g" },
-      { input: "./g", output: "http://a/b/c/g" },
-      { input: "g/", output: "http://a/b/c/g/" },
-      { input: "/g", output: "http://a/g" },
-      { input: "//g", output: "http://g" },
-      { input: "?y", output: "http://a/b/c/d;p?y" },
-      { input: "g?y", output: "http://a/b/c/g?y" },
-      { input: "#s", output: "http://a/b/c/d;p?q#s" },
-      { input: "g#s", output: "http://a/b/c/g#s" },
-      { input: "g?y#s", output: "http://a/b/c/g?y#s" },
-      { input: ";x", output: "http://a/b/c/;x" },
-      { input: "g;x", output: "http://a/b/c/g;x" },
-      { input: "g;x?y#s", output: "http://a/b/c/g;x?y#s" },
-      { input: "", output: "http://a/b/c/d;p?q" },
-      { input: ".", output: "http://a/b/c/" },
-      { input: "./", output: "http://a/b/c/" },
-      { input: "..", output: "http://a/b/" },
-      { input: "../", output: "http://a/b/" },
-      { input: "../g", output: "http://a/b/g" },
-      { input: "../..", output: "http://a/" },
-      { input: "../../", output: "http://a/" },
-      { input: "../../g", output: "http://a/g" },
-    ];
-    normalExamples.forEach((example) => {
-      it("should conform to RFC 3986 normal examples - case: " + example.input, () => {
-        const baseURL: string = "http://a/b/c/d;p?q";
-        // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
-        expect(resolveURL(baseURL, example.input)).toBe(example.output);
-      });
-    });
+describe(`utils - resolveURL ${resolveURL.name}`, () => {
+  it("should return an empty string if no argument is given", () => {
+    expect(resolveURL()).toBe("");
   });
-  const abnormalExamples = [
-    { input: "../../../g", output: "http://a/g" },
-    { input: "../../../../g", output: "http://a/g" },
-    { input: "/./g", output: "http://a/g" },
-    { input: "/../g", output: "http://a/g" },
-    { input: "g.", output: "http://a/b/c/g." },
-    { input: ".g", output: "http://a/b/c/.g" },
-    { input: "g..", output: "http://a/b/c/g.." },
-    { input: "..g", output: "http://a/b/c/..g" },
-    { input: "./../g", output: "http://a/b/g" },
-    { input: "./g/.", output: "http://a/b/c/g/" },
-    { input: "g/./h", output: "http://a/b/c/g/h" },
-    { input: "g/../h", output: "http://a/b/c/h" },
-    { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
-    { input: "g;x=1/../y", output: "http://a/b/c/y" },
-    { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
-    { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
-    { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
-    { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
+
+  it("should concatenate multiple URLs", () => {
+    expect(resolveURL("http://toto.com/a")).toBe("http://toto.com/a");
+    expect(
+      resolveURL("http://toto.com/a" /** Trailling slash missing */, "b/c/d/", "g.a"),
+    ).toBe("http://toto.com/b/c/d/g.a");
+    expect(
+      resolveURL("http://toto.com/a/" /** With a trailling slash */, "b/c/d/", "g.a"),
+    ).toBe("http://toto.com/a/b/c/d/g.a");
+  });
+
+  it("should ignore empty strings when concatenating multiple URLs", () => {
+    expect(resolveURL("", "http://toto.com/a", "")).toBe("http://toto.com/a");
+    expect(resolveURL("http://toto.com/a/", "b/c/d/", "", "g.a")).toBe(
+      "http://toto.com/a/b/c/d/g.a",
+    );
+  });
+
+  it("should handle absolute path and keep the last one only", () => {
+    expect(resolveURL("http://toto.com/a", "/b/c/d/", "/", "/g.a")).toBe(
+      "http://toto.com/g.a",
+    );
+  });
+
+  it("should reset the concatenation if a given string contains a scheme", () => {
+    expect(resolveURL("http://toto.com/a", "b/c/d/", "torrent://g.a", "b")).toBe(
+      "torrent://g.a/b",
+    );
+  });
+
+  it("should have a - fairly simple - algorithm to simplify parent directories", () => {
+    expect(
+      resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../a"),
+    ).toBe("torrent://g.a/b/c/a");
+    expect(
+      resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../c/../../a"),
+    ).toBe("torrent://g.a/b/a");
+  });
+
+  it("should have a - fairly simple - algorithm to simplify the current directory", () => {
+    expect(
+      resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "./a"),
+    ).toBe("torrent://g.a/b/c/d/a");
+    expect(
+      resolveURL("http://toto.com/a/", "b/c/d/", "torrent://g.a/b/c/d/", "../c/.././a"),
+    ).toBe("torrent://g.a/b/c/a");
+  });
+
+  it("should resolve absolute urls with overriding baseURL path", () => {
+    expect(resolveURL("http://a/b/c/d;p?q", "/g")).toBe("http://a/g");
+  });
+
+  const normalExamples = [
+    { input: "g:h", output: "g:h" },
+    { input: "g", output: "http://a/b/c/g" },
+    { input: "./g", output: "http://a/b/c/g" },
+    { input: "g/", output: "http://a/b/c/g/" },
+    { input: "/g", output: "http://a/g" },
+    { input: "//g", output: "http://g" },
+    { input: "?y", output: "http://a/b/c/d;p?y" },
+    { input: "g?y", output: "http://a/b/c/g?y" },
+    { input: "#s", output: "http://a/b/c/d;p?q#s" },
+    { input: "g#s", output: "http://a/b/c/g#s" },
+    { input: "g?y#s", output: "http://a/b/c/g?y#s" },
+    { input: ";x", output: "http://a/b/c/;x" },
+    { input: "g;x", output: "http://a/b/c/g;x" },
+    { input: "g;x?y#s", output: "http://a/b/c/g;x?y#s" },
+    { input: "", output: "http://a/b/c/d;p?q" },
+    { input: ".", output: "http://a/b/c/" },
+    { input: "./", output: "http://a/b/c/" },
+    { input: "..", output: "http://a/b/" },
+    { input: "../", output: "http://a/b/" },
+    { input: "../g", output: "http://a/b/g" },
+    { input: "../..", output: "http://a/" },
+    { input: "../../", output: "http://a/" },
+    { input: "../../g", output: "http://a/g" },
   ];
-  abnormalExamples.forEach((example) => {
-    it("should conform to RFC 3986 abnormal examples - case: " + example.input, () => {
-      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
+  normalExamples.forEach((example) => {
+    it("should conform to RFC 3986 normal examples - case: " + example.input, () => {
       const baseURL: string = "http://a/b/c/d;p?q";
+      // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1
       expect(resolveURL(baseURL, example.input)).toBe(example.output);
     });
+  });
+});
+const abnormalExamples = [
+  { input: "../../../g", output: "http://a/g" },
+  { input: "../../../../g", output: "http://a/g" },
+  { input: "/./g", output: "http://a/g" },
+  { input: "/../g", output: "http://a/g" },
+  { input: "g.", output: "http://a/b/c/g." },
+  { input: ".g", output: "http://a/b/c/.g" },
+  { input: "g..", output: "http://a/b/c/g.." },
+  { input: "..g", output: "http://a/b/c/..g" },
+  { input: "./../g", output: "http://a/b/g" },
+  { input: "./g/.", output: "http://a/b/c/g/" },
+  { input: "g/./h", output: "http://a/b/c/g/h" },
+  { input: "g/../h", output: "http://a/b/c/h" },
+  { input: "g;x=1/./y", output: "http://a/b/c/g;x=1/y" },
+  { input: "g;x=1/../y", output: "http://a/b/c/y" },
+  { input: "g?y/./x", output: "http://a/b/c/g?y/./x" },
+  { input: "g?y/../x", output: "http://a/b/c/g?y/../x" },
+  { input: "g#s/./x", output: "http://a/b/c/g#s/./x" },
+  { input: "g#s/../x", output: "http://a/b/c/g#s/../x" },
+];
+abnormalExamples.forEach((example) => {
+  it("should conform to RFC 3986 abnormal examples - case: " + example.input, () => {
+    // https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2
+    const baseURL: string = "http://a/b/c/d;p?q";
+    expect(resolveURL(baseURL, example.input)).toBe(example.output);
   });
 });
 

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -127,7 +127,7 @@ interface IParsedURL {
 /**
  * Cache to store already parsed URLs to avoid unnecessary computation when parsing the same URL again.
  */
-const parsedUrlCache = new Map<string, IParsedURL>()
+const parsedUrlCache = new Map<string, IParsedURL>();
 
 /**
  * Sets the maximum number of entries allowed in the parsedUrlCache map.
@@ -152,7 +152,7 @@ function parseURL(url: string): IParsedURL {
       authority: "",
       path: "",
       query: "",
-        fragment: "",
+      fragment: "",
     };
   } else {
     parsed = {
@@ -160,13 +160,13 @@ function parseURL(url: string): IParsedURL {
       authority: matches[2] ?? "",
       path: matches[3] ?? "",
       query: matches[4] ?? "",
-       fragment: matches[5] ?? "",
+      fragment: matches[5] ?? "",
     };
   }
   if (parsedUrlCache.size >= MAX_URL_CACHE_ENTRIES) {
     parsedUrlCache.clear();
   }
-  parsedUrlCache.set(url, parsed)
+  parsedUrlCache.set(url, parsed);
   return parsed;
 }
 /**

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -35,103 +35,6 @@ const schemeRe = /^(?:[a-z]+:)?\/\//i;
 const urlComponentRegex =
   /^(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/;
 
-// Captures "/../" or "/./".
-const selfDirRe = /\/\.{1,2}\//;
-
-/**
- * Resolve self directory and previous directory references to obtain a
- * "normalized" url.
- * @example "https://foo.bar/baz/booz/../biz" => "https://foo.bar/baz/biz"
- * @param {string} url
- * @returns {string}
- */
-function _normalizeUrl(url: string): string {
-  // fast path if no ./ or ../ are present in the url
-  if (!selfDirRe.test(url)) {
-    return url;
-  }
-
-  const newUrl: string[] = [];
-  const oldUrl = url.split("/");
-  for (let i = 0, l = oldUrl.length; i < l; i++) {
-    if (oldUrl[i] === "..") {
-      newUrl.pop();
-    } else if (oldUrl[i] === ".") {
-      continue;
-    } else {
-      newUrl.push(oldUrl[i]);
-    }
-  }
-
-  return newUrl.join("/");
-}
-
-/**
- * Simple algorithm that uses WhatWC `new URL`.
- * Fails on some rare edge case, see unit test.
- * @param args
- * @returns
- */
-export const resolveURLWhatWcURL = (...args: Array<string | undefined>): string => {
-  const filteredArgs = args.filter((val) => val !== "");
-  const len = filteredArgs.length;
-  if (len === 0) {
-    return "";
-  }
-
-  const base = filteredArgs[0] ?? "";
-  const relative = filteredArgs[1] ?? "";
-
-  const output = new URL(relative, base);
-  if (filteredArgs.length <= 2) {
-    return output.toString();
-  } else {
-    const remainingArgs = filteredArgs.slice(2);
-    return resolveURL(output.toString(), ...remainingArgs);
-  }
-};
-
-/**
- * Construct an url from the arguments given.
- * Basically:
- *   - The last arguments that contains a scheme (e.g. "http://") is the base
- *     of the url.
- *   - every subsequent string arguments are concatened to it.
- * @param {...string|undefined} args
- * @returns {string}
- */
-export const resolveURLegacy = (...args: Array<string | undefined>): string => {
-  const len = args.length;
-  if (len === 0) {
-    return "";
-  }
-
-  let base = "";
-  for (let i = 0; i < len; i++) {
-    let part = args[i];
-    if (typeof part !== "string" || part === "") {
-      continue;
-    }
-    if (schemeRe.test(part)) {
-      base = part;
-    } else {
-      // trim if begins with "/"
-      if (part[0] === "/") {
-        part = part.substring(1);
-      }
-
-      // trim if ends with "/"
-      if (base[base.length - 1] === "/") {
-        base = base.substring(0, base.length - 1);
-      }
-
-      base = base + "/" + part;
-    }
-  }
-
-  return _normalizeUrl(base);
-};
-
 /**
  * In a given URL, find the index at which the filename begins.
  * That is, this function finds the index of the last `/` character and returns
@@ -174,7 +77,7 @@ function getFilenameIndexInUrl(url: string): number {
  * @example base: http://example.com | relative: /b/c | output: http://example.com/b/c
  * @returns the resolved url
  */
-const _resolveURL = (base: string, relative: string) => {
+function _resolveURL(base: string, relative: string) {
   const baseParts = parseURL(base);
   const relativeParts = parseURL(relative);
 
@@ -211,7 +114,7 @@ const _resolveURL = (base: string, relative: string) => {
     }
   }
   return formatURL(target);
-};
+}
 
 interface ParsedURL {
   scheme: string;
@@ -335,7 +238,7 @@ function mergePaths(baseParts: ParsedURL, relativePath: string): string {
  * @param {...(string|undefined)} args - The URL segments to resolve.
  * @returns {string} The resolved URL as a string.
  */
-export const resolveURLwithRFC3689Algo = (...args: Array<string | undefined>): string => {
+export function resolveURL(...args: Array<string | undefined>): string {
   const filteredArgs = args.filter((val) => val !== "");
   const len = filteredArgs.length;
   if (len === 0) {
@@ -348,10 +251,9 @@ export const resolveURLwithRFC3689Algo = (...args: Array<string | undefined>): s
     const relativeParts = filteredArgs[1] ?? "";
     const resolvedURL = _resolveURL(basePart, relativeParts);
     const remainingArgs = filteredArgs.slice(2);
-    return resolveURLwithRFC3689Algo(resolvedURL, ...remainingArgs);
+    return resolveURL(resolvedURL, ...remainingArgs);
   }
-};
+}
 
-const resolveURL = resolveURLwithRFC3689Algo;
 export { getFilenameIndexInUrl };
 export default resolveURL;

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -14,8 +14,26 @@
  * limitations under the License.
  */
 
+import startsWith from "./starts_with";
+
 // Scheme part of an url (e.g. "http://").
 const schemeRe = /^(?:[a-z]+:)?\/\//i;
+
+/** 
+ * Match the different components of an URL.
+ * 
+ *     foo://example.com:8042/over/there?name=ferret#nose
+       \_/   \______________/\_________/ \_________/ \__/
+        |           |            |            |        |
+      scheme     authority       path        query   fragment
+ * 1st match is the scheme: (e.g. "foo://")
+ * 2nd match is the authority (e.g "example.com:8042")
+ * 3rd match is the path (e.g "/over/there")
+ * 4th match is the query params (e.g "name=ferret")
+ * 5th match is the fragment (e.g "nose")
+ * */
+const urlComponentRegex =
+  /^(?:([^:\/?#]+):)?(?:\/\/([^\/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?$/;
 
 // Captures "/../" or "/./".
 const selfDirRe = /\/\.{1,2}\//;
@@ -49,6 +67,31 @@ function _normalizeUrl(url: string): string {
 }
 
 /**
+ * Simple algorithm that uses WhatWC `new URL`.
+ * Fails on some rare edge case, see unit test.
+ * @param args
+ * @returns
+ */
+export const resolveURLWhatWcURL = (...args: Array<string | undefined>): string => {
+  const filteredArgs = args.filter((val) => val !== "");
+  const len = filteredArgs.length;
+  if (len === 0) {
+    return "";
+  }
+
+  const base = filteredArgs[0] ?? "";
+  const relative = filteredArgs[1] ?? "";
+
+  const output = new URL(relative, base);
+  if (filteredArgs.length <= 2) {
+    return output.toString();
+  } else {
+    const remainingArgs = filteredArgs.slice(2);
+    return resolveURL(output.toString(), ...remainingArgs);
+  }
+};
+
+/**
  * Construct an url from the arguments given.
  * Basically:
  *   - The last arguments that contains a scheme (e.g. "http://") is the base
@@ -57,7 +100,7 @@ function _normalizeUrl(url: string): string {
  * @param {...string|undefined} args
  * @returns {string}
  */
-export default function resolveURL(...args: Array<string | undefined>): string {
+export const resolveURLegacy = (...args: Array<string | undefined>): string => {
   const len = args.length;
   if (len === 0) {
     return "";
@@ -87,7 +130,7 @@ export default function resolveURL(...args: Array<string | undefined>): string {
   }
 
   return _normalizeUrl(base);
-}
+};
 
 /**
  * In a given URL, find the index at which the filename begins.
@@ -122,4 +165,192 @@ function getFilenameIndexInUrl(url: string): number {
   return indexOfLastSlash + 1;
 }
 
+/**
+ * Resolve the output URL from the baseURL and the relative reference as
+ * specified by RFC 3986 section 5.
+ * @param base
+ * @param relative
+ * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5
+ * @example base: http://example.com | relative: /b/c | output: http://example.com/b/c
+ * @returns the resolved url
+ */
+const _resolveURL = (base: string, relative: string) => {
+  const baseParts = parseURL(base);
+  const relativeParts = parseURL(relative);
+
+  if (relativeParts.scheme) {
+    return formatURL(relativeParts);
+  }
+
+  const target: ParsedURL = {
+    scheme: baseParts.scheme,
+    authority: baseParts.authority,
+    path: "",
+    query: relativeParts.query,
+    fragment: relativeParts.fragment,
+  };
+
+  if (relativeParts.authority) {
+    target.authority = relativeParts.authority;
+    target.path = removeDotSegment(relativeParts.path);
+    return formatURL(target);
+  }
+
+  if (relativeParts.path === "") {
+    target.path = baseParts.path;
+    if (!relativeParts.query) {
+      target.query = baseParts.query;
+    }
+  } else {
+    if (startsWith(relativeParts.path, "/")) {
+      // path is absolute
+      target.path = removeDotSegment(relativeParts.path);
+    } else {
+      // path is relative
+      target.path = removeDotSegment(mergePaths(baseParts, relativeParts.path));
+    }
+  }
+  return formatURL(target);
+};
+
+interface ParsedURL {
+  scheme: string;
+  authority: string;
+  path: string;
+  query: string;
+  fragment: string;
+}
+/**
+ * Parses a URL into its components.
+ * @param {string} url - The URL to parse.
+ * @returns {ParsedURL} The parsed URL components.
+ */
+function parseURL(url: string): ParsedURL {
+  const matches = url.match(urlComponentRegex);
+  if (matches === null) {
+    return {
+      scheme: "",
+      authority: "",
+      path: "",
+      query: "",
+      fragment: "",
+    };
+  }
+
+  return {
+    scheme: matches[1] ?? "",
+    authority: matches[2] ?? "",
+    path: matches[3] ?? "",
+    query: matches[4] ?? "",
+    fragment: matches[5] ?? "",
+  };
+}
+/**
+ * Formats a parsed URL into a string.
+ * @param {ParsedURL} parts - The parsed URL components.
+ * @returns {string} The formatted URL string.
+ */
+function formatURL(parts: ParsedURL): string {
+  let url = "";
+  if (parts.scheme) {
+    url += parts.scheme + ":";
+  }
+
+  if (parts.authority) {
+    url += "//" + parts.authority;
+  }
+  url += parts.path;
+
+  if (parts.query) {
+    url += "?" + parts.query;
+  }
+
+  if (parts.fragment) {
+    url += "#" + parts.fragment;
+  }
+  return url;
+}
+
+/**
+ * Removes "." and ".." from the URL path, as described by the algorithm
+ * in RFC 3986 Section 5.2.4.  Remove Dot Segments
+ * @param {string} path - The URL path
+ * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
+ * @returns The path with dot segments removed.
+ */
+function removeDotSegment(path: string): string {
+  const segments = path.split(/(?=\/)/);
+  const output: string[] = [];
+
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (segment === ".." || segment === "." || segment === "") {
+      continue;
+    }
+
+    if (segment === "/..") {
+      output.pop();
+      // if it's last segment push a trailing "/"
+      if (i === segments.length - 1) {
+        output.push("/");
+      }
+      continue;
+    }
+    if (segment === "/.") {
+      // if it's last segment push a trailing "/"
+      if (i === segments.length - 1) {
+        output.push("/");
+      }
+      continue;
+    }
+    output.push(segment);
+  }
+  return output.join("");
+}
+
+/**
+ * Merges a base URL path with a relative URL path, as described by
+ * the algorithm merge paths in RFC 3986 Section 5.2.3. Merge Paths
+ * @param {ParsedURL} baseParts - The parsed base URL components.
+ * @param {string} relativePath - The relative URL path.
+ * @returns {string} The merged URL path.
+ * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.3
+ */
+function mergePaths(baseParts: ParsedURL, relativePath: string): string {
+  if (baseParts.authority && baseParts.path === "") {
+    return "/" + relativePath;
+  }
+  const basePath = baseParts.path;
+  return basePath.substring(0, basePath.lastIndexOf("/") + 1) + relativePath;
+}
+/**
+ * Resolves multiple URL segments using the RFC 3986 URL resolution algorithm.
+ *
+ * This function takes a variable number of URL segments and resolves them
+ * sequentially according to the RFC 3986 URL resolution algorithm.
+ * First argument is the base URL.
+ * Empty string arguments are ignored.
+ *
+ * @param {...(string|undefined)} args - The URL segments to resolve.
+ * @returns {string} The resolved URL as a string.
+ */
+export const resolveURLwithRFC3689Algo = (...args: Array<string | undefined>): string => {
+  const filteredArgs = args.filter((val) => val !== "");
+  const len = filteredArgs.length;
+  if (len === 0) {
+    return "";
+  }
+  if (len === 1) {
+    return filteredArgs[0] ?? "";
+  } else {
+    const basePart = filteredArgs[0] ?? "";
+    const relativeParts = filteredArgs[1] ?? "";
+    const resolvedURL = _resolveURL(basePart, relativeParts);
+    const remainingArgs = filteredArgs.slice(2);
+    return resolveURLwithRFC3689Algo(resolvedURL, ...remainingArgs);
+  }
+};
+
+const resolveURL = resolveURLwithRFC3689Algo;
 export { getFilenameIndexInUrl };
+export default resolveURL;

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -273,10 +273,11 @@ function formatURL(parts: ParsedURL): string {
 
 /**
  * Removes "." and ".." from the URL path, as described by the algorithm
- * in RFC 3986 Section 5.2.4.  Remove Dot Segments
+ * in RFC 3986 Section 5.2.4. Remove Dot Segments
  * @param {string} path - The URL path
  * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
  * @returns The path with dot segments removed.
+ * @example "/baz/booz/../biz" => "/baz/biz"
  */
 function removeDotSegment(path: string): string {
   const segments = path.split(/(?=\/)/);

--- a/src/utils/resolve_url.ts
+++ b/src/utils/resolve_url.ts
@@ -85,7 +85,7 @@ function _resolveURL(base: string, relative: string) {
     return formatURL(relativeParts);
   }
 
-  const target: ParsedURL = {
+  const target: IParsedURL = {
     scheme: baseParts.scheme,
     authority: baseParts.authority,
     path: "",
@@ -116,7 +116,7 @@ function _resolveURL(base: string, relative: string) {
   return formatURL(target);
 }
 
-interface ParsedURL {
+interface IParsedURL {
   scheme: string;
   authority: string;
   path: string;
@@ -126,9 +126,9 @@ interface ParsedURL {
 /**
  * Parses a URL into its components.
  * @param {string} url - The URL to parse.
- * @returns {ParsedURL} The parsed URL components.
+ * @returns {IParsedURL} The parsed URL components.
  */
-function parseURL(url: string): ParsedURL {
+function parseURL(url: string): IParsedURL {
   const matches = url.match(urlComponentRegex);
   if (matches === null) {
     return {
@@ -150,10 +150,10 @@ function parseURL(url: string): ParsedURL {
 }
 /**
  * Formats a parsed URL into a string.
- * @param {ParsedURL} parts - The parsed URL components.
+ * @param {IParsedURL} parts - The parsed URL components.
  * @returns {string} The formatted URL string.
  */
-function formatURL(parts: ParsedURL): string {
+function formatURL(parts: IParsedURL): string {
   let url = "";
   if (parts.scheme) {
     url += parts.scheme + ":";
@@ -215,12 +215,12 @@ function removeDotSegment(path: string): string {
 /**
  * Merges a base URL path with a relative URL path, as described by
  * the algorithm merge paths in RFC 3986 Section 5.2.3. Merge Paths
- * @param {ParsedURL} baseParts - The parsed base URL components.
+ * @param {IParsedURL} baseParts - The parsed base URL components.
  * @param {string} relativePath - The relative URL path.
  * @returns {string} The merged URL path.
  * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.3
  */
-function mergePaths(baseParts: ParsedURL, relativePath: string): string {
+function mergePaths(baseParts: IParsedURL, relativePath: string): string {
   if (baseParts.authority && baseParts.path === "") {
     return "/" + relativePath;
   }


### PR DESCRIPTION
As stated in https://github.com/canalplus/rx-player/issues/1440, the RxPlayer `resolveURL` function does not support all the cases that are described in RFC 3986 (see examples at https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1). 
Especially it would not support in case the relativeReference has an absolute path such as:
```
baseURL = "http://example.com/a/b/"
relativeReference = "/c/d"
```

## Proposed solution

This PR change the `resolveURL` algorithm to address the issue. This PR implements in javascript the resolution algorithm as described by RFC 3986.


## Tests

From the tests cases, this algorithm works for every tests.

<img width="619" alt="image" src="https://github.com/canalplus/rx-player/assets/58945185/b78c67c9-3a7d-4bb3-9843-f399e7fc4617">


## Conclusion

This implementation execute the algorithm as stated from RFC 3986. This has the advantage of having the exact same resolution algorithm between different devices, as opposed to https://github.com/canalplus/rx-player/pull/1442. 
And does not need polyfill for old devices.

On the other hand this add a lot more code to maintain. I'm not sure about which solution is best for performances.
