### PR TITLE
fix(freeze-detector): perform a seek regardless of the wanted position

### DIFF
--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -117,13 +117,10 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
               ? freezing.timestamp
               : prevFreezingState.attemptTimestamp;
 
-          if (
-            !position.isAwaitingFuturePosition() &&
-            now - referenceTimestamp > UNFREEZING_SEEK_DELAY
-          ) {
+          if (now - referenceTimestamp > UNFREEZING_SEEK_DELAY) {
             log.warn("Init: trying to seek to un-freeze player");
             this._playbackObserver.setCurrentTime(
-              this._playbackObserver.getCurrentTime() + UNFREEZING_DELTA_POSITION,
+              observation.position.getWanted() + UNFREEZING_DELTA_POSITION,
             );
             prevFreezingState = { attemptTimestamp: now };
           }
@@ -477,7 +474,7 @@ function generateDiscontinuityError(stalledPosition: number, seekTo: number): Me
     "DISCONTINUITY_ENCOUNTERED",
     "A discontinuity has been encountered at position " +
       String(stalledPosition) +
-      ", seeked at position " +
+      ", seeking at position " +
       String(seekTo),
   );
 }


### PR DESCRIPTION
On devices such as Samsung the player can hang indefinitely (often when encountering discontinuities in the media data). The freeze detector should detects those freeze and perform a seek that would fix the situation.
However the current implementation does not perform a seek if the wanted position is higher than the current position.
It's an issue particularly on Samsung because the seeked time on Samsung devices is unpredictable and the current position can easily be behind the wanted position after a seek.