### PR TITLE
Add version of the RxPlayer in the debug element

### DIFF
--- a/doc/api/Miscellaneous/Debug_Element.md
+++ b/doc/api/Miscellaneous/Debug_Element.md
@@ -93,6 +93,7 @@ exactly what's going on at a particular point in time.
       buffering media) also running in a WebWorker (which should be more efficient but is
       supported by less platforms).
     - If set to `0`, the playback is in the regular "main" (single thread) mode.
+  - **v**: Current version of the RxPlayer.
   - **ks**: _Key System_. If set, the current key system used to decrypt contents.
   - **mbb**: _Max Buffer Behind_. If set, the configured `maxBufferBehind` (amount of
     buffer to keep in memory behind the current position, in seconds).

--- a/src/main_thread/api/debug/modules/general_info.ts
+++ b/src/main_thread/api/debug/modules/general_info.ts
@@ -65,7 +65,7 @@ export default function constructDebugGeneralInfo(
         valuesLine1.push(["wo", "0"]);
       }
 
-      const valuesLine2: Array<[string, string]> = [];
+      const valuesLine2: Array<[string, string]> = [["v", instance.version]];
       const ks = instance.getKeySystemConfiguration();
       if (ks !== null) {
         valuesLine2.push(["ks", ks.keySystem]);


### PR DESCRIPTION
I like relying on our debug element feature when debugging applications and other users seem to also find that element useful, sharing to us screen captures/recording of it.

In that context, it could be good to also display the current RxPlayer version in it, so we can quickly know which version is currently relied on.

Here's how it looks like as the first element of the second line (`v`):
![debugv](https://github.com/user-attachments/assets/a4ce3830-c089-40bc-bfa1-44c1db6dcaa2)
