### PR TITLE
fix(isobmff): exclude zero-filled keyId from the init segment parsing

### DIFF
--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -560,7 +560,7 @@ function getKeyIdFromInitSegment(segment: Uint8Array): Uint8Array | null {
   }
   const keyId = tenc.subarray(8, 24);
   // Zero-filled keyId should only be valid for unencrypted content
-  return keyId.every((b) => b !== 0) ? keyId : null;
+  return !keyId.every((b) => b === 0) ? keyId : null;
 }
 
 export {

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -558,7 +558,9 @@ function getKeyIdFromInitSegment(segment: Uint8Array): Uint8Array | null {
   if (tenc === null || tenc.byteLength < 24) {
     return null;
   }
-  return tenc.subarray(8, 24);
+  const keyId = tenc.subarray(8, 24);
+  // Zero-filled keyId should only be valid for unencrypted content
+  return keyId.every((b) => b !== 0) ? keyId : null;
 }
 
 export {

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -560,7 +560,7 @@ function getKeyIdFromInitSegment(segment: Uint8Array): Uint8Array | null {
   }
   const keyId = tenc.subarray(8, 24);
   // Zero-filled keyId should only be valid for unencrypted content
-  return !keyId.every((b) => b === 0) ? keyId : null;
+  return keyId.every((b) => b === 0) ? null : keyId;
 }
 
 export {


### PR DESCRIPTION
- A zero-filled keyId makes all streams undecipherable.

fix #1458 
