### PR TITLE
[Proposal] Add `getWallClockOffset` API

### DIFF
--- a/doc/api/Basic_Methods/.docConfig.json
+++ b/doc/api/Basic_Methods/.docConfig.json
@@ -33,6 +33,10 @@
       "displayName": "getWallClockTime"
     },
     {
+      "path": "./getWallClockOffset.md",
+      "displayName": "getWallClockOffset"
+    },
+    {
       "path": "./seekTo.md",
       "displayName": "seekTo"
     },

--- a/doc/api/Basic_Methods/getWallClockOffset.md
+++ b/doc/api/Basic_Methods/getWallClockOffset.md
@@ -1,0 +1,50 @@
+# getWallClockOffset
+
+## Description
+
+When playing live contents, you might want to display in your interface time adjusted so
+it corresponds to the diffusion time (e.g. `09:00` if a live program begins at 9) and not
+the more abstract position returned by API like `getPosition`, `getMinimumPosition` or
+`getMaximumPosition`.
+
+For the current position, you can just call
+[the `getWallClockTime` method](./getWallClockTime.md) for this, however for other API
+(like `getMinimumPosition` etc.) there's no specialized method to adjust that time.
+
+That is what `getWallClockOffset` is for, it returns the offset allowing to convert the
+media position you get from most RxPlayer API into a live-adjusted unix timestamp (in
+seconds) by adding the two.
+
+For example, the following equality is true:
+
+```js
+player.getPosition() + player.getWallClockOffset() === player.getWallClockTime();
+```
+
+You may want to use this method to simplify conversion between the two units.
+
+Note that there's nothing guaranteeing that this offset won't evolve over time for a given
+content. You should call this method every time you need to perform the conversion.
+
+### Example
+
+```js
+const wallClockTime = player.getWallClockTime();
+
+// This one is expressed as a media position
+const maximumPosition = player.getMaximumPosition();
+
+// convert wall-clock time to a media position
+const currentPosition = wallClockTime - player.getWallClockOffset();
+
+console.log("delay from maximum position, in seconds", maximumPosition - currentPosition);
+```
+
+## Syntax
+
+```js
+const offset = player.getWallClockOffset();
+```
+
+- **return value** `number`: The offset in seconds to add to a media position to obtain
+  the "wall-clock time" (live-adjusted time, in seconds).

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -227,6 +227,9 @@ events and so on.
 - [`getWallClockTime`](../api/Basic_Methods/getWallClockTime.md): Get the current playback
   condition offseted to be relative to the the current date.
 
+- [`getWallClockOffset`](../api/Basic_Methods/getWallClockOffset.md): Get the offset to
+  add to a media time to obtain a date-adjusted "wall-clock time".
+
 - [`seekTo`](../api/Basic_Methods/seekTo.md): Seek in the current content.
 
 - [`getMinimumPosition`](../api/Basic_Methods/getMinimumPosition.md): Get the minimum

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1618,16 +1618,58 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (this._priv_contentInfos === null) {
       return this.videoElement.currentTime;
     }
+    const wallClockOffset = this.getWallClockOffset();
+    const currentTime = this.videoElement.currentTime;
+    return currentTime + wallClockOffset;
+  }
+
+  /**
+   * Get value allowing to convert the media position, as returned by
+   * `getPosition` to a "wall-clock time", as returned by `getWallClockTime`, by
+   * additioning the first two:
+   * ```js
+   * player.getPosition() + player.getWallClockOffset() === player.getWallClockTime();
+   * ```
+   *
+   * As most of the RxPlayer API relies on the media position as returned by
+   * `getPosition`, you may want to use this method to simplify conversion if
+   * what you have right now is a wall-clock time. For example:
+   *
+   * ```js
+   * const wallClockTime = player.getWallClockTime();
+   *
+   * // This one is expressed as a media position
+   * const maximumPosition = player.getMaximumPosition();
+   *
+   * // convert wall-clock time to a media position
+   * const currentPosition = wallClockTime - player.getWallClockOffset();
+   *
+   * console.log(
+   *   "delay from maximum position, in seconds",
+   *   maximumPosition - currentPosition
+   * );
+   * ```
+   *
+   * Note that there's nothing guaranteeing that this offset won't evolve over
+   * time for a given content. You should call this method every time you need
+   * to perform the conversion.
+   * @returns {number}
+   */
+  getWallClockOffset(): number {
+    if (this.videoElement === null) {
+      return 0;
+    }
+    if (this._priv_contentInfos === null) {
+      return 0;
+    }
 
     const { isDirectFile, manifest } = this._priv_contentInfos;
     if (isDirectFile) {
       const startDate = getStartDate(this.videoElement);
-      return (startDate ?? 0) + this.videoElement.currentTime;
+      return startDate ?? 0;
     }
     if (manifest !== null) {
-      const currentTime = this.videoElement.currentTime;
-      const ast = manifest.availabilityStartTime ?? 0;
-      return currentTime + ast;
+      return manifest.availabilityStartTime ?? 0;
     }
     return 0;
   }


### PR DESCRIPTION
I was lately working on an application relying on the RxPlayer at Canal+, and trying to see how our upcoming thumbnail API ( #1496  ) could be integrated in their projects.

I found out that this application relied only on `getWallClockTime` for storing the current playback position.
The value returned by this method is basically the current position offseted so it corresponds to the unix timestamp at which the corresponding media data was intended to be broadcasted.

In other words, doing `new Date(wallClockTime * 1000)` will translate that position into the corresponding date, whereas our `getPosition` API, returns a more arbitrary timestamp without special meaning, that we will call here the "media position" (it is the actual position advertised by the HTML video element in the page).

Applications like to use the `wallClockTime` for live contents as this allows to display a seeking bar with the date in an e.g. `hours:minutes:seconds` format which is much more useful to a final user than a timestamp without any special meaning.
We even also rely on `wallClockTime` ourselves on the demo page.

However, most other RxPlayer API rely on the media position instead. For example, `getAvailablePeriods`, `getMinimumPosition`, `getLiveEdge` and future thumbnail API all will provide timestamp in the "meaningless" media position format.

---

Converting from the `wallClockTime` to the "media position" and vice-versa was awkward before, you basically had to re-call `player.getWallClockTime() - player.getPosition()` to obtain the difference and thus to convert the `wallClockTime` you're using in your application into a media position you can use more easily with the RxPlayer API.

Instead, I propose here to add the `player.getWallClockOffset()` API, which returns that difference in a more explicit way.

You can then do something like:

```js
function compareWithMaximumPosition(wallClockTime) {
  const wallClockOffset = rxPlayer.getWallClockOffset();
  const currentPosition = wallClockTime - wallClockOffset;

  const maximumPosition = rxPlayer.getMaximumPosition();
  const deltaFromMax = maximumPosition - currentPosition;
  console.log(
    `We are ${deltaFromMax} seconds behind the maximum seekable position`,
  );
}
```

Which makes more sense and seems feels more stable than randomly re-obtaining the same offset by doing:

```js
const wallClockOffset = player.getWallClockTime() - player.getPosition();
```

Note that we could have added a `rxPlayer.toMediaPosition(wallClockTime)` method instead, which may be even more easily discoverable, but I found `getWallClockOffset` more useful and still approachable.