### PR TITLE
[Proposal] export a build script to facilitate rx-player tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,7 +14,6 @@
 
 /doc
 /.github
-/scripts
 # rust build artifacts
 /src/parsers/manifest/dash/wasm-parser/target
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,45 @@ demonstrating a simple usage of the player.
 Demo pages for our previous versions are also available
 [here](https://developers.canal-plus.com/rx-player/demo_page_by_version.html).
 
+## Test an RxPlayer branch from your application
+
+We're experimenting with the possibility to allow users to rely on pending RxPlayer
+developments directly in their applications.
+
+On most recent development branches and commits, you can directly
+[rely on the GitHub URL in your package.json](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#github-urls)
+and after installing it as a dependency, build the RxPlayer locally calling our new
+node.js build script we export from `"rx-player/scripts/build"`.
+
+That script will install locally our own dependencies and then produce the RxPlayer builds
+(which are not pushed to GitHub). Because of Node.js limitations, we sadly have to go
+through a temporary file (with an `mjs` extension) here. To save your time, here's the
+full commands you can run after installing an RxPlayer branch (or commit hash) in your
+project:
+
+```sh
+# Write temporary building file
+echo 'import { build } from "rx-player/scripts/build"; build();' > rx_build.tmp.mjs
+node rx_build.tmp.mjs # Run it to build the RxPlayer
+rm rx_build.tmp.mjs # Remove the temporary file
+```
+
+Alternatively you can also just add the following `postinstall` script to your
+[package.json scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts):
+
+```json
+"postinstall": "echo 'import { build } from \"rx-player/scripts/build\"; build();' > tmp_rxb.mjs && node tmp_rxb.mjs && rm tmp_rxb.mjs",
+```
+
+Note however that depending on an RxPlayer branch or commit should not be done in
+production and may be removed or updated in the future. It should only be used to check
+and prepare work linked to future RxPlayer fixes and features.
+
+The dependencies loaded may weigh in the several hundred of megabytes once uncompressed.
+If that's a problem for you, you can set the `cleanAfterBuild` option when calling the
+`build` function (`build({ cleanAfterBuild: true })`), this will remove the now-unrequired
+build-time dependencies once the build is produced.
+
 ## Contribute
 
 Details on how to contribute is written in the [CONTRIBUTING.md file](./CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "require": "./dist/commonjs/index.js",
       "default": "./dist/es2017/index.js"
     },
+    "./scripts/build": {
+      "import": "./scripts/clean_build.mjs",
+      "default": "./scripts/clean_build.mjs"
+    },
     "./experimental": {
       "import": "./dist/es2017/experimental/index.js",
       "require": "./dist/commonjs/experimental/index.js",

--- a/scripts/build_wasm_release.sh
+++ b/scripts/build_wasm_release.sh
@@ -3,13 +3,21 @@
 # TODO documentation
 
 print_toolchain_installation_notice() {
-  echo " +----------------------------------------------------------------------------------+"
-  echo " |  A rust toolchain will be installed locally in a temporary directory (./tmp).    |"
-  echo " |                                                                                  |"
-  echo " |  If you intend to develop on the RxPlayer regularly, it is recommended that you  |"
-  echo " |  install globally rustup (with the \"wasm32-unknown-unknown\" target) as well as   |"
-  echo " |  binaryen. Once done, please remove this \"tmp\" directory.                        |"
-  echo " +----------------------------------------------------------------------------------+"
+  echo ""
+  echo ""
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer building Info  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo ""
+  echo "   A Rust toolchain is needed to build some components of the RxPlayer."
+  echo "   We will thus now install one locally in the following temporary directory:"
+  echo "   $(pwd)/tmp "
+  echo ""
+  echo "   If you intend to develop or build the RxPlayer regularly, you can install rustup or"
+  echo "   cargo globally (with the \"wasm32-unknown-unknown\" target) as well as binaryen."
+  echo "   Once done, this \"tmp\" directory can be removed."
+  echo ""
+  echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+  echo ""
+  echo ""
 }
 
 has_local_cargo=false
@@ -47,18 +55,18 @@ fi
 
 # Move to MPD parser directory
 cd ./src/parsers/manifest/dash/wasm-parser
-echo "Building mpd-parser WebAssembly file with Cargo..."
+echo " 🦀 Building mpd-parser WebAssembly file with Cargo..."
 if $has_local_cargo; then
-  echo "⚠️  NOTE  ⚠️ : Relying on local cargo in ./tmp/cargo/bin/cargo"
+  echo "NOTE: Relying on local cargo in ./tmp/cargo/bin/cargo"
   . ../../../../../tmp/cargo/env
-  ../../../../../tmp/cargo/bin/cargo build --target wasm32-unknown-unknown --release
+  ../../../../../tmp/cargo/bin/cargo build --target wasm32-unknown-unknown --release -q
 else
-  cargo build --target wasm32-unknown-unknown --release
+  cargo build --target wasm32-unknown-unknown --release -q
 fi
 
-echo "Optimizing mpd-parser WebAssembly build..."
+echo " 🪚 Optimizing mpd-parser WebAssembly build..."
 if $has_local_wasmopt; then
-  echo "⚠️  NOTE  ⚠️ : Relying on local wasm-opt in ./tmp/binaryen/bin/wasm-opt"
+  echo "NOTE: Relying on local wasm-opt in ./tmp/binaryen/bin/wasm-opt"
   ../../../../../tmp/binaryen/bin/wasm-opt target/wasm32-unknown-unknown/release/mpd_node_parser.wasm --signext-lowering --strip-dwarf -O4 -o ../../../../../dist/mpd-parser.wasm
 else
   wasm-opt target/wasm32-unknown-unknown/release/mpd_node_parser.wasm --signext-lowering --strip-dwarf -O4 -o ../../../../../dist/mpd-parser.wasm

--- a/scripts/clean_build.mjs
+++ b/scripts/clean_build.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import { spawn, execSync } from "child_process";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import removeDir from "./remove_dir.mjs";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.join(currentDirectory, "..");
+
+// If true, this script is called directly
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  build();
+}
+
+/**
+ * @param {Object} [options]
+ * @param {boolean} [options.cleanAfterBuild]
+ * @param {boolean} [options.verbose]
+ * @returns {Promise}
+ */
+export async function build(options = {}) {
+  console.log(` 🚚 Installing JS development dependencies...`);
+  try {
+    await npmInstall({ verbose: options.verbose === true });
+    console.log(" 🚧 Dependencies installed. Now switching to building the RxPlayer...");
+
+    // Note we dynamically export only know because we required some dependencies
+    // that are only now imported. This is hacky... but it works!
+    const { default: generateBuilds } = await import(
+      path.join(currentDirectory, "generate_build.mjs")
+    );
+    await generateBuilds({ devMode: false });
+    if (options.cleanAfterBuild) {
+      cleanAfterBuild();
+    }
+  } catch (err) {
+    if (options.cleanAfterBuild) {
+      try {
+        cleanAfterBuild();
+      } catch (_e) {}
+    }
+    console.error(err instanceof Error ? err.toString() : "Unknown Error");
+    process.exit(1);
+  }
+}
+
+async function cleanAfterBuild() {
+  console.log(" 🧼 Cleaning build dependencies...");
+  await Promise.all([
+    removeDir(path.join(ROOT_DIR, "node_modules")),
+    removeDir(path.join(ROOT_DIR, "tmp")),
+  ]);
+  console.log(" ✅ Cleaned");
+}
+
+/**
+ * @param {Object} options
+ * @param {boolean} options.verbose
+ * @returns {Promise}
+ */
+function npmInstall({ verbose }) {
+  return new Promise((res, rej) => {
+    const npmExecutable = getRightNpmExecutablePath();
+    process.chdir(ROOT_DIR);
+    if (verbose) {
+      console.info(
+        `Calling "${npmExecutable} install"`,
+        `from the "${ROOT_DIR}" directory`,
+      );
+    }
+    spawn(npmExecutable, ["ci", "--silent"], {
+      shell: true,
+      stdio: "inherit",
+    }).on("close", (code) => {
+      if (code !== 0) {
+        rej(new Error(`Dependency installation process exited with code ${code}`));
+      }
+      res();
+    });
+  });
+}
+
+/**
+ * Returns name of the executable to run `npm` on a shell.
+ *
+ * When running from an npm script context (e.g. a `postinstall` script),
+ * node might rely on the corresponding package's node_modules/npm directory
+ * first before the PATH when calling the `npm` executable.
+ *
+ * Due to how the JS ecosystem is, those are often subdependencies and are
+ * very often much less up-to-date that a local `npm`, which - if the user
+ * has node.js installed on his / her / its (e.g. CI) computer, is probably
+ * already there too.
+ *
+ * Yet we've seen issues with old (2017?) npm versions where installing our
+ * dependencies would randomly break (maybe due to one of our dependencies'
+ * `postinstall` script? I didn't dive into it yet), so if we are left
+ * with an old npm executable here, we check if we're in the `node_modules`
+ * situation by checking things with `whereis` + `command -v` (which we guess
+ * the user also generally have - unless they rely on more exotic OSs and
+ * they should generally know what to do to debug things here, or they
+ * rely on Windows without WSL and, well, those people are already
+ * masochistic to begin with, so added pain for them is fine).
+ *
+ * If something doesn't work here, we just throw and abort the operation.
+ * @returns {string}
+ */
+function getRightNpmExecutablePath() {
+  let npmExecutable = "npm";
+  const npmVersion = String(execSync(npmExecutable + " -v"));
+  const majorVersion = parseInt(npmVersion.split(".")[0], 10);
+  if (!isNaN(majorVersion) && majorVersion < 6) {
+    // Older versions of `npm` seem to break (seen on npm 5, but we'll also
+    // consider 6 here as a security
+    const whichNpm = String(execSync("command -v npm")).trim();
+    let npmLocations = String(execSync("whereis npm"))
+      .split(" ")
+      // Maybe not needed, but better safe than sorry
+      .filter((s) => s.trim().length > 0);
+
+    if (npmLocations[0] === "npm:") {
+      npmLocations = npmLocations.slice(1);
+    }
+    if (
+      whichNpm.indexOf("node_modules") >= 0 &&
+      ((npmLocations.includes(whichNpm) && npmLocations.length > 1) ||
+        npmLocations.length >= 1)
+    ) {
+      if (npmLocations[0] === whichNpm) {
+        npmExecutable = npmLocations[1].trim();
+      } else {
+        npmExecutable = npmLocations[0].trim();
+      }
+      console.warn(
+        `The "npm" command seems to call a local package ("${whichNpm}").` +
+          ` Relying on "${npmExecutable}" instead`,
+      );
+    }
+  }
+  return npmExecutable;
+}

--- a/scripts/generate_build.mjs
+++ b/scripts/generate_build.mjs
@@ -55,7 +55,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
  * @param {Object|undefined} options
  * @returns {Promise}
  */
-async function generateBuild(options = {}) {
+export default async function generateBuild(options = {}) {
   try {
     const devMode = options.devMode === true;
     console.log(" 🧹 Removing previous build artefacts...");
@@ -70,7 +70,7 @@ async function generateBuild(options = {}) {
     if (!fs.existsSync(dashWasmDir)) {
       console.log(" 🏭 Generating WebAssembly file...");
       await spawnProm(
-        "npm run " + (devMode ? "build:wasm:debug" : "build:wasm:release"),
+        "npm run --silent " + (devMode ? "build:wasm:debug" : "build:wasm:release"),
         [],
         (code) => new Error(`WebAssembly compilation process exited with code ${code}`),
       );

--- a/scripts/install_rust_toolchain.sh
+++ b/scripts/install_rust_toolchain.sh
@@ -4,7 +4,7 @@
 
 # Log a line to stdout, prefixing it with the name of this script
 log() {
-  printf 'install_rust_toolchain: %s\n' "$1"
+  printf 'rx-player > install_rust_toolchain: %s\n' "$1"
 }
 
 # Log a line to sterr, prefixing it with the name of this script
@@ -32,7 +32,8 @@ ensure() {
   fi
 }
 
-log "This script will only install dependencies locally in a ./tmp directory"
+log "This script will install Rust dependencies locally in the following directory: $(pwd)/tmp"
+log "A lot of logs may be produced by this installation, they can mostly be ignored."
 
 requires_cmd curl
 requires_cmd tar
@@ -143,5 +144,5 @@ if ! [ -f tmp/binaryen/bin/wasm-opt ]; then
   err "Error after installing binaryen: wasm-opt not available in ./tmp/binaryen/bin/wasm-opt"
 fi
 
-echo ""
-echo "All dependencies have been installed with success!"
+log "All Rust dependencies have been installed"
+log "Exiting the current script with success!"


### PR DESCRIPTION
Quick description
-----------------

This PR is a proposal to allow applications using the RxPlayer to easily depend on an RxPlayer development branch or any commit pushed to Github directly in their package.json, which is as easy as adding:
```json
    "rx-player": "canalplus/rx-player#<GIT_BRANCH_OR_SHA_1>",
```
To the `package.json` (instead of the usual version).

_Almost too easy, surely this has nothing to do with npm being a Github subsidiary._

Once they do that, [they just have to run a script we export](https://github.com/canalplus/rx-player/blob/bf506575929ced0a94dc906011fe0e98b66d7232/README.md#test-an-rxplayer-branch-from-your-application), which will allow them to very easily test future features, fixes and improvements without our active involvement.

Previous situation
------------------

Doing this previously was never really easy in the end because we don't push builds to GitHub, and so npm/yarn, in the applications' project, would just pull our source code and then don't know what to do with it, ultimately throwing on unfound files when they try to build their project.

We, RxPlayer developers, relied on that trick as we knew how to navigate that type of situation but didn't ask application developers to do so because the work-arounds to do depended on the project and were sometimes hacky (updating things in their CI, circumventing a local npm install etc.).

Instead, when we had to ask developers to test, we had several solutions on a case-by-case basis, yet none of them were perfect.

The added `clean_build.mjs` script
----------------------------------

This PR adds a file `scripts/clean_build.mjs` which doesn't require any dependency besides node standard ones.
It dynamically calls `npm install` and then once done build the rx-player in place, by importing the right script.

There are some tricks because node/npm/yarn like doing black magic, one of the main one is an issue we had for a long time on one of Canal+'s application: For some reasons, they depend on a very old version of a dependency (from 2017) which for some other very weird reason has an hard dependency on `npm` (also one from 2017, a literal dinosaur).

Because of this, a very old version of `npm` is installed in their `node_modules` directory, and thus when running the `clean_build.mjs` script from a `package.json`'s script (which is the easiest way to run it), the `npm` command actually call that very old version which somehow do not succeed to install our dependencies (one of ours must have a nasty poorly compatible `postinstall` script I guess?).

So I added here a kind-of ugly work-around: if `npm --version` seems to return a very old version, we check if we're not relying on a local npm. If we are (there's `node_modules` in the path), we use `whereis` to use another one if it exists. This is complex magic thing I don't like to do, but when the opponent also rely on magic I have few choices left.

How to run this
---------------

At first, I thought I could just add a `postinstall` script inside the RxPlayer, which would check if the builds are made on the pulled dependency, and if not, produce them.

It works and would have made depending on a git branch **VERY** easy, but I thought it wasn't really polite to execute on all applications pulling us some random scripts - which could have bugs - and which ran some executable (`npm`, `whereis` etc.) on the host.

So I changed my mind and chose to expose the `clean_build.mjs` script from the `"rx-player/scripts/build"` path instead.

The idea is that an application will have to iself create some script (doable from a `package.json` `postinstall` script), which will import that file and call the build function from it.

This is a little more involved, even more due to the CommonJS/ES module shenanigans which kind of forces us to create a temporary file in the meantime with an `.mjs` extension, but everyone should be able to do it.

Thus I chose to add instructions in our `README.md` to tell people how to run this, the idea is that we would redirect people both to the git hash to pull and to that `README.md` chapter to tell them how they can test it in their application.