### PR TITLE
v3: Add make-official-release script

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -106,73 +106,13 @@ The RxPlayer has several types of releases:
 
   When published on `npm`, they have the `canal` tag.
 
-## Workflow for an official release
+## To publish an official release
 
-Before each official releases, a list of steps are performed by its maintainers:
+Before publishing an official RxPlayer releases, a list of steps should be performed by
+its maintainers.
 
-1. Checkout the branch that will be the base of the next release: generally it is
-   `legacy-v3` (for v3 releases)
+First, checkout the branch `legacy-v3` (as I assume you want to produce a `v3` release,
+if not, you're on the wrong base branch here).
 
-2. From there, create a branch named `release/vXX.XX.XX`, where XX.XX.XX is the semver of
-   the wanted new version.
-
-3. Update `CHANGELOG.md` file to add this new version's changelog and commit it.
-
-4. Call the npm script `update-version` for that release
-   (`npm run update-version XX.XX.XX`, where XX.XX.XX is the wanted new version SEMVER).
-
-5. Check that the modifications it did make sense and create a signed commit (`-S` option
-   when commiting with git) updating the staged built files in step `8`.
-
-6. Open a Pull Request on Github, named after the branch, putting the release's changelog
-   in the Pull Request's comment, and optional additional comments.
-
-7. Check that sonarcloud validated that branch. Resolve every bug and code smells it
-   finds.
-
-8. Ensure that the CI doesn't detect any issue and fix them if that's the case.
-
-9. Run sanity checks on myCanal's repository, by using this new version instead as a
-   dependency.
-
-10. If and only if no problem was seen perform a signed merge without fast-forward of the
-    release branch into legacy-v3 (`git merge -S --no-ff release/vXX.XX.XX legacy-v3`)
-
-11. Launch script to update the gh-pages demo (`./scripts/update_gh-pages_demo`)
-
-12. Launch script to update the gh-pages doc (`./scripts/update_gh-pages_doc`)
-
-13. Check that both of those worked, perform manual updates and update the concerned
-    scripts in other cases.
-
-14. Check that the new demo and the new doc work as expected
-
-15. If all seems good, push to remote `legacy-v3` your local `legacy-v3` branch.
-
-16. run `npm publish --tag legacy-v3` to publish the new version on npm's registry with
-    the `legacy-v3` tag.
-
-17. Test that importing this new version doesn't cause bundling issues (you may do so
-    through a ad-hoc package, or just myCanal for example).
-
-18. Create the new release through github's interface - don't forget to include the built
-    files on it.
-
-If any of the testing steps failed (after step `3`), run the following steps:
-
-1. Fix the problem (!)
-
-2. Create a commit for the fix with a meaningful message.
-
-3. If (and only if) it make sense, update the changelog and create a commit for it.
-
-4. Call the npm script `update-version` for that release
-   (`npm run update-version XX.XX.XX`, where XX.XX.XX is the wanted new version SEMVER).
-
-5. Check that the modifications of that last step made sense and create a signed commit
-   (`-S` option when commiting with git) updating the staged built files.
-
-6. Depending on the nature of the fix, either create a new branch and add a Pull Request
-   to merge it in the release branch or push it to the release branch directly.
-
-7. Go back to step `8` (sonarcloud + CI) of the previous workflow
+Then, the following steps are mostly automatized by the `releases:official` script, which
+may be run by calling `npm run releases:official`.

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -111,8 +111,8 @@ The RxPlayer has several types of releases:
 Before publishing an official RxPlayer releases, a list of steps should be performed by
 its maintainers.
 
