### PR TITLE
[Proposal] Add buffer size estimate to debug buffer content graph

### DIFF
--- a/src/main_thread/api/debug/modules/segment_buffer_content.ts
+++ b/src/main_thread/api/debug/modules/segment_buffer_content.ts
@@ -28,6 +28,7 @@ export default function createSegmentSinkGraph(
   const bufferGraphWrapper = createElement("div");
   const bufferTitle = createMetricTitle(title);
   const canvasElt = createGraphCanvas();
+  const bufferSizeElt = document.createElement("span");
   const currentRangeRepInfoElt = createElement("div");
   const loadingRangeRepInfoElt = createElement("div");
   const bufferGraph = new SegmentSinkGraph(canvasElt);
@@ -48,8 +49,11 @@ export default function createSegmentSinkGraph(
 
   bufferGraphWrapper.appendChild(bufferTitle);
   bufferGraphWrapper.appendChild(canvasElt);
+  bufferGraphWrapper.appendChild(bufferSizeElt);
   bufferGraphWrapper.appendChild(currentRangeRepInfoElt);
   bufferGraphWrapper.appendChild(loadingRangeRepInfoElt);
+  bufferSizeElt.style.marginLeft = "5px";
+  bufferSizeElt.style.fontSize = "0.9em";
   bufferGraphWrapper.style.padding = "5px 0px";
   update();
   return bufferGraphWrapper;
@@ -75,13 +79,29 @@ export default function createSegmentSinkGraph(
 
   function updateBufferMetrics() {
     const showAllInfo = isExtendedMode(parentElt);
-    const inventory = bufferMetrics?.segmentSinks[bufferType].segmentInventory;
+    const metricsForType = bufferMetrics?.segmentSinks[bufferType];
+    const inventory = metricsForType?.segmentInventory;
     if (bufferMetrics === null || inventory === undefined) {
       bufferGraphWrapper.style.display = "none";
+      bufferSizeElt.innerHTML = "";
       currentRangeRepInfoElt.innerHTML = "";
       loadingRangeRepInfoElt.innerHTML = "";
     } else {
       bufferGraphWrapper.style.display = "block";
+      if (metricsForType?.sizeEstimate !== undefined) {
+        const sizeEstimate = metricsForType.sizeEstimate;
+        let sizeStr: string;
+        if (sizeEstimate > 2e6) {
+          sizeStr = (sizeEstimate / 1e6).toFixed(2) + "MB";
+        } else if (sizeEstimate > 2e3) {
+          sizeStr = (sizeEstimate / 1e3).toFixed(2) + "kB";
+        } else {
+          sizeStr = sizeEstimate + "B";
+        }
+        bufferSizeElt.innerHTML = sizeStr;
+      } else {
+        bufferSizeElt.innerHTML = "";
+      }
       const currentTime = instance.getPosition();
       const width = Math.min(parentElt.clientWidth - 150, 600);
       bufferGraph.update({


### PR DESCRIPTION
While continuing proof-of-concepts related to how much buffer we build, I found that our estimate of the current buffer size in bytes (more exactly the combined size of pushed segments that still have at least a sub-part present in the buffer) was a potentially-interesting metric that we did not expose anywhere: neither in logs nor in our DEBUG_ELEMENT feature.

This commit adds it to the `DEBUG_ELEMENT` feature, just after the corresponding buffer content graph.

![bufferSize](https://github.com/user-attachments/assets/acd44df9-5933-489d-b75a-84837b44e39a)
_Screenshot: I'm here talking about the `157.711MB` for video appearing at the end of `vbuf` and `1811KB` at the end of `abuf`_

It may be even more useful in logs, but I did not bother to do it for now as I currently mainly relied on the debug element.