### PR TITLE
Set-up a comprehensive check when trying to reuse MediaKeySystemAccess

### DIFF
--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -81,9 +81,9 @@ interface IKeySystemType {
    * system.
    */
   keyName: string | undefined;
-  /** keyType: keySystem type (e.g. "com.widevine.alpha") */
+  /** KeySystem type (e.g. "com.widevine.alpha") */
   keyType: string;
-  /** keySystem {Object}: the original keySystem object */
+  /** The original keySystem object */
   keySystemOptions: IKeySystemOption;
 }
 
@@ -403,14 +403,7 @@ export default function getMediaKeySystemAccess(
   cancelSignal: CancellationSignal,
 ): Promise<IFoundMediaKeySystemAccessEvent> {
   log.info("DRM: Searching for compatible MediaKeySystemAccess");
-  /**
-   * Array of set keySystems for this content.
-   * Each item of this array is an object containing the following keys:
-   *   - keyName {string}: keySystem canonical name (e.g. "widevine")
-   *   - keyType {string}: keySystem type (e.g. "com.widevine.alpha")
-   *   - keySystem {Object}: the original keySystem object
-   * @type {Array.<Object>}
-   */
+  /** Array of set keySystems for this content. */
   const keySystemsType: IKeySystemType[] = keySystemsConfigs.reduce(
     (arr: IKeySystemType[], keySystemOptions) => {
       const { EME_KEY_SYSTEMS } = config.getCurrent();


### PR DESCRIPTION
While working on cases where an application wants to set-up different DRM configurations depending on the content, yet still keep the same `MediaKeys` instance if possible (to keep our `MediaKeySession` cache), I tried to make sure we support at worse a case where a more constrained configuration would still be considered as compatible to a less constrained one - as long as there's no loss of features / capabilities between the two.

After attempts specific to the RxPlayer's `keySystems` API format, I ended up relying on the asked `MediaKeySystemConfiguration`s (both the new wanted one and the one that led to the current `MediaKeySystemAccess`) instead, as the corresponding logic seemed easier to me to maintain.