### PR TITLE
DASH: Implement Manifest-chaining

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1589,6 +1589,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     playerStateRef.onUpdate(
       (newState: IPlayerState) => {
         updateReloadingMetadata(newState);
+        if (newState === "ENDED") {
+          this._priv_loadChainedManifests();
+          if (currentContentCanceller.isUsed()) {
+            return;
+          }
+        }
         this._priv_setPlayerState(newState);
 
         if (currentContentCanceller.isUsed()) {
@@ -3798,6 +3804,31 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (this._priv_currentError === formattedError) {
       this.trigger("error", formattedError);
     }
+  }
+
+  /**
+   * Load the chained Manifest if one with roughly the same options than the
+   * previous `loadVideo` call (beside `startAt`).
+   * Do nothing if no Manifest to chain to exist or if it's not possible to do
+   * Manifest chaining in the current context.
+   */
+  private _priv_loadChainedManifests(): void {
+    const nextManifestUrls = this._priv_contentInfos?.manifest?.chainedManifests;
+    if (isNullOrUndefined(nextManifestUrls) || nextManifestUrls.length === 0) {
+      return;
+    }
+    const options = this._priv_reloadingMetadata.options;
+    if (options === undefined) {
+      log.error("API", "Chaining Manifest despite not having any load option");
+      return;
+    }
+
+    const nextUrl = nextManifestUrls[0];
+    log.info("API", "Going to chained Manifest", { nextUrl });
+    const newOptions = { ...options, url: nextUrl, startAt: undefined };
+    this._priv_reloadingMetadata = { options: newOptions };
+    this._priv_initializeContentPlayback(newOptions);
+    this._priv_lastAutoPlay = newOptions.autoPlay;
   }
 
   /**

--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -309,6 +309,14 @@ export default class Manifest
   };
 
   /**
+   * Manifests can have a reference to another Manifest that should be played
+   * once the previous one is finished.
+   * If that's the case, `chainedManifests` is set to the wanted Manifests' URL,
+   * by order of preference.
+   */
+  public chainedManifests: string[] | null;
+
+  /**
    * Caches the information if a codec is supported or not in the context of the
    * current content.
    */
@@ -360,6 +368,7 @@ export default class Manifest
     this.suggestedPresentationDelay = parsedManifest.suggestedPresentationDelay;
     this.availabilityStartTime = parsedManifest.availabilityStartTime;
     this.publishTime = parsedManifest.publishTime;
+    this.chainedManifests = parsedManifest.chainedManifests;
   }
 
   /**
@@ -653,6 +662,7 @@ export default class Manifest
       uris: this.uris,
       availabilityStartTime: this.availabilityStartTime,
       timeBounds: this.timeBounds,
+      chainedManifests: this.chainedManifests,
     };
   }
 

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -213,6 +213,13 @@ export interface IManifestMetadata {
       time: number;
     };
   };
+  /**
+   * Manifests can have a reference to another Manifest that should be played
+   * once the previous one is finished.
+   * If that's the case, `chainedManifests` is set to the wanted Manifests' URL,
+   * by order of preference.
+   */
+  chainedManifests: string[] | null;
 }
 
 /**

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -418,6 +418,25 @@ function parseCompleteIntermediateRepresentation(
       (parsedPeriods[parsedPeriods.length - 1]?.end !== undefined ||
         mpdIR.attributes.mediaPresentationDuration !== undefined));
 
+  let chainedManifests: null | string[] = null;
+  for (const prop of ["EssentialProperty", "SupplementalProperty"] as const) {
+    if (Array.isArray(mpdIR.children[prop])) {
+      const propChainedManifests = mpdIR.children[prop].reduce((acc: string[], s) => {
+        if (
+          s.attributes.schemeIdUri === "urn:mpeg:dash:chaining:2016" &&
+          s.attributes.value !== undefined
+        ) {
+          acc.push(s.attributes.value);
+        }
+        return acc;
+      }, []);
+      if (propChainedManifests.length > 0) {
+        chainedManifests = chainedManifests ?? [];
+        chainedManifests.push(...propChainedManifests);
+      }
+    }
+  }
+
   const parsedMPD: IParsedManifest = {
     availabilityStartTime,
     clockOffset: args.externalClockOffset,
@@ -437,6 +456,7 @@ function parseCompleteIntermediateRepresentation(
     uris: isNullOrUndefined(args.url)
       ? rootChildren.Location.map((l) => l.value)
       : [args.url, ...rootChildren.Location.map((l) => l.value)],
+    chainedManifests,
   };
 
   return { type: "done", value: { parsed: parsedMPD, warnings } };

--- a/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
@@ -48,6 +48,8 @@ function parseMPDChildren(
     Period: [],
     UTCTiming: [],
     ContentProtection: [],
+    EssentialProperty: [],
+    SupplementalProperty: [],
   };
 
   let warnings: Error[] = [];
@@ -97,6 +99,14 @@ function parseMPDChildren(
         }
         break;
       }
+
+      case "EssentialProperty":
+        ret.EssentialProperty.push(parseScheme(currentNode));
+        break;
+
+      case "SupplementalProperty":
+        ret.SupplementalProperty.push(parseScheme(currentNode));
+        break;
     }
   }
   return [ret, warnings];

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -67,6 +67,10 @@ export interface IMPDChildren {
   UTCTiming: ISchemeIntermediateRepresentation[];
   /** Encryption-related metadata. */
   ContentProtection: IContentProtectionIntermediateRepresentation[];
