### PR TITLE
Implement mocked content playback on `DummyMediaElement`

### DIFF
--- a/src/experimental/tools/DummyMediaElement/html5.ts
+++ b/src/experimental/tools/DummyMediaElement/html5.ts
@@ -6,12 +6,12 @@ import type {
 import type { IEmeApiImplementation } from "../../../compat/eme";
 import { createCompatibleEventListener } from "../../../compat/event_listeners";
 import EventEmitter from "../../../utils/event_emitter";
+import getMonotonicTimeStamp from "../../../utils/monotonic_timestamp";
 import noop from "../../../utils/noop";
 import type { IRange } from "../../../utils/ranges";
 import {
   convertToRanges,
   insertInto,
-  isTimeInRanges,
   keepRangeIntersection,
 } from "../../../utils/ranges";
 import TaskCanceller from "../../../utils/task_canceller";
@@ -20,8 +20,24 @@ import type { IRequestMediaKeySystemAccessConfig } from "./eme";
 import { DummyMediaSource } from "./mse";
 import TimeRangesWithMetadata, { EventScheduler } from "./utils";
 
+/** Constructor options for a `DummyMediaElement`. */
 export interface IDummyMediaElementOptions {
+  /**
+   * The type of node our `DummyMediaElement` should have:
+   *   - `"AUDIO"` for an `HTMLAudioElement`
+   *   - `"VIDEO"` for an `HTMLVideoElement`
+   *   - Anything else for the default (`HTMLMediaElement`)
+   */
   nodeName?: "AUDIO" | "VIDEO" | undefined | null;
+  /**
+   * If set explicitly to `false`, act as if the current browser forbid
+   * content playback (`play` and `autoplay` will return the `NotAllowedError`
+   * specified by the WHATWG HTML5 specification in that case).
+   */
+  allowedToPlay?: boolean;
+  /**
+   * Options linked to DRM / EME API matters.
+   */
   drmOptions?:
     | {
         requestMediaKeySystemAccessConfig?:
@@ -31,34 +47,84 @@ export interface IDummyMediaElementOptions {
     | undefined;
 }
 
+/**
+ * Minimum amount of buffer remaining in front of the currently-played position
+ * in seconds from which content playback happens. If we're below that value,
+ * the `DummyMediaElement` will start rebuffering itself.
+ */
+const MINIMUM_BUFFER_SIZE_FOR_PLAYBACK = 0.1;
+
+/**
+ * The maximum interval in milliseonds at which we re-check the current playback
+ * conditions (the `currentTime`, the `readyState` if we're waiting for data
+ * etc.)
+ * Note that this logic also happens on specific events: new media is added,
+ * removed, methods are called...
+ */
+const TICK_INTERVAL = 40;
+
+/**
+ * `HTMLMediaElement` implementation that should be compatible to the
+ * `RxPlayer`.
+ *
+ * This class will act as if it is a regular `HTMLMediaElement` playing media
+ * provided through the linked MSE API mocks.
+ * Properties will try to mimick what an actual `HTMLMediaElement` would return
+ * but the content won't actually be decoded nor deciphered.
+ * @class DummyMediaElement
+ */
 export class DummyMediaElement
   extends EventEmitter<IMediaElementEventMap>
   implements IMediaElement
 {
-  public readonly autoplay: false;
-  public readonly childNodes: [];
-  public readonly ended: boolean;
+  /** Property indicating that we're relying on a `DummyMediaElement. */
   public readonly isDummy: true;
-  public readonly nodeName: "AUDIO" | "VIDEO";
-  public readonly textTracks: never[];
+  /**
+   * Property providing the MSE API implementation we should rely on, instead
+   * of the one provided by the browser.
+   */
   public readonly FORCED_MEDIA_SOURCE: typeof DummyMediaSource;
+  /**
+   * Property providing the EME API implementation we should rely on, instead
+   * of the one provided by the browser.
+   */
   public readonly FORCED_EME_API: IEmeApiImplementation;
+  /** `Node.childNodes` property. */
+  public readonly childNodes: [];
+  /** `Node.nodeName` property. */
+  public readonly nodeName: "AUDIO" | "VIDEO";
+  /** `HTMLMediaElement.textTracks` property. */
+  public readonly textTracks: never[];
 
-  public src: "";
+  /** `HTMLMediaElement.ended` property. */
+  public ended: boolean;
+  /** `HTMLMediaElement.buffered` property. */
   public buffered: TimeRangesWithMetadata<null>;
+  /** `Element.clientHeight` property. */
   public clientHeight: undefined;
+  /** `Element.clientWidth` property. */
   public clientWidth: undefined;
+  /** `HTMLMediaElement.error` property. */
   public error: MediaError | null;
+  /** `HTMLMediaElement.muted` property. */
   public muted: boolean;
+  /** `HTMLMediaElement.paused` property. */
   public paused: boolean;
+  /** `HTMLMediaElement.preload` property. */
   public preload: "auto";
+  /** `HTMLMediaElement.readyState` property. */
   public readyState: number;
+  /** `HTMLMediaElement.seekable` property. */
   public seekable: TimeRangesWithMetadata<null>;
+  /** `HTMLMediaElement.seeking` property. */
   public seeking: boolean;
+  /** `HTMLMediaElement.volume` property. */
   public volume: number;
+  /** EME's `HTMLMediaElement.mediaKeys` property. */
   public mediaKeys: DummyMediaKeys | null;
 
-  // events
+  // event handlers from HTML specs:
+
   public onencrypted: ((evt: MediaEncryptedEvent) => void) | null;
   public oncanplay: ((evt: Event) => void) | null;
   public oncanplaythrough: ((evt: Event) => void) | null;
@@ -79,23 +145,85 @@ export class DummyMediaElement
   public onvolumechange: ((evt: Event) => void) | null;
   public onwaiting: ((evt: Event) => void) | null;
 
+  /**
+   * Correspond to the "allowed to play" flag from the WHATWG HTML5
+   * specification.
+   */
+  private _allowedToPlay: boolean;
+  /**
+   * The `DummyMediaSource` currently "attached" to this `DummyMediaElement`.
+   *
+   * `null` if not `DummyMediaSource` is attached.
+   */
   private _attachedMediaSource: null | DummyMediaSource;
+  /**
+   * The real `HTMLMediaElement.autoplay` value, as it is set as getter/setter
+   * methods here.
+   */
+  private _autoplay: boolean;
+  /**
+   * Correspond to the "can autoplay" flag from the WHATWG HTML5
+   * specification.
+   */
+  private _canAutoPlay: boolean;
+  /**
+   * `TaskCanceller` linked to the current playing content (presumably on the
+   * `attachedMediaSource`).
+   * Cancelling it should free resources linked to that content.
+   */
   private _currentContentCanceller: TaskCanceller | null;
+  /**
+   * The real `HTMLMediaElement.duration` value, as it is set as getter/setter
+   * methods here.
+   */
   private _duration: number;
+  /** Abstraction simplifying the mechanism of sending DOM events. */
   private _eventScheduler: EventScheduler;
-  private _lastPosition: number;
+  /**
+   * Object allowing to calculate easily the current playback position.
+   *
+   * It is important to re-compute that object each time a property linked
+   * to the rate at which playback happens has changed: `paused`,
+   * `playbackRate` etc., as the time is calculated in fine by deducing the
+   * amount of playback time that should have elapsed since the last time
+   * that object was computed.
+   */
+  private _lastPosition: {
+    /** Position calculated at `timestamp`. */
+    position: number;
+    /** The monotonically-increasing timestamp at which `position` was calculated. */
+    timestamp: number;
+  };
+  /** Capture WHATWG's `pending play promises` concept. */
+  private _pendingPlayPromises: Array<{
+    resolve: () => void;
+    reject: (err: Error) => void;
+  }>;
+  /**
+   * The real `HTMLMediaElement.playbackRate` value, as it is set as
+   * getter/setter methods here.
+   */
   private _playbackRate: number;
-  // private _allowedToPlay: boolean;
-  // private _canAutoPlay: boolean;
-  // private _pendingPlayPromises: Array<{
-  //   resolve: () => void;
-  //   reject: (err: Error) => void;
-  // }>;
+  /**
+   * The real `HTMLMediaElement.src` value, as it is set as getter/setter
+   * methods here.
+   */
+  private _src: string;
+  /**
+   * If `true`, the `"loaded"` event was already sent for the current content
+   * played. This is necessary as this event is supposed to be only sent once
+   * per content as per the WHATWG specification.
+   */
+  private _wasLoadedDataSentForCurrentContent: boolean;
+  /**
+   * If `true`, the current content was played at least once.
+   * `false` if there's no content or if it was always paused.
+   */
+  private _wasPlayPerformedOnCurrentContent: boolean;
 
   constructor(opts: IDummyMediaElementOptions = {}) {
     super();
 
-    this.autoplay = false;
     this.buffered = new TimeRangesWithMetadata();
     this.childNodes = [];
     this.ended = false;
@@ -109,19 +237,26 @@ export class DummyMediaElement
     this.readyState = 0;
     this.seekable = new TimeRangesWithMetadata();
     this.seeking = false;
-    this.src = "";
+
     this.textTracks = [];
     this.volume = 1;
 
+    this._allowedToPlay = opts.allowedToPlay !== false;
     this._attachedMediaSource = null;
+    this._autoplay = false;
+    this._canAutoPlay = true;
     this._currentContentCanceller = null;
     this._duration = NaN;
     this._eventScheduler = new EventScheduler();
-    this._lastPosition = 0;
+    this._lastPosition = {
+      position: 0,
+      timestamp: getMonotonicTimeStamp(),
+    };
+    this._pendingPlayPromises = [];
     this._playbackRate = 1;
-    // this._allowedToPlay = true;
-    // this._canAutoPlay = true;
-    // this._pendingPlayPromises = [];
+    this._src = "";
+    this._wasLoadedDataSentForCurrentContent = false;
+    this._wasPlayPerformedOnCurrentContent = false;
 
     this.onencrypted = null;
     this.oncanplay = null;
@@ -151,11 +286,11 @@ export class DummyMediaElement
         mediaElement.mediaKeys = mediaKeys;
         if (mediaElement === this && mediaKeys instanceof DummyMediaKeys) {
           mediaKeys.onSessionKeyUpdates = () => {
-            this._updateBufferedAndReadyState();
+            this._tick();
           };
         }
         resolve(undefined);
-        this._updateBufferedAndReadyState();
+        this._tick();
       });
     };
 
@@ -170,47 +305,153 @@ export class DummyMediaElement
     };
   }
 
