### PR TITLE
ci: add workflow to publish a package with gzip

### DIFF
--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -1,0 +1,91 @@
+name: Publish preview package
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+jobs:
+  inform-preview:
+    if: ${{github.repository != 'canalplus/rx-player' && 
+      github.event.action == 'opened'}}
+    runs-on: [ubuntu-latest]
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `You can deploy a preview version of the RxPlayer with the current branch by adding the tag \`deploy\` to the pull request.`
+            })
+
+  publish-preview-package:
+    # This action only runs on forks because it pushes a new release.
+    # It is not wanted on the main repository as it would spam the releases.
+    if: ${{github.repository != 'canalplus/rx-player' && 
+      (github.event.action == 'opened' ||
+      github.event.action == 'synchronize' ||
+      github.event.action == 'reopened') &&
+      contains(github.event.pull_request.labels.*.name, 'deploy') ||
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'deploy'}}
+
+    runs-on: [ubuntu-latest]
+    permissions:
+      packages: write
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 20
+          scope: "@${{ github.repository_owner }}"
+          registry-url: "https://npm.pkg.github.com"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Library
+        run: npm run build
+
+      - name: Create Zip file
+        run: echo "npm-pack=$(npm pack)" >> $GITHUB_OUTPUT
+        id: npm-pack
+      
+      - name: Upload Zip to release
+        uses: svenstaro/upload-release-action@v2
+        id: upload-action
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.npm-pack.outputs.npm-pack }}
+          asset_name: rx-player.tgz
+          tag: "preview.${{ github.sha }}"
+          release_name: "preview.${{ github.sha }}"
+          overwrite: true
+          body: "This is my release text"
+
+      - name: Comment PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `A gzipped version of the branch has been deployed to the following URL:  
+            ${{steps.upload-action.outputs.browser_download_url}}  
+            
+            You can import it by changing your \`package.json\`:
+            \`\`\`json
+            "rx-player": "${{steps.upload-action.outputs.browser_download_url}}"
+            \`\`\`
+            Then run:
+            \`npm install\``
+            })

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -55,11 +55,11 @@ jobs:
       - name: Build Library
         run: npm run build
 
-      - name: Create Zip file
+      - name: Create archive
         run: echo "npm-pack=$(npm pack)" >> $GITHUB_OUTPUT
         id: npm-pack
       
-      - name: Upload Zip to release
+      - name: Upload archive to release
         uses: svenstaro/upload-release-action@v2
         id: upload-action
         with:
@@ -69,7 +69,7 @@ jobs:
           tag: "preview.${{ github.sha }}"
           release_name: "preview.${{ github.sha }}"
           overwrite: true
-          body: "This is my release text"
+          body: "Autobuild from branch ${{github.ref_name}}, commit hash: ${{github.sha}}, date: ${{ github.event.repository.updated_at }}"
 
       - name: Comment PR
         uses: actions/github-script@v6

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -19,7 +19,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `You can deploy a preview version of the RxPlayer with the current branch by adding the tag \`deploy\` to the pull request.`
+              body: `You can deploy a preview version of the RxPlayer with the current branch by adding the label \`deploy\` to the pull request.`
             })
 
   publish-preview-package:

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
-  inform-autobuilt:
+  inform-autobuild:
     if: ${{github.repository != 'canalplus/rx-player' && github.event.action == 'opened'}}
     runs-on: [ubuntu-latest]
     permissions:
@@ -18,7 +18,8 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `You can deploy a built version of the RxPlayer with the current branch by adding the label \`deploy\` to the pull request.`
+              body: `You can deploy a built version of the RxPlayer with the current branch by adding the label \`deploy\` to the pull request.
+              This will create a release on your github fork with name \`autobuild.${{ github.sha }}\` `
             })
 
   publish-autobuild-package:

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -1,10 +1,10 @@
-name: Publish preview package
+name: Publish autobuild package
 on: 
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
-  inform-preview:
+  inform-autobuilt:
     if: ${{github.repository != 'canalplus/rx-player' && 
       github.event.action == 'opened'}}
     runs-on: [ubuntu-latest]
@@ -19,10 +19,10 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `You can deploy a preview version of the RxPlayer with the current branch by adding the label \`deploy\` to the pull request.`
+              body: `You can deploy a built version of the RxPlayer with the current branch by adding the label \`deploy\` to the pull request.`
             })
 