+  /** DASH `EssentialProperties` elements at the MPD level. */
+  EssentialProperty: ISchemeIntermediateRepresentation[];
+  /** DASH `SupplementalProperties` elements at the MPD level. */
+  SupplementalProperty: ISchemeIntermediateRepresentation[];
 }
 
 /* Intermediate representation for the root's attributes. */

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
@@ -20,6 +20,7 @@ import type {
   IMPDAttributes,
   IMPDChildren,
   IPeriodIntermediateRepresentation,
+  ISchemeAttributes,
 } from "../../../node_parser_types.ts";
 import type { IAttributeParser, IChildrenParser } from "../parsers_stack.ts";
 import type ParsersStack from "../parsers_stack.ts";
@@ -103,6 +104,28 @@ export function generateMPDChildrenParser(
           linearMemory,
         );
         parsersStack.pushParsers(nodeId, noop, contentProtAttrParser);
+        break;
+      }
+
+      case TagName.EssentialProperty: {
+        const schemeAttrs: ISchemeAttributes = {};
+        if (mpdChildren.EssentialProperty === undefined) {
+          mpdChildren.EssentialProperty = [];
+        }
+        mpdChildren.EssentialProperty.push({ attributes: schemeAttrs });
+        const attributeParser = generateSchemeAttrParser(schemeAttrs, linearMemory);
+        parsersStack.pushParsers(nodeId, noop, attributeParser);
+        break;
+      }
+
+      case TagName.SupplementalProperty: {
+        const schemeAttrs = {};
+        if (mpdChildren.SupplementalProperty === undefined) {
+          mpdChildren.SupplementalProperty = [];
+        }
+        mpdChildren.SupplementalProperty.push({ attributes: schemeAttrs });
+        const attributeParser = generateSchemeAttrParser(schemeAttrs, linearMemory);
+        parsersStack.pushParsers(nodeId, noop, attributeParser);
         break;
       }
 

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
@@ -43,6 +43,8 @@ export function generateRootChildrenParser(
             Period: [],
             UTCTiming: [],
             ContentProtection: [],
+            EssentialProperty: [],
+            SupplementalProperty: [],
           },
           attributes: {},
         };

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -74,6 +74,7 @@ export default function parseLocalManifest(
       },
     },
     periods: parsedPeriods,
+    chainedManifests: null,
   };
 }
 

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -359,6 +359,7 @@ function createManifest(
       },
     },
     lifetime: mplData.pollInterval,
+    chainedManifests: null,
   };
 
   return manifest;

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -695,6 +695,7 @@ function createSmoothStreamingParser(
       suggestedPresentationDelay,
       transportType: "smooth",
       uris: isNullOrUndefined(url) ? [] : [url],
+      chainedManifests: null,
     };
     checkManifestIDs(manifest);
     return manifest;

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -456,4 +456,11 @@ export interface IParsedManifest {
   suggestedPresentationDelay?: number | undefined;
   /** URIs where the manifest can be refreshed by order of importance. */
   uris?: string[] | undefined;
+  /**
+   * Manifests can have a reference to another Manifest that should be played
+   * once the previous one is finished.
+   * If that's the case, `chainedManifests` is set to the wanted Manifests' URL,
+   * by order of preference.
+   */
+  chainedManifests: string[] | null;
 }

