### PR TITLE
DRM: Don't work-around firefox issue if the application asked for specific capabilities

### DIFF
--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -275,6 +275,31 @@ function buildKeySystemConfigurations(
     sessionTypes,
   };
 
+  if (audioCapabilitiesConfig !== undefined) {
+    if (videoCapabilitiesConfig !== undefined) {
+      return [wantedMediaKeySystemConfiguration];
+    }
+    return [
+      wantedMediaKeySystemConfiguration,
+      {
+        ...wantedMediaKeySystemConfiguration,
+        // Re-try without `videoCapabilities` in case the EME implementation is
+        // buggy
+        videoCapabilities: undefined,
+      } as unknown as MediaKeySystemConfiguration,
+    ];
+  } else if (videoCapabilitiesConfig !== undefined) {
+    return [
+      wantedMediaKeySystemConfiguration,
+      {
+        ...wantedMediaKeySystemConfiguration,
+        // Re-try without `audioCapabilities` in case the EME implementation is
+        // buggy
+        audioCapabilities: undefined,
+      } as unknown as MediaKeySystemConfiguration,
+    ];
+  }
+
   return [
     wantedMediaKeySystemConfiguration,
 


### PR DESCRIPTION
In #1495, we recently worked around an issue specific to firefox on windows where asking for at least one unsupported video or audio capability resulted (in our opinion, incorrectly) to a `navigator.requestMediaKeySystemAccess` API call failure.

To work-around this and other similar bugs, we decided to just always perform a second `navigator.requestMediaKeySystemAccess` call in our logic which doesn't ask for any capability.

However, I just realized that this may break some API usages.

For example let's imagine that an application specifically set an `audioCapabilitiesConfig` or `videoCapabilitiesConfig` in a `loadVideo` call to ask for specific capabilities (either specific codecs, or specific robustnesses like PlayReady SL3000 or Widevine L1).

Here, we would first perform a check with the asked capabilities, yet also a second one without. Meaning that an application could be left with a key system that is not the one it explicitely asked for (e.g. we could be playing with PlayReady SL2000 when the application asked explicitely for PlayReady SL3000).

So the fix here is to disable the "no capabilities" work-around if an application explicitely ask for specific capabilities.