### PR TITLE
Reuse cache even if key system type given in API is not the same

### DIFF
--- a/src/main_thread/decrypt/__tests__/find_key_system.test.ts
+++ b/src/main_thread/decrypt/__tests__/find_key_system.test.ts
@@ -150,6 +150,7 @@ describe("find_key_systems - ", () => {
   it("should create a media key the first time and then reuse the previous one if it's the same configuration", async () => {
     requestMediaKeySystemAccessMock.mockImplementation(() => {
       return {
+        keySystem: "com.widevine.alpha",
         createMediaKeys: () => ({
           createSession: () => ({
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -200,6 +201,7 @@ describe("find_key_systems - ", () => {
   it("should create a media key the first time and then create another one if the previous is not compatible.", async () => {
     requestMediaKeySystemAccessMock.mockImplementation(() => {
       return {
+        keySystem: "com.widevine.alpha",
         createMediaKeys: () => ({
           createSession: () => ({
             // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -258,6 +260,7 @@ describe("find_key_systems - ", () => {
   it("should create a media key the first time and then reuse the previous one if it's a different configuration but it's a compatible configuration.", async () => {
     requestMediaKeySystemAccessMock.mockImplementation(() => {
       return {
+        keySystem: "com.widevine.alpha",
         createMediaKeys: () => ({
           createSession: () => ({
             // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -478,7 +478,7 @@ export default function getMediaKeySystemAccess(
         currentState !== null &&
         !shouldRenewMediaKeySystemAccess() &&
         // TODO: Do it with MediaKeySystemAccess.prototype.keySystem instead?
-        keyType === currentState.keySystemOptions.type &&
+        keyType === currentState.mediaKeySystemAccess.keySystem &&
         eme.implementation === currentState.emeImplementation.implementation &&
         isNewMediaKeySystemConfigurationCompatibleWithPreviousOne(
           keySystemConfiguration,


### PR DESCRIPTION
Thanks to the PR #1478, that basically allows integration tests on our DRM logic without a real encrypted or decodable contents nor MSE/EME available, I noticed that I very recently brought a minor regression in the rewrite of the `MediaKeySystemAccess` cache reusage rules (not yet released).

We relied on the `keySystems[].type` API to see if the cached one was compatible to the new wanted one, we probably wanted to compare the former with the `type` actually provided as argument to the `navigator.requestMediaKeySystemAccess` API instead (e.g. `keySystems[].type` could be set just to `widevine`, in which case the RxPlayer will probably ask for `com.widevine.alpha` instead).

Thankfully, EME defines a `MediaKeySystemAccess.prototype.keySystem` property [that seems to always be equal to the asked `keySystem`](https://www.w3.org/TR/encrypted-media-2/#dom-navigator-requestmediakeysystemaccess).