### PR TITLE
[v3]  DRM: Re-create MediaKeys for each content on Philips' NETTV 

### DIFF
--- a/src/compat/__tests__/can_reuse_media_keys.test.ts
+++ b/src/compat/__tests__/can_reuse_media_keys.test.ts
@@ -8,10 +8,14 @@ describe("Compat - canReuseMediaKeys", () => {
     jest.resetModules();
   });
 
-  it("should return true on any browser but WebOS", () => {
+  it("should return true on most browsers", () => {
     jest.mock("../browser_detection", () => {
-      return { __esModule: true as const,
-               isWebOs: false };
+      return {
+        __esModule: true as const,
+        isWebOs: false,
+        isPhilipsNetTv: false,
+        isPanasonic: false,
+      };
     });
     const canReuseMediaKeys =
       jest.requireActual("../can_reuse_media_keys.ts");
@@ -20,12 +24,43 @@ describe("Compat - canReuseMediaKeys", () => {
 
   it("should return false on WebOs", () => {
     jest.mock("../browser_detection", () => {
-      return { __esModule: true as const,
-               isWebOs: true,
-               isWebOs2022: false };
+      return {
+        __esModule: true as const,
+        isWebOs: true,
+        isWebOs2022: false,
+        isPanasonic: false,
+        isPhilipsNetTv: false,
+      };
     });
-    const canReuseMediaKeys =
-      jest.requireActual("../can_reuse_media_keys.ts");
+    const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on Panasonic", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: true,
+        isPhilipsNetTv: false,
+      };
+    });
+    const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on Philips' NETTV", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: false,
+        isPhilipsNetTv: true,
+      };
+    });
+    const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");
     expect(canReuseMediaKeys.default()).toBe(false);
   });
 });

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -60,6 +60,9 @@ let isWebOs2022 = false;
 /** `true` for Panasonic devices. */
 let isPanasonic = false;
 
+/** `true` we're relying on Philips's NetTv browser. */
+let isPhilipsNetTv = false;
+
 /** `true` for the PlayStation 5 game console. */
 let isPlayStation5 = false;
 
@@ -143,6 +146,11 @@ let isXbox = false;
     ) {
       isWebOs2021 = true;
     }
+  } else if (
+    navigator.userAgent.indexOf("NETTV") !== -1 &&
+    navigator.userAgent.indexOf("Philips") !== -1
+  ) {
+    isPhilipsNetTv = true;
   } else if (/[Pp]anasonic/.test(navigator.userAgent)) {
     isPanasonic = true;
   } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
@@ -160,6 +168,7 @@ export {
   isIEOrEdge,
   isFirefox,
   isPanasonic,
+  isPhilipsNetTv,
   isPlayStation5,
   isXbox,
   isSafariDesktop,

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,5 +1,6 @@
 import {
   isPanasonic,
+  isPhilipsNetTv,
   isWebOs,
 } from "./browser_detection";
 
@@ -12,9 +13,11 @@ import {
  *   - (2022-11-21): WebOS (LG TVs), for some encrypted contents, just
  *     rebuffered indefinitely when loading a content already-loaded on the
  *     HTMLMediaElement.
+ *   - (2024-08-23): Seen on Philips 2024 and 2023 in:
+ *     https://github.com/canalplus/rx-player/issues/1464
  *
  * @returns {boolean}
  */
-export default function canReuseMediaKeys() : boolean {
-  return !isWebOs && !isPanasonic;
+export default function canReuseMediaKeys(): boolean {
+  return !isWebOs && !isPhilipsNetTv && !isPanasonic;
 }


### PR DESCRIPTION
 This is a backport of #1515 for the v3