### PR TITLE
Work-around firefox 129 windows bug

### DIFF
--- a/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
@@ -41,6 +41,22 @@ const incompatibleMKSAErrorMessage =
   "INCOMPATIBLE_KEYSYSTEMS: No key system compatible " +
   "with your wanted configuration has been found in the current browser.";
 
+function removeCapabiltiesFromConfig(
+  baseConfig: MediaKeySystemConfiguration[],
+): MediaKeySystemConfiguration[] {
+  return baseConfig.map(
+    (config) =>
+      ({
+        ...config,
+        audioCapabilities: undefined,
+        videoCapabilities: undefined,
+        // Note: TypeScript is wrong here (2024-08-07), it thinks that
+        // `audioCapabilities` and `videoCapabilities` cannot be set to
+        // `undefined`, though they definitely can.
+      }) as unknown as MediaKeySystemConfiguration,
+  );
+}
+
 /**
  * Check that the given `keySystemsConfigs` lead to an
  * `INCOMPATIBLE_KEYSYSTEMS` error.
@@ -97,8 +113,17 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: getLicenseFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
   });
 
   it("should throw if given multiple incompatible keySystemsConfigs", async () => {
@@ -114,7 +139,7 @@ describe("decrypt - global tests - media key system access", () => {
       { type: "baz", getLicense: neverCalledFn },
     ];
     await checkIncompatibleKeySystemsErrorMessage(config);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(3);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "foo",
@@ -122,13 +147,28 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "foo",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "bar",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      3,
+      4,
+      "bar",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      5,
       "baz",
       defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      6,
+      "baz",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
   });
 
@@ -142,8 +182,17 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
   });
 
   it('should set persistentState value if persistentState is set to "required"', async () => {
@@ -156,12 +205,21 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: neverCalledFn, persistentState: "required" },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, persistentState: "required" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it('should set persistentState value if persistentState is set to "not-allowed"', async () => {
@@ -178,12 +236,21 @@ describe("decrypt - global tests - media key system access", () => {
         persistentState: "not-allowed",
       },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, persistentState: "not-allowed" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it('should set persistentState value if persistentState is set to "optional"', async () => {
@@ -196,12 +263,21 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: neverCalledFn, persistentState: "optional" },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, persistentState: "optional" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it('should set distinctiveIdentifier value if distinctiveIdentifier is set to "required"', async () => {
@@ -218,12 +294,21 @@ describe("decrypt - global tests - media key system access", () => {
         distinctiveIdentifier: "required",
       },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, distinctiveIdentifier: "required" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it('should set distinctiveIdentifier value if distinctiveIdentifier is set to "not-allowed"', async () => {
@@ -240,12 +325,21 @@ describe("decrypt - global tests - media key system access", () => {
         distinctiveIdentifier: "not-allowed",
       },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, distinctiveIdentifier: "not-allowed" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it('should set distinctiveIdentifier value if distinctiveIdentifier is set to "optional"', async () => {
@@ -262,12 +356,21 @@ describe("decrypt - global tests - media key system access", () => {
         distinctiveIdentifier: "optional",
       },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return { ...conf, distinctiveIdentifier: "optional" };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it("should want persistent sessions if persistentLicenseConfig is set", async () => {
@@ -288,16 +391,25 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: neverCalledFn, persistentLicenseConfig },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
 
-    const expectedConfig = defaultKSConfig.map((conf) => {
+    const expectedConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map((conf) => {
       return {
         ...conf,
         persistentState: "required",
         sessionTypes: ["temporary", "persistent-license"],
       };
     });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", expectedConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      expectedConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(expectedConfig),
+    );
   });
 
   it("should do nothing if persistentLicenseConfig is set to null", async () => {
@@ -310,8 +422,17 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "foo", getLicense: neverCalledFn, persistentLicenseConfig: null },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
   });
 
   it("should do nothing if persistentLicenseConfig is set to undefined", async () => {
@@ -328,8 +449,17 @@ describe("decrypt - global tests - media key system access", () => {
         persistentLicenseConfig: undefined,
       },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith("foo", defaultKSConfig);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
+      "foo",
+      defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "foo",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
   });
 
   it("should translate a `clearkey` keySystem", async () => {
@@ -342,7 +472,7 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "clearkey", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(4);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "webkit-org.w3.clearkey",
@@ -350,8 +480,18 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "webkit-org.w3.clearkey",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "org.w3.clearkey",
       defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      4,
+      "org.w3.clearkey",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
   });
 
@@ -365,10 +505,16 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "widevine", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith(
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      1,
       "com.widevine.alpha",
       defaultWidevineConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "com.widevine.alpha",
+      removeCapabiltiesFromConfig(defaultWidevineConfig),
     );
   });
 
@@ -382,7 +528,7 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "playready", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(4);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(8);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.microsoft.playready.recommendation",
@@ -390,18 +536,38 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "com.microsoft.playready.recommendation",
+      removeCapabiltiesFromConfig(defaultPRRecommendationKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "com.microsoft.playready",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      3,
+      4,
+      "com.microsoft.playready",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      5,
       "com.chromecast.playready",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      4,
+      6,
+      "com.chromecast.playready",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      7,
       "com.youtube.playready",
       defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      8,
+      "com.youtube.playready",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
   });
 
@@ -415,10 +581,14 @@ describe("decrypt - global tests - media key system access", () => {
     await checkIncompatibleKeySystemsErrorMessage([
       { type: "fairplay", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith(
       "com.apple.fps.1_0",
       defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledWith(
+      "com.apple.fps.1_0",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
   });
 
@@ -433,7 +603,7 @@ describe("decrypt - global tests - media key system access", () => {
       { type: "playready", getLicense: neverCalledFn },
       { type: "clearkey", getLicense: neverCalledFn },
     ]);
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(12);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.microsoft.playready.recommendation",
@@ -441,28 +611,48 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "com.microsoft.playready.recommendation",
+      removeCapabiltiesFromConfig(defaultPRRecommendationKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "com.microsoft.playready",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      3,
+      4,
+      "com.microsoft.playready",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      5,
       "com.chromecast.playready",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      4,
-      "com.youtube.playready",
-      defaultKSConfig,
+      6,
+      "com.chromecast.playready",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      5,
+      9,
       "webkit-org.w3.clearkey",
       defaultKSConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      6,
+      10,
+      "webkit-org.w3.clearkey",
+      removeCapabiltiesFromConfig(defaultKSConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      11,
       "org.w3.clearkey",
       defaultKSConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      12,
+      "org.w3.clearkey",
+      removeCapabiltiesFromConfig(defaultKSConfig),
     );
   });
 
@@ -492,7 +682,15 @@ describe("decrypt - global tests - media key system access", () => {
         getLicense: neverCalledFn,
       },
     ]);
-    const expectedPRRecommendationPersistentConfig = defaultPRRecommendationKSConfig.map(
+    const expectedPRRecommendationPersistentConfig: MediaKeySystemConfiguration[] =
+      defaultPRRecommendationKSConfig.map((conf) => {
+        return {
+          ...conf,
+          persistentState: "required",
+          sessionTypes: ["temporary", "persistent-license"],
+        };
+      });
+    const expectedPersistentConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map(
       (conf) => {
         return {
           ...conf,
@@ -501,17 +699,12 @@ describe("decrypt - global tests - media key system access", () => {
         };
       },
     );
-    const expectedPersistentConfig = defaultKSConfig.map((conf) => {
-      return {
-        ...conf,
-        persistentState: "required",
-        sessionTypes: ["temporary", "persistent-license"],
-      };
-    });
-    const expectedIdentifierConfig = defaultKSConfig.map((conf) => {
-      return { ...conf, distinctiveIdentifier: "required" };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
+    const expectedIdentifierConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map(
+      (conf) => {
+        return { ...conf, distinctiveIdentifier: "required" };
+      },
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(12);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.microsoft.playready.recommendation",
@@ -519,28 +712,58 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "com.microsoft.playready.recommendation",
+      removeCapabiltiesFromConfig(expectedPRRecommendationPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "com.microsoft.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      3,
+      4,
+      "com.microsoft.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      5,
       "com.chromecast.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      4,
+      6,
+      "com.chromecast.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      7,
       "com.youtube.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      5,
+      8,
+      "com.youtube.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      9,
       "webkit-org.w3.clearkey",
       expectedIdentifierConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      6,
+      10,
+      "webkit-org.w3.clearkey",
+      removeCapabiltiesFromConfig(expectedIdentifierConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      11,
       "org.w3.clearkey",
       expectedIdentifierConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      12,
+      "org.w3.clearkey",
+      removeCapabiltiesFromConfig(expectedIdentifierConfig),
     );
   });
 
@@ -565,18 +788,24 @@ describe("decrypt - global tests - media key system access", () => {
         getLicense: neverCalledFn,
       },
     ]);
-    const expectedPersistentConfig = defaultWidevineConfig.map((conf) => {
-      return {
-        ...conf,
-        persistentState: "required",
-        sessionTypes: ["temporary", "persistent-license"],
-      };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    const expectedPersistentConfig: MediaKeySystemConfiguration[] =
+      defaultWidevineConfig.map((conf) => {
+        return {
+          ...conf,
+          persistentState: "required",
+          sessionTypes: ["temporary", "persistent-license"],
+        };
+      });
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.widevine.alpha",
       expectedPersistentConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "com.widevine.alpha",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
     );
   });
 
@@ -606,24 +835,29 @@ describe("decrypt - global tests - media key system access", () => {
         getLicense: neverCalledFn,
       },
     ]);
-    const expectedPersistentConfig = defaultKSConfig.map((conf) => {
-      return {
-        ...conf,
-        persistentState: "required",
-        sessionTypes: ["temporary", "persistent-license"],
-      };
-    });
-    const expectedRecoPersistentConfig = defaultPRRecommendationKSConfig.map((conf) => {
-      return {
-        ...conf,
-        persistentState: "required",
-        sessionTypes: ["temporary", "persistent-license"],
-      };
-    });
-    const expectedIdentifierConfig = defaultKSConfig.map((conf) => {
-      return { ...conf, distinctiveIdentifier: "required" };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(6);
+    const expectedPersistentConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map(
+      (conf) => {
+        return {
+          ...conf,
+          persistentState: "required",
+          sessionTypes: ["temporary", "persistent-license"],
+        };
+      },
+    );
+    const expectedRecoPersistentConfig: MediaKeySystemConfiguration[] =
+      defaultPRRecommendationKSConfig.map((conf) => {
+        return {
+          ...conf,
+          persistentState: "required",
+          sessionTypes: ["temporary", "persistent-license"],
+        };
+      });
+    const expectedIdentifierConfig: MediaKeySystemConfiguration[] = defaultKSConfig.map(
+      (conf) => {
+        return { ...conf, distinctiveIdentifier: "required" };
+      },
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(12);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.microsoft.playready.recommendation",
@@ -631,28 +865,58 @@ describe("decrypt - global tests - media key system access", () => {
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       2,
+      "com.microsoft.playready.recommendation",
+      removeCapabiltiesFromConfig(expectedRecoPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      3,
       "com.microsoft.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      3,
+      4,
+      "com.microsoft.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      5,
       "com.chromecast.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      4,
+      6,
+      "com.chromecast.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      7,
       "com.youtube.playready",
       expectedPersistentConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      5,
+      8,
+      "com.youtube.playready",
+      removeCapabiltiesFromConfig(expectedPersistentConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      9,
       "webkit-org.w3.clearkey",
       expectedIdentifierConfig,
     );
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
-      6,
+      10,
+      "webkit-org.w3.clearkey",
+      removeCapabiltiesFromConfig(expectedIdentifierConfig),
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      11,
       "org.w3.clearkey",
       expectedIdentifierConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      12,
+      "org.w3.clearkey",
+      removeCapabiltiesFromConfig(expectedIdentifierConfig),
     );
   });
 
@@ -677,18 +941,24 @@ describe("decrypt - global tests - media key system access", () => {
         getLicense: neverCalledFn,
       },
     ]);
-    const expectedRecoPersistentConfig = defaultPRRecommendationKSConfig.map((conf) => {
-      return {
-        ...conf,
-        persistentState: "required",
-        sessionTypes: ["temporary", "persistent-license"],
-      };
-    });
-    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(1);
+    const expectedRecoPersistentConfig: MediaKeySystemConfiguration[] =
+      defaultPRRecommendationKSConfig.map((conf) => {
+        return {
+          ...conf,
+          persistentState: "required",
+          sessionTypes: ["temporary", "persistent-license"],
+        };
+      });
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
     expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
       1,
       "com.microsoft.playready.recommendation",
       expectedRecoPersistentConfig,
+    );
+    expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+      2,
+      "com.microsoft.playready.recommendation",
+      removeCapabiltiesFromConfig(expectedRecoPersistentConfig),
     );
   });
 
@@ -723,11 +993,10 @@ describe("decrypt - global tests - media key system access", () => {
   });
 
   it("should successfully create a MediaKeySystemAccess if given multiple configurations where one works", async () => {
-    let callNb = 0;
     const mockRequestMediaKeySystemAccess = vi
       .fn()
       .mockImplementation((keyType, conf) => {
-        if (++callNb === 2) {
+        if (keyType === "some-other-working-key-system") {
           return requestMediaKeySystemAccessNoMediaKeys(keyType, conf);
         }
         return Promise.reject("nope");
@@ -749,7 +1018,7 @@ describe("decrypt - global tests - media key system access", () => {
         rej(error);
       });
       setTimeout(() => {
-        expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(2);
+        expect(mockRequestMediaKeySystemAccess).toHaveBeenCalledTimes(3);
         expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
           1,
           "com.widevine.alpha",
@@ -757,6 +1026,11 @@ describe("decrypt - global tests - media key system access", () => {
         );
         expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
           2,
+          "com.widevine.alpha",
+          removeCapabiltiesFromConfig(defaultWidevineConfig),
+        );
+        expect(mockRequestMediaKeySystemAccess).toHaveBeenNthCalledWith(
+          3,
           "some-other-working-key-system",
           defaultKSConfig,
         );

--- a/src/main_thread/decrypt/__tests__/__global__/utils.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/utils.ts
@@ -21,7 +21,7 @@ import { strToUtf8, utf8ToStr } from "../../../../utils/string_parsing";
 import type { CancellationSignal } from "../../../../utils/task_canceller";
 
 /** Default MediaKeySystemAccess configuration used by the RxPlayer. */
