### PR TITLE
[Proposal] Re-export config in v4 and synchronize main thread config and worker config

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
       "require": "./dist/commonjs/experimental/index.js",
       "default": "./dist/es2017/experimental/index.js"
     },
+    "./experimental/config": {
+      "import": "./dist/es2017/config.js",
+      "require": "./dist/commonjs/config.js",
+      "default": "./dist/es2017/config.js"
+    },
     "./experimental/features": {
       "import": "./dist/es2017/experimental/features/index.js",
       "require": "./dist/commonjs/experimental/features/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,13 +9,21 @@
 import type { IDefaultConfig } from "./default_config";
 import DEFAULT_CONFIG from "./default_config";
 import deepMerge from "./utils/deep_merge";
+import EventEmitter from "./utils/event_emitter";
 
-class ConfigHandler {
-  _config = DEFAULT_CONFIG;
+interface IConfigHandlerEvents {
+  update: Partial<IDefaultConfig>;
+}
+
+class ConfigHandler extends EventEmitter<IConfigHandlerEvents> {
+  public updated = false;
+  private _config = DEFAULT_CONFIG;
 
   update(config: Partial<IDefaultConfig>) {
     const newConfig = deepMerge(this._config, config);
     this._config = newConfig;
+    this.updated = true;
+    this.trigger("update", config);
   }
 
   getCurrent(): IDefaultConfig {

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -401,6 +401,11 @@ export default function initializeWorkerMain() {
         break;
       }
 
+      case MainThreadMessageType.ConfigUpdate: {
+        config.update(msg.value);
+        break;
+      }
+
       default:
         assertUnreachable(msg);
     }

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1195,3 +1195,24 @@ const DEFAULT_CONFIG = {
 
 export type IDefaultConfig = typeof DEFAULT_CONFIG;
 export default DEFAULT_CONFIG;
+
+// NOTE Because the config may have to be serialized and shared between several
+// environments, we check here that some strict type is respected:
+//   - only a subset of types are authorized for now, just make it easier to
+//     reason about.
+//   - Needs to make sense in JSON: no `function`, no `Date`, no `undefined`...
+interface IGenericConfigData {
+  [key: string]:
+    | string
+    | number
+    | boolean
+    | number[]
+    | string[]
+    | Partial<Record<string, string[]>>
+    | IGenericConfigData;
+}
+
+function checkIsSerializable(_conf: IGenericConfigData): void {
+  // noop
+}
+checkIsSerializable(DEFAULT_CONFIG);

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -14,6 +14,7 @@ import type {
   IRepresentationsChoice,
   ITrackSwitchingMode,
 } from "./core/types";
+import type { IDefaultConfig } from "./default_config";
 import type {
   ISerializedMediaError,
   ISerializedNetworkError,
@@ -156,6 +157,12 @@ export interface ILogLevelUpdateMessage {
      */
     sendBackLogs: boolean;
   };
+}
+
+/** Message sent by the main thread to update the Worker's global config. */
+export interface IConfigUpdateMessage {
+  type: MainThreadMessageType.ConfigUpdate;
+  value: Partial<IDefaultConfig>;
 }
 
 /**
@@ -542,6 +549,7 @@ export const enum MainThreadMessageType {
   RemoveTextDataError = "remove-text-error",
   CodecSupportUpdate = "codec-support-update",
   ContentUrlsUpdate = "urls-update",
+  ConfigUpdate = "config-update",
   DecipherabilityStatusUpdate = "decipherability-update",
   LogLevelUpdate = "log-level-update",
   MediaSourceReadyStateChange = "media-source-ready-state-change",
@@ -560,6 +568,7 @@ export const enum MainThreadMessageType {
 export type IMainThreadMessage =
   | IInitMessage
   | ILogLevelUpdateMessage
+  | IConfigUpdateMessage
   | IPrepareContentMessage
   | IStopContentMessage
   | IStartPreparedContentMessage


### PR DESCRIPTION
In the RxPlayer team, we very often have to debug devices presenting some type of issue.

What we do usually is to create an RxPlayer branch (through `git`), push that branch to GitHub, then find a way (sometimes it's not so simple though) in the application in question to rely on the branch (we try to avoid pushing builds on GitHub, so we often rely on e.g. `postinstall` tricks to build the player in that application when installing / updating its dependencies).

Yet, having to dive into the application's CI / dependency system / build system is no fun and often breaks.

Diagnostics often follow similar RxPlayer code modifications, so I'm wondering if we could not bring back an idea we had in the `v3` era:
The idea is to expose through an experimental export our global configuration, to allow updates of the RxPlayer config properties inside that application. Then we could add that custom logic inside the RxPlayer code and only enable it when a config property is enabled.

Config properties is not defined in the API, are comparable to globals (they don't need to be communicated at the function-level) and as such adding custom behavior based on config updates is relatively simple to do.

For example, for the now frequent need when debugging new devices of only loading segments once we now they are decipherable, we could just add in the target application (or even ask them to add temporarily):
```js
import RxPlayerConfig from "rx-player/experimental/config";

RxPlayerConfig.update({
  LOAD_SEGMENTS_ONLY_IF_DECIPHERABLE: true,
})
```

Because in multithreading mode, we might have to synchronize the main thread's config to the worker's config, I also had to add some synchronization code. It is in essence the exact same problem than for our logger, so I kind of repeated the same logic here.