### PR TITLE
Add `isRepresentationPlayable` util

### DIFF
--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -6,6 +6,7 @@ import type {
   IRepresentation,
   ISegment,
 } from "../../manifest";
+import { isRepresentationPlayable } from "../../manifest";
 import type {
   IReadOnlyPlaybackObserver,
   IRebufferingStatus,
@@ -333,10 +334,7 @@ export default class CmcdDataBuilder {
     props.st = content.manifest.isDynamic ? "l" : "v";
     props.tb = content.adaptation.representations.reduce(
       (acc: number | undefined, representation: IRepresentation) => {
-        if (
-          representation.isSupported !== true ||
-          representation.decipherable === false
-        ) {
+        if (isRepresentationPlayable(representation) !== true) {
           return acc;
         }
         if (acc === undefined) {

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -6,7 +6,6 @@ import type {
   IRepresentation,
   ISegment,
 } from "../../manifest";
-import { isRepresentationPlayable } from "../../manifest";
 import type {
   IReadOnlyPlaybackObserver,
   IRebufferingStatus,
@@ -334,7 +333,7 @@ export default class CmcdDataBuilder {
     props.st = content.manifest.isDynamic ? "l" : "v";
     props.tb = content.adaptation.representations.reduce(
       (acc: number | undefined, representation: IRepresentation) => {
-        if (isRepresentationPlayable(representation) !== true) {
+        if (representation.isPlayable() !== true) {
           return acc;
         }
         if (acc === undefined) {

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -2,6 +2,7 @@ import config from "../../../config";
 import { formatError } from "../../../errors";
 import log from "../../../log";
 import type { IRepresentation } from "../../../manifest";
+import { isRepresentationPlayable } from "../../../manifest";
 import arrayIncludes from "../../../utils/array_includes";
 import { assertUnreachable } from "../../../utils/assert";
 import cancellableSleep from "../../../utils/cancellable_sleep";
@@ -95,10 +96,7 @@ export default function AdaptationStream(
 
   const initialRepIds = content.representations.getValue().representationIds;
   const initialRepresentations = content.adaptation.representations.filter(
-    (r) =>
-      arrayIncludes(initialRepIds, r.id) &&
-      r.decipherable !== false &&
-      r.isSupported !== false,
+    (r) => arrayIncludes(initialRepIds, r.id) && isRepresentationPlayable(r) !== false,
   );
 
   /** Emit the list of Representation for the adaptive logic. */

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -2,7 +2,6 @@ import config from "../../../config";
 import { formatError } from "../../../errors";
 import log from "../../../log";
 import type { IRepresentation } from "../../../manifest";
-import { isRepresentationPlayable } from "../../../manifest";
 import arrayIncludes from "../../../utils/array_includes";
 import { assertUnreachable } from "../../../utils/assert";
 import cancellableSleep from "../../../utils/cancellable_sleep";
@@ -96,7 +95,7 @@ export default function AdaptationStream(
 
   const initialRepIds = content.representations.getValue().representationIds;
   const initialRepresentations = content.adaptation.representations.filter(
-    (r) => arrayIncludes(initialRepIds, r.id) && isRepresentationPlayable(r) !== false,
+    (r) => arrayIncludes(initialRepIds, r.id) && r.isPlayable() !== false,
   );
 
   /** Emit the list of Representation for the adaptive logic. */

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -18,7 +18,7 @@ import config from "../../../config";
 import { formatError, MediaError } from "../../../errors";
 import log from "../../../log";
 import type { IAdaptation, IPeriod } from "../../../manifest";
-import { toTaggedTrack } from "../../../manifest";
+import { isRepresentationPlayable, toTaggedTrack } from "../../../manifest";
 import type { IReadOnlyPlaybackObserver } from "../../../playback_observer";
 import type { ITrackType } from "../../../public_types";
 import arrayFind from "../../../utils/array_find";
@@ -472,9 +472,9 @@ function createOrReuseSegmentSink(
  * @returns {string}
  */
 function getFirstDeclaredMimeType(adaptation: IAdaptation): string {
-  const representations = adaptation.representations.filter((r) => {
-    return r.isSupported === true && r.decipherable !== false;
-  });
+  const representations = adaptation.representations.filter(
+    (r) => isRepresentationPlayable(r) !== false,
+  );
   if (representations.length === 0) {
     const noRepErr = new MediaError(
       "NO_PLAYABLE_REPRESENTATION",

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -18,7 +18,7 @@ import config from "../../../config";
 import { formatError, MediaError } from "../../../errors";
 import log from "../../../log";
 import type { IAdaptation, IPeriod } from "../../../manifest";
-import { isRepresentationPlayable, toTaggedTrack } from "../../../manifest";
+import { toTaggedTrack } from "../../../manifest";
 import type { IReadOnlyPlaybackObserver } from "../../../playback_observer";
 import type { ITrackType } from "../../../public_types";
 import arrayFind from "../../../utils/array_find";
@@ -473,7 +473,7 @@ function createOrReuseSegmentSink(
  */
 function getFirstDeclaredMimeType(adaptation: IAdaptation): string {
   const representations = adaptation.representations.filter(
-    (r) => isRepresentationPlayable(r) !== false,
+    (r) => r.isPlayable() !== false,
   );
   if (representations.length === 0) {
     const noRepErr = new MediaError(

--- a/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
@@ -16,7 +16,6 @@
 
 import config from "../../../../config";
 import type { IAdaptation, IPeriod } from "../../../../manifest";
-import { isRepresentationPlayable } from "../../../../manifest";
 import type { IReadOnlyPlaybackObserver } from "../../../../playback_observer";
 import areCodecsCompatible from "../../../../utils/are_codecs_compatible";
 import type { IRange } from "../../../../utils/ranges";
@@ -190,7 +189,7 @@ export default function getAdaptationSwitchStrategy(
 function hasCompatibleCodec(adaptation: IAdaptation, segmentSinkCodec: string): boolean {
   return adaptation.representations.some(
     (rep) =>
-      isRepresentationPlayable(rep) === true &&
+      rep.isPlayable() === true &&
       areCodecsCompatible(rep.getMimeTypeString(), segmentSinkCodec),
   );
 }

--- a/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
+++ b/src/core/stream/period/utils/get_adaptation_switch_strategy.ts
@@ -16,6 +16,7 @@
 
 import config from "../../../../config";
 import type { IAdaptation, IPeriod } from "../../../../manifest";
+import { isRepresentationPlayable } from "../../../../manifest";
 import type { IReadOnlyPlaybackObserver } from "../../../../playback_observer";
 import areCodecsCompatible from "../../../../utils/are_codecs_compatible";
 import type { IRange } from "../../../../utils/ranges";
@@ -189,8 +190,7 @@ export default function getAdaptationSwitchStrategy(
 function hasCompatibleCodec(adaptation: IAdaptation, segmentSinkCodec: string): boolean {
   return adaptation.representations.some(
     (rep) =>
-      rep.isSupported === true &&
-      rep.decipherable !== false &&
+      isRepresentationPlayable(rep) === true &&
       areCodecsCompatible(rep.getMimeTypeString(), segmentSinkCodec),
   );
 }

--- a/src/main_thread/tracks_store/track_dispatcher.ts
+++ b/src/main_thread/tracks_store/track_dispatcher.ts
@@ -4,6 +4,7 @@ import type {
   ITrackSwitchingMode,
 } from "../../core/types";
 import type { IAdaptationMetadata, IRepresentationMetadata } from "../../manifest";
+import { isRepresentationPlayable } from "../../manifest";
 import type {
   IAudioRepresentationsSwitchingMode,
   IVideoRepresentationsSwitchingMode,
@@ -186,11 +187,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
       if (repSettings === null) {
         // unlocking
         playableRepresentations = trackInfo.adaptation.representations.filter(
-          (representation) => {
-            return (
-              representation.isSupported === true && representation.decipherable !== false
-            );
-          },
+          (representation) => isRepresentationPlayable(representation) === true,
         );
 
         // No need to remove the previous content when unlocking
@@ -202,7 +199,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
           arrayIncludes(representationIds, r.id),
         );
         playableRepresentations = representations.filter(
-          (r) => r.isSupported === true && r.decipherable !== false,
+          (representation) => isRepresentationPlayable(representation) === true,
         );
         if (playableRepresentations.length === 0) {
           self.trigger("noPlayableLockedRepresentation", null);

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -30,6 +30,7 @@ import type {
 } from "../../manifest";
 import {
   getSupportedAdaptations,
+  isRepresentationPlayable,
   toAudioTrack,
   toTextTrack,
   toVideoTrack,
@@ -399,7 +400,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
             return false;
           }
           const playableRepresentations = adaptation.representations.filter(
-            (r) => r.isSupported === true && r.decipherable !== false,
+            (r) => isRepresentationPlayable(r) === true,
           );
           return playableRepresentations.length > 0;
         },

--- a/src/manifest/classes/representation.ts
+++ b/src/manifest/classes/representation.ts
@@ -15,7 +15,7 @@
  */
 
 import log from "../../log";
-import type { IRepresentationMetadata } from "../../manifest";
+import { isRepresentationPlayable, type IRepresentationMetadata } from "../../manifest";
 import type {
   ICdnMetadata,
   IContentProtections,
@@ -427,6 +427,23 @@ class Representation implements IRepresentationMetadata {
     // init data type in this.contentProtections.initData.
     this.contentProtections.initData.push({ type: initDataType, values: data });
     return true;
+  }
+
+  /**
+   * Returns `true` if the `Representation` has a high chance of being playable on
+   * the current device (its codec seems supported and we don't consider it to be
+   * un-decipherable).
+   *
+   * Returns `false` if the `Representation` has a high chance of being unplayable
+   * on the current device (its codec seems unsupported and/or we consider it to
+   * be un-decipherable).
+   *
+   * Returns `undefined` if we don't know as the codec has not been checked yet.
+   *
+   * @returns {boolean|undefined}
+   */
+  public isPlayable(): boolean | undefined {
+    return isRepresentationPlayable(this);
   }
 
   /**

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -237,9 +237,7 @@ export function toAudioTrack(
     audioDescription: adaptation.isAudioDescription === true,
     id: adaptation.id,
     representations: (filterPlayable
-      ? adaptation.representations.filter(
-          (r) => r.isSupported === true && r.decipherable !== false,
-        )
+      ? adaptation.representations.filter((r) => isRepresentationPlayable(r))
       : adaptation.representations
     ).map(toAudioRepresentation),
     label: adaptation.label,
@@ -283,7 +281,7 @@ export function toVideoTrack(
           const representations = (
             filterPlayable
               ? trickModeAdaptation.representations.filter(
-                  (r) => r.isSupported === true && r.decipherable !== false,
+                  (r) => isRepresentationPlayable(r) === true,
                 )
               : trickModeAdaptation.representations
           ).map(toVideoRepresentation);
@@ -302,9 +300,7 @@ export function toVideoTrack(
   const videoTrack: IVideoTrack = {
     id: adaptation.id,
     representations: (filterPlayable
-      ? adaptation.representations.filter(
-          (r) => r.isSupported === true && r.decipherable !== false,
-        )
+      ? adaptation.representations.filter((r) => isRepresentationPlayable(r) === true)
       : adaptation.representations
     ).map(toVideoRepresentation),
     label: adaptation.label,
@@ -387,6 +383,32 @@ export function toTaggedTrack(adaptation: IAdaptation): ITaggedTrack {
     case "text":
       return { type: "text", track: toTextTrack(adaptation) };
   }
+}
+
+/**
+ * Returns `true` if the `Representation` has a high chance of being playable on
+ * the current device (its codec seems supported and we don't consider it to be
+ * un-decipherable).
+ *
+ * Returns `false` if the `Representation` has a high chance of being unplayable
+ * on the current device (its codec seems unsupported and/or we consider it to
+ * be un-decipherable).
+ *
+ * Returns `undefined` if we don't know as the codec has not been checked yet.
+ *
+ * @param {Object} representation
+ * @returns {boolean|undefined}
+ */
+export function isRepresentationPlayable(
+  representation: IRepresentationMetadata,
+): boolean | undefined {
+  if (representation.isSupported === undefined) {
+    if (representation.decipherable === false) {
+      return false;
+    }
+    return undefined;
+  }
+  return representation.isSupported && representation.decipherable !== false;
 }
 
 /**

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -402,13 +402,10 @@ export function toTaggedTrack(adaptation: IAdaptation): ITaggedTrack {
 export function isRepresentationPlayable(
   representation: IRepresentationMetadata,
 ): boolean | undefined {
-  if (representation.isSupported === undefined) {
-    if (representation.decipherable === false) {
-      return false;
-    }
-    return undefined;
+  if (representation.decipherable === false) {
+    return false;
   }
-  return representation.isSupported && representation.decipherable !== false;
+  return representation.isSupported;
 }
 
 /**


### PR DESCRIPTION
While working on #1533, I noticed that there is a high number of places in the code where we want to know if a given Representation can probably be playable or not (is not known to be undecipherable and in an unsupported codec).

I added an `isRepresentationPlayable` util to make  those places more clear about the intent than checking a couple properties.

I made it return `undefined` for the special case where the codec support is still `undefined` as what we would want to do in this case depends.