### PR TITLE
Fix launch_static_server script when only HTTP is wanted

### DIFF
--- a/scripts/launch_static_server.mjs
+++ b/scripts/launch_static_server.mjs
@@ -74,6 +74,7 @@ export default function launchStaticServer(path, config) {
     httpServer.listen(config.httpPort, onHttpConnection);
 
     if (!shouldStartHttps) {
+      httpsServerStatus = "disabled";
       return;
     }
 
@@ -124,7 +125,7 @@ export default function launchStaticServer(path, config) {
         httpServerStatus = "error";
         if (httpsServerStatus === "success") {
           res({ http: false, https: true });
-        } else if (httpsServerStatus === "error") {
+        } else if (httpsServerStatus === "error" || httpsServerStatus === "disabled") {
           rej(err);
         }
         httpServer.close();


### PR DESCRIPTION
We have "performance" tests which allow to ensure that we're not having what we could call "performance regressions", such as a higher delay to have a content loaded from a `loadVideo` call.

I wanted to run them yesterday for #1607, but they hanged indefinitely.

Turns out that our static server script, that we use here just to host and serve our testing scripts returned a promise that was never resolved.

_(Note: we don't rely on external test runners nor on test frameworks for our performance tests, we manually detect and launch local chrome + firefox binaries on a local server serving our bundled scripts (themselves importing the RxPlayer), and at runtime those scripts send results to another "result" server when they're done)_

It was never resolved because we never properly handled the case in that script were we wanted to launch an HTTP server but not an HTTPS one for the same resource(s). This is now fixed.

Hopeful that performance tests now work correctly, it's been a long time since I last ran them.