### PR TITLE
Fix typo which prevented MediaKeys reusage and fix corresponding eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -191,7 +191,20 @@ module.exports = {
     ],
     "@typescript-eslint/no-shadow": ["error"],
     "@typescript-eslint/restrict-plus-operands": "error",
-    "@typescript-eslint/strict-boolean-expressions": "error",
+    "@typescript-eslint/strict-boolean-expressions": [
+      "error",
+      {
+        allowAny: false,
+        allowNullableBoolean: false,
+        allowNullableEnum: false,
+        allowNullableNumber: false,
+        allowNullableObject: false,
+        allowNullableString: false,
+        allowNumber: false,
+        allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing: false,
+        allowString: false,
+      },
+    ],
     "@typescript-eslint/triple-slash-reference": [
       "error",
       {

--- a/src/compat/browser_detection.ts
+++ b/src/compat/browser_detection.ts
@@ -170,7 +170,7 @@ let isA1KStb40xx = false;
     isPanasonic = true;
   } else if (navigator.userAgent.indexOf("Xbox") !== -1) {
     isXbox = true;
-  } else if (navigator.userAgent.indexOf("Model/a1-kstb40xx")) {
+  } else if (navigator.userAgent.indexOf("Model/a1-kstb40xx") !== -1) {
     isA1KStb40xx = true;
   }
 })();

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1335,7 +1335,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * `false` otherwise.
    */
   isPaused(): boolean {
-    if (this.videoElement) {
+    if (this.videoElement !== null) {
       if (arrayIncludes(["LOADING", "RELOADING"], this.state)) {
         return !this._priv_lastAutoPlay;
       } else {
@@ -2778,7 +2778,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     // Emit initial events for the Period
     if (!isNullOrUndefined(tracksStore)) {
       const periodRef = tracksStore.getPeriodObjectFromPeriod(period);
-      if (periodRef) {
+      if (periodRef !== undefined) {
         const audioTrack = tracksStore.getChosenAudioTrack(periodRef, true);
         this._priv_triggerEventIfNotStopped("audioTrackChange", audioTrack, cancelSignal);
         const textTrack = tracksStore.getChosenTextTrack(periodRef);

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -315,7 +315,7 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
     }
     const observation = this._playbackObserver.getReference().getValue();
     if (
-      !observation.rebuffering ||
+      observation.rebuffering === null ||
       observation.paused ||
       this._speed.getValue() <= 0 ||
       (bufferType !== "audio" && bufferType !== "video")

--- a/src/main_thread/text_displayer/html/text_track_cues_store.ts
+++ b/src/main_thread/text_displayer/html/text_track_cues_store.ts
@@ -358,7 +358,7 @@ export default class TextTrackCuesStore {
       }
     }
 
-    if (cuesBuffer.length) {
+    if (cuesBuffer.length > 0) {
       const lastCue = cuesBuffer[cuesBuffer.length - 1];
       if (areNearlyEqual(lastCue.end, start, relativeDelta)) {
         // Match the end of the previous cue to the start of the following one

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -94,7 +94,7 @@ function getHDRInformation({
         return { eotf: "hlg" };
     }
   }
-  if (codecs !== undefined && /^vp(08|09|10)/.exec(codecs)) {
+  if (codecs !== undefined && /^vp(08|09|10)/.test(codecs)) {
     return getWEBMHDRInformation(codecs);
   }
 }
@@ -205,7 +205,7 @@ export default function parseRepresentations(
         (r) =>
           r.schemeIdUri === "tag:dolby.com,2018:dash:EC3_ExtensionType:2018" &&
           r.value === "JOC",
-      )
+      ) !== undefined
     ) {
       parsedRepresentation.isSpatialAudio = true;
     }

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -837,7 +837,7 @@ function getFreezingStatus(
   bufferGap: number | undefined,
 ): IFreezingStatus | null {
   const { MINIMUM_BUFFER_AMOUNT_BEFORE_FREEZING } = config.getCurrent();
-  if (prevObservation.freezing) {
+  if (prevObservation.freezing !== null) {
     if (
       currentInfo.ended ||
       currentInfo.paused ||

--- a/src/utils/url-utils.ts
+++ b/src/utils/url-utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import isNonEmptyString from "./is_non_empty_string";
 import startsWith from "./starts_with";
 
 // Scheme part of an url (e.g. "http://").
@@ -135,12 +136,12 @@ function getRelativeUrl(baseUrl: string, newUrl: string): string | null {
   let result = relativePath;
   if (relativePath === "" && newParts.query === baseParts.query) {
     // path and query is the same, we don't need to rewrite it
-  } else if (newParts.query) {
+  } else if (isNonEmptyString(newParts.query)) {
     result += "?";
     result += newParts.query;
   }
 
-  if (newParts.fragment) {
+  if (isNonEmptyString(newParts.fragment)) {
     result += "#";
     result += newParts.fragment;
   }
@@ -160,7 +161,7 @@ function _resolveURL(base: string, relative: string) {
   const baseParts = parseURL(base);
   const relativeParts = parseURL(relative);
 
-  if (relativeParts.scheme) {
+  if (isNonEmptyString(relativeParts.scheme)) {
     return formatURL(relativeParts);
   }
 
@@ -172,7 +173,7 @@ function _resolveURL(base: string, relative: string) {
     fragment: relativeParts.fragment,
   };
 
-  if (relativeParts.authority) {
+  if (isNonEmptyString(relativeParts.authority)) {
     target.authority = relativeParts.authority;
     target.path = removeDotSegment(relativeParts.path);
     return formatURL(target);
@@ -180,7 +181,7 @@ function _resolveURL(base: string, relative: string) {
 
   if (relativeParts.path === "") {
     target.path = baseParts.path;
-    if (!relativeParts.query) {
+    if (!isNonEmptyString(relativeParts.query)) {
       target.query = baseParts.query;
     }
   } else {
@@ -255,20 +256,20 @@ function parseURL(url: string): IParsedURL {
  */
 function formatURL(parts: IParsedURL): string {
   let url = "";
-  if (parts.scheme) {
+  if (isNonEmptyString(parts.scheme)) {
     url += parts.scheme + ":";
   }
 
-  if (parts.authority) {
+  if (isNonEmptyString(parts.authority)) {
     url += "//" + parts.authority;
   }
   url += parts.path;
 
-  if (parts.query) {
+  if (isNonEmptyString(parts.query)) {
     url += "?" + parts.query;
   }
 
-  if (parts.fragment) {
+  if (isNonEmptyString(parts.fragment)) {
     url += "#" + parts.fragment;
   }
   return url;
@@ -321,7 +322,7 @@ function removeDotSegment(path: string): string {
  * @see https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.3
  */
 function mergePaths(baseParts: IParsedURL, relativePath: string): string {
-  if (baseParts.authority && baseParts.path === "") {
+  if (isNonEmptyString(baseParts.authority) && baseParts.path === "") {
     return "/" + relativePath;
   }
   const basePath = baseParts.path;

--- a/src/utils/xml-parser.ts
+++ b/src/utils/xml-parser.ts
@@ -6,6 +6,8 @@
  * https://github.com/TobiasNickel/tXml
  */
 
+import isNonEmptyString from "./is_non_empty_string";
+
 // import arrayIncludes from "./array_includes";
 
 /**
@@ -94,7 +96,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
     out = parseChildren("");
   }
 
-  if (options.filter) {
+  if (options.filter !== undefined) {
     out = filter(out, options.filter);
   }
   return out;
@@ -106,7 +108,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
    */
   function parseChildren(tagName: string): Array<ITNode | string> {
     const children: Array<ITNode | string> = [];
-    while (src[pos]) {
+    while (src[pos] !== undefined) {
       if (src.charCodeAt(pos) === openBracketCC) {
         if (src.charCodeAt(pos + 1) === slashCC) {
           const closeStart = pos + 2;
@@ -170,7 +172,10 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
             const startDoctype = pos + 1;
             pos += 2;
             let encapsuled = false;
-            while ((src.charCodeAt(pos) !== closeBracketCC || encapsuled) && src[pos]) {
+            while (
+              (src.charCodeAt(pos) !== closeBracketCC || encapsuled) &&
+              src[pos] !== undefined
+            ) {
               if (src.charCodeAt(pos) === openCornerBracketCC) {
                 encapsuled = true;
               } else if (encapsuled && src.charCodeAt(pos) === closeCornerBracketCC) {
@@ -221,7 +226,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
 
   function parseName(): string {
     const start = pos;
-    while (nameSpacer.indexOf(src[pos]) === -1 && src[pos]) {
+    while (nameSpacer.indexOf(src[pos]) === -1 && src[pos] !== undefined) {
       pos++;
     }
     return src.slice(start, pos);
@@ -235,7 +240,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
     let children: Array<ITNode | string> = [];
 
     // parsing attributes
-    while (src.charCodeAt(pos) !== closeBracketCC && src[pos]) {
+    while (src.charCodeAt(pos) !== closeBracketCC && src[pos] !== undefined) {
       const c = src.charCodeAt(pos);
       if ((c > 64 && c < 91) || (c > 96 && c < 123)) {
         // if('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.indexOf(src[pos])!==-1 ){
@@ -243,7 +248,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
         // search beginning of the string
         let code = src.charCodeAt(pos);
         while (
-          code &&
+          !isNaN(code) &&
           code !== singleQuoteCC &&
           code !== doubleQuoteCC &&
           !((code > 64 && code < 91) || (code > 96 && code < 123)) &&
@@ -298,7 +303,7 @@ function parseXml(src: string, options: ITParseOptions = {}): Array<ITNode | str
     const r = new RegExp(
       "\\s" + options.attrName + "\\s*=['\"]" + options.attrValue + "['\"]",
     ).exec(src);
-    if (r) {
+    if (r !== null) {
       return r.index;
     } else {
       return -1;
@@ -328,7 +333,7 @@ function filter(
           child.children,
           f,
           dept + 1,
-          (path ? path + "." : "") + i + "." + child.tagName,
+          (isNonEmptyString(path) ? path + "." : "") + i + "." + child.tagName,
         );
         out = out.concat(kids);
       }


### PR DESCRIPTION
I saw a very unfortunate typo which seems to prevent the RxPlayer from re-using a `MediaKeys` instance between contents sometimes (excepted on some identified platforms: xbox, playstation, smart TVs etc.) since the v4.2.0.

I saw that issue while continuing my work on integration tests in the massive #1478 PR.

I thought our linter's [`strict-boolean-expressions` rule](https://typescript-eslint.io/rules/strict-boolean-expressions/) protected us against those types of typos but it turns out that for some weird reason the persons implementing that rule thought that numbers, strings and nullable objects were OK (I just learned that, and I cannot understand why they thought it would be a good default behavior for a rule called **strict-boolean-expressions** with documentation `Forbids usage of non-boolean types in expressions where a boolean is expected` grrrrr).

So I fixed that rule, and BIM, multiple typos/missed post-refacto issues were all over the code.
Thankfully, it doesn't seem to have created issues other than the aforementioned one.