### PR TITLE
Remove fake server in tests and the necessity of using sinonjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@canalplus/readme.doc": "0.5.0",
         "@types/react": "18.2.45",
         "@types/react-dom": "18.2.18",
-        "@types/sinon": "17.0.2",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "@vitest/browser": "^1.6.0",
@@ -34,7 +33,6 @@
         "regenerator-runtime": "0.14.1",
         "rimraf": "5.0.5",
         "semver": "7.5.4",
-        "sinon": "17.0.1",
         "typescript": "5.3.3",
         "vitest": "^1.6.0",
         "webdriverio": "^8.38.2"
@@ -1112,50 +1110,6 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers/node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
-      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -1242,21 +1196,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
-    },
-    "node_modules/@types/sinon": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.2.tgz",
-      "integrity": "sha512-Zt6heIGsdqERkxctIpvN5Pv3edgBrhoeb3yHyxffd4InN0AX2SVNKSrhdDZKGQICVOxWP/q4DyhpfPNMSrpIiA==",
-      "dev": true,
-      "dependencies": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
-      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "node_modules/@types/which": {
@@ -5728,12 +5667,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -5948,12 +5881,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6127,12 +6054,6 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6433,28 +6354,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/nise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
       }
     },
     "node_modules/node-domexception": {
@@ -7902,72 +7801,6 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/sinon": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
-      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/samsam": "^8.0.0",
-        "diff": "^5.1.0",
-        "nise": "^5.1.5",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/commons": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.0"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/sinon/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sinon/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/sirv": {
       "version": "2.0.4",
@@ -10735,52 +10568,6 @@
       "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
       "dev": true
     },
-    "@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^3.0.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-          "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        }
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
-      "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "@szmarczak/http-timer": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
@@ -10858,21 +10645,6 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "dev": true
-    },
-    "@types/sinon": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.2.tgz",
-      "integrity": "sha512-Zt6heIGsdqERkxctIpvN5Pv3edgBrhoeb3yHyxffd4InN0AX2SVNKSrhdDZKGQICVOxWP/q4DyhpfPNMSrpIiA==",
-      "dev": true,
-      "requires": {
-        "@types/sinonjs__fake-timers": "*"
-      }
-    },
-    "@types/sinonjs__fake-timers": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz",
-      "integrity": "sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==",
       "dev": true
     },
     "@types/which": {
@@ -14004,12 +13776,6 @@
         "get-intrinsic": "^1.1.1"
       }
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -14189,12 +13955,6 @@
         }
       }
     },
-    "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
-    },
     "keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -14324,12 +14084,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -14553,30 +14307,6 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true
-    },
-    "nise": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.5.tgz",
-      "integrity": "sha512-VJuPIfUFaXNRzETTQEEItTOP8Y171ijr+JLq42wHes3DiryR8vT+1TXQW/Rx8JNUhyYYWyIvjXTU6dOhJcs9Nw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      },
-      "dependencies": {
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "dev": true,
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        }
-      }
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -15605,61 +15335,6 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
-    },
-    "sinon": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-17.0.1.tgz",
-      "integrity": "sha512-wmwE19Lie0MLT+ZYNpDymasPHUKTaZHUH/pKEubRXIzySv9Atnlw+BUMGCzWgV7b7wO+Hw6f1TEOr0IUnmU8/g==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^3.0.0",
-        "@sinonjs/fake-timers": "^11.2.2",
-        "@sinonjs/samsam": "^8.0.0",
-        "diff": "^5.1.0",
-        "nise": "^5.1.5",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "@sinonjs/commons": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
-          "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
-          "dev": true,
-          "requires": {
-            "type-detect": "4.0.8"
-          }
-        },
-        "@sinonjs/fake-timers": {
-          "version": "11.2.2",
-          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
-          "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
-          "dev": true,
-          "requires": {
-            "@sinonjs/commons": "^3.0.0"
-          }
-        },
-        "diff": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "sirv": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "@canalplus/readme.doc": "0.5.0",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.18",
-    "@types/sinon": "17.0.2",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vitest/browser": "^1.6.0",
@@ -219,7 +218,6 @@
     "regenerator-runtime": "0.14.1",
     "rimraf": "5.0.5",
     "semver": "7.5.4",
-    "sinon": "17.0.1",
     "typescript": "5.3.3",
     "vitest": "^1.6.0",
     "webdriverio": "^8.38.2"

--- a/tests/integration/scenarios/manifest_error.test.js
+++ b/tests/integration/scenarios/manifest_error.test.js
@@ -1,12 +1,9 @@
 import sleep from "../../utils/sleep.js";
