### PR TITLE
[v3] Fix auto-play on tizen when it starts on a discontinuity

### DIFF
--- a/src/core/init/utils/initial_seek_and_play.ts
+++ b/src/core/init/utils/initial_seek_and_play.ts
@@ -17,6 +17,7 @@
 import { shouldValidateMetadata } from "../../../compat";
 import { READY_STATES } from "../../../compat/browser_compatibility_types";
 import { isSafariMobile } from "../../../compat/browser_detection";
+import isSeekingApproximate from "../../../compat/is_seeking_approximate";
 /* eslint-disable-next-line max-len */
 import shouldPreventSeekingAt0Initially from "../../../compat/should_prevent_seeking_at_0_initially";
 import { MediaError } from "../../../errors";
@@ -165,7 +166,10 @@ export default function performInitialSeekAndPlay(
       }
       if (!isAwaitingSeek &&
           !observation.seeking &&
-          observation.rebuffering === null &&
+          (
+            (isSeekingApproximate && observation.readyState >= 3) ||
+            observation.rebuffering === null
+          ) &&
           observation.readyState >= 1)
       {
         stopListening();


### PR DESCRIPTION
In one of our recent updates on the initial seek and play, we appeared to have broken autoPlay on Samsung TVs when they started on a discontinuity.

This is yet again an issue linked to those infamous Tizen seek-backs I love to complain about.

The fix proposed here is to just call the HTML5 `play` API even if we appear to be rebuffering from the amount of buffered data in front of us on Tizen if it tells us that it actually have enough data to play through its `readyState` property.

This shouldn't break things and seems logical. I hesitated doing the same fix for all targets but the `readyState` property is known to be sometimes wrong on some devices so I didn't.

NOTE: Maybe we can do the same thing on V4, even if this shouldn't be required there.