### PR TITLE
Fix keySystems option changing when reusing MediaKeySystemAccess

### DIFF
--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -491,7 +491,7 @@ export default function getMediaKeySystemAccess(
           value: {
             mediaKeySystemAccess: currentState.mediaKeySystemAccess,
             askedConfiguration: currentState.askedConfiguration,
-            options: currentState.keySystemOptions,
+            options: keySystemOptions,
             codecSupport: extractCodecSupportListFromConfiguration(
               currentState.askedConfiguration,
               currentState.mediaKeySystemAccess.getConfiguration(),


### PR DESCRIPTION
I noticed yet another bug while continuing to add DRM integration tests thanks to #1478.

If the `keySystems` `loadVideo` option was subtly modified between loadVideo calls, yet if we reused the same cached `MediaKeySystemAccess` we risked to rely on the old `keySystems` option, not on the new one.

It seems this bug was always there, so it shouldn't have impacted much applications (we would have heard of it)? But it seems relatively important to me.

I saw that issue in my integration tests while playing with the `serverCertificate` option. Changing it without changing the key system between `loadVideo` calls weirdly resulted in the first `serverCertificate` being used instead.