### PR TITLE
Fix bug where active Period might never be known

### DIFF
--- a/src/core/segment_sinks/segment_buffers_store.ts
+++ b/src/core/segment_sinks/segment_buffers_store.ts
@@ -18,6 +18,7 @@ import { MediaError } from "../../errors";
 import log from "../../log";
 import type { IMediaSourceInterface } from "../../mse";
 import { SourceBufferType } from "../../mse";
+import assert from "../../utils/assert";
 import createCancellablePromise from "../../utils/create_cancellable_promise";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { CancellationSignal } from "../../utils/task_canceller";
@@ -251,7 +252,8 @@ export default class SegmentSinksStore {
     }
     this._initializedSegmentSinks[bufferType] = null;
     if (SegmentSinksStore.isNative(bufferType)) {
-      this._onNativeBufferAddedOrDisabled.forEach((cb) => cb());
+      this._onNativeBufferAddedOrDisabled.slice().forEach((cb) => cb());
+      assert(this._onNativeBufferAddedOrDisabled.length === 0);
     }
   }
 
@@ -295,7 +297,8 @@ export default class SegmentSinksStore {
         this._mediaSource,
       );
       this._initializedSegmentSinks[bufferType] = nativeSegmentSink;
-      this._onNativeBufferAddedOrDisabled.forEach((cb) => cb());
+      this._onNativeBufferAddedOrDisabled.slice().forEach((cb) => cb());
+      assert(this._onNativeBufferAddedOrDisabled.length === 0);
       return nativeSegmentSink;
     }
 


### PR DESCRIPTION
While testing for an upcoming release, we found a bug where an application wasn't able to tell which period was currently-played and thus wasn't able to show the audio and text track list for the current Period to its user.

Turns out that the issue at its base, is due to my poor comprehension of the `Array.prototype.forEach` JS API. I thought that it operated on a sliced/cloned array but it actually appears to re-consider the source array at each iteration, raising internally an index while doing so, until what seems to be the minimum between the current end of the array and the length the base array had at the beginning.

What I mean is that:
```js
var a = [0, 1]
a.forEach((b) => {
  console.log(b);
  a.splice(0, 1);
});
```

Logs:

```
0
```

Where I thought it would have logged:

```
0
1
```

And:
```js
var a = [0, 1]
a.forEach((b) => {
  console.log(b);
  a.push(5);
});
```

Logs (counter-intuitively to me due to the above behavior):

```
0
1
```

Despite `a` now being equal to `[0, 1, 5, 5]`

I hope this is the only place where that trick was done. I'll have to review all those iterator methods just to check!

There's also weird things happening with other operators such as `Array.prototype.map` where the initial length of the source array becomes the length of the destination array, even if the source array's length is updated inside map's callback, we may thus end-up with "empty" slot in the resulting array if the source array is shrinked (and missing on the new values if the source array grows).