### PR TITLE
[Proposal] Add integration tests notice

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,10 +188,11 @@
     "start": "node ./scripts/start_demo_web_server.mjs",
     "start:wasm": "node ./scripts/start_demo_web_server.mjs --include-wasm",
     "test:integration": "npm run test:integration:chrome && npm run test:integration:firefox",
-    "test:integration:chrome": "cross-env BROWSER_CONFIG=chrome vitest run tests/integration/scenarios",
-    "test:integration:chrome:watch": "cross-env BROWSER_CONFIG=chrome vitest watch tests/integration/scenarios",
-    "test:integration:firefox": "cross-env BROWSER_CONFIG=firefox vitest run tests/integration/scenarios",
-    "test:integration:firefox:watch": "cross-env BROWSER_CONFIG=firefox vitest watch tests/integration/scenarios",
+    "test:integration:chrome": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest run tests/integration/scenarios",
+    "test:integration:chrome:watch": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest watch tests/integration/scenarios",
+    "test:integration:firefox": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=firefox vitest run tests/integration/scenarios",
+    "test:integration:firefox:watch": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=firefox vitest watch tests/integration/scenarios",
+    "test:integration:notice": "echo \"~~~ ⚠️ NOTICE ⚠️\n~~~ Integration tests rely on the RxPlayer build.\n~~~ Make sure you called the \\`build\\` script succesfully first.\n\"",
     "test:memory": "cross-env BROWSER_CONFIG=chrome vitest run tests/memory",
     "test:memory:chrome:watch": "cross-env BROWSER_CONFIG=chrome vitest watch tests/memory",
     "test:unit": "vitest --config vitest.config.unit.mjs",
@@ -260,7 +261,7 @@
       "fmt:rust:check": "Check that Rust files are well-formatted"
     },
     "Run tests": {
-      "Integration tests (test the whole API, ensure the RxPlayer build is made BEFORE running them)": {
+      "Integration tests (test the whole API, call the `build` script BEFORE running them)": {
         "test:integration": "Launch integration tests in multiple browser environments",
         "test:integration:chrome": "Launch integration tests in a Chrome browser.",
         "test:integration:chrome:watch": "Launch integration tests in Chrome each times the files update",


### PR DESCRIPTION
Our integration tests import the built RxPlayer as they test the final behavior and API of the RxPlayer, post-build scripts and all.

I consequently hesitated to force a building step before calling the integration tests scripts (or even to make it a step inside those integration tests - e.g. through `vitest`'s "globalSetup" concept) but finally refrained for that both in the name of simplicity (`npm run test:integration` just performs integration tests) and "performance" (you might just want to re-call `npm run test:integration` after fixing/adding new tests in which case there's no need to re-build the RxPlayer).

Instead of alternatives like adding a poorly-discoverable option/env, a prompt or some documentation somewhere I here propose to just print a warning notice each time integration tests are run notifying that the wanted RxPlayer build must have been produced first.

I did this at the `package.json` level, though I could have done it at `vitest`'s globalSetup level. I chose the `package.json` approach for now because a developer this way has a chance of seeing that warning before actually running the test:integration` script just by looking at available scripts.