### PR TITLE
feature: add the possibility to rely on managedMediaSource on iOS devices

### DIFF
--- a/src/compat/__tests__/browser_compatibility_types.test.ts
+++ b/src/compat/__tests__/browser_compatibility_types.test.ts
@@ -7,6 +7,7 @@ describe("compat - browser compatibility types", () => {
     MozMediaSource?: unknown;
     WebKitMediaSource?: unknown;
     MSMediaSource?: unknown;
+    ManagedMediaSource?: unknown;
   }
   const gs = globalScope as IFakeWindow;
   beforeEach(() => {
@@ -22,11 +23,13 @@ describe("compat - browser compatibility types", () => {
     const origMozMediaSource = gs.MozMediaSource;
     const origWebKitMediaSource = gs.WebKitMediaSource;
     const origMSMediaSource = gs.MSMediaSource;
+    const origManagedMediaSource = gs.ManagedMediaSource;
 
     gs.MediaSource = { a: 1 };
     gs.MozMediaSource = { a: 2 };
     gs.WebKitMediaSource = { a: 3 };
     gs.MSMediaSource = { a: 4 };
+    gs.ManagedMediaSource = { a: 5 };
 
     const { MediaSource_ } = await vi.importActual("../browser_compatibility_types");
     expect(MediaSource_).toEqual({ a: 1 });
@@ -35,6 +38,7 @@ describe("compat - browser compatibility types", () => {
     gs.MozMediaSource = origMozMediaSource;
     gs.WebKitMediaSource = origWebKitMediaSource;
     gs.MSMediaSource = origMSMediaSource;
+    gs.ManagedMediaSource = origManagedMediaSource;
   });
 
   it("should use MozMediaSource if defined and MediaSource is not", async () => {
@@ -46,6 +50,7 @@ describe("compat - browser compatibility types", () => {
     const origMozMediaSource = gs.MozMediaSource;
     const origWebKitMediaSource = gs.WebKitMediaSource;
     const origMSMediaSource = gs.MSMediaSource;
+    const origManagedMediaSource = gs.ManagedMediaSource;
 
     gs.MediaSource = undefined;
     gs.MozMediaSource = { a: 2 };
@@ -59,6 +64,7 @@ describe("compat - browser compatibility types", () => {
     gs.MozMediaSource = origMozMediaSource;
     gs.WebKitMediaSource = origWebKitMediaSource;
     gs.MSMediaSource = origMSMediaSource;
+    gs.ManagedMediaSource = origManagedMediaSource;
   });
 
   it("should use WebKitMediaSource if defined and MediaSource is not", async () => {
@@ -70,6 +76,7 @@ describe("compat - browser compatibility types", () => {
     const origMozMediaSource = gs.MozMediaSource;
     const origWebKitMediaSource = gs.WebKitMediaSource;
     const origMSMediaSource = gs.MSMediaSource;
+    const origManagedMediaSource = gs.ManagedMediaSource;
 
     gs.MediaSource = undefined;
     gs.MozMediaSource = undefined;
@@ -83,6 +90,7 @@ describe("compat - browser compatibility types", () => {
     gs.MozMediaSource = origMozMediaSource;
     gs.WebKitMediaSource = origWebKitMediaSource;
     gs.MSMediaSource = origMSMediaSource;
+    gs.ManagedMediaSource = origManagedMediaSource;
   });
 
   it("should use MSMediaSource if defined and MediaSource is not", async () => {
@@ -94,6 +102,7 @@ describe("compat - browser compatibility types", () => {
     const origMozMediaSource = gs.MozMediaSource;
     const origWebKitMediaSource = gs.WebKitMediaSource;
     const origMSMediaSource = gs.MSMediaSource;
+    const origManagedMediaSource = gs.ManagedMediaSource;
 
     gs.MediaSource = undefined;
     gs.MozMediaSource = undefined;
@@ -107,5 +116,33 @@ describe("compat - browser compatibility types", () => {
     gs.MozMediaSource = origMozMediaSource;
     gs.WebKitMediaSource = origWebKitMediaSource;
     gs.MSMediaSource = origMSMediaSource;
+    gs.ManagedMediaSource = origManagedMediaSource;
+  });
+
+  it("should use ManagedMediaSource if defined and MediaSource is not", async () => {
+    vi.doMock("../../utils/is_node", () => ({
+      default: false,
+    }));
+
+    const origMediaSource = gs.MediaSource;
+    const origMozMediaSource = gs.MozMediaSource;
+    const origWebKitMediaSource = gs.WebKitMediaSource;
+    const origMSMediaSource = gs.MSMediaSource;
+    const origManagedMediaSource = gs.ManagedMediaSource;
+
+    gs.MediaSource = undefined;
+    gs.MozMediaSource = undefined;
+    gs.WebKitMediaSource = undefined;
+    gs.MSMediaSource = undefined;
+    gs.ManagedMediaSource = { a: 5 };
+
+    const { MediaSource_ } = await vi.importActual("../browser_compatibility_types");
+    expect(MediaSource_).toEqual({ a: 5 });
+
+    gs.MediaSource = origMediaSource;
+    gs.MozMediaSource = origMozMediaSource;
+    gs.WebKitMediaSource = origWebKitMediaSource;
+    gs.MSMediaSource = origMSMediaSource;
+    gs.ManagedMediaSource = origManagedMediaSource;
   });
 });

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -16,7 +16,6 @@
 
 import type { IListener } from "../utils/event_emitter";
 import globalScope from "../utils/global_scope";
-import isNullOrUndefined from "../utils/is_null_or_undefined";
 
 /** Regular MediaKeys type + optional functions present in IE11. */
 interface ICompatMediaKeysConstructor {
@@ -116,6 +115,8 @@ export interface IMediaSourceEventMap {
   sourceopen: Event;
   sourceended: Event;
   sourceclose: Event;
+  startstreaming: Event;
+  endstreaming: Event;
 }
 
 /**
@@ -136,6 +137,7 @@ export interface IMediaSource extends IEventTarget<IMediaSourceEventMap> {
   handle?: MediaProvider | IMediaSource | undefined;
   readyState: "closed" | "open" | "ended";
   sourceBuffers: ISourceBufferList;
+  streaming?: boolean | undefined;
 
   addSourceBuffer(type: string): ISourceBuffer;
   clearLiveSeekableRange(): void;
@@ -252,6 +254,7 @@ export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
   srcObject?: undefined | null | MediaProvider;
   textTracks: TextTrackList | never[];
   volume: number;
+  disableRemotePlayback?: boolean;
 
   addTextTrack: (kind: TextTrackKind) => TextTrack;
   appendChild<T extends Node>(x: T): void;
@@ -407,15 +410,15 @@ const gs = globalScope as any;
 const MediaSource_:
   | { new (): IMediaSource; isTypeSupported(type: string): boolean }
   | undefined =
-  gs === undefined
-    ? undefined
-    : !isNullOrUndefined(gs.MediaSource)
-      ? gs.MediaSource
-      : !isNullOrUndefined(gs.MozMediaSource)
-        ? gs.MozMediaSource
-        : !isNullOrUndefined(gs.WebKitMediaSource)
-          ? gs.WebKitMediaSource
-          : gs.MSMediaSource;
+  gs?.MediaSource ??
+  gs?.MozMediaSource ??
+  gs?.WebKitMediaSource ??
+  gs?.MSMediaSource ??
+  gs?.ManagedMediaSource ??
+  undefined;
+
+const isManagedMediaSource =
+  MediaSource_ !== undefined && MediaSource_ === gs?.ManagedMediaSource;
 /* eslint-enable */
 
 /** List an HTMLMediaElement's possible values for its readyState property. */
@@ -448,4 +451,4 @@ export type {
   ICompatVTTCue,
   ICompatVTTCueConstructor,
 };
-export { MediaSource_, READY_STATES };
+export { MediaSource_, isManagedMediaSource, READY_STATES };

--- a/src/core/fetchers/segment/segment_queue_creator.ts
+++ b/src/core/fetchers/segment/segment_queue_creator.ts
@@ -16,6 +16,7 @@
 
 import config from "../../../config";
 import type { ISegmentPipeline, ITransportPipelines } from "../../../transports";
+import type SharedReference from "../../../utils/reference";
 import type { CancellationSignal } from "../../../utils/task_canceller";
 import type CmcdDataBuilder from "../../cmcd";
 import type { IBufferType } from "../../segment_sinks";
@@ -96,6 +97,7 @@ export default class SegmentQueueCreator {
   public createSegmentQueue(
     bufferType: IBufferType,
     eventListeners: ISegmentFetcherLifecycleCallbacks,
+    canLoad: SharedReference<boolean>,
   ): SegmentQueue<unknown> {
     const requestOptions = getSegmentFetcherRequestOptions(this._backoffOptions);
     const pipelines = this._transport[bufferType];
@@ -113,7 +115,7 @@ export default class SegmentQueueCreator {
       this._prioritizer,
       segmentFetcher,
     );
-    return new SegmentQueue(prioritizedSegmentFetcher);
+    return new SegmentQueue(prioritizedSegmentFetcher, canLoad);
   }
 }
 

--- a/src/core/fetchers/segment/segment_queue_creator.ts
+++ b/src/core/fetchers/segment/segment_queue_creator.ts
@@ -90,6 +90,8 @@ export default class SegmentQueueCreator {
    * @param {string} bufferType - The type of buffer concerned (e.g. "audio",
    * "video", etc.)
    * @param {Object} eventListeners
+   * @param {Object} isMediaSegmentQueueInterrupted - Wheter the downloading of media
+   * segment should be interrupted or not.
    * @returns {Object} - `SegmentQueue`, which is an abstraction allowing to
    * perform a queue of segment requests for a given media type (here defined by
    * `bufferType`) with associated priorities.
@@ -97,7 +99,7 @@ export default class SegmentQueueCreator {
   public createSegmentQueue(
     bufferType: IBufferType,
     eventListeners: ISegmentFetcherLifecycleCallbacks,
-    canLoad: SharedReference<boolean>,
+    isMediaSegmentQueueInterrupted: SharedReference<boolean>,
   ): SegmentQueue<unknown> {
     const requestOptions = getSegmentFetcherRequestOptions(this._backoffOptions);
     const pipelines = this._transport[bufferType];
@@ -115,7 +117,7 @@ export default class SegmentQueueCreator {
       this._prioritizer,
       segmentFetcher,
     );
-    return new SegmentQueue(prioritizedSegmentFetcher, canLoad);
+    return new SegmentQueue(prioritizedSegmentFetcher, isMediaSegmentQueueInterrupted);
   }
 }
 

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -116,6 +116,16 @@ export default function AdaptationStream(
     adapStreamCanceller.signal,
   );
 
+  const canStream = new SharedReference<boolean>(true);
+  /** Update the `canLoad` ref on observation update */
+  playbackObserver.listen((observation) => {
+    const observationCanStream = observation.canStream ?? true;
+    if (canStream.getValue() !== observationCanStream) {
+      log.debug("Stream: observation.canStream updated to", observationCanStream);
+      canStream.setValue(observationCanStream);
+    }
+  });
+
   /** Allows a `RepresentationStream` to easily fetch media segments. */
   const segmentQueue = segmentQueueCreator.createSegmentQueue(
     adaptation.type,
@@ -126,6 +136,7 @@ export default function AdaptationStream(
       onProgress: abrCallbacks.requestProgress,
       onMetrics: abrCallbacks.metrics,
     },
+    canStream,
   );
   /* eslint-enable @typescript-eslint/unbound-method */
 

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -118,13 +118,16 @@ export default function AdaptationStream(
 
   const canStream = new SharedReference<boolean>(true);
   /** Update the `canLoad` ref on observation update */
-  playbackObserver.listen((observation) => {
-    const observationCanStream = observation.canStream ?? true;
-    if (canStream.getValue() !== observationCanStream) {
-      log.debug("Stream: observation.canStream updated to", observationCanStream);
-      canStream.setValue(observationCanStream);
-    }
-  });
+  playbackObserver.listen(
+    (observation) => {
+      const observationCanStream = observation.canStream ?? true;
+      if (canStream.getValue() !== observationCanStream) {
+        log.debug("Stream: observation.canStream updated to", observationCanStream);
+        canStream.setValue(observationCanStream);
+      }
+    },
+    { clearSignal: adapStreamCanceller.signal },
+  );
 
   /** Allows a `RepresentationStream` to easily fetch media segments. */
   const segmentQueue = segmentQueueCreator.createSegmentQueue(

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -116,14 +116,17 @@ export default function AdaptationStream(
     adapStreamCanceller.signal,
   );
 
-  const canStream = new SharedReference<boolean>(true);
+  const isMediaSegmentQueueInterrupted = new SharedReference<boolean>(false);
   /** Update the `canLoad` ref on observation update */
   playbackObserver.listen(
     (observation) => {
       const observationCanStream = observation.canStream ?? true;
-      if (canStream.getValue() !== observationCanStream) {
-        log.debug("Stream: observation.canStream updated to", observationCanStream);
-        canStream.setValue(observationCanStream);
+      if (isMediaSegmentQueueInterrupted.getValue() === observationCanStream) {
+        log.debug(
+          "Stream: isMediaSegmentQueueInterrupted updated to",
+          !observationCanStream,
+        );
+        isMediaSegmentQueueInterrupted.setValue(!observationCanStream);
       }
     },
     { clearSignal: adapStreamCanceller.signal },
@@ -139,7 +142,7 @@ export default function AdaptationStream(
       onProgress: abrCallbacks.requestProgress,
       onMetrics: abrCallbacks.metrics,
     },
-    canStream,
+    isMediaSegmentQueueInterrupted,
   );
   /* eslint-enable @typescript-eslint/unbound-method */
 

--- a/src/core/stream/adaptation/types.ts
+++ b/src/core/stream/adaptation/types.ts
@@ -122,6 +122,16 @@ export interface IAdaptationStreamPlaybackObservation
   duration: number;
   /** Theoretical maximum position on the content that can currently be played. */
   maximumPosition: number;
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  canStream: boolean;
 }
 
 /** Arguments given when creating a new `AdaptationStream`. */

--- a/src/core/stream/period/types.ts
+++ b/src/core/stream/period/types.ts
@@ -96,6 +96,16 @@ export interface IPeriodStreamPlaybackObservation {
    * `null` if no buffer exists for that type of media.
    */
   buffered: Record<ITrackType, IRange[] | null>;
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  canStream: boolean;
 }
 
 /** Arguments required by the `PeriodStream`. */

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -27,7 +27,6 @@ import config from "../../../config";
 import log from "../../../log";
 import type { ISegment } from "../../../manifest";
 import objectAssign from "../../../utils/object_assign";
-import SharedReference from "../../../utils/reference";
 import type { CancellationSignal } from "../../../utils/task_canceller";
 import TaskCanceller, { CancellationError } from "../../../utils/task_canceller";
 import type {
@@ -208,19 +207,6 @@ export default function RepresentationStream<TSegmentDataType>(
         .catch(onFatalBufferError);
     },
     segmentsLoadingCanceller.signal,
-  );
-
-  const canStream = new SharedReference<boolean>(true);
-
-  playbackObserver.listen(
-    (observation) => {
-      const observationCanStream = observation.canStream ?? true;
-      if (canStream.getValue() !== observationCanStream) {
-        log.debug("Stream: observation.canStream updated to", observationCanStream);
-        canStream.setValue(observationCanStream);
-      }
-    },
-    { clearSignal: segmentsLoadingCanceller.signal },
   );
 
   /** Emit the last scheduled downloading queue for segments. */

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -212,20 +212,19 @@ export default function RepresentationStream<TSegmentDataType>(
 
   const canStream = new SharedReference<boolean>(true);
 
-  playbackObserver.listen((observation) => {
-    const observationCanStream = observation.canStream ?? true;
-    if (canStream.getValue() !== observationCanStream) {
-      log.debug("Stream: observation.canStream updated to", observationCanStream);
-      canStream.setValue(observationCanStream);
-    }
-  });
+  playbackObserver.listen(
+    (observation) => {
+      const observationCanStream = observation.canStream ?? true;
+      if (canStream.getValue() !== observationCanStream) {
+        log.debug("Stream: observation.canStream updated to", observationCanStream);
+        canStream.setValue(observationCanStream);
+      }
+    },
+    { clearSignal: segmentsLoadingCanceller.signal },
+  );
 
   /** Emit the last scheduled downloading queue for segments. */
-  const segmentsToLoadRef = segmentQueue.resetForContent(
-    content,
-    hasInitSegment,
-    canStream,
-  );
+  const segmentsToLoadRef = segmentQueue.resetForContent(content, hasInitSegment);
 
   segmentsLoadingCanceller.signal.register(() => {
     segmentQueue.stop();

--- a/src/core/stream/representation/types.ts
+++ b/src/core/stream/representation/types.ts
@@ -192,6 +192,16 @@ export interface IRepresentationStreamPlaybackObservation {
   paused: IPausedPlaybackObservation;
   /** Last "playback rate" asked by the user. */
   speed: number;
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  canStream: boolean;
 }
 
 /** Pause-related information linked to an emitted Playback observation. */

--- a/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import {
-  isManagedMediaSource,
-  MediaSource_,
-} from "../../../compat/browser_compatibility_types";
+import { MediaSource_ } from "../../../compat/browser_compatibility_types";
 import type { IMediaElement } from "../../../compat/browser_compatibility_types";
 import log from "../../../log";
-import { resetMediaElement } from "../../../main_thread/init/utils/create_media_source";
+import {
+  resetMediaElement,
+  disableRemotePlayback,
+} from "../../../main_thread/init/utils/create_media_source";
 import { SourceBufferType } from "../../../mse";
 import type { MainSourceBufferInterface } from "../../../mse/main_media_source_interface";
 import MainMediaSourceInterface from "../../../mse/main_media_source_interface";
@@ -69,26 +69,7 @@ export default function prepareSourceBuffer(
         resetMediaElement(videoElement, objectURL);
       });
     }
-    if (isManagedMediaSource && "disableRemotePlayback" in videoElement) {
-      const disableRemotePlaybackPreviousValue = videoElement.disableRemotePlayback;
-      cleanUpSignal.register(() => {
-        /**
-         * Restore the disableRemotePlayback attribute to the previous value
-         * in order to leave the <video> element in the same state has it was set
-         * by the application before calling the RxPlayer.
-         */
-        if (disableRemotePlaybackPreviousValue !== undefined) {
-          videoElement.disableRemotePlayback = disableRemotePlaybackPreviousValue;
-        }
-      });
-
-      /**
-       * Using ManagedMediaSource needs to disableRemotePlayback or to provide
-       * an Airplay source alternative, such as HLS.
-       * https://github.com/w3c/media-source/issues/320
-       */
-      videoElement.disableRemotePlayback = true;
-    }
+    disableRemotePlayback(videoElement, cleanUpSignal);
 
     mediaSource.addEventListener("mediaSourceOpen", onSourceOpen);
     return () => {

--- a/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
@@ -19,7 +19,7 @@ import type { IMediaElement } from "../../../compat/browser_compatibility_types"
 import log from "../../../log";
 import {
   resetMediaElement,
-  disableRemotePlayback,
+  disableRemotePlaybackOnManagedMediaSource,
 } from "../../../main_thread/init/utils/create_media_source";
 import { SourceBufferType } from "../../../mse";
 import type { MainSourceBufferInterface } from "../../../mse/main_media_source_interface";
@@ -69,7 +69,7 @@ export default function prepareSourceBuffer(
         resetMediaElement(videoElement, objectURL);
       });
     }
-    disableRemotePlayback(videoElement, cleanUpSignal);
+    disableRemotePlaybackOnManagedMediaSource(videoElement, cleanUpSignal);
 
     mediaSource.addEventListener("mediaSourceOpen", onSourceOpen);
     return () => {

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,7 +1,4 @@
-import {
-  isManagedMediaSource,
-  type IMediaElement,
-} from "../../compat/browser_compatibility_types";
+import { type IMediaElement } from "../../compat/browser_compatibility_types";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store";
@@ -1800,28 +1797,10 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                 resetMediaElement(mediaElement, url);
               });
               mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);
-
-              if (isManagedMediaSource && "disableRemotePlayback" in mediaElement) {
-                const disableRemotePlaybackPreviousValue =
-                  mediaElement.disableRemotePlayback;
-                this._currentMediaSourceCanceller.signal.register(() => {
-                  /**
-                   * This reset the disableRemotePlayback attribute to the previous value
-                   * in order to restore the <video> element has it was set by the application
-                   * before calling the RxPlayer.
-                   */
-                  if (disableRemotePlaybackPreviousValue !== undefined) {
-                    mediaElement.disableRemotePlayback =
-                      disableRemotePlaybackPreviousValue;
-                  }
-                });
-                /**
-                 * Using ManagedMediaSource needs to disableRemotePlayback or to provide
-                 * an Airplay source alternative, such as HLS.
-                 * https://github.com/w3c/media-source/issues/320
-                 */
-                mediaElement.disableRemotePlayback = true;
-              }
+              disableRemotePlayback(
+                mediaElement,
+                this._currentMediaSourceCanceller.signal,
+              );
             }
           },
           {

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,4 +1,7 @@
-import type { IMediaElement } from "../../compat/browser_compatibility_types";
+import {
+  isManagedMediaSource,
+  type IMediaElement,
+} from "../../compat/browser_compatibility_types";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store";
@@ -460,6 +463,29 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                     resetMediaElement(mediaElement, mediaSourceLink.value);
                   });
                 }
+                const disableRemotePlaybackPreviousValue =
+                  mediaElement.disableRemotePlayback;
+                this._currentMediaSourceCanceller.signal.register(() => {
+                  /**
+                   * This reset the disableRemotePlayback attribute to the previous value
+                   * in order to restore the <video> element has it was set by the application
+                   * before calling the RxPlayer.
+                   */
+                  if (
+                    "disableRemotePlayback" in mediaElement &&
+                    disableRemotePlaybackPreviousValue !== undefined
+                  ) {
+                    mediaElement.disableRemotePlayback =
+                      disableRemotePlaybackPreviousValue;
+                  }
+                });
+                /**
+                 * Using ManagedMediaSource needs to disableRemotePlayback or to provide
+                 * an Airplay source alternative, such as HLS.
+                 * https://github.com/w3c/media-source/issues/320
+                 */
+                mediaElement.disableRemotePlayback = true;
+
                 mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);
               }
             },
@@ -1793,6 +1819,28 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                 resetMediaElement(mediaElement, url);
               });
               mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);
+
+              if (isManagedMediaSource && "disableRemotePlayback" in mediaElement) {
+                const disableRemotePlaybackPreviousValue =
+                  mediaElement.disableRemotePlayback;
+                this._currentMediaSourceCanceller.signal.register(() => {
+                  /**
+                   * This reset the disableRemotePlayback attribute to the previous value
+                   * in order to restore the <video> element has it was set by the application
+                   * before calling the RxPlayer.
+                   */
+                  if (disableRemotePlaybackPreviousValue !== undefined) {
+                    mediaElement.disableRemotePlayback =
+                      disableRemotePlaybackPreviousValue;
+                  }
+                });
+                /**
+                 * Using ManagedMediaSource needs to disableRemotePlayback or to provide
+                 * an Airplay source alternative, such as HLS.
+                 * https://github.com/w3c/media-source/issues/320
+                 */
+                mediaElement.disableRemotePlayback = true;
+              }
             }
           },
           {

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -62,7 +62,7 @@ import sendMessage from "./send_message";
 import type { ITextDisplayerOptions } from "./types";
 import { ContentInitializer } from "./types";
 import createCorePlaybackObserver from "./utils/create_core_playback_observer";
-import { resetMediaElement } from "./utils/create_media_source";
+import { resetMediaElement, disableRemotePlayback } from "./utils/create_media_source";
 import type { IInitialTimeOptions } from "./utils/get_initial_time";
 import getInitialTime from "./utils/get_initial_time";
 import getLoadedReference from "./utils/get_loaded_reference";
@@ -463,29 +463,10 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                     resetMediaElement(mediaElement, mediaSourceLink.value);
                   });
                 }
-                const disableRemotePlaybackPreviousValue =
-                  mediaElement.disableRemotePlayback;
-                this._currentMediaSourceCanceller.signal.register(() => {
-                  /**
-                   * This reset the disableRemotePlayback attribute to the previous value
-                   * in order to restore the <video> element has it was set by the application
-                   * before calling the RxPlayer.
-                   */
-                  if (
-                    "disableRemotePlayback" in mediaElement &&
-                    disableRemotePlaybackPreviousValue !== undefined
-                  ) {
-                    mediaElement.disableRemotePlayback =
-                      disableRemotePlaybackPreviousValue;
-                  }
-                });
-                /**
-                 * Using ManagedMediaSource needs to disableRemotePlayback or to provide
-                 * an Airplay source alternative, such as HLS.
-                 * https://github.com/w3c/media-source/issues/320
-                 */
-                mediaElement.disableRemotePlayback = true;
-
+                disableRemotePlayback(
+                  mediaElement,
+                  this._currentMediaSourceCanceller.signal,
+                );
                 mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);
               }
             },

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,4 +1,4 @@
-import { type IMediaElement } from "../../compat/browser_compatibility_types";
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store";

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -59,7 +59,10 @@ import sendMessage from "./send_message";
 import type { ITextDisplayerOptions } from "./types";
 import { ContentInitializer } from "./types";
 import createCorePlaybackObserver from "./utils/create_core_playback_observer";
