### PR TITLE
Fix `SourceBuffer.prototype.remove` error handling

### DIFF
--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -482,6 +482,9 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
                 false,
               );
         nextElem.reject(error);
+        this._currentOperations.forEach((op) => {
+          op.reject(error);
+        });
         this._currentOperations = [];
       }
     }


### PR DESCRIPTION
I noticed an issue when handling errors from the MSE `SourceBuffer.prototype.remove` API, where our MSE abstraction was emptying all pending operations (`appendBuffer` calls and `remove` calls after that one) yet wasn't also rejecting those other operations' Promise, meaning that the RxPlayer logic wouldn't be notified that those operations were canceled.

This may lead to some rare infinite rebuffering.