### PR TITLE
Demo: allow seeking even when LOADING/RELOADING

### DIFF
--- a/demo/scripts/controllers/ProgressBar.tsx
+++ b/demo/scripts/controllers/ProgressBar.tsx
@@ -4,6 +4,7 @@ import ToolTip from "../components/ToolTip";
 import VideoThumbnail from "../components/VideoThumbnail";
 import useModuleState from "../lib/useModuleState";
 import type { IPlayerModule } from "../modules/player/index";
+import isNullOrUndefined from "../../../src/utils/is_null_or_undefined";
 
 function ProgressBar({
   player,
@@ -13,10 +14,10 @@ function ProgressBar({
   player: IPlayerModule;
   enableVideoThumbnails: boolean;
   onSeek: () => void;
-}): JSX.Element {
+}): JSX.Element | null {
   const bufferGap = useModuleState(player, "bufferGap");
   const currentTime = useModuleState(player, "currentTime");
-  const isContentLoaded = useModuleState(player, "isContentLoaded");
+  const isStopped = useModuleState(player, "isStopped");
   const isLive = useModuleState(player, "isLive");
   const minimumPosition = useModuleState(player, "minimumPosition");
   const livePosition = useModuleState(player, "livePosition");
@@ -111,18 +112,14 @@ function ProgressBar({
     [player, showTimeIndicator, showThumbnail],
   );
 
+  if (isStopped) {
+    return null;
+  }
+
   const toolTipOffset =
     wrapperElementRef.current !== null
       ? wrapperElementRef.current.getBoundingClientRect().left
       : 0;
-
-  if (!isContentLoaded) {
-    return (
-      <div className="progress-bar-parent" ref={wrapperElementRef}>
-        <div className="progress-bar-wrapper" />
-      </div>
-    );
-  }
 
   let thumbnailElement: JSX.Element | null = null;
   if (thumbnailIsVisible) {
@@ -134,6 +131,7 @@ function ProgressBar({
     }
   }
 
+  const progressBarMaximum = livePosition ?? maximumPosition;
   return (
     <div className="progress-bar-parent" ref={wrapperElementRef}>
       {timeIndicatorVisible ? (
@@ -145,14 +143,16 @@ function ProgressBar({
         />
       ) : null}
       {thumbnailElement}
-      {currentTime === undefined ? null : (
+      {currentTime === undefined ||
+      isNullOrUndefined(minimumPosition) ||
+      isNullOrUndefined(progressBarMaximum) ? null : (
         <ProgressbarComponent
           seek={seek}
           onMouseOut={hideToolTips}
           onMouseMove={onMouseMove}
           position={currentTime}
           minimumPosition={minimumPosition}
-          maximumPosition={livePosition ?? maximumPosition}
+          maximumPosition={progressBarMaximum}
           bufferGap={bufferGap}
         />
       )}

--- a/demo/scripts/modules/player/events.ts
+++ b/demo/scripts/modules/player/events.ts
@@ -216,6 +216,7 @@ function linkPlayerEventsToState(
 
     switch (playerState) {
       case "LOADING":
+        startPositionUpdates();
         stateUpdates.useWorker = player.getCurrentModeInformation()?.useWorker === true;
         break;
       case "ENDED":
@@ -230,7 +231,6 @@ function linkPlayerEventsToState(
         stateUpdates.isPaused = false;
         break;
       case "LOADED":
-        startPositionUpdates();
         stateUpdates.isPaused = true;
         stateUpdates.isLive = player.isLive();
         break;

--- a/demo/styles/style.css
+++ b/demo/styles/style.css
@@ -360,7 +360,7 @@ header .right {
   cursor: pointer;
   display: flex;
   position: relative;
-  background-color: #000;
+  background-color: #333333;
   width: 100%;
   margin: auto;
   transition: all 0.2s ease;
@@ -387,7 +387,7 @@ header .right {
 .progress-bar-buffered {
   position: absolute;
   height: 100%;
-  background-color: #333;
+  background-color: #686868;
   z-index: 2;
   transition-duration: 0.3s;
 }


### PR DESCRIPTION
This PR builds on #1607 to allow users of the demo to seek in the content even as it is still loading.

In real use cases, a final user might rely on e.g. seeking thumbnails to already know where to seek to without having to wait for initial segments to be loaded.
This is a functionality we do see with other media players, YouTube also does this for example.

To make the seeking bar more visible, I lightly changed its CSS rules.

Also, I conditioned the appearance of the "ProgressBar" based on if the minimum and maximum seekable positions are known, as else, seeking in that bar is not going to lead to a precize seek. This makes the content not seekable until the Manifest has been loaded.

This is how it looks like now (I throttle the network excessively so we better see the steps before that content loads):
<video src="https://github.com/user-attachments/assets/644fcd75-6973-460d-892d-92f3aa0b1cdd" />

(Link if not available: https://github.com/user-attachments/assets/644fcd75-6973-460d-892d-92f3aa0b1cdd)

_As we can see in that video, the content is only seekable once the `stream.mpd` (the Manifest file) is loaded and it is then seekable. The content will start at the last set position. This looks natural but needed the development of #1607 to be possible._

_There's a delay after the first manual seek until the result is visible because we still need to push the first init segment before actually seeking through a media element, and the demo is relying on the latter for its rendering of the progress bar. We definitely could improve on that part._

This is how it looked before:
<video src="https://github.com/user-attachments/assets/586caa59-ac77-481e-bab6-05c7b173dc20" />

(Link if not available: https://github.com/user-attachments/assets/586caa59-ac77-481e-bab6-05c7b173dc20)

_Before, seeking before the `LOADED` state was not possible, we always started at the initial position regardless_



