### PR TITLE
[Proposal] DEBUG_ELEMENT: Add `hdr` information to video Representation

### DIFF
--- a/src/main_thread/api/debug/modules/segment_buffer_content.ts
+++ b/src/main_thread/api/debug/modules/segment_buffer_content.ts
@@ -155,7 +155,7 @@ function constructRepresentationInfo(content: {
     isSignInterpreted,
     type: bufferType,
   } = content.adaptation;
-  const { id, height, width, bitrate, codecs } = content.representation;
+  const { id, height, width, bitrate, codecs, hdrInfo } = content.representation;
   let representationInfo = `"${id}" `;
   if (height !== undefined && width !== undefined) {
     representationInfo += `${width}x${height} `;
@@ -168,6 +168,9 @@ function constructRepresentationInfo(content: {
   }
   if (language !== undefined) {
     representationInfo += `l:"${language}" `;
+  }
+  if (bufferType === "video" && hdrInfo !== undefined) {
+    representationInfo += "hdr:1 ";
   }
   if (bufferType === "video" && typeof isSignInterpreted === "boolean") {
     representationInfo += `si:${isSignInterpreted ? 1 : 0} `;


### PR DESCRIPTION
This has been a request: to clearly indicate when the current Representation has linked HDR information in our debug element.

I don't think it causes issue and it makes sense, so I wrote the proposal commit here. It could also be useful when we do the debugging ourselves.