### PR TITLE
v3:  Fix off by 1 issue in when relying on keySystems[].maxSessionCacheSize

### DIFF
--- a/src/core/decrypt/create_or_load_session.ts
+++ b/src/core/decrypt/create_or_load_session.ts
@@ -82,7 +82,12 @@ export default async function createOrLoadSession(
     }
   }
 
-  await cleanOldLoadedSessions(loadedSessionsStore, maxSessionCacheSize);
+  await cleanOldLoadedSessions(
+    loadedSessionsStore,
+    // Account for the next session we will be creating
+    // Note that `maxSessionCacheSize < 0 has special semantic (no limit)`
+    maxSessionCacheSize <= 0 ? maxSessionCacheSize : maxSessionCacheSize - 1,
+  );
   if (cancelSignal.cancellationError !== null) {
     throw cancelSignal.cancellationError; // stop here if cancelled since
   }

--- a/src/core/decrypt/utils/clean_old_loaded_sessions.ts
+++ b/src/core/decrypt/utils/clean_old_loaded_sessions.ts
@@ -30,7 +30,7 @@ export default async function cleanOldLoadedSessions(
   loadedSessionsStore: LoadedSessionsStore,
   limit: number,
 ): Promise<void> {
-  if (limit < 0 || limit > loadedSessionsStore.getLength()) {
+  if (limit < 0 || limit >= loadedSessionsStore.getLength()) {
     return;
   }
   log.info("DRM: LSS cache limit exceeded", limit, loadedSessionsStore.getLength());

--- a/src/core/decrypt/utils/clean_old_loaded_sessions.ts
+++ b/src/core/decrypt/utils/clean_old_loaded_sessions.ts
@@ -30,7 +30,7 @@ export default async function cleanOldLoadedSessions(
   loadedSessionsStore: LoadedSessionsStore,
   limit: number,
 ): Promise<void> {
-  if (limit < 0 || limit >= loadedSessionsStore.getLength()) {
+  if (limit < 0 || limit > loadedSessionsStore.getLength()) {
     return;
   }
   log.info("DRM: LSS cache limit exceeded", limit, loadedSessionsStore.getLength());


### PR DESCRIPTION
This is a backport of #1565 for the v3