### PR TITLE
chore: add macOS generated file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # IDE files
 /.idea
 /.vscode
+
+.DS_Store


### PR DESCRIPTION
macOS create automatically ".DS_Store" file when browsing a directory with the finder (the macOS file explorer)