### PR TITLE
Fix issue when reloading while a reload is pending.

### DIFF
--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -884,6 +884,10 @@ function loadOrReloadPreparedContent(
         );
       },
       (err: unknown) => {
+        if (TaskCanceller.isCancellationError(err)) {
+          log.info("WP: A reloading operation was cancelled");
+          return;
+        }
         sendMessage({
           type: WorkerMessageType.Error,
           contentId,


### PR DESCRIPTION
I noticed of an issue with the `MULTI_THREAD` feature, where an application would receive a `CancellationError` in the very rare (possible right now?) occurrence where we're reloading while a reload operation is already pending.

We don't ever want to leak `CancellationError` which is just an internal mechanism. I thought that we can just ignore that one.

NOTE: This was seen after testing #1523 on some devices