### PR TITLE
Add A1 KSTB 40XX to our list of devices which cannot reuse MediaKeys

### DIFF
--- a/src/compat/__tests__/can_reuse_media_keys.test.ts
+++ b/src/compat/__tests__/can_reuse_media_keys.test.ts
@@ -8,7 +8,12 @@ describe("Compat - canReuseMediaKeys", () => {
 
   it("should return true on most browsers", async () => {
     vi.doMock("../browser_detection", () => {
-      return { isWebOs: false, isPhilipsNetTv: false, isPanasonic: false };
+      return {
+        isA1KStb40xx: false,
+        isWebOs: false,
+        isPhilipsNetTv: false,
+        isPanasonic: false,
+      };
     });
     const canReuseMediaKeys = (await vi.importActual("../can_reuse_media_keys.ts"))
       .default as typeof ICanReuseMediaKeys;
@@ -18,6 +23,7 @@ describe("Compat - canReuseMediaKeys", () => {
   it("should return false on WebOs", async () => {
     vi.doMock("../browser_detection", () => {
       return {
+        isA1KStb40xx: false,
         isWebOs: true,
         isWebOs2022: false,
         isPanasonic: false,
@@ -32,6 +38,7 @@ describe("Compat - canReuseMediaKeys", () => {
   it("should return false on Panasonic", async () => {
     vi.doMock("../browser_detection", () => {
       return {
+        isA1KStb40xx: false,
         isWebOs: false,
         isWebOs2022: false,
         isPanasonic: true,
@@ -46,10 +53,26 @@ describe("Compat - canReuseMediaKeys", () => {
   it("should return false on Philips' NETTV", async () => {
     vi.doMock("../browser_detection", () => {
       return {
+        isA1KStb40xx: false,
         isWebOs: false,
         isWebOs2022: false,
         isPanasonic: false,
         isPhilipsNetTv: true,
+      };
+    });
+    const canReuseMediaKeys = (await vi.importActual("../can_reuse_media_keys.ts"))
+      .default as typeof ICanReuseMediaKeys;
+    expect(canReuseMediaKeys()).toBe(false);
+  });
+
+  it("should return false on A1 KSTB 40xxx", async () => {
+    vi.doMock("../browser_detection", () => {
+      return {
+        isA1KStb40xx: true,
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: false,
+        isPhilipsNetTv: false,
       };
     });
     const canReuseMediaKeys = (await vi.importActual("../can_reuse_media_keys.ts"))

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -79,6 +79,9 @@ let isPlayStation5 = false;
 /** `true` for the Xbox game consoles. */
 let isXbox = false;
 
+/** `true` for specific A1 STB: KSTB 40xx from Kaon Media. */
+let isA1KStb40xx = false;
+
 (function findCurrentBrowser(): void {
   if (isNode) {
     return;
@@ -167,24 +170,30 @@ let isXbox = false;
     isPanasonic = true;
   } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
     isXbox = true;
+  } else if (navigator.userAgent.indexOf("Model/a1-kstb40xx")) {
+    isA1KStb40xx = true;
   }
 })();
 
 export {
+  // browsers
   isEdgeChromium,
+  isFirefox,
   isIE11,
   isIEOrEdge,
-  isFirefox,
+  isSafariDesktop,
+  isSafariMobile,
+
+  // specific devices
+  isA1KStb40xx,
   isPanasonic,
   isPhilipsNetTv,
   isPlayStation4,
   isPlayStation5,
-  isXbox,
-  isSafariDesktop,
-  isSafariMobile,
   isSamsungBrowser,
   isTizen,
   isWebOs,
   isWebOs2021,
   isWebOs2022,
+  isXbox,
 };

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,4 +1,4 @@
-import { isPanasonic, isPhilipsNetTv, isWebOs } from "./browser_detection";
+import { isA1KStb40xx, isPanasonic, isPhilipsNetTv, isWebOs } from "./browser_detection";
 
 /**
  * Returns `true` if a `MediaKeys` instance (the  `Encrypted Media Extension`
@@ -11,9 +11,13 @@ import { isPanasonic, isPhilipsNetTv, isWebOs } from "./browser_detection";
  *     HTMLMediaElement.
  *   - (2024-08-23): Seen on Philips 2024 and 2023 in:
  *     https://github.com/canalplus/rx-player/issues/1464
+ *   - (2024-09-04): Another case seen on an "A1" set-top box model made by
+ *     Kaonmedia we will call the KSTB40xx.
+ *     It may share the problematic with other devices, but we have only seen
+ *     the problem on this one for now.
  *
  * @returns {boolean}
  */
 export default function canReuseMediaKeys(): boolean {
-  return !isWebOs && !isPhilipsNetTv && !isPanasonic;
+  return !isWebOs && !isPhilipsNetTv && !isPanasonic && !isA1KStb40xx;
 }


### PR DESCRIPTION
A partner encountered new cases where multiple content loadings lead to issues, that disappeared if we re-create the `MediaKeys` instance at each load.

There may be a common denominator (like common software) between the raising list of devices on which we see the issue recently, but we did not pinpoint it for now, here so I only detect the specific device and perform the work-around on it and the other devices on which it has been seen for now.