### PR TITLE
[Proposal] DRM: add `failOnEncryptedAfterClear` keySystems option

### DIFF
--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -473,6 +473,19 @@ interface IBufferingInitializationInformation {
    */
   drmSystemId: string | undefined;
   /**
+   * If `true`, protection data as found in the content can be manipulated so
+   * e.g. only the data linked to the given systemId may be communicated.
+   *
+   * If `false` the full extent of the protection data, in exactly the way it
+   * has been found in the content, should be communicated.
+   */
+  canFilterProtectionData: boolean;
+  /**
+   * If `true`, the current device is known to not be able to begin playback of
+   * encrypted content if there's already clear content playing.
+   */
+  failOnEncryptedAfterClear: boolean;
+  /**
    * Enable/Disable fastSwitching: allow to replace lower-quality segments by
    * higher-quality ones to have a faster transition.
    */
@@ -522,7 +535,14 @@ function loadOrReloadPreparedContent(
     segmentSinksStore,
     segmentQueueCreator,
   } = preparedContent;
-  const { drmSystemId, enableFastSwitching, initialTime, onCodecSwitch } = val;
+  const {
+    canFilterProtectionData,
+    failOnEncryptedAfterClear,
+    drmSystemId,
+    enableFastSwitching,
+    initialTime,
+    onCodecSwitch,
+  } = val;
   playbackObservationRef.onUpdate(
     (observation) => {
       if (preparedContent.decipherabilityFreezeDetector.needToReload(observation)) {
@@ -604,6 +624,8 @@ function loadOrReloadPreparedContent(
       maxVideoBufferSize,
       maxBufferAhead,
       maxBufferBehind,
+      canFilterProtectionData,
+      failOnEncryptedAfterClear,
       drmSystemId,
       enableFastSwitching,
       onCodecSwitch,
@@ -887,6 +909,8 @@ function loadOrReloadPreparedContent(
           {
             initialTime: newInitialTime,
             drmSystemId: val.drmSystemId,
+            canFilterProtectionData: val.canFilterProtectionData,
+            failOnEncryptedAfterClear: val.failOnEncryptedAfterClear,
             enableFastSwitching: val.enableFastSwitching,
             onCodecSwitch: val.onCodecSwitch,
           },

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -464,6 +464,7 @@ export default function AdaptationStream(
           bufferGoal,
           maxBufferSize,
           drmSystemId: options.drmSystemId,
+          canFilterProtectionData: options.canFilterProtectionData,
           fastSwitchThreshold,
         },
       },

--- a/src/core/stream/adaptation/types.ts
+++ b/src/core/stream/adaptation/types.ts
@@ -188,6 +188,14 @@ export interface IAdaptationStreamOptions {
    * those devices.
    */
   enableFastSwitching: boolean;
+  /**
+   * If `true`, protection data as found in the content can be manipulated so
+   * e.g. only the data linked to the given systemId may be communicated.
+   *
+   * If `false` the full extent of the protection data, in exactly the way it
+   * has been found in the content, should be communicated.
+   */
+  canFilterProtectionData: boolean;
 }
 
 /** Object indicating a choice of Adaptation made by the user. */

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -109,6 +109,22 @@ export default function StreamOrchestrator(
     MAXIMUM_MAX_BUFFER_BEHIND,
   } = config.getCurrent();
 
+  // Some DRM issues force us to check whether we're initially pushing clear
+  // segments.
+  //
+  // NOTE: Theoretically `initialPeriod` may not be the first Period for
+  // which we push segments (e.g. we may have a small seek which lead to
+  // another Period being streamed instead).
+  // This means that we could have an issue if `initialPeriod` leads to encrypted
+  // content, but the actually first-pushed segments do not. Here
+  // `shouldReloadOnEncryptedContent` would be set to `false` despiste the fact
+  // that it should be set to `true`.
+  // Yet, checking the first Period for which we pushed segments seems very hard,
+  // and all that for what is now (2024-07-31) a PlayReady bug, I don't have the
+  // will.
+  const shouldReloadOnEncryptedContent =
+    options.failOnEncryptedAfterClear && !hasEncryptedContentInPeriod(initialPeriod);
+
   // Keep track of a unique BufferGarbageCollector created per
   // SegmentSink.
   const garbageCollectors = new WeakMapMemory((segmentSink: SegmentSink) => {
@@ -449,6 +465,29 @@ export default function StreamOrchestrator(
   ): void {
     log.info("Stream: Creating new Stream for", bufferType, basePeriod.start);
 
+    if (shouldReloadOnEncryptedContent) {
+      if (hasEncryptedContentInPeriod(basePeriod)) {
+        playbackObserver.listen(
+          (pos) => {
+            if (pos.position.getWanted() > basePeriod.start - 0.01) {
+              callbacks.needsMediaSourceReload({
+                timeOffset: 0,
+                minimumPosition: basePeriod.start,
+                maximumPosition: basePeriod.end,
+              });
+            } else {
+              callbacks.lockedStream({
+                period: basePeriod,
+                bufferType,
+              });
+            }
+          },
+          { clearSignal: cancelSignal },
+        );
+        return;
+      }
+    }
+
     /**
      * Contains properties linnked to the next chronological `PeriodStream` that
      * may be created here.
@@ -656,6 +695,11 @@ export type IStreamOrchestratorOptions = IPeriodStreamOptions & {
   maxVideoBufferSize: IReadOnlySharedReference<number>;
   maxBufferAhead: IReadOnlySharedReference<number>;
   maxBufferBehind: IReadOnlySharedReference<number>;
+  /**
+   * If `true`, the current device is known to not be able to begin playback of
+   * encrypted content if there's already clear content playing.
+   */
+  failOnEncryptedAfterClear: boolean;
 };
 
 /** Callbacks called by the `StreamOrchestrator` on various events. */
@@ -758,6 +802,24 @@ export interface ILockedStreamPayload {
   period: IPeriod;
   /** Buffer type concerned. */
   bufferType: IBufferType;
+}
+
+/**
+ * Return `true` if the given Period has at least one Representation which is
+ * known to be encrypted.
+ *
+ * @param {Object} period
+ * @returns {boolean}
+ */
+function hasEncryptedContentInPeriod(period: IPeriod): boolean {
+  for (const adaptation of period.getAdaptations()) {
+    for (const representation of adaptation.representations) {
+      if (representation.contentProtections !== undefined) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -96,7 +96,13 @@ export default function RepresentationStream<TSegmentDataType>(
     content.representation.bitrate,
   );
   const { period, adaptation, representation } = content;
-  const { bufferGoal, maxBufferSize, drmSystemId, fastSwitchThreshold } = options;
+  const {
+    bufferGoal,
+    maxBufferSize,
+    drmSystemId,
+    canFilterProtectionData,
+    fastSwitchThreshold,
+  } = options;
   const bufferType = adaptation.type;
 
   /** `TaskCanceller` stopping ALL operations performed by the `RepresentationStream` */
@@ -141,7 +147,7 @@ export default function RepresentationStream<TSegmentDataType>(
   // If the DRM system id is already known, and if we already have encryption data
   // for it, we may not need to wait until the initialization segment is loaded to
   // signal required protection data, thus performing License negotiations sooner
-  if (drmSystemId !== undefined) {
+  if (canFilterProtectionData && drmSystemId !== undefined) {
     const encryptionData = representation.getEncryptionData(drmSystemId);
 
     // If some key ids are not known yet, it may be safer to wait for this initialization

--- a/src/core/stream/representation/types.ts
+++ b/src/core/stream/representation/types.ts
@@ -323,6 +323,14 @@ export interface IRepresentationStreamOptions {
    * `0` can be emitted to disable any kind of fast-switching.
    */
   fastSwitchThreshold: IReadOnlySharedReference<undefined | number>;
+  /**
+   * If `true`, protection data as found in the content can be manipulated so
+   * e.g. only the data linked to the given systemId may be communicated.
+   *
+   * If `false` the full extent of the protection data, in exactly the way it
+   * has been found in the content, should be communicated.
+   */
+  canFilterProtectionData: boolean;
 }
 
 /** Object indicating a choice of allowed Representations made by the user. */

--- a/src/main_thread/decrypt/__tests__/__global__/init_data.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/init_data.test.ts
@@ -1,6 +1,9 @@
 import { describe, afterEach, it, expect, vi } from "vitest";
 import type IContentDecryptor from "../../content_decryptor";
-import type { ContentDecryptorState as IContentDecryptorState } from "../../types";
+import type {
+  ContentDecryptorState as IContentDecryptorState,
+  IContentDecryptorStateData,
+} from "../../types";
 import {
   formatFakeChallengeFromInitData,
   MediaKeySessionImpl,
@@ -45,9 +48,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -101,9 +104,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -177,9 +180,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -281,9 +284,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -356,9 +359,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -416,9 +419,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -498,9 +501,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -598,9 +601,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();
@@ -686,9 +689,9 @@ describe("decrypt - global tests - init data", () => {
       const contentDecryptor = new ContentDecryptor(videoElt, ksConfig);
       contentDecryptor.addEventListener(
         "stateChange",
-        (newState: IContentDecryptorState) => {
-          if (newState !== ContentDecryptorState.WaitingForAttachment) {
-            rej(new Error(`Unexpected state: ${newState}`));
+        (newState: IContentDecryptorStateData) => {
+          if (newState.name !== ContentDecryptorState.WaitingForAttachment) {
+            rej(new Error(`Unexpected state: ${newState.name}`));
           }
           contentDecryptor.removeEventListener("stateChange");
           contentDecryptor.attach();

--- a/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
@@ -2,6 +2,8 @@ import { describe, beforeEach, afterEach, it, expect, vi } from "vitest";
 import type { ICustomMediaKeySystemAccess } from "../../../../compat/eme";
 import type { IKeySystemOption } from "../../../../public_types";
 import type IContentDecryptor from "../../content_decryptor";
+import type { IContentDecryptorStateData } from "../../types";
+import { ContentDecryptorState } from "../../types";
 import {
   defaultKSConfig,
   defaultPRRecommendationKSConfig,
@@ -971,9 +973,14 @@ describe("decrypt - global tests - media key system access", () => {
 
       const mediaElement = document.createElement("video");
       const contentDecryptor = new ContentDecryptor(mediaElement, config);
-      contentDecryptor.addEventListener("error", (error) => {
-        rej(error);
-      });
+      contentDecryptor.addEventListener(
+        "stateChange",
+        (state: IContentDecryptorStateData) => {
+          if (state.name === ContentDecryptorState.Error) {
+            rej(state.payload);
+          }
+        },
+      );
       setTimeout(() => {
         expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
         expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith(
@@ -1007,9 +1014,14 @@ describe("decrypt - global tests - media key system access", () => {
 
       const mediaElement = document.createElement("video");
       const contentDecryptor = new ContentDecryptor(mediaElement, config);
-      contentDecryptor.addEventListener("error", (error) => {
-        rej(error);
-      });
+      contentDecryptor.addEventListener(
+        "stateChange",
+        (state: IContentDecryptorStateData) => {
+          if (state.name === ContentDecryptorState.Error) {
+            rej(state.payload);
+          }
+        },
+      );
       setTimeout(() => {
         expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(3);
         expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
@@ -1056,9 +1068,14 @@ describe("decrypt - global tests - media key system access", () => {
         { type: "baz", getLicense: neverCalledFn },
       ];
       contentDecryptor = new ContentDecryptor(mediaElement, config);
-      contentDecryptor.addEventListener("error", (error) => {
-        rej(error);
-      });
+      contentDecryptor.addEventListener(
+        "stateChange",
+        (state: IContentDecryptorStateData) => {
+          if (state.name === ContentDecryptorState.Error) {
+            rej(state.payload);
+          }
+        },
+      );
       setTimeout(() => {
         expect(rmksHasBeenCalled).toEqual(true);
         expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
@@ -1088,10 +1105,15 @@ describe("decrypt - global tests - media key system access", () => {
 
       const config = [{ type: "foo", getLicense: neverCalledFn }];
       const contentDecryptor = new ContentDecryptor(mediaElement, config);
-      contentDecryptor.addEventListener("error", () => {
-        expect(rmksHasBeenCalled).toEqual(true);
-        res();
-      });
+      contentDecryptor.addEventListener(
+        "stateChange",
+        (state: IContentDecryptorStateData) => {
+          if (state.name === ContentDecryptorState.Error) {
+            expect(rmksHasBeenCalled).toEqual(true);
+            res();
+          }
+        },
+      );
       setTimeout(() => {
         rej(new Error("timeout exceeded"));
       }, 10);

--- a/src/main_thread/decrypt/__tests__/__global__/utils.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/utils.ts
@@ -9,6 +9,8 @@ import flatMap from "../../../../utils/flat_map";
 import { strToUtf8, utf8ToStr } from "../../../../utils/string_parsing";
 import type { CancellationSignal } from "../../../../utils/task_canceller";
 import type IContentDecryptor from "../../content_decryptor";
+import type { IContentDecryptorStateData } from "../../types";
+import { ContentDecryptorState } from "../../types";
 
 /** Default MediaKeySystemAccess configuration used by the RxPlayer. */
 export const defaultKSConfig: MediaKeySystemConfiguration[] = [
@@ -462,9 +464,14 @@ export function testContentDecryptorError(
 ): Promise<Error> {
   return new Promise((res, rej) => {
     const contentDecryptor = new ContentDecryptor(mediaElement, keySystemsConfigs);
-    contentDecryptor.addEventListener("error", (error) => {
-      res(error);
-    });
+    contentDecryptor.addEventListener(
+      "stateChange",
+      (state: IContentDecryptorStateData) => {
+        if (state.name === ContentDecryptorState.Error) {
+          res(state.payload);
+        }
+      },
+    );
     setTimeout(() => {
       rej(new Error("Timeout exceeded"));
     }, 10);

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -45,6 +45,12 @@ import type {
   IMediaKeySessionStores,
   IProcessedProtectionData,
   IContentDecryptorEvent,
+  IContentDecryptorStateData,
+  IInitializingContentDecryptorState,
+  IWaitingForAttachmentContentDecryptorState,
+  IReadyForContentContentDecryptorState,
+  IDisposedContentDecryptorState,
+  IErrorContentDecryptorState,
 } from "./types";
 import { MediaKeySessionLoadingType, ContentDecryptorState } from "./types";
 import { DecommissionedSessionError } from "./utils/check_key_statuses";
@@ -87,12 +93,6 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   public systemId: string | undefined;
 
   /**
-   * Set only if the `ContentDecryptor` failed on an error.
-   * The corresponding Error.
-   */
-  public error: Error | null;
-
-  /**
    * State of the ContentDecryptor (@see ContentDecryptorState) and associated
    * data.
    *
@@ -100,7 +100,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * This private property stores the current state and the potentially linked
    * data.
    */
-  private _stateData: IContentDecryptorStateData;
+  private _stateData: IContentDecryptorStateMetadata;
 
   /**
    * Contains information about all key sessions loaded for this current
@@ -165,13 +165,15 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     this._canceller = canceller;
     this._initDataQueue = [];
     this._stateData = {
-      state: ContentDecryptorState.Initializing,
+      state: {
+        name: ContentDecryptorState.Initializing,
+        payload: null,
+      },
       isMediaKeysAttached: MediaKeyAttachmentStatus.NotAttached,
       isInitDataQueueLocked: true,
       data: null,
     };
     this._supportedCodecWhenEncrypted = [];
-    this.error = null;
 
     eme.onEncrypted(
       mediaElement,
@@ -187,30 +189,21 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
     initMediaKeys(mediaElement, ksOptions, canceller.signal)
       .then((mediaKeysInfo) => {
-        const { options, mediaKeySystemAccess } = mediaKeysInfo;
+        const { mediaKeySystemAccess } = mediaKeysInfo;
         this._supportedCodecWhenEncrypted = mediaKeysInfo.codecSupport;
         /**
          * String identifying the key system, allowing the rest of the code to
          * only advertise the required initialization data for license requests.
-         *
-         * Note that we only set this value if retro-compatibility to older
-         * persistent logic in the RxPlayer is not important, as the
-         * optimizations this property unlocks can break the loading of
-         * MediaKeySessions persisted in older RxPlayer's versions.
          */
-        let systemId: string | undefined;
-        if (
-          isNullOrUndefined(options.persistentLicenseConfig) ||
-          options.persistentLicenseConfig.disableRetroCompatibility === true
-        ) {
-          systemId = getDrmSystemId(mediaKeySystemAccess.keySystem);
-        }
-
+        const systemId = getDrmSystemId(mediaKeySystemAccess.keySystem);
         this.systemId = systemId;
-        if (this._stateData.state === ContentDecryptorState.Initializing) {
+        if (this._stateData.state.name === ContentDecryptorState.Initializing) {
           log.debug("DRM: Waiting for attachment.");
           this._stateData = {
-            state: ContentDecryptorState.WaitingForAttachment,
+            state: {
+              name: ContentDecryptorState.WaitingForAttachment,
+              payload: null,
+            },
             isInitDataQueueLocked: true,
             isMediaKeysAttached: MediaKeyAttachmentStatus.NotAttached,
             data: { mediaKeysInfo, mediaElement },
@@ -230,7 +223,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * @see ContentDecryptorState
    * @returns {Object}
    */
-  public getState(): ContentDecryptorState {
+  public getState(): IContentDecryptorStateData {
     return this._stateData.state;
   }
 
@@ -244,12 +237,13 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * state is reached, for compatibility reasons.
    */
   public attach(): void {
-    if (this._stateData.state !== ContentDecryptorState.WaitingForAttachment) {
+    if (this._stateData.state.name !== ContentDecryptorState.WaitingForAttachment) {
       throw new Error(
         "`attach` should only be called when " + "in the WaitingForAttachment state",
       );
     } else if (
-      this._stateData.isMediaKeysAttached !== MediaKeyAttachmentStatus.NotAttached
+      this._stateData.isMediaKeysAttached !== MediaKeyAttachmentStatus.NotAttached ||
+      this._stateData.data === null
     ) {
       log.warn("DRM: ContentDecryptor's `attach` method called more than once.");
       return;
@@ -260,10 +254,20 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       mediaKeysInfo;
     const shouldDisableLock = options.disableMediaKeysAttachmentLock === true;
 
+    const canFilterProtectionData =
+      isNullOrUndefined(options.persistentLicenseConfig) ||
+      options.persistentLicenseConfig.disableRetroCompatibility === true;
     if (shouldDisableLock) {
       log.debug("DRM: disabling MediaKeys attachment lock. Ready for content");
       this._stateData = {
-        state: ContentDecryptorState.ReadyForContent,
+        state: {
+          name: ContentDecryptorState.ReadyForContent,
+          payload: {
+            systemId: this.systemId,
+            canFilterProtectionData,
+            failOnEncryptedAfterClear: options.failOnEncryptedAfterClear === true,
+          },
+        },
         isInitDataQueueLocked: true,
         isMediaKeysAttached: MediaKeyAttachmentStatus.Pending,
         data: { mediaKeysInfo, mediaElement },
@@ -304,16 +308,20 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
           return;
         }
 
-        const prevState = this._stateData.state;
         this._stateData = {
-          state: ContentDecryptorState.ReadyForContent,
+          state: {
+            name: ContentDecryptorState.ReadyForContent,
+            payload: {
+              systemId: this.systemId,
+              canFilterProtectionData,
+              failOnEncryptedAfterClear: options.failOnEncryptedAfterClear === true,
+            },
+          },
           isMediaKeysAttached: MediaKeyAttachmentStatus.Attached,
           isInitDataQueueLocked: false,
           data: { mediaKeysData: mediaKeysInfo },
         };
-        if (prevState !== ContentDecryptorState.ReadyForContent) {
-          this.trigger("stateChange", ContentDecryptorState.ReadyForContent);
-        }
+        this.trigger("stateChange", this._stateData.state);
         if (!this._isStopped()) {
           this._processCurrentInitDataQueue();
         }
@@ -334,7 +342,10 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   public dispose() {
     this.removeEventListener();
     this._stateData = {
-      state: ContentDecryptorState.Disposed,
+      state: {
+        name: ContentDecryptorState.Disposed,
+        payload: null,
+      },
       isMediaKeysAttached: undefined,
       isInitDataQueueLocked: undefined,
       data: null,
@@ -355,15 +366,15 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * @returns {boolean}
    */
   public isCodecSupported(mimeType: string, codec: string): boolean | undefined {
-    if (this._stateData.state === ContentDecryptorState.Initializing) {
+    if (this._stateData.state.name === ContentDecryptorState.Initializing) {
       log.error(
         "DRM: Asking for codec support while the ContentDecryptor is still initializing",
       );
       return undefined;
     }
     if (
-      this._stateData.state === ContentDecryptorState.Error ||
-      this._stateData.state === ContentDecryptorState.Disposed
+      this._stateData.state.name === ContentDecryptorState.Error ||
+      this._stateData.state.name === ContentDecryptorState.Disposed
     ) {
       log.error("DRM: Asking for codec support while the ContentDecryptor is disposed");
     }
@@ -909,19 +920,20 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     }
     const formattedErr =
       err instanceof Error ? err : new OtherError("NONE", "Unknown decryption error");
-    this.error = formattedErr;
     this._initDataQueue.length = 0;
     this._stateData = {
-      state: ContentDecryptorState.Error,
+      state: {
+        name: ContentDecryptorState.Error,
+        payload: formattedErr,
+      },
       isMediaKeysAttached: undefined,
       isInitDataQueueLocked: undefined,
       data: null,
     };
     this._canceller.cancel();
-    this.trigger("error", formattedErr);
 
     // The previous trigger might have lead to a disposal of the `ContentDecryptor`.
-    if (this._stateData.state === ContentDecryptorState.Error) {
+    if (this._stateData.state.name === ContentDecryptorState.Error) {
       this.trigger("stateChange", this._stateData.state);
     }
   }
@@ -933,8 +945,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    */
   private _isStopped(): boolean {
     return (
-      this._stateData.state === ContentDecryptorState.Disposed ||
-      this._stateData.state === ContentDecryptorState.Error
+      this._stateData.state.name === ContentDecryptorState.Disposed ||
+      this._stateData.state.name === ContentDecryptorState.Error
     );
   }
 
@@ -1215,7 +1227,7 @@ function addKeyIdsFromPeriod(set: Set<Uint8Array>, period: IPeriodMetadata) {
 }
 
 /** Possible states the ContentDecryptor is in and associated data for each one. */
-type IContentDecryptorStateData =
+type IContentDecryptorStateMetadata =
   | IInitializingStateData
   | IWaitingForAttachmentStateData
   | IReadyForContentStateDataUnattached
@@ -1223,15 +1235,15 @@ type IContentDecryptorStateData =
   | IDisposeStateData
   | IErrorStateData;
 
-/** Skeleton that all variants of `IContentDecryptorStateData` use. */
+/** Skeleton that all variants of `IContentDecryptorStateMetadata` use. */
 interface IContentDecryptorStateBase<
-  TStateName extends ContentDecryptorState,
+  TStateData extends IContentDecryptorStateData,
   TIsQueueLocked extends boolean | undefined,
   TIsMediaKeyAttached extends MediaKeyAttachmentStatus | undefined,
   TData,
 > {
   /** Identify the ContentDecryptor's state. */
-  state: TStateName;
+  state: TStateData;
   /**
    * If `true`, the `ContentDecryptor` will wait before processing
    * newly-received initialization data.
@@ -1259,7 +1271,7 @@ const enum MediaKeyAttachmentStatus {
 
 /** ContentDecryptor's internal data when in the `Initializing` state. */
 type IInitializingStateData = IContentDecryptorStateBase<
-  ContentDecryptorState.Initializing,
+  IInitializingContentDecryptorState,
   true, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.NotAttached, // isMediaKeysAttached
   null // data
@@ -1267,7 +1279,7 @@ type IInitializingStateData = IContentDecryptorStateBase<
 
 /** ContentDecryptor's internal data when in the `WaitingForAttachment` state. */
 type IWaitingForAttachmentStateData = IContentDecryptorStateBase<
-  ContentDecryptorState.WaitingForAttachment,
+  IWaitingForAttachmentContentDecryptorState,
   true, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.NotAttached, // isMediaKeysAttached
   // data
@@ -1279,7 +1291,7 @@ type IWaitingForAttachmentStateData = IContentDecryptorStateBase<
  * it has attached the `MediaKeys` to the media element.
  */
 type IReadyForContentStateDataUnattached = IContentDecryptorStateBase<
-  ContentDecryptorState.ReadyForContent,
+  IReadyForContentContentDecryptorState,
   true, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.NotAttached | MediaKeyAttachmentStatus.Pending, // isMediaKeysAttached
   { mediaKeysInfo: IMediaKeysInfos; mediaElement: IMediaElement } // data
@@ -1290,7 +1302,7 @@ type IReadyForContentStateDataUnattached = IContentDecryptorStateBase<
  * it has attached the `MediaKeys` to the media element.
  */
 type IReadyForContentStateDataAttached = IContentDecryptorStateBase<
-  ContentDecryptorState.ReadyForContent,
+  IReadyForContentContentDecryptorState,
   boolean, // isInitDataQueueLocked
   MediaKeyAttachmentStatus.Attached, // isMediaKeysAttached
   {
@@ -1307,7 +1319,7 @@ type IReadyForContentStateDataAttached = IContentDecryptorStateBase<
 
 /** ContentDecryptor's internal data when in the `Disposed` state. */
 type IDisposeStateData = IContentDecryptorStateBase<
-  ContentDecryptorState.Disposed,
+  IDisposedContentDecryptorState,
   undefined, // isInitDataQueueLocked
   undefined, // isMediaKeysAttached
   null // data
@@ -1315,7 +1327,7 @@ type IDisposeStateData = IContentDecryptorStateBase<
 
 /** ContentDecryptor's internal data when in the `Error` state. */
 type IErrorStateData = IContentDecryptorStateBase<
-  ContentDecryptorState.Error,
+  IErrorContentDecryptorState,
   undefined, // isInitDataQueueLocked
   undefined, // isMediaKeysAttached
   null // data

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -137,7 +137,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
 
     drmInitRef.onUpdate(
       (evt, stopListeningToDrmUpdates) => {
-        if (evt.initializationState.type === "uninitialized") {
+        if (evt.type === "uninitialized") {
           return; // nothing done yet
         }
         stopListeningToDrmUpdates();
@@ -150,11 +150,11 @@ export default class DirectFileContentInitializer extends ContentInitializer {
           clearElementSrc(mediaElement);
         });
 
-        if (evt.initializationState.type === "awaiting-media-link") {
-          evt.initializationState.value.isMediaLinked.setValue(true);
+        if (evt.type === "awaiting-media-link") {
+          evt.value.isMediaLinked.setValue(true);
           drmInitRef.onUpdate(
             (newDrmStatus, stopListeningToDrmUpdatesAgain) => {
-              if (newDrmStatus.initializationState.type === "initialized") {
+              if (newDrmStatus.type === "initialized") {
                 stopListeningToDrmUpdatesAgain();
                 this._seekAndPlay(mediaElement, playbackObserver);
               }
@@ -162,7 +162,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
             { emitCurrentValue: true, clearSignal: cancelSignal },
           );
         } else {
-          assert(evt.initializationState.type === "initialized");
+          assert(evt.type === "initialized");
           this._seekAndPlay(mediaElement, playbackObserver);
         }
       },

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -210,7 +210,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           mediaElement,
           initResult.mediaSource,
           playbackObserver,
-          initResult.drmSystemId,
+          {
+            drmSystemId: initResult.drmSystemId,
+            canFilterProtectionData: initResult.canFilterProtectionData,
+            failOnEncryptedAfterClear: initResult.failOnEncryptedAfterClear,
+          },
           initResult.unlinkMediaSource,
         ),
       )
@@ -259,6 +263,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   private _setupInitialMediaSourceAndDecryption(mediaElement: IMediaElement): Promise<{
     mediaSource: MainMediaSourceInterface;
     drmSystemId: string | undefined;
+    canFilterProtectionData: boolean;
+    failOnEncryptedAfterClear: boolean;
     unlinkMediaSource: TaskCanceller;
   }> {
     const initCanceller = this._initCanceller;
@@ -333,7 +339,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
       drmInitRef.onUpdate(
         (drmStatus, stopListeningToDrmUpdates) => {
-          if (drmStatus.initializationState.type === "uninitialized") {
+          if (drmStatus.type === "uninitialized") {
             return;
           }
           stopListeningToDrmUpdates();
@@ -343,15 +349,19 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           createMediaSource(mediaElement, mediaSourceCanceller.signal)
             .then((mediaSource) => {
               const lastDrmStatus = drmInitRef.getValue();
-              if (lastDrmStatus.initializationState.type === "awaiting-media-link") {
-                lastDrmStatus.initializationState.value.isMediaLinked.setValue(true);
+              if (lastDrmStatus.type === "awaiting-media-link") {
+                lastDrmStatus.value.isMediaLinked.setValue(true);
                 drmInitRef.onUpdate(
                   (newDrmStatus, stopListeningToDrmUpdatesAgain) => {
-                    if (newDrmStatus.initializationState.type === "initialized") {
+                    if (newDrmStatus.type === "initialized") {
                       stopListeningToDrmUpdatesAgain();
                       resolve({
                         mediaSource,
-                        drmSystemId: newDrmStatus.drmSystemId,
+                        drmSystemId: newDrmStatus.value.drmSystemId,
+                        canFilterProtectionData:
+                          newDrmStatus.value.canFilterProtectionData,
+                        failOnEncryptedAfterClear:
+                          newDrmStatus.value.failOnEncryptedAfterClear,
                         unlinkMediaSource: mediaSourceCanceller,
                       });
                       return;
@@ -359,10 +369,12 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                   },
                   { emitCurrentValue: true, clearSignal: initCanceller.signal },
                 );
-              } else if (drmStatus.initializationState.type === "initialized") {
+              } else if (drmStatus.type === "initialized") {
                 resolve({
                   mediaSource,
-                  drmSystemId: drmStatus.drmSystemId,
+                  drmSystemId: drmStatus.value.drmSystemId,
+                  canFilterProtectionData: drmStatus.value.canFilterProtectionData,
+                  failOnEncryptedAfterClear: drmStatus.value.failOnEncryptedAfterClear,
                   unlinkMediaSource: mediaSourceCanceller,
                 });
                 return;
@@ -384,7 +396,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     mediaElement: IMediaElement,
     initialMediaSource: MainMediaSourceInterface,
     playbackObserver: IMediaElementPlaybackObserver,
-    drmSystemId: string | undefined,
+    decryptionParameters: {
+      drmSystemId: string | undefined;
+      canFilterProtectionData: boolean;
+      failOnEncryptedAfterClear: boolean;
+    },
     initialMediaSourceCanceller: TaskCanceller,
   ): Promise<void> {
     const {
@@ -439,7 +455,12 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     /** Choose the right "Representation" for a given "Adaptation". */
     const representationEstimator = AdaptiveRepresentationSelector(adaptiveOptions);
     const subBufferOptions = objectAssign(
-      { textTrackOptions, drmSystemId },
+      {
+        textTrackOptions,
+        drmSystemId: decryptionParameters.drmSystemId,
+        canFilterProtectionData: decryptionParameters.canFilterProtectionData,
+        failOnEncryptedAfterClear: decryptionParameters.failOnEncryptedAfterClear,
+      },
       bufferOptions,
     );
 
@@ -1093,7 +1114,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         supportedIfEncrypted = true;
       } else {
         const contentDecryptor = this._decryptionCapabilities.value;
-        if (contentDecryptor.getState() !== ContentDecryptorState.Initializing) {
+        if (contentDecryptor.getState().name !== ContentDecryptorState.Initializing) {
           // No information is available regarding the support status.
           // Defaulting to assume the codec is supported.
           supportedIfEncrypted =

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -51,7 +51,7 @@ import SharedReference from "../../utils/reference";
 import { RequestError } from "../../utils/request";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import TaskCanceller, { CancellationError } from "../../utils/task_canceller";
-import type { IContentProtection } from "../decrypt";
+import type { IContentDecryptorStateData, IContentProtection } from "../decrypt";
 import type IContentDecryptor from "../decrypt";
 import { ContentDecryptorState, getKeySystemConfiguration } from "../decrypt";
 import type { ITextDisplayer } from "../text_displayer";
@@ -384,7 +384,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     );
     drmInitializationStatus.onUpdate(
       (initializationStatus, stopListeningDrm) => {
-        if (initializationStatus.initializationState.type === "initialized") {
+        if (initializationStatus.type === "initialized") {
           stopListeningDrm();
           this._startPlaybackIfReady(playbackStartParams);
         }
@@ -1189,7 +1189,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     reloadMediaSource: () => void,
     cancelSignal: CancellationSignal,
   ): {
-    statusRef: IReadOnlySharedReference<IDrmInitializationStatus>;
+    statusRef: IReadOnlySharedReference<IDecryptionInitializationState>;
     contentDecryptor: IContentDecryptor | null;
   } {
     const { keySystems } = this._settings;
@@ -1210,12 +1210,12 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         { clearSignal: cancelSignal },
       );
       const ref = new SharedReference({
-        initializationState: {
-          type: "initialized" as const,
-          value: null,
+        type: "initialized" as const,
+        value: {
+          drmSystemId: undefined,
+          canFilterProtectionData: true,
+          failOnEncryptedAfterClear: false,
         },
-        contentDecryptor: null,
-        drmSystemId: undefined,
       });
       ref.finish(); // We know that no new value will be triggered
       return { statusRef: ref, contentDecryptor: null };
@@ -1233,16 +1233,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     }
     log.debug("MTCI: Creating ContentDecryptor");
     const contentDecryptor = new ContentDecryptor(mediaElement, keySystems);
-    const drmStatusRef = new SharedReference<IDrmInitializationStatus>(
-      {
-        initializationState: { type: "uninitialized", value: null },
-        drmSystemId: undefined,
-      },
+    const drmStatusRef = new SharedReference<IDecryptionInitializationState>(
+      { type: "uninitialized", value: null },
       cancelSignal,
     );
 
-    const updateCodecSupportOnStateChange = (state: ContentDecryptorState) => {
-      if (state > ContentDecryptorState.Initializing) {
+    const updateCodecSupportOnStateChange = (state: IContentDecryptorStateData) => {
+      if (state.name > ContentDecryptorState.Initializing) {
         const manifest = this._currentContentInfo?.manifest;
         if (isNullOrUndefined(manifest)) {
           return;
@@ -1313,31 +1310,38 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       this.trigger("decipherabilityUpdate", manUpdates);
     });
     contentDecryptor.addEventListener("stateChange", (state) => {
-      if (state === ContentDecryptorState.WaitingForAttachment) {
-        mediaSourceStatus.onUpdate(
-          (currStatus, stopListening) => {
-            if (currStatus === MediaSourceInitializationStatus.Nothing) {
-              mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);
-            } else if (currStatus === MediaSourceInitializationStatus.Attached) {
-              stopListening();
-              if (state === ContentDecryptorState.WaitingForAttachment) {
-                contentDecryptor.attach();
-              }
-            }
-          },
-          { clearSignal: cancelSignal, emitCurrentValue: true },
-        );
-      } else if (state === ContentDecryptorState.ReadyForContent) {
-        drmStatusRef.setValue({
-          initializationState: { type: "initialized", value: null },
-          drmSystemId: contentDecryptor.systemId,
-        });
-        contentDecryptor.removeEventListener("stateChange");
-      }
-    });
+      switch (state.name) {
+        case ContentDecryptorState.Error:
+          this._onFatalError(state.payload);
+          break;
 
-    contentDecryptor.addEventListener("error", (error) => {
-      this._onFatalError(error);
+        case ContentDecryptorState.WaitingForAttachment:
+          mediaSourceStatus.onUpdate(
+            (currStatus, stopListening) => {
+              if (currStatus === MediaSourceInitializationStatus.Nothing) {
+                mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);
+              } else if (currStatus === MediaSourceInitializationStatus.Attached) {
+                stopListening();
+                if (state.name === ContentDecryptorState.WaitingForAttachment) {
+                  contentDecryptor.attach();
+                }
+              }
+            },
+            { clearSignal: cancelSignal, emitCurrentValue: true },
+          );
+          break;
+
+        case ContentDecryptorState.ReadyForContent:
+          drmStatusRef.setValue({
+            type: "initialized",
+            value: {
+              drmSystemId: state.payload.systemId,
+              canFilterProtectionData: state.payload.canFilterProtectionData,
+              failOnEncryptedAfterClear: state.payload.failOnEncryptedAfterClear,
+            },
+          });
+          break;
+      }
     });
 
     contentDecryptor.addEventListener("warning", (error) => {
@@ -1660,16 +1664,17 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     mediaElement: IMediaElement;
     textDisplayer: ITextDisplayer | null;
     playbackObserver: IMediaElementPlaybackObserver;
-    drmInitializationStatus: IReadOnlySharedReference<IDrmInitializationStatus>;
+    drmInitializationStatus: IReadOnlySharedReference<IDecryptionInitializationState>;
     mediaSourceStatus: IReadOnlySharedReference<MediaSourceInitializationStatus>;
   }): boolean {
     if (this._currentContentInfo === null || this._currentContentInfo.manifest === null) {
       return false;
     }
     const drmInitStatus = parameters.drmInitializationStatus.getValue();
-    if (drmInitStatus.initializationState.type !== "initialized") {
+    if (drmInitStatus.type !== "initialized") {
       return false;
     }
+    const drmPayload = drmInitStatus.value;
     const msInitStatus = parameters.mediaSourceStatus.getValue();
     if (msInitStatus !== MediaSourceInitializationStatus.Attached) {
       return false;
@@ -1708,7 +1713,9 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       value: {
         initialTime,
         initialObservation: sentInitialObservation,
-        drmSystemId: drmInitStatus.drmSystemId,
+        drmSystemId: drmPayload.drmSystemId,
+        canFilterProtectionData: drmPayload.canFilterProtectionData,
+        failOnEncryptedAfterClear: drmPayload.failOnEncryptedAfterClear,
         enableFastSwitching,
         onCodecSwitch,
       },
@@ -2052,17 +2059,6 @@ const enum MediaSourceInitializationStatus {
   Attached,
 }
 
-interface IDrmInitializationStatus {
-  /** Current initialization state the decryption logic is in. */
-  initializationState: IDecryptionInitializationState;
-  /**
-   * If set, corresponds to the hex string describing the current key system
-   * used.
-   * `undefined` if unknown or if it does not apply.
-   */
-  drmSystemId: string | undefined;
-}
-
 /** Initialization steps to add decryption capabilities to an `HTMLMediaElement`. */
 type IDecryptionInitializationState =
   /**
@@ -2077,7 +2073,27 @@ type IDecryptionInitializationState =
    */
   | {
       type: "initialized";
-      value: null;
+      value: {
+        /**
+         * If set, corresponds to the hex string describing the current key system
+         * used.
+         * `undefined` if unknown.
+         */
+        drmSystemId: string | undefined;
+        /**
+         * If `true`, protection data as found in the content can be manipulated so
+         * e.g. only the data linked to the given systemId may be communicated.
+         *
+         * If `false` the full extent of the protection data, in exactly the way it
+         * has been found in the content, should be communicated.
+         */
+        canFilterProtectionData: boolean;
+        /**
+         * if `true`, the current device is known to not be able to begin playback of
+         * encrypted content if there's already clear content playing.
+         */
+        failOnEncryptedAfterClear: boolean;
+      };
     };
 
 function formatSourceBufferError(error: unknown): SourceBufferError {

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -100,7 +100,7 @@ export function updateManifestCodecSupport(
         // encrypted codec is supported
         isSupportedEncrypted: true,
       };
-    } else if (contentDecryptor.getState() === ContentDecryptorState.Initializing) {
+    } else if (contentDecryptor.getState().name === ContentDecryptorState.Initializing) {
       newData = {
         isSupportedClear: true,
         isSupportedEncrypted: undefined,

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -226,6 +226,19 @@ export interface IStartPreparedContentMessageValue {
    */
   drmSystemId: string | undefined;
   /**
+   * If `true`, protection data as found in the content can be manipulated so
+   * e.g. only the data linked to the given systemId may be communicated.
+   *
+   * If `false` the full extent of the protection data, in exactly the way it
+   * has been found in the content, should be communicated.
+   */
+  canFilterProtectionData: boolean;
+  /**
+   * If `true`, the current device is known to not be able to begin playback of
+   * encrypted content if there's already clear content playing.
+   */
+  failOnEncryptedAfterClear: boolean;
+  /**
    * Enable/Disable fastSwitching: allow to replace lower-quality segments by
    * higher-quality ones to have a faster transition.
    */

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -634,6 +634,12 @@ export interface IKeySystemOption {
   disableMediaKeysAttachmentLock?: boolean;
 
   /**
+   * If `true`, the current device is known to not be able to begin playback of
+   * encrypted content if there's already clear content playing.
+   */
+  failOnEncryptedAfterClear?: boolean | undefined;
+
+  /**
    * Behavior the RxPlayer should have when one of the key has the
    * `MediaKeyStatus` `"internal-error"`.
    *


### PR DESCRIPTION
An application reported to us an issue where they couldn't play a content of mixed clear and encrypted contents on PlayReady devices.

After a LOT of attempts at work-arounds, some of them described [here](https://github.com/canalplus/rx-player/issues/1403), we didn't succeed to actually find a good solution that would both allow smooth transition between Periods and a mix of encrypted and unencrypted content with the provided contents on PlayReady devices.

So I attempted to play the same content with other players:

  - dash.js didn't had a smooth transition between Periods here, it first loaded and played the clear content, then once finished, loaded and played the encrypted content, with a black screen and license request in-between.

  - The shaka-player failed to play the content, I tried to debug it but I did not succeed to make it play the content.

This is very probably an issue with PlayReady (and perhaps with the content? Though I haven't found anything wrong), yet they historically haven't been quick to fix issues we reported, so we may have to provide a perhaps-temporary solution here.

That's why I'm introducing the for-now undocumented (and experimental feature?) `keySystems[].failOnEncryptedAfterClear` `loadVideo` option.

When set to `true`, we'll reload if an encrypted Period is encountered after a clear Period has been played. The logic for now is not perfect with very rare risks of false negatives.

NOTE: I also profited from this commit to add the `canFilterProtectionData` option to the streams. Previously it was implicitly enabled when the `drmSystemId` was defined.