### PR TITLE
 fix: on chrome display correctly the error message in the console when an error is thrown

### DIFF
--- a/src/errors/custom_loader_error.ts
+++ b/src/errors/custom_loader_error.ts
@@ -25,7 +25,6 @@
  */
 export default class CustomLoaderError extends Error {
   public readonly name: "CustomLoaderError";
-  public readonly message: string;
   public readonly canRetry: boolean;
   public readonly xhr: XMLHttpRequest | undefined;
 
@@ -40,8 +39,6 @@ export default class CustomLoaderError extends Error {
     Object.setPrototypeOf(this, CustomLoaderError.prototype);
 
     this.name = "CustomLoaderError";
-
-    this.message = message;
     this.canRetry = canRetry;
     this.xhr = xhr;
   }

--- a/src/errors/custom_loader_error.ts
+++ b/src/errors/custom_loader_error.ts
@@ -35,7 +35,7 @@ export default class CustomLoaderError extends Error {
    * @param {XMLHttpRequest} xhr
    */
   constructor(message: string, canRetry: boolean, xhr: XMLHttpRequest | undefined) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, CustomLoaderError.prototype);
 

--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -30,7 +30,6 @@ export default class EncryptedMediaError extends Error {
   public readonly type: "ENCRYPTED_MEDIA_ERROR";
   public readonly code: IEncryptedMediaErrorCode;
   public readonly keyStatuses?: IEncryptedMediaErrorKeyStatusObject[];
-  public message: string;
   public fatal: boolean;
   private _originalMessage: string;
 
@@ -63,7 +62,6 @@ export default class EncryptedMediaError extends Error {
 
     this.code = code;
     this._originalMessage = reason;
-    this.message = errorMessage(this.code, reason);
     this.fatal = false;
 
     if (typeof supplementaryInfos?.keyStatuses === "string") {

--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -54,7 +54,7 @@ export default class EncryptedMediaError extends Error {
       | { keyStatuses?: IEncryptedMediaErrorKeyStatusObject[] | undefined }
       | undefined,
   ) {
-    super();
+    super(errorMessage(code, reason));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, EncryptedMediaError.prototype);
 

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -70,7 +70,7 @@ export default class MediaError extends Error {
         }
       | undefined,
   ) {
-    super();
+    super(errorMessage(code, reason));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, MediaError.prototype);
 

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -34,7 +34,6 @@ type ICodeWithAdaptationType =
 export default class MediaError extends Error {
   public readonly name: "MediaError";
   public readonly type: "MEDIA_ERROR";
-  public readonly message: string;
   public readonly code: IMediaErrorCode;
   public readonly tracksInfo: ITaggedTrack[] | undefined;
   public fatal: boolean;
@@ -79,7 +78,6 @@ export default class MediaError extends Error {
     this._originalMessage = reason;
 
     this.code = code;
-    this.message = errorMessage(this.code, reason);
     this.fatal = false;
     if (context?.tracks !== undefined && context?.tracks.length > 0) {
       this.tracksInfo = context.tracks;

--- a/src/errors/network_error.ts
+++ b/src/errors/network_error.ts
@@ -41,7 +41,7 @@ export default class NetworkError extends Error {
    * @param {Error} baseError
    */
   constructor(code: INetworkErrorCode, baseError: RequestError) {
-    super();
+    super(errorMessage(code, baseError.message));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, NetworkError.prototype);
 

--- a/src/errors/network_error.ts
+++ b/src/errors/network_error.ts
@@ -28,7 +28,6 @@ import errorMessage from "./error_message";
 export default class NetworkError extends Error {
   public readonly name: "NetworkError";
   public readonly type: "NETWORK_ERROR";
-  public readonly message: string;
   public readonly code: INetworkErrorCode;
   public readonly url: string;
   public readonly status: number;
@@ -54,7 +53,6 @@ export default class NetworkError extends Error {
     this._baseError = baseError;
 
     this.code = code;
-    this.message = errorMessage(this.code, baseError.message);
     this.fatal = false;
   }
 

--- a/src/errors/other_error.ts
+++ b/src/errors/other_error.ts
@@ -35,7 +35,7 @@ export default class OtherError extends Error {
    * @param {string} reason
    */
   constructor(code: IOtherErrorCode, reason: string) {
-    super();
+    super(errorMessage(code, reason));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, OtherError.prototype);
 

--- a/src/errors/other_error.ts
+++ b/src/errors/other_error.ts
@@ -25,7 +25,6 @@ import errorMessage from "./error_message";
 export default class OtherError extends Error {
   public readonly name: "OtherError";
   public readonly type: "OTHER_ERROR";
-  public readonly message: string;
   public readonly code: IOtherErrorCode;
   public fatal: boolean;
   private _originalMessage: string;
@@ -43,7 +42,6 @@ export default class OtherError extends Error {
     this.type = ErrorTypes.OTHER_ERROR;
 
     this.code = code;
-    this.message = errorMessage(this.code, reason);
     this.fatal = false;
     this._originalMessage = reason;
   }

--- a/src/errors/source_buffer_error.ts
+++ b/src/errors/source_buffer_error.ts
@@ -6,7 +6,6 @@
 export default class SourceBufferError extends Error {
   public readonly name: "SourceBufferError";
   public readonly errorName: string;
-  public readonly message: string;
   public readonly isBufferFull: boolean;
 
   /**
@@ -22,7 +21,6 @@ export default class SourceBufferError extends Error {
 
     this.name = "SourceBufferError";
     this.errorName = errorName;
-    this.message = message;
     this.isBufferFull = isBufferFull;
   }
 

--- a/src/errors/source_buffer_error.ts
+++ b/src/errors/source_buffer_error.ts
@@ -16,7 +16,7 @@ export default class SourceBufferError extends Error {
    * that the `SourceBuffer` was full.
    */
   constructor(errorName: string, message: string, isBufferFull: boolean) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, SourceBufferError.prototype);
 

--- a/src/errors/worker_initialization_error.ts
+++ b/src/errors/worker_initialization_error.ts
@@ -22,7 +22,7 @@ export default class WorkerInitializationError extends Error {
    * @param {string} message
    */
   constructor(code: IWorkerInitializationErrorCode, message: string) {
-    super();
+    super(errorMessage(code, message));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, WorkerInitializationError.prototype);
 

--- a/src/errors/worker_initialization_error.ts
+++ b/src/errors/worker_initialization_error.ts
@@ -14,7 +14,6 @@ type IWorkerInitializationErrorCode =
 export default class WorkerInitializationError extends Error {
   public readonly name: "WorkerInitializationError";
   public readonly type: "WORKER_INITIALIZATION_ERROR";
-  public readonly message: string;
   public readonly code: IWorkerInitializationErrorCode;
 
   /**
@@ -29,6 +28,5 @@ export default class WorkerInitializationError extends Error {
     this.name = "WorkerInitializationError";
     this.type = "WORKER_INITIALIZATION_ERROR";
     this.code = code;
-    this.message = errorMessage(this.code, message);
   }
 }

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader_error.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader_error.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import errorMessage from "../../../errors/error_message";
+
 // Returned error when rejecting
 export default class VideoThumbnailLoaderError extends Error {
   public readonly name: "VideoThumbnailLoaderError";
@@ -25,10 +27,10 @@ export default class VideoThumbnailLoaderError extends Error {
    * @param {string} message
    */
   constructor(code: string, message: string) {
-    super();
+    super(errorMessage(code, message));
     Object.setPrototypeOf(this, VideoThumbnailLoaderError.prototype);
     this.name = "VideoThumbnailLoaderError";
     this.code = code;
-    this.message = message;
+    this.message = errorMessage(code, message);
   }
 }

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader_error.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader_error.ts
@@ -19,7 +19,6 @@ import errorMessage from "../../../errors/error_message";
 // Returned error when rejecting
 export default class VideoThumbnailLoaderError extends Error {
   public readonly name: "VideoThumbnailLoaderError";
-  public readonly message: string;
   public readonly code: string;
 
   /**
@@ -31,6 +30,5 @@ export default class VideoThumbnailLoaderError extends Error {
     Object.setPrototypeOf(this, VideoThumbnailLoaderError.prototype);
     this.name = "VideoThumbnailLoaderError";
     this.code = code;
-    this.message = errorMessage(code, message);
   }
 }

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -338,7 +338,7 @@ export interface IKeyUpdateValue {
 export class BlacklistedSessionError extends Error {
   public sessionError: IPlayerError;
   constructor(sessionError: IPlayerError) {
-    super();
+    super(sessionError.message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, BlacklistedSessionError.prototype);
     this.sessionError = sessionError;
@@ -352,7 +352,7 @@ export class BlacklistedSessionError extends Error {
  */
 export class GetLicenseTimeoutError extends Error {
   constructor(message: string) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, BlacklistedSessionError.prototype);
     this.message = message;

--- a/src/main_thread/decrypt/utils/check_key_statuses.ts
+++ b/src/main_thread/decrypt/utils/check_key_statuses.ts
@@ -43,7 +43,7 @@ export class DecommissionedSessionError extends Error {
    * current MediaKeySession. Should be used for reporting purposes.
    */
   constructor(reason: IPlayerError) {
-    super();
+    super(reason.message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, DecommissionedSessionError.prototype);
     this.reason = reason;

--- a/src/parsers/manifest/dash/fast-js-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/fast-js-parser/node_parsers/utils.ts
@@ -361,7 +361,6 @@ function ValueParser<T>(dest: T, warnings: Error[]) {
  */
 class MPDError extends Error {
   public readonly name: "MPDError";
-  public readonly message: string;
 
   /**
    * @param {string} message
@@ -372,7 +371,6 @@ class MPDError extends Error {
     Object.setPrototypeOf(this, MPDError.prototype);
 
     this.name = "MPDError";
-    this.message = message;
   }
 }
 

--- a/src/parsers/manifest/dash/fast-js-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/fast-js-parser/node_parsers/utils.ts
@@ -367,7 +367,7 @@ class MPDError extends Error {
    * @param {string} message
    */
   constructor(message: string) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, MPDError.prototype);
 

--- a/src/parsers/manifest/dash/native-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/native-parser/node_parsers/utils.ts
@@ -357,8 +357,6 @@ function ValueParser<T>(dest: T, warnings: Error[]) {
  */
 class MPDError extends Error {
   public readonly name: "MPDError";
-  public readonly message: string;
-
   /**
    * @param {string} message
    */
@@ -368,7 +366,6 @@ class MPDError extends Error {
     Object.setPrototypeOf(this, MPDError.prototype);
 
     this.name = "MPDError";
-    this.message = message;
   }
 }
 

--- a/src/parsers/manifest/dash/native-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/native-parser/node_parsers/utils.ts
@@ -363,7 +363,7 @@ class MPDError extends Error {
    * @param {string} message
    */
   constructor(message: string) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, MPDError.prototype);
 

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -32,7 +32,7 @@ export class AssertionError extends Error {
    * @param {string} message
    */
   constructor(message: string) {
-    super();
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, AssertionError.prototype);
 

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -26,7 +26,6 @@ import isNullOrUndefined from "./is_null_or_undefined";
  */
 export class AssertionError extends Error {
   public readonly name: "AssertionError";
-  public readonly message: string;
 
   /**
    * @param {string} message
@@ -37,7 +36,6 @@ export class AssertionError extends Error {
     Object.setPrototypeOf(this, AssertionError.prototype);
 
     this.name = "AssertionError";
-    this.message = message;
   }
 }
 

--- a/src/utils/request/request_error.ts
+++ b/src/utils/request/request_error.ts
@@ -26,7 +26,6 @@
 export default class RequestError extends Error {
   public readonly name: "RequestError";
   public readonly type: IRequestErrorType;
-  public readonly message: string;
   public readonly url: string;
   public readonly status: number;
 
@@ -62,7 +61,6 @@ export default class RequestError extends Error {
     this.url = url;
     this.status = status;
     this.type = type;
-    this.message = message;
   }
 
   public serialize(): ISerializedRequestError {

--- a/src/utils/request/request_error.ts
+++ b/src/utils/request/request_error.ts
@@ -36,7 +36,25 @@ export default class RequestError extends Error {
    * @param {string} type
    */
   constructor(url: string, status: number, type: IRequestErrorType) {
-    super();
+    let message: string;
+    switch (type) {
+      case "TIMEOUT":
+        message = "The request timed out";
+        break;
+      case "ERROR_EVENT":
+        message = "An error prevented the request to be performed successfully";
+        break;
+      case "PARSE_ERROR":
+        message = "An error happened while formatting the response data";
+        break;
+      case "ERROR_HTTP_CODE":
+        message =
+          "An HTTP status code indicating failure was received: " + String(status);
+        break;
+    }
+
+    super(message);
+
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, RequestError.prototype);
 
@@ -44,22 +62,7 @@ export default class RequestError extends Error {
     this.url = url;
     this.status = status;
     this.type = type;
-
-    switch (type) {
-      case "TIMEOUT":
-        this.message = "The request timed out";
-        break;
-      case "ERROR_EVENT":
-        this.message = "An error prevented the request to be performed successfully";
-        break;
-      case "PARSE_ERROR":
-        this.message = "An error happened while formatting the response data";
-        break;
-      case "ERROR_HTTP_CODE":
-        this.message =
-          "An HTTP status code indicating failure was received: " + String(this.status);
-        break;
-    }
+    this.message = message;
   }
 
   public serialize(): ISerializedRequestError {

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -338,12 +338,13 @@ export class CancellationError extends Error {
   public readonly message: string;
 
   constructor() {
-    super();
+    const message = "This task was cancelled.";
+    super(message);
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, CancellationError.prototype);
 
     this.name = "CancellationError";
-    this.message = "This task was cancelled.";
+    this.message = message;
   }
 }
 

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -335,7 +335,6 @@ export type ICancellationListener = (error: CancellationError) => void;
  */
 export class CancellationError extends Error {
   public readonly name: "CancellationError";
-  public readonly message: string;
 
   constructor() {
     const message = "This task was cancelled.";
@@ -344,7 +343,6 @@ export class CancellationError extends Error {
     Object.setPrototypeOf(this, CancellationError.prototype);
 
     this.name = "CancellationError";
-    this.message = message;
   }
 }
 

--- a/tests/integration/scenarios/video_thumbnail_loader.test.js
+++ b/tests/integration/scenarios/video_thumbnail_loader.test.js
@@ -38,7 +38,8 @@ describe("Video Thumbnail Loader", () => {
     }
     expect(error).not.to.equal(undefined);
     expect(error.message).to.equal(
-      "VideoThumbnailLoaderError: No imported " + "loader for this transport type: dash",
+      "NO_LOADER: VideoThumbnailLoaderError: No imported " +
+        "loader for this transport type: dash",
     );
   });
 
@@ -56,7 +57,9 @@ describe("Video Thumbnail Loader", () => {
     }
     expect(error).not.to.equal(undefined);
     expect(time).to.equal(undefined);
-    expect(error.message).to.equal("Couldn't find a trickmode track for this time.");
+    expect(error.message).to.equal(
+      "NO_TRACK: Couldn't find a trickmode track for this time.",
+    );
   });
 
   it("should not work when no period at given time", async () => {
@@ -75,7 +78,9 @@ describe("Video Thumbnail Loader", () => {
     }
     expect(error).not.to.equal(undefined);
     expect(time).to.equal(undefined);
-    expect(error.message).to.equal("Couldn't find a trickmode track for this time.");
+    expect(error.message).to.equal(
+      "NO_TRACK: Couldn't find a trickmode track for this time.",
+    );
   });
 
   it("should load one thumbnail", async () => {
@@ -291,7 +296,7 @@ describe("Video Thumbnail Loader", () => {
     }
 
     expect(error1).not.to.equal(undefined);
-    expect(error1.message).to.equal("VideoThumbnailLoaderError: Aborted job.");
+    expect(error1.message).to.equal("ABORTED: VideoThumbnailLoaderError: Aborted job.");
     expect(error2).to.equal(undefined);
     expect(time).to.equal(wantedThumbnail2.time);
     expect(videoElement.buffered.length).to.equal(1);


### PR DESCRIPTION
Custom errors are not logged well on the console on Chrome, the error message is not displayed, only the error name and the call stack are displayed:

```
MediaError
    at new Manifest (manifest.js:75:27)
    ...
```

This PR fixes this issues and display the message

```
MediaError: MANIFEST_INCOMPATIBLE_CODECS_ERROR: An Adaptation contains only incompatible codecs.
    at new Manifest (manifest.js:75:27)
    ...
```
