### PR TITLE
[v3] Add A1 KSTB 40XX to our list of devices which cannot reuse MediaKeys

### DIFF
--- a/src/compat/__tests__/can_reuse_media_keys.test.ts
+++ b/src/compat/__tests__/can_reuse_media_keys.test.ts
@@ -12,13 +12,13 @@ describe("Compat - canReuseMediaKeys", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true as const,
+        isA1KStb40xx: false,
         isWebOs: false,
         isPhilipsNetTv: false,
         isPanasonic: false,
       };
     });
-    const canReuseMediaKeys =
-      jest.requireActual("../can_reuse_media_keys.ts");
+    const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");
     expect(canReuseMediaKeys.default()).toBe(true);
   });
 
@@ -26,6 +26,7 @@ describe("Compat - canReuseMediaKeys", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true as const,
+        isA1KStb40xx: false,
         isWebOs: true,
         isWebOs2022: false,
         isPanasonic: false,
@@ -40,6 +41,7 @@ describe("Compat - canReuseMediaKeys", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true as const,
+        isA1KStb40xx: false,
         isWebOs: false,
         isWebOs2022: false,
         isPanasonic: true,
@@ -54,10 +56,26 @@ describe("Compat - canReuseMediaKeys", () => {
     jest.mock("../browser_detection", () => {
       return {
         __esModule: true as const,
+        isA1KStb40xx: false,
         isWebOs: false,
         isWebOs2022: false,
         isPanasonic: false,
         isPhilipsNetTv: true,
+      };
+    });
+    const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");
+    expect(canReuseMediaKeys.default()).toBe(false);
+  });
+
+  it("should return false on A1 KSTB 40xxx", () => {
+    jest.mock("../browser_detection", () => {
+      return {
+        __esModule: true as const,
+        isA1KStb40xx: true,
+        isWebOs: false,
+        isWebOs2022: false,
+        isPanasonic: false,
+        isPhilipsNetTv: false,
       };
     });
     const canReuseMediaKeys = jest.requireActual("../can_reuse_media_keys.ts");

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -69,6 +69,9 @@ let isPlayStation5 = false;
 /** `true` for the Xbox game consoles. */
 let isXbox = false;
 
+/** `true` for specific A1 STB: KSTB 40xx from Kaon Media. */
+let isA1KStb40xx = false;
+
 ((function findCurrentBrowser() : void {
   if (isNode) {
     return ;
@@ -155,6 +158,8 @@ let isXbox = false;
     isPanasonic = true;
   } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
     isXbox = true;
+  } else if (navigator.userAgent.indexOf("Model/a1-kstb40xx")) {
+    isA1KStb40xx = true;
   }
 })());
 
@@ -163,19 +168,23 @@ interface ISafariWindowObject extends Window {
 }
 
 export {
+  // browsers
   isEdgeChromium,
+  isFirefox,
   isIE11,
   isIEOrEdge,
-  isFirefox,
+  isSafariDesktop,
+  isSafariMobile,
+
+  // specific devices
+  isA1KStb40xx,
   isPanasonic,
   isPhilipsNetTv,
   isPlayStation5,
-  isXbox,
-  isSafariDesktop,
-  isSafariMobile,
   isSamsungBrowser,
   isTizen,
   isWebOs,
   isWebOs2021,
   isWebOs2022,
+  isXbox,
 };

--- a/src/compat/can_reuse_media_keys.ts
+++ b/src/compat/can_reuse_media_keys.ts
@@ -1,4 +1,5 @@
 import {
+  isA1KStb40xx,
   isPanasonic,
   isPhilipsNetTv,
   isWebOs,
@@ -15,9 +16,13 @@ import {
  *     HTMLMediaElement.
  *   - (2024-08-23): Seen on Philips 2024 and 2023 in:
  *     https://github.com/canalplus/rx-player/issues/1464
+ *   - (2024-09-04): Another case seen on an "A1" set-top box model made by
+ *     Kaonmedia we will call the KSTB40xx.
+ *     It may share the problematic with other devices, but we have only seen
+ *     the problem on this one for now.
  *
  * @returns {boolean}
  */
 export default function canReuseMediaKeys(): boolean {
-  return !isWebOs && !isPhilipsNetTv && !isPanasonic;
+  return !isWebOs && !isPhilipsNetTv && !isPanasonic && !isA1KStb40xx;
 }


### PR DESCRIPTION
This is a backport of #1530 for the v3