### PR TITLE
[Proposal] Add `checkManifestIntegrity` and `checkMediaSegmentIntegrity` checkboxes to the demo

### DIFF
--- a/demo/scripts/components/Options/RequestConfig.tsx
+++ b/demo/scripts/components/Options/RequestConfig.tsx
@@ -20,11 +20,15 @@ const DEFAULT_MANIFEST_REQUEST_TIMEOUT =
 function RequestConfig({
   manifestRequestTimeout,
   manifestRetry,
+  checkManifestIntegrity,
+  checkMediaSegmentIntegrity,
   cmcdCommunicationMethod,
   onManifestRequestTimeoutChange,
   onManifestRetryChange,
   onSegmentRequestTimeoutChange,
   onSegmentRetryChange,
+  onCheckManifestIntegrityChange,
+  onCheckMediaSegmentIntegrityChange,
   onCmcdChange,
   segmentRequestTimeout,
   segmentRetry,
@@ -32,6 +36,10 @@ function RequestConfig({
   manifestRequestTimeout: number;
   manifestRetry: number;
   cmcdCommunicationMethod: string;
+  checkMediaSegmentIntegrity: boolean;
+  checkManifestIntegrity: boolean;
+  onCheckMediaSegmentIntegrityChange: (val: boolean) => void;
+  onCheckManifestIntegrityChange: (val: boolean) => void;
   onManifestRequestTimeoutChange: (val: number) => void;
   onManifestRetryChange: (val: number) => void;
   onSegmentRequestTimeoutChange: (val: number) => void;
@@ -315,6 +323,40 @@ function RequestConfig({
           CMCD (Common Media Client Data) communication type
         </Select>
         <span className="option-desc">{cmcdDescMsg}</span>
+      </li>
+
+      <li>
+        <Checkbox
+          className="playerOptionsCheckBox playerOptionsCheckBoxTitle"
+          ariaLabel="Check segment integrity"
+          name="checkMediaSegmentIntegrity"
+          checked={checkMediaSegmentIntegrity}
+          onChange={onCheckMediaSegmentIntegrityChange}
+        >
+          Check Media Segment integrity
+        </Checkbox>
+        <span className="option-desc">
+          {checkMediaSegmentIntegrity
+            ? "Retry segment requests if those delivered by the CDN appear truncated."
+            : "Do not retry request if a segment seems truncated."}
+        </span>
+      </li>
+
+      <li>
+        <Checkbox
+          className="playerOptionsCheckBox playerOptionsCheckBoxTitle"
+          ariaLabel="Check Manifest integrity"
+          name="checkManifestIntegrity"
+          checked={checkManifestIntegrity}
+          onChange={onCheckManifestIntegrityChange}
+        >
+          Check Manifest integrity
+        </Checkbox>
+        <span className="option-desc">
+          {checkManifestIntegrity
+            ? "Retry Manifest requests if those delivered by the CDN appear truncated."
+            : "Do not retry request if a Manifest seems truncated."}
+        </span>
       </li>
     </Fragment>
   );

--- a/demo/scripts/controllers/Settings.tsx
+++ b/demo/scripts/controllers/Settings.tsx
@@ -65,6 +65,8 @@ function Settings({
     cmcd,
     defaultAudioTrackSwitchingMode,
     enableFastSwitching,
+    checkMediaSegmentIntegrity,
+    checkManifestIntegrity,
     requestConfig,
     onCodecSwitch,
   } = loadVideoOptions;
@@ -216,6 +218,30 @@ function Settings({
             }),
           }),
         });
+      });
+    },
+    [updateLoadVideoOptions],
+  );
+
+  const onCheckMediaSegmentIntegrityChange = useCallback(
+    (checkMediaSegmentIntegrity: boolean) => {
+      updateLoadVideoOptions((prevOptions) => {
+        if (checkMediaSegmentIntegrity === prevOptions.checkMediaSegmentIntegrity) {
+          return prevOptions;
+        }
+        return Object.assign({}, prevOptions, { checkMediaSegmentIntegrity });
+      });
+    },
+    [updateLoadVideoOptions],
+  );
+
+  const onCheckManifestIntegrityChange = useCallback(
+    (checkManifestIntegrity: boolean) => {
+      updateLoadVideoOptions((prevOptions) => {
+        if (checkManifestIntegrity === prevOptions.checkManifestIntegrity) {
+          return prevOptions;
+        }
+        return Object.assign({}, prevOptions, { checkManifestIntegrity });
       });
     },
     [updateLoadVideoOptions],
@@ -376,11 +402,15 @@ function Settings({
             segmentRetry={segmentRetry}
             segmentRequestTimeout={segmentRequestTimeout}
             manifestRetry={manifestRetry}
+            checkManifestIntegrity={checkManifestIntegrity}
+            checkMediaSegmentIntegrity={checkMediaSegmentIntegrity}
             cmcdCommunicationMethod={cmcdCommunicationMethod}
             onSegmentRetryChange={onSegmentRetryChange}
             onSegmentRequestTimeoutChange={onSegmentRequestTimeoutChange}
             onManifestRetryChange={onManifestRetryChange}
             onManifestRequestTimeoutChange={onManifestRequestTimeoutChange}
+            onCheckManifestIntegrityChange={onCheckManifestIntegrityChange}
+            onCheckMediaSegmentIntegrityChange={onCheckMediaSegmentIntegrityChange}
             onCmcdChange={onCmcdChange}
           />
         </Option>

--- a/demo/scripts/lib/defaultOptionsValues.ts
+++ b/demo/scripts/lib/defaultOptionsValues.ts
@@ -15,6 +15,8 @@ const defaultOptionsValues = {
   },
   loadVideo: {
     autoPlay: true,
+    checkManifestIntegrity: false,
+    checkMediaSegmentIntegrity: false,
     cmcd: undefined as ICmcdOptions | undefined,
     defaultAudioTrackSwitchingMode: "reload",
     enableFastSwitching: true,


### PR DESCRIPTION
In #1471, I added the `checkManifestIntegrity` option because we noticed issues at Canal+ of incomplete MPD delivered by the CDN.

This is most probably a back-end issue, but we added that option because of the slow progression in fixing that issue.

Here, I propose to add both that check and the older `checkMediaSegmentIntegrity` check to the demo page. This might help us debugging issues in the future yet is also useful to showcase those options to people looking at our player first without diving into our API documentation.

Note that the `Request Configuration` part of our settings becomes quite large but this isn't much of an issue for me.