### PR TITLE
Update README.doc to 0.6.0

### DIFF
--- a/doc/.docConfig.json
+++ b/doc/.docConfig.json
@@ -45,5 +45,6 @@
       "type": "version",
       "link": "https://developers.canal-plus.com/rx-player/documentation_pages_by_version.html"
     }
-  ]
+  ],
+  "siteMapRoot": "https://developers.canal-plus.com/rx-player/doc/"
 }

--- a/doc/api/Decryption_Options.md
+++ b/doc/api/Decryption_Options.md
@@ -251,7 +251,7 @@ Note that if setting that property to `true` fixes your issue, it may be that it
 the [`maxSessionCacheSize`](#maxsessioncachesize) which is for now too high.
 
 However if your problem doesn't disappear after setting `closeSessionsOnStop` to `true`,
-you may try [`reuseMediaKeys`](#renewmediakeys) next.
+you may try [`reuseMediaKeys`](#reusemediakeys) next.
 
 ### reuseMediaKeys
 

--- a/doc/api/Miscellaneous/plugins.md
+++ b/doc/api/Miscellaneous/plugins.md
@@ -430,7 +430,8 @@ The representationFilter will be called each time we load a
 
   - `hdrInfo` (`Object|undefined`): If the `Representation` is from a video track and if
     it has HDR information associated to it, this is set to an object describing the hdr
-    characteristics of the track. (see [HDR support documentation](../hdr.md#hdrinfo))
+    characteristics of the track. (see
+    [HDR support documentation](.././Miscellaneous/hdr.md#hdrinfo))
 
   - `contentProtections` (`Object|undefined`): Encryption information linked to this
     content.

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -262,7 +262,7 @@ the following properties:
   - `frameRate` (`string|undefined`): The video frame rate.
 
   - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-    (see [HDR support documentation](hdr.md#hdrinfo))
+    (see [HDR support documentation](./Miscellaneous/hdr.md#hdrinfo))
 
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -257,7 +257,7 @@ The array emitted contains object describing each available video track:
   - `frameRate` (`number|undefined`): The video framerate.
 
   - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-    (see [HDR support documentation](hdr.md#hdrinfo))
+    (see [HDR support documentation](./Miscellaneous/hdr.md#hdrinfo))
 
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
@@ -476,7 +476,7 @@ The payload is an object describing the new track, with the following properties
   - `frameRate` (`number|undefined`): The video framerate.
 
   - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-    (see [HDR support documentation](hdr.md#hdrinfo))
+    (see [HDR support documentation](./Miscellaneous/hdr.md#hdrinfo))
 
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.
@@ -565,7 +565,7 @@ properties:
 - `frameRate` (`number|undefined`): The video framerate.
 
 - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-  (see [HDR support documentation](hdr.md#hdrinfo))
+  (see [HDR support documentation](./Miscellaneous/hdr.md#hdrinfo))
 
 - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that Representation
   is supported by the current platform.

--- a/doc/api/Representation_Selection/getVideoRepresentation.md
+++ b/doc/api/Representation_Selection/getVideoRepresentation.md
@@ -36,7 +36,7 @@ method will return an object with the following properties:
 - `frameRate` (`number|undefined`): The video frame rate, in frames per second.
 
 - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the
-  Representation. (see [HDR support documentation](../hdr.md#hdrinfo))
+  Representation. (see [HDR support documentation](.././Miscellaneous/hdr.md#hdrinfo))
 
 - `contentProtections` (`Object|undefined`): Encryption information linked to this
   Representation.

--- a/doc/api/Track_Selection/getAvailableVideoTracks.md
+++ b/doc/api/Track_Selection/getAvailableVideoTracks.md
@@ -39,7 +39,7 @@ Each of the objects in the returned array have the following properties:
   - `frameRate` (`number|undefined`): The video framerate.
 
   - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-    (see [HDR support documentation](../hdr.md#hdrinfo))
+    (see [HDR support documentation](.././Miscellaneous/hdr.md#hdrinfo))
 
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.

--- a/doc/api/Track_Selection/getVideoTrack.md
+++ b/doc/api/Track_Selection/getVideoTrack.md
@@ -44,7 +44,7 @@ object with the following properties:
   - `frameRate` (`number|undefined`): The video frame rate, in frames per second.
 
   - `hdrInfo` (`Object|undefined`) Information about the hdr characteristics of the track.
-    (see [HDR support documentation](../hdr.md#hdrinfo))
+    (see [HDR support documentation](.././Miscellaneous/hdr.md#hdrinfo))
 
   - `isCodecSupported` (`Boolean|undefined`): If `true` the codec(s) of that
     Representation is supported by the current platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@canalplus/readme.doc": "0.5.0",
+        "@canalplus/readme.doc": "0.6.0",
         "@types/react": "19.0.2",
         "@types/react-dom": "19.0.2",
         "@typescript-eslint/eslint-plugin": "^8.18.1",
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@canalplus/readme.doc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@canalplus/readme.doc/-/readme.doc-0.5.0.tgz",
-      "integrity": "sha512-Zo21qd347E/AtVT8bYfyp/dA7zrWcRdmDpt4MT1q1oJJg2SShv3IzLOHG/iGBcIjbBhTkllzTEz6QSwPPCM6Qg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@canalplus/readme.doc/-/readme.doc-0.6.0.tgz",
+      "integrity": "sha512-4dSSODejmw2dTGC7tezATk74QmiE0VkJC4F4uEZzVQ+pAkq6NBIShFRCEx9UqY+olq6why0KpGvp5Qbwvo1Skw==",
       "dev": true,
       "license": "WTFPL",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "url": "git://github.com/canalplus/rx-player.git"
   },
   "devDependencies": {
-    "@canalplus/readme.doc": "0.5.0",
+    "@canalplus/readme.doc": "0.6.0",
     "@types/react": "19.0.2",
     "@types/react-dom": "19.0.2",
     "@typescript-eslint/eslint-plugin": "^8.18.1",


### PR DESCRIPTION
This PR updates `README.doc`, our documentation generator to `0.6.0` (that I've just published).

It adds an hopefully better search ([different search lib](https://github.com/canalplus/README/pull/3), [search trees](https://github.com/canalplus/README/pull/1)) and [sitemap generation](https://github.com/canalplus/README/pull/2).

I also profited from this to detect and fix documentation link issues.