### PR TITLE
Prevent logs from being outputed in our unit tests

### DIFF
--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/DRMInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/DRMInfos.test.ts
@@ -12,7 +12,7 @@ describe("MediaCapabilitiesProber probers - DRMInfos", () => {
     const probeDRMInfos = (await vi.importActual("../../probers/DRMInfos"))
       .default as typeof IProbeDRMInfos;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeDRMInfos(configuration)).rejects.toEqual(
+    await expect(probeDRMInfos(configuration)).rejects.toEqual(
       "MediaCapabilitiesProber >>> API_CALL: " +
         "Missing a type argument to request a media key system access.",
     );
@@ -25,7 +25,7 @@ describe("MediaCapabilitiesProber probers - DRMInfos", () => {
     const probeDRMInfos = (await vi.importActual("../../probers/DRMInfos"))
       .default as typeof IProbeDRMInfos;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeDRMInfos(configuration)).rejects.toEqual(
+    await expect(probeDRMInfos(configuration)).rejects.toEqual(
       "MediaCapabilitiesProber >>> API_CALL: " +
         "Missing a type argument to request a media key system access.",
     );
@@ -43,7 +43,7 @@ describe("MediaCapabilitiesProber probers - DRMInfos", () => {
     const probeDRMInfos = (await vi.importActual("../../probers/DRMInfos"))
       .default as typeof IProbeDRMInfos;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeDRMInfos(configuration)).resolves.toEqual([
+    await expect(probeDRMInfos(configuration)).resolves.toEqual([
       ProberStatus.NotSupported,
       { configuration: {}, type: "clearkick" },
     ]);

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/HDCPPolicy.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/HDCPPolicy.test.ts
@@ -14,7 +14,7 @@ describe("MediaCapabilitiesProber probers - HDCPPolicy", () => {
     const probeHDCPPolicy = (await vi.importActual("../../probers/HDCPPolicy"))
       .default as typeof IProbeHDCPPolicy;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeHDCPPolicy({})).rejects.toEqual(
+    await expect(probeHDCPPolicy({})).rejects.toEqual(
       "MediaCapabilitiesProber >>> API_CALL: API not available",
     );
   });
@@ -33,7 +33,7 @@ describe("MediaCapabilitiesProber probers - HDCPPolicy", () => {
     const probeHDCPPolicy = (await vi.importActual("../../probers/HDCPPolicy"))
       .default as typeof IProbeHDCPPolicy;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeHDCPPolicy({})).rejects.toEqual(
+    await expect(probeHDCPPolicy({})).rejects.toEqual(
       "MediaCapabilitiesProber >>> API_CALL: " +
         "Missing policy argument for calling getStatusForPolicy.",
     );

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/decodingInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/decodingInfos.test.ts
@@ -162,17 +162,17 @@ describe("MediaCapabilitiesProber probers - decodingInfo", () => {
       });
   });
 
-  it("should throw if API mediaCapabilities not available", () => {
+  it("should throw if API mediaCapabilities not available", async () => {
     // @ts-expect-error: `navigator.mediaCapabilities` is read-only normally, for
     // now, we're going through JSDom through so that's OK.
     delete navigator.mediaCapabilities;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeDecodingInfos({})).rejects.toThrowError(
+    await expect(probeDecodingInfos({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: MediaCapabilities API not available",
     );
   });
 
-  it("should throw if API decodingInfo not available", () => {
+  it("should throw if API decodingInfo not available", async () => {
     if (!isNullOrUndefined(navigator.mediaCapabilities)) {
       // @ts-expect-error: `navigator.mediaCapabilities` is read-only normally, for
       // now, we're going through JSDom through so that's OK.
@@ -183,7 +183,7 @@ describe("MediaCapabilitiesProber probers - decodingInfo", () => {
       navigator.mediaCapabilities = {};
     }
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeDecodingInfos({})).rejects.toThrowError(
+    await expect(probeDecodingInfos({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: Decoding Info not available",
     );
   });

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaContentType.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaContentType.test.ts
@@ -16,7 +16,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
       await vi.importActual("../../probers/mediaContentType")
     ).default as typeof IProbeMediaContentType;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeMediaContentType({})).rejects.toThrowError(
+    await expect(probeMediaContentType({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: " + "MediaSource API not available",
     );
   });
@@ -31,7 +31,7 @@ describe("MediaCapabilitiesProber - probers probeMediaContentType", () => {
       await vi.importActual("../../probers/mediaContentType")
     ).default as typeof IProbeMediaContentType;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeMediaContentType({})).rejects.toThrowError(
+    await expect(probeMediaContentType({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: " + "isTypeSupported not available",
     );
   });

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/mediaDisplayInfos.test.ts
@@ -15,7 +15,7 @@ describe("MediaCapabilitiesProber probers probeMediaDisplayInfos", () => {
       await vi.importActual("../../probers/mediaDisplayInfos")
     ).default as typeof IProbeMediaDisplayInfos;
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(probeMediaDisplayInfos({})).rejects.toThrowError(
+    await expect(probeMediaDisplayInfos({})).rejects.toThrowError(
       "MediaCapabilitiesProber >>> API_CALL: matchMedia not available",
     );
     (

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Logger from "../logger";
 
 /**
@@ -17,6 +18,48 @@ import Logger from "../logger";
  */
 
 describe("utils - Logger", () => {
+  const logMsgs: unknown[][] = [];
+  const errorMsgs: unknown[][] = [];
+  const warningMsgs: unknown[][] = [];
+  const infoMsgs: unknown[][] = [];
+  const debugMsgs: unknown[][] = [];
+  let mockLog: MockInstance;
+  let mockError: MockInstance;
+  let mockWarn: MockInstance;
+  let mockInfo: MockInstance;
+  let mockDebug: MockInstance;
+
+  beforeEach(() => {
+    mockLog = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logMsgs.push(args);
+    });
+    mockError = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      errorMsgs.push(args);
+    });
+    mockWarn = vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warningMsgs.push(args);
+    });
+    mockInfo = vi.spyOn(console, "info").mockImplementation((...args: unknown[]) => {
+      infoMsgs.push(args);
+    });
+    mockDebug = vi.spyOn(console, "debug").mockImplementation((...args: unknown[]) => {
+      debugMsgs.push(args);
+    });
+  });
+
+  afterEach(() => {
+    mockLog.mockRestore();
+    mockError.mockRestore();
+    mockWarn.mockRestore();
+    mockInfo.mockRestore();
+    mockDebug.mockRestore();
+    logMsgs.length = 0;
+    errorMsgs.length = 0;
+    warningMsgs.length = 0;
+    infoMsgs.length = 0;
+    debugMsgs.length = 0;
+  });
+
   it('should set a default logger level of "NONE"', () => {
     const logger = new Logger();
     expect(logger.getLevel()).toEqual("NONE");
@@ -72,12 +115,6 @@ describe("utils - Logger", () => {
   });
 
   it('should never call console.* functions if logger level is set to "NONE"', () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(vi.fn());
-    const mockError = vi.spyOn(console, "error").mockImplementation(vi.fn());
-    const mockWarn = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-    const mockInfo = vi.spyOn(console, "info").mockImplementation(vi.fn());
-    const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
-
     const logger = new Logger();
     logger.error("test");
     logger.warn("test");
@@ -96,12 +133,6 @@ describe("utils - Logger", () => {
   });
 
   it('should only call console.error if logger level is set to "ERROR"', () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(vi.fn());
-    const mockError = vi.spyOn(console, "error").mockImplementation(vi.fn());
-    const mockWarn = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-    const mockInfo = vi.spyOn(console, "info").mockImplementation(vi.fn());
-    const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
-
     const logger = new Logger();
     logger.setLevel("ERROR", "standard");
     logger.error("test");
@@ -121,12 +152,6 @@ describe("utils - Logger", () => {
   });
 
   it('should call console.{error,warn} if logger level is set to "WARNING"', () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(vi.fn());
-    const mockError = vi.spyOn(console, "error").mockImplementation(vi.fn());
-    const mockWarn = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-    const mockInfo = vi.spyOn(console, "info").mockImplementation(vi.fn());
-    const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
-
     const logger = new Logger();
     logger.setLevel("WARNING", "standard");
     logger.error("test");
@@ -146,12 +171,6 @@ describe("utils - Logger", () => {
   });
 
   it('should call console.{error,warn,info} if logger level is set to "INFO"', () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(vi.fn());
-    const mockError = vi.spyOn(console, "error").mockImplementation(vi.fn());
-    const mockWarn = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-    const mockInfo = vi.spyOn(console, "info").mockImplementation(vi.fn());
-    const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
-
     const logger = new Logger();
     logger.setLevel("INFO", "standard");
     logger.error("test");
@@ -171,12 +190,6 @@ describe("utils - Logger", () => {
   });
 
   it('should call console.{error,warn,info, log} if logger level is set to "DEBUG"', () => {
-    const mockLog = vi.spyOn(console, "log").mockImplementation(vi.fn());
-    const mockError = vi.spyOn(console, "error").mockImplementation(vi.fn());
-    const mockWarn = vi.spyOn(console, "warn").mockImplementation(vi.fn());
-    const mockInfo = vi.spyOn(console, "info").mockImplementation(vi.fn());
-    const mockDebug = vi.spyOn(console, "debug").mockImplementation(vi.fn());
-
     const logger = new Logger();
     logger.setLevel("DEBUG", "standard");
     logger.error("test");
@@ -263,35 +276,6 @@ describe("utils - Logger", () => {
   });
 
   it('should format logs with more information when `LogFormat` is set to "full"', () => {
-    const logMsgs: unknown[][] = [];
-    const errorMsgs: unknown[][] = [];
-    const warningMsgs: unknown[][] = [];
-    const infoMsgs: unknown[][] = [];
-    const debugMsgs: unknown[][] = [];
-    const mockLog = vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
-      logMsgs.push(args);
-    });
-    const mockError = vi
-      .spyOn(console, "error")
-      .mockImplementation((...args: unknown[]) => {
-        errorMsgs.push(args);
-      });
-    const mockWarn = vi
-      .spyOn(console, "warn")
-      .mockImplementation((...args: unknown[]) => {
-        warningMsgs.push(args);
-      });
-    const mockInfo = vi
-      .spyOn(console, "info")
-      .mockImplementation((...args: unknown[]) => {
-        infoMsgs.push(args);
-      });
-    const mockDebug = vi
-      .spyOn(console, "debug")
-      .mockImplementation((...args: unknown[]) => {
-        debugMsgs.push(args);
-      });
-
     const logger = new Logger();
 
     logger.setLevel("DEBUG", "full");


### PR DESCRIPTION
Our unit tests had become noisy with deprecation notices and RxPlayer log outputs.

That noise doesn't play well with how those unit tests report as we generally configure them to have a compact output in the terminal (with the idea that a passing test is not useful information but a breaking test is).
Those added logs break that compact output into a unreadable mess of uninteresting warnings, which I find especially problematic for tests.

So here, I remove the 2 culprits for those logs:

  - deprecation notices from vitest have been handled by updating the tests (though I'm not sure of why they print deprecation logs each time when the same deprecated logic is encountered multiple times, one signal would have been enough and preferable IMO)

  - All logger unit tests mock `console` functions now