### PR TITLE
Actually rely on `connectionTimeout` on DASH low-latency contents

### DIFF
--- a/src/transports/dash/low_latency_segment_loader.ts
+++ b/src/transports/dash/low_latency_segment_loader.ts
@@ -84,6 +84,7 @@ export default function lowLatencySegmentLoader(
     headers,
     onData,
     timeout: options.timeout,
+    connectionTimeout: options.connectionTimeout,
     cancelSignal,
   }).then((res) => ({
     resultType: "chunk-complete" as const,


### PR DESCRIPTION
It turns out that our new (v4.0.0) `connectionTimeout` properties that can be set on the `requestConfig` `loadVideo` option was not exploited when requesting segment in a Chunked transfer mode, which is only used with low-latency DASH contents.

This PR fixes that.