### PR TITLE
Demo: Only include DASH_WASM parser when explicitly asked for

### DIFF
--- a/demo/scripts/modules/player/index.ts
+++ b/demo/scripts/modules/player/index.ts
@@ -455,7 +455,7 @@ const PlayerModule = declareModule(
       player
         .attachWorker({
           workerUrl: "./worker.js",
-          dashWasmUrl: "./mpd-parser.wasm",
+          dashWasmUrl: __INCLUDE_WASM_PARSER__ ? "./mpd-parser.wasm" : undefined,
         })
         .catch((err) => {
           // eslint-disable-next-line no-console


### PR DESCRIPTION
In our demo, we have specific scripts to start that demo with our WebAssembly MPD parser, the `DASH_WASM` feature.

What those do is to set a `__INCLUDE_WASM_PARSER__` boolean to `true` in global scope, which signals to the demo page that it should include the `DASH_WASM` feature and load the corresponding WebAssembly file.

However I noticed that when enabling "multithreading" mode in our demo page, it tried to download the WebAssembly MPD parser regardless of the `__INCLUDE_WASM_PARSER__` boolean.

This made sense pre-`v4.1.0` when we only relied on the WebAssembly parser to parse a DASH MPD in "multithreading" mode. But now that we also have a JS parser embedded inside our worker code, it seems unnecessary.

It also led to some http 404 when testing the demo locally without having built the WebAssembly file. Those don't matter much though because the RxPlayer automatically fallbacks to the JS parser.

Also, the demo built on our GitHub pages accessible on https://developers.canal-plus.com/rx-player/ do have the WebAssembly MPD parser file built. This means that when enabling the "multithreading" mode on that demo, we're actually loading and using that WebAssembly file to parse MPDs.

Doing the change I'm proposing here of only using the WebAssembly parser if `__INCLUDE_WASM_PARSER__` is set to `true` will thus lead to a small change in the globally-accessible demo page, where we will be using the default JS parser instead in "multithreading" mode.

We could also in the future add a checkbox in our demo specifically for the inclusion or not of the WebAssembly parser.