-export const defaultKSConfig = [
+export const defaultKSConfig: MediaKeySystemConfiguration[] = [
   {
     audioCapabilities: [
       { contentType: 'audio/mp4;codecs="mp4a.40.2"' },
@@ -38,21 +38,13 @@ export const defaultKSConfig = [
       { contentType: 'video/webm;codecs="vp8"' },
     ],
   },
-  {
-    audioCapabilities: undefined,
-    distinctiveIdentifier: "optional" as const,
-    initDataTypes: ["cenc"] as const,
-    persistentState: "optional" as const,
-    sessionTypes: ["temporary"] as const,
-    videoCapabilities: undefined,
-  },
 ];
 
 /**
  * Default "com.microsoft.playready.recommendation" MediaKeySystemAccess
  * configuration used by the RxPlayer.
  */
-export const defaultPRRecommendationKSConfig = [
+export const defaultPRRecommendationKSConfig: MediaKeySystemConfiguration[] = [
   {
     audioCapabilities: [
       { robustness: "3000", contentType: 'audio/mp4;codecs="mp4a.40.2"' },
@@ -75,18 +67,10 @@ export const defaultPRRecommendationKSConfig = [
       { robustness: "2000", contentType: 'video/webm;codecs="vp8"' },
     ],
   },
-  {
-    audioCapabilities: undefined,
-    distinctiveIdentifier: "optional" as const,
-    initDataTypes: ["cenc"] as const,
-    persistentState: "optional" as const,
-    sessionTypes: ["temporary"] as const,
-    videoCapabilities: undefined,
-  },
 ];
 
 /** Default Widevine MediaKeySystemAccess configuration used by the RxPlayer. */
-export const defaultWidevineConfig = (() => {
+export const defaultWidevineConfig: MediaKeySystemConfiguration[] = (() => {
   const ROBUSTNESSES = [
     "HW_SECURE_ALL",
     "HW_SECURE_DECODE",
@@ -108,10 +92,7 @@ export const defaultWidevineConfig = (() => {
       { contentType: "audio/webm;codecs=opus", robustness },
     ];
   });
-  return [
-    { ...defaultKSConfig[0], audioCapabilities, videoCapabilities },
-    defaultKSConfig[1],
-  ];
+  return [{ ...defaultKSConfig[0], audioCapabilities, videoCapabilities }];
 })();
 
 /**

--- a/src/main_thread/decrypt/attach_media_keys.ts
+++ b/src/main_thread/decrypt/attach_media_keys.ts
@@ -55,6 +55,7 @@ export default async function attachMediaKeys(
   {
     emeImplementation,
     keySystemOptions,
+    askedConfiguration,
     loadedSessionsStore,
     mediaKeySystemAccess,
     mediaKeys,
@@ -81,6 +82,7 @@ export default async function attachMediaKeys(
     mediaKeySystemAccess,
     mediaKeys,
     loadedSessionsStore,
+    askedConfiguration,
   });
   if (mediaElement.mediaKeys === mediaKeys) {
     return;
@@ -109,6 +111,11 @@ export interface IMediaKeysState {
   mediaKeySystemAccess: MediaKeySystemAccess | ICustomMediaKeySystemAccess;
   /** The MediaKeys instance to attach to the media element. */
   mediaKeys: MediaKeys | ICustomMediaKeys;
+  /**
+   * The MediaKeySystemConfiguration that has been provided to the
+   * `requestMediaKeySystemAccess` API.
+   */
+  askedConfiguration: MediaKeySystemConfiguration;
   /**
    * The chosen EME implementation abstraction linked to `mediaKeys`.
    * Different EME implementation might for example be used while debugging or

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -255,7 +255,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     }
 
     const { mediaElement, mediaKeysInfo } = this._stateData.data;
-    const { options, mediaKeys, mediaKeySystemAccess, stores } = mediaKeysInfo;
+    const { options, mediaKeys, mediaKeySystemAccess, stores, askedConfiguration } =
+      mediaKeysInfo;
     const shouldDisableLock = options.disableMediaKeysAttachmentLock === true;
 
     if (shouldDisableLock) {
@@ -279,6 +280,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       loadedSessionsStore: stores.loadedSessionsStore,
       mediaKeySystemAccess,
       mediaKeys,
+      askedConfiguration,
       keySystemOptions: options,
     };
 

--- a/src/main_thread/decrypt/get_media_keys.ts
+++ b/src/main_thread/decrypt/get_media_keys.ts
@@ -51,6 +51,11 @@ function createPersistentSessionsStorage(
 export interface IMediaKeysInfos {
   /** The MediaKeySystemAccess which allowed to create the MediaKeys instance. */
   mediaKeySystemAccess: MediaKeySystemAccess | ICustomMediaKeySystemAccess;
+  /**
+   * The MediaKeySystemConfiguration that has been provided to the
+   * `requestMediaKeySystemAccess` API.
+   */
+  askedConfiguration: MediaKeySystemConfiguration;
   /** The MediaKeys instance. */
   mediaKeys: MediaKeys | ICustomMediaKeys;
   /** Stores allowing to create and retrieve MediaKeySessions. */
@@ -88,7 +93,7 @@ export default async function getMediaKeysInfos(
     throw cancelSignal.cancellationError;
   }
 
-  const { options, mediaKeySystemAccess, codecSupport } = evt.value;
+  const { options, mediaKeySystemAccess, askedConfiguration, codecSupport } = evt.value;
   const currentState = MediaKeysInfosStore.getState(mediaElement);
   const persistentSessionsStore = createPersistentSessionsStorage(options);
 
@@ -110,6 +115,7 @@ export default async function getMediaKeysInfos(
       return {
         mediaKeys,
         mediaKeySystemAccess,
+        askedConfiguration,
         stores: { loadedSessionsStore, persistentSessionsStore },
         options,
         codecSupport,
@@ -123,6 +129,7 @@ export default async function getMediaKeysInfos(
   return {
     mediaKeys,
     mediaKeySystemAccess,
+    askedConfiguration,
     stores: { loadedSessionsStore, persistentSessionsStore },
     options,
     codecSupport,

--- a/src/main_thread/decrypt/utils/media_keys_infos_store.ts
+++ b/src/main_thread/decrypt/utils/media_keys_infos_store.ts
@@ -31,6 +31,12 @@ export interface IMediaElementMediaKeysInfos {
   keySystemOptions: IKeySystemOption;
 
   /**
+   * The actual MediaKeySystemConfiguration asked to the
+   * `requestMediaKeySystemAccess` API.
+   */
+  askedConfiguration: MediaKeySystemConfiguration;
+
+  /**
    * Last MediaKeySystemAccess used to create a MediaKeys bound to that
    * HTMLMediaElement.
    */


### PR DESCRIPTION
We noticed a pretty big issue on firefox 129 (released yesterday) on windows where we cannot play encrypted contents anymore (seen on production with multiple applications relying on the RxPlayer - so it's a relatively big issue).

It seems that since this release, the
`navigator.requestMediaKeySystemAccess` EME API, which we use to poll available decryption capabilities in the current environment, will fail as soon as there's at least one asked "robustness" (allows for example to ask for hardware-based DRM) isn't supported even if we're also asking for e.g. software-based DRM, which we know the device has.

It seems likely this is a firefox issue, but it seems too big for us to just do nothing and throw the bug at them.

Other streaming actors, such as Netflix and Amazon Prime Video don't seem to be impacted by the issue at first glance.
In fact, they are, but they have a fallback call where they are calling the `navigator.requestMediaKeySystemAccess` API without any robustness just in case the API is broken like here.

Yet, we also have the same work-around, but we integrated both configurations (the first with robustnesses, the second without), in the same `navigator.requestMediaKeySystemAccess` call, whereas they're doing two calls each with an array of a single element (the first with, the second without like us).

So to """""fix""""" the issue, I decided to align with their work-arounds (so the next time it breaks, browser devs will see it also breaks Netflix and thus maybe detect the issue faster).

For the same key system type, doing one call with multiple configurations or multiple calls with one configuration seems equivalent from my understanding of the EME recommendation, so what I did here should change nothing EME-wise (except more EME API calls), it is just to align the code with others.

I still had to change our recently-added code about codec checking, to make it work robustly in that new scenario.