### PR TITLE
tests: try vitest's github-actions reporter

### DIFF
--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -40,7 +40,7 @@ const DEFAULT_CONFIG = {
    * improve.
    * When disabled, segments of a lower-quality will not be replaced.
    */
-  DEFAULT_ENABLE_FAST_SWITCHING: true,
+  DEFAULT_ENABLE_FAST_SWITCHING: false,
 
   /**
    * In some cases after switching the current track or bitrate, the RxPlayer

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -70,7 +70,7 @@ export default defineConfig({
   test: {
     watch: false,
     globals: false,
-    reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
+    reporters: ["dot", "github-actions"],
     include: [
       // integration tests
       "tests/integration/scenarios/**/*.[jt]s?(x)",

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -70,7 +70,7 @@ export default defineConfig({
   test: {
     watch: false,
     globals: false,
-    reporters: "dot",
+    reporters: process.env.GITHUB_ACTIONS ? ["dot", "github-actions"] : ["dot"],
     include: [
       // integration tests
       "tests/integration/scenarios/**/*.[jt]s?(x)",


### PR DESCRIPTION
Interestingly (yet weirdly), `vitest` integrates directly a "Github Actions Reporter"
(https://vitest.dev/guide/reporters#github-actions-reporter).

I just wanted to check how it works here: I broke some random behavior and now await for the result.