### PR TITLE
[WIP] Try to fully support key rotation AND maxSessionCacheSize on devices with very limited key slots

### DIFF
--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -26,12 +26,13 @@ import areArraysOfNumbersEqual from "../../utils/are_arrays_of_numbers_equal";
 import arrayFind from "../../utils/array_find";
 import arrayIncludes from "../../utils/array_includes";
 import EventEmitter from "../../utils/event_emitter";
+import flatMap from "../../utils/flat_map";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import { objectValues } from "../../utils/object_values";
 import { bytesToHex } from "../../utils/string_parsing";
 import TaskCanceller from "../../utils/task_canceller";
 import attachMediaKeys from "./attach_media_keys";
-import createOrLoadSession from "./create_or_load_session";
+import createOrLoadSession, { NoSessionSpaceError } from "./create_or_load_session";
 import type { ICodecSupportList } from "./find_key_system";
 import type { IMediaKeysInfos } from "./get_media_keys";
 import initMediaKeys from "./init_media_keys";
@@ -47,6 +48,8 @@ import type {
   IContentDecryptorEvent,
 } from "./types";
 import { MediaKeySessionLoadingType, ContentDecryptorState } from "./types";
+import type { IActiveSessionInfo } from "./utils/active_sessions_store";
+import ActiveSessionsStore from "./utils/active_sessions_store";
 import { DecommissionedSessionError } from "./utils/check_key_statuses";
 import cleanOldStoredPersistentInfo from "./utils/clean_old_stored_persistent_info";
 import getDrmSystemId from "./utils/get_drm_system_id";
@@ -103,12 +106,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   private _stateData: IContentDecryptorStateData;
 
   /**
-   * Contains information about all key sessions loaded for this current
-   * content.
-   * This object is most notably used to check which keys are already obtained,
-   * thus avoiding to perform new unnecessary license requests and CDM interactions.
+   * Regroups information on `MediaKeySession` currently actively used by this
+   * `ContentDecryptor`.
+   * @see ActiveSessionsStore
    */
-  private _currentSessions: IActiveSessionInfo[];
+  private _activeSessionsStore: ActiveSessionsStore;
 
   /**
    * Allows to dispose the resources taken by the current instance of the
@@ -117,14 +119,31 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   private _canceller: TaskCanceller;
 
   /**
-   * This queue stores initialization data which hasn't been processed yet,
-   * probably because the "queue is locked" for now. (@see _stateData private
-   * property).
-   *
-   * For example, this queue stores initialization data communicated while
-   * initializing so it can be processed when the initialization is done.
+   * The `ContentDecryptor` may have to bufferize some initialization data
+   * proccessing. This is done through queues set up in this Object.
    */
