### PR TITLE
Treat codecs beginning with `hev1` as hevc

### DIFF
--- a/src/utils/are_codecs_compatible.ts
+++ b/src/utils/are_codecs_compatible.ts
@@ -35,7 +35,11 @@ function areCodecsCompatible(a: string, b: string): boolean {
   if (codecsA === "" || codecsB === "") {
     return false;
   }
-  if (codecsA.split(".")[0] !== codecsB.split(".")[0]) {
+  let initialPartA = codecsA.split(".")[0];
+  initialPartA = initialPartA === "hev1" ? "hvc1" : initialPartA;
+  let initialPartB = codecsB.split(".")[0];
+  initialPartB = initialPartB === "hev1" ? "hvc1" : initialPartB;
+  if (initialPartA !== initialPartB) {
     return false;
   }
   return true;


### PR DESCRIPTION
While working on new DRM integration test in #1478, to add tests for the not-yet-released features proposed by #1484, I noticed that some contents anounced HEVC by beginning the codec string with `hev` and others with `hvc`.

When comparing family of codecs, we thus had false negative which may mean we would have ended up playing encrypted hevc on devices where it wasn't supported, if it was anounced in the MPD as `hev1...`.

I now treat both the same way.