### PR TITLE
fix: correctly remove period from active periods if time get out of period range in mutli-thread

### DIFF
--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -744,6 +744,7 @@ function loadOrReloadPreparedContent(
           }
         }
 
+        contentTimeBoundariesObserver.onPeriodCleared(value.type, value.period);
         preparedContent.trackChoiceSetter.removeTrackSetter(value.period.id, value.type);
         sendMessage({
           type: WorkerMessageType.PeriodStreamCleared,


### PR DESCRIPTION
When a content has several periods, `RxPlayer.getCurrentPeriods()` return the first active period, however in the multi_thread mode, active periods are not correctly remove once the period has been fully played, this result with `RxPlayer.getCurrentPeriods()` to return incorrect period that are not active anymore.

fixes https://github.com/canalplus/rx-player/issues/1525