### PR TITLE
[Proposal] set LogFormat to `full` on RxPlayer's debug mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ Player.addFeatures([
   HTML_SRT_PARSER,
 ]);
 if (isDebugModeEnabled()) {
-  logger.setLevel("DEBUG", "standard");
+  logger.setLevel("DEBUG", "full");
 } else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL, "standard");
 }

--- a/src/minimal.ts
+++ b/src/minimal.ts
@@ -29,7 +29,7 @@ import Player from "./main_thread/api";
 patchWebkitSourceBuffer();
 
 if (isDebugModeEnabled()) {
-  logger.setLevel("DEBUG", "standard");
+  logger.setLevel("DEBUG", "full");
 } else if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
   logger.setLevel(__LOGGER_LEVEL__.CURRENT_LEVEL, "standard");
 }


### PR DESCRIPTION
The `__RX_PLAYER_DEBUG_MODE__` boolean
--------------------------------------

The RxPlayer has a hidden feature where if an `__RX_PLAYER_DEBUG_MODE__` boolean is declared globally and set to `true` before the RxPlayer's code is imported, it will output debug logs.

This was initially added as a mean to facilitate debugging, especially while relying on our [RxPaired](https://github.com/canalplus/RxPaired) inspector.

Though we now end up communicating that trick to more people to facilitate quick checks:

  - applications relying on the RxPlayer which seem to have a fairly simple issue can set this to very quickly communicate us logs without having to understand our debug tools nor perform re-builds on their side.

  - in some scenarios, we even had users (though still in a professional context) wanting us to check why the player behaved the way it did on their devices.

    As those were technical people, we had no issue just telling them to set a boolean in the console and communicate to us the outputted logs.

Problems with it
----------------

Logs are then generally just copy-pasted from e.g. Chrome's inspector, and as such have a lot of noise we don't need (call stack info, object structure from their own code, CORS from their applications etc.), no timestamp, and no clear boundary between logs vs line breaks inside a single log.

Thus, it's less convenient to us than relying on `RxPaired` or than re-building with both `LogLevel = "DEBUG"` **AND** `LogFormat = "full"`.

Proposal
--------

So I here propose that `RX_PLAYER_DEBUG_MODE__` also set `LogFormat` to `"full"`.

This will add timestamps + a namespace to all new logs produced by the RxPlayer, then facilitating our exploitation and opening the way for easier import into RxPaired's post-debugger mode.

Though to keep in mind that this will then always lead to `RxPaired`'s "double formatting" problem as exposed in https://github.com/canalplus/RxPaired/pull/22.

As such https://github.com/canalplus/RxPaired/pull/22 or a similar work-around is a requirement before merging this.

_Note that there are other solutions to fix this, like creating two global booleans, e.g. one used by RxPaired and one for users, but here I ended up preferring the ugly double formatting work-around as a lesser evil._