### PR TITLE
[Proposal] Add noCheck scripts and use it in our publish_test_package CI script

### DIFF
--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci
 
       - name: Build Library
-        run: npm run build
+        run: npm run build:noCheck
 
       - name: Create archive
         run: echo "npm-pack=$(npm pack)" >> $GITHUB_OUTPUT

--- a/package.json
+++ b/package.json
@@ -146,8 +146,10 @@
   "sideEffects": false,
   "scripts": {
     "build": "./scripts/generate_build.mjs",
+    "build:noCheck": "./scripts/generate_build.mjs --no-check",
     "build:all": "npm run clean:build && npm run build:wasm:release && npm run bundle && npm run bundle:min && npm run build",
     "build:dev": "./scripts/generate_build.mjs --dev-mode",
+    "build:dev:noCheck": "./scripts/generate_build.mjs --dev-mode --no-check",
     "build:wasm:debug": "mkdir -p dist && cd ./src/parsers/manifest/dash/wasm-parser && cargo build --target wasm32-unknown-unknown && cp target/wasm32-unknown-unknown/debug/mpd_node_parser.wasm ../../../../../dist/mpd-parser.wasm",
     "build:wasm:release": "./scripts/build_wasm_release.sh",
     "bundle": "./scripts/run_bundler.mjs src/index.ts --production-mode --globals -o dist/rx-player.js",
@@ -271,7 +273,9 @@
     "Build the player or one of its sub-parts": {
       "Regular builds (used by JS bundlers)": {
         "build": "Build the rx-player code in release mode",
-        "build:dev": "Build the rx-player code in development mode (more runtime checks, non-minified worker)"
+        "build:dev": "Build the rx-player code in development mode (more runtime checks, non-minified worker)",
+        "build:noCheck": "Build the rx-player code in release mode without performing compile-time type checks",
+        "build:dev:noCheck": "Build the rx-player code in development mode (more runtime checks, non-minified worker) without performing compile-time type checks"
       },
       "Legacy bundle builds (single-file bundles exporting to window.RxPlayer)": {
         "bundle": "Build the player in dist/rx-player.js",


### PR DESCRIPTION
When debugging an application, we often have to do quick and dirty updates to the RxPlayer code.

When doing this, TypeScript's type-checking can get in the way - and what could amount to a few-seconds-update finally can take a few minutes just to make TypeScript happy.

Thankfully, [TypeScript 5.6](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/), which I just updated the project to, has now a [`--noCheck` option](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#the---nocheck-option) allowing to skip type checking.

I consequently:
 - added the `build:noCheck` an `build:dev:noCheck` npm scripts to the `package.json`
 - added a new `--no-check`/`-n` flag to our `scripts/generate_build.mjs` script
 - Made our publish_test_package CI script now rely on the `noCheck` variant, as this is mainly used for quick and dirty checks and as another CI check is there for type-checking anyway.

There's maybe other places where we could skip checks.