+  /**
+   * `HTMLMediaElement.duration` property getter.
+   */
   public get duration(): number {
     // TODO liveSeekableRange etc.
 
     return this._duration;
   }
 
+  /**
+   * `HTMLMediaElement.autoplay` property getter.
+   */
+  public get autoplay(): boolean {
+    return this._autoplay;
+  }
+
+  /**
+   * `HTMLMediaElement.autoplay` property setter.
+   *
+   * A paused content may play if paused while autoplay is set to `true` and
+   * if the current content was never played until now.
+   * @param {boolean} val - New `autoplay` value.
+   */
+  public set autoplay(val: boolean) {
+    this._autoplay = val;
+    if (
+      this._currentContentCanceller !== null &&
+      this.readyState >= 4 &&
+      !this._wasPlayPerformedOnCurrentContent
+    ) {
+      this._tick();
+      this.paused = false;
+      this._wasPlayPerformedOnCurrentContent = true;
+      this._eventScheduler
+        .schedule(this, "play", this._currentContentCanceller.signal)
+        .catch(noop);
+      this._notifyAboutPlaying();
+    }
+  }
+
+  /**
+   * `HTMLMediaElement.src` property getter.
+   */
+  public get src(): string {
+    return this._src;
+  }
+
+  /**
+   * `HTMLMediaElement.src` property setter.
+   *
+   * For now, we assume that on a `DummyMediaElement` it is only useful to play
+   * "directfile" contents which we don't support for now.
+   * @param {string} val - The new URL
+   */
+  public set src(val: string) {
+    this._src = val;
+    this.srcObject = null;
+    this._currentContentCanceller?.cancel();
+    const canceller = new TaskCanceller();
+    this._currentContentCanceller = canceller;
+    setTimeout(() => {
+      while (this._pendingPlayPromises.length > 0) {
+        const error = new Error("A new source was set");
+        error.name = "AbortError";
+        this._pendingPlayPromises.shift()?.reject(error);
+      }
+      const err = new Error("Failed to open media") as {
+        message: string;
+        name: string;
+        code: number;
+        MEDIA_ERR_ABORTED: 1;
+        MEDIA_ERR_NETWORK: 2;
+        MEDIA_ERR_DECODE: 3;
+        MEDIA_ERR_SRC_NOT_SUPPORTED: 4;
+      };
+      err.name = "MediaError";
+      err.code = 4;
+      err.MEDIA_ERR_ABORTED = 1;
+      err.MEDIA_ERR_NETWORK = 2;
+      err.MEDIA_ERR_DECODE = 3;
+      err.MEDIA_ERR_SRC_NOT_SUPPORTED = 4;
+      this.error = err;
+      this._eventScheduler.schedule(this, "error", canceller.signal).catch(noop);
+    });
+  }
+
+  /**
+   * An `HTMLMediaElement`'s `addTextTrack` method.
+   * Here I did not want to implement that complexity for now as we don't really
+   * need it at the time I'm writing this. So it just throws.
+   */
   public addTextTrack(): never {
     throw new Error("Not implemented yet");
   }
 
