### PR TITLE
[Proposal] Make SharedReference's clearSignal param mandatory

### DIFF
--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -258,7 +258,7 @@ export default class PlaybackObserver {
   /**
    * Register a callback so it regularly receives playback observations.
    * @param {Function} cb
-   * @param {Object} options - Configuration options:
+   * @param {Object} params - Configuration parameters:
    *   - `includeLastObservation`: If set to `true` the last observation will
    *     be first emitted synchronously.
    *   - `clearSignal`: If set, the callback will be unregistered when this
@@ -266,17 +266,17 @@ export default class PlaybackObserver {
    */
   public listen(
     cb: (observation: IPlaybackObservation, stopListening: () => void) => void,
-    options?: {
+    params: {
       includeLastObservation?: boolean | undefined;
-      clearSignal?: CancellationSignal | undefined;
+      clearSignal: CancellationSignal;
     },
   ) {
-    if (this._canceller.isUsed() || options?.clearSignal?.isCancelled() === true) {
+    if (this._canceller.isUsed() || params.clearSignal.isCancelled()) {
       return noop;
     }
     this._observationRef.onUpdate(cb, {
-      clearSignal: options?.clearSignal,
-      emitCurrentValue: options?.includeLastObservation,
+      clearSignal: params.clearSignal,
+      emitCurrentValue: params.includeLastObservation,
     });
   }
 

--- a/src/playback_observer/types.ts
+++ b/src/playback_observer/types.ts
@@ -216,9 +216,9 @@ export interface IReadOnlyPlaybackObserver<TObservationType> {
    */
   listen(
     cb: (observation: TObservationType, stopListening: () => void) => void,
-    options?: {
+    options: {
       includeLastObservation?: boolean | undefined;
-      clearSignal?: CancellationSignal | undefined;
+      clearSignal: CancellationSignal;
     },
   ): void;
   /**

--- a/src/playback_observer/utils/generate_read_only_observer.ts
+++ b/src/playback_observer/utils/generate_read_only_observer.ts
@@ -36,20 +36,17 @@ export default function generateReadOnlyObserver<TSource, TDest>(
     },
     listen(
       cb: (observation: TDest, stopListening: () => void) => void,
-      options?: {
+      params: {
         includeLastObservation?: boolean | undefined;
-        clearSignal?: CancellationSignal | undefined;
+        clearSignal: CancellationSignal;
       },
     ): void {
-      if (
-        cancellationSignal.isCancelled() ||
-        options?.clearSignal?.isCancelled() === true
-      ) {
+      if (cancellationSignal.isCancelled() || params.clearSignal.isCancelled()) {
         return;
       }
       mappedRef.onUpdate(cb, {
-        clearSignal: options?.clearSignal,
-        emitCurrentValue: options?.includeLastObservation,
+        clearSignal: params.clearSignal,
+        emitCurrentValue: params.includeLastObservation,
       });
     },
     deriveReadOnlyObserver<TNext>(

--- a/src/playback_observer/worker_playback_observer.ts
+++ b/src/playback_observer/worker_playback_observer.ts
@@ -111,21 +111,18 @@ export default class WorkerPlaybackObserver
 
   public listen(
     cb: (observation: IWorkerPlaybackObservation, stopListening: () => void) => void,
-    options?: {
+    params: {
       includeLastObservation?: boolean | undefined;
-      clearSignal?: CancellationSignal | undefined;
+      clearSignal: CancellationSignal;
     },
   ): void {
-    if (
-      this._cancelSignal.isCancelled() ||
-      options?.clearSignal?.isCancelled() === true
-    ) {
+    if (this._cancelSignal.isCancelled() || params.clearSignal.isCancelled()) {
       return;
     }
 
     this._src.onUpdate(cb, {
-      clearSignal: options?.clearSignal,
-      emitCurrentValue: options?.includeLastObservation,
+      clearSignal: params.clearSignal,
+      emitCurrentValue: params.includeLastObservation,
     });
   }
 


### PR DESCRIPTION
_NOTE: Most updates here are prettier being prettier and re-indenting things. No logic beside one handling the `clearSignal` parameter should have been updated._

We've seen minor memory leaks in the project due to forgetting to clean-up what's basically event listeners (mainly JS-only ones, not DOM ones).

To put a supplementary level of security against memory leaks, I propose here to make the `SharedReference` and any `IPlaybackObserver`'s `clearSignal` parameter as mandatory.

Note that this is not always needed to clean up a listener, there's for example the `stopListening` argument provided in the callback, "finishing" the reference etc., so a reference without a CancellationSignal could still not be leaking, but ensuring there's a CancellationSignal also attached looks like a minor sacrifice to limit memory leaks to me.