### PR TITLE
Fix logging string in a Worker environment sent back to main thread

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -138,18 +138,17 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
       /* eslint-enable no-console */
       /* eslint-enable no-invalid-this */
     } else {
-      const produceLogFn = (logLevel: ILoggerLevel, namespace: string) => {
+      const produceLogFn = (logLevel: ILoggerLevel) => {
         return level >= this._levels[logLevel]
           ? (...args: IAcceptedLogValue[]) => {
-              const now = getMonotonicTimeStamp();
-              return logFn(logLevel, [now, namespace, ...args]);
+              return logFn(logLevel, args);
             }
           : noop;
       };
-      this.error = produceLogFn("ERROR", "error");
-      this.warn = produceLogFn("WARNING", "warn");
-      this.info = produceLogFn("INFO", "info");
-      this.debug = produceLogFn("DEBUG", "log");
+      this.error = produceLogFn("ERROR");
+      this.warn = produceLogFn("WARNING");
+      this.info = produceLogFn("INFO");
+      this.debug = produceLogFn("DEBUG");
     }
 
     this.trigger("onLogLevelChange", {


### PR DESCRIPTION
I noticed that when logs were produced Worker-side then sent back to the main thread - something only possible under `__RX_PLAYER_DEBUG_MODE__` (which I would guess is for now only used by our `RxPaired` remote debugger and our closed-source html logger) - they repeated the timestamp and level on the log message itself, even in a `standard` `LogFormat` (whereas this behavior looks like the one under the `full` `LogFormat`).

I don't remember what the idea was, but it seems unnecessary, even under a `full` `LogFormat`, the supplementary timestamp and level information would be added on main thread anyway.

The only advantage I can think of is that here we also were having a worker-side timestamp, which would be more precize on when the log has been produced. I'm however not sure we would need this.