### PR TITLE
tests: Remove homemade arraybuffer vitest plugin

### DIFF
--- a/tests/contents/imagetracks/infos.js
+++ b/tests/contents/imagetracks/infos.js
@@ -8,5 +8,5 @@ const BASE_URL =
   "/imagetracks/";
 
 export default {
-  url: BASE_URL + "example.bif",
+  url: BASE_URL + "image.bif",
 };

--- a/tests/contents/urls.mjs
+++ b/tests/contents/urls.mjs
@@ -13,6 +13,7 @@ import urls8 from "./directfile_webm/urls.mjs";
 import urls9 from "./DASH_dynamic_SegmentTemplate_Multi_Periods/urls.mjs";
 import urls10 from "./DASH_static_broken_cenc_in_MPD/urls.mjs";
 import urls11 from "./DASH_static_number_based_SegmentTimeline/urls.mjs";
+import urls12 from "./imagetracks/urls.mjs";
 
 export default [
   ...urls1,
@@ -26,4 +27,5 @@ export default [
   ...urls9,
   ...urls10,
   ...urls11,
+  ...urls12,
 ];

--- a/tests/integration/scenarios/parseBifThumbnails.test.js
+++ b/tests/integration/scenarios/parseBifThumbnails.test.js
@@ -1,10 +1,12 @@
-import canalBIF from "../../contents/imagetracks/example.bif?arraybuffer";
+import canalBifInfo from "../../contents/imagetracks/infos.js";
 import { parseBifThumbnails } from "../../../dist/es2017/tools";
 import { describe, it, expect } from "vitest";
 
 describe("parseBifThumbnails", () => {
-  it("should correctly parse given thumbnails", () => {
-    const parsedBIFs = parseBifThumbnails(canalBIF);
+  it("should correctly parse given thumbnails", async () => {
+    const bifRes = await fetch(canalBifInfo.url);
+    const bifAb = await bifRes.arrayBuffer();
+    const parsedBIFs = parseBifThumbnails(bifAb);
     expect(typeof parsedBIFs).to.equal("object");
     expect(parsedBIFs.version).to.equal("0.0.0.0");
     expect(parsedBIFs.images).to.be.an.instanceof(Array);

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,22 +1,4 @@
 import { defineConfig } from "vitest/config";
-import { promises as fs } from "fs";
-
-// https://github.com/tachibana-shin/vite-plugin-arraybuffer/blob/main/src/main.ts
-function vitePluginArraybuffer() {
-  return {
-    name: "array-buffer-loader",
-    async load(id) {
-      if (id.endsWith("?arraybuffer")) {
-        const filePath = id.replace(/\?arraybuffer$/, "");
-        const fileBuffer = await fs.readFile(filePath);
-        return {
-          code: `export default new Uint8Array([${new Uint8Array(fileBuffer).join(",")}]).buffer`,
-          map: { mappings: "" },
-        };
-      }
-    },
-  };
-}
 
 function getBrowserConfig(browser) {
   switch (browser) {
@@ -69,7 +51,6 @@ function getBrowserConfig(browser) {
 }
 
 export default defineConfig({
-  plugins: [vitePluginArraybuffer()],
   define: {
     // global variables
     __TEST_CONTENT_SERVER__: {


### PR DESCRIPTION
I noticed that the arraybuffer plugin we defined to allow arraybuffer ES imports in vitest was unnecessary.

We already start a "content server" in our integration tests to serve contents like manifest or segments, and we could just make an HTTP request to the corresponding file instead of importing it directly.

This seems simpler to me as we do not rely on vitest inner workings and plugin system for this: it could make it easier to debug and it facilitates maintainance as framework updates / switching are often un-fun timesinks.

Our vitest config file now becomes just about defining some globals, running our content server script and launching browsers with specific flags on listed test files, which seems simple enough to me.