### PR TITLE
[Proposal] add LogFormat static property

### DIFF
--- a/doc/api/Static_Properties.md
+++ b/doc/api/Static_Properties.md
@@ -42,6 +42,27 @@ import RxPlayer from "rx-player";
 RxPlayer.LogLevel = "WARNING";
 ```
 
+## LogFormat
+
+Allows to configure the format log messages will have.
+
+Can be set to either:
+
+- `"standard"`: Regular log messages will be printed, this is the default format.
+
+- `"full"`: Log messages will be enriched with timestamps and namespaces, which allows
+  them to be easier to programatically exploit.
+
+  You may for example prefer that format when reporting issues to the RxPlayer's
+  maintainers, so we are able to extract more information from those logs.
+
+### Example
+
+```js
+import RxPlayer from "rx-player";
+RxPlayer.LogFormat = "full";
+```
+
 ## ErrorTypes
 
 The different "types" of Error you can get on playback error,

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -392,6 +392,9 @@ events and so on.
 - [`LogLevel`](../api/Static_Properties.md#loglevel): Update the verbosity of the RxPlayer
   logger.
 
+- [`LogFormat`](../api/Static_Properties.md#logformat): Update the format of logs produced
+  by the logger.
+
 - [`ErrorTypes`](../api/Static_Properties.md#errortypes): All Error types that can be
   encountered.
 

--- a/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api/index.ts
@@ -58,7 +58,7 @@ const mediaCapabilitiesProber = {
    * @param {string} level
    */
   set LogLevel(level: string) {
-    log.setLevel(level);
+    log.setLevel(level, log.getFormat());
   },
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,9 @@ Player.addFeatures([
   HTML_SRT_PARSER,
 ]);
 if (isDebugModeEnabled()) {
-  logger.setLevel("DEBUG");
+  logger.setLevel("DEBUG", "standard");
 } else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
-  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
+  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL, "standard");
 }
 export default Player;
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -322,7 +322,21 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     return log.getLevel();
   }
   static set LogLevel(logLevel: string) {
-    log.setLevel(logLevel);
+    log.setLevel(logLevel, log.getFormat());
+  }
+
+  /**
+   * Current log format.
+   * Should be either (by verbosity ascending):
+   *   - "standard": Regular log messages.
+   *   - "full": More verbose format, including a timestamp and a namespace.
+   * Any other value will be translated to "standard".
+   */
+  static get LogFormat(): string {
+    return log.getFormat();
+  }
+  static set LogFormat(format: string) {
+    log.setLevel(log.getLevel(), format);
   }
 
   /**
@@ -531,6 +545,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         value: {
           dashWasmUrl: workerSettings.dashWasmUrl,
           logLevel: log.getLevel(),
+          logFormat: log.getFormat(),
           sendBackLogs: isDebugModeEnabled(),
           date: Date.now(),
           timestamp: getMonotonicTimeStamp(),
@@ -540,7 +555,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       });
       log.addEventListener(
         "onLogLevelChange",
-        (logLevel) => {
+        (logInfo) => {
           if (this._priv_worker === null) {
             return;
           }
@@ -548,7 +563,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           this._priv_worker.postMessage({
             type: MainThreadMessageType.LogLevelUpdate,
             value: {
-              logLevel,
+              logLevel: logInfo.level,
+              logFormat: logInfo.format,
               sendBackLogs: isDebugModeEnabled(),
             },
           });

--- a/src/minimal.ts
+++ b/src/minimal.ts
@@ -36,9 +36,9 @@ patchWebkitSourceBuffer();
 features.codecSupportProber = MainCodecSupportProber;
 
 if (isDebugModeEnabled()) {
-  logger.setLevel("DEBUG");
+  logger.setLevel("DEBUG", "standard");
 } else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
-  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL);
+  logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL, "standard");
 }
 
 /**

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -30,7 +30,7 @@ import type {
 import type { IFreezingStatus, IRebufferingStatus } from "./playback_observer";
 import type { ITrackType } from "./public_types";
 import type { ITransportOptions } from "./transports";
-import type { ILoggerLevel } from "./utils/logger";
+import type { ILogFormat, ILoggerLevel } from "./utils/logger";
 import type { IRange } from "./utils/ranges";
 
 /**
@@ -65,6 +65,12 @@ export interface IInitMessage {
     hasMseInWorker: boolean;
     /** Initial logging level that should be set. */
     logLevel: ILoggerLevel;
+    /** Intitial logger's log format that should be set. */
+    logFormat: ILogFormat;
+    /**
+     * If `true`, logs should be sent back to the main thread, through a
+     * `ILogMessageWorkerMessage` message.
+     */
     sendBackLogs: boolean;
     /**
      * Value of `Date.now()` at the time the `timestamp` property was generated.
@@ -138,6 +144,12 @@ export interface ILogLevelUpdateMessage {
   value: {
     /** The new logger level that should be set. */
     logLevel: ILoggerLevel;
+    /** Intitial logger's log format that should be set. */
+    logFormat: ILogFormat;
+    /**
+     * If `true`, logs should be sent back to the main thread, through a
+     * `ILogMessageWorkerMessage` message.
+     */
     sendBackLogs: boolean;
   };
 }

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -24,50 +24,50 @@ describe("utils - Logger", () => {
 
   it('should be able to change the logger level to "ERROR"', () => {
     const logger = new Logger();
-    logger.setLevel("ERROR");
+    logger.setLevel("ERROR", "standard");
     expect(logger.getLevel()).toEqual("ERROR");
   });
 
   it('should be able to change the logger level to "WARNING"', () => {
     const logger = new Logger();
-    logger.setLevel("WARNING");
+    logger.setLevel("WARNING", "standard");
     expect(logger.getLevel()).toEqual("WARNING");
   });
 
   it('should be able to change the logger level to "INFO"', () => {
     const logger = new Logger();
-    logger.setLevel("INFO");
+    logger.setLevel("INFO", "standard");
     expect(logger.getLevel()).toEqual("INFO");
   });
 
   it('should be able to change the logger level to "DEBUG"', () => {
     const logger = new Logger();
-    logger.setLevel("DEBUG");
+    logger.setLevel("DEBUG", "standard");
     expect(logger.getLevel()).toEqual("DEBUG");
   });
 
   it("should be able to update the logger level multiple times", () => {
     const logger = new Logger();
-    logger.setLevel("DEBUG");
+    logger.setLevel("DEBUG", "standard");
     expect(logger.getLevel()).toEqual("DEBUG");
-    logger.setLevel("WARNING");
+    logger.setLevel("WARNING", "standard");
     expect(logger.getLevel()).toEqual("WARNING");
-    logger.setLevel("ERROR");
+    logger.setLevel("ERROR", "standard");
     expect(logger.getLevel()).toEqual("ERROR");
-    logger.setLevel("INFO");
+    logger.setLevel("INFO", "standard");
     expect(logger.getLevel()).toEqual("INFO");
-    logger.setLevel("WARNING");
+    logger.setLevel("WARNING", "standard");
     expect(logger.getLevel()).toEqual("WARNING");
-    logger.setLevel("ERROR");
+    logger.setLevel("ERROR", "standard");
     expect(logger.getLevel()).toEqual("ERROR");
   });
 
   it('should default unrecognized logger levels to "NONE"', () => {
     const logger = new Logger();
-    logger.setLevel("TOTO");
+    logger.setLevel("TOTO", "standard");
     expect(logger.getLevel()).toEqual("NONE");
-    logger.setLevel("DEBUG"); // initialize to another thing than "NONE"
-    logger.setLevel("TITI");
+    logger.setLevel("DEBUG", "standard"); // initialize to another thing than "NONE"
+    logger.setLevel("TITI", "standard");
     expect(logger.getLevel()).toEqual("NONE");
   });
 
@@ -103,7 +103,7 @@ describe("utils - Logger", () => {
     const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
 
     const logger = new Logger();
-    logger.setLevel("ERROR");
+    logger.setLevel("ERROR", "standard");
     logger.error("test");
     logger.warn("test");
     logger.info("test");
@@ -128,7 +128,7 @@ describe("utils - Logger", () => {
     const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
 
     const logger = new Logger();
-    logger.setLevel("WARNING");
+    logger.setLevel("WARNING", "standard");
     logger.error("test");
     logger.warn("test");
     logger.info("test");
@@ -153,7 +153,7 @@ describe("utils - Logger", () => {
     const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
 
     const logger = new Logger();
-    logger.setLevel("INFO");
+    logger.setLevel("INFO", "standard");
     logger.error("test");
     logger.warn("test");
     logger.info("test");
@@ -178,7 +178,7 @@ describe("utils - Logger", () => {
     const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
 
     const logger = new Logger();
-    logger.setLevel("DEBUG");
+    logger.setLevel("DEBUG", "standard");
     logger.error("test");
     logger.warn("test");
     logger.info("test");
@@ -188,6 +188,163 @@ describe("utils - Logger", () => {
     expect(mockWarn).toHaveBeenCalled();
     expect(mockInfo).toHaveBeenCalled();
     expect(mockDebug).not.toHaveBeenCalled();
+    mockLog.mockRestore();
+    mockError.mockRestore();
+    mockWarn.mockRestore();
+    mockInfo.mockRestore();
+    mockDebug.mockRestore();
+  });
+
+  it('should set a default logger format of "standard"', () => {
+    const logger = new Logger();
+    expect(logger.getFormat()).toEqual("standard");
+  });
+
+  it('should allow setting a format of "full" or "standard"', () => {
+    const logger = new Logger();
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel(logger.getLevel(), "full");
+    expect(logger.getFormat()).toEqual("full");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel(logger.getLevel(), "standard");
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("NONE");
+  });
+
+  it('should fallback unknown values to "standard"', () => {
+    const logger = new Logger();
+    expect(logger.getFormat()).toEqual("standard");
+
+    logger.setLevel(logger.getLevel(), "foo");
+    expect(logger.getFormat()).toEqual("standard");
+
+    logger.setLevel(logger.getLevel(), "full");
+    expect(logger.getFormat()).toEqual("full");
+
+    logger.setLevel(logger.getLevel(), "foo");
+    expect(logger.getFormat()).toEqual("standard");
+  });
+
+  it("should be able to change both level and format", () => {
+    const logger = new Logger();
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel("foo", "foo");
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel("foo", "full");
+    expect(logger.getFormat()).toEqual("full");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel("foo", "foo");
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel("INFO", "foo");
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("INFO");
+
+    logger.setLevel("foo", "full");
+    expect(logger.getFormat()).toEqual("full");
+    expect(logger.getLevel()).toEqual("NONE");
+
+    logger.setLevel("DEBUG", "standard");
+    expect(logger.getFormat()).toEqual("standard");
+    expect(logger.getLevel()).toEqual("DEBUG");
+
+    logger.setLevel("ERROR", "full");
+    expect(logger.getFormat()).toEqual("full");
+    expect(logger.getLevel()).toEqual("ERROR");
+  });
+
+  it('should format logs with more information when `LogFormat` is set to "full"', () => {
+    const logMsgs: unknown[][] = [];
+    const errorMsgs: unknown[][] = [];
+    const warningMsgs: unknown[][] = [];
+    const infoMsgs: unknown[][] = [];
+    const debugMsgs: unknown[][] = [];
+    const mockLog = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logMsgs.push(args);
+    });
+    const mockError = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args: unknown[]) => {
+        errorMsgs.push(args);
+      });
+    const mockWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation((...args: unknown[]) => {
+        warningMsgs.push(args);
+      });
+    const mockInfo = vi
+      .spyOn(console, "info")
+      .mockImplementation((...args: unknown[]) => {
+        infoMsgs.push(args);
+      });
+    const mockDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation((...args: unknown[]) => {
+        debugMsgs.push(args);
+      });
+
+    const logger = new Logger();
+
+    logger.setLevel("DEBUG", "full");
+    expect(mockLog).toHaveBeenCalledTimes(1);
+    expect(logMsgs).toHaveLength(1);
+    expect(logMsgs[0]).toHaveLength(3);
+    expect(logMsgs[0][0]).toMatch(/\d+\.\d\d/);
+    expect(logMsgs[0][1]).toMatch("[Init]");
+    expect(logMsgs[0][2]).toMatch(/Local-Date: \d+/);
+
+    expect(mockError).not.toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
+    expect(mockInfo).not.toHaveBeenCalled();
+    expect(mockDebug).not.toHaveBeenCalled();
+
+    logger.error("teste", "e r");
+    logger.warn("testw", "w a");
+    logger.info("testi", "i n");
+    logger.debug("testd", "d e");
+
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(errorMsgs).toHaveLength(1);
+    expect(errorMsgs[0]).toHaveLength(4);
+    expect(errorMsgs[0][0]).toMatch(/\d+\.\d\d/);
+    expect(errorMsgs[0][1]).toMatch("[error]");
+    expect(errorMsgs[0][2]).toMatch("teste");
+    expect(errorMsgs[0][3]).toMatch("e r");
+
+    expect(mockWarn).toHaveBeenCalledTimes(1);
+    expect(warningMsgs).toHaveLength(1);
+    expect(warningMsgs[0]).toHaveLength(4);
+    expect(warningMsgs[0][0]).toMatch(/\d+\.\d\d/);
+    expect(warningMsgs[0][1]).toMatch("[warn]");
+    expect(warningMsgs[0][2]).toMatch("testw");
+    expect(warningMsgs[0][3]).toMatch("w a");
+
+    expect(mockInfo).toHaveBeenCalledTimes(1);
+    expect(infoMsgs).toHaveLength(1);
+    expect(infoMsgs[0]).toHaveLength(4);
+    expect(infoMsgs[0][0]).toMatch(/\d+\.\d\d/);
+    expect(infoMsgs[0][1]).toMatch("[info]");
+    expect(infoMsgs[0][2]).toMatch("testi");
+    expect(infoMsgs[0][3]).toMatch("i n");
+
+    expect(mockDebug).not.toHaveBeenCalled();
+
+    expect(mockLog).toHaveBeenCalledTimes(2);
+    expect(logMsgs[1]).toHaveLength(4);
+    expect(logMsgs[1][0]).toMatch(/\d+\.\d\d/);
+    expect(logMsgs[1][1]).toMatch("[log]");
+    expect(logMsgs[1][2]).toMatch("testd");
+    expect(logMsgs[1][3]).toMatch("d e");
+
     mockLog.mockRestore();
     mockError.mockRestore();
     mockWarn.mockRestore();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -15,9 +15,12 @@
  */
 
 import EventEmitter from "./event_emitter";
+import getMonotonicTimeStamp from "./monotonic_timestamp";
 import noop from "./noop";
 
 export type ILoggerLevel = "NONE" | "ERROR" | "WARNING" | "INFO" | "DEBUG";
+
+export type ILogFormat = "standard" | "full";
 
 type IAcceptedLogValue = boolean | string | number | Error | null | undefined;
 
@@ -30,7 +33,10 @@ const DEFAULT_LOG_LEVEL: ILoggerLevel = "NONE";
  * are the corresponding payloads.
  */
 interface ILoggerEvents {
-  onLogLevelChange: ILoggerLevel;
+  onLogLevelChange: {
+    level: ILoggerLevel;
+    format: ILogFormat;
+  };
 }
 
 /**
@@ -43,6 +49,7 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
   public info: IConsoleFn;
   public debug: IConsoleFn;
   private _currentLevel: ILoggerLevel;
+  private _currentFormat: ILogFormat;
   private readonly _levels: Record<ILoggerLevel, number>;
 
   constructor() {
@@ -52,15 +59,23 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
     this.info = noop;
     this.debug = noop;
     this._levels = { NONE: 0, ERROR: 1, WARNING: 2, INFO: 3, DEBUG: 4 };
+    this._currentFormat = "standard";
     this._currentLevel = DEFAULT_LOG_LEVEL;
   }
 
   /**
-   * @param {string} levelStr
-   * @param {function} [logFn]
+   * Update the logger's level to increase or decrease its verbosity, to change
+   * its format with a newly set one, or to update its logging function.
+   * @param {string} levelStr - One of the [upper-case] logger level. If the
+   * given level is not valid, it will default to `"NONE"`.
+   * @param {function|undefined} [logFn] - Optional logger function which will
+   * be called with logs (with the corresponding upper-case logger level as
+   * first argument).
+   * Can be omited to just rely on regular logging functions.
    */
   public setLevel(
     levelStr: string,
+    format: string,
     logFn?: (
       levelStr: ILoggerLevel,
       logs: Array<boolean | string | number | Error | null | undefined>,
@@ -77,31 +92,86 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
       this._currentLevel = "NONE";
     }
 
+    let actualFormat: ILogFormat;
+    if (format === "standard" || format === "full") {
+      actualFormat = format;
+    } else {
+      actualFormat = "standard";
+    }
+    if (actualFormat === "full" && actualFormat !== this._currentFormat) {
+      // Add the current Date so we can see at which time logs are displayed
+      const now = getMonotonicTimeStamp();
+      /* eslint-disable-next-line no-console */
+      console.log(String(now.toFixed(2)), "[Init]", `Local-Date: ${Date.now()}`);
+    }
+    this._currentFormat = actualFormat;
+
+    const generateLogFn =
+      this._currentFormat === "full"
+        ? (namespace: string, consoleFn: IConsoleFn): IConsoleFn => {
+            return (...args: IAcceptedLogValue[]) => {
+              const now = getMonotonicTimeStamp();
+              return consoleFn(String(now.toFixed(2)), `[${namespace}]`, ...args);
+            };
+          }
+        : (_namespace: string, consoleFn: IConsoleFn): IConsoleFn => consoleFn;
+
     if (logFn === undefined) {
       /* eslint-disable no-invalid-this */
       /* eslint-disable no-console */
-      this.error = level >= this._levels.ERROR ? console.error.bind(console) : noop;
-      this.warn = level >= this._levels.WARNING ? console.warn.bind(console) : noop;
-      this.info = level >= this._levels.INFO ? console.info.bind(console) : noop;
-      this.debug = level >= this._levels.DEBUG ? console.log.bind(console) : noop;
+      this.error =
+        level >= this._levels.ERROR
+          ? generateLogFn("error", console.error.bind(console))
+          : noop;
+      this.warn =
+        level >= this._levels.WARNING
+          ? generateLogFn("warn", console.warn.bind(console))
+          : noop;
+      this.info =
+        level >= this._levels.INFO
+          ? generateLogFn("info", console.info.bind(console))
+          : noop;
+      this.debug =
+        level >= this._levels.DEBUG
+          ? generateLogFn("log", console.log.bind(console))
+          : noop;
       /* eslint-enable no-console */
       /* eslint-enable no-invalid-this */
     } else {
-      this.error = level >= this._levels.ERROR ? (...args) => logFn("ERROR", args) : noop;
-      this.warn =
-        level >= this._levels.WARNING ? (...args) => logFn("WARNING", args) : noop;
-      this.info = level >= this._levels.INFO ? (...args) => logFn("INFO", args) : noop;
-      this.debug = level >= this._levels.DEBUG ? (...args) => logFn("DEBUG", args) : noop;
+      const produceLogFn = (logLevel: ILoggerLevel, namespace: string) => {
+        return level >= this._levels[logLevel]
+          ? (...args: IAcceptedLogValue[]) => {
+              const now = getMonotonicTimeStamp();
+              return logFn(logLevel, [now, namespace, ...args]);
+            }
+          : noop;
+      };
+      this.error = produceLogFn("ERROR", "error");
+      this.warn = produceLogFn("WARNING", "warn");
+      this.info = produceLogFn("INFO", "info");
+      this.debug = produceLogFn("DEBUG", "log");
     }
 
-    this.trigger("onLogLevelChange", this._currentLevel);
+    this.trigger("onLogLevelChange", {
+      level: this._currentLevel,
+      format: this._currentFormat,
+    });
   }
 
   /**
+   * Get the last set logger level, as an upper-case string value.
    * @returns {string}
    */
   public getLevel(): ILoggerLevel {
     return this._currentLevel;
+  }
+
+  /**
+   * Get the last set logger's log format.
+   * @returns {string}
+   */
+  public getFormat(): ILogFormat {
+    return this._currentFormat;
   }
 
   /**


### PR DESCRIPTION
A large amount of time spent when maintaining the RxPlayer is actually spent on debugging device-specific issues.

Consequently, we beefed-up our debugging capabilities: we added a LOT of logs, developed [our own specialized remote
debugger](https://github.com/canalplus/RxPaired/) so we can be monitoring low-end devices for a long amount of time (unlike chromium's or webkit's debugger), added the `DEBUG_ELEMENT` feature, developed some reverse-engineering tools as well as (closed-source) visual logging tools.

Now that we have many tools at our disposition, I see that our regular logs (that can e.g. be produced by calling `RxPlayer.LogLevel = "DEBUG"`) - the most relied on way by application developpers - are lacking.

The most evident lacking data is some kind of timestamp, to better understand time-related issues, which are frequent.

But more than that, there's a lot of comfort in being able to rely on our aforementioned RxPaired remote debugger, so I was wondering if we could allow the production of logs in a format that could be easily imported by it.

Hence the idea of a supplementary `RxPlayer.LogFormat` property. It is by default set to `"standard"` - which is the currently-existing format, but can also be set to the RxPaired-compatible `"full"` format which:

  - Immediately produces the `[Init]` log, which today only serves to provide a way to convert between date representations (date on the device or monotonic timestamp since the page was opened) inside RxPaired (and also ultimately perform protocol version detection).

  - Prepend each log with a timestamp and the "namespace" of the log (e.g. `[error]` for error logs).

Here, we could tell application developpers not only to call:
```js
RxPlayer.LogLevel = "DEBUG";
```

But also:
```js
RxPlayer.LogFormat = "full";
```

When the idea is about communicating logs to us (if they just want to display logs for initial debugging steps of an issue potentially on their side or the content's side, the `"standard"` format may be clearer to them as less verbose).

Thoughts?