### PR TITLE
Fix SyncOrAsync util syncValue transfer

### DIFF
--- a/src/utils/sync_or_async.ts
+++ b/src/utils/sync_or_async.ts
@@ -78,12 +78,14 @@ const SyncOrAsync = {
    * @returns {Object}
    */
   createAsync<T>(val: Promise<T>): ISyncOrAsyncValue<T> {
-    let ret = null;
-    val.then((resolved) => {
+    let ret: T | null = null;
+    val.then((resolved: T) => {
       ret = resolved;
     }, noop);
     return {
-      syncValue: ret,
+      get syncValue(): T | null {
+        return ret;
+      },
       getValueAsAsync() {
         return val;
       },


### PR DESCRIPTION
Note: this was part of the #1413 PR, which was a collection of unrelated improvements. I Chose to open individual pull requests instead so it's easier to review and discuss.

---

Our `SyncOrAsync` util is used for cases where a task is >99% of the time synchronous, yet <1% of the time asynchronous, and where we don't want to incur any overhead/supplementary complexity of awaiting a Promise which inherently schedule a microtask when the value is most probably already there.

It worked well for most usages, but it turns out that a task that starts as asynchronous would then always lead to the need to rely on Promises, even once the task is finished (basically, if it started as an "async value" it could never transform itself to a "sync value").

This does not create any issue but we could gain some minuscule advantage (well, we could argue that `SyncOrAsync`'s advantage is in itself minuscule) here by just relying on the value synchronously once the task is finished.