### PR TITLE
[v3] api: throw an error if an application use a video element in multiple instance of the RxPlayer

### DIFF
--- a/demo/full/scripts/controllers/Player.tsx
+++ b/demo/full/scripts/controllers/Player.tsx
@@ -119,6 +119,9 @@ function Player(): JSX.Element {
     ) {
       return;
     }
+    if (playerModule) {
+      playerModule.destroy();
+    }
     const playerMod = new PlayerModule(
       Object.assign(
         {},
@@ -131,7 +134,7 @@ function Player(): JSX.Element {
     );
     setPlayerModule(playerMod);
     return playerMod;
-  }, [playerOpts]);
+  }, [playerOpts, playerModule]);
 
   const onVideoClick = useCallback(() => {
     if (playerModule === null) {

--- a/src/core/api/__tests__/public_api.test.ts
+++ b/src/core/api/__tests__/public_api.test.ts
@@ -853,5 +853,60 @@ describe("API - Public API", () => {
         expect(player.getMinimumPosition()).toBe(null);
       });
     });
+
+
+    describe("Player instantiation", () => {
+      /* eslint-disable-next-line max-len */
+      it("should log a warning if creating two players attached to the same video element", () => {
+        const PublicAPI = jest.requireActual("../public_api").default;
+        const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
+        const videoElement = document.createElement("video");
+        const player1 = new PublicAPI({ videoElement });
+        expect(player1.getVideoElement()).toBe(videoElement);
+
+        const errorMessage =
+          "The video element is already attached to another RxPlayer instance." +
+          "\nMake sure to dispose the previous instance with player.dispose() " +
+          "before creating a new player instance attaching that video element.";
+
+        new PublicAPI({ videoElement });
+        expect(warn).toHaveBeenCalledWith(errorMessage);
+        expect(warn).toHaveBeenCalledTimes(1);
+
+        warn.mockClear();
+        /*
+         * TODO: for next major version 5.0: this need to throw an error instead
+         * of just logging this was not done for minor version as it could be
+         * considerated a breaking change
+         *
+         * expect(() => {
+         *    new PublicAPI({ videoElement });
+         * }).toThrow(errorMessage);
+         */
+      });
+
+      it(`should not log a warning if creating a player attached to
+        the same video element after the previous one was disposed`, () => {
+        const PublicAPI = jest.requireActual("../public_api").default;
+        const warn = jest.spyOn(console, "warn").mockImplementation(jest.fn());
+        const videoElement = document.createElement("video");
+        const player1 = new PublicAPI({ videoElement });
+        expect(player1.getVideoElement()).toBe(videoElement);
+
+        player1.dispose();
+        expect(warn).not.toHaveBeenCalled();
+        /*
+         * TODO: for next major version 5.0: this need to throw an error
+         * instead of just logging this was not done for minor version as it
+         * could be considerated a breaking change.
+         *
+         * expect(() => {
+         *   new PublicAPI({ videoElement });
+         * }).not.toThrow();
+         *
+         */
+        warn.mockClear();
+      });
+    });
   });
 });


### PR DESCRIPTION
This is an adaptation of https://github.com/canalplus/rx-player/pull/1394 for our legacy v3 versions, which still get some bug fixes backported from the v4