-  private _initDataQueue: IProtectionData[];
+  private _initDataQueues: {
+    /**
+     * This queue stores initialization data which hasn't been processed yet,
+     * probably because the "queue is locked" for now. (@see _stateData private
+     * property).
+     *
+     * For example, this queue stores initialization data communicated while
+     * initializing so it can be processed when the initialization is done.
+     */
+    mainQueue: IProcessedProtectionData[];
+    /**
+     * The `ContentDecryptor` may have a limit of `MediaKeySession` it can rely
+     * on at the same time.
+     * If the processing of newly-received initialization data risks to go over
+     * that limit, the `ContentDecryptor` is sending its `tooMuchSessions` event
+     * and adding the corresponding initialization data to this queue.
+     *
+     * The `ContentDecryptor` will then handle this queue in priority if/when
+     * the overflow has ended.
+     */
+    overflowQueue: IProcessedProtectionData[];
+  };
 
   /**
    * Store the list of supported codecs with the current key system configuration.
@@ -161,9 +180,12 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     log.debug("DRM: Starting ContentDecryptor logic.");
 
     const canceller = new TaskCanceller();
-    this._currentSessions = [];
+    this._activeSessionsStore = new ActiveSessionsStore();
     this._canceller = canceller;
-    this._initDataQueue = [];
+    this._initDataQueues = {
+      mainQueue: [],
+      overflowQueue: [],
+    };
     this._stateData = {
       state: ContentDecryptorState.Initializing,
       isMediaKeysAttached: MediaKeyAttachmentStatus.NotAttached,
@@ -380,24 +402,97 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * @param {Object} initializationData
    */
   public onInitializationData(initializationData: IProtectionData): void {
-    if (this._stateData.isInitDataQueueLocked !== false) {
-      if (this._isStopped()) {
-        throw new Error("ContentDecryptor either disposed or stopped.");
-      }
-      this._initDataQueue.push(initializationData);
-      return;
-    }
-
-    const { mediaKeysData } = this._stateData.data;
     const processedInitializationData = {
       ...initializationData,
       values: new InitDataValuesContainer(initializationData.values),
     };
+    if (this._stateData.isInitDataQueueLocked !== false) {
+      if (this._isStopped()) {
+        throw new Error("ContentDecryptor either disposed or stopped.");
+      }
+      this._initDataQueues.mainQueue.push(processedInitializationData);
+      return;
+    }
+
+    const { mediaKeysData } = this._stateData.data;
     this._processInitializationData(processedInitializationData, mediaKeysData).catch(
       (err) => {
         this._onFatalError(err);
       },
     );
+  }
+
+  /**
+   * Indicate that a key being handled by the `ContentDecryptor` can be "freed",
+   * meaning that we won't be using it anymore (not for the current content, nor
+   * for a future content).
+   *
+   * This call may lead to close the corresponding `MediaKeySession` if all its
+   * linked keys are not needed anymore.
+   * Note that this is not always wanted for keys of already-played content, as
+   * it prevent the `ContentDecryptor` from caching the key if the corresponding
+   * content is played again in the future.
+   *
+   * Calling this method is thus mainly useful if no new `MediaKeySession` can
+   * be created due to the current limit of simultaneous `MediaKeySession` being
+   * reached.
+   * You may know whether that's the case by listening for the `tooMuchSessions`
+   * event or by calling the `isOverflowing` method.
+   *
+   * The boolean returned by this method indicates if the key id freeing led to
+   * `MediaKeySession` that are relied on for the current content have in
+   * consequence been closed:
+   *
+   *   - If `false`, and if we're currently unable to create new
+   *     `MediaKeySession` due to the set limit being reached, we're still not
+   *     able to create new `MediaKeySession`.
+   *
+   *   - It `true`, and if we were unable to create new `MediaKeySession` due
+   *     to the limit being reached, the issue **may** now be resolved.
+   *
+   *     Note that this is not a certitude. You will receive a `tooMuchSessions`
+   *     event soon after if it ended up that there's still too many
+   *     simultaneous `MediaKeySession` created.
+   *
+   * @param {Array.<Uint8Array>} keyIds
+   * @returns {boolean}
+   */
+  public freeKeyIds(keyIds: Uint8Array[]): boolean {
+    if (this._stateData.isMediaKeysAttached !== MediaKeyAttachmentStatus.Attached) {
+      log.warn(
+        "DRM: Invalid state when freeing key ids",
+        this._stateData.isMediaKeysAttached,
+      );
+      return false;
+    }
+
+    const loadedSessionsStore =
+      this._stateData.data.mediaKeysData.stores.loadedSessionsStore;
+    const entries = loadedSessionsStore.getAll();
+    for (const entry of entries) {
+      const { keySessionRecord } = entry;
+      const keyIdsFromSession = keySessionRecord.getAssociatedKeyIds();
+      if (areAllKeyIdsContainedIn(keyIdsFromSession, keyIds)) {
+        loadedSessionsStore.closeSession(entry.mediaKeySession).catch((err) => {
+          const errorMsg = err instanceof Error ? err.message : "Unknown Error";
+          log.warn("DRM: Failed to close mediaKeySession in `freeKeyIds`", errorMsg);
+        });
+      }
+    }
+
+    const currentActiveSessions = this._activeSessionsStore.getSessions();
+    for (let i = currentActiveSessions.length - 1; i >= 0; i--) {
+      const session = currentActiveSessions[i];
+      if (!loadedSessionsStore.hasEntryForRecord(session.record)) {
+        this._activeSessionsStore.removeSession(session);
+      }
+    }
+
+    return !this._activeSessionsStore.isFull();
+  }
+
+  public isOverflowing(): boolean {
+    return this._initDataQueues.overflowQueue.length > 0;
   }
 
   /**
@@ -433,7 +528,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
     if (options.singleLicensePer === "content") {
       const firstCreatedSession = arrayFind(
-        this._currentSessions,
+        this._activeSessionsStore.getSessions(),
         (x) => x.source === MediaKeySessionLoadingType.Created,
       );
 
@@ -475,9 +570,9 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       initializationData.content !== undefined
     ) {
       const { period } = initializationData.content;
-      const createdSessions = this._currentSessions.filter(
-        (x) => x.source === MediaKeySessionLoadingType.Created,
-      );
+      const createdSessions = this._activeSessionsStore
+        .getSessions()
+        .filter((x) => x.source === MediaKeySessionLoadingType.Created);
       const periodKeys = new Set<Uint8Array>();
       addKeyIdsFromPeriod(periodKeys, period);
       for (const createdSess of createdSessions) {
@@ -545,13 +640,51 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         ? options.maxSessionCacheSize
         : EME_DEFAULT_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS;
 
-    const sessionRes = await createOrLoadSession(
-      initializationData,
-      stores,
-      wantedSessionType,
-      maxSessionCacheSize,
-      this._canceller.signal,
-    );
+    const activeRecords = this._activeSessionsStore.getSessions().map((s) => s.record);
+    let sessionRes;
+    try {
+      sessionRes = await createOrLoadSession(
+        {
+          activeRecords,
+          initializationData,
+          sessionStores: stores,
+          sessionType: wantedSessionType,
+          maxSessionCacheSize,
+        },
+        this._canceller.signal,
+      );
+    } catch (err) {
+      if (!(err instanceof NoSessionSpaceError)) {
+        throw err;
+      }
+      if (this._isStopped()) {
+        return;
+      }
+
+      // We have no space for further sessions for that content, trigger a
+      // "tooMuchSessions" event.
+      this._activeSessionsStore.markAsFull();
+      if (this._initDataQueues.overflowQueue.indexOf(initializationData) === -1) {
+        this._initDataQueues.overflowQueue.push(initializationData);
+      }
+
+      // We unlock the init data queue first, to avoid weird states.
+      this._unlockInitDataQueue();
+      if (this._isStopped()) {
+        return;
+      }
+      if (this._activeSessionsStore.isFull()) {
+        this.trigger("tooMuchSessions", {
+          waitingKeyIds: flatMap(this._initDataQueues.overflowQueue, (k) => {
+            return k.keyIds ?? [];
+          }),
+          activeKeyIds: flatMap(activeRecords, (r: KeySessionRecord): Uint8Array[] => {
+            return r.getAssociatedKeyIds();
+          }),
+        });
+      }
+      return;
+    }
     if (this._isStopped()) {
       return;
     }
@@ -562,7 +695,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       keyStatuses: { whitelisted: [], blacklisted: [] },
       blacklistedSessionError: null,
     };
-    this._currentSessions.push(sessionInfo);
+    this._activeSessionsStore.addSession(sessionInfo);
 
     const { mediaKeySession, sessionType } = sessionRes.value;
 
@@ -631,10 +764,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
           if (err instanceof DecommissionedSessionError) {
             log.warn("DRM: A session's closing condition has been triggered");
             this._lockInitDataQueue();
-            const indexOf = this._currentSessions.indexOf(sessionInfo);
-            if (indexOf >= 0) {
-              this._currentSessions.splice(indexOf);
-            }
+            this._activeSessionsStore.removeSession(sessionInfo);
             if (initializationData.content !== undefined) {
               this.trigger("keyIdsCompatibilityUpdate", {
                 whitelistedKeyIds: [],
@@ -698,10 +828,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         const entry = stores.loadedSessionsStore.getEntryForSession(mediaKeySession);
         if (entry === null || entry.closingStatus.type !== "none") {
           // MediaKeySession closing/closed: Just remove from handled list and abort.
-          const indexInCurrent = this._currentSessions.indexOf(sessionInfo);
-          if (indexInCurrent >= 0) {
-            this._currentSessions.splice(indexInCurrent, 1);
-          }
+          this._activeSessionsStore.removeSession(sessionInfo);
           return Promise.resolve();
         }
         throw new EncryptedMediaError(
@@ -724,8 +851,9 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
      * If set, a currently-used key session is already compatible to this
      * initialization data.
      */
