### PR TITLE
[v3]   When listing segments needed, stop filtering the current range

### DIFF
--- a/src/core/stream/representation/utils/get_needed_segments.ts
+++ b/src/core/stream/representation/utils/get_needed_segments.ts
@@ -29,7 +29,7 @@ import {
   IBufferedHistoryEntry,
   IChunkContext,
 } from "../../../segment_buffers/inventory";
-
+import { ChunkStatus } from "../../../segment_buffers/inventory/segment_inventory";
 
 interface IContentContext {
   adaptation: Adaptation;
@@ -229,7 +229,7 @@ export default function getNeededSegments({
       // periods, we should consider a segment as already downloaded if
       // it is from same period (but can be from different adaptation or
       // representation)
-      if (areFromSamePeriod) {
+      if (completeSeg.status === ChunkStatus.Complete && areFromSamePeriod) {
         const completeSegInfos = completeSeg.infos.segment;
         if (time - completeSegInfos.time > -ROUNDING_ERROR &&
             completeSegInfos.end - end > -ROUNDING_ERROR)


### PR DESCRIPTION
This is an adaptation of #1421 for our legacy v3 versions, which still get some bug fixes backported from the v4