### PR TITLE
Retry memory tests multiple times

### DIFF
--- a/tests/memory/index.test.js
+++ b/tests/memory/index.test.js
@@ -63,7 +63,10 @@ describe("Memory tests", () => {
     `);
       expect(heapDifference).to.be.below(2e6);
     },
-    15 * 60 * 1000,
+    {
+      timeout: 15 * 60 * 1000,
+      retry: 2,
+    },
   );
 
   it(
@@ -112,7 +115,10 @@ describe("Memory tests", () => {
     `);
       expect(heapDifference).to.be.below(7e6);
     },
-    10 * 60 * 1000,
+    {
+      timeout: 10 * 60 * 1000,
+      retry: 2,
+    },
   );
 
   it(
@@ -153,7 +159,10 @@ describe("Memory tests", () => {
     `);
       expect(heapDifference).to.be.below(7e6);
     },
-    30 * 60 * 1000,
+    {
+      timeout: 30 * 60 * 1000,
+      retry: 2,
+    },
   );
 
   it(
@@ -223,7 +232,10 @@ describe("Memory tests", () => {
     `);
       expect(heapDifference).to.be.below(9e6);
     },
-    15 * 60 * 1000,
+    {
+      timeout: 15 * 60 * 1000,
+      retry: 2,
+    },
   );
 
   // TODO FIXME This one failed after a chrome update, no idea why for now
@@ -279,6 +291,9 @@ describe("Memory tests", () => {
     `);
       expect(heapDifference).to.be.below(1e6);
     },
-    5 * 60 * 1000,
+    {
+      timeout: 5 * 60 * 1000,
+      retry: 2,
+    },
   );
 });


### PR DESCRIPTION
We have "memory tests" which check for memory leaks in several scenarios.

To do this in a sufficiently-precize way, we rely on Chrome and its `--js-flags=--expose-gc` option, allowing us to trigger some level of garbage-collection programatically in JavaScript.

However since several chrome versions, the browser's behavior seems to be different enough for the tests to sometimes fail. As an alternative solution, what we've done is to both use the capabilities exposed by that flag, and also wait some amount of time at the end of our tests before checking for memory usage, just in case other gc rounds are triggered later (or periodically).

It improved the situation and our memory tests now usually pass. Yet they still appear to fail like 1 time out of four attempts.

As a supplementary solution, I rely here on the `retry` `vitest`'s test option, which will retry the tests if they fail. I set it to `2` for each tests, which - if I followed vitest's documentation correctly, means at most 3 attempts.

If it passes before those 3 attempts, it will stop retrying and mark the test as passing. This is OK for us I guess, as I would say that the memory leak those tests try to catch should be reproducible at 100%, so tests should also fail at 100%.