-    const compatibleSessionInfo = arrayFind(this._currentSessions, (x) =>
-      x.record.isCompatibleWith(initializationData),
+    const compatibleSessionInfo = arrayFind(
+      this._activeSessionsStore.getSessions(),
+      (x) => x.record.isCompatibleWith(initializationData),
     );
 
     if (compatibleSessionInfo === undefined) {
@@ -837,16 +965,15 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
     // Session not found in `loadedSessionsStore`, it might have been closed
     // since.
-    // Remove from `this._currentSessions` and start again.
-    const indexOf = this._currentSessions.indexOf(compatibleSessionInfo);
-    if (indexOf === -1) {
+    // Remove from `this._activeSessionsStore` and start again.
+    const hasRemoved = this._activeSessionsStore.removeSession(compatibleSessionInfo);
+    if (!hasRemoved) {
       log.error("DRM: Unable to remove processed init data: not found.");
     } else {
       log.debug(
         "DRM: A session from a processed init data is not available " +
           "anymore. Re-processing it.",
       );
-      this._currentSessions.splice(indexOf, 1);
     }
     return false;
   }
@@ -877,19 +1004,19 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
      * If set, a currently-used key session is already compatible to this
      * initialization data.
      */
-    const compatibleSessionInfo = arrayFind(this._currentSessions, (x) =>
-      x.record.isCompatibleWith(initData),
+    const compatibleSessionInfo = arrayFind(
+      this._activeSessionsStore.getSessions(),
+      (x) => x.record.isCompatibleWith(initData),
     );
     if (compatibleSessionInfo === undefined) {
       return;
     }
     /** Remove the session from the currentSessions */
-    const indexOf = this._currentSessions.indexOf(compatibleSessionInfo);
-    if (indexOf !== -1) {
+    const hasRemoved = this._activeSessionsStore.removeSession(compatibleSessionInfo);
+    if (hasRemoved) {
       log.debug(
         "DRM: A session from a processed init is removed due to forceSessionRecreation policy.",
       );
-      this._currentSessions.splice(indexOf, 1);
     }
   }
 
@@ -910,7 +1037,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     const formattedErr =
       err instanceof Error ? err : new OtherError("NONE", "Unknown decryption error");
     this.error = formattedErr;
-    this._initDataQueue.length = 0;
+    this._initDataQueues.overflowQueue.length = 0;
+    this._initDataQueues.mainQueue.length = 0;
     this._stateData = {
       state: ContentDecryptorState.Error,
       isMediaKeysAttached: undefined,
@@ -944,11 +1072,18 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    */
   private _processCurrentInitDataQueue(): void {
     while (this._stateData.isInitDataQueueLocked === false) {
-      const initData = this._initDataQueue.shift();
+      const initData =
+        this._initDataQueues.overflowQueue.length > 0 &&
+        !this._activeSessionsStore.isFull()
+          ? this._initDataQueues.overflowQueue.shift()
+          : this._initDataQueues.mainQueue.shift();
       if (initData === undefined) {
         return;
       }
-      this.onInitializationData(initData);
+      const { mediaKeysData } = this._stateData.data;
+      this._processInitializationData(initData, mediaKeysData).catch((err) => {
+        this._onFatalError(err);
+      });
     }
   }
 
@@ -1320,38 +1455,6 @@ type IErrorStateData = IContentDecryptorStateBase<
   undefined, // isMediaKeysAttached
   null // data
 >;
-
-/** Information linked to a session created by the `ContentDecryptor`. */
-interface IActiveSessionInfo {
-  /**
-   * Record associated to the session.
-   * Most notably, it allows both to identify the session as well as to
-   * anounce and find out which key ids are already handled.
-   */
-  record: KeySessionRecord;
-
-  /** Current keys' statuses linked that session. */
-  keyStatuses: {
-    /** Key ids linked to keys that are "usable". */
-    whitelisted: Uint8Array[];
-    /**
-     * Key ids linked to keys that are not considered "usable".
-     * Content linked to those keys are not decipherable and may thus be
-     * fallbacked from.
-     */
-    blacklisted: Uint8Array[];
-  };
-
-  /** Source of the MediaKeySession linked to that record. */
-  source: MediaKeySessionLoadingType;
-
-  /**
-   * If different than `null`, all initialization data compatible with this
-   * processed initialization data has been blacklisted with this corresponding
-   * error.
-   */
-  blacklistedSessionError: BlacklistedSessionError | null;
-}
 
 /**
  * Sent when the created (or already created) MediaKeys is attached to the

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -140,7 +140,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
      * and adding the corresponding initialization data to this queue.
      *
      * The `ContentDecryptor` will then handle this queue in priority if/when
-     * the overflow has ended.
+     * this "overflow" has ended.
      */
     overflowQueue: IProcessedProtectionData[];
   };
@@ -437,7 +437,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    * be created due to the current limit of simultaneous `MediaKeySession` being
    * reached.
    * You may know whether that's the case by listening for the `tooMuchSessions`
-   * event or by calling the `isOverflowing` method.
+   * event or by calling the `hasTooMuchSessions` method.
    *
    * The boolean returned by this method indicates if the key id freeing led to
    * `MediaKeySession` that are relied on for the current content have in
@@ -491,8 +491,21 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     return !this._activeSessionsStore.isFull();
   }
 
-  public isOverflowing(): boolean {
-    return this._initDataQueues.overflowQueue.length > 0;
+  /**
+   * Returns `true` if the `ContentDecryptor` is known to currently depend on
+   * too much `MediaKeySession` for the current configuration, and is thus
+   * unable to create more, limiting the possibility to handle further keys.
+   *
+   * To allow the `ContentDecryptor` to remove some of those `MediaKeySession`,
+   * you're advised to call the `freeKeyIds` method for keys you don't want to
+   * be handling anymore.
+   *
+   * @returns {boolean}
+   */
+  public hasTooMuchSessions(): boolean {
+    return (
+      this._initDataQueues.overflowQueue.length > 0 && this._activeSessionsStore.isFull()
+    );
   }
 
   /**

--- a/src/main_thread/decrypt/create_or_load_session.ts
+++ b/src/main_thread/decrypt/create_or_load_session.ts
@@ -20,9 +20,13 @@ import type { CancellationSignal } from "../../utils/task_canceller";
 import createSession from "./create_session";
 import type { IProcessedProtectionData, IMediaKeySessionStores } from "./types";
 import { MediaKeySessionLoadingType } from "./types";
-import cleanOldLoadedSessions from "./utils/clean_old_loaded_sessions";
+import cleanOldLoadedSessions, {
+  NoSessionSpaceError,
+} from "./utils/clean_old_loaded_sessions";
 import isSessionUsable from "./utils/is_session_usable";
 import type KeySessionRecord from "./utils/key_session_record";
+
+export { NoSessionSpaceError };
 
 /**
  * Handle MediaEncryptedEvents sent by a HTMLMediaElement:
@@ -34,24 +38,34 @@ import type KeySessionRecord from "./utils/key_session_record";
  * `EME_MAX_SIMULTANEOUS_MEDIA_KEY_SESSIONS` config property.
  *
  * You can refer to the events emitted to know about the current situation.
- * @param {Object} initializationData
- * @param {Object} stores
- * @param {string} wantedSessionType
- * @param {number} maxSessionCacheSize
+ * @param {Object} arg
+ * @param {Object} arg.initializationData
+ * @param {Object} arg.sessionStores
+ * @param {string} arg.sessionType
+ * @param {number} arg.maxSessionCacheSize
  * @param {Object} cancelSignal
  * @returns {Promise}
  */
 export default async function createOrLoadSession(
-  initializationData: IProcessedProtectionData,
-  stores: IMediaKeySessionStores,
-  wantedSessionType: MediaKeySessionType,
-  maxSessionCacheSize: number,
+  {
+    initializationData,
+    sessionStores,
+    sessionType,
+    activeRecords,
+    maxSessionCacheSize,
+  }: {
+    initializationData: IProcessedProtectionData;
+    sessionStores: IMediaKeySessionStores;
+    sessionType: MediaKeySessionType;
+    activeRecords: KeySessionRecord[];
+    maxSessionCacheSize: number;
+  },
   cancelSignal: CancellationSignal,
 ): Promise<ICreateOrLoadSessionResult> {
   /** Store previously-loaded compatible MediaKeySession, if one. */
   let previousLoadedSession: MediaKeySession | ICustomMediaKeySession | null = null;
 
-  const { loadedSessionsStore, persistentSessionsStore } = stores;
+  const { loadedSessionsStore, persistentSessionsStore } = sessionStores;
   const entry = loadedSessionsStore.reuse(initializationData);
   if (entry !== null) {
     previousLoadedSession = entry.mediaKeySession;
@@ -84,6 +98,7 @@ export default async function createOrLoadSession(
 
   await cleanOldLoadedSessions(
     loadedSessionsStore,
+    activeRecords,
     // Account for the next session we will be creating
     // Note that `maxSessionCacheSize < 0 has special semantic (no limit)`
     maxSessionCacheSize <= 0 ? maxSessionCacheSize : maxSessionCacheSize - 1,
@@ -93,9 +108,9 @@ export default async function createOrLoadSession(
   }
 
   const evt = await createSession(
-    stores,
+    sessionStores,
     initializationData,
-    wantedSessionType,
+    sessionType,
     cancelSignal,
   );
   return {

--- a/src/main_thread/decrypt/types.ts
+++ b/src/main_thread/decrypt/types.ts
@@ -41,6 +41,11 @@ export interface IContentDecryptorEvent {
    */
   warning: IPlayerError;
 
+  tooMuchSessions: {
+    waitingKeyIds: Uint8Array[];
+    activeKeyIds: Uint8Array[];
+  };
+
   /**
    * Event emitted when the `ContentDecryptor`'s state changed.
    * States are a central aspect of the `ContentDecryptor`, be sure to check the

--- a/src/main_thread/decrypt/utils/__tests__/clean_old_loaded_sessions.test.ts
+++ b/src/main_thread/decrypt/utils/__tests__/clean_old_loaded_sessions.test.ts
@@ -64,7 +64,7 @@ async function checkNothingHappen(
   limit: number,
 ): Promise<void> {
   const mockCloseSession = vi.spyOn(loadedSessionsStore, "closeSession");
-  await cleanOldLoadedSessions(loadedSessionsStore, limit);
+  await cleanOldLoadedSessions(loadedSessionsStore, [], limit);
   expect(mockCloseSession).not.toHaveBeenCalled();
   mockCloseSession.mockRestore();
 }
@@ -85,7 +85,7 @@ async function checkEntriesCleaned(
   entries: Array<{ sessionId: string }>,
 ): Promise<void> {
   const mockCloseSession = vi.spyOn(loadedSessionsStore, "closeSession");
-  const prom = cleanOldLoadedSessions(loadedSessionsStore, limit).then(() => {
+  const prom = cleanOldLoadedSessions(loadedSessionsStore, [], limit).then(() => {
     expect(mockCloseSession).toHaveBeenCalledTimes(entries.length);
     mockCloseSession.mockRestore();
   });

--- a/src/main_thread/decrypt/utils/active_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/active_sessions_store.ts
@@ -1,0 +1,143 @@
+import type { BlacklistedSessionError } from "../session_events_listener";
+import type { MediaKeySessionLoadingType } from "../types";
+import type KeySessionRecord from "./key_session_record";
+
+/**
+ * Contains information about all key sessions loaded for the current
+ * content.
+ * This object is most notably used to check which keys are already obtained,
+ * thus avoiding to perform new unnecessary license requests and CDM
+ * interactions.
+ *
+ * It is important to create only one `ActiveSessionsStore` for a given
+ * `MediaKeys` to prevent conflicts.
+ *
+ * An `ActiveSessionsStore` instance can also be "marked" as full with the
+ * `markAsFull` method.
+ * "Marking as full" this way does not change your ability do add new session,
+ * but the `isFull` method will return `true` until at least a single session is
+ * removed from this `ActiveSessionsInfo`.
+ * This "full" flag allows to simplify overflowing MediaKeySession management, by
+ * storing in a single place whether this event has been encountered and whether
+ * it had chance to be resolved since.
+ *
+ * @class ActiveSessionsInfo
+ */
+export default class ActiveSessionsStore {
+  /** Metadata on each `MediaKeySession` stored here. */
+  private _sessions: IActiveSessionInfo[];
+
+  /**
+   * `true` after the `markAsFull` method has been called, until `removeSession`
+   * is called **and** led to a `MediaKeySession` has been removed.
+   *
+   * This boolean has no impact on the creation of new `MediaKeySession`, it is
+   * only here as a flag to indicate that an overflow of `MediaKeySession`
+   * linked to this `ActiveSessionsStore` has been detected and only resets to
+   * `false` when it has chances to be resolved (when a `MediaKeySession` has
+   * since been removed).
+   */
+  private _isFull: boolean;
+
+  constructor() {
+    this._sessions = [];
+    this._isFull = false;
+  }
+
+  /**
+   * Set the `isFull` flag to true meaning that the `isFull` method will from
+   * now on return `true` until at least one `MediaKeySession` has been removed
+   * from this `ActiveSessionsStore` (through the `removeSession` method).
+   *
+   * This flag allows to store the information of whether an "overflow" of
+   * active `MediaKeySession` has been detected.
+   */
+  public markAsFull(): void {
+    this._isFull = true;
+  }
+
+  /**
+   * Add a new `MediaKeySession`, and its associated information, to the
+   * `ActiveSessionsStore`.
+   * @param {Object} sessionInfo
+   */
+  public addSession(sessionInfo: IActiveSessionInfo) {
+    this._sessions.push(sessionInfo);
+  }
+
+  /**
+   * Returns all information in the `ActiveSessionsStore` by order of insertion.
+   * @returns {Array.<Object>}
+   */
+  public getSessions(): IActiveSessionInfo[] {
+    return this._sessions;
+  }
+
+  /**
+   * Remove element with the corresponding `MediaKeySession` information from
+   * the `ActiveSessionsStore` if found.
+   *
+   * Returns `true` if the corresponding element has been found and removed, or
+   * `false` if it wasn't found.
+   *
+   * @param {Object} sessionInfo
+   * @returns {boolean}
+   */
+  public removeSession(sessionInfo: IActiveSessionInfo): boolean {
+    const indexOf = this._sessions.indexOf(sessionInfo);
+    if (indexOf >= 0) {
+      this._sessions.splice(indexOf, 1);
+      this._isFull = false;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * If `true`, we know that there's too much `MediaKeySession` currently
+   * created and we thus cannot create any more.
+   *
+   * Supplementary "overflowing" initialization data may in this state awaiting
+   * in one of the `ContentDecryptor`'s queue.
+   *
+   * If `false` we've either have less `MediaKeySession` active than the
+   * current limit currently or we don't know whether we reached the limit
+   * yet.
+   * @returns {boolean}
+   */
+  public isFull(): boolean {
+    return this._isFull;
+  }
+}
+
+/** Information linked to a session created by the `ContentDecryptor`. */
+export interface IActiveSessionInfo {
+  /**
+   * Record associated to the session.
+   * Most notably, it allows both to identify the session as well as to
+   * anounce and find out which key ids are already handled.
+   */
+  record: KeySessionRecord;
+
+  /** Current keys' statuses linked that session. */
+  keyStatuses: {
+    /** Key ids linked to keys that are "usable". */
+    whitelisted: Uint8Array[];
+    /**
+     * Key ids linked to keys that are not considered "usable".
+     * Content linked to those keys are not decipherable and may thus be
+     * fallbacked from.
+     */
+    blacklisted: Uint8Array[];
+  };
+
+  /** Source of the MediaKeySession linked to that record. */
+  source: MediaKeySessionLoadingType;
+
+  /**
+   * If different than `null`, all initialization data compatible with this
+   * processed initialization data has been blacklisted with this corresponding
+   * error.
+   */
+  blacklistedSessionError: BlacklistedSessionError | null;
+}

--- a/src/main_thread/decrypt/utils/active_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/active_sessions_store.ts
@@ -17,9 +17,10 @@ import type KeySessionRecord from "./key_session_record";
  * "Marking as full" this way does not change your ability do add new session,
  * but the `isFull` method will return `true` until at least a single session is
  * removed from this `ActiveSessionsInfo`.
- * This "full" flag allows to simplify overflowing MediaKeySession management, by
- * storing in a single place whether this event has been encountered and whether
- * it had chance to be resolved since.
+ * This "full" flag allows to simplify the management of having too many
+ * simultaneous `MediaKeySession` on the current device, by storing in a single
+ * place whether this event has been encountered and whether it had chance to
+ * be resolved since.
  *
  * @class ActiveSessionsInfo
  */
@@ -32,7 +33,7 @@ export default class ActiveSessionsStore {
    * is called **and** led to a `MediaKeySession` has been removed.
    *
    * This boolean has no impact on the creation of new `MediaKeySession`, it is
-   * only here as a flag to indicate that an overflow of `MediaKeySession`
+   * only here as a flag to indicate that a surplus of `MediaKeySession`
    * linked to this `ActiveSessionsStore` has been detected and only resets to
    * `false` when it has chances to be resolved (when a `MediaKeySession` has
    * since been removed).
@@ -49,8 +50,8 @@ export default class ActiveSessionsStore {
    * now on return `true` until at least one `MediaKeySession` has been removed
    * from this `ActiveSessionsStore` (through the `removeSession` method).
    *
-   * This flag allows to store the information of whether an "overflow" of
-   * active `MediaKeySession` has been detected.
+   * This flag allows to store the information of whether too much
+   * `MediaKeySession` seems to be created right now.
    */
   public markAsFull(): void {
     this._isFull = true;
@@ -95,14 +96,9 @@ export default class ActiveSessionsStore {
 
   /**
    * If `true`, we know that there's too much `MediaKeySession` currently
-   * created and we thus cannot create any more.
+   * created.
    *
-   * Supplementary "overflowing" initialization data may in this state awaiting
-   * in one of the `ContentDecryptor`'s queue.
-   *
-   * If `false` we've either have less `MediaKeySession` active than the
-   * current limit currently or we don't know whether we reached the limit
-   * yet.
+   * @see `markAsFull` method.
    * @returns {boolean}
    */
   public isFull(): boolean {

--- a/src/main_thread/decrypt/utils/loaded_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/loaded_sessions_store.ts
@@ -120,6 +120,17 @@ export default class LoadedSessionsStore {
     return null;
   }
 
+  public hasEntryForRecord(
+    keySessionRecord: KeySessionRecord
+  ): boolean {
+    for (const stored of this._storage) {
+      if (stored.keySessionRecord === keySessionRecord) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Get `LoadedSessionsStore`'s entry for a given MediaKeySession.
    * Returns `null` if the given MediaKeySession is not stored in the

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -101,6 +101,9 @@ export default class DirectFileContentInitializer extends ContentInitializer {
         onWarning: (err: IPlayerError) => this.trigger("warning", err),
         onBlackListProtectionData: noop,
         onKeyIdsCompatibilityUpdate: noop,
+        onTooMuchSessions: () => {
+          log.error("Init: There's currently too much MediaKeySession created");
+        },
       },
       cancelSignal,
     );

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -62,8 +62,8 @@ import SyncOrAsync from "../../utils/sync_or_async";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import TaskCanceller from "../../utils/task_canceller";
 import { ContentDecryptorState, getKeySystemConfiguration } from "../decrypt";
-import type { IProcessedProtectionData } from "../decrypt";
 import type ContentDecryptor from "../decrypt";
+import type { IProcessedProtectionData } from "../decrypt";
 import type { ITextDisplayer } from "../text_displayer";
 import type { ITextDisplayerOptions } from "./types";
 import { ContentInitializer } from "./types";
@@ -204,7 +204,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       this._initCanceller.signal,
     );
 
-    this._setupInitialMediaSourceAndDecryption(mediaElement)
+    this._setupInitialMediaSourceAndDecryption(mediaElement, playbackObserver)
       .then((initResult) =>
         this._onInitialMediaSourceReady(
           mediaElement,
@@ -256,7 +256,10 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
    * @param {HTMLMediaElement|null} mediaElement
    * @returns {Promise.<Object>}
    */
-  private _setupInitialMediaSourceAndDecryption(mediaElement: IMediaElement): Promise<{
+  private _setupInitialMediaSourceAndDecryption(
+    mediaElement: IMediaElement,
+    playbackObserver: IMediaElementPlaybackObserver,
+  ): Promise<{
     mediaSource: MainMediaSourceInterface;
     drmSystemId: string | undefined;
     unlinkMediaSource: TaskCanceller;
@@ -272,6 +275,22 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         {
           onWarning: (err: IPlayerError) => this.trigger("warning", err),
           onError: (err: Error) => this._onFatalError(err),
+          onTooMuchSessions: (val: {
+            waitingKeyIds: Uint8Array[];
+            activeKeyIds: Uint8Array[];
+          }) => {
+            if (!contentDecryptor.enabled) {
+              log.error(
+                "Init: Received tooMuchSessions error before getting a ContentDecryptor",
+              );
+              return;
+            }
+            this._onTooMuchMediaKeySessions(
+              contentDecryptor.value,
+              playbackObserver,
+              val,
+            );
+          },
           onBlackListProtectionData: (val) => {
             // Ugly IIFE workaround to allow async event listener
             (async () => {
@@ -1128,6 +1147,77 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         manifest.updateCodecSupport(codecsSupportInfo);
       } catch (err) {
         this._onFatalError(err);
+      }
+    }
+  }
+
+  /**
+   * Logic performed when the `ContentDecryptor` tells us that there are too
+   * many DRM sessions created for the current content.
+   *
+   * We here try to determine which keys aren't needed anymore on the current
+   * content, and indicate to the `ContentDecryptor` that it can "free" them.
+   *
+   * @param {Object} contentDecryptor - The `ContentDecryptor` instance which
+   * has encountered the issue.
+   * @param {Object} playbackObserver - The playbackObserver linked to the same
+   * media element than the one handled by the `ContentDecryptor`.
+   * @param {Object} payload - The payload from the `tooMuchSessions` event from
+   * the `ContentDecryptor`.
+   */
+  private _onTooMuchMediaKeySessions(
+    contentDecryptor: ContentDecryptor,
+    playbackObserver: IMediaElementPlaybackObserver,
+    payload: {
+      waitingKeyIds: Uint8Array[];
+      activeKeyIds: Uint8Array[];
+    },
+  ): void {
+    const manifest = this._manifest?.syncValue;
+    if (isNullOrUndefined(manifest)) {
+      log.error("Init: Received tooMuchSessions error before fetching the Manifest");
+      return;
+    }
+
+    // We will here free all keys that aren't needed for the content buffered
+    // forward.
+
+    const basePosition = Math.min(
+      playbackObserver.getCurrentTime(),
+      playbackObserver.getReference().getValue().position.getWanted(),
+    );
+
+    const keyIdsToCheck = payload.activeKeyIds.slice();
+    for (const period of manifest.periods) {
+      if (period.end !== undefined && period.end < basePosition) {
+        continue;
+      }
+      for (const adaptation of period.getAdaptations()) {
+        for (const representation of adaptation.representations) {
+          const repKeyIds = representation.contentProtections?.keyIds;
+          if (repKeyIds === undefined) {
+            break;
+          }
+          for (let i = keyIdsToCheck.length - 1; i >= 0; i--) {
+            const kidToCheck = keyIdsToCheck[i];
+            for (const repKid of repKeyIds) {
+              if (areArraysOfNumbersEqual(kidToCheck, repKid)) {
+                keyIdsToCheck.splice(i, 1);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (keyIdsToCheck.length === 0) {
+      // FIXME:
+      log.error("Init: Too much MediaKeySession but found none to free");
+    } else {
+      const hasFreedSession = contentDecryptor.freeKeyIds(keyIdsToCheck);
+      if (!hasFreedSession) {
+        // FIXME:
+        log.error("Init: Too much MediaKeySession even after freeing some keys");
       }
     }
   }

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -72,6 +72,7 @@ import createMediaSource from "./utils/create_media_source";
 import type { IInitialTimeOptions } from "./utils/get_initial_time";
 import getInitialTime from "./utils/get_initial_time";
 import getLoadedReference from "./utils/get_loaded_reference";
+import handleTooMuchMediaKeySessions from "./utils/handle_too_much_media_key_sessions";
 import performInitialSeekAndPlay from "./utils/initial_seek_and_play";
 import initializeContentDecryption from "./utils/initialize_content_decryption";
 import MainThreadTextDisplayerInterface from "./utils/main_thread_text_displayer_interface";
@@ -279,14 +280,19 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             waitingKeyIds: Uint8Array[];
             activeKeyIds: Uint8Array[];
           }) => {
-            if (!contentDecryptor.enabled) {
+            if (
+              !contentDecryptor.enabled ||
+              this._manifest === null ||
+              this._manifest?.syncValue === null
+            ) {
               log.error(
-                "Init: Received tooMuchSessions error before getting a ContentDecryptor",
+                "Init: Received tooMuchSessions error before getting a Manifest or ContentDecryptor",
               );
               return;
             }
-            this._onTooMuchMediaKeySessions(
+            handleTooMuchMediaKeySessions(
               contentDecryptor.value,
+              this._manifest.syncValue,
               playbackObserver,
               val,
             );
@@ -1147,77 +1153,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         manifest.updateCodecSupport(codecsSupportInfo);
       } catch (err) {
         this._onFatalError(err);
-      }
-    }
-  }
-
-  /**
-   * Logic performed when the `ContentDecryptor` tells us that there are too
-   * many DRM sessions created for the current content.
-   *
-   * We here try to determine which keys aren't needed anymore on the current
-   * content, and indicate to the `ContentDecryptor` that it can "free" them.
-   *
-   * @param {Object} contentDecryptor - The `ContentDecryptor` instance which
-   * has encountered the issue.
-   * @param {Object} playbackObserver - The playbackObserver linked to the same
-   * media element than the one handled by the `ContentDecryptor`.
-   * @param {Object} payload - The payload from the `tooMuchSessions` event from
-   * the `ContentDecryptor`.
-   */
-  private _onTooMuchMediaKeySessions(
-    contentDecryptor: ContentDecryptor,
-    playbackObserver: IMediaElementPlaybackObserver,
-    payload: {
-      waitingKeyIds: Uint8Array[];
-      activeKeyIds: Uint8Array[];
-    },
-  ): void {
-    const manifest = this._manifest?.syncValue;
-    if (isNullOrUndefined(manifest)) {
-      log.error("Init: Received tooMuchSessions error before fetching the Manifest");
-      return;
-    }
-
-    // We will here free all keys that aren't needed for the content buffered
-    // forward.
-
-    const basePosition = Math.min(
-      playbackObserver.getCurrentTime(),
-      playbackObserver.getReference().getValue().position.getWanted(),
-    );
-
-    const keyIdsToCheck = payload.activeKeyIds.slice();
-    for (const period of manifest.periods) {
-      if (period.end !== undefined && period.end < basePosition) {
-        continue;
-      }
-      for (const adaptation of period.getAdaptations()) {
-        for (const representation of adaptation.representations) {
-          const repKeyIds = representation.contentProtections?.keyIds;
-          if (repKeyIds === undefined) {
-            break;
-          }
-          for (let i = keyIdsToCheck.length - 1; i >= 0; i--) {
-            const kidToCheck = keyIdsToCheck[i];
-            for (const repKid of repKeyIds) {
-              if (areArraysOfNumbersEqual(kidToCheck, repKid)) {
-                keyIdsToCheck.splice(i, 1);
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (keyIdsToCheck.length === 0) {
-      // FIXME:
-      log.error("Init: Too much MediaKeySession but found none to free");
-    } else {
-      const hasFreedSession = contentDecryptor.freeKeyIds(keyIdsToCheck);
-      if (!hasFreedSession) {
-        // FIXME:
-        log.error("Init: Too much MediaKeySession even after freeing some keys");
       }
     }
   }

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -63,6 +63,7 @@ import { resetMediaElement } from "./utils/create_media_source";
 import type { IInitialTimeOptions } from "./utils/get_initial_time";
 import getInitialTime from "./utils/get_initial_time";
 import getLoadedReference from "./utils/get_loaded_reference";
+import handleTooMuchMediaKeySessions from "./utils/handle_too_much_media_key_sessions";
 import performInitialSeekAndPlay from "./utils/initial_seek_and_play";
 import RebufferingController from "./utils/rebuffering_controller";
 import StreamEventsEmitter from "./utils/stream_events_emitter/stream_events_emitter";
@@ -356,6 +357,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     const { statusRef: drmInitializationStatus, contentDecryptor } =
       this._initializeContentDecryption(
         mediaElement,
+        playbackObserver,
         lastContentProtection,
         mediaSourceStatus,
         () => reloadMediaSource(0, undefined, undefined),
@@ -1178,6 +1180,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
 
   private _initializeContentDecryption(
     mediaElement: IMediaElement,
+    playbackObserver: IMediaElementPlaybackObserver,
     lastContentProtection: IReadOnlySharedReference<null | IContentProtection>,
     mediaSourceStatus: SharedReference<MediaSourceInitializationStatus>,
     reloadMediaSource: () => void,
@@ -1328,6 +1331,20 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         });
         contentDecryptor.removeEventListener("stateChange");
       }
+    });
+
+    contentDecryptor.addEventListener("tooMuchSessions", (payload) => {
+      const manifest = this._currentContentInfo?.manifest;
+      if (isNullOrUndefined(manifest)) {
+        log.error("Init: Received tooMuchSessions error before getting a Manifest");
+        return;
+      }
+      handleTooMuchMediaKeySessions(
+        contentDecryptor,
+        manifest,
+        playbackObserver,
+        payload,
+      );
     });
 
     contentDecryptor.addEventListener("error", (error) => {

--- a/src/main_thread/init/utils/handle_too_much_media_key_sessions.ts
+++ b/src/main_thread/init/utils/handle_too_much_media_key_sessions.ts
@@ -1,0 +1,79 @@
+import log from "../../../log";
+import type ContentDecryptor from "../../../main_thread/decrypt";
+import type { IManifestMetadata } from "../../../manifest";
+import { getAdaptations } from "../../../manifest";
+import type { IMediaElementPlaybackObserver } from "../../../playback_observer";
+import areArraysOfNumbersEqual from "../../../utils/are_arrays_of_numbers_equal";
+import isNullOrUndefined from "../../../utils/is_null_or_undefined";
+
+/**
+ * Logic performed when the `ContentDecryptor` tells us that there are too
+ * many DRM sessions created for the current content.
+ *
+ * We here try to determine which keys aren't needed anymore on the current
+ * content, and indicate to the `ContentDecryptor` that it can "free" them.
+ *
+ * @param {Object} contentDecryptor - The `ContentDecryptor` instance which
+ * has encountered the issue.
+ * @param {Object} manifest - Metadata on the content currently being played.
+ * @param {Object} playbackObserver - The PlaybackObserver linked to the same
+ * media element than the one handled by the `ContentDecryptor`.
+ * @param {Object} payload - The payload from the `tooMuchSessions` event from
+ * the `ContentDecryptor`.
+ */
+export default function handleTooMuchMediaKeySessions(
+  contentDecryptor: ContentDecryptor,
+  manifest: IManifestMetadata,
+  playbackObserver: IMediaElementPlaybackObserver,
+  payload: {
+    waitingKeyIds: Uint8Array[];
+    activeKeyIds: Uint8Array[];
+  },
+): void {
+  if (isNullOrUndefined(manifest)) {
+    log.error("Init: Received tooMuchSessions error before fetching the Manifest");
+    return;
+  }
+
+  // We will here free all keys that aren't needed for the content buffered
+  // forward.
+
+  const basePosition = Math.min(
+    playbackObserver.getCurrentTime(),
+    playbackObserver.getReference().getValue().position.getWanted(),
+  );
+
+  const keyIdsToCheck = payload.activeKeyIds.slice();
+  for (const period of manifest.periods) {
+    if (period.end !== undefined && period.end < basePosition) {
+      continue;
+    }
+    for (const adaptation of getAdaptations(period)) {
+      for (const representation of adaptation.representations) {
+        const repKeyIds = representation.contentProtections?.keyIds;
+        if (repKeyIds === undefined) {
+          break;
+        }
+        for (let i = keyIdsToCheck.length - 1; i >= 0; i--) {
+          const kidToCheck = keyIdsToCheck[i];
+          for (const repKid of repKeyIds) {
+            if (areArraysOfNumbersEqual(kidToCheck, repKid)) {
+              keyIdsToCheck.splice(i, 1);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (keyIdsToCheck.length === 0) {
+    // FIXME:
+    log.error("Init: Too much MediaKeySession but found none to free");
+  } else {
+    const hasFreedSession = contentDecryptor.freeKeyIds(keyIdsToCheck);
+    if (!hasFreedSession) {
+      // FIXME:
+      log.error("Init: Too much MediaKeySession even after freeing some keys");
+    }
+  }
+}

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -39,6 +39,10 @@ export default function initializeContentDecryption(
     onWarning: (err: IPlayerError) => void;
     onError: (err: Error) => void;
     onBlackListProtectionData: (val: IProcessedProtectionData) => void;
+    onTooMuchSessions: (arg: {
+      waitingKeyIds: Uint8Array[];
+      activeKeyIds: Uint8Array[];
+    }) => void;
     onKeyIdsCompatibilityUpdate: (updates: {
       whitelistedKeyIds: Uint8Array[];
       blacklistedKeyIds: Uint8Array[];
@@ -137,6 +141,10 @@ export default function initializeContentDecryption(
 
   contentDecryptor.addEventListener("keyIdsCompatibilityUpdate", (x) => {
     callbacks.onKeyIdsCompatibilityUpdate(x);
+  });
+
+  contentDecryptor.addEventListener("tooMuchSessions", (e) => {
+    callbacks.onTooMuchSessions(e);
   });
 
   decryptorCanceller.signal.register(() => {


### PR DESCRIPTION
Since Monday, I'm trying to fix the theoretical issue described here, but it proved very hard to actually implement.

As such, I chose to open its Pull Request despite it still being non-functional, to expose (to other developers and also to myself), what I tried and what wall I encountered here.

We may in the end try different solutions.

The issue
=========

Preamble: conditions
--------------------

This work is about a specific and for now never seen issue that has chance to pop up under the following conditions:

  - The current content make use of per-Period key rotation (NOTE: this is also possible without key rotation, but this is made much more probable by it).

  - The device on which we we play that content has a very limited number of key slots available simultaneously for decryption  (sometimes **VERY** limited, e.g. `6`, so we can at most rely on 6 keys simultaneously.

    We for now know of two different set-top boxes with that limitation.

The `maxSessionCacheSize` option
---------------------------------------------

Theoretically, an application can rely there on the `keySystems[].maxSessionCacheSize` option to set a maximum number of `MediaKeySession` we may keep at at the same time.

_Note that we prefer here to rely on a number of `MediaKeySession` and not of keys, because the RxPlayer is not able to predict how many keys it will find inside a license (NOTE: to simplify, let's just say that 1 `MediaKeySession` == 1 license here, as it's very predominantly the case) nor is it able to not communicate some keys that are found in a given license._
_Yet an application generally has a rough idea of how many keys it's going to find in a license a most, and can set up its `maxSessionCacheSize` accordingly (e.g. if there's max `10` key slots available on the device and `5` keys per license maximum, it could just communicate to us a `maxSessionCacheSize` of `2`)._

So problem solved right? WRONG!

The RxPlayer, when exploiting the `maxSessionCacheSize` property, will when that limit is reached just close the `MediaKeySession` it has least recently seen the need for (basically, when the RxPlayer loads segment for a new Period/track/Representation, it asks our decryption logic to make sure it has the right key, this is how our decryption logic know that a `MediaKeySession` or more precizely a key it can make use of, has been needed recently.

Example scenario
----------------

So let's just imagine a scenario:

  1. we're currently loading a Period A with encrypted content and buffering a future Period B with content encrypted with a different key.

  2. we're asking the decryption logic to make sure the key is loaded for future Period B

  3. The decryption logic sees that it doesn't have the key yet, and thus has to create a new `MediaKeySession`.

     Yet, it sees that it cannot create a new `MediaKeySession` for that new key without closing an old one to respect the `keySystems[].maxSessionCacheSize` option, and it turns out one relied on to play Period A was the least recently needed for some reason.

  4. The decryption logic closes a `MediaKeySession` for Period `A` that was currently relied on.

  5. ??? I don't know what happens, the `MediaKeySession` closure may fail in which case we could be left with too many key slots used on the device and some random error, or content playback may just fail directly.

     In any case, I wouldn't bet on something good happening.

Other types of scenarios are possible, e.g. we could be closing a `MediaKeySession` needed in the future and not think to re-create it when playing that future Period, potentially leading to a future infinite rebuffering.

Solution I'm proposing here
===========================

The solution I tried to implement tries the following logic:

  - When closing a `MediaKeySession` linked to the current content, it will stop relying on "least-recently used" principles (this algorithm will still be relied on for "cached" `MediaKeySession` - e.g. when switching between multiple TV channels).

    The idea here is more aligned with usual buffer-linked eviction algorithms:

  - We'll begin to close `MediaKeySession` linked only to already-played `Period`, in theory beginning by those further in the past.

    In reality let's just close all of them.

  - if it's not sufficient, we'll close `MediaKeySession` linked to `Period` distant in the future (like further in the future first).

  - if it's not sufficient, e.g. if even just for the current Period there's too many `MediaKeySession`, I'm not sure of what to do for now (probably do nothing and let things break)

This only take into consideration the concept of `Period`, even if theoretically a `MediaKeySession` could only be linked to a particular track or `Representation`.

This is only because - when implementing the solution - my brain already hurt thinking about the very simple concept of per-Period licenses, I didn't want to go to other aspects, we'll see those details later (even if they are also very possible - the solution I write here also work for them, even if we could also have an even better one taking into consideration e.g. the current tracks).

How I'm implementing this
=========================

On the `ContentDecryptor`-side
------------------------------

This feature has been a little hard to actually implement.

First, as we now have a difference in our `MediaKeySession`-closing algorithm depending on if the `MediaKeySession` is linked to the current content or not, I chose in our `ContentDecryptor` module that:

  1. `MediaKeySession` that are not linked to the current content keep being closed as before: least recently needed first.

  2. `MediaKeySession` that are linked to the current content are never directly closed by the `ContentDecryptor`.

     Instead, the `ContentDecryptor` module basically signals, when only left with `MediaKeySession` for the current content yet going over the `maxSessionCacheSize` limit, a `tooMuchSessions` event and lock its queue of protection data (it stops basically creating new `MediaKeySession` until older sessions are closed).

The `ContentDecryptor` also exposes a new method, `freeKeyIds`. You communicate to it the key id you don't need anymore, then the `ContentDecryptor` will see if can consequently close `MediaKeySession`, then check if the `maxSessionCacheSize` is respected, restart its queue if it is, and so on.

On the `ContentInitializer`-side
--------------------------------

The `ContentInitializer` module then reception `tooMuchSessions` events coming from the `ContentDecryptor`, and rely on our newly-defined algorithm to know which `MediaKeySession` it can let go.

Though this is where for now I'm lost due to edge cases:

  - When closing `MediaKeySession` linked to future `Period`, the `Stream` modules loading their linked content might be in the process of running, and they won't know for now that the `MediaKeySession` has been closed and thus not think about re-asking for the decryption key.

    There's many potential solutions here (relying on the concept of `lockedStream`, reloading, actually communicating to those streams that for now a `MediaKeySession` is closed, re-asking for the right key once the content is playing inside the `ContentInitializer`), yet any of them are very hard to get right and all of them have inconvenients.

  - There's still the issue of what should happen if we're left only with the current Period. I already lost many neurons on the simpler first simpler future-Period case, and in consequence had none to spare for this more complex possibility.

  - This is on another level, but what if while we were running this algorithm, some random `MediaKeySession` is closed by the browser (or some RxPlayer/application logic running in concurrence)?

    We may theoretically go below the `maxSessionCacheSize` limit at any time, due to some outside behavior, and in the end not actually need to continue running the algorithm.

    For now, even if that one is possible, I chose that having perfect code that would restart processing init data by itself due to that type of event too difficult to actually implement.

    So we'll probably should not show broken behavior if that actually happens, but I wasn't explicitely handling it here.