--- a/tests/integration/scenarios/dash_fake_live.test.js
+++ b/tests/integration/scenarios/dash_fake_live.test.js
@@ -181,7 +181,6 @@ describe("DASH live content (SegmentTimeline)", function () {
         manifestLoader,
         segmentLoader,
       });
-      expect(player.getAvailableVideoTracks()).to.eql([]);
 
       await sleep(0);
       expect(manifestLoaderCalledTimes).to.equal(1);

--- a/tests/unit/src/main_thread/init/utils/update_manifest_codec_support.test.ts
+++ b/tests/unit/src/main_thread/init/utils/update_manifest_codec_support.test.ts
@@ -69,6 +69,7 @@ function generateFakeManifestWithRepresentations(
     id: "manifest1",
     isDynamic: false,
     isLive: false,
+    chainedManifests: null,
     timeBounds: {
       minimumSafePosition: 0,
       timeshiftDepth: null,

--- a/tests/unit/src/manifest/classes/manifest.test.ts
+++ b/tests/unit/src/manifest/classes/manifest.test.ts
@@ -96,6 +96,7 @@ describe("Manifest - Manifest", () => {
       isDynamic: false,
       isLive: false,
       duration: 5,
+      chainedManifests: null,
       timeBounds: {
         minimumSafePosition: 0,
         timeshiftDepth: null,
@@ -138,6 +139,7 @@ describe("Manifest - Manifest", () => {
       isDynamic: false,
       isLive: false,
       duration: 5,
+      chainedManifests: null,
       timeBounds: {
         minimumSafePosition: 0,
         timeshiftDepth: null,
@@ -189,6 +191,7 @@ describe("Manifest - Manifest", () => {
       isLastPeriodKnown: true,
       isLive: false,
       duration: 5,
+      chainedManifests: null,
       timeBounds: {
         minimumSafePosition: 0,
         timeshiftDepth: null,
@@ -243,6 +246,7 @@ describe("Manifest - Manifest", () => {
       isLastPeriodKnown: true,
       isLive: false,
       duration: 5,
+      chainedManifests: null,
       timeBounds: {
         minimumSafePosition: 0,
         timeshiftDepth: null,
@@ -291,6 +295,7 @@ describe("Manifest - Manifest", () => {
     const oldManifestArgs = {
       availabilityStartTime: 5,
       duration: 12,
+      chainedManifests: null,
       id: "man",
       transportType: "dash",
       isLastPeriodKnown: true,
@@ -359,6 +364,7 @@ describe("Manifest - Manifest", () => {
     const oldManifestArgs1 = {
       availabilityStartTime: 5,
       duration: 12,
+      chainedManifests: null,
       id: "man",
       isDynamic: false,
       isLive: false,
@@ -386,6 +392,7 @@ describe("Manifest - Manifest", () => {
     const oldManifestArgs2 = {
       availabilityStartTime: 5,
       duration: 12,
+      chainedManifests: null,
       id: "man",
       isDynamic: false,
       isLive: false,
@@ -428,6 +435,7 @@ describe("Manifest - Manifest", () => {
     const oldManifestArgs = {
       availabilityStartTime: 5,
       duration: 12,
+      chainedManifests: null,
       id: "man",
       transportType: "dash",
       isLastPeriodKnown: true,


### PR DESCRIPTION
__NOTE__: To facilitate tests, I deployed that work on the https://developers.canal-plus.com/rx-player/mpd-chaining demo page

This is a very naive implementation of the DASH Manifest chaining concept which allows to signal a next content to load from the first content's MPD. Use cases we've heard of are mainly pre-roll or post-roll contents (basically ad before and after a content) including for live contents.

I only handle the chaining at the end of the previous content for now. There is a second situation "Fallback Chaining" which is supposed to do so at the "failure" of a content that I do not yet handle as it poses much more questions in terms of RxPlayer API.

Even in that very simple chaining after ENDED, there is still some API question left: should we send an event when chaining? What loadVideo options should we set, should we ask the application? How can an application configure the start time of one of the chained content?

To note also that some other players preload the future content at the end of the previous one with the goal of having a lower transition time, I saw mainly the shaka-player with this. The RxPlayer has no preload concept yet.