### PR TITLE
MULTI_THREAD: Fix onmessageerror being undefined

### DIFF
--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -19,6 +19,7 @@ import type { IPlayerError, ITrackType } from "../../../public_types";
 import createDashPipelines from "../../../transports/dash";
 import arrayFind from "../../../utils/array_find";
 import assert, { assertUnreachable } from "../../../utils/assert";
+import globalScope from "../../../utils/global_scope";
 import type { ILogFormat, ILoggerLevel } from "../../../utils/logger";
 import { scaleTimestamp } from "../../../utils/monotonic_timestamp";
 import objectAssign from "../../../utils/object_assign";
@@ -80,7 +81,7 @@ export default function initializeWorkerMain() {
    */
   let playbackObservationRef: SharedReference<IWorkerPlaybackObservation> | null = null;
 
-  onmessageerror = (_msg: MessageEvent) => {
+  globalScope.onmessageerror = (_msg: MessageEvent) => {
     log.error("MTCI: Error when receiving message from main thread.");
   };
   onmessage = function (e: MessageEvent<IMainThreadMessage>) {


### PR DESCRIPTION
We recently defined a `onmessageerror` global callback on the WebWorker-side of the `MULTI_THREAD` feature, thinking that it was defined, like the `onmessage` callback, as long as WebWorker were accessible.

Turns out that was not the case at all, and the multithreading mode was breaking on older device. Oops, sorry about that.

As it is not required, we can just access it through our `globalScope` shortcut to the global object. This way, it will just define a callback which will never be called if it does not exist.