### PR TITLE
[Proposal] Add to config most compat switches

### DIFF
--- a/src/compat/can_rely_on_request_media_key_system_access.ts
+++ b/src/compat/can_rely_on_request_media_key_system_access.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -41,6 +42,10 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export function canRelyOnRequestMediaKeySystemAccess(keySystem: string): boolean {
+  const { FORCE_CANNOT_RELY_ON_REQUEST_MEDIA_KEY_SYSTEM_ACCESS } = config.getCurrent();
+  if (FORCE_CANNOT_RELY_ON_REQUEST_MEDIA_KEY_SYSTEM_ACCESS) {
+    return false;
+  }
   if (
     (EnvDetector.browser === EnvDetector.BROWSERS.EdgeChromium ||
       EnvDetector.browser === EnvDetector.BROWSERS.Firefox) &&

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -19,7 +20,9 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function canReuseMediaKeys(): boolean {
+  const { FORCE_CANNOT_REUSE_MEDIA_KEYS } = config.getCurrent();
   return (
+    !FORCE_CANNOT_REUSE_MEDIA_KEYS &&
     EnvDetector.device !== EnvDetector.DEVICES.WebOs2021 &&
     EnvDetector.device !== EnvDetector.DEVICES.WebOs2022 &&
     EnvDetector.device !== EnvDetector.DEVICES.WebOsOther &&

--- a/src/compat/has_issues_with_high_media_source_duration.ts
+++ b/src/compat/has_issues_with_high_media_source_duration.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -21,7 +22,11 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function hasIssuesWithHighMediaSourceDuration(): boolean {
+  const { FORCE_HAS_ISSUES_WITH_HIGH_MEDIA_SOURCE_DURATION } = config.getCurrent();
   // For now only seen on the Webkit present in the PlayStation 5, for which the
   // alternative is known to work.
-  return EnvDetector.device === EnvDetector.DEVICES.PlayStation5;
+  return (
+    FORCE_HAS_ISSUES_WITH_HIGH_MEDIA_SOURCE_DURATION ||
+    EnvDetector.device === EnvDetector.DEVICES.PlayStation5
+  );
 }

--- a/src/compat/is_seeking_approximate.ts
+++ b/src/compat/is_seeking_approximate.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -29,5 +30,6 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function isSeekingApproximate(): boolean {
-  return EnvDetector.device === EnvDetector.DEVICES.Tizen;
+  const { FORCE_IS_SEEKING_APPROXIMATE } = config.getCurrent();
+  return FORCE_IS_SEEKING_APPROXIMATE || EnvDetector.device === EnvDetector.DEVICES.Tizen;
 }

--- a/src/compat/may_media_element_fail_on_undecipherable_data.ts
+++ b/src/compat/may_media_element_fail_on_undecipherable_data.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -16,5 +17,9 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function mayMediaElementFailOnUndecipherableData(): boolean {
-  return EnvDetector.device === EnvDetector.DEVICES.PlayStation5;
+  const { FORCE_MEDIA_ELEMENT_FAIL_ON_UNDECIPHERABLE_DATA } = config.getCurrent();
+  return (
+    FORCE_MEDIA_ELEMENT_FAIL_ON_UNDECIPHERABLE_DATA ||
+    EnvDetector.device === EnvDetector.DEVICES.PlayStation5
+  );
 }

--- a/src/compat/should_await_set_media_keys.ts
+++ b/src/compat/should_await_set_media_keys.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -16,7 +17,9 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function shouldAwaitSetMediaKeys(): boolean {
+  const { FORCE_SHOULD_AWAIT_SET_MEDIA_KEYS } = config.getCurrent();
   return (
+    FORCE_SHOULD_AWAIT_SET_MEDIA_KEYS ||
     EnvDetector.device === EnvDetector.DEVICES.WebOs2021 ||
     EnvDetector.device === EnvDetector.DEVICES.WebOs2022 ||
     EnvDetector.device === EnvDetector.DEVICES.WebOsOther

--- a/src/compat/should_favour_custom_safari_EME.ts
+++ b/src/compat/should_favour_custom_safari_EME.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import { getWebKitMediaKeysConstructor } from "./eme/custom_media_keys";
 import EnvDetector from "./env_detector";
 
@@ -25,6 +26,10 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function shouldFavourCustomSafariEME(): boolean {
+  const { FORCE_SHOULD_FAVOUR_CUSTOM_SAFARI_EME } = config.getCurrent();
+  if (FORCE_SHOULD_FAVOUR_CUSTOM_SAFARI_EME) {
+    return true;
+  }
   return (
     (EnvDetector.browser === EnvDetector.BROWSERS.SafariDesktop ||
       EnvDetector.browser === EnvDetector.BROWSERS.SafariMobile) &&

--- a/src/compat/should_reload_media_source_on_decipherability_update.ts
+++ b/src/compat/should_reload_media_source_on_decipherability_update.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import config from "../config";
+
 /**
  * Returns true if we have to reload the MediaSource due to an update in the
  * decipherability status of some segments based on the current key sytem.
@@ -27,5 +29,11 @@
 export default function shouldReloadMediaSourceOnDecipherabilityUpdate(
   currentKeySystem: string | undefined,
 ): boolean {
-  return currentKeySystem === undefined || currentKeySystem.indexOf("widevine") < 0;
+  const { FORCE_SHOULD_RELOAD_MEDIA_SOURCE_ON_DECIPHERABILITY_UPDATE } =
+    config.getCurrent();
+  return (
+    FORCE_SHOULD_RELOAD_MEDIA_SOURCE_ON_DECIPHERABILITY_UPDATE ||
+    currentKeySystem === undefined ||
+    currentKeySystem.indexOf("widevine") < 0
+  );
 }

--- a/src/compat/should_renew_media_key_system_access.ts
+++ b/src/compat/should_renew_media_key_system_access.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -22,6 +23,10 @@ import EnvDetector from "./env_detector";
  * @returns {Boolean}
  */
 export default function shouldRenewMediaKeySystemAccess(keySystem: string): boolean {
+  const { FORCE_SHOULD_RENEW_MEDIA_KEY_SYSTEM_ACCESS } = config.getCurrent();
+  if (FORCE_SHOULD_RENEW_MEDIA_KEY_SYSTEM_ACCESS) {
+    return true;
+  }
   return (
     keySystem.indexOf("playready") !== -1 &&
     (EnvDetector.browser === EnvDetector.BROWSERS.Ie11 ||

--- a/src/compat/should_seek_only_after_canplay.ts
+++ b/src/compat/should_seek_only_after_canplay.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -8,7 +9,9 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function shouldWaitCanPlayEventForSeeking(): boolean {
+  const { FORCE_WAIT_CAN_PLAY_FOR_SEEKING } = config.getCurrent();
   return (
+    FORCE_WAIT_CAN_PLAY_FOR_SEEKING ||
     EnvDetector.browser === EnvDetector.BROWSERS.SafariMobile ||
     EnvDetector.browser === EnvDetector.BROWSERS.SafariDesktop
   );

--- a/src/compat/should_unset_media_keys.ts
+++ b/src/compat/should_unset_media_keys.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -23,5 +24,8 @@ import EnvDetector from "./env_detector";
  * @returns {Boolean}
  */
 export default function shouldUnsetMediaKeys(): boolean {
-  return EnvDetector.browser === EnvDetector.BROWSERS.Ie11;
+  const { FORCE_SHOULD_UNSET_MEDIA_KEYS } = config.getCurrent();
+  return (
+    FORCE_SHOULD_UNSET_MEDIA_KEYS || EnvDetector.browser === EnvDetector.BROWSERS.Ie11
+  );
 }

--- a/src/compat/should_validate_metadata.ts
+++ b/src/compat/should_validate_metadata.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -23,5 +24,6 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function shouldValidateMetadata(): boolean {
-  return EnvDetector.isSamsungBrowser;
+  const { FORCE_SHOULD_VALIDATE_METADATA } = config.getCurrent();
+  return FORCE_SHOULD_VALIDATE_METADATA || EnvDetector.isSamsungBrowser;
 }

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -25,6 +26,10 @@ import EnvDetector from "./env_detector";
  * @returns {Boolean}
  */
 export default function shouldWaitForDataBeforeLoaded(isDirectfile: boolean): boolean {
+  const { FORCE_DONT_WAIT_FOR_DATA_BEFORE_LOADED } = config.getCurrent();
+  if (FORCE_DONT_WAIT_FOR_DATA_BEFORE_LOADED) {
+    return false;
+  }
   if (
     isDirectfile &&
     (EnvDetector.browser === EnvDetector.BROWSERS.SafariMobile ||

--- a/src/compat/should_wait_for_have_enough_data.ts
+++ b/src/compat/should_wait_for_have_enough_data.ts
@@ -1,3 +1,4 @@
+import config from "../config";
 import EnvDetector from "./env_detector";
 
 /**
@@ -13,5 +14,9 @@ import EnvDetector from "./env_detector";
  * @returns {boolean}
  */
 export default function shouldWaitForHaveEnoughData(): boolean {
-  return EnvDetector.device === EnvDetector.DEVICES.PlayStation5;
+  const { FORCE_WAIT_FOR_HAVE_ENOUGH_DATA } = config.getCurrent();
+  return (
+    FORCE_WAIT_FOR_HAVE_ENOUGH_DATA ||
+    EnvDetector.device === EnvDetector.DEVICES.PlayStation5
+  );
 }

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1259,6 +1259,87 @@ const DEFAULT_CONFIG = {
    * @type {Number}
    */
   DEFAULT_THUMBNAIL_CONNECTION_TIMEOUT: 7 * 1000,
+
+  // Compatibility toggles:
+
+  /**
+   * If set to `true`, we'll always try to check thoroughly that a
+   * `MediaKeySystemAccess` can be relied on.
+   */
+  FORCE_CANNOT_RELY_ON_REQUEST_MEDIA_KEY_SYSTEM_ACCESS: false,
+
+  /**
+   * If set to `true`, we'll always re-create a `MediaKeys` instance for each
+   * encrypted content where we need one.
+   */
+  FORCE_CANNOT_REUSE_MEDIA_KEYS: false,
+
+  /**
+   * If set to `true`, we'll never seek directly after receiving the
+   * `loadedmetadata` event from an `HTMLMediaElement`, instead waiting a small
+   * amount of time before.
+   */
+  FORCE_WAIT_CAN_PLAY_FOR_SEEKING: false,
+
+  /**
+   * If set to `true`, force work-around for devices which have issues with
+   * `MediaSource` objects with a high `duration` property.
+   */
+  FORCE_HAS_ISSUES_WITH_HIGH_MEDIA_SOURCE_DURATION: false,
+
+  /**
+   * If set to `true`, the device might seek before what we actually tell it to,
+   * breaking other RxPlayer behaviors in the process.
+   * Setting it to `true` allows to enable work-arounds.
+   */
+  FORCE_IS_SEEKING_APPROXIMATE: false,
+
+  /**
+   * If set to `true`, the device might fail directly after uncountering
+   * decipherable data.
+   */
+  FORCE_MEDIA_ELEMENT_FAIL_ON_UNDECIPHERABLE_DATA: false,
+
+  /**
+   * If set to `true` we'll await a `MediaKeys` attachment on a given
+   * `HTMLMediaElement` before trying to set a new one.
+   */
+  FORCE_SHOULD_AWAIT_SET_MEDIA_KEYS: false,
+
+  /** If set to `true` we'll rely on Safari's Webkit flavor of the EME API. */
+  FORCE_SHOULD_FAVOUR_CUSTOM_SAFARI_EME: false,
+
+  /**
+   * If `true`, we'll reload if unencrypted data is encountered close to
+   * the current position.
+   */
+  FORCE_SHOULD_RELOAD_MEDIA_SOURCE_ON_DECIPHERABILITY_UPDATE: false,
+
+  /** If `true`, we'll for each content re-create a `MediaKeySystemAccess`. */
+  FORCE_SHOULD_RENEW_MEDIA_KEY_SYSTEM_ACCESS: false,
+
+  /** If `true`, we'll unset the `MediaKeys` at each stop. */
+  FORCE_SHOULD_UNSET_MEDIA_KEYS: false,
+
+  /**
+   * If `true`, we cannot trust that a `loadedmetadata` event from the
+   * `HTMLMediaElement` is sent after the browser has parsed key metadata such
+   * as the content's duration.
+   */
+  FORCE_SHOULD_VALIDATE_METADATA: false,
+
+  /**
+   * If `true`, we have to announce the content as loaded even if no data is
+   * actually loaded, because that target do not preload, meaning a `play` call
+   * is required.
+   */
+  FORCE_DONT_WAIT_FOR_DATA_BEFORE_LOADED: false,
+
+  /**
+   * If `true`, we have to wait for the `HAVE_ENOUGH_DATA` `readyState` before
+   * announcing the content as loaded.
+   */
+  FORCE_WAIT_FOR_HAVE_ENOUGH_DATA: false,
 };
 
 export type IDefaultConfig = typeof DEFAULT_CONFIG;


### PR DESCRIPTION
Based on #1510, the idea behind this proposal is to add to our config properties allowing to force toggles we for now only enable for specific devices.

The goal is to simplify the debugging of issues seen on specific devices (which is the huge majority of them), by just having to update the config in the corresponding application (as proposed by #1510).

So for example let's say that we encounter a new device where relying on the same `MediaKeys` instance for multiple contents may fail after a time (bug encountered on LG's WebOS, on some Panasonic TVs, and now, in issue #1464, on Philips's TitanOS), we could just initially tell application people to try setting that experimental flag.

If it fixes the issue, we will add a supplementary device check inside the corresponding compat function.

This seems faster and less bothersome to me than having to create special builds of the RxPlayer, and there our role could just be to redirect the developer seeing the issue to the right config option (as opposed to having to build a player, then link that player to the application, making sure that their CI like us etc.).