### PR TITLE
[Proposal] Remove webdriverio deprecation notice the ugly way

### DIFF
--- a/tests/contents/server.mjs
+++ b/tests/contents/server.mjs
@@ -19,7 +19,7 @@ const DEFAULT_CONTENT_SERVER_PORT = 3000;
  * @param {number} port
  * @returns {Object}
  */
-export function createContentServer(port = DEFAULT_CONTENT_SERVER_PORT) {
+export default function createContentServer(port = DEFAULT_CONTENT_SERVER_PORT) {
   const server = createServer(function (req, res) {
     if (routeObj[req.url] == null) {
       res.setHeader("Content-Type", "text/plain");
@@ -143,10 +143,3 @@ function parseRangeHeader(rangeHeader, dataLength) {
   }
   return [rangesNb[0], rangesNb[1]];
 }
-/** Default export that returns a teardown function that is executed by
- * Vitest on test run
- * @see https://vitest.dev/config/#globalsetup
- * */
-export default () => {
-  createContentServer();
-};

--- a/tests/globalSetup.mjs
+++ b/tests/globalSetup.mjs
@@ -1,0 +1,43 @@
+import createContentServer from "./contents/server.mjs";
+
+const realConsoleWarn = console.warn;
+let contentServer;
+
+/**
+ * Peform actions we want to setup before tests.
+ */
+export function setup() {
+  removeAnnoyingDeprecationNotice();
+  contentServer = createContentServer();
+}
+
+/**
+ * Peform actions to clean-up after tests.
+ */
+export function teardown() {
+  contentServer?.close();
+}
+
+/**
+ * Webdriverio just spams a deprecation notice with the current version of
+ * vitest (one per test, though as we have thousands of tests, it just fills the
+ * output into something unreadable).
+ *
+ * This is so annoying that I just chose to mute it by monkey-patching the
+ * console function here.
+ *
+ * This should hopefully be very temporary.
+ */
+function removeAnnoyingDeprecationNotice() {
+  console.warn = function (...args) {
+    if (
+      typeof args[0] === "string" &&
+      args[0].startsWith(
+        '⚠️ [WEBDRIVERIO DEPRECATION NOTICE] The "switchToFrame" command is deprecated and we encourage everyone to use `switchFrame` instead for switching into frames.',
+      )
+    ) {
+      return;
+    }
+    return realConsoleWarn.apply(console, args);
+  };
+}

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -97,7 +97,7 @@ export default defineConfig({
       // memory tests
       "tests/memory/**/*.[jt]s?(x)",
     ],
-    globalSetup: "tests/contents/server.mjs",
+    globalSetup: "tests/globalSetup.mjs",
     browser: getBrowserConfig(process.env.BROWSER_CONFIG ?? "chrome"),
   },
 });


### PR DESCRIPTION
Our tests run with the test framework `vitest`, which is for now using the `webdriverio` dependency to run it on real browser environments.

However, it seems that `vitest` is using a deprecated API for each tests resulting in `webdriverio` outputing a warning log after each of them.

https://github.com/user-attachments/assets/1bcc4f41-0fa0-4eef-a595-ab1b833ca915

_Video: to the left, our integration tests currently. To the right, re-running those integration tests with that patch._

Considering that we have multiple thousands of tests, it makes the outputs of integration tests unreadable (and very difficult to scroll back), output which is particularly important when running test scripts.

This could be considered as a `vitest` issue, and they have been made aware of it through their #6804 issue (I'm not linking it in any way here as GitHub has the annoying tendency of spamming messages to the original issue when it is linked that way, it's the one named "`switchToFrame` deprecated in WebdriverIO v9").

This could also be "resolved" by just installing an older version of webdriverio without that deprecation notice but everything works right now beside that notice and I don't like the idea of locking a very specific version just because of a log.

In the meantime it has been several months and it's hard to write and run integration tests with that mess. So here I'm proposing to just uglily patch console functions in `vitest`'s "globalSetup" script.