### PR TITLE
Common Media Client Data (CMCD) implementation

### DIFF
--- a/demo/full/scripts/components/Options/RequestConfig.tsx
+++ b/demo/full/scripts/components/Options/RequestConfig.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import Checkbox from "../CheckBox";
 import DEFAULT_VALUES from "../../lib/defaultOptionsValues";
 import PlayerOptionNumberInput from "./PlayerOptionNumberInput";
+import Select from "../Select";
 
 const { Fragment, useCallback, useEffect, useState } = React;
 
@@ -19,19 +20,23 @@ const DEFAULT_MANIFEST_REQUEST_TIMEOUT =
 function RequestConfig({
   manifestRequestTimeout,
   manifestRetry,
+  cmcdCommunicationMethod,
   onManifestRequestTimeoutChange,
   onManifestRetryChange,
   onSegmentRequestTimeoutChange,
   onSegmentRetryChange,
+  onCmcdChange,
   segmentRequestTimeout,
   segmentRetry,
 }: {
   manifestRequestTimeout: number;
   manifestRetry: number;
+  cmcdCommunicationMethod: string;
   onManifestRequestTimeoutChange: (val: number) => void;
   onManifestRetryChange: (val: number) => void;
   onSegmentRequestTimeoutChange: (val: number) => void;
   onSegmentRetryChange: (val: number) => void;
+  onCmcdChange: (val: string) => void;
   segmentRequestTimeout: number;
   segmentRetry: number;
 }): JSX.Element {
@@ -74,6 +79,27 @@ function RequestConfig({
    */
   const [isManifestRequestTimeoutLimited, setManifestRequestTimeoutLimit] = useState(
     manifestRequestTimeout !== -1,
+  );
+
+  let cmcdDescMsg;
+  switch (cmcdCommunicationMethod) {
+    case "disabled":
+      cmcdDescMsg = "Not relying on CMCD with the CDN";
+      break;
+    case "query":
+      cmcdDescMsg = "Communicate CMCD payload through URL's query strings";
+      break;
+    case "headers":
+      cmcdDescMsg = "Communicate CMCD payload through HTTP(S) headers";
+      break;
+    default:
+      cmcdDescMsg = "Unknown value";
+      break;
+  }
+
+  const onCmcdSelection = React.useCallback(
+    ({ value }: { value: string }) => onCmcdChange(value),
+    [onCmcdChange],
   );
 
   // Update manifestRequestTimeout when its linked text change
@@ -274,6 +300,21 @@ function RequestConfig({
             ? "Perform manifest requests without timeout"
             : `Stop manifest requests after ${manifestRequestTimeout} millisecond(s)`}
         </span>
+      </li>
+
+      <li className="featureWrapperWithSelectMode">
+        <Select
+          ariaLabel="Selecting the CMCD communication method"
+          disabled={false}
+          className="playerOptionInput"
+          name="cmcd"
+          onChange={onCmcdSelection}
+          selected={{ value: cmcdCommunicationMethod, index: undefined }}
+          options={["disabled", "query", "headers"]}
+        >
+          CMCD (Common Media Client Data) communication type
+        </Select>
+        <span className="option-desc">{cmcdDescMsg}</span>
       </li>
     </Fragment>
   );

--- a/demo/full/scripts/controllers/Settings.tsx
+++ b/demo/full/scripts/controllers/Settings.tsx
@@ -10,8 +10,9 @@ import type {
   IConstructorSettings,
   ILoadVideoSettings,
 } from "../lib/defaultOptionsValues";
-import {
+import type {
   IAudioRepresentationsSwitchingMode,
+  ICmcdOptions,
   IVideoRepresentationsSwitchingMode,
 } from "../../../../src/public_types";
 
@@ -61,11 +62,13 @@ function Settings({
   } = playerOptions;
   const {
     autoPlay,
+    cmcd,
     defaultAudioTrackSwitchingMode,
     enableFastSwitching,
     requestConfig,
     onCodecSwitch,
   } = loadVideoOptions;
+  const cmcdCommunicationMethod = cmcd?.communicationType ?? "disabled";
   const { manifest: manifestRequestConfig, segment: segmentRequestConfig } =
     requestConfig;
   const { maxRetry: segmentRetry, timeout: segmentRequestTimeout } = segmentRequestConfig;
@@ -89,6 +92,33 @@ function Settings({
       updateTryRelyOnWorker(tryRelyOnWorker);
     },
     [updateTryRelyOnWorker],
+  );
+
+  const onCmcdChange = useCallback(
+    (value: string) => {
+      updateLoadVideoOptions((prevOptions) => {
+        let newCmcdType: ICmcdOptions["communicationType"] | undefined;
+        if (value === "query") {
+          newCmcdType = "query";
+        } else if (value === "headers") {
+          newCmcdType = "headers";
+        } else {
+          newCmcdType = undefined;
+        }
+        if (newCmcdType === prevOptions.cmcd?.communicationType) {
+          return prevOptions;
+        }
+        return Object.assign({}, prevOptions, {
+          cmcd:
+            newCmcdType === undefined
+              ? undefined
+              : {
+                  communicationType: newCmcdType,
+                },
+        });
+      });
+    },
+    [updateLoadVideoOptions],
   );
 
   const onVideoResolutionLimitChange = useCallback(
@@ -346,10 +376,12 @@ function Settings({
             segmentRetry={segmentRetry}
             segmentRequestTimeout={segmentRequestTimeout}
             manifestRetry={manifestRetry}
+            cmcdCommunicationMethod={cmcdCommunicationMethod}
             onSegmentRetryChange={onSegmentRetryChange}
             onSegmentRequestTimeoutChange={onSegmentRequestTimeoutChange}
             onManifestRetryChange={onManifestRetryChange}
             onManifestRequestTimeoutChange={onManifestRequestTimeoutChange}
+            onCmcdChange={onCmcdChange}
           />
         </Option>
         <Option title="Track Switch Mode">

--- a/demo/full/scripts/lib/defaultOptionsValues.ts
+++ b/demo/full/scripts/lib/defaultOptionsValues.ts
@@ -1,4 +1,5 @@
 import type {
+  ICmcdOptions,
   IConstructorOptions,
   ILoadVideoOptions,
 } from "../../../../src/public_types";
@@ -14,6 +15,7 @@ const defaultOptionsValues = {
   },
   loadVideo: {
     autoPlay: true,
+    cmcd: undefined as ICmcdOptions | undefined,
     defaultAudioTrackSwitchingMode: "reload",
     enableFastSwitching: true,
     requestConfig: {

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -807,6 +807,41 @@ If not set or set to `"auto"`, you can see which mode is effective by calling th
 If the `useWorker` property is set to `false`, you're running in `"main"` mode, if set to
 `true`, you're running in `"multithread"` mode.
 
+### cmcd
+
+_type_: `Object|undefined`
+
+_defaults_: `"undefined"`
+
+<div class="warning">
+This option has no effect in <i>DirectFile</i> mode (see <a href="#transport">
+transport option</a>)
+</div>
+
+When set to an object, it enables "Common Media Client Data" (CMCD) so the RxPlayer is
+able to report playback conditions to the CDN.
+
+If set to `undefined` or not defined, CMCD will be disabled.
+
+When set to an Object, it can have the following properties:
+
+- `contentId` (`string|undefined`): Content ID delivered by CMCD metadata for that
+  content. If not specified, a default one will be generated.
+
+  It is heavily recommended that you provide your own content identifier here.
+
+- `sessionId` (`string|undefined`): Session ID delivered by CMCD metadata. If not
+  specified, a default one will be generated.
+
+- `communicationType` (`string|undefined`): Way in which the CMCD metadata is
+  communicated.
+
+  Can be set to `"query"` for communicating it through query strings or `"headers"` for
+  communicating it through headers (which may lead to supplementary complexities linked to
+  CORS policies such as preflight request, blocking etc.).
+
+  If not set, the RxPlayer will automatically select the most appropriate way instead.
+
 ### checkMediaSegmentIntegrity
 
 _type_: `Function|undefined`

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -145,10 +145,10 @@ As you can see, this function takes two arguments:
      When `type` is set to `"query"`, then `value` represents a CMCD payload formatted to
      be inserted in a query string. It is in this case an array of 2-tuples with the first
      value being a field's name as a string and the second element being either that
-     field's value if set to a string or indicating that the field has no value.
-     For example a `value` set to `[["first", "val"], ["second", null],
-     ["third", "something"]]` could be translated into the query string
-     `?first=val&second&third=something`.
+     field's value if set to a string or indicating that the field has no value. For
+     example a `value` set to
+     `[["first", "val"], ["second", null], ["third", "something"]]` could be translated
+     into the query string `?first=val&second&third=something`.
 
      When `type` is set to `"headers"`, then `value` represents a CMCD payload formatted
      to be inserted as headers. It is in this case an object where keys are header names
@@ -315,10 +315,10 @@ As you can see, this function takes three arguments:
      When `type` is set to `"query"`, then `value` represents a CMCD payload formatted to
      be inserted in a query string. It is in this case an array of 2-tuples with the first
      value being a field's name as a string and the second element being either that
-     field's value if set to a string or indicating that the field has no value.
-     For example a `value` set to `[["first", "val"], ["second", null],
-     ["third", "something"]]` could be translated into the query string
-     `?first=val&second&third=something`.
+     field's value if set to a string or indicating that the field has no value. For
+     example a `value` set to
+     `[["first", "val"], ["second", null], ["third", "something"]]` could be translated
+     into the query string `?first=val&second&third=something`.
 
      When `type` is set to `"headers"`, then `value` represents a CMCD payload formatted
      to be inserted as headers. It is in this case an object where keys are header names

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -136,6 +136,24 @@ As you can see, this function takes two arguments:
    - _trackType_ (`string`): The concerned type of track. Can be `"video"`, `"audio"`,
      `"text"` (for subtitles)
 
+   - _cmcdPayload_ (`Object|undefined`): Optional object that describes the "Common Media
+     Client Data" (CMCD) that may be provided alongside the resource for this request.
+
+     When set, takes the form of an object with two fields: `type` (a `string`) and value,
+     whose format will depend on the value of `type`.
+
+     When `type` is set to `"query"`, then `value` represents a CMCD payload formatted to
+     be inserted in a query string. It is in this case an array of 2-tuples with the first
+     value being a field's name as a string and the second element being either that
+     field's value if set to a string or indicating that the field has no value.
+     For example a `value` set to `[["first", "val"], ["second", null],
+     ["third", "something"]]` could be translated into the query string
+     `?first=val&second&third=something`.
+
+     When `type` is set to `"headers"`, then `value` represents a CMCD payload formatted
+     to be inserted as headers. It is in this case an object where keys are header names
+     and values are the corresponding header values.
+
 2. **callbacks**: An object containing multiple callbacks to allow this `segmentLoader` to
    communicate various events to the RxPlayer.
 
@@ -287,6 +305,24 @@ As you can see, this function takes three arguments:
 
      This property is mainly indicative, you may or may not want to exploit this
      information depending on your use cases.
+
+   - _cmcdPayload_ (`Object|undefined`): Optional object that describes the "Common Media
+     Client Data" (CMCD) that may be provided alongside the resource for this request.
+
+     When set, takes the form of an object with two fields: `type` (a `string`) and value,
+     whose format will depend on the value of `type`.
+
+     When `type` is set to `"query"`, then `value` represents a CMCD payload formatted to
+     be inserted in a query string. It is in this case an array of 2-tuples with the first
+     value being a field's name as a string and the second element being either that
+     field's value if set to a string or indicating that the field has no value.
+     For example a `value` set to `[["first", "val"], ["second", null],
+     ["third", "something"]]` could be translated into the query string
+     `?first=val&second&third=something`.
+
+     When `type` is set to `"headers"`, then `value` represents a CMCD payload formatted
+     to be inserted as headers. It is in this case an object where keys are header names
+     and values are the corresponding header values.
 
 2. **callbacks**: An object containing multiple callbacks to allow this `manifestLoader`
    to communicate the loaded Manifest or an encountered error to the RxPlayer.

--- a/src/README.md
+++ b/src/README.md
@@ -29,7 +29,7 @@ it:
                |                                             |
                +---------------------------------------------+
                          |
-                         | call RxPlayer API
+                         | call the RxPlayer API
                          |
 -------------------------|- RxPlayer Main Thread ---------------------------
                          |
@@ -52,29 +52,32 @@ it:
  |(./main_thread/init)|            creates          |  Text Displayer  |
  |                    | --------------------------->|(./main_thread/te |
  +--------------------+                             |xt_displayer)     |
-        |  ^                                        +------------------+
-        |  | Message exchanges                                          ^
-        |  |                                                            |
---------|--|------ RxPlayer Core (May run in a WebWorker) --------------|---
-        v  |                                                            |
+   |  ^                                             +------------------+
+   |  | Message exchanges                                          ^
+   |  |                                                            |
+---|--|----------- RxPlayer Core (May run in a WebWorker) ---------|---
+   |  |                                                            |
+   |  |  (*Only if running in a WebWorker)
+   |  |  Exchange messages with the main
+   V  |  thread and process them.
   +---------------------------+         +----------------------------+  |
   |                           | creates |                            |  |
   |        Worker Main*       |-------->|       Manifest Fetcher     |  |
   |   (./core/main/worker)    |         | (./core/fetchers/manifest) |  |
   |                           |         |                            |  |
   +---------------------------+         +----------------------------+  |
-  (*Only if running in a   |            Load and     |                  |
-  WebWorker)               |            refresh the  | Ask to load      |
-  Exchange messages with   |            Manifest     | and parse the    |
-  the main thread and      |                         | Manifest         |
-  process them.            |                         v                  |
-                           |        +--------------------+              |   ` Internet
-                           |        |                    |   request    |   `    ,,,,,
-                           |        |      transport     |--------------+---`-->( CDN )
-                   creates |        | (./core/transport) |              |   `    `````
-                           |        |                    |<---+         |   `
-                           |        +--------------------+     \        |
-                           |        Abstract the streaming      \       |
+     | Creates             |            Load and     |                  |
+     V                     |            refresh the  | Ask to load      |
+   +-------------------+   |            Manifest     | and parse the    |
+   |                   |   | creates                 | Manifest         |
+   | CMCD data builder |   |                         v                  |
+   |  (./core/cmcd)    |   |        +--------------------+              |   ` Internet
+   |                   |   |        |                    |   request    |   `    ,,,,,
+   +-------------------+   |        |      transport     |--------------+---`-->( CDN )
+   Perform data collection |        |    (./transport)   |              |   `    `````
+   for the "Common Media   |        |                    |<---+         |   `
+   Client Data" (CMCD)     |        +--------------------+     \        |
+   scheme.                 |        Abstract the streaming      \       |
                            |        protocol (e.g. DASH)         \      |
                            |                                      \     |
 Stream (./core/stream)     |                                       \    |
@@ -248,10 +251,10 @@ The previous schema mostly illustrated the most complex code path of the three (
    `DirectfileContentInitializer` is called by the API to start-up such contents and a
    specialized `MediaElementTracksStore` is handling tracks specifically for directfile
    contents (as they are handled differently than for other code paths, here trough API
-   exposed by the browser)have .
+   exposed by the browser).
 
 2. A second code path, we may call the "monothreaded code path" apply for non-directfile
-   contents (so, contents which rely on MSE API instead) loaded in monothreaded mode,
+   contents (so, contents which rely on the MSE API instead) loaded in monothreaded mode,
    which is the default.
 
    It is much closer to the schema of the previous chapter:

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -51,3 +51,8 @@ Those modules are:
   Link the `transports` module with the rest of the code, to download segments,
   download/refresh the manifest and collect data (such as the user's bandwidth) for the
   other modules.
+
+- **the `CmcdDataBuilder` (./cmcd)**
+
+  Perform data collection and retrieval for the "Common Media Client Data" scheme, which
+  is a specification allowing to communicate about playback conditions with a CDN.

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -1,0 +1,645 @@
+import log from "../../log";
+import type {
+  IAdaptation,
+  IManifest,
+  IPeriod,
+  IRepresentation,
+  ISegment,
+} from "../../manifest";
+import type {
+  IReadOnlyPlaybackObserver,
+  IRebufferingStatus,
+  ObservationPosition,
+} from "../../playback_observer";
+import type { ICmcdOptions, ITrackType } from "../../public_types";
+import createUuid from "../../utils/create_uuid";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
+import type { IRange } from "../../utils/ranges";
+import TaskCanceller from "../../utils/task_canceller";
+
+/**
+ * `rtp`, for "REQUESTED_MAXIMUM_THROUGHPUT", indicates the maximum throughput
+ * needed to load a given segment without experience degration.
+ * It acts as a hint to a CDN so it can scale its resources between multiple
+ * clients.
+ *
+ * We could indicate through `rtp` the exact minimum bandwidth needed, but this
+ * may lead to much higher risk of rebuffering, so we prefer to multiply that
+ * value by a safe-enough factor, this `RTP_FACTOR`.
+ */
+const RTP_FACTOR = 4;
+
+/**
+ * Information that should be provided to the `CmcdDataBuilder` when getting the
+ * CMCD payload for a segment.
+ */
+export interface ICmcdSegmentInfo {
+  /** Manifest metadata linked to the wanted segment. */
+  manifest: IManifest;
+  /** Period metadata linked to the wanted segment. */
+  period: IPeriod;
+  /** Adaptation metadata linked to the wanted segment. */
+  adaptation: IAdaptation;
+  /** Representation metadata linked to the wanted segment. */
+  representation: IRepresentation;
+  /** Segment metadata linked to the wanted segment. */
+  segment: ISegment;
+}
+
+/**
+ * Payload to add to a request to provide CMCD metadata through HTTP request
+ * headers.
+ *
+ * This is an object where keys are header names and values are header contents.
+ */
+export type ICmcdHeadersData = Record<string, string>;
+
+/**
+ * Payload to add to a request to provide CMCD metadata through an URL's query
+ * string.
+ *
+ * This is an array of all fields and corresponding values that should be
+ * added to the query string, the order should be kept.
+ *
+ * `null` indicates that the field has no value and should be added as is.
+ */
+export type ICmcdQueryData = Array<[string, string | null]>;
+
+/**
+ * `CmcdDataBuilder`'s return type when CMCD metadata should be added through
+ * headers to the HTTP request for the corresponding resource.
+ */
+export interface ICmcdHeadersPayload {
+  type: "headers";
+  value: ICmcdHeadersData;
+}
+
+/**
+ * `CmcdDataBuilder`'s return type when CMCD metadata should be added through
+ * the query string to the HTTP request for the corresponding resource.
+ */
+export interface ICmcdQueryPayload {
+  type: "query";
+  value: ICmcdQueryData;
+}
+
+/**
+ * `CmcdDataBuilder`'s return type to indicate that CMCD metadata should be
+ * added to the HTTP request for the corresponding resource.
+ */
+export type ICmcdPayload = ICmcdHeadersPayload | ICmcdQueryPayload;
+
+/**
+ * Media playback observation's properties the `CmcdDataBuilder` wants to have
+ * access to.
+ */
+export interface ICmcdDataBuilderPlaybackObservation {
+  /**
+   * Ranges of buffered data per type of media.
+   * `null` if no buffer exists for that type of media.
+   */
+  buffered: Record<ITrackType, IRange[] | null>;
+  /**
+   * Information on the current media position in seconds at the time of the
+   * Observation.
+   */
+  position: ObservationPosition;
+  /** Target playback rate at which we want to play the content. */
+  speed: number;
+  /**
+   * Describes when the player is "rebuffering" and what event started that
+   * status.
+   * "Rebuffering" is a status where the player has not enough buffer ahead to
+   * play reliably.
+   * The RxPlayer should pause playback when a playback observation indicates the
+   * rebuffering status.
+   */
+  rebuffering: IRebufferingStatus | null;
+}
+
+/**
+ * Class allowing to easily obtain "Common Media Client Data" (CMCD) properties
+ * that may be relied on while performing HTTP(S) requests on a CDN.
+ *
+ * @class CmcdDataBuilder
+ */
+export default class CmcdDataBuilder {
+  private _sessionId: string;
+  private _contentId: string;
+  private _typePreference: TypePreference;
+  private _lastThroughput: Partial<Record<ITrackType, number | undefined>>;
+  private _playbackObserver: IReadOnlyPlaybackObserver<ICmcdDataBuilderPlaybackObservation> | null;
+  private _bufferStarvationToggle: boolean;
+  private _canceller: TaskCanceller | null;
+
+  constructor(options: ICmcdOptions) {
+    this._sessionId = options.sessionId ?? createUuid();
+    this._contentId = options.contentId ?? createUuid();
+    this._typePreference =
+      options.communicationType === "headers"
+        ? TypePreference.Headers
+        : TypePreference.QueryString;
+    this._bufferStarvationToggle = false;
+    this._playbackObserver = null;
+    this._lastThroughput = {};
+    this._canceller = null;
+  }
+
+  public startMonitoringPlayback(
+    playbackObserver: IReadOnlyPlaybackObserver<ICmcdDataBuilderPlaybackObservation>,
+  ): void {
+    this._canceller?.cancel();
+    this._canceller = new TaskCanceller();
+    this._playbackObserver = playbackObserver;
+    playbackObserver.listen(
+      (obs) => {
+        if (obs.rebuffering !== null) {
+          this._bufferStarvationToggle = true;
+        }
+      },
+      { includeLastObservation: true, clearSignal: this._canceller.signal },
+    );
+  }
+
+  public stopMonitoringPlayback(): void {
+    this._canceller?.cancel();
+    this._canceller = null;
+    this._playbackObserver = null;
+  }
+
+  public updateThroughput(trackType: ITrackType, throughput: number | undefined) {
+    this._lastThroughput[trackType] = throughput;
+  }
+
+  private _getCommonCmcdData(lastThroughput: number | undefined): ICmcdProperties {
+    const props: ICmcdProperties = {};
+    props.bs = this._bufferStarvationToggle;
+    this._bufferStarvationToggle = false;
+    props.cid = this._contentId;
+    props.mtp =
+      lastThroughput !== undefined
+        ? Math.floor(Math.round(lastThroughput / 1000 / 100) * 100)
+        : undefined;
+    props.sid = this._sessionId;
+
+    const lastObservation = this._playbackObserver?.getReference().getValue();
+    props.pr =
+      lastObservation === undefined || lastObservation.speed === 1
+        ? undefined
+        : lastObservation.speed;
+    if (lastObservation !== undefined) {
+      props.su = lastObservation.rebuffering !== null;
+    }
+
+    return props;
+  }
+
+  public getCmcdDataForManifest(transportType: string): ICmcdPayload {
+    const props = this._getCommonCmcdData(
+      this._lastThroughput.video ?? this._lastThroughput.audio,
+    );
+    props.ot = "m";
+
+    switch (transportType) {
+      case "dash":
+        props.sf = "d";
+        break;
+      case "smooth":
+        props.sf = "s";
+        break;
+      default:
+        props.sf = "o";
+        break;
+    }
+    return this._producePayload(props);
+  }
+
+  public getCmcdDataForSegmentRequest(content: ICmcdSegmentInfo): ICmcdPayload {
+    const lastObservation = this._playbackObserver?.getReference().getValue();
+
+    const props = this._getCommonCmcdData(this._lastThroughput[content.adaptation.type]);
+    props.br = Math.round(content.representation.bitrate / 1000);
+    props.d = Math.round(content.segment.duration * 1000);
+    // TODO nor (next object request) and nrr (next range request)
+
+    switch (content.adaptation.type) {
+      case "video":
+        props.ot = "v";
+        break;
+      case "audio":
+        props.ot = "a";
+        break;
+      case "text":
+        props.ot = "c";
+        break;
+    }
+    if (content.segment.isInit) {
+      props.ot = "i";
+    }
+
+    let precizeBufferLengthMs;
+    if (
+      lastObservation !== undefined &&
+      (props.ot === "v" || props.ot === "a" || props.ot === "av")
+    ) {
+      const bufferedForType = lastObservation.buffered[content.adaptation.type];
+      if (!isNullOrUndefined(bufferedForType)) {
+        // TODO more precize position estimate?
+        const position =
+          this._playbackObserver?.getCurrentTime() ??
+          lastObservation.position.getWanted() ??
+          lastObservation.position.getPolled();
+        for (const range of bufferedForType) {
+          if (position >= range.start && position < range.end) {
+            precizeBufferLengthMs = (range.end - position) * 1000;
+            props.bl = Math.floor(Math.round(precizeBufferLengthMs / 100) * 100);
+            break;
+          }
+        }
+      }
+    }
+
+    const precizeDeadlineMs =
+      precizeBufferLengthMs === undefined || lastObservation === undefined
+        ? undefined
+        : precizeBufferLengthMs / lastObservation.speed;
+
+    props.dl =
+      precizeDeadlineMs === undefined
+        ? undefined
+        : Math.floor(Math.round(precizeDeadlineMs / 100) * 100);
+
+    if (precizeDeadlineMs !== undefined) {
+      // estimate the file size, in kilobits
+      const estimatedFileSizeKb =
+        (content.representation.bitrate * content.segment.duration) / 1000;
+      const wantedCeilBandwidthKbps = estimatedFileSizeKb / (precizeDeadlineMs / 1000);
+      props.rtp = Math.floor(
+        Math.round((wantedCeilBandwidthKbps * RTP_FACTOR) / 100) * 100,
+      );
+    }
+
+    switch (content.manifest.transport) {
+      case "dash":
+        props.sf = "d";
+        break;
+      case "smooth":
+        props.sf = "s";
+        break;
+      default:
+        props.sf = "o";
+        break;
+    }
+    props.st = content.manifest.isDynamic ? "l" : "v";
+    props.tb = content.adaptation.representations.reduce(
+      (acc: number | undefined, representation: IRepresentation) => {
+        if (
+          representation.isSupported !== true ||
+          representation.decipherable === false
+        ) {
+          return acc;
+        }
+        if (acc === undefined) {
+          return Math.round(representation.bitrate / 1000);
+        }
+        return Math.max(acc, Math.round(representation.bitrate / 1000));
+      },
+      undefined,
+    );
+    return this._producePayload(props);
+  }
+
+  private _producePayload(props: ICmcdProperties): ICmcdPayload {
+    let cmcdObjectValue = "";
+    let cmcdRequestValue = "";
+    let cmcdSessionValue = "";
+    let cmcdStatusValue = "";
+    let queryStringPayload = "";
+    if (props.br !== undefined) {
+      queryStringPayload += `br=${String(props.br)},`;
+      const toAdd = `br=${String(props.br)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdObjectValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.bl !== undefined) {
+      const toAdd = `bl=${String(props.bl)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdRequestValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.bs === true) {
+      const toAdd = "bs,";
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdStatusValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.cid !== undefined) {
+      const toAdd = `cid=${formatStringPayload(props.cid)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdSessionValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.d !== undefined) {
+      const toAdd = `d=${String(props.d)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdObjectValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.dl !== undefined) {
+      const toAdd = `dl=${String(props.dl)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdRequestValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.mtp !== undefined) {
+      const toAdd = `mtp=${String(props.mtp)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdRequestValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.ot !== undefined) {
+      const toAdd = `ot=${props.ot},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdObjectValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.pr !== undefined) {
+      const toAdd = `pr=${String(props.pr)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdSessionValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.rtp !== undefined) {
+      const toAdd = `rtp=${String(props.rtp)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdStatusValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.sf !== undefined) {
+      const toAdd = `sf=${props.sf},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdSessionValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.sid !== undefined) {
+      const toAdd = `sid=${formatStringPayload(props.sid)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdSessionValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.st !== undefined) {
+      const toAdd = `st=${props.st},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdSessionValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.su === true) {
+      const toAdd = "su,";
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdRequestValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+    if (props.tb !== undefined) {
+      const toAdd = `tb=${String(props.tb)},`;
+      if (this._typePreference === TypePreference.Headers) {
+        cmcdObjectValue += toAdd;
+      } else {
+        queryStringPayload += toAdd;
+      }
+    }
+
+    if (this._typePreference === TypePreference.Headers) {
+      if (cmcdObjectValue[cmcdObjectValue.length - 1] === ",") {
+        cmcdObjectValue = cmcdObjectValue.substring(0, cmcdObjectValue.length - 1);
+      }
+      if (cmcdRequestValue[cmcdRequestValue.length - 1] === ",") {
+        cmcdRequestValue = cmcdRequestValue.substring(0, cmcdRequestValue.length - 1);
+      }
+      if (cmcdSessionValue[cmcdSessionValue.length - 1] === ",") {
+        cmcdSessionValue = cmcdSessionValue.substring(0, cmcdSessionValue.length - 1);
+      }
+      if (cmcdStatusValue[cmcdStatusValue.length - 1] === ",") {
+        cmcdStatusValue = cmcdStatusValue.substring(0, cmcdStatusValue.length - 1);
+      }
+      log.debug("CMCD: proposing headers payload");
+      return {
+        type: "headers",
+        value: {
+          /* eslint-disable @typescript-eslint/naming-convention */
+          "CMCD-Object": cmcdObjectValue,
+          "CMCD-Request": cmcdRequestValue,
+          "CMCD-Session": cmcdSessionValue,
+          "CMCD-Status": cmcdStatusValue,
+          /* eslint-enable @typescript-eslint/naming-convention */
+        },
+      };
+    }
+
+    if (queryStringPayload[queryStringPayload.length - 1] === ",") {
+      queryStringPayload = queryStringPayload.substring(0, queryStringPayload.length - 1);
+    }
+    queryStringPayload = encodeURIComponent(queryStringPayload);
+    log.debug("CMCD: proposing query string payload", queryStringPayload);
+    return {
+      type: "query",
+      value: [["CMCD", queryStringPayload]],
+    };
+  }
+}
+
+/**
+ * How CMCD metadata should be communicated.
+ */
+const enum TypePreference {
+  /** The CMCD metadata should be communicated through HTTP request headers. */
+  Headers,
+  /** The CMCD metadata should be communicated through a query string. */
+  QueryString,
+}
+
+/** Every properties that can be constructed under the CMCD scheme. */
+interface ICmcdProperties {
+  /*
+   * Encoded bitrate (br)
+   * The encoded bitrate of the audio or video object being requested.
+   * This may not be known precisely by the player; however, it MAY be
+   * estimated based upon playlist/manifest declarations. If the playlist
+   * declares both peak and average bitrate values, the peak value should
+   * be transmitted.
+   *
+   * In kbps.
+   */
+  br?: number | undefined;
+  /**
+   * Buffer starvation (bs)
+   * Key is included without a value if the buffer was starved at some point
+   * between the prior request and this object request, resulting in the
+   * player being in a rebuffering state and the video or audio playback being
+   * stalled. This key MUST NOT be sent if the buffer was not starved since
+   * the prior request. If the object type ‘ot’ key is sent along with this
+   * key, then the ‘bs’ key refers to the buffer associated with the
+   * particular object type. If no object type is communicated, then the
+   * buffer state applies to the current session.
+   */
+  bs?: boolean | undefined;
+  /**
+   * Buffer length (bl)
+   * The buffer length associated with the media object being requested. This
+   * value MUST be rounded to the nearest 100 ms. This key SHOULD only be sent
+   * with an object type of ‘a’, ‘v’ or ‘av’.
+   * In milliseconds
+   */
+  bl?: number | undefined;
+  /**
+   * Content ID (cid)
+   * A unique string identifying the current content.
+   * Maximum length is 64 characters. This value is consistent across
+   * multiple different sessions and devices and is defined and
+   * updated at the discretion of the service provider
+   */
+  cid?: string | undefined;
+
+  /**
+   * Object duration (d)
+   * The playback duration in milliseconds of the object being requested. If
+   * a partial segment is being requested, then this value MUST indicate
+   * the playback duration of that part and not that of its parent segment.
+   * This value can be an approximation of the estimated duration if the
+   * explicit value is not known.
+   * In milliseconds.
+   */
+  d?: number | undefined;
+  /**
+   * Deadline (dl)
+   * Deadline from the request time until the first sample of this
+   * Segment/Object needs to be available in order to not create a buffer
+   * underrun or any other playback problems. This value MUST be rounded to
+   * the nearest 100ms. For a playback rate of 1, this may be equivalent to
+   * the player’s remaining buffer length.
+   * In milliseconds.
+   */
+  dl?: number | undefined;
+  /**
+   * Measured throughput (mtp)
+   * The throughput between client and server, as measured by the client and
+   * MUST be rounded to the nearest 100 kbps. This value, however derived,
+   * SHOULD be the value that the client is using to make its next Adaptive
+   * Bitrate switching decision.
+   * If the client is connected to multiple servers concurrently, it must take
+   * care to report only the throughput measured against the receiving server.
+   * If the client has multiple concurrent connections to the server, then the
+   * intent is that this value communicates the aggregate throughput the
+   * client sees across all those connections.
+   * In kbps.
+   */
+  mtp?: number | undefined;
+  /**
+   * Object type (ot)
+   * The media type of the current object being requested:
+   *   - m = text file, such as a manifest or playlist
+   *   - a = audio only
+   *   - v = video only
+   *   - av = muxed audio and video
+   *   - i = init segment
+   *   - c = caption or subtitle
+   *   - tt = ISOBMFF timed text track
+   *   - k = cryptographic key, license or certificate.
+   *   - o = other
+   * If the object type being requested is unknown, then this key MUST NOT be used.
+   */
+  ot?: string | undefined;
+  /**
+   * Playback rate (pr)
+   * 1 if real-time, 2 if double speed, 0 if not playing.
+   * SHOULD only be sent if not equal to 1.
+   */
+  pr?: number | undefined;
+  /**
+   * Requested maximum throughput (rtp)
+   * The requested maximum throughput that the client considers sufficient
+   * for delivery of the asset.
+   * Values MUST be rounded to the nearest 100kbps.
+   * For example, a client would indicate that the current segment, encoded at
+   * 2Mbps, is to be delivered at no more than 10Mbps, by using rtp=10000.
+   * Note: This can benefit clients by preventing buffer saturation through
+   * over-delivery and can also deliver a community benefit through fair-share
+   * delivery. The concept is that each client receives the throughput
+   * necessary for great performance, but no more. The CDN may not support the
+   * rtp feature.
+   * In kbps.
+   */
+  rtp?: number | undefined;
+  /**
+   * Streaming format (sf)
+   * The streaming format that defines the current request.
+   *   - d = MPEG DASH
+   *   - h = HTTP Live Streaming (HLS)
+   *   - s = Smooth Streaming
+   *   - o = other
+   * If the streaming format being requested is unknown, then this key MUST
+   * NOT be used.
+   */
+  sf?: string | undefined;
+  /**
+   * Session ID (sid)
+   * A GUID identifying the current playback session. A playback session
+   * typically ties together segments belonging to a single media asset.
+   * Maximum length is 64 characters. It is RECOMMENDED to conform to the
+   * UUID specification
+   */
+  sid?: string | undefined;
+  /**
+   * Stream type (st)
+   * v = all segments are available – e.g., VOD
+   * l = segments become available over time – e.g., LIVE
+   */
+  st?: string | undefined;
+  /**
+   * Startup (su)
+   * Key is included without a value if the object is needed urgently due to
+   * startup, seeking or recovery after a buffer-empty event. The media SHOULD
+   * not be rendering when this request is made. This key MUST not be sent if
+   * it is FALSE.
+   */
+  su?: boolean | undefined;
+  /**
+   * Top bitrate (tb)
+   * The highest bitrate rendition in the manifest or playlist that the client
+   * is allowed to play, given current codec, licensing and sizing constraints.
+   * In kbps.
+   */
+  tb?: number | undefined;
+}
+
+function formatStringPayload(str: string): string {
+  return `"${str.replace("\\", "\\\\").replace('"', '\\"')}"`;
+}

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -11,7 +11,7 @@ import type {
   IRebufferingStatus,
   ObservationPosition,
 } from "../../playback_observer";
-import type { ICmcdOptions, ITrackType } from "../../public_types";
+import type { ICmcdOptions, ICmcdPayload, ITrackType } from "../../public_types";
 import createUuid from "../../utils/create_uuid";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { IRange } from "../../utils/ranges";
@@ -45,49 +45,6 @@ export interface ICmcdSegmentInfo {
   /** Segment metadata linked to the wanted segment. */
   segment: ISegment;
 }
-
-/**
- * Payload to add to a request to provide CMCD metadata through HTTP request
- * headers.
- *
- * This is an object where keys are header names and values are header contents.
- */
-export type ICmcdHeadersData = Record<string, string>;
-
-/**
- * Payload to add to a request to provide CMCD metadata through an URL's query
- * string.
- *
- * This is an array of all fields and corresponding values that should be
- * added to the query string, the order should be kept.
- *
- * `null` indicates that the field has no value and should be added as is.
- */
-export type ICmcdQueryData = Array<[string, string | null]>;
-
-/**
- * `CmcdDataBuilder`'s return type when CMCD metadata should be added through
- * headers to the HTTP request for the corresponding resource.
- */
-export interface ICmcdHeadersPayload {
-  type: "headers";
-  value: ICmcdHeadersData;
-}
-
-/**
- * `CmcdDataBuilder`'s return type when CMCD metadata should be added through
- * the query string to the HTTP request for the corresponding resource.
- */
-export interface ICmcdQueryPayload {
-  type: "query";
-  value: ICmcdQueryData;
-}
-
-/**
- * `CmcdDataBuilder`'s return type to indicate that CMCD metadata should be
- * added to the HTTP request for the corresponding resource.
- */
-export type ICmcdPayload = ICmcdHeadersPayload | ICmcdQueryPayload;
 
 /**
  * Media playback observation's properties the `CmcdDataBuilder` wants to have

--- a/src/core/cmcd/index.ts
+++ b/src/core/cmcd/index.ts
@@ -1,0 +1,12 @@
+import CmcdDataBuilder from "./cmcd_data_builder";
+
+export type {
+  ICmcdSegmentInfo,
+  ICmcdHeadersData,
+  ICmcdQueryData,
+  ICmcdHeadersPayload,
+  ICmcdQueryPayload,
+  ICmcdPayload,
+  ICmcdDataBuilderPlaybackObservation,
+} from "./cmcd_data_builder";
+export default CmcdDataBuilder;

--- a/src/core/cmcd/index.ts
+++ b/src/core/cmcd/index.ts
@@ -2,11 +2,6 @@ import CmcdDataBuilder from "./cmcd_data_builder";
 
 export type {
   ICmcdSegmentInfo,
-  ICmcdHeadersData,
-  ICmcdQueryData,
-  ICmcdHeadersPayload,
-  ICmcdQueryPayload,
-  ICmcdPayload,
   ICmcdDataBuilderPlaybackObservation,
 } from "./cmcd_data_builder";
 export default CmcdDataBuilder;

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -253,15 +253,8 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       const requestOptions: IManifestLoaderOptions = {
         timeout: requestTimeout,
         connectionTimeout,
+        cmcdPayload: settings.cmcdDataBuilder?.getCmcdDataForManifest(transportName),
       };
-      const cmcdPayload = settings.cmcdDataBuilder?.getCmcdDataForManifest(transportName);
-      if (cmcdPayload !== undefined) {
-        if (cmcdPayload.type === "headers") {
-          requestOptions.headers = cmcdPayload.value;
-        } else if (cmcdPayload.type === "query") {
-          requestOptions.queryString = cmcdPayload.value;
-        }
-      }
       const callLoader = () => loadManifest(manifestUrl, requestOptions, cancelSignal);
       return scheduleRequestPromise(callLoader, backoffSettings, cancelSignal);
     }

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -103,6 +103,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
   const requestOptions: ISegmentLoaderOptions = {
     timeout: options.requestTimeout < 0 ? undefined : options.requestTimeout,
     connectionTimeout,
+    cmcdPayload: undefined,
   };
 
   /**
@@ -292,14 +293,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>(
     function callLoaderWithUrl(
       cdnMetadata: ICdnMetadata | null,
     ): ReturnType<ISegmentLoader<TLoadedFormat>> {
-      const cmcdPayload = cmcdDataBuilder?.getCmcdDataForSegmentRequest(content);
-      if (cmcdPayload !== undefined) {
-        if (cmcdPayload.type === "headers") {
-          requestOptions.headers = cmcdPayload.value;
-        } else if (cmcdPayload.type === "query") {
-          requestOptions.queryString = cmcdPayload.value;
-        }
-      }
+      requestOptions.cmcdPayload = cmcdDataBuilder?.getCmcdDataForSegmentRequest(content);
       return loadSegment(
         cdnMetadata,
         context,

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -23,7 +23,7 @@ import CdnPrioritizer from "../cdn_prioritizer";
 import type { IPrioritizedSegmentFetcher } from "./prioritized_segment_fetcher";
 import applyPrioritizerToSegmentFetcher from "./prioritized_segment_fetcher";
 import type { ISegmentFetcherLifecycleCallbacks } from "./segment_fetcher";
-import createSegmentFetcher, { getSegmentFetcherOptions } from "./segment_fetcher";
+import createSegmentFetcher, { getSegmentFetcherRequestOptions } from "./segment_fetcher";
 import TaskPrioritizer from "./task_prioritizer";
 
 /**
@@ -85,25 +85,25 @@ export default class SegmentFetcherCreator {
    * Create a segment fetcher, allowing to easily perform segment requests.
    * @param {string} bufferType - The type of buffer concerned (e.g. "audio",
    * "video", etc.)
-   * @param {Object} callbacks
+   * @param {Object} eventListeners
    * @returns {Object}
    */
   createSegmentFetcher(
     bufferType: IBufferType,
-    callbacks: ISegmentFetcherLifecycleCallbacks,
+    eventListeners: ISegmentFetcherLifecycleCallbacks,
   ): IPrioritizedSegmentFetcher<unknown> {
-    const backoffOptions = getSegmentFetcherOptions(this._backoffOptions);
+    const requestOptions = getSegmentFetcherRequestOptions(this._backoffOptions);
     const pipelines = this._transport[bufferType];
 
     // Types are very complicated here as they are per-type of buffer.
-    const segmentFetcher = createSegmentFetcher<unknown, unknown>(
+    const segmentFetcher = createSegmentFetcher<unknown, unknown>({
       bufferType,
-      pipelines as ISegmentPipeline<unknown, unknown>,
-      this._cdnPrioritizer,
-      this._cmcdDataBuilder,
-      callbacks,
-      backoffOptions,
-    );
+      pipeline: pipelines as ISegmentPipeline<unknown, unknown>,
+      cdnPrioritizer: this._cdnPrioritizer,
+      cmcdDataBuilder: this._cmcdDataBuilder,
+      eventListeners,
+      requestOptions,
+    });
     return applyPrioritizerToSegmentFetcher(this._prioritizer, segmentFetcher);
   }
 }

--- a/src/core/fetchers/segment/segment_fetcher_creator.ts
+++ b/src/core/fetchers/segment/segment_fetcher_creator.ts
@@ -17,6 +17,7 @@
 import config from "../../../config";
 import type { ISegmentPipeline, ITransportPipelines } from "../../../transports";
 import type { CancellationSignal } from "../../../utils/task_canceller";
+import type CmcdDataBuilder from "../../cmcd";
 import type { IBufferType } from "../../segment_sinks";
 import CdnPrioritizer from "../cdn_prioritizer";
 import type { IPrioritizedSegmentFetcher } from "./prioritized_segment_fetcher";
@@ -54,11 +55,14 @@ export default class SegmentFetcherCreator {
 
   private readonly _cdnPrioritizer: CdnPrioritizer;
 
+  private _cmcdDataBuilder: CmcdDataBuilder | null;
+
   /**
    * @param {Object} transport
    */
   constructor(
     transport: ITransportPipelines,
+    cmcdDataBuilder: CmcdDataBuilder | null,
     options: ISegmentFetcherCreatorBackoffOptions,
     cancelSignal: CancellationSignal,
   ) {
@@ -74,6 +78,7 @@ export default class SegmentFetcherCreator {
     });
     this._cdnPrioritizer = cdnPrioritizer;
     this._backoffOptions = options;
+    this._cmcdDataBuilder = cmcdDataBuilder;
   }
 
   /**
@@ -95,6 +100,7 @@ export default class SegmentFetcherCreator {
       bufferType,
       pipelines as ISegmentPipeline<unknown, unknown>,
       this._cdnPrioritizer,
+      this._cmcdDataBuilder,
       callbacks,
       backoffOptions,
     );

--- a/src/core/main/README.md
+++ b/src/core/main/README.md
@@ -7,11 +7,11 @@
 
 [1] In a Multithreading mode, no file from that directory should ever be imported by
 external code but the `WorkerMain` to generate the worker bundle. In a monothreading mode,
-any files may be directly imported.
+any file may be directly imported.
 
 ## Overview
 
-The Core Main serves as the entry point of the `core` code, which may optionally runs in a
+The Core Main serves as the entry point of the `core` code, which may optionally run in a
 WebWorker.
 
 When in monothreading mode, files declared here may be imported directly to make the link

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -508,6 +508,7 @@ function loadOrReloadPreparedContent(
   }
   const {
     contentId,
+    cmcdDataBuilder,
     manifest,
     mediaSource,
     representationEstimator,
@@ -554,6 +555,10 @@ function loadOrReloadPreparedContent(
     sendMessage,
     currentLoadCanceller.signal,
   );
+  cmcdDataBuilder?.startMonitoringPlayback(playbackObserver);
+  currentLoadCanceller.signal.register(() => {
+    cmcdDataBuilder?.stopMonitoringPlayback();
+  });
 
   const contentTimeBoundariesObserver = createContentTimeBoundariesObserver(
     manifest,
@@ -750,6 +755,13 @@ function loadOrReloadPreparedContent(
       },
 
       bitrateEstimateChange(payload) {
+        if (preparedContent !== null) {
+          preparedContent.cmcdDataBuilder?.updateThroughput(
+            payload.type,
+            payload.bitrate,
+          );
+        }
+
         // TODO for low-latency contents it is __VERY__ frequent.
         // Considering this is only for an unimportant undocumented API, we may
         // throttle such messages. (e.g. max one per 2 seconds for each type?).

--- a/src/core/segment_sinks/README.md
+++ b/src/core/segment_sinks/README.md
@@ -33,7 +33,7 @@ Here's a simplified architecture schema of the code in that directory:
    +--------------------------------------------------------------------------+
                                 |       ^
  Ask to get / create / remove   |       | Returns created SegmentSink or
- SegmentSink for a given type |       | wanted information
+ SegmentSink for a given type   |       | wanted information
  or get information about the   |       |
  available types                |       |
                                 |       |

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4,6 +4,13 @@ import type {
   IResolutionInfo,
 } from "./adaptive";
 import type {
+  ICmcdHeadersData,
+  ICmcdQueryData,
+  ICmcdHeadersPayload,
+  ICmcdQueryPayload,
+  ICmcdPayload,
+} from "./cmcd";
+import type {
   IManifestFetcherSettings,
   ISegmentFetcherCreatorBackoffOptions,
 } from "./fetchers";
@@ -50,4 +57,11 @@ export type {
   IStreamOrchestratorPlaybackObservation,
   IRepresentationsChoice,
   ITrackSwitchingMode,
+
+  // CMCD
+  ICmcdHeadersData,
+  ICmcdQueryData,
+  ICmcdHeadersPayload,
+  ICmcdQueryPayload,
+  ICmcdPayload,
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -4,13 +4,6 @@ import type {
   IResolutionInfo,
 } from "./adaptive";
 import type {
-  ICmcdHeadersData,
-  ICmcdQueryData,
-  ICmcdHeadersPayload,
-  ICmcdQueryPayload,
-  ICmcdPayload,
-} from "./cmcd";
-import type {
   IManifestFetcherSettings,
   ISegmentFetcherCreatorBackoffOptions,
 } from "./fetchers";
@@ -57,11 +50,4 @@ export type {
   IStreamOrchestratorPlaybackObservation,
   IRepresentationsChoice,
   ITrackSwitchingMode,
-
-  // CMCD
-  ICmcdHeadersData,
-  ICmcdQueryData,
-  ICmcdHeadersPayload,
-  ICmcdQueryPayload,
-  ICmcdPayload,
 };

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -180,21 +180,21 @@ export default class VideoThumbnailLoader {
     let lastRepInfo: IVideoThumbnailLoaderRepresentationInfo;
     if (this._lastRepresentationInfo === null) {
       const lastRepInfoCleaner = new TaskCanceller();
-      const segmentFetcher = createSegmentFetcher(
-        "video",
-        loader.video,
-        null,
-        null,
-        // We don't care about the SegmentFetcher's lifecycle events
-        {},
-        {
+      const segmentFetcher = createSegmentFetcher({
+        bufferType: "video",
+        pipeline: loader.video,
+        cdnPrioritizer: null,
+        cmcdDataBuilder: null,
+        requestOptions: {
           baseDelay: 0,
           maxDelay: 0,
           maxRetry: 0,
           requestTimeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
           connectionTimeout: config.getCurrent().DEFAULT_CONNECTION_TIMEOUT,
         },
-      ) as ISegmentFetcher<ArrayBuffer | Uint8Array>;
+        // We don't care about the SegmentFetcher's lifecycle events
+        eventListeners: {},
+      }) as ISegmentFetcher<ArrayBuffer | Uint8Array>;
       const initSegment = content.representation.index.getInitSegment();
       const initSegmentUniqueId =
         initSegment !== null ? content.representation.uniqueId : null;

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -184,6 +184,7 @@ export default class VideoThumbnailLoader {
         "video",
         loader.video,
         null,
+        null,
         // We don't care about the SegmentFetcher's lifecycle events
         {},
         {

--- a/src/main_thread/README.md
+++ b/src/main_thread/README.md
@@ -31,7 +31,7 @@ Those modules are:
 
   Ease up text/audio/video track switching to provide a simple-to-use API.
 
-  It as another sister block the `MediaElementTracksStore`
+  It has another sister block the `MediaElementTracksStore`
   (./tracks_store/media_element_tracks_store.ts), has the same role but for "directfile"
   contents - which are contents directly played by the browser (by setting the media file
   as the `src` of a media element).

--- a/src/main_thread/api/option_utils.ts
+++ b/src/main_thread/api/option_utils.ts
@@ -33,6 +33,7 @@ import type {
   ISegmentLoader,
   IServerSyncInfos,
   IRxPlayerMode,
+  ICmcdOptions,
 } from "../../public_types";
 import arrayIncludes from "../../utils/array_includes";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
@@ -84,6 +85,7 @@ interface IParsedLoadVideoOptionsBase {
   segmentLoader?: ISegmentLoader | undefined;
   serverSyncInfos?: IServerSyncInfos | undefined;
   mode: IRxPlayerMode;
+  cmcd: ICmcdOptions | undefined;
   __priv_manifestUpdateUrl?: string | undefined;
   __priv_patchLastSegmentInSidx?: boolean | undefined;
 }
@@ -456,6 +458,7 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     transport,
     mode,
     url,
+    cmcd: options.cmcd,
   };
 }
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -730,6 +730,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_initializeContentPlayback(options: IParsedLoadVideoOptions): void {
     const {
       autoPlay,
+      cmcd,
       defaultAudioTrackSwitchingMode,
       enableFastSwitching,
       initialManifest,
@@ -896,6 +897,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           adaptiveOptions,
           autoPlay,
           bufferOptions,
+          cmcd,
           keySystems,
           lowLatencyMode,
           transport: transportPipelines,
@@ -936,6 +938,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           adaptiveOptions,
           autoPlay,
           bufferOptions,
+          cmcd,
           keySystems,
           lowLatencyMode,
           transportOptions,

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -28,7 +28,7 @@ import type {
   SourceBufferType,
 } from "./mse";
 import type { IFreezingStatus, IRebufferingStatus } from "./playback_observer";
-import type { ITrackType } from "./public_types";
+import type { ICmcdOptions, ITrackType } from "./public_types";
 import type { ITransportOptions } from "./transports";
 import type { ILoggerLevel } from "./utils/logger";
 import type { IRange } from "./utils/ranges";
@@ -98,6 +98,10 @@ export interface IContentInitializationData {
    */
   contentId: string;
   /**
+   * When set to an object, enable "Common Media Client Data", or "CMCD".
+   */
+  cmcd?: ICmcdOptions | undefined;
+  /**
    * URL at which the content's Manifest is accessible.
    * `undefined` if unknown.
    */
@@ -128,7 +132,7 @@ export interface IContentInitializationData {
   /**
    * Options relative to the fetching and refreshing of the Manifest.
    */
-  manifestRetryOptions: IManifestFetcherSettings;
+  manifestRetryOptions: Omit<IManifestFetcherSettings, "cmcdDataBuilder">;
   /** Options relative to the fetching of media segments. */
   segmentRetryOptions: ISegmentFetcherCreatorBackoffOptions;
 }

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -429,10 +429,58 @@ export interface ISegmentLoaderContext {
   byteRanges?: Array<[number, number]> | undefined;
   /** Type of the corresponding track. */
   trackType: ITrackType;
+  /**
+   * Optional "Common Media Client Data" (CMCD) payload that may be added to
+   * the request.
+   */
+  cmcdPayload?: ICmcdPayload | undefined;
 }
 
 /** Every possible value for the Adaptation's `type` property. */
 export type ITrackType = "video" | "audio" | "text";
+
+/**
+ * Payload to add to a request to provide CMCD metadata through HTTP request
+ * headers.
+ *
+ * This is an object where keys are header names and values are header contents.
+ */
+export type ICmcdHeadersData = Record<string, string>;
+
+/**
+ * Payload to add to a request to provide CMCD metadata through an URL's query
+ * string.
+ *
+ * This is an array of all fields and corresponding values that should be
+ * added to the query string, the order should be kept.
+ *
+ * `null` indicates that the field has no value and should be added as is.
+ */
+export type ICmcdQueryData = Array<[string, string | null]>;
+
+/**
+ * Type when CMCD metadata should be added through headers to the HTTP request
+ * for the corresponding resource.
+ */
+export interface ICmcdHeadersPayload {
+  type: "headers";
+  value: ICmcdHeadersData;
+}
+
+/**
+ * Type when CMCD metadata should be added through the query string to the HTTP
+ * request for the corresponding resource.
+ */
+export interface ICmcdQueryPayload {
+  type: "query";
+  value: ICmcdQueryData;
+}
+
+/**
+ * Type to indicate that CMCD metadata should be added to the request for the
+ * corresponding resource.
+ */
+export type ICmcdPayload = ICmcdHeadersPayload | ICmcdQueryPayload;
 
 export type ILoadedManifestFormat = IInitialManifest;
 
@@ -458,8 +506,14 @@ export type IManifestLoader = (
 (() => void) | void;
 
 export interface IManifestLoaderInfo {
+  /** URL at which the wanted Manifest can be accessed. */
   url: string | undefined;
   timeout: number | undefined;
+  /**
+   * Optional "Common Media Client Data" (CMCD) payload that may be added to
+   * the request.
+   */
+  cmcdPayload: ICmcdPayload | undefined;
 }
 
 /** Options related to a single key system. */

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -29,6 +29,26 @@ export interface IWorkerSettings {
   dashWasmUrl?: string | ArrayBuffer | undefined;
 }
 
+/** Object that defines Common Media Client Data (CMCD) options. */
+export interface ICmcdOptions {
+  /**
+   * Content ID delivered by CMCD metadata for that content.
+   * If not specified, a default one will be generated.
+   */
+  contentId?: string;
+  /**
+   * Session ID delivered by CMCD metadata.
+   * If not specified, a default one will be generated.
+   */
+  sessionId?: string;
+  /**
+   * Allow to force the way in which the CMCD payload should be communicated.
+   *
+   * If not set, the most appropriate type will be relied on.
+   */
+  communicationType?: "headers" | "query";
+}
+
 /** Every options that can be given to the RxPlayer's constructor. */
 export interface IConstructorOptions {
   maxBufferAhead?: number;
@@ -150,6 +170,11 @@ export interface ILoadVideoOptions {
    * in "multithread" mode) for that content.
    */
   mode?: IRxPlayerMode | undefined;
+
+  /**
+   * When set to an object, enable "Common Media Client Data", or "CMCD".
+   */
+  cmcd?: ICmcdOptions | undefined;
 }
 
 /** Value of the `serverSyncInfos` transport option. */

--- a/src/transports/dash/init_segment_loader.ts
+++ b/src/transports/dash/init_segment_loader.ts
@@ -48,16 +48,17 @@ export default function initSegmentLoader(
   | ISegmentLoaderResultSegmentCreated<ArrayBuffer | Uint8Array>
   | ISegmentLoaderResultChunkedComplete
 > {
-  const url =
-    options.queryString === undefined
-      ? initialUrl
-      : addQueryString(initialUrl, options.queryString);
-
+  let url = initialUrl;
+  if (options.cmcdPayload?.type === "query") {
+    url = addQueryString(url, options.cmcdPayload.value);
+  }
+  const cmcdHeaders =
+    options.cmcdPayload?.type === "headers" ? options.cmcdPayload.value : undefined;
   if (segment.range === undefined) {
     return request({
       url,
       responseType: "arraybuffer",
-      headers: options.headers,
+      headers: cmcdHeaders,
       timeout: options.timeout,
       connectionTimeout: options.connectionTimeout,
       cancelSignal,
@@ -69,7 +70,7 @@ export default function initSegmentLoader(
     return request({
       url,
       headers: {
-        ...options.headers,
+        ...cmcdHeaders,
         Range: byteRange(segment.range),
       },
       responseType: "arraybuffer",
@@ -85,7 +86,7 @@ export default function initSegmentLoader(
     return request({
       url,
       headers: {
-        ...options.headers,
+        ...cmcdHeaders,
         Range: byteRange([segment.range[0], segment.indexRange[1]]),
       },
       responseType: "arraybuffer",
@@ -99,7 +100,7 @@ export default function initSegmentLoader(
   const rangeRequest$ = request({
     url,
     headers: {
-      ...options.headers,
+      ...cmcdHeaders,
       Range: byteRange(segment.range),
     },
     responseType: "arraybuffer",
@@ -111,7 +112,7 @@ export default function initSegmentLoader(
   const indexRequest$ = request({
     url,
     headers: {
-      ...options.headers,
+      ...cmcdHeaders,
       Range: byteRange(segment.indexRange),
     },
     responseType: "arraybuffer",

--- a/src/transports/dash/load_chunked_segment_data.ts
+++ b/src/transports/dash/load_chunked_segment_data.ts
@@ -20,12 +20,9 @@ import type { IFetchedDataObject } from "../../utils/request/fetch";
 import fetchRequest from "../../utils/request/fetch";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import type {
-  ISegmentContext,
   ISegmentLoaderCallbacks,
-  ISegmentLoaderOptions,
   ISegmentLoaderResultChunkedComplete,
 } from "../types";
-import byteRange from "../utils/byte_range";
 
 /**
  * Load segments through a "chunk" mode (decodable chunk by decodable chunk).
@@ -33,22 +30,27 @@ import byteRange from "../utils/byte_range";
  * This method is particularly adapted to low-latency streams.
  *
  * @param {string} url - URL of the segment to download.
- * @param {Object} content - Context of the segment needed.
- * @param {Object} options
+ * @param {Object} requestOptions
+ * @param {Object|undefined} requestOptions.headers - Headers for the
+ * low-latency request
+ * @param {number|undefined} requestOptions.timeout - Request timeout for the
+ * low-latency request.
+ * @param {number|undefined} requestOptions.connectionTimeout - HTTP connection
+ * timeout for the low-latency request.
  * @param {Object} callbacks
  * @param {CancellationSignal} cancelSignal
  * @returns {Promise}
  */
-export default function lowLatencySegmentLoader(
+export default async function loadChunkedSegmentData(
   url: string,
-  content: ISegmentContext,
-  options: ISegmentLoaderOptions,
+  requestOptions: {
+    headers: Record<string, string> | undefined;
+    timeout: number | undefined;
+    connectionTimeout: number | undefined;
+  },
   callbacks: ISegmentLoaderCallbacks<Uint8Array>,
   cancelSignal: CancellationSignal,
 ): Promise<ISegmentLoaderResultChunkedComplete> {
-  const { segment } = content;
-  const headers =
-    segment.range !== undefined ? { Range: byteRange(segment.range) } : undefined;
   let partialChunk: Uint8Array | null = null;
 
   /**
@@ -79,15 +81,16 @@ export default function lowLatencySegmentLoader(
     }
   }
 
-  return fetchRequest({
+  const res = await fetchRequest({
     url,
-    headers,
+    headers: requestOptions.headers,
     onData,
-    timeout: options.timeout,
-    connectionTimeout: options.connectionTimeout,
+    timeout: requestOptions.timeout,
+    connectionTimeout: requestOptions.connectionTimeout,
     cancelSignal,
-  }).then((res) => ({
+  });
+  return {
     resultType: "chunk-complete" as const,
     resultData: res,
-  }));
+  };
 }

--- a/src/transports/dash/pipelines.ts
+++ b/src/transports/dash/pipelines.ts
@@ -42,6 +42,7 @@ export default function (options: ITransportOptions): ITransportPipelines {
   const textTrackParser = generateTextTrackParser(options);
 
   return {
+    transportName: "dash",
     manifest: { loadManifest: manifestLoader, parseManifest: manifestParser },
     audio: {
       loadSegment: segmentLoader,

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -71,19 +71,22 @@ export async function regularSegmentLoader(
   }
 
   const url =
-    options.queryString === undefined
-      ? initialUrl
-      : addQueryString(initialUrl, options.queryString);
+    options.cmcdPayload?.type === "query"
+      ? addQueryString(initialUrl, options.cmcdPayload.value)
+      : initialUrl;
+
+  const cmcdHeaders =
+    options.cmcdPayload?.type === "headers" ? options.cmcdPayload.value : undefined;
 
   const { segment } = context;
   let headers;
   if (segment.range !== undefined) {
     headers = {
-      ...options.headers,
+      ...cmcdHeaders,
       Range: byteRange(segment.range),
     };
-  } else if (options.headers !== undefined) {
-    headers = options.headers;
+  } else if (cmcdHeaders !== undefined) {
+    headers = cmcdHeaders;
   }
 
   const containerType = inferSegmentContainer(context.type, context.mimeType);
@@ -281,6 +284,7 @@ export default function generateSegmentLoader({
         byteRanges,
         trackType: context.type,
         url,
+        cmcdPayload: options.cmcdPayload,
       };
       const abort = customSegmentLoader(args, customCallbacks);
 

--- a/src/transports/dash/segment_loader.ts
+++ b/src/transports/dash/segment_loader.ts
@@ -30,16 +30,17 @@ import type {
   ISegmentLoaderResultSegmentCreated,
   ISegmentLoaderResultSegmentLoaded,
 } from "../types";
+import addQueryString from "../utils/add_query_string";
 import byteRange from "../utils/byte_range";
 import inferSegmentContainer from "../utils/infer_segment_container";
 import addSegmentIntegrityChecks from "./add_segment_integrity_checks_to_loader";
 import constructSegmentUrl from "./construct_segment_url";
 import initSegmentLoader from "./init_segment_loader";
-import lowLatencySegmentLoader from "./low_latency_segment_loader";
+import loadChunkedSegmentData from "./load_chunked_segment_data";
 
 /**
  * Segment loader triggered if there was no custom-defined one in the API.
- * @param {string} url
+ * @param {string} initialUrl
  * @param {Object} context
  * @param {boolean} lowLatencyMode
  * @param {Object} options
@@ -47,8 +48,8 @@ import lowLatencySegmentLoader from "./low_latency_segment_loader";
  * @param {Object} cancelSignal
  * @returns {Promise}
  */
-export function regularSegmentLoader(
-  url: string,
+export async function regularSegmentLoader(
+  initialUrl: string,
   context: ISegmentContext,
   lowLatencyMode: boolean,
   options: ISegmentLoaderOptions,
@@ -60,13 +61,44 @@ export function regularSegmentLoader(
   | ISegmentLoaderResultChunkedComplete
 > {
   if (context.segment.isInit) {
-    return initSegmentLoader(url, context.segment, options, cancelSignal, callbacks);
+    return initSegmentLoader(
+      initialUrl,
+      context.segment,
+      options,
+      cancelSignal,
+      callbacks,
+    );
+  }
+
+  const url =
+    options.queryString === undefined
+      ? initialUrl
+      : addQueryString(initialUrl, options.queryString);
+
+  const { segment } = context;
+  let headers;
+  if (segment.range !== undefined) {
+    headers = {
+      ...options.headers,
+      Range: byteRange(segment.range),
+    };
+  } else if (options.headers !== undefined) {
+    headers = options.headers;
   }
 
   const containerType = inferSegmentContainer(context.type, context.mimeType);
   if (lowLatencyMode && (containerType === "mp4" || containerType === undefined)) {
     if (fetchIsSupported()) {
-      return lowLatencySegmentLoader(url, context, options, callbacks, cancelSignal);
+      return loadChunkedSegmentData(
+        url,
+        {
+          headers,
+          timeout: options.timeout,
+          connectionTimeout: options.connectionTimeout,
+        },
+        callbacks,
+        cancelSignal,
+      );
     } else {
       warnOnce(
         "DASH: Your browser does not have the fetch API. You will have " +
@@ -75,17 +107,16 @@ export function regularSegmentLoader(
     }
   }
 
-  const { segment } = context;
-  return request({
+  const data = await request({
     url,
     responseType: "arraybuffer",
-    headers:
-      segment.range !== undefined ? { Range: byteRange(segment.range) } : undefined,
+    headers,
     timeout: options.timeout,
     connectionTimeout: options.connectionTimeout,
     cancelSignal,
     onProgress: callbacks.onProgress,
-  }).then((data) => ({ resultType: "segment-loaded", resultData: data }));
+  });
+  return { resultType: "segment-loaded", resultData: data };
 }
 
 /**
@@ -101,6 +132,7 @@ export default function generateSegmentLoader({
   segmentLoader?: ICustomSegmentLoader | undefined;
   checkMediaSegmentIntegrity?: boolean | undefined;
 }): ISegmentLoader<Uint8Array | ArrayBuffer | null> {
+  // XXX TODO what to do here?
   return checkMediaSegmentIntegrity !== true
     ? segmentLoader
     : addSegmentIntegrityChecks(segmentLoader);

--- a/src/transports/dash/text_loader.ts
+++ b/src/transports/dash/text_loader.ts
@@ -86,18 +86,21 @@ export default function generateTextTrackLoader({
     }
 
     const url =
-      options.queryString === undefined
-        ? initialUrl
-        : addQueryString(initialUrl, options.queryString);
+      options.cmcdPayload?.type === "query"
+        ? addQueryString(initialUrl, options.cmcdPayload.value)
+        : initialUrl;
+
+    const cmcdHeaders =
+      options.cmcdPayload?.type === "headers" ? options.cmcdPayload.value : undefined;
 
     let headers;
     if (segment.range !== undefined) {
       headers = {
-        ...options.headers,
+        ...cmcdHeaders,
         Range: byteRange(segment.range),
       };
-    } else if (options.headers !== undefined) {
-      headers = options.headers;
+    } else if (cmcdHeaders !== undefined) {
+      headers = cmcdHeaders;
     }
 
     const containerType = inferSegmentContainer(context.type, context.mimeType);

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -88,6 +88,7 @@ export default function getLocalManifestPipelines(
   };
 
   return {
+    transportName: "local",
     manifest: manifestPipeline,
     audio: segmentPipeline,
     video: segmentPipeline,

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -35,13 +35,18 @@ function regularManifestLoader(
   if (initialUrl === undefined) {
     throw new Error("Cannot perform HTTP(s) request. URL not known");
   }
+
   const url =
-    loaderOptions.queryString === undefined
-      ? initialUrl
-      : addQueryString(initialUrl, loaderOptions.queryString);
+    loaderOptions.cmcdPayload?.type === "query"
+      ? addQueryString(initialUrl, loaderOptions.cmcdPayload.value)
+      : initialUrl;
+
   return request({
     url,
-    headers: loaderOptions.headers,
+    headers:
+      loaderOptions.cmcdPayload?.type === "headers"
+        ? loaderOptions.cmcdPayload.value
+        : undefined,
     responseType: "text",
     timeout: loaderOptions.timeout,
     connectionTimeout: loaderOptions.connectionTimeout,

--- a/src/transports/metaplaylist/manifest_loader.ts
+++ b/src/transports/metaplaylist/manifest_loader.ts
@@ -18,24 +18,30 @@ import type { IManifestLoader, ILoadedManifestFormat } from "../../public_types"
 import request from "../../utils/request";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import type { IManifestLoaderOptions, IRequestedData } from "../types";
+import addQueryString from "../utils/add_query_string";
 import callCustomManifestLoader from "../utils/call_custom_manifest_loader";
 
 /**
  * Manifest loader triggered if there was no custom-defined one in the API.
- * @param {string} url
+ * @param {string} initialUrl
  * @param {Object} loaderOptions
  * @param {Object} cancelSignal
  */
 function regularManifestLoader(
-  url: string | undefined,
+  initialUrl: string | undefined,
   loaderOptions: IManifestLoaderOptions,
   cancelSignal: CancellationSignal,
 ): Promise<IRequestedData<ILoadedManifestFormat>> {
-  if (url === undefined) {
+  if (initialUrl === undefined) {
     throw new Error("Cannot perform HTTP(s) request. URL not known");
   }
+  const url =
+    loaderOptions.queryString === undefined
+      ? initialUrl
+      : addQueryString(initialUrl, loaderOptions.queryString);
   return request({
     url,
+    headers: loaderOptions.headers,
     responseType: "text",
     timeout: loaderOptions.timeout,
     connectionTimeout: loaderOptions.connectionTimeout,

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -392,6 +392,7 @@ export default function (options: ITransportOptions): ITransportPipelines {
   };
 
   return {
+    transportName: "metaplaylist",
     manifest: manifestPipeline,
     audio: audioPipeline,
     video: videoPipeline,

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -177,6 +177,7 @@ export default function (options: ITransportOptions): ITransportPipelines {
             const manOpts = {
               timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
               connectionTimeout: config.getCurrent().DEFAULT_CONNECTION_TIMEOUT,
+              cmcdPayload: undefined,
             };
             return transport.manifest.loadManifest(resource.url, manOpts, cancelSignal);
           }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -221,10 +221,13 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
       if (!isMP4) {
         return request({
           url:
-            loaderOptions.queryString === undefined
-              ? url
-              : addQueryString(url, loaderOptions.queryString),
-          headers: loaderOptions.headers,
+            loaderOptions.cmcdPayload?.type === "query"
+              ? addQueryString(url, loaderOptions.cmcdPayload.value)
+              : url,
+          headers:
+            loaderOptions.cmcdPayload?.type === "headers"
+              ? loaderOptions.cmcdPayload.value
+              : undefined,
           responseType: "text",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,
@@ -237,10 +240,13 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
       } else {
         return request({
           url:
-            loaderOptions.queryString === undefined
-              ? url
-              : addQueryString(url, loaderOptions.queryString),
-          headers: loaderOptions.headers,
+            loaderOptions.cmcdPayload?.type === "query"
+              ? addQueryString(url, loaderOptions.cmcdPayload.value)
+              : url,
+          headers:
+            loaderOptions.cmcdPayload?.type === "headers"
+              ? loaderOptions.cmcdPayload.value
+              : undefined,
           responseType: "arraybuffer",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -41,6 +41,7 @@ import type {
   ITransportOptions,
   ITransportPipelines,
 } from "../types";
+import addQueryString from "../utils/add_query_string";
 import checkISOBMFFIntegrity from "../utils/check_isobmff_integrity";
 import generateManifestLoader from "../utils/generate_manifest_loader";
 import extractTimingsInfos from "./extract_timings_infos";
@@ -219,7 +220,11 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
       const isMP4 = isMP4EmbeddedTrack(context.mimeType);
       if (!isMP4) {
         return request({
-          url,
+          url:
+            loaderOptions.queryString === undefined
+              ? url
+              : addQueryString(url, loaderOptions.queryString),
+          headers: loaderOptions.headers,
           responseType: "text",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,
@@ -231,7 +236,11 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
         }));
       } else {
         return request({
-          url,
+          url:
+            loaderOptions.queryString === undefined
+              ? url
+              : addQueryString(url, loaderOptions.queryString),
+          headers: loaderOptions.headers,
           responseType: "arraybuffer",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,
@@ -408,6 +417,7 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
   };
 
   return {
+    transportName: "smooth",
     manifest: manifestPipeline,
     audio: audioVideoPipeline,
     video: audioVideoPipeline,

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -43,6 +43,9 @@ export type ITransportFunction = (options: ITransportOptions) => ITransportPipel
  * parse the Manifest or any segment.
  */
 export interface ITransportPipelines {
+  /** Name describing the current transport pipeline. */
+  transportName: ITransportName;
+
   /** Functions allowing to load an parse the Manifest for this transport. */
   manifest: ITransportManifestPipeline;
 
@@ -60,6 +63,9 @@ export interface ITransportPipelines {
   text: ISegmentPipeline<ILoadedTextSegmentFormat, ITextTrackSegmentData | null>;
 }
 
+/** Name describing the transport pipeline. */
+export type ITransportName = "dash" | "smooth" | "local" | "metaplaylist";
+
 /** Functions allowing to load and parse the Manifest. */
 export interface ITransportManifestPipeline {
   /**
@@ -69,6 +75,7 @@ export interface ITransportManifestPipeline {
    * @param {string|undefined} url - URL of the Manifest we want to load.
    * `undefined` if the Manifest doesn't have an URL linked to it, in which case
    * the Manifest should be loaded through another mean.
+   * @param {Object} options - Various options linked to the manifest request
    * @param {CancellationSignal} cancellationSignal - Signal which will allow to
    * cancel the loading operation if the Manifest is not needed anymore (for
    * example, if the content has just been stopped).
@@ -173,6 +180,24 @@ export interface IManifestLoaderOptions {
    * Do not set or set to "undefined" to disable it.
    */
   connectionTimeout?: number | undefined;
+  /**
+   * Optional headers that should be added to the Manifest request if it
+   * involves HTTP(S).
+   *
+   * Note that a request itself might already necessitate headers, in which case
+   * they'll have priority if there's an header name conflict.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Optional supplementary elements to add to the query string that should be
+   * added to the Manifest request if it involves HTTP(S).
+   *
+   * This is an array of all fields and corresponding values that should be
+   * added to the query string, the order should be kept.
+   *
+   * `null` indicates that the field has no value and should be added as is.
+   */
+  queryString?: Array<[string, string | null]>;
 }
 
 /** Functions allowing to load and parse segments of any type. */
@@ -225,6 +250,24 @@ export interface ISegmentLoaderOptions {
    * Do not set or set to "undefined" to disable it.
    */
   connectionTimeout?: number | undefined;
+  /**
+   * Optional headers that should be added to the Manifest request if it
+   * involves HTTP(S).
+   *
+   * Note that a request itself might already necessitate headers, in which case
+   * they'll have priority if there's an header name conflict.
+   */
+  headers?: Record<string, string>;
+  /**
+   * Optional supplementary elements to add to the query string that should be
+   * added to the Manifest request if it involves HTTP(S).
+   *
+   * This is an array of all fields and corresponding values that should be
+   * added to the query string, the order should be kept.
+   *
+   * `null` indicates that the field has no value and should be added as is.
+   */
+  queryString?: Array<[string, string | null]>;
 }
 
 /**

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -25,6 +25,7 @@ import type {
   ISegmentLoader as ICustomSegmentLoader,
   IServerSyncInfos,
   IPlayerError,
+  ICmcdPayload,
 } from "../public_types";
 import type { CancellationSignal } from "../utils/task_canceller";
 import type TaskCanceller from "../utils/task_canceller";
@@ -181,23 +182,10 @@ export interface IManifestLoaderOptions {
    */
   connectionTimeout?: number | undefined;
   /**
-   * Optional headers that should be added to the Manifest request if it
-   * involves HTTP(S).
-   *
-   * Note that a request itself might already necessitate headers, in which case
-   * they'll have priority if there's an header name conflict.
+   * Optional "Common Media Client Data" (CMCD) payload that may be added to
+   * the request.
    */
-  headers?: Record<string, string>;
-  /**
-   * Optional supplementary elements to add to the query string that should be
-   * added to the Manifest request if it involves HTTP(S).
-   *
-   * This is an array of all fields and corresponding values that should be
-   * added to the query string, the order should be kept.
-   *
-   * `null` indicates that the field has no value and should be added as is.
-   */
-  queryString?: Array<[string, string | null]>;
+  cmcdPayload: ICmcdPayload | undefined;
 }
 
 /** Functions allowing to load and parse segments of any type. */
@@ -251,23 +239,10 @@ export interface ISegmentLoaderOptions {
    */
   connectionTimeout?: number | undefined;
   /**
-   * Optional headers that should be added to the Manifest request if it
-   * involves HTTP(S).
-   *
-   * Note that a request itself might already necessitate headers, in which case
-   * they'll have priority if there's an header name conflict.
+   * Optional "Common Media Client Data" (CMCD) payload that may be added to
+   * the request.
    */
-  headers?: Record<string, string>;
-  /**
-   * Optional supplementary elements to add to the query string that should be
-   * added to the Manifest request if it involves HTTP(S).
-   *
-   * This is an array of all fields and corresponding values that should be
-   * added to the query string, the order should be kept.
-   *
-   * `null` indicates that the field has no value and should be added as is.
-   */
-  queryString?: Array<[string, string | null]>;
+  cmcdPayload: ICmcdPayload | undefined;
 }
 
 /**

--- a/src/transports/utils/__tests__/add_query_string.test.ts
+++ b/src/transports/utils/__tests__/add_query_string.test.ts
@@ -16,6 +16,7 @@ describe("addQueryString", () => {
       ]),
     ).toEqual("https://www.example.com?first=val&second&third=something");
   });
+
   it("should add query string before present fragment", () => {
     expect(
       addQueryString("https://www.example.com#toto", [
@@ -24,7 +25,77 @@ describe("addQueryString", () => {
         ["third", "something"],
       ]),
     ).toEqual("https://www.example.com?first=val&second&third=something#toto");
+    expect(
+      addQueryString("https://www.example.com#t?oto", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#t?oto");
+    expect(
+      addQueryString("https://www.example.com#?toto", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#?toto");
   });
+
+  it("should have special handling if only the ? character is already present in query string", () => {
+    expect(
+      addQueryString("https://www.example.com?#?toto", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#?toto");
+    expect(
+      addQueryString("https://www.example.com?", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something");
+    expect(
+      addQueryString("https://www.example.com?#", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#");
+    expect(
+      addQueryString("https://www.example.com?#??????", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#??????");
+  });
+
+  it("should combine with already-present query string", () => {
+    expect(
+      addQueryString("https://www.example.com?before=5", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?before=5&first=val&second&third=something");
+    expect(
+      addQueryString("https://www.example.com?someBool", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?someBool&first=val&second&third=something");
+    expect(
+      addQueryString("https://www.example.com?a", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?a&first=val&second&third=something");
+  });
+
   it("should combine with already-present query string and fragment", () => {
     expect(
       addQueryString("https://www.example.com?before=5#test", [

--- a/src/transports/utils/__tests__/add_query_string.test.ts
+++ b/src/transports/utils/__tests__/add_query_string.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import addQueryString from "../add_query_string";
+
+describe("addQueryString", () => {
+  it("should do nothing if no query string is wanted", () => {
+    expect(addQueryString("https://www.example.com", [])).toEqual(
+      "https://www.example.com",
+    );
+  });
+  it("should add query string to a simple URL", () => {
+    expect(
+      addQueryString("https://www.example.com", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something");
+  });
+  it("should add query string before present fragment", () => {
+    expect(
+      addQueryString("https://www.example.com#toto", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?first=val&second&third=something#toto");
+  });
+  it("should combine with already-present query string and fragment", () => {
+    expect(
+      addQueryString("https://www.example.com?before=5#test", [
+        ["first", "val"],
+        ["second", null],
+        ["third", "something"],
+      ]),
+    ).toEqual("https://www.example.com?before=5&first=val&second&third=something#test");
+  });
+});

--- a/src/transports/utils/add_query_string.ts
+++ b/src/transports/utils/add_query_string.ts
@@ -16,43 +16,26 @@ export default function addQueryString(
   if (supplementaryQueryStringData.length === 0) {
     return baseUrl;
   }
-  let urlPrefix: string;
-  let urlSuffix: string | null;
   let queryStringStartingChar: "?" | "&" | "";
-  const indexOfQueryString = baseUrl.indexOf("?");
-  if (indexOfQueryString === -1) {
-    queryStringStartingChar = "?";
-    const indexOfFragment = baseUrl.indexOf("#");
-    if (indexOfFragment >= 0) {
-      urlPrefix = baseUrl.substring(0, indexOfFragment);
-      urlSuffix = baseUrl.substring(indexOfFragment);
-    } else {
-      urlPrefix = baseUrl;
-      urlSuffix = null;
-    }
-  } else {
-    let indexOfFragment = baseUrl.substring(indexOfQueryString).indexOf("#");
-    if (indexOfFragment >= 0) {
-      indexOfFragment += indexOfQueryString;
-      if (indexOfQueryString + 1 === indexOfFragment) {
-        queryStringStartingChar = "";
-      } else {
-        queryStringStartingChar = "&";
-      }
-      urlPrefix = baseUrl.substring(0, indexOfFragment);
-      urlSuffix = baseUrl.substring(indexOfFragment);
-    } else {
-      if (indexOfQueryString === baseUrl.length - 1) {
-        queryStringStartingChar = "";
-      } else {
-        queryStringStartingChar = "&";
-      }
-      urlPrefix = baseUrl;
-      urlSuffix = null;
-    }
+
+  let urlFragment = "";
+  const indexOfFragment = baseUrl.indexOf("#");
+  let baseUrlWithoutFragment = baseUrl;
+  if (indexOfFragment >= 0) {
+    urlFragment = baseUrl.substring(indexOfFragment);
+    baseUrlWithoutFragment = baseUrl.substring(0, indexOfFragment);
   }
 
-  let url = urlPrefix + queryStringStartingChar;
+  const indexOfQueryString = baseUrlWithoutFragment.indexOf("?");
+  if (indexOfQueryString === -1) {
+    queryStringStartingChar = "?";
+  } else if (indexOfQueryString + 1 === baseUrlWithoutFragment.length) {
+    queryStringStartingChar = "";
+  } else {
+    queryStringStartingChar = "&";
+  }
+
+  let url = baseUrlWithoutFragment + queryStringStartingChar;
   for (let i = 0; i < supplementaryQueryStringData.length; i++) {
     const queryStringElt = supplementaryQueryStringData[i];
     if (queryStringElt[1] === null) {
@@ -64,8 +47,8 @@ export default function addQueryString(
       url += "&";
     }
   }
-  if (urlSuffix !== null) {
-    url += urlSuffix;
+  if (urlFragment.length > 0) {
+    url += urlFragment;
   }
   return url;
 }

--- a/src/transports/utils/add_query_string.ts
+++ b/src/transports/utils/add_query_string.ts
@@ -1,0 +1,71 @@
+/**
+ * Add to an URL a query string corresponding to `supplementaryQueryStringData`,
+ * being tuples where the first element is a query string's property name and the
+ * second element is its value (or null if there's no associated value.
+ *
+ * If the given URL already has a query string, the new query string elements
+ * will just be appended.
+ * @param {string} baseUrl
+ * @param {Array.<Array.<string|null>>} supplementaryQueryStringData
+ * @returns {string}
+ */
+export default function addQueryString(
+  baseUrl: string,
+  supplementaryQueryStringData: Array<[string, string | null]>,
+): string {
+  if (supplementaryQueryStringData.length === 0) {
+    return baseUrl;
+  }
+  let urlPrefix: string;
+  let urlSuffix: string | null;
+  let queryStringStartingChar: "?" | "&" | "";
+  const indexOfQueryString = baseUrl.indexOf("?");
+  if (indexOfQueryString === -1) {
+    queryStringStartingChar = "?";
+    const indexOfFragment = baseUrl.indexOf("#");
+    if (indexOfFragment >= 0) {
+      urlPrefix = baseUrl.substring(0, indexOfFragment);
+      urlSuffix = baseUrl.substring(indexOfFragment);
+    } else {
+      urlPrefix = baseUrl;
+      urlSuffix = null;
+    }
+  } else {
+    let indexOfFragment = baseUrl.substring(indexOfQueryString).indexOf("#");
+    if (indexOfFragment >= 0) {
+      indexOfFragment += indexOfQueryString;
+      if (indexOfQueryString + 1 === indexOfFragment) {
+        queryStringStartingChar = "";
+      } else {
+        queryStringStartingChar = "&";
+      }
+      urlPrefix = baseUrl.substring(0, indexOfFragment);
+      urlSuffix = baseUrl.substring(indexOfFragment);
+    } else {
+      if (indexOfQueryString === baseUrl.length - 1) {
+        queryStringStartingChar = "";
+      } else {
+        queryStringStartingChar = "&";
+      }
+      urlPrefix = baseUrl;
+      urlSuffix = null;
+    }
+  }
+
+  let url = urlPrefix + queryStringStartingChar;
+  for (let i = 0; i < supplementaryQueryStringData.length; i++) {
+    const queryStringElt = supplementaryQueryStringData[i];
+    if (queryStringElt[1] === null) {
+      url += queryStringElt[0];
+    } else {
+      url += `${queryStringElt[0]}=${queryStringElt[1]}`;
+    }
+    if (i < supplementaryQueryStringData.length - 1) {
+      url += "&";
+    }
+  }
+  if (urlSuffix !== null) {
+    url += urlSuffix;
+  }
+  return url;
+}

--- a/src/transports/utils/call_custom_manifest_loader.ts
+++ b/src/transports/utils/call_custom_manifest_loader.ts
@@ -44,7 +44,7 @@ export default function callCustomManifestLoader(
 
       /**
        * Callback triggered when the custom manifest loader has a response.
-       * @param {Object} args
+       * @param {Object} _args
        */
       const resolve = (_args: {
         data: ILoadedManifestFormat;
@@ -120,7 +120,7 @@ export default function callCustomManifestLoader(
 
       const callbacks = { reject, resolve, fallback };
       const abort = customManifestLoader(
-        { url, timeout: loaderOptions.timeout },
+        { url, timeout: loaderOptions.timeout, cmcdPayload: loaderOptions.cmcdPayload },
         callbacks,
       );
 

--- a/src/transports/utils/generate_manifest_loader.ts
+++ b/src/transports/utils/generate_manifest_loader.ts
@@ -44,9 +44,14 @@ function generateRegularManifestLoader(
     }
 
     const url =
-      loaderOptions.queryString === undefined
-        ? initialUrl
-        : addQueryString(initialUrl, loaderOptions.queryString);
+      loaderOptions.cmcdPayload?.type === "query"
+        ? addQueryString(initialUrl, loaderOptions.cmcdPayload.value)
+        : initialUrl;
+
+    const cmcdHeaders =
+      loaderOptions.cmcdPayload?.type === "headers"
+        ? loaderOptions.cmcdPayload.value
+        : undefined;
 
     // What follows could be written in a single line, but TypeScript wouldn't
     // shut up.
@@ -55,7 +60,7 @@ function generateRegularManifestLoader(
       case "arraybuffer":
         return request({
           url,
-          headers: loaderOptions.headers,
+          headers: cmcdHeaders,
           responseType: "arraybuffer",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,
@@ -64,7 +69,7 @@ function generateRegularManifestLoader(
       case "text":
         return request({
           url,
-          headers: loaderOptions.headers,
+          headers: cmcdHeaders,
           responseType: "text",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,
@@ -73,7 +78,7 @@ function generateRegularManifestLoader(
       case "document":
         return request({
           url,
-          headers: loaderOptions.headers,
+          headers: cmcdHeaders,
           responseType: "document",
           timeout: loaderOptions.timeout,
           connectionTimeout: loaderOptions.connectionTimeout,

--- a/src/utils/create_uuid.ts
+++ b/src/utils/create_uuid.ts
@@ -1,0 +1,28 @@
+import globalScope from "./global_scope";
+import getMonotonicTimeStamp from "./monotonic_timestamp";
+
+/**
+ * Create and return a Universally Unique IDentifier (UUID) as defined by
+ * RFC4122.
+ * Depending on browser API availability, we may be generating an approximation
+ * of what the RFC indicates instead.
+ * @returns {string}
+ */
+export default function createUuid(): string {
+  if (typeof globalScope.crypto?.randomUUID === "function") {
+    return globalScope.crypto.randomUUID();
+  }
+  let ts1 = new Date().getTime();
+  let ts2 = getMonotonicTimeStamp();
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (c) {
+    let r = Math.random() * 16;
+    if (ts1 > 0) {
+      r = (ts1 + r) % 16 | 0;
+      ts1 = Math.floor(ts1 / 16);
+    } else {
+      r = (ts2 + r) % 16 | 0;
+      ts2 = Math.floor(ts2 / 16);
+    }
+    return (c === "x" ? r : (r & 0x3) | 0x8).toString(16);
+  });
+}

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -81,8 +81,8 @@ export interface IFetchOptions {
    * reject with the corresponding `CancellationError`.
    */
   cancelSignal: CancellationSignal;
-  /** Optional headers for the HTTP GET request perfomed by `fetchRequest`. */
-  headers?: { [header: string]: string } | undefined | null;
+  /** Dictionary of headers you want to set. `null` or `undefined` for no header. */
+  headers?: Record<string, string> | null | undefined;
   /**
    * Optional timeout for the HTTP GET request perfomed by `fetchRequest`.
    * This timeout is just enabled until the HTTP response from the server, even
@@ -108,7 +108,7 @@ const _AbortController: IAbortControllerConstructor | null =
 export default function fetchRequest(
   options: IFetchOptions,
 ): Promise<IFetchedStreamComplete> {
-  let headers: Headers | { [key: string]: string } | undefined;
+  let headers: Headers | Record<string, string> | undefined;
   if (!isNullOrUndefined(options.headers)) {
     if (isNullOrUndefined(_Headers)) {
       headers = options.headers;

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -264,7 +264,7 @@ export interface IRequestOptions<ResponseType> {
   /** URL you want to request. */
   url: string;
   /** Dictionary of headers you want to set. `null` or `undefined` for no header. */
-  headers?: { [header: string]: string } | null | undefined;
+  headers?: Record<string, string> | null | undefined;
   /** Wanted format for the response */
   responseType?: ResponseType | undefined;
   /**


### PR DESCRIPTION
This is a work-in-progress and proposal for a CMCD integration inside the RxPlayer.

CMCD is for "Common Media Client Data", and it allows a media player to communicate metrics related to playback conditions and wanted segments to the CDN.
In turn, this can be then used on the CDN-side theoretically for things like monitoring (e.g. why and when users encounter rebuffering periods), QoE improvements (e.g. putting more priority on users with a low buffer health) and caching improvements thanks to the client hinting at what it's going to request next.

This communication can go through several means: here I implemented through the URL's query string by default or through headers (which might necessitate preflight requests because of CORS policies) optionally.
It will be opt-in and disabled by default.

---

Specifics:

  - The CMCD properties `nor` and `nrr`, used for segment pre-fetching be integrated is not yet relied on because it necessitates some refactoring first
  
  - For now, CMCD is always integrated in all builds, as opposed to an optional feature to explicitly import
  
 - When in a multithreading mode, it is possible that the estimated current position that is relied on for several CMCD fields is actually behind the real current position, as we rely on the last communicated one there (we could alternatively estimate a more precize position by looking at adding the time difference from the point at which the object was constructed)