### PR TITLE
Simplify a Representation's `keyIds` metadata

### DIFF
--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -1147,8 +1147,8 @@ function addKeyIdsFromPeriod(set: Set<Uint8Array>, period: IPeriodMetadata) {
         representation.contentProtections !== undefined &&
         representation.contentProtections.keyIds !== undefined
       ) {
-        for (const kidInf of representation.contentProtections.keyIds) {
-          set.add(kidInf.keyId);
+        for (const kid of representation.contentProtections.keyIds) {
+          set.add(kid);
         }
       }
     }

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -1267,17 +1267,17 @@ function updateKeyIdsDecipherabilityOnManifest(
     if (contentKIDs !== undefined) {
       for (const elt of contentKIDs) {
         for (const blacklistedKeyId of blacklistedKeyIds) {
-          if (areArraysOfNumbersEqual(blacklistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(blacklistedKeyId, elt)) {
             return false;
           }
         }
         for (const whitelistedKeyId of whitelistedKeyIds) {
-          if (areArraysOfNumbersEqual(whitelistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(whitelistedKeyId, elt)) {
             return true;
           }
         }
         for (const delistedKeyId of delistedKeyIds) {
-          if (areArraysOfNumbersEqual(delistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(delistedKeyId, elt)) {
             return undefined;
           }
         }

--- a/src/manifest/classes/adaptation.ts
+++ b/src/manifest/classes/adaptation.ts
@@ -180,9 +180,7 @@ export default class Adaptation implements IAdaptationMetadata {
         if (representation.contentProtections !== undefined) {
           reprObject.contentProtections = {};
           if (representation.contentProtections.keyIds !== undefined) {
-            const keyIds = representation.contentProtections.keyIds.map(
-              ({ keyId }) => keyId,
-            );
+            const keyIds = representation.contentProtections.keyIds;
             reprObject.contentProtections.keyIds = keyIds;
           }
         }

--- a/src/manifest/classes/representation.ts
+++ b/src/manifest/classes/representation.ts
@@ -281,7 +281,7 @@ class Representation implements IRepresentationMetadata {
       for (let j = 0; j < initData.values.length; j++) {
         if (initData.values[j].systemId.toLowerCase() === drmSystemId.toLowerCase()) {
           if (!createdObjForType) {
-            const keyIds = this.contentProtections?.keyIds?.map((val) => val.keyId);
+            const keyIds = this.contentProtections?.keyIds;
             filtered.push({
               type: initData.type,
               keyIds,
@@ -330,7 +330,7 @@ class Representation implements IRepresentationMetadata {
     ) {
       return [];
     }
-    const keyIds = this.contentProtections?.keyIds?.map((val) => val.keyId);
+    const keyIds = this.contentProtections?.keyIds;
     return this.contentProtections.initData.map((x) => {
       return { type: x.type, keyIds, values: x.values };
     });
@@ -363,7 +363,7 @@ class Representation implements IRepresentationMetadata {
     let hasUpdatedProtectionData = false;
     if (this.contentProtections === undefined) {
       this.contentProtections = {
-        keyIds: keyId !== undefined ? [{ keyId }] : [],
+        keyIds: keyId !== undefined ? [keyId] : [],
         initData: [{ type: initDataType, values: data }],
       };
       return true;
@@ -372,17 +372,17 @@ class Representation implements IRepresentationMetadata {
     if (keyId !== undefined) {
       const keyIds = this.contentProtections.keyIds;
       if (keyIds === undefined) {
-        this.contentProtections.keyIds = [{ keyId }];
+        this.contentProtections.keyIds = [keyId];
       } else {
         let foundKeyId = false;
         for (const knownKeyId of keyIds) {
-          if (areArraysOfNumbersEqual(knownKeyId.keyId, keyId)) {
+          if (areArraysOfNumbersEqual(knownKeyId, keyId)) {
             foundKeyId = true;
           }
         }
         if (!foundKeyId) {
           log.warn("Manifest: found unanounced key id.");
-          keyIds.push({ keyId });
+          keyIds.push(keyId);
         }
       }
     }

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -407,9 +407,10 @@ export interface IDecipherabilityStatusChangedElement {
  *     decipherability updated to `undefined`.
  *
  * @param {Object} manifest
- * @param {Array.<Uint8Array>} whitelistedKeyIds
- * @param {Array.<Uint8Array>} blacklistedKeyIds
- * @param {Array.<Uint8Array>} delistedKeyIds
+ * @param {Object} updates
+ * @param {Array.<Uint8Array>} updates.whitelistedKeyIds
+ * @param {Array.<Uint8Array>} updates.blacklistedKeyIds
+ * @param {Array.<Uint8Array>} updates.delistedKeyIds
  */
 export function updateDecipherabilityFromKeyIds(
   manifest: IManifestMetadata,
@@ -428,17 +429,17 @@ export function updateDecipherabilityFromKeyIds(
     if (contentKIDs !== undefined) {
       for (const elt of contentKIDs) {
         for (const blacklistedKeyId of blacklistedKeyIds) {
-          if (areArraysOfNumbersEqual(blacklistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(blacklistedKeyId, elt)) {
             return false;
           }
         }
         for (const whitelistedKeyId of whitelistedKeyIds) {
-          if (areArraysOfNumbersEqual(whitelistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(whitelistedKeyId, elt)) {
             return true;
           }
         }
         for (const delistedKeyId of delistedKeyIds) {
-          if (areArraysOfNumbersEqual(delistedKeyId, elt.keyId)) {
+          if (areArraysOfNumbersEqual(delistedKeyId, elt)) {
             return undefined;
           }
         }

--- a/src/parsers/manifest/dash/common/content_protection_parser.ts
+++ b/src/parsers/manifest/dash/common/content_protection_parser.ts
@@ -214,13 +214,13 @@ function parseContentProtection(
     contentProtectionIr.attributes.keyId !== undefined &&
     contentProtectionIr.attributes.keyId.length > 0
   ) {
-    const kidObj = { keyId: contentProtectionIr.attributes.keyId, systemId };
+    const kid = contentProtectionIr.attributes.keyId;
     if (representation.contentProtections === undefined) {
-      representation.contentProtections = { keyIds: [kidObj], initData: [] };
+      representation.contentProtections = { keyIds: [kid], initData: [] };
     } else if (representation.contentProtections.keyIds === undefined) {
-      representation.contentProtections.keyIds = [kidObj];
+      representation.contentProtections.keyIds = [kid];
     } else {
-      representation.contentProtections.keyIds.push(kidObj);
+      representation.contentProtections.keyIds.push(kid);
     }
   }
 

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -169,7 +169,7 @@ function parseRepresentation(
 function formatContentProtections(
   localContentProtections: ILocalContentProtections,
 ): IContentProtections {
-  const keyIds = localContentProtections.keyIds;
+  const keyIds = localContentProtections.keyIds.map((k) => k.keyId);
   const initData: IContentProtectionInitData[] = Object.keys(
     localContentProtections.initData,
   ).map((currType) => {

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -27,7 +27,6 @@ import { getFilenameIndexInUrl } from "../../../utils/resolve_url";
 import { hexToBytes } from "../../../utils/string_parsing";
 import { createBox } from "../../containers/isobmff";
 import type {
-  IContentProtectionKID,
   IParsedAdaptation,
   IParsedAdaptations,
   IParsedManifest,
@@ -371,15 +370,12 @@ function createSmoothStreamingParser(
         (!isNullOrUndefined(codecs) ? codecs + "-" : "") +
         String(qualityLevel.bitrate);
 
-      const keyIDs: IContentProtectionKID[] = [];
+      const keyIDs: Uint8Array[] = [];
       let firstProtection: IContentProtectionSmooth | undefined;
       if (protections.length > 0) {
         firstProtection = protections[0];
         protections.forEach((protection) => {
-          const keyId = protection.keyId;
-          protection.keySystems.forEach((keySystem) => {
-            keyIDs.push({ keyId, systemId: keySystem.systemId });
-          });
+          keyIDs.push(protection.keyId);
         });
       }
 

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -39,12 +39,6 @@ export interface IParsedStreamEventData {
   };
 }
 
-/** Describes information about an encryption Key ID of a given media. */
-export interface IContentProtectionKID {
-  keyId: Uint8Array;
-  systemId?: string | undefined;
-}
-
 /**
  * Encryption initialization data.
  * This is the data used to initialize a license request.
@@ -85,7 +79,7 @@ export interface IContentProtections {
    * `undefined` if the key id(s) associated with that content may exist but are
    * not known.
    */
-  keyIds: IContentProtectionKID[] | undefined;
+  keyIds: Uint8Array[] | undefined;
   /** The different encryption initialization data associated with that content. */
   initData: IContentProtectionInitData[];
 }


### PR DESCRIPTION
`Representation` objects allow in the RxPlayer code to store the metadata linked to a given [audio, video or text] media quality.

One of its properties `contentProtections`, allowed to store DRM-related information linked to that quality.

Amongs its two properties, `keyIds` was in my opinion unnecessarily complex: it contained not only the key-id(s), as `Uint8Array`(s), but also optionally the corresponding `systemId` (an identifier for the DRM scheme to which that key id is related) for each.

This doesn't appear to be necessary nor make much sense in most contexts: a key id is supposed to uniquely identify a given decryption key, and is generally the same regardless of the system/technology if the same decryption key is relied on (e.g. through common encryption schemes which is the norm when multiple key systems are relied on).

Even in purely theoretical cases where multiple key ids would exist depending on the key system for whatever reason or where different parts of the media data would be decrypted depending on the key system with different keys and thus different key ids, I suppose that no conflict should exist where a key id in one key system would lead to a different key in another key system - meaning that that metadata (which is mainly used as an identification mechanism) should not conflict.

If for whatever reasons we do encounter such case in the future, we may re-complexify the logic.