-  // TODO
-  // private _resolvePendingPlayPromises() {
-  //   while (true) {
-  //     const next = this._pendingPlayPromises.shift();
-  //     if (next === undefined) {
-  //       return;
-  //     }
-  //     next.resolve();
-  //   }
-  // }
-
+  /**
+   * `HTMLMediaElement.srcObject` property setter,
+   *
+   * Right now, that the main way to attach a `DummyMediaSource` to a
+   * `DummyMediaElement`.
+   * @param {Object|null} val - The `DummyMediaSource` wanted or `null` to stop
+   * playback.
+   */
   public set srcObject(val: MediaProvider | null) {
-    if (!(val instanceof DummyMediaSource)) {
-      throw new Error("A DummyMediaElement can only be linked to a DummyMediaSource");
-    }
+    // media element load algorithm
 
-    this.currentTime = 0;
+    this._currentContentCanceller?.cancel();
+    this._wasLoadedDataSentForCurrentContent = false;
+    this._wasPlayPerformedOnCurrentContent = false;
     this.buffered = new TimeRangesWithMetadata();
-    this._lastPosition = 0;
+    this.seekable = new TimeRangesWithMetadata();
     this._duration = NaN;
     this.error = null;
+    this._canAutoPlay = true;
     this.seeking = false;
     this.readyState = 0;
+    this.paused = true;
+    this._lastPosition = {
+      position: 0,
+      timestamp: getMonotonicTimeStamp(),
+    };
+    this.ended = false;
+    this.playbackRate = 1;
+
+    while (this._pendingPlayPromises.length > 0) {
+      const error = new Error("A new source was set");
+      error.name = "AbortError";
+      this._pendingPlayPromises.shift()?.reject(error);
+    }
 
     const prev = this._attachedMediaSource;
-    this._attachedMediaSource = val;
+    prev?.destroy();
     if (val !== null) {
+      if (!(val instanceof DummyMediaSource) && val !== null) {
+        this._attachedMediaSource = null;
+        throw new Error("A DummyMediaElement can only be linked to a DummyMediaSource");
+      }
+      this._attachedMediaSource = val;
       this._currentContentCanceller = new TaskCanceller();
+      const intervalId = setInterval(() => {
+        this._tick();
+      }, TICK_INTERVAL);
+      this._currentContentCanceller.signal.register(() => {
+        clearInterval(intervalId);
+      });
       this._attachCurrentMediaSource();
-    } else if (prev !== null) {
-      prev.destroy();
+    } else {
       this._attachedMediaSource = null;
     }
   }
@@ -219,15 +460,28 @@ export class DummyMediaElement
     return this._attachedMediaSource as unknown as MediaProvider;
   }
 
-  public appendChild<T extends Node>(_child: T): void {
-    throw new Error("Unimplemented");
-  }
-
+  /**
+   * EME's `HTMLMediaElement.setMediaKeys` method.
+   * Here we go through the `FORCED_EME_API` property instead, so that method
+   * just throws.
+   */
   public setMediaKeys(_mk: IMediaKeys | null): Promise<void> {
     return Promise.reject("EME not implemented on dummy media element.");
   }
 
