### PR TITLE
fix(safari): initial seek time not taken into account with fromLastPosition

### DIFF
--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -254,7 +254,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
 function getDirectFileInitialTime(
   mediaElement: IMediaElement,
   startAt?: IInitialTimeOptions,
-): number {
+): number | undefined {
   if (isNullOrUndefined(startAt)) {
     return 0;
   }
@@ -268,28 +268,38 @@ function getDirectFileInitialTime(
   }
 
   const duration = mediaElement.duration;
-
   if (typeof startAt.fromLastPosition === "number") {
-    if (isNullOrUndefined(duration) || !isFinite(duration)) {
-      log.warn(
-        "startAt.fromLastPosition set but no known duration, " + "beginning at 0.",
-      );
-      return 0;
+    if (!isNullOrUndefined(duration) && isFinite(duration)) {
+      return Math.max(0, duration + startAt.fromLastPosition);
     }
-    return Math.max(0, duration + startAt.fromLastPosition);
+
+    if (mediaElement.seekable.length > 0) {
+      const lastSegmentEnd = mediaElement.seekable.end(mediaElement.seekable.length - 1);
+      if (isFinite(lastSegmentEnd)) {
+        return Math.max(0, lastSegmentEnd + startAt.fromLastPosition);
+      }
+    }
+    log.warn(
+      "Init: startAt.fromLastPosition set but no known duration, " +
+        "it may be too soon to seek",
+    );
+    return undefined;
   } else if (typeof startAt.fromLivePosition === "number") {
     const livePosition =
       mediaElement.seekable.length > 0 ? mediaElement.seekable.end(0) : duration;
     if (isNullOrUndefined(livePosition)) {
       log.warn(
-        "startAt.fromLivePosition set but no known live position, " + "beginning at 0.",
+        "Init: startAt.fromLivePosition set but no known live position, " +
+          "beginning at 0.",
       );
       return 0;
     }
     return Math.max(0, livePosition + startAt.fromLivePosition);
   } else if (!isNullOrUndefined(startAt.percentage)) {
     if (isNullOrUndefined(duration) || !isFinite(duration)) {
-      log.warn("startAt.percentage set but no known duration, " + "beginning at 0.");
+      log.warn(
+        "Init: startAt.percentage set but no known duration, " + "beginning at 0.",
+      );
       return 0;
     }
     const { percentage } = startAt;


### PR DESCRIPTION
fix a bug on Safari where a live stream will play at the time=0 rather than next to the live edge when using `startAt:fromLastPosition`. This appears on some contents that have different protection Key for each of their track.