### PR TITLE
tests: better target tests through vitest and set default browser config

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -90,9 +90,14 @@ export default defineConfig({
     watch: false,
     globals: false,
     reporters: "dot",
-    include: ["tests/**/*.[jt]s?(x)"],
-    exclude: ["tests/performance/**/*.[jt]s?(x)"],
+    include: [
+      // integration tests
+      "tests/integration/scenarios/**/*.[jt]s?(x)",
+      "tests/integration/**/*.test.[jt]s?(x)",
+      // memory tests
+      "tests/memory/**/*.[jt]s?(x)",
+    ],
     globalSetup: "tests/contents/server.mjs",
-    browser: getBrowserConfig(process.env.BROWSER_CONFIG),
+    browser: getBrowserConfig(process.env.BROWSER_CONFIG ?? "chrome"),
   },
 });


### PR DESCRIPTION
I'm PoCing a common config for most kinds of tests in the RxPlayer (integration, memory and unit tests, so we just exclude the very situational "performance" and "conformance" tests).

All three of them are relying on `vitest` but integration+memory tests run in a browser and unit tests run in a jsdom-ed Node.js environment.

With the goal of performing every tests in a web browser/user-agent to better reflect actual RxPlayer usage (in production, we need to run on something that has HTML5 video/audio and preferably EME+MSE, so Node.js isn't a realist target today) and of having the simplicity of just being able to call `npx vitest` to run all those tests with a common environment, I'm currently updating `vitest` configs and unit tests.

This PR is an offshoot of that work that is compatible to what we already do today:

  - `vitest`'s config more explicitly include memory+integration tests.

  - I added a default browser (sadly, I chose here Chrome, for popularity and universality reasons) for when no browser is asked for (this is only useful when calling `npx vitest` directly, which we never do but which a developer could want to do - in which case running all tests in chrome would be better than just failing randomly).