-import sinon from "sinon";
 
 import RxPlayer from "../../../dist/es2017";
 
 import { manifestInfos } from "../../contents/DASH_dynamic_SegmentTimeline";
 import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
-
-const MANIFEST_URL_INFOS = manifestInfos.url;
 
 /**
  *  Workaround to provide a "real" sleep function, which does not depend on
@@ -31,220 +28,338 @@ const sleepWithoutFakeTimer = (function () {
  */
 describe("manifest error management", function () {
   let player;
-  let fakeServer;
 
   beforeEach(() => {
     player = new RxPlayer();
-    fakeServer = sinon.fakeServer.create();
   });
 
   afterEach(() => {
     player.dispose();
-    fakeServer.restore();
   });
 
   it("should retry to download the manifest 5 times", async () => {
     vi.useFakeTimers();
-    fakeServer.respondWith("GET", MANIFEST_URL_INFOS.url, (res) => res.respond(500));
-
+    const awaitingRequestCallbacks = [];
     player.loadVideo({
       url: manifestInfos.url,
       transport: manifestInfos.transport,
+      manifestLoader: async ({ url }, callbacks) => {
+        if (url !== manifestInfos.url) {
+          callbacks.fallback();
+          return;
+        }
+        awaitingRequestCallbacks.push(() => {
+          const err = new Error("Retry please");
+          err.canRetry = true;
+          callbacks.reject(err);
+        });
+      },
     });
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()();
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()();
     await sleepWithoutFakeTimer(0);
     vi.advanceTimersByTime(5000);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()();
     await sleepWithoutFakeTimer(0);
     vi.advanceTimersByTime(5000);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()();
     await sleepWithoutFakeTimer(0);
     vi.advanceTimersByTime(5000);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
     await sleepWithoutFakeTimer(0);
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()();
     await sleepWithoutFakeTimer(0);
 
     vi.useRealTimers();
 
     await sleep(5);
+    expect(awaitingRequestCallbacks).toHaveLength(0);
     const error = player.getError();
     expect(error).not.to.equal(null);
-    expect(error.type).to.equal(RxPlayer.ErrorTypes.NETWORK_ERROR);
+    expect(error.type).to.equal(RxPlayer.ErrorTypes.OTHER_ERROR);
     expect(error.code).to.equal(RxPlayer.ErrorCodes.PIPELINE_LOAD_ERROR);
   });
 
   it("should parse the manifest if it works the second time", async () => {
     vi.useFakeTimers();
 
-    fakeServer.respondWith("GET", MANIFEST_URL_INFOS.url, (xhr) => {
-      return xhr.respond(500);
-    });
+    const awaitingRequestCallbacks = [];
 
     player.loadVideo({
       url: manifestInfos.url,
       transport: manifestInfos.transport,
+      manifestLoader: async ({ url }, callbacks) => {
+        if (url !== manifestInfos.url) {
+          callbacks.fallback();
+          return;
+        }
+        awaitingRequestCallbacks.push((shouldManifestRequestWork) => {
+          if (shouldManifestRequestWork) {
+            callbacks.fallback();
+            return;
+          }
+
+          const err = new Error("Retry please");
+          err.canRetry = true;
+          callbacks.reject(err);
+        });
+      },
     });
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
     await sleepWithoutFakeTimer(0);
-    fakeServer.restore();
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
     vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(true);
+    await sleepWithoutFakeTimer(0);
 
     expect(player.getError()).to.equal(null);
-    await sleepWithoutFakeTimer(50);
 
+    vi.advanceTimersByTime(100000);
     vi.useRealTimers();
 
-    await sleep(50);
+    await sleepWithoutFakeTimer(0);
     expect(player.getError()).to.equal(null);
   });
 
   it("should parse the manifest if it works the third time", async () => {
     vi.useFakeTimers();
-    fakeServer.respondWith("GET", MANIFEST_URL_INFOS.url, (xhr) => {
-      return xhr.respond(500);
-    });
+
+    const awaitingRequestCallbacks = [];
 
     player.loadVideo({
       url: manifestInfos.url,
       transport: manifestInfos.transport,
+      manifestLoader: async ({ url }, callbacks) => {
+        if (url !== manifestInfos.url) {
+          callbacks.fallback();
+          return;
+        }
+        awaitingRequestCallbacks.push((shouldManifestRequestWork) => {
+          if (shouldManifestRequestWork) {
+            callbacks.fallback();
+            return;
+          }
+
+          const err = new Error("Retry please");
+          err.canRetry = true;
+          callbacks.reject(err);
+        });
+      },
     });
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
     await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
     vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(true);
+    await sleepWithoutFakeTimer(0);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
-    fakeServer.restore();
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-    await sleepWithoutFakeTimer(50);
-
+    vi.advanceTimersByTime(100000);
     vi.useRealTimers();
 
-    await sleep(1000);
+    await sleepWithoutFakeTimer(0);
     expect(player.getError()).to.equal(null);
-  }, 10000);
+  });
 
   it("should parse the manifest if it works the fourth time", async () => {
     vi.useFakeTimers();
-    fakeServer.respondWith("GET", MANIFEST_URL_INFOS.url, (xhr) => {
-      return xhr.respond(500);
-    });
+
+    const awaitingRequestCallbacks = [];
 
     player.loadVideo({
       url: manifestInfos.url,
       transport: manifestInfos.transport,
+      manifestLoader: async ({ url }, callbacks) => {
+        if (url !== manifestInfos.url) {
+          callbacks.fallback();
+          return;
+        }
+        awaitingRequestCallbacks.push((shouldManifestRequestWork) => {
+          if (shouldManifestRequestWork) {
+            callbacks.fallback();
+            return;
+          }
+
+          const err = new Error("Retry please");
+          err.canRetry = true;
+          callbacks.reject(err);
+        });
+      },
     });
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
     await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
     vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(true);
+    await sleepWithoutFakeTimer(0);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
-    fakeServer.restore();
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-    await sleepWithoutFakeTimer(50);
-
+    vi.advanceTimersByTime(100000);
     vi.useRealTimers();
 
-    await sleep(5);
+    await sleepWithoutFakeTimer(0);
     expect(player.getError()).to.equal(null);
   });
 
   it("should parse the manifest if it works the fifth time", async () => {
     vi.useFakeTimers();
-    fakeServer.respondWith("GET", MANIFEST_URL_INFOS.url, (xhr) => {
-      return xhr.respond(500);
-    });
+
+    const awaitingRequestCallbacks = [];
 
     player.loadVideo({
       url: manifestInfos.url,
       transport: manifestInfos.transport,
+      manifestLoader: async ({ url }, callbacks) => {
+        if (url !== manifestInfos.url) {
+          callbacks.fallback();
+          return;
+        }
+        awaitingRequestCallbacks.push((shouldManifestRequestWork) => {
+          if (shouldManifestRequestWork) {
+            callbacks.fallback();
+            return;
+          }
+
+          const err = new Error("Retry please");
+          err.canRetry = true;
+          callbacks.reject(err);
+        });
+      },
     });
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
     await sleepWithoutFakeTimer(0);
-    vi.advanceTimersByTime(5000);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
     vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(false);
+    await sleepWithoutFakeTimer(0);
+
+    vi.advanceTimersByTime(5000);
+    await sleepWithoutFakeTimer(0);
+    expect(player.getError()).to.equal(null);
+
+    await sleepWithoutFakeTimer(0);
+    expect(awaitingRequestCallbacks).toHaveLength(1);
+    awaitingRequestCallbacks.pop()(true);
+    await sleepWithoutFakeTimer(0);
 
     expect(player.getError()).to.equal(null);
 
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-
-    await sleepWithoutFakeTimer(50);
-    fakeServer.respond();
-    await sleepWithoutFakeTimer(0);
-    fakeServer.restore();
-    vi.advanceTimersByTime(5000);
-
-    expect(player.getError()).to.equal(null);
-    await sleepWithoutFakeTimer(50);
-
+    vi.advanceTimersByTime(100000);
     vi.useRealTimers();
 
-    await sleep(5);
+    await sleepWithoutFakeTimer(0);
     expect(player.getError()).to.equal(null);
   });
 });


### PR DESCRIPTION
We were still relying on a complex XHR patch exposed by sinonjs in our integration tests - the last part of our codebase that needed sinon - to test our manifest retry logic.

This was unneeded as we can just rely on our `manifestLoader` API and return a retry-able error with the same effect, without the need of any complex and incomplete monkey-patching.

The potential for this commit was seen while PoCing new test strategies where both requests and MSE+EME API are completely mocked (to facilitate adding new tests, as that would mean we wouldn't have to provide real media segments and licenses anymore for each scenario).
After first trying to find a maintainable way to patch our request logic, I ended up founding that relying on our `manifestLoader` and `segmentLoader` API may in fact be much simpler and is already available.