-First, checkout the branch `legacy-v3` (as I assume you want to produce a `v3` release,
-if not, you're on the wrong base branch here).
+First, checkout the branch `legacy-v3` (as I assume you want to produce a `v3` release, if
+not, you're on the wrong base branch here).
 
-Then, the following steps are mostly automatized by the `releases:official` script,
-which may be run by calling `npm run releases:official`.
+Then, the following steps are mostly automatized by the `releases:official` script, which
+may be run by calling `npm run releases:official`.

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -114,5 +114,5 @@ its maintainers.
 First, checkout the branch `legacy-v3` (as I assume you want to produce a `v3` release,
 if not, you're on the wrong base branch here).
 
-Then, the following steps are mostly automatized by the `releases:official` script, which
-may be run by calling `npm run releases:official`.
+Then, the following steps are mostly automatized by the `releases:official` script,
+which may be run by calling `npm run releases:official`.

--- a/scripts/make-dev-releases
+++ b/scripts/make-dev-releases
@@ -4,7 +4,7 @@
 # =================
 #
 # This script produces pre-releases on top of the current branch for the
-# `dev` and `canal` versions (as per their npm tags).
+# `dev-v3` and `canal-v3` versions (as per their npm tags).
 #
 # To use it:
 #
@@ -161,7 +161,7 @@ while true; do
   esac
 done
 git push origin ${dev_branch}
-npm publish --tag dev-v4
+npm publish --tag dev-v3
 
 git checkout $current_branch
 
@@ -180,4 +180,4 @@ while true; do
   *) echo "Please answer y or n." ;;
   esac
 done
-npm publish --tag canal
+npm publish --tag canal-v3

--- a/scripts/make-dev-releases
+++ b/scripts/make-dev-releases
@@ -41,7 +41,7 @@ err() {
 }
 
 if [ $# -eq 0 ]; then
-  read -r -p "Please enter the wanted version number (example: 4.12.1): " version
+  read -r -p "Please enter the wanted version number (example: 3.12.1): " version
   echo ""
   if [ -z "${version}" ]; then
     # TODO SEMVER REGEX?
@@ -181,3 +181,4 @@ while true; do
   esac
 done
 npm publish --tag canal-v3
+

--- a/scripts/make-official-release.sh
+++ b/scripts/make-official-release.sh
@@ -7,7 +7,7 @@
 #
 # To use it:
 #
-#   1. Be sure that you're on the `legacy-v3` branch 
+#   1. Be sure that you're on the `legacy-v3` branch
 #
 #   2. Call this script, you may optionally provide the wanted version as an
 #      argument to this script. If no argument is provided, the script will ask
@@ -75,7 +75,7 @@ check_dependency sleep
 base_branch=$(current_branch)
 
 if ! [ "$base_branch" == "legacy-v3" ]; then
-  err "The base branch for releases should be \"legacy-v3\""
+  err "The base branch for v3 releases should be \"legacy-v3\""
 fi
 
 if [ -n "$(git status --porcelain)" ]; then
@@ -86,7 +86,7 @@ echo "Checking current branch is synchronized with remote..."
 check_branch_synchronized_with_remote
 
 if [ $# -eq 0 ]; then
-  read -r -p "Please enter the wanted version number (example: 4.12.1): " version
+  read -r -p "Please enter the wanted version number (example: 3.12.1): " version
   echo ""
   if [ -z "${version}" ]; then
     # TODO SEMVER REGEX?
@@ -327,11 +327,10 @@ done
 echo ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
 log ""
-log "The legacy-v3 branch has been updated to now point to the v$version release and"
-log "has been pushed to remote."
+log "The legacy-v3 branch has been updated to now point to the v$version release"
+log "and has been pushed to remote."
 log ""
-log 'You may now run "npm publish --tag legacy-v3", check the published package, '
-log 'and then create log "the release on GitHub's interface (don't forget to '
-log "include builds in it)."
+log 'You may now run "npm publish", check the published package, and then create'
+log "the release on GitHub's interface (don't forget to include builds in it)."
 log ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/make-official-release.sh
+++ b/scripts/make-official-release.sh
@@ -330,7 +330,8 @@ log ""
 log "The legacy-v3 branch has been updated to now point to the v$version release"
 log "and has been pushed to remote."
 log ""
-log 'You may now run "npm publish", check the published package, and then create'
-log "the release on GitHub's interface (don't forget to include builds in it)."
+log 'You may now run "npm publish --tag legacy-v3", check the published package,'
+log "and then create the release on GitHub's interface (don't forget to include"
+log "builds in it)."
 log ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/update-version
+++ b/scripts/update-version
@@ -38,7 +38,7 @@ sed -i.bak -E -e "s/^\#\# Unreleased/\#\# v${version} \(${date_iso}\)/gi" CHANGE
 sed -i.bak -E -e "s/\/\\* PLAYER_VERSION \\*\/[[:space:]]*\".*\";/\/* PLAYER_VERSION *\/ \"${version}\";/g" src/main_thread/api/public_api.ts && rm src/main_thread/api/public_api.ts.bak
 sed -i.bak -E -e "s/\"version\":[[:space:]]*\"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\"]*\"/\"version\": \"${version}\"/g" package.json && rm package.json.bak
 sed -i.bak -E -e "s/sonar\.projectVersion= *.*/sonar.projectVersion=${version}/g" sonar-project.properties && rm sonar-project.properties.bak
-echo $version > VERSION
+echo $version >VERSION
 
 npm install
 npm run build
@@ -50,4 +50,5 @@ echo "creating types for legacy code bases..."
 rm -f dist/rx-player.d.ts rx-player.min.d.ts
 echo "${copyright_text}
 import RxPlayer from \"./_esm5.processed/minimal\";
-export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts > /dev/null
+export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
+

--- a/scripts/update-version
+++ b/scripts/update-version
@@ -38,7 +38,7 @@ sed -i.bak -E -e "s/^\#\# Unreleased/\#\# v${version} \(${date_iso}\)/gi" CHANGE
 sed -i.bak -E -e "s/\/\\* PLAYER_VERSION \\*\/[[:space:]]*\".*\";/\/* PLAYER_VERSION *\/ \"${version}\";/g" src/main_thread/api/public_api.ts && rm src/main_thread/api/public_api.ts.bak
 sed -i.bak -E -e "s/\"version\":[[:space:]]*\"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\"]*\"/\"version\": \"${version}\"/g" package.json && rm package.json.bak
 sed -i.bak -E -e "s/sonar\.projectVersion= *.*/sonar.projectVersion=${version}/g" sonar-project.properties && rm sonar-project.properties.bak
-echo $version >VERSION
+echo $version > VERSION
 
 npm install
 npm run build
@@ -50,4 +50,4 @@ echo "creating types for legacy code bases..."
 rm -f dist/rx-player.d.ts rx-player.min.d.ts
 echo "${copyright_text}
 import RxPlayer from \"./_esm5.processed/minimal\";
-export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
+export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts > /dev/null


### PR DESCRIPTION
I was trying to backport https://github.com/canalplus/rx-player/pull/1524 to the v3 so we can easily make a v3 release.
However due to a cascade of hardware issues, I currently cannot use any other software than a web browser basically.

Navigating through unfamiliar web-only tools (mainly VSCode so familiar to many, but I wasn't nor with any other non-terminal editor), I did my backport, but seeing now the diff on GitHub's interface for the first time it seems that the development was already backported and that this PR only fixes some mistakes.

Well, this PR's modifications still have a point, so I keep it.