+  /**
+   * `HTMLMediaElement.currentTime` property getter.
+   */
+  public get currentTime(): number {
+    return this._tick();
+  }
+
+  /**
+   * `HTMLMediaElement.currentTime` property setter.
+   */
   public set currentTime(val: number) {
+    this._tick();
+    const prevPosition = this._lastPosition.position;
     const canceller = this._currentContentCanceller;
     if (canceller === null || this.readyState === 0) {
       return;
@@ -240,107 +494,192 @@ export class DummyMediaElement
       seekingPos = this._duration;
     }
 
-    let distance: [number, number | undefined] = [Infinity, undefined];
+    // From the WHATWG spec:
+    // If the playback position is not in one of the ranges given in the
+    // seekable attribute, then let it be the position in one of the ranges
+    // given in the seekable attribute that is the nearest to the new playback
+    // position.
+
+    /**
+     * Offset to add to `seekingPos` so it is contianed in a seekable range.
+     * `null` if no seekable range is found for now.
+     */
+    let currentBestOffset = null;
     for (let i = 0; i < this.seekable.length; i++) {
       if (seekingPos >= this.seekable.start(i) && seekingPos <= this.seekable.end(i)) {
-        distance = [0, i];
+        currentBestOffset = 0;
         break;
       } else {
-        const rangeDistance = Math.min(
-          Math.abs(this.seekable.end(i) - seekingPos),
-          Math.abs(this.seekable.start(i) - seekingPos),
-        );
-        if (rangeDistance < distance[0]) {
-          distance = [rangeDistance, i];
-        } else if (rangeDistance === distance[0]) {
-          // TODO
+        let distance;
+        if (seekingPos < this.seekable.start(i)) {
+          distance = this.seekable.start(i) - seekingPos;
+        } else {
+          distance = this.seekable.end(i) - seekingPos;
+        }
+        if (currentBestOffset === null) {
+          currentBestOffset = distance;
+        } else if (Math.abs(distance) < Math.abs(currentBestOffset)) {
+          currentBestOffset = distance;
+        } else {
+          // From the WHATWG spec:
+          // If two positions both satisfy that constraint (i.e. the new playback
+          // position is exactly in the middle between two ranges in the seekable
+          // attribute) then use the position that is closest to the current
+          // playback position.
+          const prevCandidatePosition = currentBestOffset + seekingPos;
+          const newCandidatePosition = distance + seekingPos;
+
+          if (
+            Math.abs(prevPosition - newCandidatePosition) <
+            Math.abs(prevPosition - prevCandidatePosition)
+          ) {
+            currentBestOffset = distance;
+          }
         }
       }
     }
 
-    if (distance[0] === Infinity) {
-      seekingPos = 0;
+    if (currentBestOffset === null) {
+      this.seeking = false;
+      return;
     }
 
-    this._lastPosition = val;
-    this._eventScheduler
-      .schedule(this, "seeking", canceller.signal)
-      .then(() => {
-        this.seeking = false;
-        return Promise.all([
-          this._eventScheduler.schedule(this, "timeupdate", canceller.signal),
-          this._eventScheduler.schedule(this, "seeked", canceller.signal),
-        ]);
-      })
-      .catch(noop);
-    this._updateBufferedAndReadyState();
+    if (currentBestOffset !== 0) {
+      seekingPos += currentBestOffset;
+    }
+
+    this._lastPosition.position = val;
+    this._lastPosition.timestamp = getMonotonicTimeStamp();
+    this.seeking = true;
+    this._eventScheduler.schedule(this, "seeking", canceller.signal).catch(noop);
+    this._tick();
   }
 
-  public get currentTime(): number {
-    return this._lastPosition;
-  }
-
+  /**
+   * HTMLMediaElement.playbackRate property setter.
+   */
   public set playbackRate(val: number) {
+    this._tick();
     this._playbackRate = val;
     this._eventScheduler.schedule(this, "ratechange", null).catch(noop);
   }
 
+  /**
+   * HTMLMediaElement.playbackRate property getter.
+   */
   public get playbackRate(): number {
     return this._playbackRate;
   }
 
+  /**
+   * HTMLMediaElement.pause() method.
+   */
   public play(): Promise<void> {
-    const error = new Error("Dummy media element cannot play");
-    error.name = "NotAllowedError";
-    return Promise.reject(error);
+    if (!this._allowedToPlay) {
+      const error = new Error("Dummy media element cannot play");
+      error.name = "NotAllowedError";
+      return Promise.reject(error);
+    }
+    if (this.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
+      const error = new Error("`play` call on not supported content");
+      error.name = "NotSupportedError";
+      return Promise.reject(error);
+    }
 
-    // TODO
-    // if (!this._allowedToPlay) {
-    //   const error = new Error("Dummy media element cannot play");
-    //   error.name = "NotAllowedError";
-    //   return Promise.reject(error);
-    // }
-    // if (this.error?.code === MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
-    //   const error = new Error("`play` call on not supported content");
-    //   error.name = "NotSupportedError";
-    //   return Promise.reject(error);
-    // }
-    // if (this.ended) {
-    //   this.currentTime =
-    //     this.seekable.length > 0 ? this.seekable.start(0) : this.currentTime;
-    // }
-    // if (this._currentContentCanceller !== null && this.paused) {
-    //   this.paused = false;
-    //   this._eventScheduler.schedule(this, "play", this._currentContentCanceller.signal)
-    //     .catch(noop);
-    //   if (this.readyState <= 2) {
-    //     this._eventScheduler.schedule(this, "waiting", this._currentContentCanceller.signal)
-    //       .catch(noop);
-    //   } else {
-    //     this._eventScheduler.schedule(this, "playing", this._currentContentCanceller.signal)
-    //       .catch(noop);
-    //   }
-    // } else if (this.readyState >= 3) {
-    // }
-    // this._pendingPlayPromise.push(res);
-    // this._canAutoPlay = false;
+    const promise = new Promise<void>((res: () => void, rej: (err: Error) => void) => {
+      this._pendingPlayPromises.push({ resolve: res, reject: rej });
+    });
+
+    if (this.ended && this.playbackRate >= 0) {
+      this.ended = false;
+      this._lastPosition.position =
+        this.seekable.length > 0 ? this.seekable.start(0) : this._lastPosition.position;
+      this._lastPosition.timestamp = getMonotonicTimeStamp();
+    }
+
+    if (this._currentContentCanceller !== null && this.paused) {
+      this._tick();
+      this.paused = false;
+      this._wasPlayPerformedOnCurrentContent = true;
+
+      // run the time marches on steps
+
+      this._eventScheduler
+        .schedule(this, "play", this._currentContentCanceller.signal)
+        .catch(noop);
+
+      if (this.readyState <= 2) {
+        this._eventScheduler
+          .schedule(this, "waiting", this._currentContentCanceller.signal)
+          .catch(noop);
+      } else {
+        this._notifyAboutPlaying();
+      }
+    } else if (this._currentContentCanceller !== null && this.readyState >= 3) {
+      // take pending play promises and queue a media element task given the
+      // media element to resolve pending play promises with the result.
+      while (this._pendingPlayPromises.length > 0) {
+        const playPromise = this._pendingPlayPromises.shift();
+        playPromise?.resolve();
+      }
+    }
+    this._canAutoPlay = false;
+    return promise;
   }
 
+  /**
+   * HTMLMediaElement.pause() method.
+   */
   public pause(): void {
-    // TODO
+    this._internalPauseSteps();
   }
 
+  /**
+   * An `Element`'s `removeAttribute` method.
+   * Here I did not want to implement that complexity for now as we don't really
+   * need it at the time I'm writing this beside removing the `"src"` attribute.
+   * So I just allow to do that
+   * @param {string} attr
+   */
   public removeAttribute(attr: "src"): void {
     if (attr === "src") {
       this.src = "";
+    } else {
+      throw new Error(
+        'Removing the attribute + "' +
+          String(attr) +
+          '" is not yet supported on a `DummyMediaElement`.',
+      );
     }
     return;
   }
 
+  /**
+   * A `Node`'s `hasChildNodes` method.
+   * Here I did not want to implement that complexity for now as we don't really
+   * need it at the time I'm writing this. So it just returns false.
+   * @returns {boolean}
+   */
   public hasChildNodes(): false {
     return false;
   }
 
+  /**
+   * A `Node`'s `appendChild` method.
+   * Here I did not want to implement that complexity for now as we don't really
+   * need it at the time I'm writing this. So it just throws.
+   * @param {Node} _child
+   */
+  public appendChild<T extends Node>(_child: T): void {
+    throw new Error("Unimplemented");
+  }
+
+  /**
+   * A `Node`'s `removeChild` method.
+   * Here I did not want to implement that complexity for now as we don't really
+   * need it at the time I'm writing this. So it just throws.
+   * @param {*} x
+   */
   public removeChild(x: unknown): never {
     if (x === null) {
       throw new TypeError("Asked to remove null child");
@@ -350,15 +689,316 @@ export class DummyMediaElement
     throw notFoundErr;
   }
 
-  private _updateBufferedAndReadyState(): void {
-    if (this._attachedMediaSource === null) {
-      this.buffered.remove(0, Infinity);
-      this.readyState = 0;
+  /**
+   * Method to call once playback reaches the end of the content.
+   * Will send the right events and performs the right steps at that point.
+   */
+  private _onPlayingEndOfContent(): void {
+    if (this._attachedMediaSource?.readyState !== "ended") {
+      return;
+    }
+    if (this.ended) {
       return;
     }
 
-    const allBuffered = this._attachedMediaSource.sourceBuffers.reduce(
-      (acc: IRange[] | null, sb) => {
+    // TODO: loop attribute?
+
+    const canceller = this._currentContentCanceller;
+    if (this.playbackRate < 0 || canceller === null) {
+      return;
+    }
+    this._eventScheduler.schedule(this, "timeupdate", canceller.signal).catch(noop);
+    if (!this.paused) {
+      this.paused = true;
+      this._eventScheduler.schedule(this, "pause", canceller.signal).catch(noop);
+    }
+    while (this._pendingPlayPromises.length > 0) {
+      const error = new Error("The content has ended");
+      error.name = "AbortError";
+      this._pendingPlayPromises.shift()?.reject(error);
+    }
+    this.ended = true;
+    this._eventScheduler.schedule(this, "ended", canceller.signal).catch(noop);
+  }
+
+  /**
+   * Method corresponding to the WHATWG's "is eligible for autoplay" logic.
+   * @returns {boolean}
+   */
+  private _isEligibleForAutoplay(): boolean {
+    return this._canAutoPlay && this.paused && this.autoplay;
+  }
+
+  /**
+   * Performs steps on the `_attachedMediaSource` that have to happen on it when
+   * it is attached to the `HTMLMediaElement`.
+   */
+  private _attachCurrentMediaSource(): void {
+    const dummyMs = this._attachedMediaSource;
+    if (dummyMs === null) {
+      return;
+    }
+    dummyMs.updateCallbacks({
+      hasMediaElementErrored: () => {
+        return this.error !== null;
+      },
+
+      onBufferedUpdate: () => {
+        this._tick();
+      },
+
+      updateMediaElementDuration: (duration: number) => {
+        // TODO check
+        this._duration = duration;
+        if (this._lastPosition.position > this._duration) {
+          this._lastPosition.position = this._duration;
+          this._lastPosition.timestamp = getMonotonicTimeStamp();
+        }
+      },
+    });
+    dummyMs.readyState = "open";
+    dummyMs.eventScheduler.schedule(dummyMs, "sourceopen", null).catch(noop);
+  }
+
+  /**
+   * Performs the WHATWG "notify about playing" steps.
+   */
+  private _notifyAboutPlaying(): void {
+    this._eventScheduler
+      .schedule(this, "playing", this._currentContentCanceller?.signal)
+      .catch(noop);
+    while (this._pendingPlayPromises.length > 0) {
+      const playPromise = this._pendingPlayPromises.shift();
+      playPromise?.resolve();
+    }
+  }
+
+  /**
+   * Performs the WHATWG "internal pause steps".
+   */
+  private _internalPauseSteps(): void {
+    // "Set the media element's can autoplay flag to false."
+    this._canAutoPlay = false;
+    if (!this.paused) {
+      this._tick();
+      this.paused = true; // "Change the value of paused to true."
+
+      this._eventScheduler
+        .schedule(this, "timeupdate", this._currentContentCanceller?.signal)
+        .catch(noop);
+      this._eventScheduler
+        .schedule(this, "pause", this._currentContentCanceller?.signal)
+        .catch(noop);
+
+      while (this._pendingPlayPromises.length > 0) {
+        const error = new Error("The content was paused");
+        error.name = "AbortError";
+        this._pendingPlayPromises.shift()?.reject(error);
+      }
+    }
+  }
+
+  /**
+   * Method re-checking the current position to see if we should begin
+   * rebuffering, ending the content, changing the `readyState` etc.
+   *
+   * Should be called at regular intervals and everytime one of the property
+   * that has an effect on the playback speed (`paused`, `playbackRate` etc.)
+   * will change just before it changes (so the `lastPosition` object is
+   * updated accordingly).
+   *
+   * Returns the new calculated `currentTime` property.
+   *
+   * @returns {number} - The new `currentTime` property.
+   */
+  private _tick(): number {
+    this._updateBufferedRanges();
+    const bufferInfo = this._getCurrentBufferHealth();
+    if (
+      this._attachedMediaSource !== null &&
+      this._lastPosition.position >= this._attachedMediaSource.duration
+    ) {
+      this._lastPosition.position = this._attachedMediaSource.duration;
+      this._lastPosition.timestamp = getMonotonicTimeStamp();
+      this._updateReadyState({
+        isMissingMetadata: bufferInfo.isMissingMetadata,
+        isMissingKey: bufferInfo.isMissingKey,
+      });
+      this._onPlayingEndOfContent();
+      return this._lastPosition.position;
+    }
+
+    if (bufferInfo.range === null) {
+      this._updateReadyState({
+        isMissingMetadata: bufferInfo.isMissingMetadata,
+        isMissingKey: bufferInfo.isMissingKey,
+      });
+      this._lastPosition.timestamp = getMonotonicTimeStamp();
+      return this._lastPosition.position;
+    }
+
+    const playbackSpeed =
+      bufferInfo.isMissingKey ||
+      bufferInfo.isMissingMetadata ||
+      this.paused ||
+      this.ended ||
+      this.readyState < 3 ||
+      this.playbackRate <= 0
+        ? 0
+        : this.playbackRate;
+    const now = getMonotonicTimeStamp();
+    const elapsedTime = now - this._lastPosition.timestamp;
+    let newPosition = this._lastPosition.position + (elapsedTime * playbackSpeed) / 1000;
+    if (newPosition > bufferInfo.range.end) {
+      newPosition = bufferInfo.range.end;
+    }
+    this._lastPosition.position = newPosition;
+    this._lastPosition.timestamp = now;
+    this._updateReadyState({
+      isMissingMetadata: bufferInfo.isMissingMetadata,
+      isMissingKey: bufferInfo.isMissingKey,
+    });
+    if (
+      this._attachedMediaSource !== null &&
+      this._lastPosition.position >= this._attachedMediaSource.duration
+    ) {
+      this._onPlayingEndOfContent();
+    }
+    return this._lastPosition.position;
+  }
+
+  /**
+   * Check if the current `readyState` property is the right one according to
+   * the `DummyMediaElement`'s state.
+   * If not update it and send the right events.
+   * @param {Object} obj
+   * @param {boolean} obj.isMissingMetadata - If `true`, at least one active
+   * buffer doesn't have enough metadata for the `HAVE_METADATA` `readyState`
+   * yet.
+   * @param {boolean} obj.isMissingKey - If `true`, at least one active
+   * buffer is missing the decryption key for the media at the current
+   * position.
+   */
+  private _updateReadyState({
+    isMissingMetadata,
+    isMissingKey,
+  }: {
+    isMissingMetadata: boolean;
+    isMissingKey: boolean;
+  }): void {
+    const canceller = this._currentContentCanceller;
+    if (this.readyState === 0) {
+      if (canceller === null || isMissingMetadata) {
+        return;
+      }
+      this.readyState = 1;
+      this.seekable.insert(0, Infinity, null);
+      this._eventScheduler.schedule(this, "loadedmetadata", canceller.signal).catch(noop);
+    }
+
+    const currentRange = this.buffered.getRangeFor(this._lastPosition.position);
+    if (this.readyState === 1) {
+      if (isMissingMetadata) {
+        this.readyState = 0;
+        return;
+      }
+
+      if (
+        currentRange === null ||
+        isMissingKey ||
+        ((this._attachedMediaSource === null ||
+          currentRange.end < this._attachedMediaSource.duration) &&
+          currentRange.end - this._lastPosition.position <
+            MINIMUM_BUFFER_SIZE_FOR_PLAYBACK)
+      ) {
+        return;
+      }
+
+      if (canceller === null) {
+        return;
+      }
+      this.readyState = 3;
+      const loadedDataProm = this._wasLoadedDataSentForCurrentContent
+        ? Promise.resolve()
+        : this._eventScheduler.schedule(this, "loadeddata", canceller.signal);
+
+      this._wasLoadedDataSentForCurrentContent = true;
+      loadedDataProm
+        .then(() => {
+          return this._eventScheduler.schedule(this, "canplay", canceller.signal);
+        })
+        .then(() => {
+          this.readyState = 4;
+          if (!this.paused) {
+            this._notifyAboutPlaying();
+          } else if (this._isEligibleForAutoplay()) {
+            this._tick();
+            this.paused = false;
+            this._wasPlayPerformedOnCurrentContent = true;
+            this._eventScheduler.schedule(this, "play", canceller.signal).catch(noop);
+            this._notifyAboutPlaying();
+          }
+
+          if (this.seeking) {
+            this.seeking = false;
+            this._eventScheduler
+              .schedule(this, "timeupdate", canceller.signal)
+              .catch(noop);
+            this._eventScheduler.schedule(this, "seeked", canceller.signal).catch(noop);
+          }
+          return this._eventScheduler.schedule(this, "canplaythrough", canceller.signal);
+        })
+        .catch(noop);
+    } else if (this.readyState > 1) {
+      if (isMissingMetadata) {
+        this.readyState = 0;
+        return;
+      }
+
+      if (
+        currentRange === null ||
+        isMissingKey ||
+        ((this._attachedMediaSource === null ||
+          this._attachedMediaSource.readyState !== "ended" ||
+          currentRange.end < this._attachedMediaSource.duration) &&
+          currentRange.end - this._lastPosition.position <
+            MINIMUM_BUFFER_SIZE_FOR_PLAYBACK)
+      ) {
+        if (canceller === null) {
+          return;
+        }
+
+        this.readyState = 1;
+        if (!this.paused && this.error === null) {
+          this._eventScheduler
+            .schedule(this, "timeupdate", canceller.signal)
+            .then(() => this._eventScheduler.schedule(this, "waiting", canceller.signal))
+            .catch(noop);
+        }
+      }
+
+      if (this.seeking) {
+        this.seeking = false;
+        if (canceller !== null) {
+          this._eventScheduler.schedule(this, "timeupdate", canceller.signal).catch(noop);
+          this._eventScheduler.schedule(this, "seeked", canceller.signal).catch(noop);
+        }
+      }
+    }
+  }
+
+  /**
+   * Update `buffered` HTML5 property based on what MSE sourceBuffers have
+   * themselves buffered.
+   */
+  private _updateBufferedRanges(): void {
+    if (this._attachedMediaSource === null) {
+      this.buffered.remove(0, Infinity);
+      return;
+    }
+
+    const allBuffered =
+      this._attachedMediaSource.sourceBuffers.reduce((acc: IRange[] | null, sb) => {
         if (acc === null) {
           return convertToRanges(sb.buffered);
         }
@@ -370,21 +1010,54 @@ export class DummyMediaElement
           return acc;
         }
         return keepRangeIntersection(acc, convertToRanges(sb.buffered));
-      },
-      null,
-    );
+      }, null) ?? [];
 
-    if (allBuffered === null) {
+    this.buffered = new TimeRangesWithMetadata();
+    for (const newRange of allBuffered) {
+      this.buffered.insert(newRange.start, newRange.end, null);
+    }
+
+    if (this.buffered.length > 0) {
+      const bufferEnd = this.buffered.end(this.buffered.length - 1);
+      if (bufferEnd > this.duration) {
+        this._duration = bufferEnd;
+      }
+    }
+  }
+
+  /**
+   * Get key information on the media buffers linked to this media element.
+   * @returns {Object}
+   */
+  private _getCurrentBufferHealth(): {
+    /** The currently played range in the buffer. */
+    range: { start: number; end: number } | null;
+    /**
+     * If `true`, at least one active buffer doesn't have enough metadata
+     * for the `HAVE_METADATA` `readyState` yet.
+     */
+    isMissingMetadata: boolean;
+    /**
+     * If `true`, at least one active buffer is missing the decryption key for
+     * the media at the current position.
+     */
+    isMissingKey: boolean;
+  } {
+    if (this._attachedMediaSource === null) {
       this.buffered.remove(0, Infinity);
       this.readyState = 0;
-      return;
+      return {
+        range: null,
+        isMissingMetadata: true,
+        isMissingKey: false,
+      };
     }
 
     const isMissingMetadata = this._attachedMediaSource.sourceBuffers.some((sb) => {
       return !sb.hasMetadata;
     });
     const isMissingKey = this._attachedMediaSource.sourceBuffers.some((sb) => {
-      const metadata = sb.buffered.getMetadataFor(this._lastPosition);
+      const metadata = sb.buffered.getMetadataFor(this._lastPosition.position);
       if (metadata === null || metadata.keyIds === null) {
         return false;
       }
@@ -405,77 +1078,10 @@ export class DummyMediaElement
       });
     });
 
-    for (const range of allBuffered) {
-      this.buffered.insert(range.start, range.end, null);
-    }
-
-    if (this.readyState === 0) {
-      const canceller = this._currentContentCanceller;
-      if (canceller === null) {
-        return;
-      }
-      this.readyState = 1;
-      this.seekable.insert(0, Infinity, null);
-      this._eventScheduler.schedule(this, "loadedmetadata", canceller.signal).catch(noop);
-    } else if (this.readyState === 1) {
-      if (
-        !isTimeInRanges(allBuffered, this.currentTime) ||
-        isMissingKey ||
-        isMissingMetadata
-      ) {
-        return;
-      }
-      const canceller = this._currentContentCanceller;
-      if (canceller === null) {
-        return;
-      }
-      this.readyState = 3;
-      this._eventScheduler
-        .schedule(this, "loadeddata", canceller.signal)
-        .then(() => {
-          return this._eventScheduler.schedule(this, "canplay", canceller.signal);
-        })
-        .then(() => {
-          this.readyState = 4;
-          return this._eventScheduler.schedule(this, "canplaythrough", canceller.signal);
-        })
-        .catch(noop);
-    } else {
-      // For readyState > 1
-      if (
-        isTimeInRanges(allBuffered, this.currentTime) &&
-        !isMissingKey &&
-        !isMissingMetadata
-      ) {
-        return;
-      }
-      this.readyState = 1;
-    }
-  }
-
-  private _attachCurrentMediaSource(): void {
-    const dummyMs = this._attachedMediaSource;
-    if (dummyMs === null) {
-      return;
-    }
-    dummyMs.updateCallbacks({
-      hasMediaElementErrored: () => {
-        return this.error !== null;
-      },
-
-      onBufferedUpdate: () => {
-        this._updateBufferedAndReadyState();
-      },
-
-      updateMediaElementDuration: (duration: number) => {
-        // TODO check
-        this._duration = duration;
-        if (this.currentTime > this._duration) {
-          this.currentTime = this._duration;
-        }
-      },
-    });
-    dummyMs.readyState = "open";
-    dummyMs.eventScheduler.schedule(dummyMs, "sourceopen", null).catch(noop);
+    return {
+      range: this.buffered.getRangeFor(this._lastPosition.position) ?? null,
+      isMissingMetadata,
+      isMissingKey,
+    };
   }
 }

--- a/src/experimental/tools/DummyMediaElement/utils.ts
+++ b/src/experimental/tools/DummyMediaElement/utils.ts
@@ -32,17 +32,17 @@ export class EventScheduler {
   public schedule(
     obj: DummyMediaElement,
     evtName: keyof IMediaElementEventMap,
-    cancelSignal: CancellationSignal | null,
+    cancelSignal: CancellationSignal | null | undefined,
   ): Promise<void>;
   public schedule(
     obj: DummyMediaSource,
     evtName: keyof IMediaSourceEventMap,
-    cancelSignal: CancellationSignal | null,
+    cancelSignal: CancellationSignal | null | undefined,
   ): Promise<void>;
   public schedule(
     obj: DummySourceBuffer,
     evtName: keyof ISourceBufferEventMap,
-    cancelSignal: CancellationSignal | null,
+    cancelSignal: CancellationSignal | null | undefined,
   ): Promise<void>;
   public schedule(
     obj: DummyMediaElement | DummyMediaSource | DummySourceBuffer,
@@ -50,7 +50,7 @@ export class EventScheduler {
       | keyof IMediaElementEventMap
       | keyof IMediaSourceEventMap
       | keyof ISourceBufferEventMap,
-    cancelSignal: CancellationSignal | null,
+    cancelSignal: CancellationSignal | null | undefined,
   ): Promise<void> {
     return new Promise<void>((res, rej) => {
       /* eslint-disable */
@@ -59,7 +59,7 @@ export class EventScheduler {
         reject: rej,
         obj: obj as any,
         evtName: evtName as any,
-        cancelSignal,
+        cancelSignal: cancelSignal ?? null,
       });
       /* eslint-enable */
       if (this._scheduled.length === 1) {
@@ -149,6 +149,15 @@ export default class TimeRangesWithMetadata<T> implements TimeRanges {
     for (const element of this._rangesWithMetadata) {
       if (element.start <= time && element.end > time) {
         return element.info;
+      }
+    }
+    return null;
+  }
+
+  getRangeFor(time: number): { start: number; end: number } | null {
+    for (const element of this._rangesWithMetadata) {
+      if (element.start <= time && element.end > time) {
+        return { start: element.start, end: element.end };
       }
     }
     return null;


### PR DESCRIPTION
This is based on #1478.

On #1478, I was mocking MSE+EME + a part of the [HTML5 media spec](https://html.spec.whatwg.org/#media-elements) to allow advanced integration tests without having to create encrypted contents nor having to physically test on all encountered environments.

The subset of the MSE and EME API that we use isn't very complex, the harder part was to mock an `HTMLMediaElement`: especially the evolution of the current position, rebuffering, ending, readyState, autoplay etc.

A shortcut I consequently took in #1478 was to rely on a potential browser behavior: [the allowed to play](https://html.spec.whatwg.org/#allowed-to-play) concept.
By forbidding playback through this mechanism, I could avoid all those complex features while still being spec-compliant.

However forbidding playback prevents us from making a lot of useful tests: e.g. on freezing, rebuffering, ending, auto-play etc.

So this PR is an attempt to implement that. I relied on the WHATWG HTML spec but I took many shortcuts, especially by removing parts that aren't relied on at all by the RxPlayer.

It's possible that I missed some quirks or that it still has some bugs, but it right now seems to following the behavior of a real `HTMLMediaElement` well enough.

I also did not implement "directfile" playback for now. For all those missing features, we may ideally throw or indicate in some way that this is not yet implemented.

<video src="https://github.com/user-attachments/assets/a737f00d-0279-411a-8af1-bf4c6fe3c385"></video>

If the video doesn't work: https://github.com/user-attachments/assets/a737f00d-0279-411a-8af1-bf4c6fe3c385

_Video: content playback in the demo page with a mocked media element, where I try different things (seeking in an unbuffered part, in a buffered part, updating the playback rate, rebuffering, ending, play after ending)._

_The RxPlayer here believes it is playing in a media element but it's just a mock fully written in JavaScript that was provided to it. That mock is able to extract timing information and encryption metadata from media segments but does not actually decode nor decrypt the content._

_We can see a delay between the debug information and what is actually happening (e.g. between the spinner being displayed and a the `BUFFERING` state being shown in the debug element, because the debug element today only updates itself on an interval, this is not linked to this PR_