-import { resetMediaElement, disableRemotePlayback } from "./utils/create_media_source";
+import {
+  resetMediaElement,
+  disableRemotePlaybackOnManagedMediaSource,
+} from "./utils/create_media_source";
 import type { IInitialTimeOptions } from "./utils/get_initial_time";
 import getInitialTime from "./utils/get_initial_time";
 import getLoadedReference from "./utils/get_loaded_reference";
@@ -460,7 +463,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                     resetMediaElement(mediaElement, mediaSourceLink.value);
                   });
                 }
-                disableRemotePlayback(
+                disableRemotePlaybackOnManagedMediaSource(
                   mediaElement,
                   this._currentMediaSourceCanceller.signal,
                 );
@@ -1797,7 +1800,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                 resetMediaElement(mediaElement, url);
               });
               mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);
-              disableRemotePlayback(
+              disableRemotePlaybackOnManagedMediaSource(
                 mediaElement,
                 this._currentMediaSourceCanceller.signal,
               );

--- a/src/main_thread/init/utils/create_media_source.ts
+++ b/src/main_thread/init/utils/create_media_source.ts
@@ -71,7 +71,7 @@ export function resetMediaElement(
  * @param {CancellationSignal} cancellationSignal - The signal that, when triggered,
  * restores the `disableRemotePlayback` attribute to its original value.
  */
-export function disableRemotePlayback(
+export function disableRemotePlaybackOnManagedMediaSource(
   mediaElement: IMediaElement,
   cancellationSignal: CancellationSignal,
 ) {
@@ -115,7 +115,7 @@ function createMediaSource(
   const oldSrc = isNonEmptyString(mediaElement.src) ? mediaElement.src : null;
   resetMediaElement(mediaElement, oldSrc);
   const mediaSource = new MainMediaSourceInterface(generateMediaSourceId());
-  disableRemotePlayback(mediaElement, unlinkSignal);
+  disableRemotePlaybackOnManagedMediaSource(mediaElement, unlinkSignal);
   unlinkSignal.register(() => {
     mediaSource.dispose();
   });

--- a/src/main_thread/init/utils/create_media_source.ts
+++ b/src/main_thread/init/utils/create_media_source.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { IMediaElement } from "../../../compat/browser_compatibility_types";
+import {
+  isManagedMediaSource,
+  type IMediaElement,
+} from "../../../compat/browser_compatibility_types";
 import clearElementSrc from "../../../compat/clear_element_src";
 import log from "../../../log";
 import MainMediaSourceInterface from "../../../mse/main_media_source_interface";
@@ -76,6 +79,26 @@ function createMediaSource(
   const oldSrc = isNonEmptyString(mediaElement.src) ? mediaElement.src : null;
   resetMediaElement(mediaElement, oldSrc);
   const mediaSource = new MainMediaSourceInterface(generateMediaSourceId());
+
+  if (isManagedMediaSource && "disableRemotePlayback" in mediaElement) {
+    const disableRemotePlaybackPreviousValue = mediaElement.disableRemotePlayback;
+    unlinkSignal.register(() => {
+      /**
+       * Restore the disableRemotePlayback attribute to the previous value
+       * in order to leave the <video> element in the same state has it was set
+       * by the application before calling the RxPlayer.
+       */
+      if (disableRemotePlaybackPreviousValue !== undefined) {
+        mediaElement.disableRemotePlayback = disableRemotePlaybackPreviousValue;
+      }
+    });
+    /**
+     * Using ManagedMediaSource needs to disableRemotePlayback or to provide
+     * an Airplay source alternative, such as HLS.
+     * https://github.com/w3c/media-source/issues/320
+     */
+    mediaElement.disableRemotePlayback = true;
+  }
   unlinkSignal.register(() => {
     mediaSource.dispose();
   });
@@ -106,7 +129,6 @@ export default function openMediaSource(
       },
       unlinkSignal,
     );
-
     log.info("MTCI: Attaching MediaSource URL to the media element");
     if (mediaSource.handle.type === "handle") {
       mediaElement.srcObject = mediaSource.handle.value;

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -44,6 +44,18 @@ export default class MainMediaSourceInterface
   public sourceBuffers: MainSourceBufferInterface[];
   /** @see IMediaSourceInterface */
   public readyState: ReadyState;
+  /**
+   * The `ManagedMediaSource.streaming` attribute
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * The value can be `undefined` if the user agent does not provide this indicator.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  public streaming?: boolean;
   /** The MSE `MediaSource` instance linked to that `IMediaSourceInterface`. */
   private _mediaSource: IMediaSource;
   /**
@@ -117,6 +129,17 @@ export default class MainMediaSourceInterface
       },
       this._canceller.signal,
     );
+    if (this._mediaSource.streaming !== undefined) {
+      this.streaming = this._mediaSource.streaming;
+    }
+    this._mediaSource.addEventListener("startstreaming", () => {
+      this.streaming = true;
+      this.trigger("streamingChanged", null);
+    });
+    this._mediaSource.addEventListener("endstreaming", () => {
+      this.streaming = false;
+      this.trigger("streamingChanged", null);
+    });
   }
 
   /** @see IMediaSourceInterface */

--- a/src/mse/types.ts
+++ b/src/mse/types.ts
@@ -179,6 +179,7 @@ export type IMediaSourceHandle =
 export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfaceEvents> {
   /** `id` uniquely identifying this `IMediaSourceInterface`. */
   id: string;
+
   /**
    * Last known `ReadyState` the underlying MSE `MediaSource` was at.
    *
@@ -186,6 +187,7 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * to be notified of its change.
    */
   readyState: ReadyState;
+
   /**
    * Mean to link the underlying `MediaSource` to an `HTMLMediaElement`.
    *
@@ -194,6 +196,7 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * message by itself to the main thread for MediaSource creation.
    */
   handle: IMediaSourceHandle | undefined;
+
   /**
    * List `ISourceBufferInterface` objects linked to this
    * `IMediaSourceInterface`.
@@ -203,6 +206,19 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * `ISourceBufferInterface` useful as a discriminant for that array.
    */
   sourceBuffers: ISourceBufferInterface[];
+
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * The value can be `undefined` if the user agent does not provide this indicator.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  streaming?: boolean;
+
   /**
    * Add a new `ISourceBufferInterface` (and its corresponding underlying MSE
    * `SourceBuffer` object) linked to the given `SourceBufferType`.
@@ -214,6 +230,7 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * can be created at most per-`IMediaSourceInterface`.
    */
   addSourceBuffer(sbType: SourceBufferType, codec: string): ISourceBufferInterface;
+
   /**
    * Update `duration` property (which in reality means more the "maximum
    * reachable position") in seconds linked to the `MediaSource` (which itself
@@ -226,11 +243,13 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * `interruptDurationSetting`.
    */
   setDuration(newDuration: number, isRealEndKnown: boolean): void;
+
   /**
    * Interrupt a duration update background task previously started through
    * a `setDuration` call.
    */
   interruptDurationSetting(): void;
+
   /**
    * Signal to the `IMediaSourceInterface` that all media segments until the
    * end of the current content has been pushed through its
@@ -244,15 +263,18 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
    * new future content is now available, you should call `stopEndOfStream`.
    */
   maintainEndOfStream(): void;
+
   /**
    * Interrupt an `endOfStream` operation started with `maintainEndOfStream`.
    */
   stopEndOfStream(): void;
+
   /**
    * Free all resources taken by the `IMediaSourceInterface`, including all its
    * inner `ISourceBufferInterface` objects.
    */
   dispose(): void;
+
   /**
    * Only set for `IMediaSourceInterface` objects which cannot rely on
    * MediaSource API directly.
@@ -282,4 +304,10 @@ export interface IMediaSourceInterfaceEvents {
    * changed to `"close"`.
    */
   mediaSourceClose: null;
+
+  /**
+   * Indicate that the `IMediaSourceInterface`'s `streaming` property just
+   * changed.
+   */
+  streamingChanged: null;
 }

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -417,6 +417,16 @@ export interface ISerializedPlaybackObservation {
    * `undefined` if we cannot determine the buffer gap.
    */
   bufferGap: number | undefined;
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  canStream: boolean;
 }
 
 /**

--- a/src/playback_observer/worker_playback_observer.ts
+++ b/src/playback_observer/worker_playback_observer.ts
@@ -39,6 +39,16 @@ export interface IWorkerPlaybackObservation {
   rebuffering: IRebufferingStatus | null;
   freezing: IFreezingStatus | null;
   bufferGap: number | undefined;
+  /**
+   * Indicates whether the user agent believes it has enough buffered data to ensure
+   * uninterrupted playback for a meaningful period or needs more data.
+   * It also reflects whether the user agent can retrieve and buffer data in an
+   * energy-efficient manner while maintaining the desired memory usage.
+   * `true` indicates that the buffer is low, and more data should be buffered.
+   * `false` indicates that there is enough buffered data, and no additional data needs
+   *  to be buffered at this time.
+   */
+  canStream: boolean;
 }
 
 /** Pause-related information linked to an emitted Playback observation. */


### PR DESCRIPTION
Add the possibility to rely on `ManagedMediaSource` for devices that has no access to `MediaSource` such as iOS devices with version > 17.1

In practice that allow devices like iPhone to play DASH content with the RxPlayer.

Note that it is not possible to cast a DASH content with AirPlay, so the RxPlayer disable the possibility to stream to AirPlay by adding the `disableRemotePlayback` attribute to the video Element when a DASH content is loaded.

https://github.com/canalplus/rx-player/issues/1294