-  publish-preview-package:
+  publish-autobuild-package:
     # This action only runs on forks because it pushes a new release.
     # It is not wanted on the main repository as it would spam the releases.
     if: ${{github.repository != 'canalplus/rx-player' && 
@@ -66,8 +66,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.npm-pack.outputs.npm-pack }}
           asset_name: rx-player.tgz
-          tag: "preview.${{ github.sha }}"
-          release_name: "preview.${{ github.sha }}"
+          tag: "autobuild.${{ github.sha }}"
+          release_name: "autobuild.${{ github.sha }}"
           overwrite: true
           body: "Autobuild from branch ${{github.ref_name}}, commit hash: ${{github.sha}}, date: ${{ github.event.repository.updated_at }}"
 
@@ -79,7 +79,7 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `A gzipped version of the branch has been deployed to the following URL:  
+              body: `A built version of the branch has been deployed to the following URL:  
             ${{steps.upload-action.outputs.browser_download_url}}  
             
             You can import it by changing your \`package.json\`:

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -1,12 +1,11 @@
 name: Publish autobuild package
-on: 
+on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
   inform-autobuilt:
-    if: ${{github.repository != 'canalplus/rx-player' && 
-      github.event.action == 'opened'}}
+    if: ${{github.repository != 'canalplus/rx-player' && github.event.action == 'opened'}}
     runs-on: [ubuntu-latest]
     permissions:
       pull-requests: write
@@ -25,13 +24,11 @@ jobs:
   publish-autobuild-package:
     # This action only runs on forks because it pushes a new release.
     # It is not wanted on the main repository as it would spam the releases.
-    if: ${{github.repository != 'canalplus/rx-player' && 
-      (github.event.action == 'opened' ||
-      github.event.action == 'synchronize' ||
-      github.event.action == 'reopened') &&
-      contains(github.event.pull_request.labels.*.name, 'deploy') ||
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'deploy'}}
+    if:
+      ${{github.repository != 'canalplus/rx-player' && (github.event.action == 'opened' ||
+      github.event.action == 'synchronize' || github.event.action == 'reopened') &&
+      contains(github.event.pull_request.labels.*.name, 'deploy') || github.event.action
+      == 'labeled' && github.event.label.name == 'deploy'}}
 
     runs-on: [ubuntu-latest]
     permissions:
@@ -58,7 +55,7 @@ jobs:
       - name: Create archive
         run: echo "npm-pack=$(npm pack)" >> $GITHUB_OUTPUT
         id: npm-pack
-      
+
       - name: Upload archive to release
         uses: svenstaro/upload-release-action@v2
         id: upload-action
@@ -69,7 +66,9 @@ jobs:
           tag: "autobuild.${{ github.sha }}"
           release_name: "autobuild.${{ github.sha }}"
           overwrite: true
-          body: "Autobuild from branch ${{github.ref_name}}, commit hash: ${{github.sha}}, date: ${{ github.event.repository.updated_at }}"
+          body:
+            "Autobuild from branch ${{github.ref_name}}, commit hash: ${{github.sha}},
+            date: ${{ github.event.repository.updated_at }}"
 
       - name: Comment PR
         uses: actions/github-script@v6
@@ -81,7 +80,7 @@ jobs:
               repo: context.repo.repo,
               body: `A built version of the branch has been deployed to the following URL:  
             ${{steps.upload-action.outputs.browser_download_url}}  
-            
+
             You can import it by changing your \`package.json\`:
             \`\`\`json
             "rx-player": "${{steps.upload-action.outputs.browser_download_url}}"

--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,7 @@
 /localhost.key
 /node_modules
 /webpack-demo.config.mjs
-
+/tmp
 /demo
 
 /tests


### PR DESCRIPTION
This PR add a workflow to deploy a gzipped version of the rx-player that is uploaded to the github release.

The use case is to easily deploy a version of the player and quickly iterate based on feedback from partners who need to test early-stage changes. This approach allows for testing updates that are not yet ready for a formal release or even a beta version.
It use Github releases since it's simple enough and release can be deleted easily (in contrary to npm releases).

To keep the Releases section in the official repository clean and avoid cluttering it with development releases, this workflow run only on forks.

The workflow is trigger on pull request.

The version can be installed by changing in the package.json
```
"rx-player": "https://github.com/<user-name>/rx-player/releases/download/preview.<preview.sha>/rx-player.tgz"
```
and then running:
```
npm install
```