### PR TITLE
DRM: Re-create MediaKeys for each content on Philips' NETTV

### DIFF
--- a/src/compat/__tests__/can_reuse_media_keys.test.ts
+++ b/src/compat/__tests__/can_reuse_media_keys.test.ts
@@ -10,9 +10,9 @@ describe("Compat - canReuseMediaKeys", () => {
     vi.resetModules();
   });
 
-  it("should return true on any browser but WebOS", async () => {
+  it("should return true on most browsers", async () => {
     vi.doMock("../browser_detection", () => {
-      return { isWebOs: false, isPanasonic: false };
+      return { isWebOs: false, isPhilipsNetTv: false, isPanasonic: false };
     });
     const canReuseMediaKeys = (await vi.importActual(
       "../can_reuse_media_keys.ts",
@@ -26,6 +26,37 @@ describe("Compat - canReuseMediaKeys", () => {
         isWebOs: true,
         isWebOs2022: false,
         isPanasonic: false,
+        isPhilipsNetTv: false,
+      };
+    });
+    const canReuseMediaKeys = (await vi.importActual(
+      "../can_reuse_media_keys.ts",
+    )) as any;
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on Panasonic", async () => {
+    vi.doMock("../browser_detection", () => {
+      return {
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: true,
+        isPhilipsNetTv: false,
+      };
+    });
+    const canReuseMediaKeys = (await vi.importActual(
+      "../can_reuse_media_keys.ts",
+    )) as any;
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on Philips' NETTV", async () => {
+    vi.doMock("../browser_detection", () => {
+      return {
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: false,
+        isPhilipsNetTv: true,
       };
     });
     const canReuseMediaKeys = (await vi.importActual(

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -67,6 +67,9 @@ let isWebOs2022 = false;
 /** `true` for Panasonic devices. */
 let isPanasonic = false;
 
+/** `true` we're relying on Philips's NetTv browser. */
+let isPhilipsNetTv = false;
+
 /** `true` for the PlayStation 4 game console. */
 let isPlayStation4 = false;
 
@@ -155,6 +158,11 @@ let isXbox = false;
     ) {
       isWebOs2021 = true;
     }
+  } else if (
+    navigator.userAgent.indexOf("NETTV") !== -1 &&
+    navigator.userAgent.indexOf("Philips") !== -1
+  ) {
+    isPhilipsNetTv = true;
   } else if (/[Pp]anasonic/.test(navigator.userAgent)) {
     isPanasonic = true;
   } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
@@ -168,6 +176,7 @@ export {
   isIEOrEdge,
   isFirefox,
   isPanasonic,
+  isPhilipsNetTv,
   isPlayStation4,
   isPlayStation5,
   isXbox,

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,4 +1,4 @@
-import { isPanasonic, isWebOs } from "./browser_detection";
+import { isPanasonic, isPhilipsNetTv, isWebOs } from "./browser_detection";
 
 /**
  * Returns `true` if a `MediaKeys` instance (the  `Encrypted Media Extension`
@@ -9,9 +9,11 @@ import { isPanasonic, isWebOs } from "./browser_detection";
  *   - (2022-11-21): WebOS (LG TVs), for some encrypted contents, just
  *     rebuffered indefinitely when loading a content already-loaded on the
  *     HTMLMediaElement.
+ *   - (2024-08-23): Seen on Philips 2024 and 2023 in:
+ *     https://github.com/canalplus/rx-player/issues/1464
  *
  * @returns {boolean}
  */
 export default function canReuseMediaKeys(): boolean {
-  return !isWebOs && !isPanasonic;
+  return !isWebOs && !isPhilipsNetTv && !isPanasonic;
 }


### PR DESCRIPTION
Fixes #1464

There's a new device (after LG and Panasonic TVs) which seems to have issues when relying on the same `MediaKeys` instance on multiple contents, which seems to be Philips's NETTV (both 2023 and 2024 devices seem to have the issue as far as we know, and they advertise completely different operating systems, so instead we identified the culprit as "NETTV", which seems to be the web browser application Philips developed for their TVs and which is present on web applications' user agent on those devices).

So I disable the possibility for them here.
I still have to check if it works because I took as user-agent something I found a little randomly on the web.

Note that disabling re-usage of the `MediaKeys` instance will mean no in-memory `MediaKeySession` caching, which is a trick we use to both speed up loading a previous content and preventing to much requests on the license server also when doing that.

But we know most other players don't seem to do such tricks and the speed up is not that much noticeable, so that shouldn't be a big issue.