### PR TITLE
[Proposal] Add `contentProtections` to the tracks API

### DIFF
--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -201,6 +201,17 @@ The array emitted contains object describing each available audio track:
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 This event only concerns the currently-playing [Period](../Getting_Started/Glossary.md).
 
 ### availableVideoTracksChange
@@ -262,6 +273,17 @@ The array emitted contains object describing each available video track:
 
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
+
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
 
 - `signInterpreted` (`Boolean`): Whether the track contains sign interpretation.
 
@@ -366,6 +388,17 @@ The payload is an object describing the new track, with the following properties
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 This event only concerns the currently-playing Period. This event only concerns the
 currently-playing [Period](../Getting_Started/Glossary.md).
 
@@ -460,6 +493,17 @@ The payload is an object describing the new track, with the following properties
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 - `isTrickModeTrack` (`Boolean|undefined`): If set to `true`, this track is a trick mode
   track. This type of tracks proposes video content that is often encoded with a very low
   framerate with the purpose to be played more efficiently at a much higher speed.
@@ -538,6 +582,17 @@ properties:
   Note that because elements of the `representations` array only contains playable
   Representation, this value here cannot be set to `false` when in this array.
 
+- `contentProtections` (`Object|undefined`): Encryption information linked to this
+  Representation.
+
+  If set to an Object, the Representation is known to be encrypted. If unset or set to
+  `undefined` the Representation is either unencrypted or we don't know if it is.
+
+  When set to an object, it may contain the following properties:
+
+  - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+    Representation.
+
 A `null` payload means that no video track is available now.
 
 This event only concerns the currently-playing [Period](../Getting_Started/Glossary.md).
@@ -578,6 +633,17 @@ The payload is an object describing the new Representation, with the following p
 
   Note that because elements of the `representations` array only contains playable
   Representation, this value here cannot be set to `false` when in this array.
+
+- `contentProtections` (`Object|undefined`): Encryption information linked to this
+  Representation.
+
+  If set to an Object, the Representation is known to be encrypted. If unset or set to
+  `undefined` the Representation is either unencrypted or we don't know if it is.
+
+  When set to an object, it may contain the following properties:
+
+  - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+    Representation.
 
 This event only concerns the currently-playing [Period](../Getting_Started/Glossary.md).
 

--- a/doc/api/Track_Selection/getAudioTrack.md
+++ b/doc/api/Track_Selection/getAudioTrack.md
@@ -67,6 +67,17 @@ object with the following properties:
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 `undefined` if no audio content has been loaded yet or if its information is unknown.
 
 You can also get the information on the chosen audio track for another Period by calling

--- a/doc/api/Track_Selection/getAvailableAudioTracks.md
+++ b/doc/api/Track_Selection/getAvailableAudioTracks.md
@@ -65,6 +65,17 @@ Each of the objects in the returned array have the following properties:
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 You can also get the list of available audio tracks for a specific Period by calling
 `getAvailableAudioTracks` with the corresponding Period's id in argument. Such id can be
 obtained through the `getAvailablePeriods` method, the `newAvailablePeriods` event or the

--- a/doc/api/Track_Selection/getAvailableVideoTracks.md
+++ b/doc/api/Track_Selection/getAvailableVideoTracks.md
@@ -54,6 +54,17 @@ Each of the objects in the returned array have the following properties:
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 - `signInterpreted` (`Boolean|undefined`): If set to `true`, the track is known to contain
   an interpretation in sign language. If set to `false`, the track is known to not contain
   that type of content. If not set or set to undefined we don't know whether that video

--- a/doc/api/Track_Selection/getVideoTrack.md
+++ b/doc/api/Track_Selection/getVideoTrack.md
@@ -59,6 +59,17 @@ object with the following properties:
     Note that because elements of the `representations` array only contains playable
     Representation, this value here cannot be set to `false` when in this array.
 
+  - `contentProtections` (`Object|undefined`): Encryption information linked to this
+    Representation.
+
+    If set to an Object, the Representation is known to be encrypted. If unset or set to
+    `undefined` the Representation is either unencrypted or we don't know if it is.
+
+    When set to an object, it may contain the following properties:
+
+    - `keyIds` (`Array.<Uint8Array>|undefined`): Known key ids linked to that
+      Representation.
+
 - `signInterpreted` (`Boolean|undefined`): If set to `true`, this track is known to
   contain an interpretation in sign language. If set to `false`, the track is known to not
   contain that type of content. If not set or set to undefined we don't know whether that

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -3244,8 +3244,8 @@ interface IPublicAPIEvent {
   audioTrackChange: IAudioTrack | null;
   textTrackChange: ITextTrack | null;
   videoTrackChange: IVideoTrack | null;
-  audioRepresentationChange: IVideoRepresentation | null;
-  videoRepresentationChange: IAudioRepresentation | null;
+  audioRepresentationChange: IAudioRepresentation | null;
+  videoRepresentationChange: IVideoRepresentation | null;
   volumeChange: {
     volume: number;
     muted: boolean;

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -358,6 +358,7 @@ function toVideoRepresentation(
     hdrInfo,
     isSupported,
     decipherable,
+    contentProtections,
   } = representation;
   return {
     id,
@@ -369,6 +370,12 @@ function toVideoRepresentation(
     hdrInfo,
     isCodecSupported: isSupported,
     decipherable,
+    contentProtections:
+      contentProtections !== undefined
+        ? {
+            keyIds: contentProtections.keyIds,
+          }
+        : undefined,
   };
 }
 

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -835,6 +835,18 @@ export interface IAudioRepresentation {
    * encrypted or not in some cases).
    */
   decipherable?: boolean | undefined;
+  /**
+   * Encryption information linked to this content.
+   * If set to an Object, the Representation is known to be encrypted.
+   * If unset or set to `undefined` the Representation is either unencrypted or
+   * we don't know if it is.
+   */
+  contentProtections?:
+    | {
+        /** Known key ids linked to that Representation. */
+        keyIds?: Uint8Array[] | undefined;
+      }
+    | undefined;
 }
 
 /** Audio track returned by the RxPlayer. */
@@ -905,6 +917,18 @@ export interface IVideoRepresentation {
    * encrypted or not in some cases).
    */
   decipherable?: boolean | undefined;
+  /**
+   * Encryption information linked to this content.
+   * If set to an Object, the Representation is known to be encrypted.
+   * If unset or set to `undefined` the Representation is either unencrypted or
+   * we don't know if it is.
+   */
+  contentProtections?:
+    | {
+        /** Known key ids linked to that Representation. */
+        keyIds?: Uint8Array[] | undefined;
+      }
+    | undefined;
 }
 
 /** Video track returned by the RxPlayer. */


### PR DESCRIPTION
(based on #1504)

In the same spirit than #1501, I found out that an application had no practical way (beside the `representationFilter` API) of knowing which `Representation` (quality) was encrypted when calling video and audio track APIs.

Unlike #1501, I thought that this information could always be delivered without the need of a supplementary API.

Now comes the question of how to format that metadata: An `isEncrypted` key? A `contentProtections` object?

For now, I chose to align with the `representationFilter` API, where we have a `contentProtections` object at the Representation-level, which is either set to `undefined` if unencrypted or if we don't know if it is, or to an object with a `keyIds` property if it is.

That `keyIds` property is set as an array of `Uint8Array`, corresponding to the key id(s) linked to that Representation.

For now I chose not to also include DRM `initialization data` (e.g. the ISOBMFF's pssh box) in that object to let us the possibility to internally work on its format without having to re-format it in a specific way for the API.