### PR TITLE
[Proposal] Add `filterPlayableRepresentations` property to audio and video tracks API

### DIFF
--- a/doc/api/Track_Selection/getAudioTrack.md
+++ b/doc/api/Track_Selection/getAudioTrack.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+### Returned object
+
 Get information about the audio track currently set. `null` if no audio track is enabled
 right now.
 
@@ -35,7 +37,7 @@ object with the following properties:
   This information is usually set only if the current Manifest contains one.
 
 - `representations` (`Array.<Object>`):
-  [Representations](../../Getting_Started/Glossary.md#representation) of this video track,
+  [Representations](../../Getting_Started/Glossary.md#representation) of this audio track,
   with attributes:
 
   - `id` (`string`): The id used to identify this Representation. No other Representation
@@ -55,8 +57,9 @@ object with the following properties:
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
     `undefined` (or not set) if support of that Representation is unknown or if does not
     make sense here.
@@ -64,10 +67,13 @@ object with the following properties:
   - `decipherable` (`Boolean|undefined`): If `true` the Representation can be deciphered
     (in the eventuality it had DRM-related protection).
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
 `undefined` if no audio content has been loaded yet or if its information is unknown.
+
+### Asking for a specific Period
 
 You can also get the information on the chosen audio track for another Period by calling
 `getAudioTrack` with the corresponding Period's id in argument. Such id can be obtained
@@ -78,6 +84,34 @@ through the `getAvailablePeriods` method, the `newAvailablePeriods` event or the
 // example: getting track information for the first Period
 const periods = rxPlayer.getAvailablePeriods();
 console.log(rxPlayer.getAudioTrack(periods[0].id);
+```
+
+### Including Representations that cannot be played
+
+You can also ask `getAudioTrack` to include in its response `Representation` objects which
+will not be played because they have their `isCodecSupported` or `decipherable` property
+set to `false` (those are filtered out by default, as indicated above).
+
+To do this, you can provide an object to `getAudioTrack` with a
+`filterPlayableRepresentations` property set to `false` like this:
+
+```js
+const audioTrack = player.getAudioTrack();
+```
+
+You may for example also want to know which Representation are not playable to provide
+debug information, or to detect deterministically the capabilities of the current device.
+
+Note that this will return the metadata of the currently-chosen audio track only for the
+current Period. To obtain metadata on all representations for the currently-chosen audio
+track for another Period, you can also set a `periodId` property:
+
+```js
+const periods = rxPlayer.getAvailablePeriods();
+console.log(rxPlayer.getAudioTrack({
+    periodId: periods[0].id,
+    filterPlayableRepresentations: false,
+});
 ```
 
 <div class="warning">
@@ -92,14 +126,37 @@ audio tracks API in the browser, this method returns "undefined".
 // Get information about the currently-playing audio track
 const audioTrack = player.getAudioTrack();
 
+// Also include metadata on the non-playable Representations
+const audioTrack = player.getAudioTrack({
+  filterPlayableRepresentations: false,
+});
+
 // Get information about the audio track for a specific Period
 const audioTrack = player.getAudioTrack(periodId);
+
+// Get information about the audio track for a specific Period and also include metadata
+// on the non-playable Representations
+const audioTrack = player.getAudioTrack({
+  periodId,
+  filterPlayableRepresentations: false,
+});
 ```
 
 - **arguments**:
 
-  1.  _periodId_ `string|undefined`: The `id` of the Period for which you want to get
-      information about its current audio track. If not defined, the information
-      associated to the currently-playing Period will be returned.
+  1.  _arg_ `Object|string|undefined`: If set to a `string`, this is the `id` of the
+      Period for which you want to get information about its current audio track.
+
+      If not defined, the information associated to the currently-playing Period will be
+      returned.
+
+      If set to an Object, the following properties can be set (all optional):
+
+          - `periodId` (`string|undefined`): The `id` of the wanted Period, or
+            `undefined` (or not set) for the currently-playing Period
+
+          - `filterPlayableRepresentations` (`boolean|undefined`): If set to `false`,
+            Representation that are considered "non-playable" (which have an unsupported
+            mime-type/codec or which are undecipherable) will be included.
 
 - **return value** `Object|null|undefined`

--- a/doc/api/Track_Selection/getAvailableAudioTracks.md
+++ b/doc/api/Track_Selection/getAvailableAudioTracks.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+### Returned object
+
 Returns the list of available audio tracks for the current content.
 
 Each of the objects in the returned array have the following properties:
@@ -34,7 +36,7 @@ Each of the objects in the returned array have the following properties:
   This information is usually set only if the current Manifest contains one.
 
 - `representations` (`Array.<Object>`):
-  [Representations](../../Getting_Started/Glossary.md#representation) of this video track,
+  [Representations](../../Getting_Started/Glossary.md#representation) of this audio track,
   with attributes:
 
   - `id` (`string`): The id used to identify this Representation.
@@ -53,8 +55,9 @@ Each of the objects in the returned array have the following properties:
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
     `undefined` (or not set) if support of that Representation is unknown or if does not
     make sense here.
@@ -62,8 +65,11 @@ Each of the objects in the returned array have the following properties:
   - `decipherable` (`Boolean|undefined`): If `true` the Representation can be deciphered
     (in the eventuality it had DRM-related protection).
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
+
+### Asking for a specific Period
 
 You can also get the list of available audio tracks for a specific Period by calling
 `getAvailableAudioTracks` with the corresponding Period's id in argument. Such id can be
@@ -74,6 +80,35 @@ obtained through the `getAvailablePeriods` method, the `newAvailablePeriods` eve
 // example: getting the audio track list for the first Period
 const periods = rxPlayer.getAvailablePeriods();
 console.log(rxPlayer.getAvailableAudioTracks(periods[0].id);
+```
+
+### Including Representations that cannot be played
+
+You can also ask `getAvailableAudioTracks` to include in its response `Representation`
+objects which will not be played because they have their `isCodecSupported` or
+`decipherable` property set to `false` (those are filtered out by default, as indicated
+above).
+
+To do this, you can provide an object to `getAvailableAudioTracks` with a
+`filterPlayableRepresentations` property set to `false` like this:
+
+```js
+const audioTrack = player.getAvailableAudioTracks();
+```
+
+You may for example also want to know which Representation are not playable to provide
+debug information, or to detect deterministically the capabilities of the current device.
+
+Note that this will return the metadata of the available audio tracks only for the current
+Period. To obtain metadata on all representations for available audio tracks from another
+Period, you can also set a `periodId` property:
+
+```js
+const periods = rxPlayer.getAvailablePeriods();
+console.log(rxPlayer.getAvailableAudioTracks({
+    periodId: periods[0].id,
+    filterPlayableRepresentations: false,
+});
 ```
 
 <div class="warning">
@@ -89,14 +124,38 @@ method will return an empty Array.
 // Get list of available audio tracks for the currently-playing Period
 const audioTracks = player.getAvailableAudioTracks();
 
+// Also include metadata on the non-playable Representations
+const audioTracks = player.getAvailableAudioTracks({
+  filterPlayableRepresentations: false,
+});
+
 // Get list of available audio tracks for a specific Period
-const audioTrack = player.getAvailableAudioTracks(periodId);
+const audioTracks = player.getAvailableAudioTracks(periodId);
+
+// Get list of available audio tracks for a specific Period and also include metadata on
+// the non-playable Representations
+const audioTracks = player.getAvailableAudioTracks({
+  periodId,
+  filterPlayableRepresentations: false,
+});
 ```
 
 - **arguments**:
 
-  1.  _periodId_ `string|undefined`: The `id` of the Period for which you want to get the
-      list of available audio tracks. If not defined, this method will return the list of
-      audio tracks for the currently-playing Period.
+  1.  _arg_ `Object|string|undefined`: If set to a `string`, this is the `id` of the
+      Period for which you want to get information about the list of available audio
+      tracks.
+
+      If not defined, the information associated to the currently-playing Period will be
+      returned.
+
+      If set to an Object, the following properties can be set (all optional):
+
+          - `periodId` (`string|undefined`): The `id` of the wanted Period, or
+            `undefined` (or not set) for the currently-playing Period
+
+          - `filterPlayableRepresentations` (`boolean|undefined`): If set to `false`,
+            Representation that are considered "non-playable" (which have an unsupported
+            mime-type/codec or which are undecipherable) will be included.
 
 - **return value** `Array.<Object>`

--- a/doc/api/Track_Selection/getAvailableVideoTracks.md
+++ b/doc/api/Track_Selection/getAvailableVideoTracks.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+### Returned object
+
 Returns the list of available video tracks for the current content.
 
 Each of the objects in the returned array have the following properties:
@@ -42,8 +44,9 @@ Each of the objects in the returned array have the following properties:
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
     `undefined` (or not set) if support of that Representation is unknown or if does not
     make sense here.
@@ -51,8 +54,9 @@ Each of the objects in the returned array have the following properties:
   - `decipherable` (`Boolean|undefined`): If `true` the Representation can be deciphered
     (in the eventuality it had DRM-related protection).
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
 - `signInterpreted` (`Boolean|undefined`): If set to `true`, the track is known to contain
   an interpretation in sign language. If set to `false`, the track is known to not contain
@@ -68,6 +72,8 @@ Each of the objects in the returned array have the following properties:
   It this property is either `undefined` or not set, then this track has no linked
   trickmode video track.
 
+### Asking for a specific Period
+
 You can also get the list of available video tracks for a specific Period by calling
 `getAvailableVideoTracks` with the corresponding Period's id in argument. Such id can be
 obtained through the `getAvailablePeriods` method, the `newAvailablePeriods` event or the
@@ -77,6 +83,35 @@ obtained through the `getAvailablePeriods` method, the `newAvailablePeriods` eve
 // example: getting the video track list for the first Period
 const periods = rxPlayer.getAvailablePeriods();
 console.log(rxPlayer.getAvailableVideoTracks(periods[0].id);
+```
+
+### Including Representations that cannot be played
+
+You can also ask `getAvailableVideoTracks` to include in its response `Representation`
+objects which will not be played because they have their `isCodecSupported` or
+`decipherable` property set to `false` (those are filtered out by default, as indicated
+above).
+
+To do this, you can provide an object to `getAvailableVideoTracks` with a
+`filterPlayableRepresentations` property set to `false` like this:
+
+```js
+const videoTrack = player.getAvailableVideoTracks();
+```
+
+You may for example also want to know which Representation are not playable to provide
+debug information, or to detect deterministically the capabilities of the current device.
+
+Note that this will return the metadata of the available video tracks only for the current
+Period. To obtain metadata on all representations for available video tracks from another
+Period, you can also set a `periodId` property:
+
+```js
+const periods = rxPlayer.getAvailablePeriods();
+console.log(rxPlayer.getAvailableVideoTracks({
+    periodId: periods[0].id,
+    filterPlayableRepresentations: false,
+});
 ```
 
 <div class="warning">
@@ -92,14 +127,38 @@ method will return an empty Array.
 // Get list of available video tracks for the currently-playing Period
 const videoTracks = player.getAvailableVideoTracks();
 
+// Also include metadata on the non-playable Representations
+const videoTracks = player.getAvailableVideoTracks({
+  filterPlayableRepresentations: false,
+});
+
 // Get list of available video tracks for a specific Period
-const videoTrack = player.getAvailableVideoTracks(periodId);
+const videoTracks = player.getAvailableVideoTracks(periodId);
+
+// Get list of available video tracks for a specific Period and also include metadata on
+// the non-playable Representations
+const videoTracks = player.getAvailableVideoTracks({
+  periodId,
+  filterPlayableRepresentations: false,
+});
 ```
 
 - **arguments**:
 
-  1.  _periodId_ `string|undefined`: The `id` of the Period for which you want to get the
-      list of available video tracks. If not defined, this method will return the list of
-      video tracks for the currently-playing Period.
+  1.  _arg_ `Object|string|undefined`: If set to a `string`, this is the `id` of the
+      Period for which you want to get information about the list of available video
+      tracks.
+
+      If not defined, the information associated to the currently-playing Period will be
+      returned.
+
+      If set to an Object, the following properties can be set (all optional):
+
+          - `periodId` (`string|undefined`): The `id` of the wanted Period, or
+            `undefined` (or not set) for the currently-playing Period
+
+          - `filterPlayableRepresentations` (`boolean|undefined`): If set to `false`,
+            Representation that are considered "non-playable" (which have an unsupported
+            mime-type/codec or which are undecipherable) will be included.
 
 - **return value** `Array.<Object>`

--- a/doc/api/Track_Selection/getVideoTrack.md
+++ b/doc/api/Track_Selection/getVideoTrack.md
@@ -2,6 +2,8 @@
 
 ## Description
 
+### Returned object
+
 Get information about the video track currently set.
 
 - `null` if no video track is enabled right now.
@@ -47,8 +49,9 @@ object with the following properties:
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
     `undefined` (or not set) if support of that Representation is unknown or if does not
     make sense here.
@@ -56,8 +59,9 @@ object with the following properties:
   - `decipherable` (`Boolean|undefined`): If `true` the Representation can be deciphered
     (in the eventuality it had DRM-related protection).
 
-    Note that because elements of the `representations` array only contains playable
-    Representation, this value here cannot be set to `false` when in this array.
+    Note that unless you set the `filterPlayableRepresentations` option to `false`, no
+    Representation with a `isCodecSupported` value of `false` will be present in this
+    array (they'll all be filtered out).
 
 - `signInterpreted` (`Boolean|undefined`): If set to `true`, this track is known to
   contain an interpretation in sign language. If set to `false`, the track is known to not
@@ -80,6 +84,8 @@ object with the following properties:
   It this property is either `undefined` or not set, then this track has no linked
   trickmode video track.
 
+### Asking for a specific Period
+
 You can also get the information on the chosen video track for another Period by calling
 `getVideoTrack` with the corresponding Period's id in argument. Such id can be obtained
 through the `getAvailablePeriods` method, the `newAvailablePeriods` event or the
@@ -89,6 +95,34 @@ through the `getAvailablePeriods` method, the `newAvailablePeriods` event or the
 // example: getting track information for the first Period
 const periods = rxPlayer.getAvailablePeriods();
 console.log(rxPlayer.getVideoTrack(periods[0].id);
+```
+
+### Including Representations that cannot be played
+
+You can also ask `getVideoTrack` to include in its response `Representation` objects which
+will not be played because they have their `isCodecSupported` or `decipherable` property
+set to `false` (those are filtered out by default, as indicated above).
+
+To do this, you can provide an object to `getVideoTrack` with a
+`filterPlayableRepresentations` property set to `false` like this:
+
+```js
+const videoTrack = player.getVideoTrack();
+```
+
+You may for example also want to know which Representation are not playable to provide
+debug information, or to detect deterministically the capabilities of the current device.
+
+Note that this will return the metadata of the currently-chosen video track only for the
+current Period. To obtain metadata on all representations for the currently-chosen video
+track for another Period, you can also set a `periodId` property:
+
+```js
+const periods = rxPlayer.getAvailablePeriods();
+console.log(rxPlayer.getVideoTrack({
+    periodId: periods[0].id,
+    filterPlayableRepresentations: false,
+});
 ```
 
 <div class="warning">
@@ -103,14 +137,37 @@ video tracks API in the browser, this method returns "undefined".
 // Get information about the currently-playing video track
 const videoTrack = player.getVideoTrack();
 
+// Also include metadata on the non-playable Representations
+const videoTrack = player.getVideoTrack({
+  filterPlayableRepresentations: false,
+});
+
 // Get information about the video track for a specific Period
 const videoTrack = player.getVideoTrack(periodId);
+
+// Get information about the video track for a specific Period and also include metadata
+// on the non-playable Representations
+const videoTrack = player.getVideoTrack({
+  periodId,
+  filterPlayableRepresentations: false,
+});
 ```
 
 - **arguments**:
 
-  1.  _periodId_ `string|undefined`: The `id` of the Period for which you want to get
-      information about its current video track. If not defined, the information
-      associated to the currently-playing Period will be returned.
+  1.  _arg_ `Object|string|undefined`: If set to a `string`, this is the `id` of the
+      Period for which you want to get information about its current video track.
+
+      If not defined, the information associated to the currently-playing Period will be
+      returned.
+
+      If set to an Object, the following properties can be set (all optional):
+
+          - `periodId` (`string|undefined`): The `id` of the wanted Period, or
+            `undefined` (or not set) for the currently-playing Period
+
+          - `filterPlayableRepresentations` (`boolean|undefined`): If set to `false`,
+            Representation that are considered "non-playable" (which have an unsupported
+            mime-type/codec or which are undecipherable) will be included.
 
 - **return value** `Object|null|undefined`

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1889,10 +1889,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   /**
    * Returns every available audio tracks for a given Period - or the current
    * one if no `periodId` is given.
-   * @param {string|undefined} [periodId]
+   * @param {string|Object|undefined} [arg]
    * @returns {Array.<Object>}
    */
-  getAvailableAudioTracks(periodId?: string | undefined): IAvailableAudioTrack[] {
+  getAvailableAudioTracks(
+    arg?:
+      | string
+      | undefined
+      | {
+          periodId: string;
+          filterPlayableRepresentations: boolean;
+        },
+  ): IAvailableAudioTrack[] {
     if (this._priv_contentInfos === null) {
       return [];
     }
@@ -1900,10 +1908,20 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (isDirectFile) {
       return mediaElementTracksStore?.getAvailableAudioTracks() ?? [];
     }
+
+    let periodId: string | undefined;
+    let filterPlayableRepresentations: boolean;
+    if (typeof arg === "string") {
+      periodId = arg;
+    } else {
+      periodId = arg?.periodId;
+      filterPlayableRepresentations = arg?.filterPlayableRepresentations ?? true;
+    }
     return this._priv_callTracksStoreGetterSetter(
       periodId,
       [],
-      (tcm, periodRef) => tcm.getAvailableAudioTracks(periodRef) ?? [],
+      (tcm, periodRef) =>
+        tcm.getAvailableAudioTracks(periodRef, filterPlayableRepresentations) ?? [],
     );
   }
 
@@ -1930,10 +1948,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
   /**
    * Returns every available video tracks for the current Period.
-   * @param {string|undefined} [periodId]
+   * @param {string|Object|undefined} [arg]
    * @returns {Array.<Object>}
    */
-  getAvailableVideoTracks(periodId?: string | undefined): IAvailableVideoTrack[] {
+  getAvailableVideoTracks(
+    arg?:
+      | string
+      | undefined
+      | {
+          periodId: string;
+          filterPlayableRepresentations: boolean;
+        },
+  ): IAvailableVideoTrack[] {
     if (this._priv_contentInfos === null) {
       return [];
     }
@@ -1941,19 +1967,37 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (isDirectFile) {
       return mediaElementTracksStore?.getAvailableVideoTracks() ?? [];
     }
+
+    let periodId: string | undefined;
+    let filterPlayableRepresentations: boolean;
+    if (typeof arg === "string") {
+      periodId = arg;
+    } else {
+      periodId = arg?.periodId;
+      filterPlayableRepresentations = arg?.filterPlayableRepresentations ?? true;
+    }
     return this._priv_callTracksStoreGetterSetter(
       periodId,
       [],
-      (tcm, periodRef) => tcm.getAvailableVideoTracks(periodRef) ?? [],
+      (tcm, periodRef) =>
+        tcm.getAvailableVideoTracks(periodRef, filterPlayableRepresentations) ?? [],
     );
   }
 
   /**
    * Returns currently chosen audio language for the current Period.
-   * @param {string|undefined} [periodId]
+   * @param {string|Object|undefined} [arg]
    * @returns {Object|null|undefined}
    */
-  getAudioTrack(periodId?: string | undefined): IAudioTrack | null | undefined {
+  getAudioTrack(
+    arg?:
+      | string
+      | undefined
+      | {
+          periodId: string;
+          filterPlayableRepresentations: boolean;
+        },
+  ): IAudioTrack | null | undefined {
     if (this._priv_contentInfos === null) {
       return undefined;
     }
@@ -1964,8 +2008,17 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       }
       return mediaElementTracksStore.getChosenAudioTrack();
     }
+
+    let periodId: string | undefined;
+    let filterPlayableRepresentations: boolean;
+    if (typeof arg === "string") {
+      periodId = arg;
+    } else {
+      periodId = arg?.periodId;
+      filterPlayableRepresentations = arg?.filterPlayableRepresentations ?? true;
+    }
     return this._priv_callTracksStoreGetterSetter(periodId, undefined, (tcm, periodRef) =>
-      tcm.getChosenAudioTrack(periodRef),
+      tcm.getChosenAudioTrack(periodRef, filterPlayableRepresentations),
     );
   }
 
@@ -1992,10 +2045,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
   /**
    * Returns currently chosen video track for the current Period.
-   * @param {string|undefined} [periodId]
+   * @param {string|Object|undefined} [arg]
    * @returns {Object|null|undefined}
    */
-  getVideoTrack(periodId?: string | undefined): IVideoTrack | null | undefined {
+  getVideoTrack(
+    arg?:
+      | string
+      | undefined
+      | {
+          periodId: string;
+          filterPlayableRepresentations: boolean;
+        },
+  ): IVideoTrack | null | undefined {
     if (this._priv_contentInfos === null) {
       return undefined;
     }
@@ -2006,8 +2067,17 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       }
       return mediaElementTracksStore.getChosenVideoTrack();
     }
+
+    let periodId: string | undefined;
+    let filterPlayableRepresentations: boolean;
+    if (typeof arg === "string") {
+      periodId = arg;
+    } else {
+      periodId = arg?.periodId;
+      filterPlayableRepresentations = arg?.filterPlayableRepresentations ?? true;
+    }
     return this._priv_callTracksStoreGetterSetter(periodId, undefined, (tcm, periodRef) =>
-      tcm.getChosenVideoTrack(periodRef),
+      tcm.getChosenVideoTrack(periodRef, filterPlayableRepresentations),
     );
   }
 
@@ -2612,10 +2682,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           }
           switch (elt.adaptation.type) {
             case "audio":
-              isCurrent = tStore.getChosenAudioTrack(periodRef)?.id === elt.adaptation.id;
+              isCurrent =
+                tStore.getChosenAudioTrack(periodRef, false)?.id === elt.adaptation.id;
               break;
             case "video":
-              isCurrent = tStore.getChosenVideoTrack(periodRef)?.id === elt.adaptation.id;
+              isCurrent =
+                tStore.getChosenVideoTrack(periodRef, false)?.id === elt.adaptation.id;
               break;
             case "text":
               isCurrent = tStore.getChosenTextTrack(periodRef)?.id === elt.adaptation.id;
@@ -2690,11 +2762,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (!isNullOrUndefined(tracksStore)) {
       const periodRef = tracksStore.getPeriodObjectFromPeriod(period);
       if (periodRef) {
-        const audioTrack = tracksStore.getChosenAudioTrack(periodRef);
+        const audioTrack = tracksStore.getChosenAudioTrack(periodRef, true);
         this._priv_triggerEventIfNotStopped("audioTrackChange", audioTrack, cancelSignal);
         const textTrack = tracksStore.getChosenTextTrack(periodRef);
         this._priv_triggerEventIfNotStopped("textTrackChange", textTrack, cancelSignal);
-        const videoTrack = tracksStore.getChosenVideoTrack(periodRef);
+        const videoTrack = tracksStore.getChosenVideoTrack(periodRef, true);
         this._priv_triggerEventIfNotStopped("videoTrackChange", videoTrack, cancelSignal);
       }
     } else {
@@ -2854,7 +2926,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       }
       switch (type) {
         case "audio":
-          const audioTrack = tracksStore.getChosenAudioTrack(periodRef);
+          const audioTrack = tracksStore.getChosenAudioTrack(periodRef, true);
           this._priv_triggerEventIfNotStopped(
             "audioTrackChange",
             audioTrack,
@@ -2866,7 +2938,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           this._priv_triggerEventIfNotStopped("textTrackChange", textTrack, cancelSignal);
           break;
         case "video":
-          const videoTrack = tracksStore.getChosenVideoTrack(periodRef);
+          const videoTrack = tracksStore.getChosenVideoTrack(periodRef, true);
           this._priv_triggerEventIfNotStopped(
             "videoTrackChange",
             videoTrack,
@@ -3178,7 +3250,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
     switch (trackType) {
       case "video":
-        const videoTracks = tracksStore.getAvailableVideoTracks(periodRef);
+        const videoTracks = tracksStore.getAvailableVideoTracks(periodRef, true);
         this._priv_triggerEventIfNotStopped(
           "availableVideoTracksChange",
           videoTracks ?? [],
@@ -3186,7 +3258,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         );
         break;
       case "audio":
-        const audioTracks = tracksStore.getAvailableAudioTracks(periodRef);
+        const audioTracks = tracksStore.getAvailableAudioTracks(periodRef, true);
         this._priv_triggerEventIfNotStopped(
           "availableAudioTracksChange",
           audioTracks ?? [],

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -910,10 +910,16 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * `null` if audio tracks were disabled and `undefined` if the Period is not
    * known.
    */
-  public getChosenAudioTrack(periodObj: ITSPeriodObject): IAudioTrack | null {
+  public getChosenAudioTrack(
+    periodObj: ITSPeriodObject,
+    filterPlayableRepresentations: boolean,
+  ): IAudioTrack | null {
     return isNullOrUndefined(periodObj.audio.storedSettings)
       ? null
-      : toAudioTrack(periodObj.audio.storedSettings.adaptation, true);
+      : toAudioTrack(
+          periodObj.audio.storedSettings.adaptation,
+          filterPlayableRepresentations,
+        );
   }
 
   /**
@@ -942,12 +948,18 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * @param {Object} periodObj - The concerned Period's object
    * @returns {Object|null} - The video track chosen for this Period
    */
-  public getChosenVideoTrack(periodObj: ITSPeriodObject): IVideoTrack | null {
+  public getChosenVideoTrack(
+    periodObj: ITSPeriodObject,
+    filterPlayableRepresentations: boolean,
+  ): IVideoTrack | null {
     if (isNullOrUndefined(periodObj.video.storedSettings)) {
       return null;
     }
 
-    return toVideoTrack(periodObj.video.storedSettings.adaptation, true);
+    return toVideoTrack(
+      periodObj.video.storedSettings.adaptation,
+      filterPlayableRepresentations,
+    );
   }
 
   /**
@@ -957,10 +969,15 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * Returns `undefined` if the given Period's id is not known.
    *
    * @param {Object} periodObj - The concerned Period's object
+   * @param {boolean} filterPlayableRepresentations - If `true`, only
+   * representations considered to be "playable" will be included in the
+   * returned response.
+   * If `false`, the response should contain all linked representations.
    * @returns {Array.<Object>}
    */
   public getAvailableAudioTracks(
     periodObj: ITSPeriodObject,
+    filterPlayableRepresentations: boolean,
   ): IAvailableAudioTrack[] | undefined {
     const storedSettings = periodObj.audio.storedSettings;
     const currentId = !isNullOrUndefined(storedSettings)
@@ -969,7 +986,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const adaptations = getSupportedAdaptations(periodObj.period, "audio");
     return adaptations.map((adaptation: IAdaptationMetadata) => {
       const active = currentId === null ? false : currentId === adaptation.id;
-      return objectAssign(toAudioTrack(adaptation, true), { active });
+      return objectAssign(toAudioTrack(adaptation, filterPlayableRepresentations), {
+        active,
+      });
     });
   }
 
@@ -1004,10 +1023,15 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * Returns `undefined` if the given Period's id is not known.
    *
    * @param {Object} periodObj - The concerned Period's object
+   * @param {boolean} filterPlayableRepresentations - If `true`, only
+   * representations considered to be "playable" will be included in the
+   * returned response.
+   * If `false`, the response should contain all linked representations.
    * @returns {Array.<Object>}
    */
   public getAvailableVideoTracks(
     periodObj: ITSPeriodObject,
+    filterPlayableRepresentations: boolean,
   ): IAvailableVideoTrack[] | undefined {
     const storedSettings = periodObj.video.storedSettings;
     const currentId = isNullOrUndefined(storedSettings)
@@ -1017,7 +1041,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const adaptations = getSupportedAdaptations(periodObj.period, "video");
     return adaptations.map((adaptation) => {
       const active = currentId === null ? false : currentId === adaptation.id;
-      const track = toVideoTrack(adaptation, true);
+      const track = toVideoTrack(adaptation, filterPlayableRepresentations);
       const trickModeTracks =
         track.trickModeTracks !== undefined
           ? track.trickModeTracks.map((trickModeAdaptation) => {


### PR DESCRIPTION
Initial reason for this proposal
--------------------------------

I was prototyping an heuristic for an application where it would estimate the maximum reachable quality due to DRMs on the current device.

The idea is that the RxPlayer is (at least for now) not able to guess the security policy of provided contents in advance (before actually communicating the license to the CDM) whereas the application may have a better idea (e.g. most 1080p+ contents from some identified provider may have the same drastic security conditions, so if a quality is not playable for one content, it probably won't work for another).

Until now, the solution proposed by the RxPlayer - which also works - was to first test all qualities for all contents and then fallback from undecipherable qualities once they become known.

However, doing this at each content load may, on the more restricted devices (mostly PCs and mobile phones when on the web), mean that we'll at each load attempt to play higher qualities just to fallback to a lesser quality when we see that we cannot handle higher ones.
This fallback isn t usually perceptible much by the customer, yet up to a few hundred of milliseconds may be "lost" on each load that way (median of ~150ms on my PC on widevine L3 on frequently-encountered policy levels and provided qualities).

So to improve on this situation the idea is to be able to determine application-side when qualities become undecipherable (knowable through `representationListUpdate` events) and which have become undecipherable (no method until now could do that, you had to awkwardly diff between the list of qualities at load time and after a `representationListUpdate` event).

Then the application is able to limit the maximum played quality in further content loading through the `lockVideoRepresentations` method.

Because decipherability may evolve on a same device over time (e.g. linking / unlinking an external monitor may change the possibility to rely on the HDCP security mechanism), this algorithm on the application-side still may have to re-check periodically which qualities can or cannot be played. Though in the seen usage, this is simple to do (for example, this is mainly automatic on a `singleLicensePer: "content"` or `singleLicensePer: "periods"` mode - as we'll know the decipherability of higher qualities even without playing them, for the default mode, a more advanced strategy of trying the higher quality once enough buffer is build is possible).

Proposal
--------

Before, we only listed "playable" representations in our audio video tracks methods (`getVideoTrack`, `getAvailableVideoTracks` ...) and events (`videoTrackChange`, `availableVideoTracksChange` ...).

Now the idea is for the former (the `get` methods), to optionally also include non-supported Representations (either because in an unsupported codec, or because undecipherable, with this reason explicited through properties returned by those APIs) if a supplementary `filterPlayableRepresentations` boolean has been set to `false`.

Though the reason I implement this may be seen as somewhat niche, the possibility to obtain metadata all Representations, including the ones that are not actually playable, may also be useful if the application wants to be able to debug decipherability issues programmatically (e.g. polling from its customers how many are unable to decipher higher qualities). So this new API appears to be compatible with multiple usages.