### PR TITLE
Feat: add an option to play without audio or video if audio or video failed

### DIFF
--- a/demo/scripts/components/Options/TrackSwitch.tsx
+++ b/demo/scripts/components/Options/TrackSwitch.tsx
@@ -13,6 +13,10 @@ function TrackSwitchConfig({
   onDefaultAudioTrackSwitchingModeChange,
   onCodecSwitchChange,
   onEnableFastSwitchingChange,
+  onAudioTracksNotPlayable,
+  onAudioTracksNotPlayableChange,
+  onVideoTracksNotPlayable,
+  onVideoTracksNotPlayableChange,
 }: {
   defaultAudioTrackSwitchingMode: string;
   onDefaultAudioTrackSwitchingModeChange: (newVal: string) => void;
@@ -20,38 +24,56 @@ function TrackSwitchConfig({
   onCodecSwitch: string;
   onCodecSwitchChange: (val: string) => void;
   onEnableFastSwitchingChange: (val: boolean) => void;
+  onAudioTracksNotPlayable: string;
+  onAudioTracksNotPlayableChange: (val: string) => void;
+  onVideoTracksNotPlayable: string;
+  onVideoTracksNotPlayableChange: (val: string) => void;
 }): React.JSX.Element {
-  let defaultAudioTrackSwitchingModeDescMsg;
-  switch (defaultAudioTrackSwitchingMode) {
-    case "reload":
-      defaultAudioTrackSwitchingModeDescMsg =
-        "Reloading by default when the audio track is changed";
-      break;
-    case "direct":
-      defaultAudioTrackSwitchingModeDescMsg =
-        "Directly audible transition when the audio track is changed";
-      break;
-    case "seamless":
-      defaultAudioTrackSwitchingModeDescMsg =
-        "Smooth transition when the audio track is changed";
-      break;
-    default:
-      defaultAudioTrackSwitchingModeDescMsg = "Unknown value";
-      break;
-  }
+  const defaultAudioTrackSwitchingModeDescMsg = React.useMemo(() => {
+    switch (defaultAudioTrackSwitchingMode) {
+      case "reload":
+        return "Reloading by default when the audio track is changed";
+      case "direct":
+        return "Directly audible transition when the audio track is changed";
+      case "seamless":
+        return "Smooth transition when the audio track is changed";
+      default:
+        return "Unknown value";
+    }
+  }, [defaultAudioTrackSwitchingMode]);
 
-  let onCodecSwitchDescMsg;
-  switch (onCodecSwitch) {
-    case "reload":
-      onCodecSwitchDescMsg = "Reloading buffers when the codec changes";
-      break;
-    case "continue":
-      onCodecSwitchDescMsg = "Keeping the same buffers even when the codec changes";
-      break;
-    default:
-      onCodecSwitchDescMsg = "Unknown value";
-      break;
-  }
+  const onCodecSwitchDescMsg = React.useMemo(() => {
+    switch (onCodecSwitch) {
+      case "reload":
+        return "Reloading buffers when the codec changes";
+      case "continue":
+        return "Keeping the same buffers even when the codec changes";
+      default:
+        return "Unknown value";
+    }
+  }, [onCodecSwitch]);
+
+  const onAudioTracksNotPlayableDescMsg = React.useMemo(() => {
+    switch (onAudioTracksNotPlayable) {
+      case "error":
+        return "Throw an error if no audio track can be played";
+      case "continue":
+        return "Continue with video only if no audio track is playable";
+      default:
+        return "Unknown value";
+    }
+  }, [onAudioTracksNotPlayable]);
+
+  const onVideoTracksNotPlayableDescMsg = React.useMemo(() => {
+    switch (onVideoTracksNotPlayable) {
+      case "error":
+        return "Throw an error if no video track can be played";
+      case "continue":
+        return "Continue with audio only if no video track is playable";
+      default:
+        return "Unknown value";
+    }
+  }, [onVideoTracksNotPlayable]);
 
   const onCodecSwitchSelection = React.useCallback(
     ({ value }: { value: string }) => onCodecSwitchChange(value),
@@ -61,6 +83,16 @@ function TrackSwitchConfig({
   const onDefaultAudioTrackSwitchingModeSelection = React.useCallback(
     ({ value }: { value: string }) => onDefaultAudioTrackSwitchingModeChange(value),
     [onDefaultAudioTrackSwitchingModeChange],
+  );
+
+  const onAudioTracksNotPlayableSelection = React.useCallback(
+    ({ value }: { value: string }) => onAudioTracksNotPlayableChange(value),
+    [onAudioTracksNotPlayableChange],
+  );
+
+  const onVideoTracksNotPlayableSelection = React.useCallback(
+    ({ value }: { value: string }) => onVideoTracksNotPlayableChange(value),
+    [onVideoTracksNotPlayableChange],
   );
 
   return (
@@ -108,6 +140,35 @@ function TrackSwitchConfig({
           On Codec Switch
         </Select>
         <span className="option-desc">{onCodecSwitchDescMsg}</span>
+      </li>
+      <li className="featureWrapperWithSelectMode">
+        <Select
+          ariaLabel="Selecting the onAudioTracksNotPlayable attribute"
+          disabled={false}
+          className="playerOptionInput"
+          name="onAudioTracksNotPlayable"
+          onChange={onAudioTracksNotPlayableSelection}
+          selected={{ value: onAudioTracksNotPlayable, index: undefined }}
+          options={["continue", "error"]}
+        >
+          On Audio Tracks Not Playable
+        </Select>
+        <span className="option-desc">{onAudioTracksNotPlayableDescMsg}</span>
+      </li>
+
+      <li className="featureWrapperWithSelectMode">
+        <Select
+          ariaLabel="Selecting the onVideoTracksNotPlayable attribute"
+          disabled={false}
+          className="playerOptionInput"
+          name="onVideoTracksNotPlayable"
+          onChange={onVideoTracksNotPlayableSelection}
+          selected={{ value: onVideoTracksNotPlayable, index: undefined }}
+          options={["continue", "error"]}
+        >
+          On Video Tracks Not Playable
+        </Select>
+        <span className="option-desc">{onVideoTracksNotPlayableDescMsg}</span>
       </li>
     </>
   );

--- a/demo/scripts/controllers/Settings.tsx
+++ b/demo/scripts/controllers/Settings.tsx
@@ -69,6 +69,8 @@ function Settings({
     checkManifestIntegrity,
     requestConfig,
     onCodecSwitch,
+    onAudioTracksNotPlayable,
+    onVideoTracksNotPlayable,
   } = loadVideoOptions;
   const cmcdCommunicationMethod = cmcd?.communicationType ?? "disabled";
   const { manifest: manifestRequestConfig, segment: segmentRequestConfig } =
@@ -301,6 +303,30 @@ function Settings({
     [updateLoadVideoOptions],
   );
 
+  const onAudioTracksNotPlayableChange = useCallback(
+    (value: string) => {
+      updateLoadVideoOptions((prevOptions) => {
+        if (value === prevOptions.onAudioTracksNotPlayable) {
+          return prevOptions;
+        }
+        return Object.assign({}, prevOptions, { onAudioTracksNotPlayable: value });
+      });
+    },
+    [updateLoadVideoOptions],
+  );
+
+  const onVideoTracksNotPlayableChange = useCallback(
+    (value: string) => {
+      updateLoadVideoOptions((prevOptions) => {
+        if (value === prevOptions.onVideoTracksNotPlayable) {
+          return prevOptions;
+        }
+        return Object.assign({}, prevOptions, { onVideoTracksNotPlayable: value });
+      });
+    },
+    [updateLoadVideoOptions],
+  );
+
   const onWantedBufferAheadChange = useCallback(
     (wantedBufferAhead: number) => {
       updatePlayerOptions((prevOptions) => {
@@ -424,6 +450,10 @@ function Settings({
             }
             onEnableFastSwitchingChange={onEnableFastSwitchingChange}
             onCodecSwitchChange={onCodecSwitchChange}
+            onAudioTracksNotPlayable={onAudioTracksNotPlayable}
+            onAudioTracksNotPlayableChange={onAudioTracksNotPlayableChange}
+            onVideoTracksNotPlayable={onVideoTracksNotPlayable}
+            onVideoTracksNotPlayableChange={onVideoTracksNotPlayableChange}
           />
         </Option>
         <Option title="Buffer Options">

--- a/demo/scripts/lib/defaultOptionsValues.ts
+++ b/demo/scripts/lib/defaultOptionsValues.ts
@@ -31,6 +31,8 @@ const defaultOptionsValues = {
       },
     },
     onCodecSwitch: "continue",
+    onAudioTracksNotPlayable: "error",
+    onVideoTracksNotPlayable: "error",
   },
 } satisfies {
   player: IConstructorOptions;

--- a/demo/scripts/modules/player/index.ts
+++ b/demo/scripts/modules/player/index.ts
@@ -138,6 +138,8 @@ export interface IPlayerModuleState {
   livePosition: null | undefined | number;
   maximumPosition: null | undefined | number;
   minimumPosition: null | undefined | number;
+  onAudioTracksNotPlayable: "continue" | "error";
+  onVideoTracksNotPlayable: "continue" | "error";
   playbackRate: number;
   /** Try to play contents in "multithread" mode when possible. */
   relyOnWorker: boolean;
@@ -196,6 +198,8 @@ const PlayerModule = declareModule(
     livePosition: undefined,
     maximumPosition: undefined,
     minimumPosition: undefined,
+    onAudioTracksNotPlayable: "error",
+    onVideoTracksNotPlayable: "error",
     playbackRate: 1,
     relyOnWorker: false,
     useWorker: false,
@@ -289,6 +293,8 @@ const PlayerModule = declareModule(
             {
               mode: state.get("relyOnWorker") ? "auto" : "main",
               textTrackElement,
+              onAudioTracksNotPlayable: state.get("onAudioTracksNotPlayable"),
+              onVideoTracksNotPlayable: state.get("onVideoTracksNotPlayable"),
             },
             arg,
           ) as ILoadVideoOptions,

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -725,8 +725,8 @@ Those are the possible values for that option:
 
 <div class="note">
 
-- An event [`noPlayableTrack`](../api/Loading_a_Content) will be emitted if no audio
-  tracks are playable.
+- An event [`noPlayableTrack`](./Player_Events.md) will be emitted if no audio tracks are
+  playable.
 
 - If neither the audio nor video tracks are playable, a `"NO_AUDIO_VIDEO_TRACKS"` error
   will be thrown regardless of this setting.
@@ -753,8 +753,8 @@ Those are the possible values for that option:
 
 <div class="note">
 
-- An event [`noPlayableTrack`](../api/Loading_a_Content) will be emitted if no video
-  tracks are playable.
+- An event [`noPlayableTrack`](./Player_Events.md#noplayabletrack) will be emitted if no
+  video tracks are playable.
 
 - If neither the audio nor video tracks are playable, a `"NO_AUDIO_VIDEO_TRACKS"` error
   will be thrown regardless of this setting.

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -706,6 +706,61 @@ Those are the possible values for that option:
   More information about the `"RELOADING"` state can be found in
   [the player states documentation](./Player_States.md).
 
+### onAudioTracksNotPlayable
+
+_type_: `string|undefined`
+
+_defaults_: `"error"`
+
+Specifies the behavior when all audio tracks are not playable - This can occur if the
+device does not support the required audio codecs, or if the content cannot be decrypted,
+for example, due to an insufficient security level.
+
+Those are the possible values for that option:
+
+- `"continue"`: The player will proceed to play the content without audio.
+
+- `"error"`: The player will throw an error to indicate that the audio tracks could not be
+  played.
+
+<div class="note">
+
+- An event [`noPlayableTrack`](../api/Loading_a_Content) will be emitted if no audio
+  tracks are playable.
+
+- If neither the audio nor video tracks are playable, a `"NO_AUDIO_VIDEO_TRACKS"` error
+  will be thrown regardless of this setting.
+
+</div>
+
+### onVideoTracksNotPlayable
+
+_type_: `string|undefined`
+
+_defaults_: `"error"`
+
+Specifies the behavior when all video tracks are not playable - This can occur if the
+device does not support the required video codecs, or if the content cannot be decrypted,
+for example, due to an insufficient security level.
+
+Those are the possible values for that option:
+
+- `"continue"`: The player will proceed to play the content without video. (i.e.,
+  audio-only playback).
+
+- `"error"`: The player will throw an error to indicate that the video tracks could not be
+  played.
+
+<div class="note">
+
+- An event [`noPlayableTrack`](../api/Loading_a_Content) will be emitted if no video
+  tracks are playable.
+
+- If neither the audio nor video tracks are playable, a `"NO_AUDIO_VIDEO_TRACKS"` error
+  will be thrown regardless of this setting.
+
+</div>
+
 ### lowLatencyMode
 
 _type_: `Boolean|undefined`
@@ -927,7 +982,7 @@ The `serverSyncInfos` object contains two keys:
   <div class="note">
   The `performance.now()` API is used here because it is the main API to
   obtain a monotically increasing clock on the client-side.
-  </div</div>
+  </div>
 
 Example:
 

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -720,8 +720,9 @@ Those are the possible values for that option:
 
 - `"continue"`: The player will proceed to play the content without audio.
 
-- `"error"`: The player will throw an error to indicate that the audio tracks could not be
-  played.
+- `"error"`: The player will throw an error `MediaError` with the code
+  `MANIFEST_INCOMPATIBLE_CODECS_ERROR`, `NO_AUDIO_VIDEO_TRACKS` or
+  `NO_PLAYABLE_REPRESENTATION` to indicate that the audio tracks could not be played.
 
 <div class="note">
 
@@ -748,8 +749,9 @@ Those are the possible values for that option:
 - `"continue"`: The player will proceed to play the content without video. (i.e.,
   audio-only playback).
 
-- `"error"`: The player will throw an error to indicate that the video tracks could not be
-  played.
+- `"error"`: The player will throw an error `MediaError` with the code
+  `MANIFEST_INCOMPATIBLE_CODECS_ERROR`, `NO_AUDIO_VIDEO_TRACKS` or
+  `NO_PLAYABLE_REPRESENTATION` to indicate that the video tracks could not be played.
 
 <div class="note">
 

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -720,9 +720,14 @@ Those are the possible values for that option:
 
 - `"continue"`: The player will proceed to play the content without audio.
 
-- `"error"`: The player will throw an error `MediaError` with the code
-  `MANIFEST_INCOMPATIBLE_CODECS_ERROR`, `NO_AUDIO_VIDEO_TRACKS` or
-  `NO_PLAYABLE_REPRESENTATION` to indicate that the audio tracks could not be played.
+- `"error"`: The player will throw an error `MediaError` with one of the following codes:
+  - `"MANIFEST_INCOMPATIBLE_CODECS_ERROR"`: For this media type (audio or video), all
+    available codecs are unsupported.
+  - `"NO_AUDIO_VIDEO_TRACKS"`: There are no selected or playable audio and video tracks.
+    Therefore, there is nothing to play.
+  - `"NO_PLAYABLE_REPRESENTATION"`: At least one track has a supported codec, but none of
+    the available representations are playable. This may be due to DRM restrictions or
+    other playback constraints.
 
 <div class="note">
 
@@ -749,9 +754,14 @@ Those are the possible values for that option:
 - `"continue"`: The player will proceed to play the content without video. (i.e.,
   audio-only playback).
 
-- `"error"`: The player will throw an error `MediaError` with the code
-  `MANIFEST_INCOMPATIBLE_CODECS_ERROR`, `NO_AUDIO_VIDEO_TRACKS` or
-  `NO_PLAYABLE_REPRESENTATION` to indicate that the video tracks could not be played.
+- `"error"`: The player will throw an error `MediaError` with one of the following codes:
+  - `"MANIFEST_INCOMPATIBLE_CODECS_ERROR"`: For this media type (audio or video), all
+    available codecs are unsupported.
+  - `"NO_AUDIO_VIDEO_TRACKS"`: There are no selected or playable audio and video tracks.
+    Therefore, there is nothing to play.
+  - `"NO_PLAYABLE_REPRESENTATION"`: At least one track has a supported codec, but none of
+    the available representations are playable. This may be due to DRM restrictions or
+    other playback constraints.
 
 <div class="note">
 

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -191,6 +191,9 @@ An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
   For those errors, you may be able to know the characteristics of the corresponding
   track(s) by inspecting the error's `tracksInfo` property, described below.
 
+- `"NO_AUDIO_VIDEO_TRACKS"`: No audio and video tracks were selected. This can happen if
+  the application has disabled both audio and video.
+
 - `"MANIFEST_UPDATE_ERROR"`: This error should never be emitted as it is handled
   internally by the RxPlayer. Please open an issue if you encounter it.
 

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -572,9 +572,9 @@ continuing playback with available tracks (e.g., playing video-only if no audio 
 available).
 
 The `loadVideo()` options
-[`onAudioTracksNotPlayable`](../api/Loading_a_Content.html#onaudiotracksnotplayable) and
-[`onVideoTracksNotPlayable`](../api/Loading_a_Content.html#onvideotracksnotplayable)
-defines the player behavior when a track is not playable.
+[`onAudioTracksNotPlayable`](./Loading_a_Content.md#onaudiotracksnotplayable) and
+[`onVideoTracksNotPlayable`](./Loading_a_Content.md#onvideotracksnotplayable) defines the
+player behavior when a track is not playable.
 
 </div>
 

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -536,6 +536,48 @@ video track when in directfile mode to avoid that case (this is documented
 in the corresponding APIs).
 </div>
 
+### noPlayableTrack
+
+_payload type_: `Object`
+
+Emitted when no tracks of a given type can be selected for a given period.
+
+The payload is an object with the following properties:
+
+- `trackType` (`"audio" | "video" | "text"`): The type of the track that appears to have
+  no playable options available.
+
+- `period`: (`Object`): The period in which the track is not playable. This object has the
+  following properties:
+
+  - `id`: (`"string"`): The ID of the period.
+
+  - `start`: (`"number"`): The start time of the period.
+
+  - `end`: (`"number" | undefined`): The end time of the period. This value may be
+    `undefined` either if not known or if the Period has no end yet (e.g. for live
+    contents, the end might not be known for now)
+
+<div class="note">
+
+The `noPlayableTrack` event is emitted when none of the tracks for a specific type (audio,
+video, or subtitles) are playable for a given period.
+
+For example, this might occur if a content only has audio codecs that the device does not
+support, or if a media cannot be decrypted due to an insufficient security level.
+
+By listening for this event, the application can respond appropriately, such as notifying
+the user that the given track type is not playable, or taking corrective actions such as
+continuing playback with available tracks (e.g., playing video-only if no audio track is
+available).
+
+The `loadVideo()` options
+[`onAudioTracksNotPlayable`](../api/Loading_a_Content.html#onaudiotracksnotplayable) and
+[`onVideoTracksNotPlayable`](../api/Loading_a_Content.html#onvideotracksnotplayable)
+defines the player behavior when a track is not playable.
+
+</div>
+
 ## Representation selection events
 
 This chapter describes events linked to the current audio, video or Representation /

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -167,6 +167,12 @@ events and so on.
 - [`defaultAudioTrackSwitchingMode`](../api/Loading_a_Content.md#defaultaudiotrackswitchingmode):
   Default behavior when switching the audio track.
 
+- [`onAudioTracksNotPlayable`](../api/Loading_a_Content.md#onaudiotracksnotplayable):
+  Specifies the behavior when all audio tracks are not playable.
+
+- [`onVideoTracksNotPlayable`](../api/Loading_a_Content.md#onvideotracksnotplayable):
+  Specifies the behavior when all video tracks are not playable.
+
 - [`lowLatencyMode`](../api/Loading_a_Content.md#lowlatencymode): Allows to play
   low-latency contents efficiently.
 

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -322,10 +322,10 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
         scheduleRequest,
       );
       if (!isPromise(res)) {
-        return finish(res.manifest, res.warnings);
+        return finish(res.manifest);
       } else {
-        const { manifest, warnings } = await res;
-        return finish(manifest, warnings);
+        const { manifest } = await res;
+        return finish(manifest);
       }
     } catch (err) {
       const formattedError = formatError(err, {
@@ -376,11 +376,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      * To call once the Manifest has been parsed.
      * @param {Object} manifest
      */
-    function finish(
-      manifest: Manifest,
-      warnings: IPlayerError[],
-    ): IManifestFetcherParsedResult {
-      onWarnings(warnings);
+    function finish(manifest: Manifest): IManifestFetcherParsedResult {
       const parsingTime = getMonotonicTimeStamp() - parsingTimeStart;
       log.info(`MF: Manifest parsed in ${parsingTime}ms`);
 

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -127,7 +127,7 @@ export default function PeriodStream(
 
         const streamCanceller = new TaskCanceller();
         streamCanceller.linkToSignal(parentCancelSignal);
-        currentStreamCanceller?.cancel(); // Cancel oreviously created stream if one
+        currentStreamCanceller?.cancel(); // Cancel previously created stream if one
         currentStreamCanceller = streamCanceller;
 
         if (choice === null) {
@@ -473,7 +473,11 @@ function getFirstDeclaredMimeType(adaptation: IAdaptation): string {
   const representations = adaptation.representations.filter(
     (r) => r.isPlayable() !== false,
   );
-  if (representations.length === 0) {
+  if (representations.length > 0) {
+    return representations[0].getMimeTypeString();
+  } else if (adaptation.representations.length > 0) {
+    return adaptation.representations[0].getMimeTypeString();
+  } else {
     const noRepErr = new MediaError(
       "NO_PLAYABLE_REPRESENTATION",
       "No Representation in the chosen " + adaptation.type + " Adaptation can be played",
@@ -481,7 +485,6 @@ function getFirstDeclaredMimeType(adaptation: IAdaptation): string {
     );
     throw noRepErr;
   }
-  return representations[0].getMimeTypeString();
 }
 
 /**

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -98,6 +98,26 @@ const DEFAULT_CONFIG = {
   DEFAULT_CODEC_SWITCHING_BEHAVIOR: "continue" as "continue" | "reload",
 
   /**
+   * Specifies the behavior when all audio tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without audio.
+   * - If set to `"error"`, an error will be thrown to indicate that the audio tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  DEFAULT_AUDIO_TRACKS_NOT_PLAYABLE_BEHAVIOR: "error" as "continue" | "error",
+
+  /**
+   * Specifies the behavior when all video tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without video.
+   * - If set to `"error"`, an error will be thrown to indicate that the video tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  DEFAULT_VIDEO_TRACKS_NOT_PLAYABLE_BEHAVIOR: "error" as "continue" | "error",
+
+  /**
    * If set to true, video through loadVideo will auto play by default
    * @type {Boolean}
    */

--- a/src/errors/error_codes.ts
+++ b/src/errors/error_codes.ts
@@ -62,7 +62,8 @@ export type IMediaErrorCode =
   | "MEDIA_TIME_AFTER_MANIFEST"
   | "MEDIA_TIME_NOT_FOUND"
   | "NO_PLAYABLE_REPRESENTATION"
-  | "DISCONTINUITY_ENCOUNTERED";
+  | "DISCONTINUITY_ENCOUNTERED"
+  | "NO_AUDIO_VIDEO_TRACKS";
 
 export type INetworkErrorCode = "PIPELINE_LOAD_ERROR";
 
@@ -141,6 +142,8 @@ const ErrorCodes: Record<IErrorCode, IErrorCode> = {
   DISCONTINUITY_ENCOUNTERED: "DISCONTINUITY_ENCOUNTERED",
 
   NONE: "NONE",
+
+  NO_AUDIO_VIDEO_TRACKS: "NO_AUDIO_VIDEO_TRACKS",
 };
 
 export { ErrorTypes, ErrorCodes };

--- a/src/main_thread/api/__tests__/option_utils.test.ts
+++ b/src/main_thread/api/__tests__/option_utils.test.ts
@@ -293,6 +293,8 @@ describe("API - parseLoadVideoOptions", () => {
     minimumManifestUpdateInterval: 0,
     mode: "auto",
     onCodecSwitch: "continue",
+    onAudioTracksNotPlayable: "error",
+    onVideoTracksNotPlayable: "error",
     requestConfig: {},
     referenceDateTime: undefined,
     representationFilter: undefined,

--- a/src/main_thread/api/option_utils.ts
+++ b/src/main_thread/api/option_utils.ts
@@ -92,6 +92,10 @@ interface IParsedLoadVideoOptionsBase {
   defaultAudioTrackSwitchingMode: IAudioTrackSwitchingMode | undefined;
   /** @see ILoadVideoOptions.onCodecSwitch */
   onCodecSwitch: "continue" | "reload";
+  /** @see ILoadVideoOptions.onAudioTracksNotPlayable */
+  onAudioTracksNotPlayable: "continue" | "error";
+  /** @see ILoadVideoOptions.onVideoTracksNotPlayable */
+  onVideoTracksNotPlayable: "continue" | "error";
   /** @see ILoadVideoOptions.checkMediaSegmentIntegrity */
   checkMediaSegmentIntegrity?: boolean | undefined;
   /** @see ILoadVideoOptions.checkManifestIntegrity */
@@ -315,6 +319,8 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     DEFAULT_CODEC_SWITCHING_BEHAVIOR,
     DEFAULT_ENABLE_FAST_SWITCHING,
     DEFAULT_TEXT_TRACK_MODE,
+    DEFAULT_AUDIO_TRACKS_NOT_PLAYABLE_BEHAVIOR,
+    DEFAULT_VIDEO_TRACKS_NOT_PLAYABLE_BEHAVIOR,
   } = config.getCurrent();
 
   if (isNullOrUndefined(options)) {
@@ -402,6 +408,42 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     onCodecSwitch = DEFAULT_CODEC_SWITCHING_BEHAVIOR;
   }
 
+  let onAudioTracksNotPlayable: "continue" | "error" = isNullOrUndefined(
+    options.onAudioTracksNotPlayable,
+  )
+    ? DEFAULT_AUDIO_TRACKS_NOT_PLAYABLE_BEHAVIOR
+    : options.onAudioTracksNotPlayable;
+  if (!arrayIncludes(["continue", "error"], onAudioTracksNotPlayable)) {
+    log.warn(
+      "The `onAudioTracksNotPlayable` loadVideo option must match one of " +
+        "the following string:\n" +
+        "- `continue`\n" +
+        "- `error`\n" +
+        "If badly set, " +
+        DEFAULT_AUDIO_TRACKS_NOT_PLAYABLE_BEHAVIOR +
+        " will be used as default",
+    );
+    onAudioTracksNotPlayable = DEFAULT_AUDIO_TRACKS_NOT_PLAYABLE_BEHAVIOR;
+  }
+
+  let onVideoTracksNotPlayable: "continue" | "error" = isNullOrUndefined(
+    options.onVideoTracksNotPlayable,
+  )
+    ? DEFAULT_VIDEO_TRACKS_NOT_PLAYABLE_BEHAVIOR
+    : options.onVideoTracksNotPlayable;
+  if (!arrayIncludes(["continue", "error"], onVideoTracksNotPlayable)) {
+    log.warn(
+      "The `onVideoTracksNotPlayable` loadVideo option must match one of " +
+        "the following string:\n" +
+        "- `continue`\n" +
+        "- `error`\n" +
+        "If badly set, " +
+        DEFAULT_VIDEO_TRACKS_NOT_PLAYABLE_BEHAVIOR +
+        " will be used as default",
+    );
+    onVideoTracksNotPlayable = DEFAULT_VIDEO_TRACKS_NOT_PLAYABLE_BEHAVIOR;
+  }
+
   if (isNullOrUndefined(options.textTrackMode)) {
     textTrackMode = DEFAULT_TEXT_TRACK_MODE;
   } else {
@@ -476,6 +518,8 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     minimumManifestUpdateInterval,
     requestConfig,
     onCodecSwitch,
+    onAudioTracksNotPlayable,
+    onVideoTracksNotPlayable,
     referenceDateTime: options.referenceDateTime,
     representationFilter: options.representationFilter,
     segmentLoader: options.segmentLoader,

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -104,6 +104,7 @@ import type {
   IWorkerSettings,
   IThumbnailTrackInfo,
   IThumbnailRenderingOptions,
+  INoPlayableTrackEventPayload,
 } from "../../public_types";
 import type { IThumbnailResponse } from "../../transports";
 import arrayFind from "../../utils/array_find";
@@ -881,6 +882,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       __priv_manifestUpdateUrl,
       __priv_patchLastSegmentInSidx,
       url,
+      onAudioTracksNotPlayable,
+      onVideoTracksNotPlayable,
     } = options;
 
     // Perform multiple checks on the given options
@@ -1135,6 +1138,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         pendingRequests: new WeakMap(),
         lastResponse: null,
       },
+      onAudioTracksNotPlayable,
+      onVideoTracksNotPlayable,
     };
 
     // Bind events
@@ -2681,6 +2686,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const tracksStore = new TracksStore({
       preferTrickModeTracks: this._priv_preferTrickModeTracks,
       defaultAudioTrackSwitchingMode: contentInfos.defaultAudioTrackSwitchingMode,
+      onTracksNotPlayableForType: {
+        audio: contentInfos.onAudioTracksNotPlayable,
+        video: contentInfos.onVideoTracksNotPlayable,
+      },
     });
     contentInfos.tracksStore = tracksStore;
     tracksStore.addEventListener("newAvailablePeriods", (p) => {
@@ -2700,14 +2709,18 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         this._priv_onAvailableTracksMayHaveChanged(e.trackType);
       }
     });
-    contentInfos.tracksStore.addEventListener("warning", (err) => {
+    tracksStore.addEventListener("warning", (err) => {
       this.trigger("warning", err);
     });
-    contentInfos.tracksStore.addEventListener("error", (err) => {
+    tracksStore.addEventListener("error", (err) => {
       this._priv_onFatalError(err, contentInfos);
     });
 
-    contentInfos.tracksStore.onManifestUpdate(manifest);
+    tracksStore.addEventListener("noPlayableTrack", (noPlayableTrackEvent) => {
+      this.trigger("noPlayableTrack", noPlayableTrackEvent);
+    });
+
+    tracksStore.onManifestUpdate(manifest);
   }
 
   /**
@@ -3466,6 +3479,7 @@ interface IPublicAPIEvent {
   streamEvent: IStreamEvent;
   streamEventSkip: IStreamEvent;
   inbandEvents: IInbandEvent[];
+  noPlayableTrack: INoPlayableTrackEventPayload;
 }
 
 /** State linked to a particular contents loaded by the public API. */
@@ -3570,6 +3584,25 @@ export interface IPublicApiContentInfos {
       thumbnailTrackId: string;
     } | null;
   };
+  /**
+   * Specifies the behavior when all audio tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without audio.
+   * - If set to `"error"`, an error will be thrown to indicate that the audio tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  onAudioTracksNotPlayable: "continue" | "error";
+
+  /**
+   * Specifies the behavior when all video tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without video.
+   * - If set to `"error"`, an error will be thrown to indicate that the video tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  onVideoTracksNotPlayable: "continue" | "error";
 }
 
 export default Player;

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -677,7 +677,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
           sessionInfo.blacklistedSessionError = err;
 
           if (initializationData.content !== undefined) {
-            log.info("DRM: blacklisting Representations based on " + "protection data.");
+            log.info("DRM: blacklisting Representations based on protection data.");
             this.trigger("blackListProtectionData", initializationData);
           }
 

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -1,9 +1,7 @@
 import isCodecSupported from "../../../compat/is_codec_supported";
-import { MediaError } from "../../../errors";
 import type { IManifestMetadata } from "../../../manifest";
 import type Manifest from "../../../manifest/classes";
 import type { ICodecSupportInfo } from "../../../multithread_types";
-import type { ITrackType } from "../../../public_types";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import type ContentDecryptor from "../../decrypt";
 import { ContentDecryptorState } from "../../decrypt";
@@ -182,20 +180,6 @@ export function updateManifestCodecSupport(
         adaptation.supportStatus.hasSupportedCodec = undefined;
       } else {
         adaptation.supportStatus.hasSupportedCodec = hasSupportedCodec;
-      }
-    });
-
-    ["audio" as const, "video" as const].forEach((ttype: ITrackType) => {
-      const forType = p.adaptations[ttype];
-      if (
-        forType !== undefined &&
-        forType.every((a) => a.supportStatus.hasSupportedCodec === false)
-      ) {
-        throw new MediaError(
-          "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-          "No supported " + ttype + " adaptations",
-          { tracks: undefined },
-        );
       }
     });
   });

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -51,9 +51,10 @@ import type {
   IVideoTrackSwitchingMode,
   IPlayerError,
   ITrackType,
+  INoPlayableTrackEventPayload,
 } from "../../public_types";
 import arrayFind from "../../utils/array_find";
-import assert from "../../utils/assert";
+import assert, { assertUnreachable } from "../../utils/assert";
 import EventEmitter from "../../utils/event_emitter";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
@@ -102,9 +103,19 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    */
   private _defaultAudioTrackSwitchingMode: IAudioTrackSwitchingMode;
 
+  /** Specifies the behavior when audio or video tracks are not playable. */
+  private onTracksNotPlayableForType: {
+    audio: "error" | "continue";
+    video: "error" | "continue";
+  };
+
   constructor(args: {
     preferTrickModeTracks: boolean;
     defaultAudioTrackSwitchingMode: IAudioTrackSwitchingMode | undefined;
+    onTracksNotPlayableForType: {
+      audio: "error" | "continue";
+      video: "error" | "continue";
+    };
   }) {
     super();
     this._storedPeriodInfo = [];
@@ -114,6 +125,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     this._defaultAudioTrackSwitchingMode =
       args.defaultAudioTrackSwitchingMode ??
       config.getCurrent().DEFAULT_AUDIO_TRACK_SWITCHING_MODE;
+    this.onTracksNotPlayableForType = args.onTracksNotPlayableForType;
   }
 
   /**
@@ -139,12 +151,76 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   }
 
   /**
+   * Check that a period has a supported track for the given track type.
+   * Trigger an error with `MANIFEST_INCOMPATIBLE_CODECS_ERROR` if no codecs are
+   * supported and `onTracksNotPlayableForType[ttype]` is "error".
+   *
+   * @param period - The period to check
+   * @param ttype - The track type.
+   */
+  private checkPeriodHasSupportedTrack(
+    period: IPeriodMetadata,
+    ttype: "video" | "audio",
+  ): void {
+    const adaptationsForType = period.adaptations[ttype];
+    const audioVideoAdaptations = [
+      ...(period.adaptations.audio ?? []),
+      ...(period.adaptations.video ?? []),
+    ];
+
+    const periodHasAdaptationForType =
+      adaptationsForType !== undefined && adaptationsForType.length > 0;
+    if (!periodHasAdaptationForType) {
+      // The content does not have audio/video media, e.g. it's an audio only content.
+      // there is no track of this type to select.
+      return;
+    }
+
+    const isTypeUnsupported = adaptationsForType.every(
+      (adapt) => adapt.supportStatus.hasSupportedCodec === false,
+    );
+    const isAudioAndVideoUnsupported = audioVideoAdaptations.every(
+      (adapt) => adapt.supportStatus.hasSupportedCodec === false,
+    );
+
+    if (isTypeUnsupported) {
+      const err = new MediaError(
+        "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
+        "No supported " + ttype + " adaptations",
+        { tracks: undefined },
+      );
+      if (isAudioAndVideoUnsupported) {
+        // Both video and audio are unsupported or the content is audio/video only.
+        // The content cannot be played without this media type as there is no other media type.
+        this.trigger("error", err);
+        // The previous event trigger could have had side-effects, so we
+        // re-check if we're still mostly in the same state
+        if (this._isDisposed) {
+          return; // Someone disposed the `TracksStore` on the previous side-effect
+        }
+      } else if (this.onTracksNotPlayableForType[ttype] === "continue") {
+        // audio or video is not playable, but let's continue the playback without audio
+        // or without video because of the option was set to "continue".
+        this.trigger("warning", err);
+      } else {
+        this.trigger("error", err);
+        // The previous event trigger could have had side-effects, so we
+        // re-check if we're still mostly in the same state
+        if (this._isDisposed) {
+          return; // Someone disposed the `TracksStore` on the previous side-effect
+        }
+        this.dispose();
+        return;
+      }
+    }
+  }
+
+  /**
    * Update the list of Periods handled by the TracksStore and make a
    * track choice decision for each of them.
    * @param {Object} manifest - The new Manifest object
    */
   public onManifestUpdate(manifest: IManifestMetadata) {
-    const { DEFAULT_VIDEO_TRACK_SWITCHING_MODE } = config.getCurrent();
     const { periods } = manifest;
 
     // We assume that they are always sorted chronologically
@@ -157,6 +233,12 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
 
     /** Periods which have just been added. */
     const addedPeriods: ITSPeriodObject[] = [];
+
+    for (const period of periods) {
+      ["audio" as const, "video" as const].forEach((ttype) => {
+        this.checkPeriodHasSupportedTrack(period, ttype);
+      });
+    }
 
     let newPListIdx = 0;
     for (let i = 0; i < this._storedPeriodInfo.length; i++) {
@@ -173,137 +255,22 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       } else if (oldPeriod === newPeriod) {
         newPListIdx++;
 
-        const curWantedTextTrack = this._storedPeriodInfo[i].text.storedSettings;
-        if (!isNullOrUndefined(curWantedTextTrack)) {
-          const textAdaptations = getSupportedAdaptations(newPeriod, "text");
-          const stillHere = textAdaptations.some(
-            (a) => a.id === curWantedTextTrack.adaptation.id,
-          );
-          if (!stillHere) {
-            log.warn("TS: Chosen text Adaptation not available anymore");
-            const periodInfo = this._storedPeriodInfo[i];
-            periodInfo.text.storedSettings = null;
-            this.trigger("trackUpdate", {
-              period: toExposedPeriod(newPeriod),
-              trackType: "text",
-              reason: "missing",
-            });
+        this.resetSelectedTrackIfNotAvailableAnymore(
+          this._storedPeriodInfo[i],
+          newPeriod,
+          "video",
+        );
+        this.resetSelectedTrackIfNotAvailableAnymore(
+          this._storedPeriodInfo[i],
+          newPeriod,
+          "audio",
+        );
+        this.resetSelectedTrackIfNotAvailableAnymore(
+          this._storedPeriodInfo[i],
+          newPeriod,
+          "text",
+        );
 
-            // The previous event trigger could have had side-effects, so we
-            // re-check if we're still mostly in the same state
-            if (this._isDisposed) {
-              return; // The current TracksStore is disposed, we can abort
-            }
-            const periodItem = getPeriodItem(
-              this._storedPeriodInfo,
-              periodInfo.period.id,
-            );
-            if (
-              periodItem !== undefined &&
-              periodItem.isPeriodAdvertised &&
-              periodItem.text.storedSettings === null
-            ) {
-              periodItem.text.dispatcher?.updateTrack(null);
-            }
-          }
-        }
-
-        const curWantedVideoTrack = this._storedPeriodInfo[i].video.storedSettings;
-        if (!isNullOrUndefined(curWantedVideoTrack)) {
-          const videoAdaptations = getSupportedAdaptations(newPeriod, "video");
-          const stillHere = videoAdaptations.some(
-            (a) => a.id === curWantedVideoTrack.adaptation.id,
-          );
-          if (!stillHere) {
-            log.warn("TS: Chosen video Adaptation not available anymore");
-            const periodItem = this._storedPeriodInfo[i];
-            let storedSettings: IVideoStoredSettings;
-            if (videoAdaptations.length === 0) {
-              storedSettings = null;
-            } else {
-              const adaptationBase = videoAdaptations[0];
-              const adaptation = getRightVideoTrack(
-                adaptationBase,
-                this._isTrickModeTrackEnabled,
-              );
-              const lockedRepresentations =
-                new SharedReference<IRepresentationsChoice | null>(null);
-              storedSettings = {
-                adaptationBase,
-                adaptation,
-                switchingMode: DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
-                lockedRepresentations,
-              };
-            }
-            periodItem.video.storedSettings = storedSettings;
-            this.trigger("trackUpdate", {
-              period: toExposedPeriod(newPeriod),
-              trackType: "video",
-              reason: "missing",
-            });
-
-            // The previous event trigger could have had side-effects, so we
-            // re-check if we're still mostly in the same state
-            if (this._isDisposed) {
-              return; // Someone disposed the `TracksStore` on the previous side-effect
-            }
-            const newPeriodItem = getPeriodItem(
-              this._storedPeriodInfo,
-              periodItem.period.id,
-            );
-            if (
-              newPeriodItem !== undefined &&
-              newPeriodItem.isPeriodAdvertised &&
-              newPeriodItem.video.storedSettings === storedSettings
-            ) {
-              newPeriodItem.video.dispatcher?.updateTrack(storedSettings);
-            }
-          }
-        }
-
-        const curWantedAudioTrack = this._storedPeriodInfo[i].audio.storedSettings;
-        if (!isNullOrUndefined(curWantedAudioTrack)) {
-          const audioAdaptations = getSupportedAdaptations(newPeriod, "audio");
-          const stillHere = audioAdaptations.some(
-            (a) => a.id === curWantedAudioTrack.adaptation.id,
-          );
-          if (!stillHere) {
-            log.warn("TS: Chosen audio Adaptation not available anymore");
-            const periodItem = this._storedPeriodInfo[i];
-            const storedSettings =
-              audioAdaptations.length === 0
-                ? null
-                : {
-                    adaptation: audioAdaptations[0],
-                    switchingMode: this._defaultAudioTrackSwitchingMode,
-                    lockedRepresentations:
-                      new SharedReference<IRepresentationsChoice | null>(null),
-                  };
-            periodItem.audio.storedSettings = storedSettings;
-            this.trigger("trackUpdate", {
-              period: toExposedPeriod(newPeriod),
-              trackType: "audio",
-              reason: "missing",
-            });
-
-            // The previous event trigger could have had side-effects, so we
-            // re-check if we're still mostly in the same state
-            if (this._isDisposed) {
-              return; // Someone disposed the `TracksStore` on the previous side-effect
-            }
-            const newPeriodItem = getPeriodItem(
-              this._storedPeriodInfo,
-              periodItem.period.id,
-            );
-            if (
-              newPeriodItem !== undefined &&
-              newPeriodItem.isPeriodAdvertised &&
-              newPeriodItem.audio.storedSettings === storedSettings
-            ) {
-              newPeriodItem.audio.dispatcher?.updateTrack(storedSettings);
-            }
-          }
-        }
         // (If not, what do?)
       } else if (oldPeriod.start <= newPeriod.start) {
         // This old Period does not exist anymore.
@@ -344,6 +311,134 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       storedPeriodInfo.audio.dispatcher?.refresh();
       storedPeriodInfo.video.dispatcher?.refresh();
       storedPeriodInfo.text.dispatcher?.refresh();
+    }
+  }
+
+  /**
+   * Reset the stored settings if the track is not available anymore in
+   * the new manifest.
+   * @param periodInfo
+   * @param newPeriod
+   * @param type
+   * @returns
+   */
+  private resetSelectedTrackIfNotAvailableAnymore(
+    periodInfo: ITSPeriodObject,
+    newPeriod: IPeriodMetadata,
+    type: ITrackType,
+  ) {
+    const wantedTrack = periodInfo[type].storedSettings;
+    if (isNullOrUndefined(wantedTrack)) {
+      return;
+    }
+    const supportedAdaptations = getSupportedAdaptations(newPeriod, type);
+    const stillHere = supportedAdaptations.some(
+      (a) => a.id === wantedTrack.adaptation.id,
+    );
+
+    if (stillHere) {
+      // The track still exists, it don't need to be resetted.
+      return;
+    }
+
+    log.warn(`TS: Chosen ${type} Adaptation not available anymore`);
+
+    if (type === "video") {
+      periodInfo.video.storedSettings = this.getDefaultStoredSettingsForAdaptation(
+        supportedAdaptations,
+        "video",
+      );
+    } else if (type === "audio") {
+      periodInfo.audio.storedSettings = this.getDefaultStoredSettingsForAdaptation(
+        supportedAdaptations,
+        "audio",
+      );
+    } else if (type === "text") {
+      periodInfo.text.storedSettings = this.getDefaultStoredSettingsForAdaptation(
+        supportedAdaptations,
+        "text",
+      );
+    }
+
+    this.trigger("trackUpdate", {
+      period: toExposedPeriod(newPeriod),
+      trackType: type,
+      reason: "missing",
+    });
+
+    // The previous event trigger could have had side-effects, so we
+    // re-check if we're still mostly in the same state
+    if (this._isDisposed) {
+      return; // The current TracksStore is disposed, we can abort
+    }
+
+    const periodItem = getPeriodItem(this._storedPeriodInfo, periodInfo.period.id);
+    if (
+      periodItem !== undefined &&
+      periodItem.isPeriodAdvertised &&
+      periodItem[type].storedSettings === null
+    ) {
+      periodItem[type].dispatcher?.updateTrack(null);
+    }
+  }
+
+  // Overloading signatures
+  private getDefaultStoredSettingsForAdaptation(
+    supportedAdaptations: IAdaptationMetadata[],
+    type: "text",
+  ): null;
+  private getDefaultStoredSettingsForAdaptation(
+    supportedAdaptations: IAdaptationMetadata[],
+    type: "audio",
+  ): IAudioStoredSettings | null;
+  private getDefaultStoredSettingsForAdaptation(
+    supportedAdaptations: IAdaptationMetadata[],
+    type: "video",
+  ): IVideoStoredSettings | null;
+  private getDefaultStoredSettingsForAdaptation<B extends ITrackType>(
+    supportedAdaptations: IAdaptationMetadata[],
+    type: B,
+  ): IVideoStoredSettings | IAudioStoredSettings | null {
+    const { DEFAULT_VIDEO_TRACK_SWITCHING_MODE } = config.getCurrent();
+
+    if (type === "text") {
+      return null;
+    }
+    if (supportedAdaptations.length === 0) {
+      return null;
+    }
+    switch (type) {
+      case "text":
+        return null;
+
+      case "video": {
+        const adaptationBase = supportedAdaptations[0];
+        const adaptation = getRightVideoTrack(
+          adaptationBase,
+          this._isTrickModeTrackEnabled,
+        );
+        const lockedRepresentations = new SharedReference<IRepresentationsChoice | null>(
+          null,
+        );
+        return {
+          adaptationBase,
+          adaptation,
+          switchingMode: DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
+          lockedRepresentations,
+        };
+      }
+
+      case "audio": {
+        return {
+          adaptation: supportedAdaptations[0],
+          switchingMode: this._defaultAudioTrackSwitchingMode,
+          lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
+        };
+      }
+
+      default: {
+        assertUnreachable(type);
+      }
     }
   }
 
@@ -390,61 +485,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const dispatcher = new TrackDispatcher(adaptationRef);
     periodObj[bufferType].dispatcher = dispatcher;
 
-    dispatcher.addEventListener("noPlayableRepresentation", () => {
-      const nextAdaptation = arrayFind(
-        period.adaptations[bufferType] ?? [],
-        (adaptation) => {
-          if (
-            adaptation.supportStatus.hasSupportedCodec === false ||
-            adaptation.supportStatus.isDecipherable === false
-          ) {
-            return false;
-          }
-          const playableRepresentations = adaptation.representations.filter(
-            (r) => isRepresentationPlayable(r) === true,
-          );
-          return playableRepresentations.length > 0;
-        },
-      );
-      if (nextAdaptation === undefined) {
-        const noRepErr = new MediaError(
-          "NO_PLAYABLE_REPRESENTATION",
-          `No ${bufferType} Representation can be played`,
-          { tracks: undefined },
-        );
-        this.trigger("error", noRepErr);
-        this.dispose();
-        return;
-      }
-      let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[bufferType];
-      if (isNullOrUndefined(typeInfo)) {
-        return;
-      }
-      const switchingMode =
-        bufferType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload";
-      const storedSettings = {
-        adaptation: nextAdaptation,
-        switchingMode,
-        lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
-      };
-      typeInfo.storedSettings = storedSettings;
-      this.trigger("trackUpdate", {
-        period: toExposedPeriod(period),
-        trackType: bufferType,
-        reason: "no-playable-representation",
-      });
-
-      // The previous event trigger could have had side-effects, so we
-      // re-check if we're still mostly in the same state
-      if (this._isDisposed) {
-        return; // Someone disposed the `TracksStore` on the previous side-effect
-      }
-      typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[bufferType];
-      if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
-        return;
-      }
-      typeInfo.dispatcher?.updateTrack(storedSettings);
-    });
+    dispatcher.addEventListener("noPlayableRepresentation", () =>
+      this.onNoPlayableRepresentation(period, bufferType),
+    );
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
       // reloading
@@ -491,6 +534,108 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         return;
       }
     }
+  }
+
+  /**
+   * Handle the noPlayableRepresentation event, trigger an error if no fallback is possible.
+   * and can trigger event "noPlayableTrack"
+   * @param period - The period that has no playable representation
+   * @param trackType - The media type that is not playable
+   */
+  private onNoPlayableRepresentation(period: IPeriodMetadata, trackType: ITrackType) {
+    const periodHasAdaptationForType =
+      period.adaptations[trackType] !== undefined &&
+      period.adaptations[trackType].length > 0;
+    if (!periodHasAdaptationForType) {
+      log.debug(
+        `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
+      );
+      return;
+    }
+
+    const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
+    if (
+      firstPlayableAdaptation === undefined &&
+      (trackType === "text" || this.onTracksNotPlayableForType[trackType] === "continue")
+    ) {
+      // audio or video is not playable, but let's continue the playback without audio
+      // or without video because of the option was set to "continue".
+      log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
+      this.trigger("noPlayableTrack", {
+        trackType,
+        period: { id: period.id, start: period.start, end: period.end },
+      });
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+    } else if (firstPlayableAdaptation === undefined) {
+      const noRepErr = new MediaError(
+        "NO_PLAYABLE_REPRESENTATION",
+        `No ${trackType} Representation can be played`,
+        { tracks: undefined },
+      );
+      this.trigger("noPlayableTrack", {
+        trackType,
+        period: {
+          id: period.id,
+          start: period.start,
+          end: period.end,
+        },
+      });
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+      this.trigger("error", noRepErr);
+      this.dispose();
+      return;
+    }
+    let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
+    if (isNullOrUndefined(typeInfo)) {
+      return;
+    }
+    const selectedAdaptation = getPeriodItem(this._storedPeriodInfo, period.id)?.[
+      trackType
+    ]?.storedSettings;
+    if (selectedAdaptation === null) {
+      // The track type has been explicitly disabled, there is no need to select
+      // a new track as a fallback.
+      return;
+    }
+
+    const switchingMode =
+      trackType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload";
+    const storedSettings =
+      firstPlayableAdaptation !== undefined
+        ? {
+            adaptation: firstPlayableAdaptation,
+            switchingMode,
+            lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(
+              null,
+            ),
+          }
+        : null;
+    typeInfo.storedSettings = storedSettings;
+
+    this.trigger("trackUpdate", {
+      period: toExposedPeriod(period),
+      trackType,
+      reason: "no-playable-representation",
+    });
+
+    // The previous event trigger could have had side-effects, so we
+    // re-check if we're still mostly in the same state
+    if (this._isDisposed) {
+      return; // Someone disposed the `TracksStore` on the previous side-effect
+    }
+    typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
+    if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
+      return;
+    }
+    typeInfo.dispatcher?.updateTrack(storedSettings);
   }
 
   /**
@@ -901,6 +1046,19 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     ) {
       newPeriodItem[bufferType].dispatcher?.updateTrack(null);
     }
+
+    if (newPeriodItem !== undefined) {
+      const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
+        (ttype) => newPeriodItem[ttype].storedSettings === null,
+      );
+      if (hasNoTrackAtAll) {
+        const err = new MediaError(
+          "NO_AUDIO_VIDEO_TRACKS",
+          "No audio and no video tracks are set.",
+        );
+        this.trigger("error", err);
+      }
+    }
   }
 
   /**
@@ -1276,34 +1434,38 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         continue;
       }
 
-      const audioAdaptation = getSupportedAdaptations(period, "audio")[0];
-      trackStorePeriod.audio.storedSettings =
-        audioAdaptation === undefined
-          ? null
-          : {
-              adaptation: audioAdaptation,
-              switchingMode: this._defaultAudioTrackSwitchingMode,
-              lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(
-                null,
-              ),
-            };
+      const audioAdaptation: IAdaptationMetadata | undefined = getSupportedAdaptations(
+        period,
+        "audio",
+      )[0];
+      if (audioAdaptation === undefined) {
+        trackStorePeriod.audio.storedSettings = null;
+        this.onNoPlayableRepresentation(period, "audio");
+      } else {
+        trackStorePeriod.audio.storedSettings = {
+          adaptation: audioAdaptation,
+          switchingMode: this._defaultAudioTrackSwitchingMode,
+          lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
+        };
+      }
 
-      const baseVideoAdaptation = getSupportedAdaptations(period, "video")[0];
-      const videoAdaptation = getRightVideoTrack(
-        baseVideoAdaptation,
-        this._isTrickModeTrackEnabled,
-      );
-      trackStorePeriod.video.storedSettings =
-        videoAdaptation === undefined
-          ? null
-          : {
-              adaptation: videoAdaptation,
-              adaptationBase: baseVideoAdaptation,
-              switchingMode: DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
-              lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(
-                null,
-              ),
-            };
+      const baseVideoAdaptation: IAdaptationMetadata | undefined =
+        getSupportedAdaptations(period, "video")[0];
+      if (baseVideoAdaptation === undefined) {
+        trackStorePeriod.video.storedSettings = null;
+        this.onNoPlayableRepresentation(period, "video");
+      } else {
+        const videoAdaptation = getRightVideoTrack(
+          baseVideoAdaptation,
+          this._isTrickModeTrackEnabled,
+        );
+        trackStorePeriod.video.storedSettings = {
+          adaptation: videoAdaptation,
+          adaptationBase: baseVideoAdaptation,
+          switchingMode: DEFAULT_VIDEO_TRACK_SWITCHING_MODE,
+          lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
+        };
+      }
 
       let textAdaptation: IAdaptationMetadata | null = null;
       const forcedSubtitles = (period.adaptations.text ?? []).filter(
@@ -1457,6 +1619,28 @@ function toExposedPeriod(p: IPeriodMetadata): IPeriod {
   return { start: p.start, end: p.end, id: p.id };
 }
 
+function findFirstPlayableAdaptation(
+  period: IPeriodMetadata,
+  type: "audio" | "text" | "video",
+): IAdaptationMetadata | undefined {
+  const firstPlayableAdaptation = arrayFind(
+    period.adaptations[type] ?? [],
+    (adaptation) => {
+      if (
+        adaptation.supportStatus.hasSupportedCodec === false ||
+        adaptation.supportStatus.isDecipherable === false
+      ) {
+        return false;
+      }
+      const playableRepresentations = adaptation.representations.filter(
+        (r) => isRepresentationPlayable(r) === true,
+      );
+      return playableRepresentations.length > 0;
+    },
+  );
+  return firstPlayableAdaptation;
+}
+
 /** Every information stored for a single Period. */
 export interface ITSPeriodObject {
   /** The Period in question. */
@@ -1505,21 +1689,7 @@ interface IAudioPeriodInfo {
    * `null` if no audio track is wanted.
    * `undefined` if not set yet.
    */
-  storedSettings:
-    | {
-        /** Contains the last `Adaptation` wanted by the user. */
-        adaptation: IAdaptationMetadata;
-        /** "Switching mode" in which the track switch should happen. */
-        switchingMode: IAudioTrackSwitchingMode;
-        /**
-         * Contains the last locked `Representation`s for this `Adaptation` wanted
-         * by the user.
-         * `null` if no Representation is locked.
-         */
-        lockedRepresentations: SharedReference<IRepresentationsChoice | null>;
-      }
-    | null
-    | undefined;
+  storedSettings: IAudioStoredSettings | null | undefined;
   /**
    * Tracks are internally emitted through RxJS's `Subject`s.
    * A `TrackDispatcher` allows to facilitate and centralize the management of
@@ -1530,6 +1700,19 @@ interface IAudioPeriodInfo {
    * for now.
    */
   dispatcher: TrackDispatcher | null;
+}
+
+interface IAudioStoredSettings {
+  /** Contains the last `Adaptation` wanted by the user. */
+  adaptation: IAdaptationMetadata;
+  /** "Switching mode" in which the track switch should happen. */
+  switchingMode: IAudioTrackSwitchingMode;
+  /**
+   * Contains the last locked `Representation`s for this `Adaptation` wanted
+   * by the user.
+   * `null` if no Representation is locked.
+   */
+  lockedRepresentations: SharedReference<IRepresentationsChoice | null>;
 }
 
 /**
@@ -1592,7 +1775,7 @@ export interface IVideoPeriodInfo {
   dispatcher: TrackDispatcher | null;
 }
 
-type IVideoStoredSettings = {
+interface IVideoStoredSettings {
   /**
    * The wanted Adaptation itself (may be different from `adaptationBase` when
    * a trickmode track is chosen, in which case `adaptationBase` is the
@@ -1614,7 +1797,7 @@ type IVideoStoredSettings = {
    * `null` if no Representation is locked.
    */
   lockedRepresentations: SharedReference<IRepresentationsChoice | null>;
-} | null;
+}
 
 /** Events emitted by the TracksStore. */
 interface ITracksStoreEvents {
@@ -1623,6 +1806,7 @@ interface ITracksStoreEvents {
   trackUpdate: ITrackUpdateEventPayload;
   error: unknown;
   warning: IPlayerError;
+  noPlayableTrack: INoPlayableTrackEventPayload;
 }
 
 export interface IAudioRepresentationsLockSettings {

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -485,9 +485,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const dispatcher = new TrackDispatcher(adaptationRef);
     periodObj[bufferType].dispatcher = dispatcher;
 
-    dispatcher.addEventListener("noPlayableRepresentation", () =>
-      this.onNoPlayableRepresentation(period, bufferType),
-    );
+    dispatcher.addEventListener("noPlayableRepresentation", () => {
+      this.onNoPlayableRepresentation(period, bufferType);
+    });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
       // reloading
@@ -513,6 +513,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           end: period.end,
         },
       ]);
+
+      for (const eventToEmit of periodObj.noPlayableTrackEventToDispatch) {
+        this.trigger("noPlayableTrack", eventToEmit);
+      }
+
       if (this._isDisposed) {
         return;
       }
@@ -542,7 +547,15 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * @param period - The period that has no playable representation
    * @param trackType - The media type that is not playable
    */
-  private onNoPlayableRepresentation(period: IPeriodMetadata, trackType: ITrackType) {
+  private onNoPlayableRepresentation(
+    period: IPeriodMetadata,
+    trackType: ITrackType,
+  ): Array<{
+    trackType: ITrackType;
+    period: IPeriod;
+  }> {
+    const noPlayableTrackToTrigger = [];
+
     const periodHasAdaptationForType =
       period.adaptations[trackType] !== undefined &&
       period.adaptations[trackType].length > 0;
@@ -550,7 +563,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       log.debug(
         `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
       );
-      return;
+      return [];
     }
 
     const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
@@ -561,14 +574,14 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       // audio or video is not playable, but let's continue the playback without audio
       // or without video because of the option was set to "continue".
       log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
-      this.trigger("noPlayableTrack", {
+      noPlayableTrackToTrigger.push({
         trackType,
         period: { id: period.id, start: period.start, end: period.end },
       });
       // The previous event trigger could have had side-effects, so we
       // re-check if we're still mostly in the same state
       if (this._isDisposed) {
-        return; // Someone disposed the `TracksStore` on the previous side-effect
+        return []; // Someone disposed the `TracksStore` on the previous side-effect
       }
     } else if (firstPlayableAdaptation === undefined) {
       const noRepErr = new MediaError(
@@ -576,26 +589,22 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         `No ${trackType} Representation can be played`,
         { tracks: undefined },
       );
-      this.trigger("noPlayableTrack", {
+      noPlayableTrackToTrigger.push({
         trackType,
-        period: {
-          id: period.id,
-          start: period.start,
-          end: period.end,
-        },
+        period: { id: period.id, start: period.start, end: period.end },
       });
       // The previous event trigger could have had side-effects, so we
       // re-check if we're still mostly in the same state
       if (this._isDisposed) {
-        return; // Someone disposed the `TracksStore` on the previous side-effect
+        return []; // Someone disposed the `TracksStore` on the previous side-effect
       }
       this.trigger("error", noRepErr);
       this.dispose();
-      return;
+      return noPlayableTrackToTrigger;
     }
     let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
     if (isNullOrUndefined(typeInfo)) {
-      return;
+      return noPlayableTrackToTrigger;
     }
     const selectedAdaptation = getPeriodItem(this._storedPeriodInfo, period.id)?.[
       trackType
@@ -603,7 +612,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     if (selectedAdaptation === null) {
       // The track type has been explicitly disabled, there is no need to select
       // a new track as a fallback.
-      return;
+      return noPlayableTrackToTrigger;
     }
 
     const switchingMode =
@@ -629,13 +638,14 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     // The previous event trigger could have had side-effects, so we
     // re-check if we're still mostly in the same state
     if (this._isDisposed) {
-      return; // Someone disposed the `TracksStore` on the previous side-effect
+      return []; // Someone disposed the `TracksStore` on the previous side-effect
     }
     typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
     if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
-      return;
+      return noPlayableTrackToTrigger;
     }
     typeInfo.dispatcher?.updateTrack(storedSettings);
+    return noPlayableTrackToTrigger;
   }
 
   /**
@@ -1440,7 +1450,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       )[0];
       if (audioAdaptation === undefined) {
         trackStorePeriod.audio.storedSettings = null;
-        this.onNoPlayableRepresentation(period, "audio");
+        trackStorePeriod.noPlayableTrackEventToDispatch.push(
+          ...this.onNoPlayableRepresentation(period, "audio"),
+        );
       } else {
         trackStorePeriod.audio.storedSettings = {
           adaptation: audioAdaptation,
@@ -1453,7 +1465,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         getSupportedAdaptations(period, "video")[0];
       if (baseVideoAdaptation === undefined) {
         trackStorePeriod.video.storedSettings = null;
-        this.onNoPlayableRepresentation(period, "video");
+        trackStorePeriod.noPlayableTrackEventToDispatch.push(
+          ...this.onNoPlayableRepresentation(period, "video"),
+        );
       } else {
         const videoAdaptation = getRightVideoTrack(
           baseVideoAdaptation,
@@ -1515,6 +1529,14 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       if (!trackStorePeriod.isPeriodAdvertised) {
         continue;
       }
+
+      if (trackStorePeriod.noPlayableTrackEventToDispatch.length > 0) {
+        for (const noPlayableTrackEvent of trackStorePeriod.noPlayableTrackEventToDispatch) {
+          this.trigger("noPlayableTrack", noPlayableTrackEvent);
+        }
+        trackStorePeriod.noPlayableTrackEventToDispatch = [];
+      }
+
       const bufferTypes: ITrackType[] = ["audio", "video", "text"];
       for (const bufferType of bufferTypes) {
         const trackInfo = trackStorePeriod[bufferType];
@@ -1612,6 +1634,7 @@ function generatePeriodInfo(
     audio: { storedSettings: undefined, dispatcher: null },
     video: { storedSettings: undefined, dispatcher: null },
     text: { storedSettings: undefined, dispatcher: null },
+    noPlayableTrackEventToDispatch: [],
   };
 }
 
@@ -1677,6 +1700,16 @@ export interface ITSPeriodObject {
    * If `true`, this object was since cleaned-up.
    */
   isRemoved: boolean;
+
+  /**
+   * NoPlayableTrack events that should be emitted when the period has been advertised.
+   *
+   * This ensure the events relates to a period that was communicated via the public API.
+   */
+  noPlayableTrackEventToDispatch: Array<{
+    trackType: ITrackType;
+    period: IPeriod;
+  }>;
 }
 
 /**

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -198,6 +198,8 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         if (this._isDisposed) {
           return; // Someone disposed the `TracksStore` on the previous side-effect
         }
+        this.dispose();
+        return;
       } else if (this.onTracksNotPlayableForType[ttype] === "continue") {
         // audio or video is not playable, but let's continue the playback without audio
         // or without video because of the option was set to "continue".
@@ -238,6 +240,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       ["audio" as const, "video" as const].forEach((ttype) => {
         this.checkPeriodHasSupportedTrack(period, ttype);
       });
+      if (this._isDisposed) {
+        return;
+      }
     }
 
     let newPListIdx = 0;
@@ -600,7 +605,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       }
       this.trigger("error", noRepErr);
       this.dispose();
-      return noPlayableTrackToTrigger;
+      return [];
     }
     let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
     if (isNullOrUndefined(typeInfo)) {
@@ -644,6 +649,26 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
       return noPlayableTrackToTrigger;
     }
+
+    // Check that we're not both disabling audio and video here
+    if (storedSettings === null) {
+      const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+      if (periodItem !== undefined) {
+        const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
+          (ttype) => periodItem[ttype].storedSettings === null,
+        );
+        if (hasNoTrackAtAll) {
+          const err = new MediaError(
+            "NO_AUDIO_VIDEO_TRACKS",
+            "No audio and no video tracks are set.",
+          );
+          this.trigger("error", err);
+          this.dispose();
+          return [];
+        }
+      }
+    }
+
     typeInfo.dispatcher?.updateTrack(storedSettings);
     return noPlayableTrackToTrigger;
   }
@@ -1067,6 +1092,8 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           "No audio and no video tracks are set.",
         );
         this.trigger("error", err);
+        this.dispose();
+        return;
       }
     }
   }
@@ -1453,6 +1480,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         trackStorePeriod.noPlayableTrackEventToDispatch.push(
           ...this.onNoPlayableRepresentation(period, "audio"),
         );
+        if (this._isDisposed) {
+          return;
+        }
       } else {
         trackStorePeriod.audio.storedSettings = {
           adaptation: audioAdaptation,
@@ -1468,6 +1498,9 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         trackStorePeriod.noPlayableTrackEventToDispatch.push(
           ...this.onNoPlayableRepresentation(period, "video"),
         );
+        if (this._isDisposed) {
+          return;
+        }
       } else {
         const videoAdaptation = getRightVideoTrack(
           baseVideoAdaptation,

--- a/src/manifest/classes/__tests__/manifest.test.ts
+++ b/src/manifest/classes/__tests__/manifest.test.ts
@@ -4,9 +4,7 @@ import type {
   IParsedPeriod,
   IParsedRepresentation,
 } from "../../../parsers/manifest";
-import type { IPlayerError } from "../../../public_types";
 import getMonotonicTimeStamp from "../../../utils/monotonic_timestamp";
-import type IAdaptation from "../adaptation";
 import CodecSupportCache from "../codec_support_cache";
 import type IManifest from "../manifest";
 import type IPeriod from "../period";
@@ -82,8 +80,7 @@ describe("Manifest - Manifest", () => {
     };
 
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
-    const warnings: IPlayerError[] = [];
-    const manifest = new Manifest(simpleFakeManifest, {}, warnings);
+    const manifest = new Manifest(simpleFakeManifest, {});
 
     expect(manifest.adaptations).toEqual({});
     expect(manifest.availabilityStartTime).toEqual(undefined);
@@ -93,7 +90,6 @@ describe("Manifest - Manifest", () => {
     expect(manifest.lifetime).toEqual(undefined);
     expect(manifest.getMaximumSafePosition()).toEqual(10);
     expect(manifest.getMinimumSafePosition()).toEqual(0);
-    expect(warnings).toEqual([]);
     expect(manifest.periods).toEqual([]);
     expect(manifest.suggestedPresentationDelay).toEqual(undefined);
     expect(manifest.uris).toEqual([]);
@@ -135,17 +131,15 @@ describe("Manifest - Manifest", () => {
     }));
 
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
-    const manifest = new Manifest(simpleFakeManifest, {}, []);
+    const manifest = new Manifest(simpleFakeManifest, {});
     expect(fakePeriod).toHaveBeenCalledTimes(2);
     expect(fakePeriod).toHaveBeenCalledWith(
       period1,
-      [],
       new CodecSupportCache([]),
       undefined,
     );
     expect(fakePeriod).toHaveBeenCalledWith(
       period2,
-      [],
       new CodecSupportCache([]),
       undefined,
     );
@@ -197,19 +191,19 @@ describe("Manifest - Manifest", () => {
     }));
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
 
-    const manifest = new Manifest(simpleFakeManifest, { representationFilter }, []);
+    const manifest = new Manifest(simpleFakeManifest, {
+      representationFilter,
+    });
     expect(manifest).not.toBe(null);
 
     expect(fakePeriod).toHaveBeenCalledTimes(2);
     expect(fakePeriod).toHaveBeenCalledWith(
       period1,
-      [],
       new CodecSupportCache([]),
       representationFilter,
     );
     expect(fakePeriod).toHaveBeenCalledWith(
       period2,
-      [],
       new CodecSupportCache([]),
       representationFilter,
     );
@@ -252,17 +246,15 @@ describe("Manifest - Manifest", () => {
     }));
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
 
-    const manifest = new Manifest(simpleFakeManifest, {}, []);
+    const manifest = new Manifest(simpleFakeManifest, {});
     expect(fakePeriod).toHaveBeenCalledTimes(2);
     expect(fakePeriod).toHaveBeenCalledWith(
       period1,
-      [],
       new CodecSupportCache([]),
       undefined,
     );
     expect(fakePeriod).toHaveBeenCalledWith(
       period2,
-      [],
       new CodecSupportCache([]),
       undefined,
     );
@@ -272,81 +264,6 @@ describe("Manifest - Manifest", () => {
       { id: "foo1", start: 12, adaptations: adapP2, thumbnailTracks: [] },
     ]);
     expect(manifest.adaptations).toBe(adapP1);
-
-    expect(fakeIdGenerator).toHaveBeenCalled();
-    expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
-    expect(fakeLogger.info).not.toHaveBeenCalled();
-    expect(fakeLogger.warn).not.toHaveBeenCalled();
-  });
-
-  it("should push parsing errors if there are unsupported Adaptations", async () => {
-    const period1 = generateParsedPeriod("0", 4, undefined);
-    const period2 = generateParsedPeriod("1", 12, undefined);
-    const simpleFakeManifest = {
-      id: "man",
-      isDynamic: false,
-      isLive: false,
-      transportType: "dash",
-      isLastPeriodKnown: true,
-      duration: 5,
-      timeBounds: {
-        minimumSafePosition: 0,
-        timeshiftDepth: null,
-        maximumTimeData: {
-          livePosition: 10,
-          isLinear: false,
-          maximumSafePosition: 10,
-          time: 10,
-        },
-      },
-      periods: [period1, period2],
-    };
-
-    const fakePeriod = vi.fn(
-      (period: IParsedPeriod, unsupportedAdaptations: IAdaptation[]): IPeriod => {
-        unsupportedAdaptations.push({
-          type: "audio",
-          language: "",
-          normalized: "",
-          audioDescription: false,
-          id: period.adaptations.audio?.[0].id ?? "a",
-          representations: period.adaptations.audio?.[0].representations ?? [],
-        } as unknown as IAdaptation);
-        return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
-      },
-    );
-    vi.doMock("../period", () => ({
-      default: fakePeriod,
-    }));
-    const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
-
-    const warnings: IPlayerError[] = [];
-    new Manifest(simpleFakeManifest, {}, warnings);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].type).toEqual("MEDIA_ERROR");
-    expect(warnings[0].code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
-    expect((warnings[0] as unknown as { tracksInfo: unknown }).tracksInfo).toEqual([
-      {
-        track: {
-          language: "",
-          normalized: "",
-          audioDescription: false,
-          id: period1.adaptations.audio?.[0].id,
-          representations: period1.adaptations.audio?.[0].representations,
-        },
-        type: "audio",
-      },
-      {
-        track: {
-          language: "",
-          normalized: "",
-          audioDescription: false,
-          id: period2.adaptations.audio?.[0].id,
-          representations: period2.adaptations.audio?.[0].representations,
-        },
-        type: "audio",
-      },
-    ]);
 
     expect(fakeIdGenerator).toHaveBeenCalled();
     expect(fakeGenerateNewId).toHaveBeenCalledTimes(1);
@@ -382,22 +299,14 @@ describe("Manifest - Manifest", () => {
       uris: ["url1", "url2"],
     };
 
-    const fakePeriod = vi.fn(
-      (period: IParsedPeriod, unsupportedAdaptations: IAdaptation[]): IPeriod => {
-        unsupportedAdaptations.push({
-          id: period.adaptations.audio?.[0].id,
-          type: "audio",
-          representations: [],
-        } as unknown as IAdaptation);
-        return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
-      },
-    );
+    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+      return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
+    });
     vi.doMock("../period", () => ({
       default: fakePeriod,
     }));
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
-    const warnings: IPlayerError[] = [];
-    const manifest = new Manifest(oldManifestArgs, {}, warnings);
+    const manifest = new Manifest(oldManifestArgs, {});
 
     expect(manifest.adaptations).toEqual(oldPeriod1.adaptations);
     expect(manifest.availabilityStartTime).toEqual(5);
@@ -405,10 +314,6 @@ describe("Manifest - Manifest", () => {
     expect(manifest.isDynamic).toEqual(false);
     expect(manifest.isLive).toEqual(false);
     expect(manifest.lifetime).toEqual(13);
-
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0].type).toEqual("MEDIA_ERROR");
-    expect(warnings[0].code).toEqual("MANIFEST_INCOMPATIBLE_CODECS_ERROR");
 
     expect(manifest.getMaximumSafePosition()).toEqual(10);
     expect(manifest.getMinimumSafePosition()).toEqual(5);
@@ -437,16 +342,9 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should return all URLs given with `getContentUrls`", async () => {
-    const fakePeriod = vi.fn(
-      (period: IParsedPeriod, unsupportedAdaptations: IAdaptation[]): IPeriod => {
-        unsupportedAdaptations.push({
-          id: period.adaptations.audio?.[0].id,
-          type: "audio",
-          representations: [],
-        } as unknown as IAdaptation);
-        return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
-      },
-    );
+    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+      return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
+    });
     vi.doMock("../period", () => ({
       default: fakePeriod,
     }));
@@ -478,7 +376,7 @@ describe("Manifest - Manifest", () => {
       uris: ["url1", "url2"],
     };
 
-    const manifest1 = new Manifest(oldManifestArgs1, {}, []);
+    const manifest1 = new Manifest(oldManifestArgs1, {});
     expect(manifest1.getUrls()).toEqual(["url1", "url2"]);
 
     const oldManifestArgs2 = {
@@ -507,21 +405,14 @@ describe("Manifest - Manifest", () => {
       },
       uris: [],
     };
-    const manifest2 = new Manifest(oldManifestArgs2, {}, []);
+    const manifest2 = new Manifest(oldManifestArgs2, {});
     expect(manifest2.getUrls()).toEqual([]);
   });
 
   it("should replace with a new Manifest when calling `replace`", async () => {
-    const fakePeriod = vi.fn(
-      (period: IParsedPeriod, unsupportedAdaptations: IAdaptation[]): IPeriod => {
-        unsupportedAdaptations.push({
-          id: period.adaptations.audio?.[0].id,
-          type: "audio",
-          representations: [],
-        } as unknown as IAdaptation);
-        return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
-      },
-    );
+    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+      return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
+    });
     const fakeReplacePeriodsRes = {
       updatedPeriods: [],
       addedPeriods: [],
@@ -562,7 +453,7 @@ describe("Manifest - Manifest", () => {
     };
 
     const Manifest = (await vi.importActual("../manifest")).default as typeof IManifest;
-    const manifest = new Manifest(oldManifestArgs, {}, []);
+    const manifest = new Manifest(oldManifestArgs, {});
 
     const mockTrigger = vi
       .spyOn(

--- a/src/manifest/classes/__tests__/period.test.ts
+++ b/src/manifest/classes/__tests__/period.test.ts
@@ -27,15 +27,13 @@ describe("Manifest - Period", () => {
     const args = { id: "12", adaptations: {}, start: 0, thumbnailTracks: [] };
     let period: IPeriod | null = null;
     let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
     try {
       const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
+      period = new Period(args, codecSupportCache);
     } catch (e) {
       errorReceived = e;
     }
 
-    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -46,7 +44,9 @@ describe("Manifest - Period", () => {
     }
 
     expect((errorReceived as { code?: string }).code).toBe("MANIFEST_PARSE_ERROR");
-    expect(errorReceived.message).toContain("No supported audio and video tracks.");
+    expect(errorReceived.message).toContain(
+      "The manifest has no video nor audio tracks.",
+    );
     expect(mockAdaptation).not.toHaveBeenCalled();
   });
 
@@ -87,15 +87,13 @@ describe("Manifest - Period", () => {
     } as unknown as IParsedPeriod;
     let period: IPeriod | null = null;
     let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
     try {
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
+      period = new Period(args, codecSupportCache);
     } catch (e) {
       errorReceived = e;
     }
 
-    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -107,14 +105,16 @@ describe("Manifest - Period", () => {
 
     expect((errorReceived as { code?: string }).code).toBe("MANIFEST_PARSE_ERROR");
     expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported audio and video tracks.");
+    expect(errorReceived.message).toContain(
+      "The manifest has no video nor audio tracks.",
+    );
 
     expect(mockAdaptation).toHaveBeenCalledTimes(2);
     expect(mockAdaptation).toHaveBeenNthCalledWith(1, fooAda1, codecSupportCache, {});
     expect(mockAdaptation).toHaveBeenNthCalledWith(2, fooAda2, codecSupportCache, {});
   });
 
-  it("should throw if only empty audio and/or video adaptations is given", async () => {
+  it("should throw if only empty audio and video adaptations is given", async () => {
     const mockAdaptation = vi.fn(
       (arg: IParsedAdaptation): Adaptation =>
         ({
@@ -140,15 +140,13 @@ describe("Manifest - Period", () => {
     };
     let period: IPeriod | null = null;
     let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
     try {
       const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
+      period = new Period(args, codecSupportCache);
     } catch (e) {
       errorReceived = e;
     }
 
-    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -160,12 +158,14 @@ describe("Manifest - Period", () => {
 
     expect((errorReceived as { code?: string }).code).toBe("MANIFEST_PARSE_ERROR");
     expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported audio and video tracks.");
+    expect(errorReceived.message).toContain(
+      "The manifest has no video nor audio tracks.",
+    );
 
     expect(mockAdaptation).toHaveBeenCalledTimes(0);
   });
 
-  it("should throw if we are left with no audio representation", async () => {
+  it("should throw if there is no video nor audio representations in any adaptations.", async () => {
     const mockAdaptation = vi.fn(
       (arg: IParsedAdaptation): Adaptation =>
         ({
@@ -186,7 +186,7 @@ describe("Manifest - Period", () => {
     const videoAda1 = {
       type: "video",
       id: "54",
-      representations: [{}],
+      representations: [],
       toVideoTrack() {
         return videoAda1;
       },
@@ -194,7 +194,7 @@ describe("Manifest - Period", () => {
     const videoAda2 = {
       type: "video",
       id: "56",
-      representations: [{}],
+      representations: [],
       toVideoTrack() {
         return videoAda2;
       },
@@ -202,7 +202,7 @@ describe("Manifest - Period", () => {
     const videoAda3 = {
       type: "video",
       id: "57",
-      representations: [{}],
+      representations: [],
       toVideoTrack() {
         return videoAda3;
       },
@@ -234,15 +234,13 @@ describe("Manifest - Period", () => {
     } as unknown as IParsedPeriod;
     let period: IPeriod | null = null;
     let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
     try {
       const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
+      period = new Period(args, codecSupportCache);
     } catch (e) {
       errorReceived = e;
     }
 
-    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period).toBe(null);
     expect(errorReceived).not.toBe(null);
     expect(errorReceived).toBeInstanceOf(Error);
@@ -252,117 +250,14 @@ describe("Manifest - Period", () => {
       throw new Error("Impossible: already checked it was an Error instance");
     }
 
-    expect((errorReceived as { code?: string }).code).toBe(
-      "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-    );
+    expect((errorReceived as { code?: string }).code).toBe("MANIFEST_PARSE_ERROR");
     expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported audio adaptations");
+    expect(errorReceived.message).toContain(
+      "The manifest has no video nor audio tracks.",
+    );
   });
 
-  it("should throw if no audio Adaptation is supported", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: arg.type !== "audio",
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
-    vi.doMock("../adaptation", () => ({
-      default: mockAdaptation,
-      SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
-    }));
-
-    const Period = (await vi.importActual("../period")).default as typeof IPeriod;
-    const videoAda1 = {
-      type: "video",
-      id: "54",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda1;
-      },
-    };
-    const videoAda2 = {
-      type: "video",
-      id: "55",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda2;
-      },
-    };
-    const videoAda3 = {
-      type: "video",
-      id: "56",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda3;
-      },
-    };
-    const video: IParsedAdaptation[] = [
-      videoAda1,
-      videoAda2,
-      videoAda3,
-    ] as unknown as IParsedAdaptation[];
-
-    const audioAda1 = {
-      type: "audio",
-      id: "57",
-      representations: [{}],
-      toAudioTrack() {
-        return audioAda1;
-      },
-    };
-    const audioAda2 = {
-      type: "audio",
-      id: "58",
-      representations: [{}],
-      toAudioTrack() {
-        return audioAda1;
-      },
-    };
-    const audio: IParsedAdaptation[] = [
-      audioAda1,
-      audioAda2,
-    ] as unknown as IParsedAdaptation[];
-    const args: IParsedPeriod = {
-      id: "12",
-      adaptations: { video, audio },
-      start: 0,
-      thumbnailTracks: [],
-    };
-    let period: IPeriod | null = null;
-    let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
-    try {
-      const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    } catch (e) {
-      errorReceived = e;
-    }
-
-    expect(period).toBe(null);
-    expect(errorReceived).not.toBe(null);
-    expect(errorReceived).toBeInstanceOf(Error);
-    expect(unsupportedAdaptations).toHaveLength(2);
-    expect(unsupportedAdaptations[0].id).toEqual("57");
-    expect(unsupportedAdaptations[1].id).toEqual("58");
-
-    // Impossible check to shut-up TypeScript
-    if (!(errorReceived instanceof Error)) {
-      throw new Error("Impossible: already checked it was an Error instance");
-    }
-
-    expect((errorReceived as { code?: string }).code).toBe(
-      "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-    );
-    expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported audio adaptations");
-  });
-
-  it("should throw if we are left with no video representation", async () => {
+  it("should not throw if there is no video representation but it has an audio representation.", async () => {
     const mockAdaptation = vi.fn(
       (arg: IParsedAdaptation): Adaptation =>
         ({
@@ -376,94 +271,48 @@ describe("Manifest - Period", () => {
     );
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
-      SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
+      SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
     }));
 
     const Period = (await vi.importActual("../period")).default as typeof IPeriod;
-    const videoAda1 = {
+    const videoAdaptation = {
       type: "video",
       id: "54",
-      representations: [],
+      representations: [], // empty representations array
       toVideoTrack() {
-        return videoAda1;
+        return videoAdaptation;
       },
     };
-    const videoAda2 = {
-      type: "video",
-      id: "55",
-      representations: [],
-      toVideoTrack() {
-        return videoAda2;
-      },
-    };
-    const videoAda3 = {
-      type: "video",
-      id: "56",
-      representations: [],
-      toVideoTrack() {
-        return videoAda3;
-      },
-    };
-    const video: IParsedAdaptation[] = [
-      videoAda1,
-      videoAda2,
-      videoAda3,
-    ] as unknown as IParsedAdaptation[];
 
-    const audioAda1 = {
+    const audioAdaptation = {
       type: "audio",
       id: "58",
-      representations: [{}],
+      representations: [{}], // non empty representations array
       toAudioTrack() {
-        return audioAda1;
+        return audioAdaptation;
       },
     };
-    const audioAda2 = {
-      type: "audio",
-      id: "59",
-      representations: [{}],
-      toAudioTrack() {
-        return audioAda2;
-      },
-    };
-    const audio: IParsedAdaptation[] = [
-      audioAda1,
-      audioAda2,
-    ] as unknown as IParsedAdaptation[];
+
     const args: IParsedPeriod = {
       id: "12",
-      adaptations: { video, audio },
+      adaptations: { video: [videoAdaptation], audio: [audioAdaptation] },
       start: 0,
       thumbnailTracks: [],
-    };
+    } as unknown as IParsedPeriod;
     let period: IPeriod | null = null;
     let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
     try {
       const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
+      period = new Period(args, codecSupportCache);
     } catch (e) {
       errorReceived = e;
     }
 
-    expect(unsupportedAdaptations).toHaveLength(0);
-    expect(period).toBe(null);
-    expect(errorReceived).not.toBe(null);
-    expect(errorReceived).toBeInstanceOf(Error);
-
-    // Impossible check to shut-up TypeScript
-    if (!(errorReceived instanceof Error)) {
-      throw new Error("Impossible: already checked it was an Error instance");
-    }
-
-    expect((errorReceived as { code?: string }).code).toBe(
-      "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-    );
-    expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported video adaptation");
+    expect(period).not.toBe(null);
+    expect(errorReceived).toBe(null);
   });
 
-  it("should throw if no video adaptation is supported", async () => {
+  it("should report that all video adaptations are not supported", async () => {
     const mockAdaptation = vi.fn(
       (arg: IParsedAdaptation): Adaptation =>
         ({
@@ -534,90 +383,16 @@ describe("Manifest - Period", () => {
       start: 0,
       thumbnailTracks: [],
     };
-    let period: IPeriod | null = null;
-    let errorReceived: unknown = null;
-    const unsupportedAdaptations: Adaptation[] = [];
-    try {
-      const codecSupportCache = new CodecSupportCache([]);
-      period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    } catch (e) {
-      errorReceived = e;
-    }
-
-    expect(period).toBe(null);
-    expect(errorReceived).not.toBe(null);
-    expect(errorReceived).toBeInstanceOf(Error);
-    expect(unsupportedAdaptations).toHaveLength(3);
-
-    // Impossible check to shut-up TypeScript
-    if (!(errorReceived instanceof Error)) {
-      throw new Error("Impossible: already checked it was an Error instance");
-    }
-
-    expect((errorReceived as { code?: string }).code).toBe(
-      "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-    );
-    expect((errorReceived as { type?: string }).type).toBe("MEDIA_ERROR");
-    expect(errorReceived.message).toContain("No supported video adaptation");
-  });
-
-  it("should set a parsing error if an unsupported adaptation is given", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: arg.id !== "56",
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
-    vi.doMock("../adaptation", () => ({
-      default: mockAdaptation,
-      SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
-    }));
-
-    const Period = (await vi.importActual("../period")).default as typeof IPeriod;
-
-    const videoAda1 = {
-      type: "video",
-      id: "55",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda1;
-      },
-    };
-    const video = [videoAda1] as unknown as IParsedAdaptation[];
-    const videoAda2 = {
-      type: "video",
-      id: "56",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda2;
-      },
-    };
-    const video2 = [videoAda2] as unknown as IParsedAdaptation[];
-    const args = {
-      id: "12",
-      adaptations: { video, video2 },
-      start: 0,
-      thumbnailTracks: [],
-    };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(1);
+    const period = new Period(args, codecSupportCache);
 
-    expect(mockAdaptation).toHaveBeenCalledTimes(2);
-    expect(mockAdaptation).toHaveReturnedTimes(2);
-    expect(mockAdaptation).toHaveBeenCalledWith(videoAda1, codecSupportCache, {});
-    expect(mockAdaptation).toHaveBeenCalledWith(videoAda2, codecSupportCache, {});
-    expect(mockAdaptation).toHaveReturnedWith(period.adaptations.video?.[0]);
-
-    const [adap] = unsupportedAdaptations;
-    expect(adap.id).toBe("56");
-    expect(adap.supportStatus.hasSupportedCodec).toBe(false);
+    expect(period.adaptations.video).not.toBe(undefined);
+    expect(period.adaptations.video?.length).toBe(3);
+    expect(
+      period.adaptations.video?.every(
+        (adaptation) => adaptation.supportStatus.hasSupportedCodec === false,
+      ),
+    ).toBe(true);
   });
 
   it("should not set a parsing error if an empty unsupported adaptation is given", async () => {
@@ -649,10 +424,14 @@ describe("Manifest - Period", () => {
     };
     const video = [videoAda1] as unknown as IParsedAdaptation[];
     const bar = undefined;
-    const args = { id: "12", thumbnailTracks: [], adaptations: { bar, video }, start: 0 };
-    const unsupportedAdaptations: Adaptation[] = [];
+    const args = {
+      id: "12",
+      thumbnailTracks: [],
+      adaptations: { bar, video },
+      start: 0,
+    };
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
+    const period = new Period(args, codecSupportCache);
     expect(period.adaptations).toEqual({
       video: video.map((v) => ({
         ...v,
@@ -663,10 +442,10 @@ describe("Manifest - Period", () => {
         },
       })),
     });
-    expect(unsupportedAdaptations).toHaveLength(0);
 
     expect(mockAdaptation).toHaveBeenCalledTimes(1);
     expect(mockAdaptation).toHaveBeenCalledWith(videoAda1, codecSupportCache, {});
+    expect(period.adaptations.audio).toBe(undefined);
   });
 
   it("should give a representationFilter to the adaptation", async () => {
@@ -706,16 +485,9 @@ describe("Manifest - Period", () => {
     };
     const video = [videoAda1, videoAda2] as unknown as IParsedAdaptation[];
     const args = { id: "12", adaptations: { video }, start: 0, thumbnailTracks: [] };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(
-      args,
-      unsupportedAdaptations,
-      codecSupportCache,
-      representationFilter,
-    );
+    const period = new Period(args, codecSupportCache, representationFilter);
 
-    expect(unsupportedAdaptations).toHaveLength(0);
     expect(period.adaptations.video).toHaveLength(2);
 
     expect(mockAdaptation).toHaveBeenCalledTimes(2);
@@ -726,58 +498,6 @@ describe("Manifest - Period", () => {
       representationFilter,
     });
     expect(representationFilter).not.toHaveBeenCalled();
-  });
-
-  it("should report if Adaptations are not supported", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: arg.id === "55",
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
-    vi.doMock("../adaptation", () => ({
-      default: mockAdaptation,
-      SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
-    }));
-
-    const Period = (await vi.importActual("../period")).default as typeof IPeriod;
-    const videoAda1 = {
-      type: "video",
-      id: "54",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda1;
-      },
-    };
-    const videoAda2 = {
-      type: "video",
-      id: "55",
-      representations: [{}],
-      toVideoTrack() {
-        return videoAda2;
-      },
-    };
-    const fooAda1 = {
-      type: "foo",
-      id: "12",
-      representations: [{}],
-    };
-    const video = [videoAda1, videoAda2] as unknown as IParsedAdaptation[];
-    const foo = [fooAda1];
-    const args = { id: "12", thumbnailTracks: [], adaptations: { video, foo }, start: 0 };
-    const unsupportedAdaptations: Adaptation[] = [];
-    const codecSupportCache = new CodecSupportCache([]);
-    new Period(args, unsupportedAdaptations, codecSupportCache);
-
-    expect(unsupportedAdaptations).toHaveLength(2);
-    const [adap1, adap2] = unsupportedAdaptations;
-    expect((adap1 as { id: string }).id).toBe("54");
-    expect((adap2 as { id: string }).id).toBe("12");
   });
 
   it("should not report if an Adaptation has no Representation", async () => {
@@ -815,17 +535,22 @@ describe("Manifest - Period", () => {
       },
     };
     const fooAda1 = {
-      type: "foo",
+      type: "audio" as const,
       id: "12",
       representations: [],
     };
     const video = [videoAda1, videoAda2] as unknown as IParsedAdaptation[];
-    const foo = [fooAda1];
-    const args = { id: "12", thumbnailTracks: [], adaptations: { video, foo }, start: 0 };
-    const unsupportedAdaptations: Adaptation[] = [];
+    const audio = [fooAda1];
+    const args = {
+      id: "12",
+      thumbnailTracks: [],
+      adaptations: { video, audio },
+      start: 0,
+    };
     const codecSupportCache = new CodecSupportCache([]);
-    new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
+    // TO DO: is the test relevant?
+    expect(period.adaptations.audio?.length).toBe(0);
   });
 
   it("should set the given start", async () => {
@@ -864,10 +589,8 @@ describe("Manifest - Period", () => {
     };
     const video = [videoAda1, videoAda2] as unknown as IParsedAdaptation[];
     const args = { id: "12", adaptations: { video }, start: 72, thumbnailTracks: [] };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
     expect(period.start).toEqual(72);
     expect(period.duration).toEqual(undefined);
     expect(period.end).toEqual(undefined);
@@ -915,10 +638,8 @@ describe("Manifest - Period", () => {
       duration: 12,
       thumbnailTracks: [],
     };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
     expect(period.start).toEqual(0);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(12);
@@ -966,10 +687,8 @@ describe("Manifest - Period", () => {
       duration: 12,
       thumbnailTracks: [],
     };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
     expect(period.start).toEqual(50);
     expect(period.duration).toEqual(12);
     expect(period.end).toEqual(62);
@@ -1028,10 +747,8 @@ describe("Manifest - Period", () => {
       start: 50,
       duration: 12,
     };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
     expect(period.getAdaptations()).toHaveLength(3);
     expect(period.getAdaptations()).toContain(period.adaptations.video?.[0]);
     expect(period.getAdaptations()).toContain(period.adaptations.video?.[1]);
@@ -1091,10 +808,8 @@ describe("Manifest - Period", () => {
       start: 50,
       duration: 12,
     };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, unsupportedAdaptations, codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
 
     expect(period.getAdaptationsForType("video")).toHaveLength(2);
     expect(period.getAdaptationsForType("video")).toEqual([
@@ -1171,10 +886,8 @@ describe("Manifest - Period", () => {
       start: 50,
       duration: 12,
     };
-    const unsupportedAdaptations: Adaptation[] = [];
     const codecSupportCache = new CodecSupportCache([]);
-    const period = new Period(args, [], codecSupportCache);
-    expect(unsupportedAdaptations).toHaveLength(0);
+    const period = new Period(args, codecSupportCache);
     expect(period.getAdaptation("54")).toEqual(period.adaptations.video?.[0]);
     expect(period.getAdaptation("55")).toEqual(period.adaptations.video?.[1]);
     expect(period.getAdaptation("56")).toEqual(period.adaptations.audio?.[0]);

--- a/src/manifest/classes/__tests__/update_periods.test.ts
+++ b/src/manifest/classes/__tests__/update_periods.test.ts
@@ -1,5 +1,7 @@
 import { describe, beforeEach, it, expect, vi } from "vitest";
-import type IPeriod from "../period";
+import type { IManifestStreamEvent } from "../../../parsers/manifest";
+import type { IPeriod, IPeriodMetadata } from "../../index";
+import type { IManifestAdaptations, IThumbnailTrack } from "../period";
 import type {
   replacePeriods as IReplacePeriods,
   updatePeriods as IUpatePeriods,
@@ -16,6 +18,73 @@ const fakeUpdatePeriodInPlaceRes = {
   addedAdaptations: [],
 };
 
+class FakePeriod implements IPeriodMetadata {
+  public readonly id: string;
+  public adaptations: IManifestAdaptations;
+  public start: number;
+  public duration: number | undefined;
+  public end: number | undefined;
+  public streamEvents: IManifestStreamEvent[];
+  public thumbnailTracks: IThumbnailTrack[];
+
+  constructor({
+    id,
+    start,
+    end,
+  }: {
+    id: string;
+    start?: number | undefined;
+    end?: number | undefined;
+  }) {
+    this.id = id ?? String(start);
+    this.start = start ?? 0;
+    this.end = end;
+    this.duration = end === undefined ? undefined : end - (start ?? 0);
+    this.streamEvents = [];
+    this.adaptations = {};
+    this.thumbnailTracks = [];
+  }
+  createAdaptationsObject() {
+    return {};
+  }
+  getMediaSupport() {
+    return {
+      video: true,
+      audio: true,
+      text: true,
+    };
+  }
+
+  refreshCodecSupport() {
+    // noop
+  }
+  getAdaptations() {
+    return [];
+  }
+  getAdaptationsForType() {
+    return [];
+  }
+  getAdaptation(): undefined {
+    return undefined;
+  }
+  getSupportedAdaptations() {
+    return [];
+  }
+  containsTime() {
+    return false;
+  }
+  getMetadataSnapshot() {
+    return {
+      start: this.start ?? 0,
+      end: this.end,
+      id: this.id ?? String(this.start),
+      streamEvents: [],
+      adaptations: {},
+      thumbnailTracks: [],
+    };
+  }
+}
+
 function generateFakePeriod({
   id,
   start,
@@ -25,43 +94,7 @@ function generateFakePeriod({
   start?: number | undefined;
   end?: number | undefined;
 }): IPeriod {
-  return {
-    id: id ?? String(start),
-    start: start ?? 0,
-    end,
-    duration: end === undefined ? undefined : end - (start ?? 0),
-    streamEvents: [],
-    adaptations: {},
-    thumbnailTracks: [],
-    refreshCodecSupport() {
-      // noop
-    },
-    getAdaptations() {
-      return [];
-    },
-    getAdaptationsForType() {
-      return [];
-    },
-    getAdaptation(): undefined {
-      return undefined;
-    },
-    getSupportedAdaptations() {
-      return [];
-    },
-    containsTime() {
-      return false;
-    },
-    getMetadataSnapshot() {
-      return {
-        start: start ?? 0,
-        end,
-        id: id ?? String(start),
-        streamEvents: [],
-        adaptations: {},
-        thumbnailTracks: [],
-      };
-    },
-  };
+  return new FakePeriod({ id, start, end }) as IPeriod;
 }
 
 describe("Manifest - replacePeriods", () => {

--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -18,7 +18,7 @@ import { MediaError } from "../../errors";
 import log from "../../log";
 import { getCodecsWithUnknownSupport } from "../../main_thread/init/utils/update_manifest_codec_support";
 import type { IParsedManifest } from "../../parsers/manifest";
-import type { ITrackType, IRepresentationFilter, IPlayerError } from "../../public_types";
+import type { ITrackType, IRepresentationFilter } from "../../public_types";
 import arrayFind from "../../utils/array_find";
 import EventEmitter from "../../utils/event_emitter";
 import idGenerator from "../../utils/id_generator";
@@ -318,18 +318,10 @@ export default class Manifest
    * Construct a Manifest instance from a parsed Manifest object (as returned by
    * Manifest parsers) and options.
    *
-   * Some minor errors can arise during that construction. `warnings`
-   * will contain all such errors, in the order they have been encountered.
    * @param {Object} parsedManifest
    * @param {Object} options
-   * @param {Array.<Object>} warnings - After construction, will be optionally
-   * filled by errors expressing minor issues seen while parsing the Manifest.
    */
-  constructor(
-    parsedManifest: IParsedManifest,
-    options: IManifestParsingOptions,
-    warnings: IPlayerError[],
-  ) {
+  constructor(parsedManifest: IParsedManifest, options: IManifestParsingOptions) {
     super();
     const { representationFilter, manifestUpdateUrl } = options;
     this.manifestFormat = ManifestMetadataFormat.Class;
@@ -339,27 +331,16 @@ export default class Manifest
     this.clockOffset = parsedManifest.clockOffset;
     this._cachedCodecSupport = new CodecSupportCache([]);
 
-    const unsupportedAdaptations: Adaptation[] = [];
     this.periods = parsedManifest.periods
       .map((parsedPeriod) => {
         const period = new Period(
           parsedPeriod,
-          unsupportedAdaptations,
           this._cachedCodecSupport,
           representationFilter,
         );
         return period;
       })
       .sort((a, b) => a.start - b.start);
-
-    if (unsupportedAdaptations.length > 0) {
-      const error = new MediaError(
-        "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-        "An Adaptation contains only incompatible codecs.",
-        { tracks: unsupportedAdaptations.map(toTaggedTrack) },
-      );
-      warnings.push(error);
-    }
 
     /**
      * @deprecated It is here to ensure compatibility with the way the

--- a/src/manifest/classes/period.ts
+++ b/src/manifest/classes/period.ts
@@ -17,6 +17,7 @@ import { MediaError } from "../../errors";
 import type {
   ICdnMetadata,
   IManifestStreamEvent,
+  IParsedAdaptations,
   IParsedPeriod,
 } from "../../parsers/manifest";
 import type { ITrackType, IRepresentationFilter } from "../../public_types";
@@ -69,70 +70,25 @@ export default class Period implements IPeriodMetadata {
   /**
    * @constructor
    * @param {Object} args
-   * @param {Array.<Object>} unsupportedAdaptations - Array on which
-   * `Adaptation`s objects which have no supported `Representation` will be
-   * pushed.
-   * This array might be useful for minor error reporting.
    * @param {function|undefined} [representationFilter]
    */
   constructor(
     args: IParsedPeriod,
-    unsupportedAdaptations: Adaptation[],
     cachedCodecSupport: CodecSupportCache,
-
     representationFilter?: IRepresentationFilter | undefined,
   ) {
     this.id = args.id;
-    this.adaptations = (
-      Object.keys(args.adaptations) as ITrackType[]
-    ).reduce<IManifestAdaptations>((acc, type) => {
-      const adaptationsForType = args.adaptations[type];
-      if (isNullOrUndefined(adaptationsForType)) {
-        return acc;
-      }
-      const filteredAdaptations = adaptationsForType
-        .map((adaptation): Adaptation => {
-          const newAdaptation = new Adaptation(adaptation, cachedCodecSupport, {
-            representationFilter,
-          });
-          if (
-            newAdaptation.representations.length > 0 &&
-            newAdaptation.supportStatus.hasSupportedCodec === false
-          ) {
-            unsupportedAdaptations.push(newAdaptation);
-          }
-          return newAdaptation;
-        })
-        .filter(
-          (adaptation): adaptation is Adaptation => adaptation.representations.length > 0,
-        );
-      if (
-        filteredAdaptations.every(
-          (adaptation) => adaptation.supportStatus.hasSupportedCodec === false,
-        ) &&
-        adaptationsForType.length > 0 &&
-        (type === "video" || type === "audio")
-      ) {
-        throw new MediaError(
-          "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-          "No supported " + type + " adaptations",
-          { tracks: undefined },
-        );
-      }
 
-      if (filteredAdaptations.length > 0) {
-        acc[type] = filteredAdaptations;
-      }
-      return acc;
-    }, {});
+    this.adaptations = createAdaptationsObject(
+      args.adaptations,
+      cachedCodecSupport,
+      representationFilter,
+    );
 
-    if (
-      !Array.isArray(this.adaptations.video) &&
-      !Array.isArray(this.adaptations.audio)
-    ) {
+    if (isArrayEmpty(this.adaptations.video) && isArrayEmpty(this.adaptations.audio)) {
       throw new MediaError(
         "MANIFEST_PARSE_ERROR",
-        "No supported audio and video tracks.",
+        "The manifest has no video nor audio tracks.",
       );
     }
 
@@ -149,6 +105,7 @@ export default class Period implements IPeriodMetadata {
       end: thumbnailTrack.end,
       tileDuration: thumbnailTrack.tileDuration,
     }));
+
     this.duration = args.duration;
     this.start = args.start;
 
@@ -180,16 +137,11 @@ export default class Period implements IPeriodMetadata {
       if (adaptationsForType === undefined) {
         return;
       }
-      let hasSupportedAdaptations: boolean | undefined = false;
       for (const adaptation of adaptationsForType) {
         if (!adaptation.supportStatus.hasCodecWithUndefinedSupport) {
           // Go to next adaptation as an optimisation measure.
           // NOTE this only is true if we never change a codec from supported
           // to unsuported and its opposite.
-
-          if (adaptation.supportStatus.hasSupportedCodec === true) {
-            hasSupportedAdaptations = true;
-          }
           continue;
         }
         const wasSupported = adaptation.supportStatus.hasSupportedCodec;
@@ -200,22 +152,6 @@ export default class Period implements IPeriodMetadata {
         ) {
           unsupportedAdaptations.push(adaptation);
         }
-
-        if (hasSupportedAdaptations === false) {
-          hasSupportedAdaptations = adaptation.supportStatus.hasSupportedCodec;
-        } else if (
-          hasSupportedAdaptations === undefined &&
-          adaptation.supportStatus.hasSupportedCodec === true
-        ) {
-          hasSupportedAdaptations = true;
-        }
-      }
-      if ((ttype === "video" || ttype === "audio") && hasSupportedAdaptations === false) {
-        throw new MediaError(
-          "MANIFEST_INCOMPATIBLE_CODECS_ERROR",
-          "No supported " + ttype + " adaptations",
-          { tracks: undefined },
-        );
       }
     }, {});
   }
@@ -365,4 +301,43 @@ export interface IThumbnailTrack {
    * This is the amount of time in seconds each tile spans.
    */
   tileDuration: number | undefined;
+}
+
+function isArrayEmpty(array: unknown[] | undefined) {
+  if (!Array.isArray(array)) {
+    return true;
+  } else {
+    return array.length === 0;
+  }
+}
+/**
+ * Creates an object representing adaptations grouped by track type,
+ * from the given parsed adaptations.
+ * @param {Object} adaptations
+ * @param {Object} cachedCodecSupport
+ * @param {Object|undefined}representationFilter
+ * @returns {Object}
+ */
+function createAdaptationsObject(
+  adaptations: IParsedAdaptations,
+  cachedCodecSupport: CodecSupportCache,
+  representationFilter: IRepresentationFilter | undefined,
+): Partial<Record<ITrackType, Adaptation[]>> {
+  const manifestAdaptations: IManifestAdaptations = {};
+  for (const [type, adaptationsForType] of Object.entries(adaptations)) {
+    if (isNullOrUndefined(adaptationsForType)) {
+      continue;
+    }
+    manifestAdaptations[type as ITrackType] = adaptationsForType
+      .map((adaptation): Adaptation => {
+        const newAdaptation = new Adaptation(adaptation, cachedCodecSupport, {
+          representationFilter,
+        });
+        return newAdaptation;
+      })
+      .filter(
+        (adaptation): adaptation is Adaptation => adaptation.representations.length > 0,
+      );
+  }
+  return manifestAdaptations;
 }

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -140,6 +140,26 @@ export interface ILoadVideoOptions {
   onCodecSwitch?: "continue" | "reload";
 
   /**
+   * Specifies the behavior when all audio tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without audio.
+   * - If set to `"error"`, an error will be thrown to indicate that the audio tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  onAudioTracksNotPlayable?: "continue" | "error";
+
+  /**
+   * Specifies the behavior when all video tracks are not playable.
+   *
+   * - If set to `"continue"`, the player will proceed to play the content without video.
+   * - If set to `"error"`, an error will be thrown to indicate that the video tracks could not be played.
+   *
+   * Note: If neither the audio nor the video tracks are playable, an error will be thrown regardless of this setting.
+   */
+  onVideoTracksNotPlayable?: "continue" | "error";
+
+  /**
    * Whether we should check that an obtain segment is truncated and retry the
    * request if that's the case.
    */
@@ -1221,6 +1241,15 @@ export interface ITrackUpdateEventPayload {
     | "no-playable-representation" // Previous track had no playable Representation
     | string;
   /* eslint-enable @typescript-eslint/no-redundant-type-constituents */
+}
+
+export interface INoPlayableTrackEventPayload {
+  trackType: ITrackType;
+  period: {
+    id: string;
+    start: number;
+    end: number | undefined;
+  };
 }
 
 export interface IRepresentationListUpdateContext {

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -23,7 +23,6 @@ import type {
   IDashParserResponse,
   ILoadedResource,
 } from "../../parsers/manifest/dash/parsers_types";
-import type { IPlayerError } from "../../public_types";
 import objectAssign from "../../utils/object_assign";
 import request from "../../utils/request";
 import { strToUtf8, utf8ToStr } from "../../utils/string_parsing";
@@ -148,9 +147,8 @@ export default function generateManifestParser(
         if (cancelSignal.isCancelled()) {
           return Promise.reject(cancelSignal.cancellationError);
         }
-        const warnings: IPlayerError[] = [];
-        const manifest = new Manifest(parserResponse.value.parsed, options, warnings);
-        return { manifest, url, warnings };
+        const manifest = new Manifest(parserResponse.value.parsed, options);
+        return { manifest, url };
       }
 
       const { value } = parserResponse;

--- a/src/transports/local/pipelines.ts
+++ b/src/transports/local/pipelines.ts
@@ -22,7 +22,7 @@
 import Manifest from "../../manifest/classes";
 import type { ILocalManifest } from "../../parsers/manifest/local";
 import parseLocalManifest from "../../parsers/manifest/local";
-import type { ILoadedManifestFormat, IPlayerError } from "../../public_types";
+import type { ILoadedManifestFormat } from "../../public_types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { CancellationSignal } from "../../utils/task_canceller";
 import type {
@@ -72,9 +72,8 @@ export default function getLocalManifestPipelines(
         throw new Error("Wrong format for the manifest data");
       }
       const parsed = parseLocalManifest(loadedManifest as ILocalManifest);
-      const warnings: IPlayerError[] = [];
-      const manifest = new Manifest(parsed, transportOptions, warnings);
-      return { manifest, url: undefined, warnings };
+      const manifest = new Manifest(parsed, transportOptions);
+      return { manifest, url: undefined };
     },
   };
 

--- a/src/transports/metaplaylist/pipelines.ts
+++ b/src/transports/metaplaylist/pipelines.ts
@@ -21,7 +21,6 @@ import Manifest from "../../manifest/classes";
 import type { IParserResponse as IMPLParserResponse } from "../../parsers/manifest/metaplaylist";
 import parseMetaPlaylist from "../../parsers/manifest/metaplaylist";
 import type { ICdnMetadata, IParsedManifest } from "../../parsers/manifest/types";
-import type { IPlayerError } from "../../public_types";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import objectAssign from "../../utils/object_assign";
 import type { CancellationSignal } from "../../utils/task_canceller";
@@ -148,9 +147,8 @@ export default function (options: ITransportOptions): ITransportPipelines {
         parsedResult: IMPLParserResponse<IParsedManifest>,
       ): Promise<IManifestParserResult> {
         if (parsedResult.type === "done") {
-          const warnings: IPlayerError[] = [];
-          const manifest = new Manifest(parsedResult.value, options, warnings);
-          return Promise.resolve({ manifest, warnings });
+          const manifest = new Manifest(parsedResult.value, options);
+          return Promise.resolve({ manifest });
         }
 
         const parsedValue = parsedResult.value;

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -19,7 +19,6 @@ import Manifest from "../../manifest/classes";
 import { getMDAT } from "../../parsers/containers/isobmff";
 import type { ICdnMetadata } from "../../parsers/manifest";
 import createSmoothManifestParser from "../../parsers/manifest/smooth";
-import type { IPlayerError } from "../../public_types";
 import request from "../../utils/request";
 import { strToUtf8, utf8ToStr } from "../../utils/string_parsing";
 import type { CancellationSignal } from "../../utils/task_canceller";
@@ -77,15 +76,10 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
 
       const parserResult = smoothManifestParser(documentData, url, manifestReceivedTime);
 
-      const warnings: IPlayerError[] = [];
-      const manifest = new Manifest(
-        parserResult,
-        {
-          representationFilter: transportOptions.representationFilter,
-        },
-        warnings,
-      );
-      return { manifest, url, warnings };
+      const manifest = new Manifest(parserResult, {
+        representationFilter: transportOptions.representationFilter,
+      });
+      return { manifest, url };
     },
   };
 

--- a/src/transports/types.ts
+++ b/src/transports/types.ts
@@ -25,7 +25,6 @@ import type {
   IRepresentationFilter,
   ISegmentLoader as ICustomSegmentLoader,
   IServerSyncInfos,
-  IPlayerError,
   ICmcdPayload,
 } from "../public_types";
 import type { CancellationSignal } from "../utils/task_canceller";
@@ -416,11 +415,6 @@ export type IManifestParserRequestScheduler = (
 export interface IManifestParserResult {
   /** The parsed Manifest Object itself. */
   manifest: IManifest;
-  /**
-   * Minor issues seen while constructing the Manifest object.
-   * Empty if no issue was seen.
-   */
-  warnings: IPlayerError[];
   /**
    * "Real" URL (post-redirection) at which the Manifest can be refreshed.
    *

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/audio_only_infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/audio_only_infos.js
@@ -1,0 +1,14 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/";
+
+// Provide infos on this content under JSON.
+// Useful for integration tests on DASH parsers.
+export default {
+  url: BASE_URL + "Manifest_audio_only_unsupported.mpd",
+  transport: "dash",
+  tsbd: 5 * 60,
+};

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/audio_video_not_supported_infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/audio_video_not_supported_infos.js
@@ -1,0 +1,14 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/";
+
+// Provide infos on this content under JSON.
+// Useful for integration tests on DASH parsers.
+export default {
+  url: BASE_URL + "Manifest_audio_and_video_not_supported.mpd",
+  transport: "dash",
+  tsbd: 5 * 60,
+};

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/index.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/index.js
@@ -1,0 +1,4 @@
+import manifestInfos from "./infos";
+import manifestAudioOnlyInfos from "./audio_only_infos";
+import manifestVideoNotSupportedInfos from "./video_not_supported_infos";
+export { manifestInfos, manifestAudioOnlyInfos, manifestVideoNotSupportedInfos };

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/infos.js
@@ -1,0 +1,14 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/";
+
+// Provide infos on this content under JSON.
+// Useful for integration tests on DASH parsers.
+export default {
+  url: BASE_URL + "Manifest_audio_not_supported.mpd",
+  transport: "dash",
+  tsbd: 5 * 60,
+};

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_and_video_not_supported.mpd
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_and_video_not_supported.mpd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?"
+   maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT85S"
+   profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+   publishTime="2019-09-06T14:48:44Z" timeShiftBufferDepth="PT5M" type="dynamic"
+   ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+   xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+   <ProgramInformation>
+      <Title>Media Presentation Description from DASHI-IF live simulator</Title>
+   </ProgramInformation>
+   <BaseURL>https://livesim.dashif.org/livesim/periods_20/testpic_2s/</BaseURL>
+   <Period id="p8709894" start="PT1567780920S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation bandwidth="300000" codecs="dvh1.08.06" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709895" start="PT1567781100S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation bandwidth="300000" codecs="dvh1.08.06" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709896" start="PT1567781280S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="1567781280"
+            startNumber="783890640" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677812800"
+            startNumber="783890640" />
+         <Representation bandwidth="300000" codecs="dvh1.08.06" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_not_supported.mpd
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_not_supported.mpd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?"
+   maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT85S"
+   profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+   publishTime="2019-09-06T14:48:44Z" timeShiftBufferDepth="PT5M" type="dynamic"
+   ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+   xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+   <ProgramInformation>
+      <Title>Media Presentation Description from DASHI-IF live simulator</Title>
+   </ProgramInformation>
+   <BaseURL>https://livesim.dashif.org/livesim/periods_20/testpic_2s/</BaseURL>
+   <Period id="p8709894" start="PT1567780920S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709895" start="PT1567781100S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709896" start="PT1567781280S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="1567781280"
+            startNumber="783890640" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677812800"
+            startNumber="783890640" />
+         <Representation bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_only_unsupported.mpd
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_audio_only_unsupported.mpd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?"
+   maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT85S"
+   profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+   publishTime="2019-09-06T14:48:44Z" timeShiftBufferDepth="PT5M" type="dynamic"
+   ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+   xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+   <ProgramInformation>
+      <Title>Media Presentation Description from DASHI-IF live simulator</Title>
+   </ProgramInformation>
+   <BaseURL>https://livesim.dashif.org/livesim/periods_20/testpic_2s/</BaseURL>
+   <Period id="p8709894" start="PT1567780920S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709895" start="PT1567781100S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709896" start="PT1567781280S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="1567781280"
+            startNumber="783890640" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="ec-3" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_video_not_supported.mpd
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/Manifest_video_not_supported.mpd
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD availabilityStartTime="1970-01-01T00:00:00Z" id="Config part of url maybe?"
+   maxSegmentDuration="PT2S" minBufferTime="PT2S" minimumUpdatePeriod="PT85S"
+   profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+   publishTime="2019-09-06T14:48:44Z" timeShiftBufferDepth="PT5M" type="dynamic"
+   ns1:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+   xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:ns1="http://www.w3.org/2001/XMLSchema-instance">
+   <ProgramInformation>
+      <Title>Media Presentation Description from DASHI-IF live simulator</Title>
+   </ProgramInformation>
+   <BaseURL>https://livesim.dashif.org/livesim/periods_20/testpic_2s/</BaseURL>
+   <Period id="p8709894" start="PT1567780920S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677809200"
+            startNumber="783890460" />
+         <Representation bandwidth="300000" codecs="dvh1" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+   <Period id="p8709895" start="PT1567781100S">
+      <AdaptationSet contentType="audio" lang="eng" mimeType="audio/mp4" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation audioSamplingRate="48000" bandwidth="48000" codecs="mp4a.40.2" id="A48">
+            <AudioChannelConfiguration
+               schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+         </Representation>
+      </AdaptationSet>
+      <AdaptationSet contentType="video" maxFrameRate="60/2" maxHeight="360" maxWidth="640"
+         mimeType="video/mp4" minHeight="360" minWidth="640" par="16:9" segmentAlignment="true"
+         startWithSAP="1">
+         <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+         <SegmentTemplate timescale="10" duration="20" initialization="$RepresentationID$/init.mp4"
+            media="$RepresentationID$/$Number$.m4s" presentationTimeOffset="15677811000"
+            startNumber="783890550" />
+         <Representation bandwidth="300000" codecs="dvh1" frameRate="60/2" height="360"
+            id="V300" sar="1:1" width="640" />
+      </AdaptationSet>
+   </Period>
+</MPD>

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs
@@ -1,0 +1,37 @@
+/* eslint-env node */
+
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const BASE_URL = "/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/";
+/**
+ * URLs for which the request should be stubbed.
+ * @type {Array.<Object>}
+ */
+export default [
+  // manifest
+  {
+    url: BASE_URL + "Manifest_audio_not_supported.mpd",
+    path: path.join(currentDirectory, "./media/Manifest_audio_not_supported.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "Manifest_audio_only_unsupported.mpd",
+    path: path.join(currentDirectory, "./media/Manifest_audio_only_unsupported.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "Manifest_audio_and_video_not_supported.mpd",
+    path: path.join(
+      currentDirectory,
+      "./media/Manifest_audio_and_video_not_supported.mpd",
+    ),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "Manifest_video_not_supported.mpd",
+    path: path.join(currentDirectory, "./media/Manifest_video_not_supported.mpd"),
+    contentType: "application/dash+xml",
+  },
+];

--- a/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/video_not_supported_infos.js
+++ b/tests/contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio/video_not_supported_infos.js
@@ -1,0 +1,14 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_dynamic_SegmentTemplate_UnsupportedAudio/media/";
+
+// Provide infos on this content under JSON.
+// Useful for integration tests on DASH parsers.
+export default {
+  url: BASE_URL + "Manifest_video_not_supported.mpd",
+  transport: "dash",
+  tsbd: 5 * 60,
+};

--- a/tests/contents/urls.mjs
+++ b/tests/contents/urls.mjs
@@ -14,6 +14,7 @@ import urls9 from "./DASH_dynamic_SegmentTemplate_Multi_Periods/urls.mjs";
 import urls10 from "./DASH_static_broken_cenc_in_MPD/urls.mjs";
 import urls11 from "./DASH_static_number_based_SegmentTimeline/urls.mjs";
 import urls12 from "./imagetracks/urls.mjs";
+import urls13 from "./DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs";
 
 export default [
   ...urls1,
@@ -28,4 +29,5 @@ export default [
   ...urls10,
   ...urls11,
   ...urls12,
+  ...urls13,
 ];

--- a/tests/integration/scenarios/audio_video_not_supported.test.js
+++ b/tests/integration/scenarios/audio_video_not_supported.test.js
@@ -1,0 +1,235 @@
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import {
+  manifestInfos,
+  manifestAudioOnlyInfos,
+  manifestVideoNotSupportedInfos,
+} from "../../contents/DASH_dynamic_SegmentTemplate_UnsupportedAudio";
+import RxPlayer from "../../../dist/es2017";
+import waitForState from "../../utils/waitForPlayerState";
+import sleep from "../../utils/sleep.js";
+
+let player;
+
+describe("Content with video or audio not supported", function () {
+  beforeEach(() => {
+    player = new RxPlayer();
+  });
+
+  afterEach(() => {
+    player.dispose();
+  });
+
+  it("should trigger an error if the audio is not supported with onAudioTracksNotPlayable:'error'", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onAudioTracksNotPlayable: "error",
+    });
+    await waitForState(player, "STOPPED", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent).toBe(undefined);
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "MANIFEST_INCOMPATIBLE_CODECS_ERROR: No supported audio adaptations",
+    );
+  });
+
+  it("should trigger a noPlayableTrack event if the video is not supported with onVideoTracksNotPlayable:'continue'", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestVideoNotSupportedInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onVideoTracksNotPlayable: "continue",
+    });
+    await waitForState(player, "PLAYING", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent?.trackType).toBe("video");
+    expect(playerError).toBe(undefined);
+  });
+
+  it("should trigger an error if the video is not supported with onVideoTracksNotPlayable:'error'", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestVideoNotSupportedInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onVideoTracksNotPlayable: "error",
+    });
+    await waitForState(player, "STOPPED", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent).toBe(undefined);
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "MANIFEST_INCOMPATIBLE_CODECS_ERROR: No supported video adaptations",
+    );
+  });
+
+  it("should trigger a noPlayableTrack event if the audio is not supported with onAudioTracksNotPlayable:'continue'", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onAudioTracksNotPlayable: "continue",
+    });
+    await waitForState(player, "PLAYING", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent?.trackType).toBe("audio");
+    expect(playerError).toBe(undefined);
+  });
+
+  it("should trigger an error if the audio is not supported and the video is disabled", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onAudioTracksNotPlayable: "continue",
+    });
+    await waitForState(player, "PLAYING", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent).not.toBe(undefined);
+    expect(noPlayableTrackEvent.trackType).toBe("audio");
+
+    const waitStopped = waitForState(player, "STOPPED", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+      "PLAYING",
+    ]);
+    player.disableVideoTrack();
+    await waitStopped;
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "NO_AUDIO_VIDEO_TRACKS: No audio and no video tracks are set.",
+    );
+  });
+
+  it("should trigger an error if audio only content is not supported", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestAudioOnlyInfos;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onAudioTracksNotPlayable: "continue",
+    });
+    let playerError;
+
+    await sleep(100);
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "MANIFEST_INCOMPATIBLE_CODECS_ERROR: No supported audio adaptations",
+    );
+    expect(noPlayableTrackEvent).toBe(undefined);
+  });
+
+  it("should trigger an error if audio and video is not supported", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestAudioOnlyInfos;
+    let noPlayableTrackEvent;
+
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onAudioTracksNotPlayable: "continue",
+    });
+    let playerError;
+
+    await sleep(100);
+    expect(noPlayableTrackEvent).toBe(undefined);
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "MANIFEST_INCOMPATIBLE_CODECS_ERROR: No supported audio adaptations",
+    );
+  });
+});


### PR DESCRIPTION
Currently, the player throws an error if either all audio or all video tracks are not playable. This PR introduces two new options, onAudioTrackNotPlayable and onVideoTrackNotPlayable, to the loadVideo method. These options allow the player to continue playback even when all audio or video tracks are not playable. In such cases, the content will play without audio or video, respectively, instead of failing.

## API

`loadVideo(options)` options object has two more keys:
-  [optional]`onAudioTrackNotPlayable` : `"continue"` or `"error"`. Default if not set:  `"continue"`
-  [optional]`onVideoTrackNotPlayable` : `"continue"` or `"error"`.  Default if not set:  `"continue"`

## Usage

```js
  player.loadVideo({
    transport: "dash",
    url: "https://dash.akamaized.net/dash264/TestCasesDolby/1/Living_Room_1080p_20_96k_25fps.mpd",
    autoPlay: true,
    onAudioTrackNotPlayable: "continue",
    onVideoTrackNotPlayable: "error",
  });
```

## Example

https://codesandbox.io/p/sandbox/amazing-pare-kdf65f