### PR TITLE
[Proposal] Make DASH parsing first pass closer to original XML

### DIFF
--- a/src/parsers/manifest/dash/common/content_protection_parser.ts
+++ b/src/parsers/manifest/dash/common/content_protection_parser.ts
@@ -152,12 +152,13 @@ export default class ContentProtectionParser {
 
     // Referenced ContentProtection found, let's inherit its attributes
 
-    contentProt.children.cencPssh.push(...referenced.children.cencPssh);
+    contentProt.children["cenc:pssh"].push(...referenced.children["cenc:pssh"]);
     if (
-      contentProt.attributes.keyId === undefined &&
-      referenced.attributes.keyId !== undefined
+      contentProt.attributes["cenc:default_KID"] === undefined &&
+      referenced.attributes["cenc:default_KID"] !== undefined
     ) {
-      contentProt.attributes.keyId = referenced.attributes.keyId;
+      contentProt.attributes["cenc:default_KID"] =
+        referenced.attributes["cenc:default_KID"];
     }
     if (
       contentProt.attributes.schemeIdUri === undefined &&
@@ -211,10 +212,10 @@ function parseContentProtection(
       .toLowerCase();
   }
   if (
-    contentProtectionIr.attributes.keyId !== undefined &&
-    contentProtectionIr.attributes.keyId.length > 0
+    contentProtectionIr.attributes["cenc:default_KID"] !== undefined &&
+    contentProtectionIr.attributes["cenc:default_KID"].length > 0
   ) {
-    const kid = contentProtectionIr.attributes.keyId;
+    const kid = contentProtectionIr.attributes["cenc:default_KID"];
     if (representation.contentProtections === undefined) {
       representation.contentProtections = { keyIds: [kid], initData: [] };
     } else if (representation.contentProtections.keyIds === undefined) {
@@ -227,10 +228,10 @@ function parseContentProtection(
   if (systemId === undefined) {
     return;
   }
-  const { cencPssh } = contentProtectionIr.children;
+  const cencPssh = contentProtectionIr.children["cenc:pssh"];
   const values: Array<{ systemId: string; data: Uint8Array }> = [];
-  for (const data of cencPssh) {
-    values.push({ systemId, data });
+  for (const pssh of cencPssh) {
+    values.push({ systemId, data: pssh.value });
   }
   if (values.length === 0) {
     return;

--- a/src/parsers/manifest/dash/common/get_http_utc-timing_url.ts
+++ b/src/parsers/manifest/dash/common/get_http_utc-timing_url.ts
@@ -18,12 +18,16 @@ import type { IMPDIntermediateRepresentation } from "../node_parser_types.ts";
 
 type ISupportedHttpUtcTimingScheme =
   | {
-      schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014";
-      value: string;
+      attributes: {
+        schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014";
+        value: string;
+      };
     }
   | {
-      schemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014";
-      value: string;
+      attributes: {
+        schemeIdUri: "urn:mpeg:dash:utc:http-xsdate:2014";
+        value: string;
+      };
     };
 
 /**
@@ -33,12 +37,12 @@ type ISupportedHttpUtcTimingScheme =
 export default function getHTTPUTCTimingURL(
   mpdIR: IMPDIntermediateRepresentation,
 ): string | undefined {
-  const UTCTimingHTTP = mpdIR.children.utcTimings.filter(
+  const UTCTimingHTTP = mpdIR.children.UTCTiming.filter(
     (utcTiming): utcTiming is ISupportedHttpUtcTimingScheme =>
-      (utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-iso:2014" ||
-        utcTiming.schemeIdUri === "urn:mpeg:dash:utc:http-xsdate:2014") &&
-      utcTiming.value !== undefined,
+      (utcTiming.attributes.schemeIdUri === "urn:mpeg:dash:utc:http-iso:2014" ||
+        utcTiming.attributes.schemeIdUri === "urn:mpeg:dash:utc:http-xsdate:2014") &&
+      utcTiming.attributes.value !== undefined,
   );
 
-  return UTCTimingHTTP.length > 0 ? UTCTimingHTTP[0].value : undefined;
+  return UTCTimingHTTP.length > 0 ? UTCTimingHTTP[0].attributes.value : undefined;
 }

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -92,7 +92,7 @@ export interface IBaseIndexIndexArgument {
   timescale?: number;
   media?: string;
   indexRange?: [number, number];
-  initialization?: { media?: string; range?: [number, number] };
+  initialization?: { media?: string; range?: [number, number] } | undefined;
   startNumber?: number;
   endNumber?: number;
   /**

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -85,10 +85,12 @@ export interface IListIndex {
 export interface IListIndexIndexArgument {
   duration?: number | undefined;
   indexRange?: [number, number] | undefined;
-  initialization?: {
-    media?: string | undefined;
-    range?: [number, number] | undefined;
-  };
+  initialization?:
+    | {
+        media?: string | undefined;
+        range?: [number, number] | undefined;
+      }
+    | undefined;
   list: Array<{
     media?: string | undefined;
     mediaRange?: [number, number] | undefined;

--- a/src/parsers/manifest/dash/common/infer_adaptation_type.ts
+++ b/src/parsers/manifest/dash/common/infer_adaptation_type.ts
@@ -23,6 +23,7 @@ import isNullOrUndefined from "../../../../utils/is_null_or_undefined.ts";
 import type {
   IAdaptationSetIntermediateRepresentation,
   IRepresentationIntermediateRepresentation,
+  ISchemeIntermediateRepresentation,
 } from "../node_parser_types.ts";
 
 /** Different "type" a parsed Adaptation can be. */
@@ -30,12 +31,6 @@ type IAdaptationType = "audio" | "video" | "text";
 
 /** Different `role`s a text Adaptation can be. */
 const SUPPORTED_TEXT_TYPES = ["subtitle", "caption"];
-
-/** Structure of a parsed "scheme-like" element in the MPD. */
-interface IScheme {
-  schemeIdUri?: string | undefined;
-  value?: string | undefined;
-}
 
 /**
  * From a thumbnail AdaptationSet, returns core information such as the number
@@ -54,17 +49,17 @@ export function getThumbnailAdaptationSetInfo(
 } | null {
   const thumbnailProp =
     arrayFind(
-      adaptation.children.essentialProperties ?? [],
+      adaptation.children.EssentialProperty ?? [],
       (p) =>
-        p.schemeIdUri === "http://dashif.org/guidelines/thumbnail_tile" ||
-        p.schemeIdUri === "http://dashif.org/thumbnail_tile",
+        p.attributes.schemeIdUri === "http://dashif.org/guidelines/thumbnail_tile" ||
+        p.attributes.schemeIdUri === "http://dashif.org/thumbnail_tile",
     ) ??
     arrayFind(
-      (representation ?? adaptation.children.representations[0])?.children
-        .essentialProperties ?? [],
+      (representation ?? adaptation.children.Representation[0])?.children
+        .EssentialProperty ?? [],
       (p) =>
-        p.schemeIdUri === "http://dashif.org/guidelines/thumbnail_tile" ||
-        p.schemeIdUri === "http://dashif.org/thumbnail_tile",
+        p.attributes.schemeIdUri === "http://dashif.org/guidelines/thumbnail_tile" ||
+        p.attributes.schemeIdUri === "http://dashif.org/thumbnail_tile",
     );
   if (thumbnailProp === undefined) {
     return null;
@@ -72,13 +67,13 @@ export function getThumbnailAdaptationSetInfo(
   const tilesRegex = /(\d+)x(\d+)/;
   if (
     thumbnailProp === undefined ||
-    thumbnailProp.value === undefined ||
-    !tilesRegex.test(thumbnailProp.value)
+    thumbnailProp.attributes.value === undefined ||
+    !tilesRegex.test(thumbnailProp.attributes.value)
   ) {
     log.warn("dash", "Invalid thumbnails Representation, no tile-related information");
     return null;
   }
-  const match = thumbnailProp.value.match(tilesRegex) as RegExpMatchArray;
+  const match = thumbnailProp.attributes.value.match(tilesRegex) as RegExpMatchArray;
   const horizontalTiles = parseInt(match[1], 10);
   const verticalTiles = parseInt(match[2], 10);
   return {
@@ -118,12 +113,12 @@ export default function inferAdaptationType(
   const adaptationCodecs = isNonEmptyString(adaptation.attributes.codecs)
     ? adaptation.attributes.codecs
     : null;
-  const adaptationRoles = !isNullOrUndefined(adaptation.children.roles)
-    ? adaptation.children.roles
+  const adaptationRoles = !isNullOrUndefined(adaptation.children.Role)
+    ? adaptation.children.Role
     : null;
   function fromMimeType(
     mimeType: string,
-    roles: IScheme[] | null,
+    roles: ISchemeIntermediateRepresentation[],
   ): IAdaptationType | undefined {
     const topLevel = mimeType.split("/")[0];
     if (
@@ -139,13 +134,13 @@ export default function inferAdaptationType(
     }
     // manage DASH-IF mp4-embedded subtitles and metadata
     if (mimeType === "application/mp4") {
-      if (roles !== null) {
+      if (roles.length > 0) {
         if (
           arrayFind(
             roles,
             (role) =>
-              role.schemeIdUri === "urn:mpeg:dash:role:2011" &&
-              arrayIncludes(SUPPORTED_TEXT_TYPES, role.value),
+              role.attributes.schemeIdUri === "urn:mpeg:dash:role:2011" &&
+              arrayIncludes(SUPPORTED_TEXT_TYPES, role.attributes.value),
           ) !== undefined
         ) {
           return "text";
@@ -175,7 +170,7 @@ export default function inferAdaptationType(
     }
   }
   if (adaptationMimeType !== null) {
-    const typeFromMimeType = fromMimeType(adaptationMimeType, adaptationRoles);
+    const typeFromMimeType = fromMimeType(adaptationMimeType, adaptationRoles ?? []);
     if (typeFromMimeType !== undefined) {
       return typeFromMimeType;
     }
@@ -191,7 +186,7 @@ export default function inferAdaptationType(
     const representation = representations[i];
     const { mimeType, codecs } = representation.attributes;
     if (mimeType !== undefined) {
-      const typeFromMimeType = fromMimeType(mimeType, adaptationRoles);
+      const typeFromMimeType = fromMimeType(mimeType, adaptationRoles ?? []);
       if (typeFromMimeType !== undefined) {
         return typeFromMimeType;
       }

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -31,6 +31,7 @@ import type {
 } from "../../types.ts";
 import type {
   IAdaptationSetIntermediateRepresentation,
+  ISchemeIntermediateRepresentation,
   ISegmentTemplateIntermediateRepresentation,
 } from "../node_parser_types.ts";
 import attachTrickModeTrack from "./attach_trickmode_track.ts";
@@ -85,21 +86,19 @@ interface IAdaptationSwitchingInfos {
  * @returns {Boolean}
  */
 function isVisuallyImpaired(
-  accessibility:
-    | { schemeIdUri?: string | undefined; value?: string | undefined }
-    | undefined,
+  accessibility: ISchemeIntermediateRepresentation | undefined,
 ): boolean {
   if (accessibility === undefined) {
     return false;
   }
 
   const isVisuallyImpairedAudioDvbDash =
-    accessibility.schemeIdUri === "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
-    accessibility.value === "1";
+    accessibility.attributes.schemeIdUri === "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
+    accessibility.attributes.value === "1";
 
   const isVisuallyImpairedDashIf =
-    accessibility.schemeIdUri === "urn:mpeg:dash:role:2011" &&
-    accessibility.value === "description";
+    accessibility.attributes.schemeIdUri === "urn:mpeg:dash:role:2011" &&
+    accessibility.attributes.value === "description";
 
   return isVisuallyImpairedAudioDvbDash || isVisuallyImpairedDashIf;
 }
@@ -113,18 +112,15 @@ function isVisuallyImpaired(
  * @returns {Boolean}
  */
 function isCaptionning(
-  accessibilities:
-    | Array<{ schemeIdUri?: string | undefined; value?: string | undefined }>
-    | undefined,
-  roles:
-    | Array<{ schemeIdUri?: string | undefined; value?: string | undefined }>
-    | undefined,
+  accessibilities: ISchemeIntermediateRepresentation[] | undefined,
+  roles: ISchemeIntermediateRepresentation[] | undefined,
 ): boolean {
   if (accessibilities !== undefined) {
     const hasDvbClosedCaptionSignaling = accessibilities.some(
       (accessibility) =>
-        accessibility.schemeIdUri === "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
-        accessibility.value === "2",
+        accessibility.attributes.schemeIdUri ===
+          "urn:tva:metadata:cs:AudioPurposeCS:2007" &&
+        accessibility.attributes.value === "2",
     );
     if (hasDvbClosedCaptionSignaling) {
       return true;
@@ -133,7 +129,8 @@ function isCaptionning(
   if (roles !== undefined) {
     const hasDashCaptionSinaling = roles.some(
       (role) =>
-        role.schemeIdUri === "urn:mpeg:dash:role:2011" && role.value === "caption",
+        role.attributes.schemeIdUri === "urn:mpeg:dash:role:2011" &&
+        role.attributes.value === "caption",
     );
     if (hasDashCaptionSinaling) {
       return true;
@@ -150,17 +147,15 @@ function isCaptionning(
  * @returns {Boolean}
  */
 function hasSignLanguageInterpretation(
-  accessibility:
-    | { schemeIdUri?: string | undefined; value?: string | undefined }
-    | undefined,
+  accessibility: ISchemeIntermediateRepresentation | undefined,
 ): boolean {
   if (accessibility === undefined) {
     return false;
   }
 
   return (
-    accessibility.schemeIdUri === "urn:mpeg:dash:role:2011" &&
-    accessibility.value === "sign"
+    accessibility.attributes.schemeIdUri === "urn:mpeg:dash:role:2011" &&
+    accessibility.attributes.value === "sign"
   );
 }
 
@@ -195,8 +190,8 @@ function getAdaptationID(
   } = infos;
 
   let idString = type;
-  if (isNonEmptyString(adaptation.attributes.language)) {
-    idString += `-${adaptation.attributes.language}`;
+  if (isNonEmptyString(adaptation.attributes.lang)) {
+    idString += `-${adaptation.attributes.lang}`;
   }
   if (isClosedCaption === true) {
     idString += "-cc";
@@ -236,15 +231,15 @@ function getAdaptationID(
 function getAdaptationSetSwitchingIDs(
   adaptation: IAdaptationSetIntermediateRepresentation,
 ): string[] {
-  if (!isNullOrUndefined(adaptation.children.supplementalProperties)) {
-    const { supplementalProperties } = adaptation.children;
+  if (adaptation.children.SupplementalProperty.length > 0) {
+    const supplementalProperties = adaptation.children.SupplementalProperty;
     for (const supplementalProperty of supplementalProperties) {
       if (
-        supplementalProperty.schemeIdUri ===
+        supplementalProperty.attributes.schemeIdUri ===
           "urn:mpeg:dash:adaptation-set-switching:2016" &&
-        !isNullOrUndefined(supplementalProperty.value)
+        !isNullOrUndefined(supplementalProperty.attributes.value)
       ) {
-        return supplementalProperty.value
+        return supplementalProperty.attributes.value
           .split(",")
           .map((id) => id.trim())
           .filter((id) => isNonEmptyString(id));
@@ -286,14 +281,16 @@ export default function parseAdaptationSets(
   for (let adaptationIdx = 0; adaptationIdx < adaptationsIR.length; adaptationIdx++) {
     const adaptation = adaptationsIR[adaptationIdx];
     const adaptationChildren = adaptation.children;
-    const { essentialProperties, roles, label } = adaptationChildren;
+    const essentialProperties = adaptationChildren.EssentialProperty;
+    const roles = adaptationChildren.Role;
+    const labels = adaptationChildren.Label;
 
     const isMainAdaptation =
       Array.isArray(roles) &&
-      roles.some((role) => role.value === "main") &&
-      roles.some((role) => role.schemeIdUri === "urn:mpeg:dash:role:2011");
+      roles.some((role) => role.attributes.value === "main") &&
+      roles.some((role) => role.attributes.schemeIdUri === "urn:mpeg:dash:role:2011");
 
-    const representationsIR = adaptation.children.representations;
+    const representationsIR = adaptation.children.Representation;
 
     const availabilityTimeComplete =
       adaptation.attributes.availabilityTimeComplete ?? context.availabilityTimeComplete;
@@ -310,6 +307,7 @@ export default function parseAdaptationSets(
 
     const type = inferAdaptationType(adaptation, representationsIR);
     if (type === undefined) {
+      log.warn("dash", "unable to infer type, skip AdaptationSet");
       continue;
     }
 
@@ -320,14 +318,18 @@ export default function parseAdaptationSets(
     if (context.segmentTemplate !== undefined) {
       parentSegmentTemplates.push(context.segmentTemplate);
     }
-    if (adaptation.children.segmentTemplate !== undefined) {
-      parentSegmentTemplates.push(adaptation.children.segmentTemplate);
+    if (adaptation.children.SegmentTemplate.length > 0) {
+      parentSegmentTemplates.push(
+        adaptation.children.SegmentTemplate[
+          adaptation.children.SegmentTemplate.length - 1
+        ],
+      );
     }
 
     const reprCtxt: IRepresentationContext = {
       availabilityTimeComplete,
       availabilityTimeOffset,
-      baseURLs: resolveBaseURLs(context.baseURLs, adaptationChildren.baseURLs),
+      baseURLs: resolveBaseURLs(context.baseURLs, adaptationChildren.BaseURL),
       contentProtectionParser: context.contentProtectionParser,
       manifestBoundsCalculator: context.manifestBoundsCalculator,
       end: context.end,
@@ -342,19 +344,21 @@ export default function parseAdaptationSets(
 
     const trickModeProperty = Array.isArray(essentialProperties)
       ? arrayFind(essentialProperties, (scheme) => {
-          return scheme.schemeIdUri === "http://dashif.org/guidelines/trickmode";
+          return (
+            scheme.attributes.schemeIdUri === "http://dashif.org/guidelines/trickmode"
+          );
         })
       : undefined;
 
     const trickModeAttachedAdaptationIds: string[] | undefined =
-      trickModeProperty?.value?.split(" ");
+      trickModeProperty?.attributes.value?.split(" ");
 
     const isTrickModeTrack = trickModeAttachedAdaptationIds !== undefined;
 
-    const { accessibilities } = adaptationChildren;
+    const accessibilities = adaptationChildren.Accessibility;
 
     let isDub: boolean | undefined;
-    if (roles !== undefined && roles.some((role) => role.value === "dub")) {
+    if (roles !== undefined && roles.some((role) => role.attributes.value === "dub")) {
       isDub = true;
     }
 
@@ -370,7 +374,9 @@ export default function parseAdaptationSets(
       type === "text" &&
       roles !== undefined &&
       roles.some(
-        (role) => role.value === "forced-subtitle" || role.value === "forced_subtitle",
+        (role) =>
+          role.attributes.value === "forced-subtitle" ||
+          role.attributes.value === "forced_subtitle",
       )
     ) {
       isForcedSubtitle = true;
@@ -426,8 +432,8 @@ export default function parseAdaptationSets(
       type,
       isTrickModeTrack,
     };
-    if (!isNullOrUndefined(adaptation.attributes.language)) {
-      parsedAdaptationSet.language = adaptation.attributes.language;
+    if (!isNullOrUndefined(adaptation.attributes.lang)) {
+      parsedAdaptationSet.language = adaptation.attributes.lang;
     }
     if (!isNullOrUndefined(isClosedCaption)) {
       parsedAdaptationSet.closedCaption = isClosedCaption;
@@ -445,8 +451,8 @@ export default function parseAdaptationSets(
       parsedAdaptationSet.isSignInterpreted = true;
     }
 
-    if (label !== undefined) {
-      parsedAdaptationSet.label = label;
+    if (labels.length > 0) {
+      parsedAdaptationSet.label = labels[labels.length - 1].value;
     }
 
     if (trickModeAttachedAdaptationIds !== undefined) {
@@ -561,7 +567,7 @@ function createThumbnailTracks(
       }
       const tileInfo = getThumbnailAdaptationSetInfo(
         adaptation,
-        adaptation.children.representations[i],
+        adaptation.children.Representation[i],
       );
       if (tileInfo === null) {
         continue;

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -135,16 +135,17 @@ export default function parseMpdIr(
   if (isNullOrUndefined(args.externalClockOffset)) {
     const isDynamic: boolean = rootAttributes.type === "dynamic";
 
-    const directTiming = arrayFind(rootChildren.utcTimings, (utcTiming) => {
+    const directTiming = arrayFind(rootChildren.UTCTiming, (utcTiming) => {
       return (
-        utcTiming.schemeIdUri === "urn:mpeg:dash:utc:direct:2014" &&
-        !isNullOrUndefined(utcTiming.value)
+        utcTiming.attributes.schemeIdUri === "urn:mpeg:dash:utc:direct:2014" &&
+        !isNullOrUndefined(utcTiming.attributes.value)
       );
     });
 
     const clockOffsetFromDirectUTCTiming =
-      !isNullOrUndefined(directTiming) && !isNullOrUndefined(directTiming.value)
-        ? getClockOffset(directTiming.value)
+      !isNullOrUndefined(directTiming) &&
+      !isNullOrUndefined(directTiming.attributes.value)
+        ? getClockOffset(directTiming.attributes.value)
         : undefined;
     const clockOffset =
       !isNullOrUndefined(clockOffsetFromDirectUTCTiming) &&
@@ -184,8 +185,9 @@ export default function parseMpdIr(
   }
 
   const xlinksToLoad: Array<{ index: number; ressource: string }> = [];
-  for (let i = 0; i < rootChildren.periods.length; i++) {
-    const { xlinkHref, xlinkActuate } = rootChildren.periods[i].attributes;
+  for (let i = 0; i < rootChildren.Period.length; i++) {
+    const xlinkHref = rootChildren.Period[i].attributes["xlink:href"];
+    const xlinkActuate = rootChildren.Period[i].attributes["xlink:actuate"];
     if (!isNullOrUndefined(xlinkHref) && xlinkActuate === "onLoad") {
       xlinksToLoad.push({ index: i, ressource: xlinkHref });
     }
@@ -225,7 +227,7 @@ export default function parseMpdIr(
           }
 
           // replace original "xlinked" periods by the real deal
-          rootChildren.periods.splice(index, 1, ...periodsIR);
+          rootChildren.Period.splice(index, 1, ...periodsIR);
         }
         return parseMpdIr(mpdIR, args, warnings, hasLoadedClock, xlinkInfos);
       },
@@ -253,7 +255,7 @@ function parseCompleteIntermediateRepresentation(
     args.url !== undefined
       ? [{ url: args.url.substring(0, getFilenameIndexInUrl(args.url)) }]
       : [];
-  const mpdBaseUrls = resolveBaseURLs(initialBaseUrl, rootChildren.baseURLs);
+  const mpdBaseUrls = resolveBaseURLs(initialBaseUrl, rootChildren.BaseURL);
   const availabilityStartTime = parseAvailabilityStartTime(
     rootAttributes,
     args.referenceDateTime,
@@ -270,13 +272,13 @@ function parseCompleteIntermediateRepresentation(
     serverTimestampOffset: externalClockOffset,
   });
   const contentProtectionParser = new ContentProtectionParser();
-  contentProtectionParser.addReferences(rootChildren.contentProtections ?? []);
+  contentProtectionParser.addReferences(rootChildren.ContentProtection);
   const manifestInfos = {
     availabilityStartTime,
     baseURLs: mpdBaseUrls,
     clockOffset,
     contentProtectionParser,
-    duration: rootAttributes.duration,
+    duration: rootAttributes.mediaPresentationDuration,
     isDynamic,
     manifestBoundsCalculator,
     manifestProfiles: mpdIR.attributes.profiles,
@@ -285,9 +287,9 @@ function parseCompleteIntermediateRepresentation(
     xlinkInfos,
     xmlNamespaces: mpdIR.attributes.namespaces,
   };
-  const parsedPeriods = parsePeriods(rootChildren.periods, manifestInfos);
+  const parsedPeriods = parsePeriods(rootChildren.Period, manifestInfos);
   contentProtectionParser.finalize();
-  const mediaPresentationDuration = rootAttributes.duration;
+  const mediaPresentationDuration = rootAttributes.mediaPresentationDuration;
 
   let lifetime: number | undefined;
   let minimumTime: number | undefined;
@@ -416,7 +418,7 @@ function parseCompleteIntermediateRepresentation(
     !isDynamic ||
     (mpdIR.attributes.minimumUpdatePeriod === undefined &&
       (parsedPeriods[parsedPeriods.length - 1]?.end !== undefined ||
-        mpdIR.attributes.duration !== undefined));
+        mpdIR.attributes.mediaPresentationDuration !== undefined));
 
   const parsedMPD: IParsedManifest = {
     availabilityStartTime,
@@ -435,8 +437,8 @@ function parseCompleteIntermediateRepresentation(
     },
     lifetime,
     uris: isNullOrUndefined(args.url)
-      ? rootChildren.locations
-      : [args.url, ...rootChildren.locations],
+      ? rootChildren.Location.map((l) => l.value)
+      : [args.url, ...rootChildren.Location.map((l) => l.value)],
   };
 
   return { type: "done", value: { parsed: parsedMPD, warnings } };

--- a/src/parsers/manifest/dash/common/parse_periods.ts
+++ b/src/parsers/manifest/dash/common/parse_periods.ts
@@ -82,7 +82,7 @@ export default function parsePeriods(
     const isLastPeriod = i === periodsIR.length - 1;
     const periodIR = periodsIR[i];
     const xlinkInfos = context.xlinkInfos.get(periodIR);
-    const periodBaseURLs = resolveBaseURLs(context.baseURLs, periodIR.children.baseURLs);
+    const periodBaseURLs = resolveBaseURLs(context.baseURLs, periodIR.children.BaseURL);
 
     const { periodStart, periodDuration, periodEnd } = periodsTimeInformation[i];
 
@@ -110,8 +110,9 @@ export default function parsePeriods(
     const availabilityTimeComplete = periodIR.attributes.availabilityTimeComplete;
     const availabilityTimeOffset = periodIR.attributes.availabilityTimeOffset;
     const { manifestProfiles, contentProtectionParser } = context;
-    const { segmentTemplate } = periodIR.children;
-    contentProtectionParser.addReferences(periodIR.children.contentProtections ?? []);
+    const segmentTemplate =
+      periodIR.children.SegmentTemplate[periodIR.children.SegmentTemplate.length - 1];
+    contentProtectionParser.addReferences(periodIR.children.ContentProtection);
     const adapCtxt: IAdaptationSetContext = {
       availabilityTimeComplete,
       availabilityTimeOffset,
@@ -128,7 +129,7 @@ export default function parsePeriods(
       unsafelyBaseOnPreviousPeriod,
     };
     const { adaptations, thumbnailTracks } = parseAdaptationSets(
-      periodIR.children.adaptations,
+      periodIR.children.AdaptationSet,
       adapCtxt,
     );
 
@@ -136,7 +137,7 @@ export default function parsePeriods(
       periodIR.attributes.namespaces ?? [],
     );
     const streamEvents = generateStreamEvents(
-      periodIR.children.eventStreams,
+      periodIR.children.EventStream,
       periodStart,
       namespaces,
     );
@@ -308,7 +309,7 @@ function generateStreamEvents(
     const { schemeIdUri = "", timescale = 1 } = eventStreamIr.attributes;
     const allNamespaces = xmlNamespaces.concat(eventStreamIr.attributes.namespaces ?? []);
 
-    for (const eventIr of eventStreamIr.children.events) {
+    for (const eventIr of eventStreamIr.children.Event) {
       if (eventIr.eventStreamData !== undefined) {
         const start = (eventIr.presentationTime ?? 0) / timescale + periodStart;
         const end =

--- a/src/parsers/manifest/dash/common/parse_representation_index.ts
+++ b/src/parsers/manifest/dash/common/parse_representation_index.ts
@@ -18,13 +18,17 @@ import type {
   IRepresentationIndex,
   IRepresentation,
 } from "../../../../manifest/index.ts";
+import getLastItemFromArray from "../../../../utils/get_last_item_from_array.ts";
 import objectAssign from "../../../../utils/object_assign.ts";
 import type { IEMSG } from "../../../containers/isobmff/index.ts";
 import type {
   IAdaptationSetIntermediateRepresentation,
+  IInitializationIntermediateRepresentation,
   IRepresentationIntermediateRepresentation,
   ISegmentTemplateIntermediateRepresentation,
-  IScheme,
+  ISchemeIntermediateRepresentation,
+  ISegmentTemplateAttributes,
+  ISegmentTemplateChildren,
 } from "../node_parser_types.ts";
 import type {
   IBaseIndexContextArgument,
@@ -38,6 +42,7 @@ import {
   TemplateRepresentationIndex,
   TimelineRepresentationIndex,
 } from "./indexes/index.ts";
+import type { ITimelineIndexIndexArgument } from "./indexes/timeline/timeline_representation_index.ts";
 import type ManifestBoundsCalculator from "./manifest_bounds_calculator.ts";
 import type { IResolvedBaseUrl } from "./resolve_base_urls.ts";
 
@@ -69,7 +74,7 @@ export default function parseRepresentationIndex(
       return false;
     }
     return inbandEventStreams.some(
-      ({ schemeIdUri }) => schemeIdUri === inbandEvent.schemeIdUri,
+      ({ attributes }) => attributes.schemeIdUri === inbandEvent.schemeIdUri,
     );
   };
   const reprIndexCtxt:
@@ -87,61 +92,123 @@ export default function parseRepresentationIndex(
     periodEnd,
     periodStart,
     receivedTime,
-    representationBitrate: representation.attributes.bitrate,
+    representationBitrate: representation.attributes.bandwidth,
     representationId: representation.attributes.id,
   };
   let representationIndex: IRepresentationIndex;
-  if (representation.children.segmentBase !== undefined) {
-    const { segmentBase } = representation.children;
-    representationIndex = new BaseRepresentationIndex(segmentBase, reprIndexCtxt);
-  } else if (representation.children.segmentList !== undefined) {
-    const { segmentList } = representation.children;
-    representationIndex = new ListRepresentationIndex(segmentList, reprIndexCtxt);
-  } else if (
-    representation.children.segmentTemplate !== undefined ||
-    context.parentSegmentTemplates.length > 0
-  ) {
-    const segmentTemplates = context.parentSegmentTemplates.slice();
-    const childSegmentTemplate = representation.children.segmentTemplate;
-    if (childSegmentTemplate !== undefined) {
-      segmentTemplates.push(childSegmentTemplate);
+  const segmentBase = getLastItemFromArray(representation.children.SegmentBase);
+  const segmentList = getLastItemFromArray(representation.children.SegmentList);
+  const segmentTemplate = getLastItemFromArray(representation.children.SegmentTemplate);
+  if (segmentBase !== undefined) {
+    representationIndex = new BaseRepresentationIndex(
+      {
+        ...segmentBase.attributes,
+        initialization: parseInitializationElement(segmentBase.children.Initialization),
+      },
+      reprIndexCtxt,
+    );
+  } else if (segmentList !== undefined) {
+    representationIndex = new ListRepresentationIndex(
+      {
+        ...segmentList.attributes,
+        list: segmentList.children.SegmentURL.map((u) => u.attributes),
+        initialization: parseInitializationElement(segmentList.children.Initialization),
+      },
+      reprIndexCtxt,
+    );
+  } else if (segmentTemplate !== undefined || context.parentSegmentTemplates.length > 0) {
+    const segmentTemplates: ISegmentTemplateIntermediateRepresentation[] =
+      context.parentSegmentTemplates.slice();
+    if (segmentTemplate !== undefined) {
+      segmentTemplates.push(segmentTemplate);
     }
-    const segmentTemplate = objectAssign(
+    const combinedTimelines: Pick<
+      ISegmentTemplateChildren,
+      "timeline" | "timelineParser"
+    > = segmentTemplates.reduce(
+      (
+        acc: Pick<ISegmentTemplateChildren, "timeline" | "timelineParser">,
+        s: ISegmentTemplateIntermediateRepresentation,
+      ) => {
+        if (s.children.timeline !== undefined) {
+          acc.timeline = s.children.timeline;
+        } else if (s.children.timelineParser !== undefined) {
+          acc.timelineParser = s.children.timelineParser;
+        }
+        return acc;
+      },
       {},
-      ...(segmentTemplates as [
-        ISegmentTemplateIntermediateRepresentation,
-      ]) /* Ugly TS Hack */,
+    );
+    const combinedAttributes: ISegmentTemplateAttributes = objectAssign(
+      {},
+      ...segmentTemplates.map((s) => s.attributes),
     );
     if (
-      segmentTemplate.availabilityTimeOffset !== undefined ||
+      combinedAttributes.availabilityTimeOffset !== undefined ||
       context.availabilityTimeOffset !== undefined
     ) {
       reprIndexCtxt.availabilityTimeOffset =
-        (segmentTemplate.availabilityTimeOffset ?? 0) +
+        (combinedAttributes.availabilityTimeOffset ?? 0) +
         (context.availabilityTimeOffset ?? 0);
     }
-
     if (
-      segmentTemplate.availabilityTimeComplete !== undefined ||
+      combinedAttributes.availabilityTimeComplete !== undefined ||
       context.availabilityTimeComplete !== undefined
     ) {
       reprIndexCtxt.availabilityTimeComplete =
-        segmentTemplate.availabilityTimeComplete ?? context.availabilityTimeComplete;
+        combinedAttributes.availabilityTimeComplete ?? context.availabilityTimeComplete;
     }
 
+    let initialization: { media?: string; range?: [number, number] } | undefined;
+    for (const currentSegmentTemplate of segmentTemplates) {
+      const initializationElement = parseInitializationElement(
+        currentSegmentTemplate.children.Initialization,
+      );
+      if (initializationElement !== undefined) {
+        initialization = initializationElement;
+      } else if (currentSegmentTemplate.attributes.initialization !== undefined) {
+        initialization = {
+          media: currentSegmentTemplate.attributes.initialization,
+        };
+      }
+    }
+    const resultTemplateIdx: ITimelineIndexIndexArgument = {
+      ...combinedAttributes,
+      timeline: combinedTimelines.timeline,
+      timelineParser: combinedTimelines.timelineParser,
+      initialization,
+    };
+
     representationIndex = TimelineRepresentationIndex.isTimelineIndexArgument(
-      segmentTemplate,
+      resultTemplateIdx,
     )
-      ? new TimelineRepresentationIndex(segmentTemplate, reprIndexCtxt)
-      : new TemplateRepresentationIndex(segmentTemplate, reprIndexCtxt);
+      ? new TimelineRepresentationIndex(resultTemplateIdx, reprIndexCtxt)
+      : new TemplateRepresentationIndex(resultTemplateIdx, reprIndexCtxt);
   } else {
     const adaptationChildren = context.adaptation.children;
-    if (adaptationChildren.segmentBase !== undefined) {
-      const { segmentBase } = adaptationChildren;
-      representationIndex = new BaseRepresentationIndex(segmentBase, reprIndexCtxt);
-    } else if (adaptationChildren.segmentList !== undefined) {
-      const { segmentList } = adaptationChildren;
-      representationIndex = new ListRepresentationIndex(segmentList, reprIndexCtxt);
+    const adapSegmentBase = getLastItemFromArray(adaptationChildren.SegmentBase);
+    const adapSegmentList = getLastItemFromArray(adaptationChildren.SegmentList);
+    if (adapSegmentBase !== undefined) {
+      representationIndex = new BaseRepresentationIndex(
+        {
+          ...adapSegmentBase.attributes,
+          initialization: parseInitializationElement(
+            adapSegmentBase.children.Initialization,
+          ),
+        },
+        reprIndexCtxt,
+      );
+    } else if (adapSegmentList !== undefined) {
+      representationIndex = new ListRepresentationIndex(
+        {
+          ...adapSegmentList.attributes,
+          list: adapSegmentList.children.SegmentURL.map((u) => u.attributes),
+          initialization: parseInitializationElement(
+            adapSegmentList.children.Initialization,
+          ),
+        },
+        reprIndexCtxt,
+      );
     } else {
       representationIndex = new TemplateRepresentationIndex(
         {
@@ -155,6 +222,24 @@ export default function parseRepresentationIndex(
     }
   }
   return representationIndex;
+}
+
+function parseInitializationElement(
+  initializations: IInitializationIntermediateRepresentation[],
+): { media?: string; range?: [number, number] } | undefined {
+  const initialization = getLastItemFromArray(initializations);
+  if (initialization === undefined) {
+    return undefined;
+  }
+
+  const result: { media?: string; range?: [number, number] } = {};
+  if (initialization.attributes.sourceURL !== undefined) {
+    result.media = initialization.attributes.sourceURL;
+  }
+  if (initialization.attributes.range !== undefined) {
+    result.range = initialization.attributes.range;
+  }
+  return result;
 }
 
 /** Supplementary context needed to parse a RepresentationIndex. */
@@ -185,7 +270,7 @@ export interface IRepresentationIndexContext {
   /** End time of the current Period, in seconds. */
   end?: number | undefined;
   /** List of inband event streams that are present on the representation */
-  inbandEventStreams: IScheme[] | undefined;
+  inbandEventStreams: ISchemeIntermediateRepresentation[] | undefined;
   /**
    * Set to `true` if the linked Period is the chronologically last one in the
    * Manifest.

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -23,7 +23,7 @@ import type { IParsedRepresentation } from "../../types.ts";
 import type {
   IAdaptationSetIntermediateRepresentation,
   IRepresentationIntermediateRepresentation,
-  IScheme,
+  ISchemeIntermediateRepresentation,
 } from "../node_parser_types.ts";
 import type ContentProtectionParser from "./content_protection_parser.ts";
 import { convertSupplementalCodecsToRFC6381 } from "./convert_supplemental_codecs.ts";
@@ -42,13 +42,13 @@ import resolveBaseURLs from "./resolve_base_urls.ts";
 function combineInbandEventStreams(
   representation: IRepresentationIntermediateRepresentation,
   adaptation: IAdaptationSetIntermediateRepresentation,
-): IScheme[] | undefined {
+): ISchemeIntermediateRepresentation[] | undefined {
   const newSchemeId = [];
-  if (representation.children.inbandEventStreams !== undefined) {
-    newSchemeId.push(...representation.children.inbandEventStreams);
+  if (representation.children.InbandEventStream.length > 0) {
+    newSchemeId.push(...representation.children.InbandEventStream);
   }
-  if (adaptation.children.inbandEventStreams !== undefined) {
-    newSchemeId.push(...adaptation.children.inbandEventStreams);
+  if (adaptation.children.InbandEventStream.length > 0) {
+    newSchemeId.push(...adaptation.children.InbandEventStream);
   }
   if (newSchemeId.length === 0) {
     return undefined;
@@ -69,8 +69,8 @@ function getHDRInformation({
   codecs,
 }: {
   adaptationProfiles?: string | undefined;
-  essentialProperties?: IScheme[] | undefined;
-  supplementalProperties?: IScheme[] | undefined;
+  essentialProperties?: ISchemeIntermediateRepresentation[] | undefined;
+  supplementalProperties?: ISchemeIntermediateRepresentation[] | undefined;
   manifestProfiles?: string | undefined;
   codecs?: string | undefined;
 }): undefined | IHDRInformation {
@@ -82,7 +82,7 @@ function getHDRInformation({
   }
   const transferCharacteristicScheme = arrayFind(
     [...(essentialProperties ?? []), ...(supplementalProperties ?? [])],
-    (p) => p.schemeIdUri === "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+    (p) => p.attributes.schemeIdUri === "urn:mpeg:mpegB:cicp:TransferCharacteristics",
   );
   if (transferCharacteristicScheme !== undefined) {
     // 1: ITU-R BT.709
@@ -102,7 +102,7 @@ function getHDRInformation({
     // 16: SMPTE ST 2084, ITU-R BT.2100 PQ
     // 17: SMPTE ST 428-1
     // 18: ARIB STD-B67 (HLG)
-    switch (transferCharacteristicScheme.value) {
+    switch (transferCharacteristicScheme.attributes.value) {
       case "15":
         return undefined; // SDR
       case "16":
@@ -134,7 +134,7 @@ export default function parseRepresentations(
     let representationID =
       representation.attributes.id !== undefined
         ? representation.attributes.id
-        : String(representation.attributes.bitrate) +
+        : String(representation.attributes.bandwidth) +
           (representation.attributes.height !== undefined
             ? `-${representation.attributes.height}`
             : "") +
@@ -184,16 +184,16 @@ export default function parseRepresentations(
 
     // Find bitrate
     let representationBitrate: number;
-    if (representation.attributes.bitrate === undefined) {
-      log.warn("dash", "No usable bitrate found in the Representation.");
+    if (representation.attributes.bandwidth === undefined) {
+      log.warn("dash", "No usable bandwidth found in the Representation.");
       representationBitrate = 0;
     } else {
-      representationBitrate = representation.attributes.bitrate;
+      representationBitrate = representation.attributes.bandwidth;
     }
 
     const representationBaseURLs = resolveBaseURLs(
       context.baseURLs,
-      representation.children.baseURLs,
+      representation.children.BaseURL,
     );
 
     const cdnMetadata =
@@ -217,12 +217,12 @@ export default function parseRepresentations(
     };
 
     if (
-      representation.children.supplementalProperties !== undefined &&
+      representation.children.SupplementalProperty.length > 0 &&
       arrayFind(
-        representation.children.supplementalProperties,
+        representation.children.SupplementalProperty,
         (r) =>
-          r.schemeIdUri === "tag:dolby.com,2018:dash:EC3_ExtensionType:2018" &&
-          r.value === "JOC",
+          r.attributes.schemeIdUri === "tag:dolby.com,2018:dash:EC3_ExtensionType:2018" &&
+          r.attributes.value === "JOC",
       ) !== undefined
     ) {
       parsedRepresentation.isSpatialAudio = true;
@@ -241,10 +241,10 @@ export default function parseRepresentations(
     }
 
     let supplementalCodecs: string | undefined;
-    if (representation.attributes.supplementalCodecs !== undefined) {
-      supplementalCodecs = representation.attributes.supplementalCodecs;
-    } else if (adaptation.attributes.supplementalCodecs !== undefined) {
-      supplementalCodecs = adaptation.attributes.supplementalCodecs;
+    if (representation.attributes["scte214:supplementalCodecs"] !== undefined) {
+      supplementalCodecs = representation.attributes["scte214:supplementalCodecs"];
+    } else if (adaptation.attributes["scte214:supplementalCodecs"] !== undefined) {
+      supplementalCodecs = adaptation.attributes["scte214:supplementalCodecs"];
     }
     if (supplementalCodecs !== undefined) {
       parsedRepresentation.supplementalCodecs =
@@ -275,8 +275,8 @@ export default function parseRepresentations(
     // Content Protection parsing
     {
       const contentProtIrArr = [
-        ...(adaptation.children.contentProtections ?? []),
-        ...(representation.children.contentProtections ?? []),
+        ...adaptation.children.ContentProtection,
+        ...representation.children.ContentProtection,
       ];
       for (const contentProtIr of contentProtIrArr) {
         context.contentProtectionParser.add(parsedRepresentation, contentProtIr);
@@ -285,8 +285,8 @@ export default function parseRepresentations(
 
     parsedRepresentation.hdrInfo = getHDRInformation({
       adaptationProfiles: adaptation.attributes.profiles,
-      supplementalProperties: adaptation.children.supplementalProperties,
-      essentialProperties: adaptation.children.essentialProperties,
+      supplementalProperties: adaptation.children.SupplementalProperty,
+      essentialProperties: adaptation.children.EssentialProperty,
       manifestProfiles: context.manifestProfiles,
       codecs,
     });

--- a/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.ts
@@ -48,10 +48,20 @@ function parseAdaptationSetChildren(
   adaptationSetChildren: Array<ITNode | string>,
 ): [IAdaptationSetChildren, Error[]] {
   const children: IAdaptationSetChildren = {
-    baseURLs: [],
-    representations: [],
+    BaseURL: [],
+    Representation: [],
+    Accessibility: [],
+    ContentComponent: [],
+    ContentProtection: [],
+    EssentialProperty: [],
+    InbandEventStream: [],
+    Role: [],
+    SupplementalProperty: [],
+    SegmentBase: [],
+    SegmentList: [],
+    SegmentTemplate: [],
+    Label: [],
   };
-  const contentProtections = [];
   let warnings: Error[] = [];
   for (let i = 0; i < adaptationSetChildren.length; i++) {
     const currentNode = adaptationSetChildren[i];
@@ -60,17 +70,13 @@ function parseAdaptationSetChildren(
     }
     switch (currentNode.tagName) {
       case "Accessibility":
-        if (children.accessibilities === undefined) {
-          children.accessibilities = [parseScheme(currentNode)];
-        } else {
-          children.accessibilities.push(parseScheme(currentNode));
-        }
+        children.Accessibility.push(parseScheme(currentNode));
         break;
 
       case "BaseURL": {
         const [baseURLObj, baseURLWarnings] = parseBaseURL(currentNode);
         if (baseURLObj !== undefined) {
-          children.baseURLs.push(baseURLObj);
+          children.BaseURL.push(baseURLObj);
         }
         if (baseURLWarnings.length > 0) {
           warnings = warnings.concat(baseURLWarnings);
@@ -79,29 +85,21 @@ function parseAdaptationSetChildren(
       }
 
       case "ContentComponent":
-        children.contentComponent = parseContentComponent(currentNode);
+        children.ContentComponent.push(parseContentComponent(currentNode));
         break;
 
       case "EssentialProperty":
-        if (isNullOrUndefined(children.essentialProperties)) {
-          children.essentialProperties = [parseScheme(currentNode)];
-        } else {
-          children.essentialProperties.push(parseScheme(currentNode));
-        }
+        children.EssentialProperty.push(parseScheme(currentNode));
         break;
 
       case "InbandEventStream":
-        if (children.inbandEventStreams === undefined) {
-          children.inbandEventStreams = [];
-        }
-        children.inbandEventStreams.push(parseScheme(currentNode));
+        children.InbandEventStream.push(parseScheme(currentNode));
         break;
 
       case "Label": {
         const label = textContent(currentNode.children);
-
         if (label !== null && label !== undefined) {
-          children.label = label;
+          children.Label.push({ value: label });
         }
         break;
       }
@@ -109,7 +107,7 @@ function parseAdaptationSetChildren(
       case "Representation": {
         const [representation, representationWarnings] =
           createRepresentationIntermediateRepresentation(currentNode);
-        children.representations.push(representation);
+        children.Representation.push(representation);
         if (representationWarnings.length > 0) {
           warnings = warnings.concat(representationWarnings);
         }
@@ -117,24 +115,16 @@ function parseAdaptationSetChildren(
       }
 
       case "Role":
-        if (isNullOrUndefined(children.roles)) {
-          children.roles = [parseScheme(currentNode)];
-        } else {
-          children.roles.push(parseScheme(currentNode));
-        }
+        children.Role.push(parseScheme(currentNode));
         break;
 
       case "SupplementalProperty":
-        if (isNullOrUndefined(children.supplementalProperties)) {
-          children.supplementalProperties = [parseScheme(currentNode)];
-        } else {
-          children.supplementalProperties.push(parseScheme(currentNode));
-        }
+        children.SupplementalProperty.push(parseScheme(currentNode));
         break;
 
       case "SegmentBase": {
         const [segmentBase, segmentBaseWarnings] = parseSegmentBase(currentNode);
-        children.segmentBase = segmentBase;
+        children.SegmentBase.push(segmentBase);
         if (segmentBaseWarnings.length > 0) {
           warnings = warnings.concat(segmentBaseWarnings);
         }
@@ -143,7 +133,7 @@ function parseAdaptationSetChildren(
 
       case "SegmentList": {
         const [segmentList, segmentListWarnings] = parseSegmentList(currentNode);
-        children.segmentList = segmentList;
+        children.SegmentList.push(segmentList);
         if (segmentListWarnings.length > 0) {
           warnings = warnings.concat(segmentListWarnings);
         }
@@ -153,7 +143,7 @@ function parseAdaptationSetChildren(
       case "SegmentTemplate": {
         const [segmentTemplate, segmentTemplateWarnings] =
           parseSegmentTemplate(currentNode);
-        children.segmentTemplate = segmentTemplate;
+        children.SegmentTemplate.push(segmentTemplate);
         if (segmentTemplateWarnings.length > 0) {
           warnings = warnings.concat(segmentTemplateWarnings);
         }
@@ -167,22 +157,19 @@ function parseAdaptationSetChildren(
           warnings = warnings.concat(contentProtectionWarnings);
         }
         if (contentProtection !== undefined) {
-          contentProtections.push(contentProtection);
+          children.ContentProtection.push(contentProtection);
         }
         break;
       }
 
       // case "Rating":
-      //   children.rating = currentNode;
+      //   children.Rating.push(currentNode);
       //   break;
 
       // case "Viewpoint":
-      //   children.viewpoint = currentNode;
+      //   children.Viewpoint.push(currentNode);
       //   break;
     }
-  }
-  if (contentProtections.length > 0) {
-    children.contentProtections = contentProtections;
   }
   return [children, warnings];
 }
@@ -210,14 +197,13 @@ function parseAdaptationSetAttributes(root: ITNode): [IAdaptationSetAttributes, 
 
       case "group":
         parseValue(attributeVal, {
-          asKey: "group",
           parser: parseMPDInteger,
-          dashName: "group",
+          name: "group",
         });
         break;
 
       case "lang":
-        parsedAdaptation.language = attributeVal;
+        parsedAdaptation.lang = attributeVal;
         break;
 
       case "contentType":
@@ -230,97 +216,85 @@ function parseAdaptationSetAttributes(root: ITNode): [IAdaptationSetAttributes, 
 
       case "minBandwidth":
         parseValue(attributeVal, {
-          asKey: "minBitrate",
           parser: parseMPDInteger,
-          dashName: "minBandwidth",
+          name: "minBandwidth",
         });
         break;
 
       case "maxBandwidth":
         parseValue(attributeVal, {
-          asKey: "maxBitrate",
           parser: parseMPDInteger,
-          dashName: "maxBandwidth",
+          name: "maxBandwidth",
         });
         break;
 
       case "minWidth":
         parseValue(attributeVal, {
-          asKey: "minWidth",
           parser: parseMPDInteger,
-          dashName: "minWidth",
+          name: "minWidth",
         });
         break;
 
       case "maxWidth":
         parseValue(attributeVal, {
-          asKey: "maxWidth",
           parser: parseMPDInteger,
-          dashName: "maxWidth",
+          name: "maxWidth",
         });
         break;
 
       case "minHeight":
         parseValue(attributeVal, {
-          asKey: "minHeight",
           parser: parseMPDInteger,
-          dashName: "minHeight",
+          name: "minHeight",
         });
         break;
 
       case "maxHeight":
         parseValue(attributeVal, {
-          asKey: "maxHeight",
           parser: parseMPDInteger,
-          dashName: "maxHeight",
+          name: "maxHeight",
         });
         break;
 
       case "minFrameRate":
         parseValue(attributeVal, {
-          asKey: "minFrameRate",
           parser: parseMaybeDividedNumber,
-          dashName: "minFrameRate",
+          name: "minFrameRate",
         });
         break;
 
       case "maxFrameRate":
         parseValue(attributeVal, {
-          asKey: "maxFrameRate",
           parser: parseMaybeDividedNumber,
-          dashName: "maxFrameRate",
+          name: "maxFrameRate",
         });
         break;
 
       case "selectionPriority":
         parseValue(attributeVal, {
-          asKey: "selectionPriority",
           parser: parseMPDInteger,
-          dashName: "selectionPriority",
-        });
-        break;
-
-      case "segmentAlignment":
-        parseValue(attributeVal, {
-          asKey: "segmentAlignment",
-          parser: parseIntOrBoolean,
-          dashName: "segmentAlignment",
+          name: "selectionPriority",
         });
         break;
 
       case "subsegmentAlignment":
         parseValue(attributeVal, {
-          asKey: "subsegmentAlignment",
           parser: parseIntOrBoolean,
-          dashName: "subsegmentAlignment",
+          name: "subsegmentAlignment",
+        });
+        break;
+
+      case "segmentAlignment":
+        parseValue(attributeVal, {
+          parser: parseIntOrBoolean,
+          name: "segmentAlignment",
         });
         break;
 
       case "bitstreamSwitching":
         parseValue(attributeVal, {
-          asKey: "bitstreamSwitching",
           parser: parseBoolean,
-          dashName: "bitstreamSwitching",
+          name: "bitstreamSwitching",
         });
         break;
 
@@ -333,46 +307,41 @@ function parseAdaptationSetAttributes(root: ITNode): [IAdaptationSetAttributes, 
         break;
 
       case "scte214:supplementalCodecs":
-        parsedAdaptation.supplementalCodecs = attributeVal;
+        parsedAdaptation["scte214:supplementalCodecs"] = attributeVal;
         break;
 
       case "codingDependency":
         parseValue(attributeVal, {
-          asKey: "codingDependency",
           parser: parseBoolean,
-          dashName: "codingDependency",
+          name: "codingDependency",
         });
         break;
 
       case "frameRate":
         parseValue(attributeVal, {
-          asKey: "frameRate",
           parser: parseMaybeDividedNumber,
-          dashName: "frameRate",
+          name: "frameRate",
         });
         break;
 
       case "height":
         parseValue(attributeVal, {
-          asKey: "height",
           parser: parseMPDInteger,
-          dashName: "height",
+          name: "height",
         });
         break;
 
       case "maxPlayoutRate":
         parseValue(attributeVal, {
-          asKey: "maxPlayoutRate",
           parser: parseMPDFloat,
-          dashName: "maxPlayoutRate",
+          name: "maxPlayoutRate",
         });
         break;
 
       case "maximumSAPPeriod":
         parseValue(attributeVal, {
-          asKey: "maximumSAPPeriod",
           parser: parseMPDFloat,
-          dashName: "maximumSAPPeriod",
+          name: "maximumSAPPeriod",
         });
         break;
 
@@ -390,25 +359,22 @@ function parseAdaptationSetAttributes(root: ITNode): [IAdaptationSetAttributes, 
 
       case "width":
         parseValue(attributeVal, {
-          asKey: "width",
           parser: parseMPDInteger,
-          dashName: "width",
+          name: "width",
         });
         break;
 
       case "availabilityTimeOffset":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeOffset",
           parser: parseMPDFloat,
-          dashName: "availabilityTimeOffset",
+          name: "availabilityTimeOffset",
         });
         break;
 
       case "availabilityTimeComplete":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeComplete",
           parser: parseBoolean,
-          dashName: "availabilityTimeComplete",
+          name: "availabilityTimeComplete",
         });
         break;
     }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/ContentComponent.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/ContentComponent.ts
@@ -16,15 +16,17 @@
 
 import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
-import type { IContentComponentAttributes } from "../../node_parser_types.ts";
+import type { IContentComponentIntermediateRepresentation } from "../../node_parser_types.ts";
 
 /**
  * Parse a "ContentComponent" Element in a DASH MPD.
  * @param {Object} root
  * @returns {Object}
  */
-export default function parseContentComponent(root: ITNode): IContentComponentAttributes {
-  const ret: IContentComponentAttributes = {};
+export default function parseContentComponent(
+  root: ITNode,
+): IContentComponentIntermediateRepresentation {
+  const ret: IContentComponentIntermediateRepresentation = { attributes: {} };
   for (const attributeName of Object.keys(root.attributes)) {
     const attributeVal = root.attributes[attributeName];
     if (isNullOrUndefined(attributeVal)) {
@@ -32,16 +34,16 @@ export default function parseContentComponent(root: ITNode): IContentComponentAt
     }
     switch (attributeName) {
       case "id":
-        ret.id = attributeVal;
+        ret.attributes.id = attributeVal;
         break;
       case "lang":
-        ret.language = attributeVal;
+        ret.attributes.lang = attributeVal;
         break;
       case "contentType":
-        ret.contentType = attributeVal;
+        ret.attributes.contentType = attributeVal;
         break;
       case "par":
-        ret.par = attributeVal;
+        ret.attributes.par = attributeVal;
         break;
     }
   }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.ts
@@ -33,7 +33,7 @@ function parseContentProtectionChildren(
   contentProtectionChildren: Array<ITNode | string>,
 ): [IContentProtectionChildren, Error[]] {
   const warnings: Error[] = [];
-  const cencPssh: Uint8Array[] = [];
+  const cencPssh: Array<{ value: Uint8Array }> = [];
   for (let i = 0; i < contentProtectionChildren.length; i++) {
     const currentElement = contentProtectionChildren[i];
     if (typeof currentElement !== "string" && currentElement.tagName === "cenc:pssh") {
@@ -45,12 +45,12 @@ function parseContentProtectionChildren(
           warnings.push(error);
         }
         if (toUint8Array !== null) {
-          cencPssh.push(toUint8Array);
+          cencPssh.push({ value: toUint8Array });
         }
       }
     }
   }
-  return [{ cencPssh }, warnings];
+  return [{ ["cenc:pssh"]: cencPssh }, warnings];
 }
 
 /**
@@ -72,7 +72,7 @@ function parseContentProtectionAttributes(root: ITNode): IContentProtectionAttri
         ret.value = attributeVal;
         break;
       case "cenc:default_KID":
-        ret.keyId = hexToBytes(attributeVal.replace(/-/g, ""));
+        ret["cenc:default_KID"] = hexToBytes(attributeVal.replace(/-/g, ""));
         break;
       case "ref":
         ret.ref = attributeVal;

--- a/src/parsers/manifest/dash/js-parser/node_parsers/EventStream.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/EventStream.ts
@@ -48,9 +48,8 @@ function parseEventStreamAttributes(root: ITNode): [IEventStreamAttributes, Erro
 
       case "timescale":
         parseValue(attributeVal, {
-          asKey: "timescale",
           parser: parseMPDInteger,
-          dashName: "timescale",
+          name: "timescale",
         });
         break;
 
@@ -119,5 +118,5 @@ export function createEventStreamIntermediateRepresentation(
     }
   }
 
-  return [{ children: { events }, attributes }, warnings];
+  return [{ children: { Event: events }, attributes }, warnings];
 }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/Initialization.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/Initialization.ts
@@ -16,7 +16,7 @@
 
 import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
-import type { IInitializationAttributes } from "../../node_parser_types.ts";
+import type { IInitializationIntermediateRepresentation } from "../../node_parser_types.ts";
 import { parseByteRange, ValueParser } from "./utils.ts";
 
 /**
@@ -25,10 +25,12 @@ import { parseByteRange, ValueParser } from "./utils.ts";
  */
 export default function parseInitialization(
   root: ITNode,
-): [IInitializationAttributes, Error[]] {
-  const parsedInitialization: IInitializationAttributes = {};
+): [IInitializationIntermediateRepresentation, Error[]] {
+  const parsedInitialization: IInitializationIntermediateRepresentation = {
+    attributes: {},
+  };
   const warnings: Error[] = [];
-  const parseValue = ValueParser(parsedInitialization, warnings);
+  const parseValue = ValueParser(parsedInitialization.attributes, warnings);
   for (const attributeName of Object.keys(root.attributes)) {
     const attributeVal = root.attributes[attributeName];
     if (isNullOrUndefined(attributeVal)) {
@@ -37,14 +39,13 @@ export default function parseInitialization(
     switch (attributeName) {
       case "range":
         parseValue(attributeVal, {
-          asKey: "range",
           parser: parseByteRange,
-          dashName: "range",
+          name: "range",
         });
         break;
 
       case "sourceURL":
-        parsedInitialization.media = attributeVal;
+        parsedInitialization.attributes.sourceURL = attributeVal;
         break;
     }
   }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/MPD.ts
@@ -18,13 +18,9 @@ import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import startsWith from "../../../../../utils/starts_with.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
 import type {
-  IBaseUrlIntermediateRepresentation,
-  IContentProtectionIntermediateRepresentation,
   IMPDAttributes,
   IMPDChildren,
   IMPDIntermediateRepresentation,
-  IPeriodIntermediateRepresentation,
-  IScheme,
 } from "../../node_parser_types.ts";
 import parseBaseURL from "./BaseURL.ts";
 import parseContentProtection from "./ContentProtection.ts";
@@ -46,11 +42,13 @@ function parseMPDChildren(
   mpdChildren: Array<ITNode | string>,
   fullMpd: string,
 ): [IMPDChildren, Error[]] {
-  const baseURLs: IBaseUrlIntermediateRepresentation[] = [];
-  const locations: string[] = [];
-  const periods: IPeriodIntermediateRepresentation[] = [];
-  const utcTimings: IScheme[] = [];
-  const contentProtections: IContentProtectionIntermediateRepresentation[] = [];
+  const ret: IMPDChildren = {
+    BaseURL: [],
+    Location: [],
+    Period: [],
+    UTCTiming: [],
+    ContentProtection: [],
+  };
 
   let warnings: Error[] = [];
   for (let i = 0; i < mpdChildren.length; i++) {
@@ -62,14 +60,14 @@ function parseMPDChildren(
       case "BaseURL": {
         const [baseURLObj, baseURLWarnings] = parseBaseURL(currentNode);
         if (baseURLObj !== undefined) {
-          baseURLs.push(baseURLObj);
+          ret.BaseURL.push(baseURLObj);
         }
         warnings = warnings.concat(baseURLWarnings);
         break;
       }
 
       case "Location":
-        locations.push(textContent(currentNode.children));
+        ret.Location.push({ value: textContent(currentNode.children) });
         break;
 
       case "Period": {
@@ -77,14 +75,14 @@ function parseMPDChildren(
           currentNode,
           fullMpd,
         );
-        periods.push(period);
+        ret.Period.push(period);
         warnings = warnings.concat(periodWarnings);
         break;
       }
 
       case "UTCTiming": {
         const utcTiming = parseScheme(currentNode);
-        utcTimings.push(utcTiming);
+        ret.UTCTiming.push(utcTiming);
         break;
       }
 
@@ -95,13 +93,13 @@ function parseMPDChildren(
           warnings = warnings.concat(contentProtectionWarnings);
         }
         if (contentProtection !== undefined) {
-          contentProtections.push(contentProtection);
+          ret.ContentProtection.push(contentProtection);
         }
         break;
       }
     }
   }
-  return [{ baseURLs, locations, periods, utcTimings, contentProtections }, warnings];
+  return [ret, warnings];
 }
 
 /**
@@ -131,72 +129,62 @@ function parseMPDAttributes(root: ITNode): [IMPDAttributes, Error[]] {
 
       case "availabilityStartTime":
         parseValue(attributeVal, {
-          asKey: "availabilityStartTime",
           parser: parseDateTime,
-          dashName: "availabilityStartTime",
+          name: "availabilityStartTime",
         });
         break;
       case "availabilityEndTime":
         parseValue(attributeVal, {
-          asKey: "availabilityEndTime",
           parser: parseDateTime,
-          dashName: "availabilityEndTime",
+          name: "availabilityEndTime",
         });
         break;
       case "publishTime":
         parseValue(attributeVal, {
-          asKey: "publishTime",
           parser: parseDateTime,
-          dashName: "publishTime",
+          name: "publishTime",
         });
         break;
       case "mediaPresentationDuration":
         parseValue(attributeVal, {
-          asKey: "duration",
           parser: parseDuration,
-          dashName: "mediaPresentationDuration",
+          name: "mediaPresentationDuration",
         });
         break;
       case "minimumUpdatePeriod":
         parseValue(attributeVal, {
-          asKey: "minimumUpdatePeriod",
           parser: parseDuration,
-          dashName: "minimumUpdatePeriod",
+          name: "minimumUpdatePeriod",
         });
         break;
       case "minBufferTime":
         parseValue(attributeVal, {
-          asKey: "minBufferTime",
           parser: parseDuration,
-          dashName: "minBufferTime",
+          name: "minBufferTime",
         });
         break;
       case "timeShiftBufferDepth":
         parseValue(attributeVal, {
-          asKey: "timeShiftBufferDepth",
           parser: parseDuration,
-          dashName: "timeShiftBufferDepth",
+          name: "timeShiftBufferDepth",
         });
         break;
       case "suggestedPresentationDelay":
         parseValue(attributeVal, {
-          asKey: "suggestedPresentationDelay",
           parser: parseDuration,
-          dashName: "suggestedPresentationDelay",
+          name: "suggestedPresentationDelay",
         });
         break;
       case "maxSegmentDuration":
         parseValue(attributeVal, {
-          asKey: "maxSegmentDuration",
           parser: parseDuration,
-          dashName: "maxSegmentDuration",
+          name: "maxSegmentDuration",
         });
         break;
       case "maxSubsegmentDuration":
         parseValue(attributeVal, {
-          asKey: "maxSubsegmentDuration",
           parser: parseDuration,
-          dashName: "maxSubsegmentDuration",
+          name: "maxSubsegmentDuration",
         });
         break;
 

--- a/src/parsers/manifest/dash/js-parser/node_parsers/Period.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/Period.ts
@@ -18,14 +18,9 @@ import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import startsWith from "../../../../../utils/starts_with.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
 import type {
-  IAdaptationSetIntermediateRepresentation,
-  IBaseUrlIntermediateRepresentation,
-  IContentProtectionIntermediateRepresentation,
-  IEventStreamIntermediateRepresentation,
   IPeriodAttributes,
   IPeriodChildren,
   IPeriodIntermediateRepresentation,
-  ISegmentTemplateIntermediateRepresentation,
 } from "../../node_parser_types.ts";
 import { createAdaptationSetIntermediateRepresentation } from "./AdaptationSet.ts";
 import parseBaseURL from "./BaseURL.ts";
@@ -43,13 +38,14 @@ function parsePeriodChildren(
   periodChildren: Array<ITNode | string>,
   fullMpd: string,
 ): [IPeriodChildren, Error[]] {
-  const baseURLs: IBaseUrlIntermediateRepresentation[] = [];
-  const adaptations: IAdaptationSetIntermediateRepresentation[] = [];
-  let segmentTemplate: ISegmentTemplateIntermediateRepresentation | undefined;
-  const contentProtections: IContentProtectionIntermediateRepresentation[] = [];
-
+  const ret: IPeriodChildren = {
+    AdaptationSet: [],
+    BaseURL: [],
+    ContentProtection: [],
+    SegmentTemplate: [],
+    EventStream: [],
+  };
   let warnings: Error[] = [];
-  const eventStreams: IEventStreamIntermediateRepresentation[] = [];
   for (let i = 0; i < periodChildren.length; i++) {
     const currentElement = periodChildren[i];
     if (typeof currentElement === "string") {
@@ -59,7 +55,7 @@ function parsePeriodChildren(
       case "BaseURL": {
         const [baseURLObj, baseURLWarnings] = parseBaseURL(currentElement);
         if (baseURLObj !== undefined) {
-          baseURLs.push(baseURLObj);
+          ret.BaseURL.push(baseURLObj);
         }
         warnings = warnings.concat(baseURLWarnings);
         break;
@@ -68,7 +64,7 @@ function parsePeriodChildren(
       case "AdaptationSet": {
         const [adaptation, adaptationWarnings] =
           createAdaptationSetIntermediateRepresentation(currentElement);
-        adaptations.push(adaptation);
+        ret.AdaptationSet.push(adaptation);
         warnings = warnings.concat(adaptationWarnings);
         break;
       }
@@ -76,7 +72,7 @@ function parsePeriodChildren(
       case "EventStream": {
         const [eventStream, eventStreamWarnings] =
           createEventStreamIntermediateRepresentation(currentElement, fullMpd);
-        eventStreams.push(eventStream);
+        ret.EventStream.push(eventStream);
         warnings = warnings.concat(eventStreamWarnings);
         break;
       }
@@ -84,7 +80,7 @@ function parsePeriodChildren(
       case "SegmentTemplate": {
         const [parsedSegmentTemplate, segmentTemplateWarnings] =
           parseSegmentTemplate(currentElement);
-        segmentTemplate = parsedSegmentTemplate;
+        ret.SegmentTemplate.push(parsedSegmentTemplate);
         if (segmentTemplateWarnings.length > 0) {
           warnings = warnings.concat(segmentTemplateWarnings);
         }
@@ -98,17 +94,14 @@ function parsePeriodChildren(
           warnings = warnings.concat(contentProtectionWarnings);
         }
         if (contentProtection !== undefined) {
-          contentProtections.push(contentProtection);
+          ret.ContentProtection.push(contentProtection);
         }
         break;
       }
     }
   }
 
-  return [
-    { baseURLs, adaptations, eventStreams, segmentTemplate, contentProtections },
-    warnings,
-  ];
+  return [ret, warnings];
 }
 
 /**
@@ -131,34 +124,31 @@ function parsePeriodAttributes(root: ITNode): [IPeriodAttributes, Error[]] {
 
       case "start":
         parseValue(attributeVal, {
-          asKey: "start",
           parser: parseDuration,
-          dashName: "start",
+          name: "start",
         });
         break;
 
       case "duration":
         parseValue(attributeVal, {
-          asKey: "duration",
           parser: parseDuration,
-          dashName: "duration",
+          name: "duration",
         });
         break;
 
       case "bitstreamSwitching":
         parseValue(attributeVal, {
-          asKey: "bitstreamSwitching",
           parser: parseBoolean,
-          dashName: "bitstreamSwitching",
+          name: "bitstreamSwitching",
         });
         break;
 
       case "xlink:href":
-        res.xlinkHref = attributeVal;
+        res["xlink:href"] = attributeVal;
         break;
 
       case "xlink:actuate":
-        res.xlinkActuate = attributeVal;
+        res["xlink:actuate"] = attributeVal;
         break;
 
       default:

--- a/src/parsers/manifest/dash/js-parser/node_parsers/Representation.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/Representation.ts
@@ -44,10 +44,15 @@ function parseRepresentationChildren(
   representationChildren: Array<string | ITNode>,
 ): [IRepresentationChildren, Error[]] {
   const children: IRepresentationChildren = {
-    baseURLs: [],
+    BaseURL: [],
+    ContentProtection: [],
+    InbandEventStream: [],
+    SegmentTemplate: [],
+    SegmentBase: [],
+    SegmentList: [],
+    SupplementalProperty: [],
+    EssentialProperty: [],
   };
-  const contentProtections = [];
-
   let warnings: Error[] = [];
   for (let i = 0; i < representationChildren.length; i++) {
     const currentElement = representationChildren[i];
@@ -59,36 +64,31 @@ function parseRepresentationChildren(
       case "BaseURL": {
         const [baseURLObj, baseURLWarnings] = parseBaseURL(currentElement);
         if (baseURLObj !== undefined) {
-          children.baseURLs.push(baseURLObj);
+          children.BaseURL.push(baseURLObj);
         }
         warnings = warnings.concat(baseURLWarnings);
         break;
       }
       case "InbandEventStream":
-        if (children.inbandEventStreams === undefined) {
-          children.inbandEventStreams = [];
-        }
-        children.inbandEventStreams.push(parseScheme(currentElement));
+        children.InbandEventStream.push(parseScheme(currentElement));
         break;
       case "SegmentBase": {
         const [segmentBase, segmentBaseWarnings] = parseSegmentBase(currentElement);
-        children.segmentBase = segmentBase;
-        if (segmentBaseWarnings.length > 0) {
-          warnings = warnings.concat(segmentBaseWarnings);
-        }
+        warnings = warnings.concat(segmentBaseWarnings);
+        children.SegmentBase.push(segmentBase);
         break;
       }
       case "SegmentList": {
         const [segmentList, segmentListWarnings] = parseSegmentList(currentElement);
         warnings = warnings.concat(segmentListWarnings);
-        children.segmentList = segmentList;
+        children.SegmentList.push(segmentList);
         break;
       }
       case "SegmentTemplate": {
         const [segmentTemplate, segmentTemplateWarnings] =
           parseSegmentTemplate(currentElement);
         warnings = warnings.concat(segmentTemplateWarnings);
-        children.segmentTemplate = segmentTemplate;
+        children.SegmentTemplate.push(segmentTemplate);
         break;
       }
 
@@ -99,28 +99,17 @@ function parseRepresentationChildren(
           warnings = warnings.concat(contentProtectionWarnings);
         }
         if (contentProtection !== undefined) {
-          contentProtections.push(contentProtection);
+          children.ContentProtection.push(contentProtection);
         }
         break;
       }
       case "EssentialProperty":
-        if (isNullOrUndefined(children.essentialProperties)) {
-          children.essentialProperties = [parseScheme(currentElement)];
-        } else {
-          children.essentialProperties.push(parseScheme(currentElement));
-        }
+        children.EssentialProperty.push(parseScheme(currentElement));
         break;
       case "SupplementalProperty":
-        if (isNullOrUndefined(children.supplementalProperties)) {
-          children.supplementalProperties = [parseScheme(currentElement)];
-        } else {
-          children.supplementalProperties.push(parseScheme(currentElement));
-        }
+        children.SupplementalProperty.push(parseScheme(currentElement));
         break;
     }
-  }
-  if (contentProtections.length > 0) {
-    children.contentProtections = contentProtections;
   }
   return [children, warnings];
 }
@@ -148,9 +137,8 @@ function parseRepresentationAttributes(
 
       case "bandwidth":
         parseValue(attributeVal, {
-          asKey: "bitrate",
           parser: parseMPDInteger,
-          dashName: "bandwidth",
+          name: "bandwidth",
         });
         break;
 
@@ -160,25 +148,22 @@ function parseRepresentationAttributes(
 
       case "codingDependency":
         parseValue(attributeVal, {
-          asKey: "codingDependency",
           parser: parseBoolean,
-          dashName: "codingDependency",
+          name: "codingDependency",
         });
         break;
 
       case "frameRate":
         parseValue(attributeVal, {
-          asKey: "frameRate",
           parser: parseMaybeDividedNumber,
-          dashName: "frameRate",
+          name: "frameRate",
         });
         break;
 
       case "height":
         parseValue(attributeVal, {
-          asKey: "height",
           parser: parseMPDInteger,
-          dashName: "height",
+          name: "height",
         });
         break;
 
@@ -188,17 +173,15 @@ function parseRepresentationAttributes(
 
       case "maxPlayoutRate":
         parseValue(attributeVal, {
-          asKey: "maxPlayoutRate",
           parser: parseMPDFloat,
-          dashName: "maxPlayoutRate",
+          name: "maxPlayoutRate",
         });
         break;
 
       case "maximumSAPPeriod":
         parseValue(attributeVal, {
-          asKey: "maximumSAPPeriod",
           parser: parseMPDFloat,
-          dashName: "maximumSAPPeriod",
+          name: "maximumSAPPeriod",
         });
         break;
 
@@ -212,14 +195,13 @@ function parseRepresentationAttributes(
 
       case "qualityRanking":
         parseValue(attributeVal, {
-          asKey: "qualityRanking",
           parser: parseMPDInteger,
-          dashName: "qualityRanking",
+          name: "qualityRanking",
         });
         break;
 
       case "scte214:supplementalCodecs":
-        attributes.supplementalCodecs = attributeVal;
+        attributes["scte214:supplementalCodecs"] = attributeVal;
         break;
 
       case "segmentProfiles":
@@ -228,30 +210,27 @@ function parseRepresentationAttributes(
 
       case "width":
         parseValue(attributeVal, {
-          asKey: "width",
           parser: parseMPDInteger,
-          dashName: "width",
+          name: "width",
         });
         break;
 
       case "availabilityTimeOffset":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeOffset",
           parser: parseMPDFloat,
-          dashName: "availabilityTimeOffset",
+          name: "availabilityTimeOffset",
         });
         break;
 
       case "availabilityTimeComplete":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeComplete",
           parser: parseBoolean,
-          dashName: "availabilityTimeComplete",
+          name: "availabilityTimeComplete",
         });
         break;
     }
   }
-  if (attributes.bitrate === undefined) {
+  if (attributes.bandwidth === undefined) {
     warnings.push(new MPDError("No bitrate found on a Representation"));
   }
   return [attributes, warnings];

--- a/src/parsers/manifest/dash/js-parser/node_parsers/SegmentBase.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/SegmentBase.ts
@@ -34,17 +34,22 @@ import {
 export default function parseSegmentBase(
   root: ITNode,
 ): [ISegmentBaseIntermediateRepresentation, Error[]] {
-  const attributes: ISegmentBaseIntermediateRepresentation = {};
+  const ret: ISegmentBaseIntermediateRepresentation = {
+    children: {
+      Initialization: [],
+    },
+    attributes: {},
+  };
 
   let warnings: Error[] = [];
-  const parseValue = ValueParser(attributes, warnings);
+  const parseValue = ValueParser(ret.attributes, warnings);
   const segmentBaseChildren = root.children;
   for (let i = 0; i < segmentBaseChildren.length; i++) {
     const currentNode = segmentBaseChildren[i];
     if (typeof currentNode !== "string") {
       if (currentNode.tagName === "Initialization") {
         const [initialization, initializationWarnings] = parseInitialization(currentNode);
-        attributes.initialization = initialization;
+        ret.children.Initialization.push(initialization);
         warnings = warnings.concat(initializationWarnings);
       }
     }
@@ -58,77 +63,67 @@ export default function parseSegmentBase(
     switch (attributeName) {
       case "timescale":
         parseValue(attributeVal, {
-          asKey: "timescale",
           parser: parseMPDInteger,
-          dashName: "timescale",
+          name: "timescale",
         });
         break;
 
       case "presentationTimeOffset":
         parseValue(attributeVal, {
-          asKey: "presentationTimeOffset",
           parser: parseMPDFloat,
-          dashName: "presentationTimeOffset",
+          name: "presentationTimeOffset",
         });
         break;
 
       case "indexRange":
         parseValue(attributeVal, {
-          asKey: "indexRange",
           parser: parseByteRange,
-          dashName: "indexRange",
+          name: "indexRange",
         });
         break;
 
       case "indexRangeExact":
         parseValue(attributeVal, {
-          asKey: "indexRangeExact",
           parser: parseBoolean,
-          dashName: "indexRangeExact",
+          name: "indexRangeExact",
         });
         break;
 
       case "availabilityTimeOffset":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeOffset",
           parser: parseMPDFloat,
-          dashName: "availabilityTimeOffset",
+          name: "availabilityTimeOffset",
         });
         break;
 
       case "availabilityTimeComplete":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeComplete",
           parser: parseBoolean,
-          dashName: "availabilityTimeComplete",
+          name: "availabilityTimeComplete",
         });
         break;
 
       case "duration":
         parseValue(attributeVal, {
-          asKey: "duration",
           parser: parseMPDInteger,
-          dashName: "duration",
+          name: "duration",
         });
         break;
 
       case "startNumber":
         parseValue(attributeVal, {
-          asKey: "startNumber",
           parser: parseMPDInteger,
-          dashName: "startNumber",
+          name: "startNumber",
         });
         break;
 
       case "endNumber":
         parseValue(attributeVal, {
-          asKey: "endNumber",
           parser: parseMPDInteger,
-          dashName: "endNumber",
+          name: "endNumber",
         });
         break;
     }
   }
-
-  return [attributes, warnings];
+  return [ret, warnings];
 }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/SegmentList.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/SegmentList.ts
@@ -17,6 +17,7 @@
 import objectAssign from "../../../../../utils/object_assign.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
 import type {
+  ISegmentListChildren,
   ISegmentListIntermediateRepresentation,
   ISegmentUrlIntermediateRepresentation,
 } from "../../node_parser_types.ts";
@@ -47,6 +48,8 @@ export default function parseSegmentList(
       warnings = warnings.concat(segmentURLWarnings);
     }
   }
-  const ret = objectAssign(base, { list });
-  return [ret, warnings];
+  const children: ISegmentListChildren = objectAssign(base.children, {
+    SegmentURL: list,
+  });
+  return [{ children, attributes: base.attributes }, warnings];
 }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/SegmentTemplate.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/SegmentTemplate.ts
@@ -15,7 +15,6 @@
  */
 
 import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
-import objectAssign from "../../../../../utils/object_assign.ts";
 import type { ITNode } from "../../../../../utils/xml-parser.ts";
 import type {
   ISegmentTemplateIntermediateRepresentation,
@@ -47,12 +46,15 @@ export default function parseSegmentTemplate(
     }
   }
 
-  const ret: ISegmentTemplateIntermediateRepresentation = objectAssign({}, base, {
-    duration: base.duration,
-    timelineParser,
-  });
+  const ret: ISegmentTemplateIntermediateRepresentation = {
+    children: {
+      Initialization: base.children.Initialization,
+      timelineParser,
+    },
+    attributes: base.attributes,
+  };
 
-  const parseValue = ValueParser(ret, warnings);
+  const parseValue = ValueParser(ret.attributes, warnings);
 
   for (const attributeName of Object.keys(root.attributes)) {
     const attributeVal = root.attributes[attributeName];
@@ -61,44 +63,38 @@ export default function parseSegmentTemplate(
     }
     switch (attributeName) {
       case "initialization":
-        if (isNullOrUndefined(ret.initialization)) {
-          ret.initialization = { media: attributeVal };
-        }
+        ret.attributes.initialization = attributeVal;
         break;
 
       case "index":
-        ret.index = attributeVal;
+        ret.attributes.index = attributeVal;
         break;
 
       case "availabilityTimeOffset":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeOffset",
           parser: parseMPDFloat,
-          dashName: "availabilityTimeOffset",
+          name: "availabilityTimeOffset",
         });
         break;
 
       case "availabilityTimeComplete":
         parseValue(attributeVal, {
-          asKey: "availabilityTimeComplete",
           parser: parseBoolean,
-          dashName: "availabilityTimeComplete",
+          name: "availabilityTimeComplete",
         });
         break;
 
       case "media":
-        ret.media = attributeVal;
+        ret.attributes.media = attributeVal;
         break;
 
       case "bitstreamSwitching":
         parseValue(attributeVal, {
-          asKey: "bitstreamSwitching",
           parser: parseBoolean,
-          dashName: "bitstreamSwitching",
+          name: "bitstreamSwitching",
         });
         break;
     }
   }
-
   return [ret, warnings];
 }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/SegmentURL.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/SegmentURL.ts
@@ -28,9 +28,9 @@ import { parseByteRange, ValueParser } from "./utils.ts";
 export default function parseSegmentURL(
   root: ITNode,
 ): [ISegmentUrlIntermediateRepresentation, Error[]] {
-  const parsedSegmentURL: ISegmentUrlIntermediateRepresentation = {};
+  const parsedSegmentURL: ISegmentUrlIntermediateRepresentation = { attributes: {} };
   const warnings: Error[] = [];
-  const parseValue = ValueParser(parsedSegmentURL, warnings);
+  const parseValue = ValueParser(parsedSegmentURL.attributes, warnings);
   for (const attributeName of Object.keys(root.attributes)) {
     const attributeVal = root.attributes[attributeName];
     if (isNullOrUndefined(attributeVal)) {
@@ -38,26 +38,24 @@ export default function parseSegmentURL(
     }
     switch (attributeName) {
       case "media":
-        parsedSegmentURL.media = attributeVal;
+        parsedSegmentURL.attributes.media = attributeVal;
         break;
 
       case "indexRange":
         parseValue(attributeVal, {
-          asKey: "indexRange",
           parser: parseByteRange,
-          dashName: "indexRange",
+          name: "indexRange",
         });
         break;
 
       case "index":
-        parsedSegmentURL.index = attributeVal;
+        parsedSegmentURL.attributes.index = attributeVal;
         break;
 
       case "mediaRange":
         parseValue(attributeVal, {
-          asKey: "mediaRange",
           parser: parseByteRange,
-          dashName: "mediaRange",
+          name: "mediaRange",
         });
         break;
     }

--- a/src/parsers/manifest/dash/js-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/utils.ts
@@ -22,7 +22,7 @@ import { base64ToBytes } from "../../../../../utils/base64.ts";
 import isNonEmptyString from "../../../../../utils/is_non_empty_string.ts";
 import isNullOrUndefined from "../../../../../utils/is_null_or_undefined.ts";
 import { toContentString, type ITNode } from "../../../../../utils/xml-parser.ts";
-import type { IScheme } from "../../node_parser_types.ts";
+import type { ISchemeIntermediateRepresentation } from "../../node_parser_types.ts";
 
 const iso8601Duration =
   /^P(([\d.]*)Y)?(([\d.]*)M)?(([\d.]*)D)?T?(([\d.]*)H)?(([\d.]*)M)?(([\d.]*)S)?/;
@@ -288,7 +288,7 @@ function parseMaybeDividedNumber(
  * @param {Object} root
  * @returns {Object}
  */
-function parseScheme(root: ITNode): IScheme {
+function parseScheme(root: ITNode): ISchemeIntermediateRepresentation {
   let schemeIdUri: string | undefined;
   let value: string | undefined;
   for (const attributeName of Object.keys(root.attributes)) {
@@ -306,7 +306,7 @@ function parseScheme(root: ITNode): IScheme {
     }
   }
 
-  return { schemeIdUri, value };
+  return { attributes: { schemeIdUri, value } };
 }
 
 /**
@@ -322,34 +322,33 @@ function ValueParser<T>(dest: T, warnings: Error[]) {
    * Parse a single value and add it to the `dest` objects.
    * If an error arised while parsing, add it at the end of the `warnings` array.
    * @param {string} val - The value found in the MPD which we should parse.
-   * @param {Function} parsingFn - The parsing function adapted for this value.
-   * This is used only in error formatting,
+   * @param {Object} obj
+   * @param {Function} obj.parser - The parsing function adapted for this value.
+   * @param {string} obj.name - The name of the key as it appears in the MPD.
    */
   return function (
     val: string,
     {
-      asKey,
       parser,
-      dashName,
+      name,
     }: {
-      asKey: keyof T;
       parser: (
         value: string,
-        displayName: string,
+        displayName: keyof T,
       ) => [T[keyof T] | null, MPDError | null];
-      dashName: string;
+      name: keyof T;
     },
   ): void {
-    const [parsingResult, parsingError] = parser(val, dashName);
+    const [parsingResult, parsingError] = parser(val, name);
     if (parsingError !== null) {
       log.warn("dash", "failed to parse DASH value:", parsingError.message, {
-        dashName,
+        name: name as string,
       });
       warnings.push(parsingError);
     }
 
     if (parsingResult !== null) {
-      dest[asKey] = parsingResult;
+      dest[name] = parsingResult;
     }
   };
 }

--- a/src/parsers/manifest/dash/node_parser_types.ts
+++ b/src/parsers/manifest/dash/node_parser_types.ts
@@ -42,7 +42,7 @@ export interface IMPDChildren {
    * This is the content of all `BaseURL` elements encountered in this MPD node,
    * from the first encountered to the last encountered.
    */
-  baseURLs: IBaseUrlIntermediateRepresentation[];
+  BaseURL: IBaseUrlIntermediateRepresentation[];
   /**
    * Location(s) at which the Manifest can be refreshed.
    *
@@ -50,23 +50,23 @@ export interface IMPDChildren {
    * node,
    * from the first encountered to the last encountered.
    */
-  locations: string[];
+  Location: Array<{ value: string }>;
   /**
    * Temporal subdivisions in that Manifest.
    *
    * This is the content of all `Period` elements encountered in this MPD node,
    * from the first encountered to the last encountered.
    */
-  periods: IPeriodIntermediateRepresentation[];
+  Period: IPeriodIntermediateRepresentation[];
   /**
    * Gives way to synchronize a clock to the server time.
    *
    * This is the content of all `UTCTiming` elements encountered in this MPD
    * node, from the first encountered to the last encountered.
    */
-  utcTimings: IScheme[];
+  UTCTiming: ISchemeIntermediateRepresentation[];
   /** Encryption-related metadata. */
-  contentProtections?: IContentProtectionIntermediateRepresentation[] | undefined;
+  ContentProtection: IContentProtectionIntermediateRepresentation[];
 }
 
 /* Intermediate representation for the root's attributes. */
@@ -89,7 +89,7 @@ export interface IMPDAttributes {
   availabilityStartTime?: number;
   availabilityEndTime?: number;
   publishTime?: number;
-  duration?: number; // mediaPresentationDuration
+  mediaPresentationDuration?: number;
   minimumUpdatePeriod?: number;
   minBufferTime?: number;
   timeShiftBufferDepth?: number;
@@ -122,27 +122,27 @@ export interface IPeriodChildren {
    * This is the content of all `AdaptationSet` elements encountered in this
    * node, from the first encountered to the last encountered.
    */
-  adaptations: IAdaptationSetIntermediateRepresentation[];
+  AdaptationSet: IAdaptationSetIntermediateRepresentation[];
   /**
    * Root URL on which further relative URLs make reference.
    *
    * This is the content of all `BaseURL` elements encountered in this node,
    * from the first encountered to the last encountered.
    */
-  baseURLs: IBaseUrlIntermediateRepresentation[];
+  BaseURL: IBaseUrlIntermediateRepresentation[];
   /**
    * Provide a template with which we will be able to request segments.
    */
-  segmentTemplate?: ISegmentTemplateIntermediateRepresentation | undefined;
+  SegmentTemplate: ISegmentTemplateIntermediateRepresentation[];
   /**
    * Allows to signal events linked to this Period.
    *
    * This is the content of all `EventStream` elements encountered in this
    * node, from the first encountered to the last encountered.
    */
-  eventStreams: IEventStreamIntermediateRepresentation[];
+  EventStream: IEventStreamIntermediateRepresentation[];
   /** Encryption-related metadata. */
-  contentProtections?: IContentProtectionIntermediateRepresentation[] | undefined;
+  ContentProtection: IContentProtectionIntermediateRepresentation[];
 }
 
 /* Intermediate representation for A Period node's attributes. */
@@ -167,8 +167,8 @@ export interface IPeriodAttributes {
   bitstreamSwitching?: boolean;
   availabilityTimeComplete?: boolean;
   availabilityTimeOffset?: number;
-  xlinkHref?: string;
-  xlinkActuate?: string;
+  ["xlink:href"]?: string;
+  ["xlink:actuate"]?: string;
 
   /**
    * XML namespaces linked to the `<Period>` element.
@@ -186,24 +186,20 @@ export interface IAdaptationSetIntermediateRepresentation {
 }
 
 export interface IAdaptationSetChildren {
-  // required
-  baseURLs: IBaseUrlIntermediateRepresentation[];
-  representations: IRepresentationIntermediateRepresentation[];
-
-  // optional
-  accessibilities?: IScheme[] | undefined;
-  contentComponent?: IContentComponentAttributes | undefined;
+  BaseURL: IBaseUrlIntermediateRepresentation[];
+  Representation: IRepresentationIntermediateRepresentation[];
+  Accessibility: ISchemeIntermediateRepresentation[];
+  ContentComponent: IContentComponentIntermediateRepresentation[];
   /** Encryption-related metadata. */
-  contentProtections?: IContentProtectionIntermediateRepresentation[] | undefined;
-  essentialProperties?: IScheme[] | undefined;
-  inbandEventStreams?: IScheme[] | undefined;
-  roles?: IScheme[];
-  supplementalProperties?: IScheme[] | undefined;
-
-  segmentBase?: ISegmentBaseIntermediateRepresentation | undefined;
-  segmentList?: ISegmentListIntermediateRepresentation | undefined;
-  segmentTemplate?: ISegmentTemplateIntermediateRepresentation | undefined;
-  label?: string | undefined;
+  ContentProtection: IContentProtectionIntermediateRepresentation[];
+  EssentialProperty: ISchemeIntermediateRepresentation[];
+  InbandEventStream: ISchemeIntermediateRepresentation[];
+  Role: ISchemeIntermediateRepresentation[];
+  SupplementalProperty: ISchemeIntermediateRepresentation[];
+  SegmentBase: ISegmentBaseIntermediateRepresentation[];
+  SegmentList: ISegmentListIntermediateRepresentation[];
+  SegmentTemplate: ISegmentTemplateIntermediateRepresentation[];
+  Label: Array<{ value: string }>;
 }
 
 /* Intermediate representation for An AdaptationSet node's attributes. */
@@ -217,15 +213,15 @@ export interface IAdaptationSetAttributes {
   group?: number;
   height?: number;
   id?: string;
-  language?: string;
-  maxBitrate?: number;
+  lang?: string;
+  maxBandwidth?: number;
   maxFrameRate?: number;
   maxHeight?: number;
   maxPlayoutRate?: number;
   maxWidth?: number;
   maximumSAPPeriod?: number;
   mimeType?: string;
-  minBitrate?: number;
+  minBandwidth?: number;
   minFrameRate?: number;
   minHeight?: number;
   minWidth?: number;
@@ -235,7 +231,7 @@ export interface IAdaptationSetAttributes {
   segmentAlignment?: number | boolean;
   segmentProfiles?: string;
   subsegmentAlignment?: number | boolean;
-  supplementalCodecs?: string;
+  ["scte214:supplementalCodecs"]?: string;
   width?: number;
   availabilityTimeComplete?: boolean;
   availabilityTimeOffset?: number;
@@ -248,24 +244,21 @@ export interface IRepresentationIntermediateRepresentation {
 }
 
 export interface IRepresentationChildren {
-  // required
-  baseURLs: IBaseUrlIntermediateRepresentation[];
-
-  // optional
+  BaseURL: IBaseUrlIntermediateRepresentation[];
   /** Encryption-related metadata. */
-  contentProtections?: IContentProtectionIntermediateRepresentation[];
-  inbandEventStreams?: IScheme[];
-  segmentBase?: ISegmentBaseIntermediateRepresentation;
-  segmentList?: ISegmentListIntermediateRepresentation;
-  segmentTemplate?: ISegmentTemplateIntermediateRepresentation;
-  supplementalProperties?: IScheme[] | undefined;
-  essentialProperties?: IScheme[] | undefined;
+  ContentProtection: IContentProtectionIntermediateRepresentation[];
+  InbandEventStream: ISchemeIntermediateRepresentation[];
+  SegmentBase: ISegmentBaseIntermediateRepresentation[];
+  SegmentList: ISegmentListIntermediateRepresentation[];
+  SegmentTemplate: ISegmentTemplateIntermediateRepresentation[];
+  SupplementalProperty: ISchemeIntermediateRepresentation[];
+  EssentialProperty: ISchemeIntermediateRepresentation[];
 }
 
 /* Intermediate representation for A Representation node's attributes. */
 export interface IRepresentationAttributes {
   audioSamplingRate?: string;
-  bitrate?: number;
+  bandwidth?: number;
   codecs?: string;
   codingDependency?: boolean;
   frameRate?: number;
@@ -277,19 +270,27 @@ export interface IRepresentationAttributes {
   profiles?: string;
   qualityRanking?: number;
   segmentProfiles?: string;
-  supplementalCodecs?: string;
+  ["scte214:supplementalCodecs"]?: string;
   width?: number;
   availabilityTimeComplete?: boolean;
   availabilityTimeOffset?: number;
 }
 
 export interface ISegmentBaseIntermediateRepresentation {
+  children: ISegmentBaseChildren;
+  attributes: ISegmentBaseAttributes;
+}
+
+export interface ISegmentBaseChildren {
+  Initialization: IInitializationIntermediateRepresentation[];
+}
+
+export interface ISegmentBaseAttributes {
   availabilityTimeComplete?: boolean;
   availabilityTimeOffset?: number;
   duration?: number;
   indexRange?: [number, number];
   indexRangeExact?: boolean;
-  initialization?: IInitializationAttributes;
   media?: string;
   presentationTimeOffset?: number;
   startNumber?: number;
@@ -297,15 +298,26 @@ export interface ISegmentBaseIntermediateRepresentation {
   timescale?: number;
 }
 
+export interface IInitializationIntermediateRepresentation {
+  attributes: IInitializationAttributes;
+}
+
 export interface ISegmentListIntermediateRepresentation {
-  list: ISegmentUrlIntermediateRepresentation[];
+  children: ISegmentListChildren;
+  attributes: ISegmentListAttributes;
+}
+
+export interface ISegmentListChildren {
+  Initialization: IInitializationIntermediateRepresentation[];
+  SegmentURL: ISegmentUrlIntermediateRepresentation[];
+}
+
+export interface ISegmentListAttributes {
   availabilityTimeComplete?: boolean;
   availabilityTimeOffset?: number;
   duration?: number;
   indexRange?: [number, number];
   indexRangeExact?: boolean;
-  initialization?: IInitializationAttributes;
-  media?: string;
   presentationTimeOffset?: number;
   startNumber?: number;
   endNumber?: number;
@@ -313,6 +325,10 @@ export interface ISegmentListIntermediateRepresentation {
 }
 
 export interface ISegmentUrlIntermediateRepresentation {
+  attributes: ISegmentUrlAttributes;
+}
+
+export interface ISegmentUrlAttributes {
   media?: string;
   mediaRange?: [number, number];
   index?: string;
@@ -321,13 +337,17 @@ export interface ISegmentUrlIntermediateRepresentation {
 
 export interface IInitializationAttributes {
   range?: [number, number];
-  media?: string;
+  sourceURL?: string;
 }
 
 /** The ContentComponent once parsed. */
+export interface IContentComponentIntermediateRepresentation {
+  attributes: IContentComponentAttributes;
+}
+
 export interface IContentComponentAttributes {
   id?: string;
-  language?: string;
+  lang?: string;
   contentType?: string;
   par?: string;
 }
@@ -338,18 +358,29 @@ export interface IContentProtectionIntermediateRepresentation {
 }
 
 export interface IContentProtectionChildren {
-  cencPssh: Uint8Array[];
+  ["cenc:pssh"]: Array<{ value: Uint8Array }>;
 }
 
 export interface IContentProtectionAttributes {
   schemeIdUri?: string;
   value?: string;
-  keyId?: Uint8Array;
+  ["cenc:default_KID"]?: Uint8Array;
   refId?: string;
   ref?: string;
 }
 
 export interface ISegmentTemplateIntermediateRepresentation {
+  children: ISegmentTemplateChildren;
+  attributes: ISegmentTemplateAttributes;
+}
+
+export interface ISegmentTemplateChildren {
+  Initialization: IInitializationIntermediateRepresentation[];
+  timeline?: ISegmentTimelineElement[] | undefined;
+  timelineParser?: ITimelineParser | undefined;
+}
+
+export interface ISegmentTemplateAttributes {
   availabilityTimeComplete?: boolean | undefined;
   availabilityTimeOffset?: number | undefined;
   bitstreamSwitching?: boolean | undefined;
@@ -362,9 +393,7 @@ export interface ISegmentTemplateIntermediateRepresentation {
   startNumber?: number | undefined;
   endNumber?: number | undefined;
   timescale?: number | undefined;
-  initialization?: { media?: string } | undefined;
-  timeline?: ISegmentTimelineElement[] | undefined;
-  timelineParser?: ITimelineParser | undefined;
+  initialization?: string | undefined;
 }
 
 export interface ISegmentTimelineElement {
@@ -384,14 +413,18 @@ export interface IBaseUrlIntermediateRepresentation {
 }
 
 /** Intermediate representation for a Node following a "scheme" format. */
-export interface IScheme {
+export interface ISchemeIntermediateRepresentation {
+  attributes: ISchemeAttributes;
+}
+
+export interface ISchemeAttributes {
   /**
    * Content of the `schemeIdUri` attribute for that scheme.
    *
    * `undefined` if no `schemeIdUri` attribute has been found.
    */
   schemeIdUri?: string | undefined;
-  /** Inner content of that scheme. */
+  /** Value attribute of that scheme. */
   value?: string | undefined;
 }
 
@@ -417,7 +450,7 @@ export interface IEventStreamAttributes {
 }
 
 export interface IEventStreamChildren {
-  events: IEventStreamEventIntermediateRepresentation[];
+  Event: IEventStreamEventIntermediateRepresentation[];
 }
 
 export interface IEventStreamEventIntermediateRepresentation {

--- a/src/parsers/manifest/dash/wasm-parser/rs/events.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/events.rs
@@ -89,6 +89,9 @@ pub enum TagName {
 
     /// Indicate a <Label> node
     Label = 21,
+
+    /// Indicate an <Initialization> node
+    Initialization = 22,
 }
 
 #[derive(PartialEq, Clone, Copy)]

--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
@@ -87,7 +87,10 @@ impl MPDProcessor {
                         TagName::SegmentBase.report_tag_open();
                         attributes::report_segment_base_attrs(&tag);
                     }
-                    b"Initialization" => attributes::report_initialization_attrs(&tag),
+                    b"Initialization" => {
+                        TagName::Initialization.report_tag_open();
+                        attributes::report_initialization_attrs(&tag);
+                    }
                     b"SegmentTemplate" => {
                         TagName::SegmentTemplate.report_tag_open();
                         attributes::report_segment_template_attrs(&tag);
@@ -144,6 +147,7 @@ impl MPDProcessor {
                     b"SegmentList" => TagName::SegmentList.report_tag_close(),
                     b"SegmentURL" => TagName::SegmentUrl.report_tag_close(),
                     b"SegmentTemplate" => TagName::SegmentTemplate.report_tag_close(),
+                    b"Initialization" => TagName::Initialization.report_tag_close(),
                     b"UTCTiming" => TagName::UtcTiming.report_tag_close(),
                     _ => {}
                 },

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/AdaptationSet.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/AdaptationSet.ts
@@ -33,9 +33,15 @@ import {
   generateRepresentationChildrenParser,
 } from "./Representation.ts";
 import { generateSchemeAttrParser } from "./Scheme.ts";
-import { generateSegmentBaseAttrParser } from "./SegmentBase.ts";
+import {
+  generateSegmentBaseAttrParser,
+  generateSegmentBaseChildrenParser,
+} from "./SegmentBase.ts";
 import { generateSegmentListChildrenParser } from "./SegmentList.ts";
-import { generateSegmentTemplateAttrParser } from "./SegmentTemplate.ts";
+import {
+  generateSegmentTemplateAttrParser,
+  generateSegmentTemplateChildrenParser,
+} from "./SegmentTemplate.ts";
 
 /**
  * Generate a "children parser" once inside a `AdaptationSet` node.
@@ -52,44 +58,41 @@ export function generateAdaptationSetChildrenParser(
   return function onRootChildren(nodeId: number) {
     switch (nodeId) {
       case TagName.Accessibility: {
-        const accessibility = {};
-        if (adaptationSetChildren.accessibilities === undefined) {
-          adaptationSetChildren.accessibilities = [];
-        }
-        adaptationSetChildren.accessibilities.push(accessibility);
-        const schemeAttrParser = generateSchemeAttrParser(accessibility, linearMemory);
+        const accessibility = { attributes: {} };
+        adaptationSetChildren.Accessibility.push(accessibility);
+        const schemeAttrParser = generateSchemeAttrParser(
+          accessibility.attributes,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, noop, schemeAttrParser);
         break;
       }
 
       case TagName.BaseURL: {
         const baseUrl = { value: "", attributes: {} };
-        adaptationSetChildren.baseURLs.push(baseUrl);
+        adaptationSetChildren.BaseURL.push(baseUrl);
         const attributeParser = generateBaseUrlAttrParser(baseUrl, linearMemory);
         parsersStack.pushParsers(nodeId, noop, attributeParser);
         break;
       }
 
       case TagName.ContentComponent: {
-        const contentComponent = {};
-        adaptationSetChildren.contentComponent = contentComponent;
+        const contentComponent = { attributes: {} };
+        adaptationSetChildren.ContentComponent.push(contentComponent);
         parsersStack.pushParsers(
           nodeId,
           noop,
-          generateContentComponentAttrParser(contentComponent, linearMemory),
+          generateContentComponentAttrParser(contentComponent.attributes, linearMemory),
         );
         break;
       }
 
       case TagName.ContentProtection: {
         const contentProtection = {
-          children: { cencPssh: [] },
+          children: { ["cenc:pssh"]: [] },
           attributes: {},
         };
-        if (adaptationSetChildren.contentProtections === undefined) {
-          adaptationSetChildren.contentProtections = [];
-        }
-        adaptationSetChildren.contentProtections.push(contentProtection);
+        adaptationSetChildren.ContentProtection.push(contentProtection);
         const contentProtAttrParser = generateContentProtectionAttrParser(
           contentProtection,
           linearMemory,
@@ -99,37 +102,46 @@ export function generateAdaptationSetChildrenParser(
       }
 
       case TagName.EssentialProperty: {
-        const essentialProperty = {};
-        if (adaptationSetChildren.essentialProperties === undefined) {
-          adaptationSetChildren.essentialProperties = [];
-        }
-        adaptationSetChildren.essentialProperties.push(essentialProperty);
+        const essentialProperty = { attributes: {} };
+        adaptationSetChildren.EssentialProperty.push(essentialProperty);
 
         const childrenParser = noop; // EssentialProperty have no sub-element
-        const attributeParser = generateSchemeAttrParser(essentialProperty, linearMemory);
+        const attributeParser = generateSchemeAttrParser(
+          essentialProperty.attributes,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }
 
       case TagName.InbandEventStream: {
-        const inbandEvent = {};
-        if (adaptationSetChildren.inbandEventStreams === undefined) {
-          adaptationSetChildren.inbandEventStreams = [];
-        }
-        adaptationSetChildren.inbandEventStreams.push(inbandEvent);
+        const inbandEvent = { attributes: {} };
+        adaptationSetChildren.InbandEventStream.push(inbandEvent);
 
         const childrenParser = noop; // InbandEventStream have no sub-element
-        const attributeParser = generateSchemeAttrParser(inbandEvent, linearMemory);
+        const attributeParser = generateSchemeAttrParser(
+          inbandEvent.attributes,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }
 
       case TagName.Representation: {
         const representationObj = {
-          children: { baseURLs: [] },
+          children: {
+            BaseURL: [],
+            ContentProtection: [],
+            InbandEventStream: [],
+            SegmentBase: [],
+            SegmentList: [],
+            SegmentTemplate: [],
+            SupplementalProperty: [],
+            EssentialProperty: [],
+          },
           attributes: {},
         };
-        adaptationSetChildren.representations.push(representationObj);
+        adaptationSetChildren.Representation.push(representationObj);
         const childrenParser = generateRepresentationChildrenParser(
           representationObj.children,
           linearMemory,
@@ -144,24 +156,18 @@ export function generateAdaptationSetChildrenParser(
       }
 
       case TagName.Role: {
-        const role = {};
-        if (adaptationSetChildren.roles === undefined) {
-          adaptationSetChildren.roles = [];
-        }
-        adaptationSetChildren.roles.push(role);
-        const attributeParser = generateSchemeAttrParser(role, linearMemory);
+        const role = { attributes: {} };
+        adaptationSetChildren.Role.push(role);
+        const attributeParser = generateSchemeAttrParser(role.attributes, linearMemory);
         parsersStack.pushParsers(nodeId, noop, attributeParser);
         break;
       }
 
       case TagName.SupplementalProperty: {
-        const supplementalProperty = {};
-        if (adaptationSetChildren.supplementalProperties === undefined) {
-          adaptationSetChildren.supplementalProperties = [];
-        }
-        adaptationSetChildren.supplementalProperties.push(supplementalProperty);
+        const supplementalProperty = { attributes: {} };
+        adaptationSetChildren.SupplementalProperty.push(supplementalProperty);
         const attributeParser = generateSchemeAttrParser(
-          supplementalProperty,
+          supplementalProperty.attributes,
           linearMemory,
         );
         parsersStack.pushParsers(nodeId, noop, attributeParser);
@@ -169,21 +175,30 @@ export function generateAdaptationSetChildrenParser(
       }
 
       case TagName.SegmentBase: {
-        const segmentBaseObj = {};
-        adaptationSetChildren.segmentBase = segmentBaseObj;
+        const segmentBaseObj = { children: { Initialization: [] }, attributes: {} };
+        adaptationSetChildren.SegmentBase.push(segmentBaseObj);
         const attributeParser = generateSegmentBaseAttrParser(
           segmentBaseObj,
           linearMemory,
         );
-        parsersStack.pushParsers(nodeId, noop, attributeParser);
+        const childrenParser = generateSegmentBaseChildrenParser(
+          segmentBaseObj.children,
+          linearMemory,
+          parsersStack,
+        );
+        parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }
 
       case TagName.SegmentList: {
         const segmentListObj: ISegmentListIntermediateRepresentation = {
-          list: [],
+          children: {
+            Initialization: [],
+            SegmentURL: [],
+          },
+          attributes: {},
         };
-        adaptationSetChildren.segmentList = segmentListObj;
+        adaptationSetChildren.SegmentList.push(segmentListObj);
         const childrenParser = generateSegmentListChildrenParser(
           segmentListObj,
           linearMemory,
@@ -200,11 +215,15 @@ export function generateAdaptationSetChildrenParser(
       }
 
       case TagName.SegmentTemplate: {
-        const stObj = {};
-        adaptationSetChildren.segmentTemplate = stObj;
+        const stObj = { children: { Initialization: [] }, attributes: {} };
+        adaptationSetChildren.SegmentTemplate.push(stObj);
         parsersStack.pushParsers(
           nodeId,
-          noop, // SegmentTimeline as treated like an attribute
+          generateSegmentTemplateChildrenParser(
+            stObj.children,
+            linearMemory,
+            parsersStack,
+          ),
           generateSegmentTemplateAttrParser(stObj, linearMemory),
         );
         break;
@@ -248,12 +267,7 @@ export function generateAdaptationSetAttrParser(
         adaptationAttrs.group = dataView.getFloat64(ptr, true);
         break;
       case AttributeName.Language:
-        adaptationAttrs.language = parseString(
-          textDecoder,
-          linearMemory.buffer,
-          ptr,
-          len,
-        );
+        adaptationAttrs.lang = parseString(textDecoder, linearMemory.buffer, ptr, len);
         break;
       case AttributeName.ContentType:
         adaptationAttrs.contentType = parseString(
@@ -267,10 +281,10 @@ export function generateAdaptationSetAttrParser(
         adaptationAttrs.par = parseString(textDecoder, linearMemory.buffer, ptr, len);
         break;
       case AttributeName.MinBandwidth:
-        adaptationAttrs.minBitrate = dataView.getFloat64(ptr, true);
+        adaptationAttrs.minBandwidth = dataView.getFloat64(ptr, true);
         break;
       case AttributeName.MaxBandwidth:
-        adaptationAttrs.maxBitrate = dataView.getFloat64(ptr, true);
+        adaptationAttrs.maxBandwidth = dataView.getFloat64(ptr, true);
         break;
       case AttributeName.MinWidth:
         adaptationAttrs.minWidth = dataView.getFloat64(ptr, true);
@@ -318,7 +332,7 @@ export function generateAdaptationSetAttrParser(
         adaptationAttrs.codecs = parseString(textDecoder, linearMemory.buffer, ptr, len);
         break;
       case AttributeName.SupplementalCodecs:
-        adaptationAttrs.supplementalCodecs = parseString(
+        adaptationAttrs["scte214:supplementalCodecs"] = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,
@@ -373,10 +387,6 @@ export function generateAdaptationSetAttrParser(
       case AttributeName.AvailabilityTimeComplete:
         adaptationAttrs.availabilityTimeComplete = dataView.getUint8(0) === 0;
         break;
-
-      // TODO
-      // case AttributeName.StartsWithSap:
-      //   adaptationAttrs.startsWithSap = dataView.getFloat64(ptr, true);
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentComponent.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentComponent.ts
@@ -37,7 +37,7 @@ export function generateContentComponentAttrParser(
         break;
 
       case AttributeName.Language:
-        ccAttrs.language = parseString(textDecoder, linearMemory.buffer, ptr, len);
+        ccAttrs.lang = parseString(textDecoder, linearMemory.buffer, ptr, len);
         break;
 
       case AttributeName.ContentType:

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentProtection.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/ContentProtection.ts
@@ -43,13 +43,13 @@ export function generateContentProtectionAttrParser(
         break;
       case AttributeName.ContentProtectionKeyId: {
         const kid = parseString(textDecoder, linearMemory.buffer, ptr, len);
-        cpAttrs.keyId = hexToBytes(kid.replace(/-/g, ""));
+        cpAttrs["cenc:default_KID"] = hexToBytes(kid.replace(/-/g, ""));
         break;
       }
       case AttributeName.ContentProtectionCencPSSH:
         try {
           const b64 = parseString(textDecoder, linearMemory.buffer, ptr, len);
-          cpChildren.cencPssh.push(base64ToBytes(b64));
+          cpChildren["cenc:pssh"].push({ value: base64ToBytes(b64) });
         } catch (_) {
           /* TODO log error? register as warning? */
         }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/EventStream.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/EventStream.ts
@@ -43,7 +43,7 @@ export function generateEventStreamChildrenParser(
     switch (nodeId) {
       case TagName.EventStreamElt: {
         const event = {};
-        childrenObj.events.push(event);
+        childrenObj.Event.push(event);
         const attrParser = generateEventAttrParser(event, linearMemory, fullMpd);
         parsersStack.pushParsers(nodeId, noop, attrParser);
         break;

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Initialization.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Initialization.ts
@@ -1,0 +1,32 @@
+import type { IInitializationIntermediateRepresentation } from "../../../node_parser_types.ts";
+import type { IAttributeParser } from "../parsers_stack.ts";
+import { AttributeName } from "../types.ts";
+import { parseString } from "../utils.ts";
+
+export default function generateInitializationAttrParser(
+  initialization: IInitializationIntermediateRepresentation,
+  linearMemory: WebAssembly.Memory,
+): IAttributeParser {
+  const textDecoder = new TextDecoder();
+  return function onInitializationAttribute(attr, ptr, len) {
+    switch (attr) {
+      case AttributeName.InitializationRange: {
+        const dataView = new DataView(linearMemory.buffer);
+        initialization.attributes.range = [
+          dataView.getFloat64(ptr, true),
+          dataView.getFloat64(ptr + 8, true),
+        ];
+        break;
+      }
+
+      case AttributeName.InitializationMedia:
+        initialization.attributes.sourceURL = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
+        break;
+    }
+  };
+}

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Label.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Label.ts
@@ -10,7 +10,9 @@ export function generateLabelElementParser(
   const textDecoder = new TextDecoder();
   return function onMPDAttribute(attr: AttributeName, ptr: number, len: number) {
     if (attr === AttributeName.Text) {
-      adaptationSet.label = parseString(textDecoder, linearMemory.buffer, ptr, len);
+      adaptationSet.Label.push({
+        value: parseString(textDecoder, linearMemory.buffer, ptr, len),
+      });
     }
   };
 }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/MPD.ts
@@ -15,7 +15,12 @@
  */
 
 import noop from "../../../../../../utils/noop.ts";
-import type { IMPDAttributes, IMPDChildren } from "../../../node_parser_types.ts";
+import type {
+  IContentProtectionIntermediateRepresentation,
+  IMPDAttributes,
+  IMPDChildren,
+  IPeriodIntermediateRepresentation,
+} from "../../../node_parser_types.ts";
 import type { IAttributeParser, IChildrenParser } from "../parsers_stack.ts";
 import type ParsersStack from "../parsers_stack.ts";
 import { AttributeName, TagName } from "../types.ts";
@@ -43,7 +48,7 @@ export function generateMPDChildrenParser(
     switch (nodeId) {
       case TagName.BaseURL: {
         const baseUrl = { value: "", attributes: {} };
-        mpdChildren.baseURLs.push(baseUrl);
+        mpdChildren.BaseURL.push(baseUrl);
 
         const childrenParser = noop; // BaseURL have no sub-element
         const attributeParser = generateBaseUrlAttrParser(baseUrl, linearMemory);
@@ -52,11 +57,17 @@ export function generateMPDChildrenParser(
       }
 
       case TagName.Period: {
-        const period = {
-          children: { adaptations: [], baseURLs: [], eventStreams: [] },
+        const period: IPeriodIntermediateRepresentation = {
+          children: {
+            AdaptationSet: [],
+            BaseURL: [],
+            SegmentTemplate: [],
+            EventStream: [],
+            ContentProtection: [],
+          },
           attributes: {},
         };
-        mpdChildren.periods.push(period);
+        mpdChildren.Period.push(period);
         const childrenParser = generatePeriodChildrenParser(
           period.children,
           linearMemory,
@@ -69,24 +80,24 @@ export function generateMPDChildrenParser(
       }
 
       case TagName.UtcTiming: {
-        const utcTiming = {};
-        mpdChildren.utcTimings.push(utcTiming);
+        const utcTiming = { attributes: {} };
+        mpdChildren.UTCTiming.push(utcTiming);
 
         const childrenParser = noop; // UTCTiming have no sub-element
-        const attributeParser = generateSchemeAttrParser(utcTiming, linearMemory);
+        const attributeParser = generateSchemeAttrParser(
+          utcTiming.attributes,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }
 
       case TagName.ContentProtection: {
-        const contentProtection = {
-          children: { cencPssh: [] },
+        const contentProtection: IContentProtectionIntermediateRepresentation = {
+          children: { ["cenc:pssh"]: [] },
           attributes: {},
         };
-        if (mpdChildren.contentProtections === undefined) {
-          mpdChildren.contentProtections = [];
-        }
-        mpdChildren.contentProtections.push(contentProtection);
+        mpdChildren.ContentProtection.push(contentProtection);
         const contentProtAttrParser = generateContentProtectionAttrParser(
           contentProtection,
           linearMemory,
@@ -139,7 +150,7 @@ export function generateMPDAttrParser(
       }
       case AttributeName.MediaPresentationDuration:
         dataView = new DataView(linearMemory.buffer);
-        mpdAttrs.duration = dataView.getFloat64(ptr, true);
+        mpdAttrs.mediaPresentationDuration = dataView.getFloat64(ptr, true);
         break;
       case AttributeName.MinimumUpdatePeriod:
         dataView = new DataView(linearMemory.buffer);
@@ -167,7 +178,7 @@ export function generateMPDAttrParser(
         break;
       case AttributeName.Location: {
         const location = parseString(textDecoder, linearMemory.buffer, ptr, len);
-        mpdChildren.locations.push(location);
+        mpdChildren.Location.push({ value: location });
         break;
       }
       case AttributeName.Namespace: {

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Period.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Period.ts
@@ -34,7 +34,10 @@ import {
   generateEventStreamAttrParser,
   generateEventStreamChildrenParser,
 } from "./EventStream.ts";
-import { generateSegmentTemplateAttrParser } from "./SegmentTemplate.ts";
+import {
+  generateSegmentTemplateAttrParser,
+  generateSegmentTemplateChildrenParser,
+} from "./SegmentTemplate.ts";
 
 /**
  * Generate a "children parser" once inside a `Perod` node.
@@ -54,10 +57,24 @@ export function generatePeriodChildrenParser(
     switch (nodeId) {
       case TagName.AdaptationSet: {
         const adaptationObj = {
-          children: { baseURLs: [], representations: [] },
+          children: {
+            BaseURL: [],
+            Representation: [],
+            Accessibility: [],
+            ContentComponent: [],
+            ContentProtection: [],
+            EssentialProperty: [],
+            InbandEventStream: [],
+            Role: [],
+            SupplementalProperty: [],
+            SegmentBase: [],
+            SegmentList: [],
+            SegmentTemplate: [],
+            Label: [],
+          },
           attributes: {},
         };
-        periodChildren.adaptations.push(adaptationObj);
+        periodChildren.AdaptationSet.push(adaptationObj);
         const childrenParser = generateAdaptationSetChildrenParser(
           adaptationObj.children,
           linearMemory,
@@ -73,7 +90,7 @@ export function generatePeriodChildrenParser(
 
       case TagName.BaseURL: {
         const baseUrl = { value: "", attributes: {} };
-        periodChildren.baseURLs.push(baseUrl);
+        periodChildren.BaseURL.push(baseUrl);
         const childrenParser = noop;
         const attributeParser = generateBaseUrlAttrParser(baseUrl, linearMemory);
         parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
@@ -82,10 +99,10 @@ export function generatePeriodChildrenParser(
 
       case TagName.EventStream: {
         const eventStream: IEventStreamIntermediateRepresentation = {
-          children: { events: [] },
+          children: { Event: [] },
           attributes: {},
         };
-        periodChildren.eventStreams.push(eventStream);
+        periodChildren.EventStream.push(eventStream);
         const childrenParser = generateEventStreamChildrenParser(
           eventStream.children,
           linearMemory,
@@ -101,11 +118,15 @@ export function generatePeriodChildrenParser(
       }
 
       case TagName.SegmentTemplate: {
-        const stObj = {};
-        periodChildren.segmentTemplate = stObj;
+        const stObj = { children: { Initialization: [] }, attributes: {} };
+        periodChildren.SegmentTemplate.push(stObj);
         parsersStack.pushParsers(
           nodeId,
-          noop, // SegmentTimeline as treated like an attribute
+          generateSegmentTemplateChildrenParser(
+            stObj.children,
+            linearMemory,
+            parsersStack,
+          ),
           generateSegmentTemplateAttrParser(stObj, linearMemory),
         );
         break;
@@ -113,13 +134,10 @@ export function generatePeriodChildrenParser(
 
       case TagName.ContentProtection: {
         const contentProtection = {
-          children: { cencPssh: [] },
+          children: { ["cenc:pssh"]: [] },
           attributes: {},
         };
-        if (periodChildren.contentProtections === undefined) {
-          periodChildren.contentProtections = [];
-        }
-        periodChildren.contentProtections.push(contentProtection);
+        periodChildren.ContentProtection.push(contentProtection);
         const contentProtAttrParser = generateContentProtectionAttrParser(
           contentProtection,
           linearMemory,
@@ -163,10 +181,15 @@ export function generatePeriodAttrParser(
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       case AttributeName.XLinkHref:
-        periodAttrs.xlinkHref = parseString(textDecoder, linearMemory.buffer, ptr, len);
+        periodAttrs["xlink:href"] = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
         break;
       case AttributeName.XLinkActuate:
-        periodAttrs.xlinkActuate = parseString(
+        periodAttrs["xlink:actuate"] = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Representation.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Representation.ts
@@ -27,9 +27,15 @@ import { parseString } from "../utils.ts";
 import { generateBaseUrlAttrParser } from "./BaseURL.ts";
 import { generateContentProtectionAttrParser } from "./ContentProtection.ts";
 import { generateSchemeAttrParser } from "./Scheme.ts";
-import { generateSegmentBaseAttrParser } from "./SegmentBase.ts";
+import {
+  generateSegmentBaseAttrParser,
+  generateSegmentBaseChildrenParser,
+} from "./SegmentBase.ts";
 import { generateSegmentListChildrenParser } from "./SegmentList.ts";
-import { generateSegmentTemplateAttrParser } from "./SegmentTemplate.ts";
+import {
+  generateSegmentTemplateAttrParser,
+  generateSegmentTemplateChildrenParser,
+} from "./SegmentTemplate.ts";
 
 /**
  * Generate a "children parser" once inside a `Representation` node.
@@ -47,7 +53,7 @@ export function generateRepresentationChildrenParser(
     switch (nodeId) {
       case TagName.BaseURL: {
         const baseUrl = { value: "", attributes: {} };
-        childrenObj.baseURLs.push(baseUrl);
+        childrenObj.BaseURL.push(baseUrl);
         parsersStack.pushParsers(
           nodeId,
           noop,
@@ -58,13 +64,10 @@ export function generateRepresentationChildrenParser(
 
       case TagName.ContentProtection: {
         const contentProtection = {
-          children: { cencPssh: [] },
+          children: { ["cenc:pssh"]: [] },
           attributes: {},
         };
-        if (childrenObj.contentProtections === undefined) {
-          childrenObj.contentProtections = [];
-        }
-        childrenObj.contentProtections.push(contentProtection);
+        childrenObj.ContentProtection.push(contentProtection);
         const contentProtAttrParser = generateContentProtectionAttrParser(
           contentProtection,
           linearMemory,
@@ -74,38 +77,32 @@ export function generateRepresentationChildrenParser(
       }
 
       case TagName.InbandEventStream: {
-        const inbandEvent = {};
-        if (childrenObj.inbandEventStreams === undefined) {
-          childrenObj.inbandEventStreams = [];
-        }
-        childrenObj.inbandEventStreams.push(inbandEvent);
+        const inbandEvent = { attributes: {} };
+        childrenObj.InbandEventStream.push(inbandEvent);
         parsersStack.pushParsers(
           nodeId,
           noop,
-          generateSchemeAttrParser(inbandEvent, linearMemory),
+          generateSchemeAttrParser(inbandEvent.attributes, linearMemory),
         );
         break;
       }
 
       case TagName.EssentialProperty: {
-        const essentialProperty = {};
-        if (childrenObj.essentialProperties === undefined) {
-          childrenObj.essentialProperties = [];
-        }
-        childrenObj.essentialProperties.push(essentialProperty);
-        const attributeParser = generateSchemeAttrParser(essentialProperty, linearMemory);
+        const essentialProperty = { attributes: {} };
+        childrenObj.EssentialProperty.push(essentialProperty);
+        const attributeParser = generateSchemeAttrParser(
+          essentialProperty.attributes,
+          linearMemory,
+        );
         parsersStack.pushParsers(nodeId, noop, attributeParser);
         break;
       }
 
       case TagName.SupplementalProperty: {
-        const supplementalProperty = {};
-        if (childrenObj.supplementalProperties === undefined) {
-          childrenObj.supplementalProperties = [];
-        }
-        childrenObj.supplementalProperties.push(supplementalProperty);
+        const supplementalProperty = { attributes: {} };
+        childrenObj.SupplementalProperty.push(supplementalProperty);
         const attributeParser = generateSchemeAttrParser(
-          supplementalProperty,
+          supplementalProperty.attributes,
           linearMemory,
         );
         parsersStack.pushParsers(nodeId, noop, attributeParser);
@@ -113,21 +110,27 @@ export function generateRepresentationChildrenParser(
       }
 
       case TagName.SegmentBase: {
-        const segmentBaseObj = {};
-        childrenObj.segmentBase = segmentBaseObj;
+        const segmentBaseObj = { children: { Initialization: [] }, attributes: {} };
+        childrenObj.SegmentBase.push(segmentBaseObj);
         const attributeParser = generateSegmentBaseAttrParser(
           segmentBaseObj,
           linearMemory,
         );
-        parsersStack.pushParsers(nodeId, noop, attributeParser);
+        const childrenParser = generateSegmentBaseChildrenParser(
+          segmentBaseObj.children,
+          linearMemory,
+          parsersStack,
+        );
+        parsersStack.pushParsers(nodeId, childrenParser, attributeParser);
         break;
       }
 
       case TagName.SegmentList: {
         const segmentListObj: ISegmentListIntermediateRepresentation = {
-          list: [],
+          children: { Initialization: [], SegmentURL: [] },
+          attributes: {},
         };
-        childrenObj.segmentList = segmentListObj;
+        childrenObj.SegmentList.push(segmentListObj);
         const childrenParser = generateSegmentListChildrenParser(
           segmentListObj,
           linearMemory,
@@ -144,11 +147,15 @@ export function generateRepresentationChildrenParser(
       }
 
       case TagName.SegmentTemplate: {
-        const stObj = {};
-        childrenObj.segmentTemplate = stObj;
+        const stObj = { children: { Initialization: [] }, attributes: {} };
+        childrenObj.SegmentTemplate.push(stObj);
         parsersStack.pushParsers(
           nodeId,
-          noop, // SegmentTimeline as treated like an attribute
+          generateSegmentTemplateChildrenParser(
+            stObj.children,
+            linearMemory,
+            parsersStack,
+          ),
           generateSegmentTemplateAttrParser(stObj, linearMemory),
         );
         break;
@@ -188,7 +195,7 @@ export function generateRepresentationAttrParser(
         );
         break;
       case AttributeName.Bitrate:
-        representationAttrs.bitrate = dataView.getFloat64(ptr, true);
+        representationAttrs.bandwidth = dataView.getFloat64(ptr, true);
         break;
       case AttributeName.Codecs:
         representationAttrs.codecs = parseString(
@@ -199,7 +206,7 @@ export function generateRepresentationAttrParser(
         );
         break;
       case AttributeName.SupplementalCodecs:
-        representationAttrs.supplementalCodecs = parseString(
+        representationAttrs["scte214:supplementalCodecs"] = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/Scheme.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/Scheme.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { IScheme } from "../../../node_parser_types.ts";
+import type { ISchemeAttributes } from "../../../node_parser_types.ts";
 import type { IAttributeParser } from "../parsers_stack.ts";
 import { AttributeName } from "../types.ts";
 import { parseString } from "../utils.ts";
@@ -26,7 +26,7 @@ import { parseString } from "../utils.ts";
  * @returns {Function}
  */
 export function generateSchemeAttrParser(
-  schemeAttrs: IScheme,
+  schemeAttrs: ISchemeAttributes,
   linearMemory: WebAssembly.Memory,
 ): IAttributeParser {
   const textDecoder = new TextDecoder();

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentBase.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentBase.ts
@@ -14,69 +14,75 @@
  * limitations under the License.
  */
 
-import type { ISegmentBaseIntermediateRepresentation } from "../../../node_parser_types.ts";
-import type { IAttributeParser } from "../parsers_stack.ts";
-import { AttributeName } from "../types.ts";
-import { parseString } from "../utils.ts";
+import noop from "../../../../../../utils/noop.ts";
+import type {
+  ISegmentBaseChildren,
+  ISegmentBaseIntermediateRepresentation,
+} from "../../../node_parser_types.ts";
+import type { IAttributeParser, IChildrenParser } from "../parsers_stack.ts";
+import type ParsersStack from "../parsers_stack.ts";
+import { AttributeName, TagName } from "../types.ts";
+import generateInitializationAttrParser from "./Initialization.ts";
+
+export function generateSegmentBaseChildrenParser(
+  segmentBaseChildren: ISegmentBaseChildren,
+  linearMemory: WebAssembly.Memory,
+  parsersStack: ParsersStack,
+): IChildrenParser {
+  return function onSegmentBaseChildren(nodeId: number) {
+    if (nodeId === TagName.Initialization) {
+      const initialization = { attributes: {} };
+      segmentBaseChildren.Initialization.push(initialization);
+      parsersStack.pushParsers(
+        nodeId,
+        noop,
+        generateInitializationAttrParser(initialization, linearMemory),
+      );
+    } else {
+      parsersStack.pushParsers(nodeId, noop, noop);
+    }
+  };
+}
 
 export function generateSegmentBaseAttrParser(
   segmentBaseAttrs: ISegmentBaseIntermediateRepresentation,
   linearMemory: WebAssembly.Memory,
 ): IAttributeParser {
-  const textDecoder = new TextDecoder();
-  return function onSegmentBaseAttribute(attr, ptr, len) {
+  return function onSegmentBaseAttribute(attr, ptr) {
     switch (attr) {
-      case AttributeName.InitializationRange: {
-        const dataView = new DataView(linearMemory.buffer);
-        if (segmentBaseAttrs.initialization === undefined) {
-          segmentBaseAttrs.initialization = {};
-        }
-        segmentBaseAttrs.initialization.range = [
-          dataView.getFloat64(ptr, true),
-          dataView.getFloat64(ptr + 8, true),
-        ];
-        break;
-      }
-
-      case AttributeName.InitializationMedia:
-        if (segmentBaseAttrs.initialization === undefined) {
-          segmentBaseAttrs.initialization = {};
-        }
-        segmentBaseAttrs.initialization.media = parseString(
-          textDecoder,
-          linearMemory.buffer,
-          ptr,
-          len,
-        );
-        break;
-
       case AttributeName.AvailabilityTimeOffset: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.availabilityTimeOffset = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.availabilityTimeOffset = dataView.getFloat64(
+          ptr,
+          true,
+        );
         break;
       }
 
       case AttributeName.AvailabilityTimeComplete: {
-        segmentBaseAttrs.availabilityTimeComplete =
+        segmentBaseAttrs.attributes.availabilityTimeComplete =
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       }
 
       case AttributeName.PresentationTimeOffset: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.presentationTimeOffset = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.presentationTimeOffset = dataView.getFloat64(
+          ptr,
+          true,
+        );
         break;
       }
 
       case AttributeName.TimeScale: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.timescale = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.timescale = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.IndexRange: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.indexRange = [
+        segmentBaseAttrs.attributes.indexRange = [
           dataView.getFloat64(ptr, true),
           dataView.getFloat64(ptr + 8, true),
         ];
@@ -84,26 +90,26 @@ export function generateSegmentBaseAttrParser(
       }
 
       case AttributeName.IndexRangeExact: {
-        segmentBaseAttrs.indexRangeExact =
+        segmentBaseAttrs.attributes.indexRangeExact =
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       }
 
       case AttributeName.Duration: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.duration = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.duration = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.StartNumber: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.startNumber = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.startNumber = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.EndNumber: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentBaseAttrs.endNumber = dataView.getFloat64(ptr, true);
+        segmentBaseAttrs.attributes.endNumber = dataView.getFloat64(ptr, true);
         break;
       }
     }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentList.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentList.ts
@@ -19,6 +19,7 @@ import type { ISegmentListIntermediateRepresentation } from "../../../node_parse
 import type { IChildrenParser } from "../parsers_stack.ts";
 import type ParsersStack from "../parsers_stack.ts";
 import { TagName } from "../types.ts";
+import generateInitializationAttrParser from "./Initialization.ts";
 import { generateSegmentUrlAttrParser } from "./SegmentUrl.ts";
 
 /**
@@ -35,12 +36,20 @@ export function generateSegmentListChildrenParser(
 ): IChildrenParser {
   return function onRootChildren(nodeId: number) {
     switch (nodeId) {
+      case TagName.Initialization: {
+        const initialization = { attributes: {} };
+        segListChildren.children.Initialization.push(initialization);
+        parsersStack.pushParsers(
+          nodeId,
+          noop,
+          generateInitializationAttrParser(initialization, linearMemory),
+        );
+        break;
+      }
+
       case TagName.SegmentUrl: {
-        const segmentObj = {};
-        if (segListChildren.list === undefined) {
-          segListChildren.list = [];
-        }
-        segListChildren.list.push(segmentObj);
+        const segmentObj = { attributes: {} };
+        segListChildren.children.SegmentURL.push(segmentObj);
         const attrParser = generateSegmentUrlAttrParser(segmentObj, linearMemory);
         parsersStack.pushParsers(nodeId, noop, attrParser);
         break;

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentTemplate.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentTemplate.ts
@@ -14,10 +14,36 @@
  * limitations under the License.
  */
 
-import type { ISegmentTemplateIntermediateRepresentation } from "../../../node_parser_types.ts";
-import type { IAttributeParser } from "../parsers_stack.ts";
-import { AttributeName } from "../types.ts";
+import noop from "../../../../../../utils/noop.ts";
+import type {
+  ISegmentTemplateChildren,
+  ISegmentTemplateIntermediateRepresentation,
+} from "../../../node_parser_types.ts";
+import type { IAttributeParser, IChildrenParser } from "../parsers_stack.ts";
+import type ParsersStack from "../parsers_stack.ts";
+import { AttributeName, TagName } from "../types.ts";
 import { parseString } from "../utils.ts";
+import generateInitializationAttrParser from "./Initialization.ts";
+
+export function generateSegmentTemplateChildrenParser(
+  segmentTemplateChildren: ISegmentTemplateChildren,
+  linearMemory: WebAssembly.Memory,
+  parsersStack: ParsersStack,
+): IChildrenParser {
+  return function onSegmentTemplateChildren(nodeId: number) {
+    if (nodeId === TagName.Initialization) {
+      const initialization = { attributes: {} };
+      segmentTemplateChildren.Initialization.push(initialization);
+      parsersStack.pushParsers(
+        nodeId,
+        noop,
+        generateInitializationAttrParser(initialization, linearMemory),
+      );
+    } else {
+      parsersStack.pushParsers(nodeId, noop, noop);
+    }
+  };
+}
 
 export function generateSegmentTemplateAttrParser(
   segmentTemplateAttrs: ISegmentTemplateIntermediateRepresentation,
@@ -28,10 +54,10 @@ export function generateSegmentTemplateAttrParser(
     switch (attr) {
       case AttributeName.SegmentTimeline: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.timeline = [];
+        segmentTemplateAttrs.children.timeline = [];
         let base = ptr;
         for (let i = 0; i < len / 24; i++) {
-          segmentTemplateAttrs.timeline.push({
+          segmentTemplateAttrs.children.timeline.push({
             start: dataView.getFloat64(base, true),
             duration: dataView.getFloat64(base + 8, true),
             repeatCount: dataView.getFloat64(base + 16, true),
@@ -42,13 +68,16 @@ export function generateSegmentTemplateAttrParser(
       }
 
       case AttributeName.InitializationMedia:
-        segmentTemplateAttrs.initialization = {
-          media: parseString(textDecoder, linearMemory.buffer, ptr, len),
-        };
+        segmentTemplateAttrs.attributes.initialization = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
         break;
 
       case AttributeName.Index:
-        segmentTemplateAttrs.index = parseString(
+        segmentTemplateAttrs.attributes.index = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,
@@ -58,31 +87,37 @@ export function generateSegmentTemplateAttrParser(
 
       case AttributeName.AvailabilityTimeOffset: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.availabilityTimeOffset = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.availabilityTimeOffset = dataView.getFloat64(
+          ptr,
+          true,
+        );
         break;
       }
 
       case AttributeName.AvailabilityTimeComplete: {
-        segmentTemplateAttrs.availabilityTimeComplete =
+        segmentTemplateAttrs.attributes.availabilityTimeComplete =
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       }
 
       case AttributeName.PresentationTimeOffset: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.presentationTimeOffset = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.presentationTimeOffset = dataView.getFloat64(
+          ptr,
+          true,
+        );
         break;
       }
 
       case AttributeName.TimeScale: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.timescale = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.timescale = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.IndexRange: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.indexRange = [
+        segmentTemplateAttrs.attributes.indexRange = [
           dataView.getFloat64(ptr, true),
           dataView.getFloat64(ptr + 8, true),
         ];
@@ -90,13 +125,13 @@ export function generateSegmentTemplateAttrParser(
       }
 
       case AttributeName.IndexRangeExact: {
-        segmentTemplateAttrs.indexRangeExact =
+        segmentTemplateAttrs.attributes.indexRangeExact =
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       }
 
       case AttributeName.Media:
-        segmentTemplateAttrs.media = parseString(
+        segmentTemplateAttrs.attributes.media = parseString(
           textDecoder,
           linearMemory.buffer,
           ptr,
@@ -105,26 +140,26 @@ export function generateSegmentTemplateAttrParser(
         break;
 
       case AttributeName.BitstreamSwitching: {
-        segmentTemplateAttrs.bitstreamSwitching =
+        segmentTemplateAttrs.attributes.bitstreamSwitching =
           new DataView(linearMemory.buffer).getUint8(0) === 0;
         break;
       }
 
       case AttributeName.Duration: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.duration = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.duration = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.StartNumber: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.startNumber = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.startNumber = dataView.getFloat64(ptr, true);
         break;
       }
 
       case AttributeName.EndNumber: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentTemplateAttrs.endNumber = dataView.getFloat64(ptr, true);
+        segmentTemplateAttrs.attributes.endNumber = dataView.getFloat64(ptr, true);
         break;
       }
     }

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentUrl.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/SegmentUrl.ts
@@ -34,12 +34,17 @@ export function generateSegmentUrlAttrParser(
   return function onSegmentUrlAttribute(attr, ptr, len) {
     switch (attr) {
       case AttributeName.Index:
-        segmentUrlAttrs.index = parseString(textDecoder, linearMemory.buffer, ptr, len);
+        segmentUrlAttrs.attributes.index = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
         break;
 
       case AttributeName.IndexRange: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentUrlAttrs.indexRange = [
+        segmentUrlAttrs.attributes.indexRange = [
           dataView.getFloat64(ptr, true),
           dataView.getFloat64(ptr + 8, true),
         ];
@@ -47,12 +52,17 @@ export function generateSegmentUrlAttrParser(
       }
 
       case AttributeName.Media:
-        segmentUrlAttrs.media = parseString(textDecoder, linearMemory.buffer, ptr, len);
+        segmentUrlAttrs.attributes.media = parseString(
+          textDecoder,
+          linearMemory.buffer,
+          ptr,
+          len,
+        );
         break;
 
       case AttributeName.MediaRange: {
         const dataView = new DataView(linearMemory.buffer);
-        segmentUrlAttrs.mediaRange = [
+        segmentUrlAttrs.attributes.mediaRange = [
           dataView.getFloat64(ptr, true),
           dataView.getFloat64(ptr + 8, true),
         ];

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/XLink.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/XLink.ts
@@ -39,7 +39,13 @@ export function generateXLinkChildrenParser(
     switch (nodeId) {
       case TagName.Period: {
         const period = {
-          children: { adaptations: [], baseURLs: [], eventStreams: [] },
+          children: {
+            AdaptationSet: [],
+            BaseURL: [],
+            SegmentTemplate: [],
+            EventStream: [],
+            ContentProtection: [],
+          },
           attributes: {},
         };
         xlinkObj.periods.push(period);

--- a/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/generators/root.ts
@@ -38,10 +38,11 @@ export function generateRootChildrenParser(
       case TagName.MPD: {
         rootObj.mpd = {
           children: {
-            baseURLs: [],
-            locations: [],
-            periods: [],
-            utcTimings: [],
+            BaseURL: [],
+            Location: [],
+            Period: [],
+            UTCTiming: [],
+            ContentProtection: [],
           },
           attributes: {},
         };

--- a/src/parsers/manifest/dash/wasm-parser/ts/types.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/types.ts
@@ -111,6 +111,9 @@ export const enum TagName {
 
   /// Indicate a <Label> node
   Label = 21,
+
+  /// Indicate an <Initialization> node
+  Initialization = 22,
 }
 
 /**

--- a/src/utils/get_last_item_from_array.ts
+++ b/src/utils/get_last_item_from_array.ts
@@ -1,0 +1,9 @@
+/**
+ * From the given array, return the last element, or `undefined` if the array is
+ * empty.
+ * @param {Array} arr
+ * @returns {*}
+ */
+export default function getLastItemFromArray<T>(arr: T[]): T | undefined {
+  return arr[arr.length - 1];
+}

--- a/tests/unit/src/parsers/manifest/dash/common/get_http_utc-timing_url.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/common/get_http_utc-timing_url.test.ts
@@ -10,10 +10,11 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return undefined if the given intermediate representation has no UTCTimings element", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [],
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        UTCTiming: [],
+        ContentProtection: [],
       },
       attributes: {},
     };
@@ -23,19 +24,24 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return undefined if the given intermediate representation has no http-iso UTCTimings element", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        UTCTiming: [
           {
-            schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
-            value: "foob",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
+              value: "foob",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2009",
-            value: "foob",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2009",
+              value: "foob",
+            },
           },
         ],
+        ContentProtection: [],
       },
       attributes: {},
     };
@@ -45,19 +51,26 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return undefined if the given intermediate representation has no value for its http-iso UTCTimings element", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        ContentProtection: [],
+        UTCTiming: [
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
-            value: "foob",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
+              value: "foob",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+            },
           },
         ],
       },
@@ -69,13 +82,16 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return the value of a single http-iso UTCTimings element", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        ContentProtection: [],
+        UTCTiming: [
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar2000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar2000",
+            },
           },
         ],
       },
@@ -87,21 +103,28 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return the first value of multiple http-iso UTCTimings elements", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        ContentProtection: [],
+        UTCTiming: [
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar1000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar1000",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar2000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar2000",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar3000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar3000",
+            },
           },
         ],
       },
@@ -113,29 +136,40 @@ describe("DASH Parser - getHTTPUTCTimingURL", () => {
   it("should return the first value of a http-iso UTCTimings element when mixed with other elements", () => {
     const mpdIR: IMPDIntermediateRepresentation = {
       children: {
-        baseURLs: [],
-        locations: [],
-        periods: [],
-        utcTimings: [
+        BaseURL: [],
+        Location: [],
+        Period: [],
+        ContentProtection: [],
+        UTCTiming: [
           {
-            schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
-            value: "foob",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
+              value: "foob",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar2000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar2000",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar1000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar1000",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
-            value: "foob",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:direct-iso:2014",
+              value: "foob",
+            },
           },
           {
-            schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
-            value: "foobar1000",
+            attributes: {
+              schemeIdUri: "urn:mpeg:dash:utc:http-iso:2014",
+              value: "foobar1000",
+            },
           },
         ],
       },

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/AdaptationSet.test.ts
@@ -14,7 +14,21 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: true },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -23,7 +37,21 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -41,7 +69,21 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [error1],
     ]);
@@ -51,7 +93,7 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
@@ -61,7 +103,21 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [error2],
     ]);
@@ -71,7 +127,7 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
     spyLog.mockRestore();
   });
@@ -86,7 +142,21 @@ function testStringAttribute(attributeName: string, variableName?: string): void
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: "foobar" },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -95,7 +165,21 @@ function testStringAttribute(attributeName: string, variableName?: string): void
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: "" },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -113,7 +197,21 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: 12.4 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -122,7 +220,21 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -131,7 +243,21 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
       {
         attributes: { [_variableName]: 13.5 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -145,7 +271,24 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     const element1 = parseXml(`<AdaptationSet ${attributeName}="toto" />`)[0] as ITNode;
     const error1 = new MPDError(`\`${attributeName}\` property is invalid: "toto"`);
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error1],
     ]);
 
@@ -155,13 +298,30 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(`\`${attributeName}\` property is invalid: "PT5M"`);
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error2],
     ]);
 
@@ -171,14 +331,31 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(`\`${attributeName}\` property is invalid: ""`);
 
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error3],
     ]);
 
@@ -188,7 +365,7 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
       "dash",
       "failed to parse DASH value:",
       error3.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
     spyLog.mockRestore();
   });
@@ -203,7 +380,21 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: 12 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -212,7 +403,21 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -221,7 +426,21 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
       {
         attributes: { [_variableName]: -50.12 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -235,7 +454,24 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     const element1 = parseXml(`<AdaptationSet ${attributeName}="toto" />`)[0] as ITNode;
     const error1 = new MPDError(`\`${attributeName}\` property is invalid: "toto"`);
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error1],
     ]);
 
@@ -245,13 +481,30 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(`\`${attributeName}\` property is invalid: "PT5M"`);
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error2],
     ]);
 
@@ -261,14 +514,31 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(`\`${attributeName}\` property is invalid: ""`);
 
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error3],
     ]);
 
@@ -278,7 +548,7 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
       "dash",
       "failed to parse DASH value:",
       error3.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
     spyLog.mockRestore();
   });
@@ -293,7 +563,21 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: 12 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -302,7 +586,21 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -311,7 +609,21 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
       {
         attributes: { [_variableName]: -50 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -327,7 +639,24 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
       `\`${attributeName}\` property is not an integer value but "toto"`,
     );
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error1],
     ]);
 
@@ -337,7 +666,7 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
@@ -345,7 +674,24 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
       `\`${attributeName}\` property is not an integer value but "PT5M"`,
     );
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error2],
     ]);
 
@@ -355,7 +701,7 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
@@ -364,7 +710,24 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     );
 
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error3],
     ]);
 
@@ -374,7 +737,7 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
       "dash",
       "failed to parse DASH value:",
       error3.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
     spyLog.mockRestore();
   });
@@ -392,7 +755,21 @@ function testNumberOrBooleanAttribute(
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: 12 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -401,7 +778,21 @@ function testNumberOrBooleanAttribute(
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: 0 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -410,7 +801,21 @@ function testNumberOrBooleanAttribute(
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
       {
         attributes: { [_variableName]: -50 },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -426,7 +831,24 @@ function testNumberOrBooleanAttribute(
       `\`${attributeName}\` property is not a boolean nor an integer but "toto"`,
     );
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error1],
     ]);
 
@@ -436,7 +858,7 @@ function testNumberOrBooleanAttribute(
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
@@ -444,7 +866,24 @@ function testNumberOrBooleanAttribute(
       `\`${attributeName}\` property is not a boolean nor an integer but "PT5M"`,
     );
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error2],
     ]);
 
@@ -454,7 +893,7 @@ function testNumberOrBooleanAttribute(
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
@@ -463,7 +902,24 @@ function testNumberOrBooleanAttribute(
     );
 
     expect(createAdaptationSetIntermediateRepresentation(element3)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [error3],
     ]);
 
@@ -473,7 +929,7 @@ function testNumberOrBooleanAttribute(
       "dash",
       "failed to parse DASH value:",
       error3.message,
-      { dashName: attributeName },
+      { name: attributeName },
     );
 
     spyLog.mockRestore();
@@ -485,7 +941,21 @@ function testNumberOrBooleanAttribute(
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: { [_variableName]: true },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -494,7 +964,21 @@ function testNumberOrBooleanAttribute(
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: { [_variableName]: false },
-        children: { baseURLs: [], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
@@ -508,7 +992,24 @@ describe("DASH Node Parsers - AdaptationSet", () => {
   it("should correctly parse an AdaptationSet element without attributes nor children", () => {
     const element = parseXml("<AdaptationSet />")[0] as ITNode;
     expect(createAdaptationSetIntermediateRepresentation(element)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [],
     ]);
   });
@@ -522,15 +1023,15 @@ describe("DASH Node Parsers - AdaptationSet", () => {
   testIntegerAttribute("group");
   testIntegerAttribute("height");
   testStringAttribute("id");
-  testStringAttribute("lang", "language");
-  testIntegerAttribute("maxBandwidth", "maxBitrate");
+  testStringAttribute("lang");
+  testIntegerAttribute("maxBandwidth");
   testMaybeDividedNumber("maxFrameRate");
   testIntegerAttribute("maxHeight");
   testFloatAttribute("maxPlayoutRate");
   testIntegerAttribute("maxWidth");
   testFloatAttribute("maximumSAPPeriod");
   testStringAttribute("mimeType");
-  testIntegerAttribute("minBandwidth", "minBitrate");
+  testIntegerAttribute("minBandwidth");
   testMaybeDividedNumber("minFrameRate");
   testIntegerAttribute("minHeight");
   testIntegerAttribute("minWidth");
@@ -542,10 +1043,27 @@ describe("DASH Node Parsers - AdaptationSet", () => {
   testIntegerAttribute("width");
   testFloatAttribute("availabilityTimeOffset");
 
-  it("should correctly parse an empty baseURLs", () => {
+  it("should correctly parse an empty BaseURL", () => {
     const element1 = parseXml("<AdaptationSet><BaseURL /></AdaptationSet>")[0] as ITNode;
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [],
     ]);
 
@@ -553,19 +1071,50 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       "<AdaptationSet><BaseURL></BaseURLs</AdaptationSet>",
     )[0] as ITNode;
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
-      { attributes: {}, children: { baseURLs: [], representations: [] } },
+      {
+        attributes: {},
+        children: {
+          Accessibility: [],
+          BaseURL: [],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
+      },
       [],
     ]);
   });
 
-  it("should correctly parse a non-empty baseURLs", () => {
+  it("should correctly parse a non-empty BaseURL", () => {
     const element1 = parseXml(
       '<AdaptationSet><BaseURL serviceLocation="foo">a</BaseURL></AdaptationSet>',
     )[0] as ITNode;
     expect(createAdaptationSetIntermediateRepresentation(element1)).toEqual([
       {
         attributes: {},
-        children: { baseURLs: [{ value: "a" }], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [{ value: "a" }],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+          Representation: [],
+        },
       },
       [],
     ]);
@@ -576,13 +1125,27 @@ describe("DASH Node Parsers - AdaptationSet", () => {
     expect(createAdaptationSetIntermediateRepresentation(element2)).toEqual([
       {
         attributes: {},
-        children: { baseURLs: [{ value: "foo bar" }], representations: [] },
+        children: {
+          Accessibility: [],
+          BaseURL: [{ value: "foo bar" }],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
+        },
       },
       [],
     ]);
   });
 
-  it("should correctly parse multiple non-empty baseURLs", () => {
+  it("should correctly parse multiple non-empty BaseURL", () => {
     const element1 = parseXml(
       '<AdaptationSet><BaseURL serviceLocation="">a</BaseURL><BaseURL serviceLocation="http://test.com">b</BaseURL></AdaptationSet>',
     )[0] as ITNode;
@@ -590,8 +1153,19 @@ describe("DASH Node Parsers - AdaptationSet", () => {
       {
         attributes: {},
         children: {
-          baseURLs: [{ value: "a" }, { value: "b" }],
-          representations: [],
+          Accessibility: [],
+          BaseURL: [{ value: "a" }, { value: "b" }],
+          Representation: [],
+          ContentComponent: [],
+          ContentProtection: [],
+          EssentialProperty: [],
+          InbandEventStream: [],
+          Label: [],
+          Role: [],
+          SegmentBase: [],
+          SegmentList: [],
+          SegmentTemplate: [],
+          SupplementalProperty: [],
         },
       },
       [],

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/ContentComponent.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/ContentComponent.test.ts
@@ -11,21 +11,25 @@ function testStringAttribute(attributeName: string, variableName?: string): void
       `<contentComponent ${attributeName}="foobar" />`,
     )[0] as ITNode;
     expect(parseContentComponent(element1)).toEqual({
-      [_variableName]: "foobar",
+      attributes: {
+        [_variableName]: "foobar",
+      },
     });
 
     const element2 = parseXml(`<contentComponent ${attributeName}="" />`)[0] as ITNode;
-    expect(parseContentComponent(element2)).toEqual({ [_variableName]: "" });
+    expect(parseContentComponent(element2)).toEqual({
+      attributes: { [_variableName]: "" },
+    });
   });
 }
 
 describe("DASH Node Parsers - ContentComponent", () => {
   it("should correctly parse a ContentComponent element without attributes", () => {
     const element = parseXml("<Content />")[0] as ITNode;
-    expect(parseContentComponent(element)).toEqual({});
+    expect(parseContentComponent(element)).toEqual({ attributes: {} });
   });
   testStringAttribute("id");
-  testStringAttribute("lang", "language");
+  testStringAttribute("lang", "lang");
   testStringAttribute("contentType");
   testStringAttribute("par");
 
@@ -39,10 +43,12 @@ describe("DASH Node Parsers - ContentComponent", () => {
         />`,
     )[0] as ITNode;
     expect(parseContentComponent(element)).toEqual({
-      id: "foo",
-      language: "bar",
-      contentType: "audio/mp5",
-      par: "3/4",
+      attributes: {
+        id: "foo",
+        lang: "bar",
+        contentType: "audio/mp5",
+        par: "3/4",
+      },
     });
   });
 });

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.test.ts
@@ -20,13 +20,16 @@ function testStringAttribute(attributeName: string, variableName?: string): void
       `<ContentProtection ${attributeName}="foobar" />`,
     )[0] as ITNode;
     expect(parseContentProtection(element1)).toEqual([
-      { attributes: { [_variableName]: "foobar" }, children: { cencPssh: [] } },
+      {
+        attributes: { [_variableName]: "foobar" },
+        children: { ["cenc:pssh"]: [] },
+      },
       [],
     ]);
 
     const element2 = parseXml(`<ContentProtection ${attributeName}="" />`)[0] as ITNode;
     expect(parseContentProtection(element2)).toEqual([
-      { attributes: { [_variableName]: "" }, children: { cencPssh: [] } },
+      { attributes: { [_variableName]: "" }, children: { ["cenc:pssh"]: [] } },
       [],
     ]);
   });
@@ -43,7 +46,7 @@ describe("DASH Node Parsers - ContentProtection", () => {
   it("should correctly parse a ContentProtection element without attributes", () => {
     const element = parseXml("<ContentProtection />")[0] as ITNode;
     expect(parseContentProtection(element)).toEqual([
-      { attributes: {}, children: { cencPssh: [] } },
+      { attributes: {}, children: { ["cenc:pssh"]: [] } },
       [],
     ]);
   });
@@ -61,7 +64,7 @@ describe("DASH Node Parsers - ContentProtection", () => {
     )[0] as ITNode;
 
     expect(parseContentProtection(element1)).toEqual([
-      { attributes: { keyId }, children: { cencPssh: [] } },
+      { attributes: { ["cenc:default_KID"]: keyId }, children: { ["cenc:pssh"]: [] } },
       [],
     ]);
     expect(mocks.hexToBytes).toHaveBeenCalledTimes(1);
@@ -82,8 +85,8 @@ describe("DASH Node Parsers - ContentProtection", () => {
     )[0] as ITNode;
     expect(parseContentProtection(element)).toEqual([
       {
-        attributes: { keyId, schemeIdUri: "foo", value: "bar" },
-        children: { cencPssh: [] },
+        attributes: { ["cenc:default_KID"]: keyId, schemeIdUri: "foo", value: "bar" },
+        children: { ["cenc:pssh"]: [] },
       },
       [],
     ]);
@@ -102,7 +105,14 @@ describe("DASH Node Parsers - ContentProtection", () => {
       {
         attributes: {},
         children: {
-          cencPssh: [new Uint8Array([0, 0, 65, 8]), new Uint8Array([0, 0, 1, 0])],
+          ["cenc:pssh"]: [
+            {
+              value: new Uint8Array([0, 0, 65, 8]),
+            },
+            {
+              value: new Uint8Array([0, 0, 1, 0]),
+            },
+          ],
         },
       },
       [],
@@ -126,9 +136,16 @@ describe("DASH Node Parsers - ContentProtection", () => {
     )[0] as ITNode;
     expect(parseContentProtection(element)).toEqual([
       {
-        attributes: { keyId, schemeIdUri: "foo", value: "bar" },
+        attributes: { ["cenc:default_KID"]: keyId, schemeIdUri: "foo", value: "bar" },
         children: {
-          cencPssh: [new Uint8Array([0, 0, 65, 8]), new Uint8Array([0, 0, 1, 0])],
+          ["cenc:pssh"]: [
+            {
+              value: new Uint8Array([0, 0, 65, 8]),
+            },
+            {
+              value: new Uint8Array([0, 0, 1, 0]),
+            },
+          ],
         },
       },
       [],
@@ -145,7 +162,7 @@ describe("DASH Node Parsers - ContentProtection", () => {
     const parsed = parseContentProtection(element);
     expect(parsed[0]).toEqual({
       attributes: {},
-      children: { cencPssh: [new Uint8Array([0, 0, 1, 0])] },
+      children: { ["cenc:pssh"]: [{ value: new Uint8Array([0, 0, 1, 0]) }] },
     });
     expect(parsed[1]).not.toBe(null);
     expect(parsed[1]).toHaveLength(1);

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/Initialization.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/Initialization.test.ts
@@ -19,20 +19,26 @@ describe("DASH Node Parsers - Initialization", () => {
 
   it("should correctly parse an element with no known attribute", () => {
     const element1 = parseXml("<Foo />")[0] as ITNode;
-    expect(parseInitialization(element1)).toEqual([{}, []]);
+    expect(parseInitialization(element1)).toEqual([{ attributes: {} }, []]);
 
     const element2 = parseXml('<Foo test="" />')[0] as ITNode;
-    expect(parseInitialization(element2)).toEqual([{}, []]);
+    expect(parseInitialization(element2)).toEqual([{ attributes: {} }, []]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("should correctly parse an element with a well-formed `range` attribute", () => {
     const element1 = parseXml('<Foo range="0-1" />')[0] as ITNode;
-    expect(parseInitialization(element1)).toEqual([{ range: [0, 1] }, []]);
+    expect(parseInitialization(element1)).toEqual([
+      { attributes: { range: [0, 1] } },
+      [],
+    ]);
 
     const element2 = parseXml('<Foo range="100-1000" />')[0] as ITNode;
-    expect(parseInitialization(element2)).toEqual([{ range: [100, 1000] }, []]);
+    expect(parseInitialization(element2)).toEqual([
+      { attributes: { range: [100, 1000] } },
+      [],
+    ]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
@@ -40,42 +46,51 @@ describe("DASH Node Parsers - Initialization", () => {
   it("should correctly parse an element with an incorrect `range` attribute", () => {
     const element1 = parseXml('<Foo range="a" />')[0] as ITNode;
     const error1 = new MPDError('`range` property has an unrecognized format "a"');
-    expect(parseInitialization(element1)).toEqual([{}, [error1]]);
+    expect(parseInitialization(element1)).toEqual([{ attributes: {} }, [error1]]);
 
     expect(logWarn).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: "range" },
+      { name: "range" },
     );
 
     const element2 = parseXml('<Foo range="" />')[0] as ITNode;
     const error2 = new MPDError('`range` property has an unrecognized format ""');
-    expect(parseInitialization(element2)).toEqual([{}, [error2]]);
+    expect(parseInitialization(element2)).toEqual([{ attributes: {} }, [error2]]);
 
     expect(logWarn).toHaveBeenCalledTimes(2);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: "range" },
+      { name: "range" },
     );
   });
 
   it("should correctly parse an element with a sourceURL attribute", () => {
     const element1 = parseXml('<Foo sourceURL="a" />')[0] as ITNode;
-    expect(parseInitialization(element1)).toEqual([{ media: "a" }, []]);
+    expect(parseInitialization(element1)).toEqual([
+      { attributes: { sourceURL: "a" } },
+      [],
+    ]);
 
     const element2 = parseXml('<Foo sourceURL="" />')[0] as ITNode;
-    expect(parseInitialization(element2)).toEqual([{ media: "" }, []]);
+    expect(parseInitialization(element2)).toEqual([
+      { attributes: { sourceURL: "" } },
+      [],
+    ]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("should correctly parse an element with both a sourceURL and range attributes", () => {
     const element1 = parseXml('<Foo sourceURL="a" range="4-10" />')[0] as ITNode;
-    expect(parseInitialization(element1)).toEqual([{ media: "a", range: [4, 10] }, []]);
+    expect(parseInitialization(element1)).toEqual([
+      { attributes: { sourceURL: "a", range: [4, 10] } },
+      [],
+    ]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/SegmentURL.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/SegmentURL.test.ts
@@ -19,20 +19,26 @@ describe("DASH Node Parsers - SegmentURL", () => {
 
   it("should correctly parse an element with no known attribute", () => {
     const element1 = parseXml("<Foo />")[0] as ITNode;
-    expect(parseSegmentURL(element1)).toEqual([{}, []]);
+    expect(parseSegmentURL(element1)).toEqual([{ attributes: {} }, []]);
 
     const element2 = parseXml('<Foo test="" />')[0] as ITNode;
-    expect(parseSegmentURL(element2)).toEqual([{}, []]);
+    expect(parseSegmentURL(element2)).toEqual([{ attributes: {} }, []]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("should correctly parse an element with a well-formed `mediaRange` attribute", () => {
     const element1 = parseXml('<Foo mediaRange="10-100" />')[0] as ITNode;
-    expect(parseSegmentURL(element1)).toEqual([{ mediaRange: [10, 100] }, []]);
+    expect(parseSegmentURL(element1)).toEqual([
+      { attributes: { mediaRange: [10, 100] } },
+      [],
+    ]);
 
     const element2 = parseXml('<Foo mediaRange="0-1" />')[0] as ITNode;
-    expect(parseSegmentURL(element2)).toEqual([{ mediaRange: [0, 1] }, []]);
+    expect(parseSegmentURL(element2)).toEqual([
+      { attributes: { mediaRange: [0, 1] } },
+      [],
+    ]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
@@ -40,35 +46,41 @@ describe("DASH Node Parsers - SegmentURL", () => {
   it("should correctly parse an element with an incorrect `mediaRange` attribute", () => {
     const element1 = parseXml('<Foo mediaRange="a" />')[0] as ITNode;
     const error1 = new MPDError('`mediaRange` property has an unrecognized format "a"');
-    expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
+    expect(parseSegmentURL(element1)).toEqual([{ attributes: {} }, [error1]]);
 
     expect(logWarn).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: "mediaRange" },
+      { name: "mediaRange" },
     );
 
     const element2 = parseXml('<Foo mediaRange="" />')[0] as ITNode;
     const error2 = new MPDError('`mediaRange` property has an unrecognized format ""');
-    expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
+    expect(parseSegmentURL(element2)).toEqual([{ attributes: {} }, [error2]]);
 
     expect(logWarn).toHaveBeenCalledTimes(2);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: "mediaRange" },
+      { name: "mediaRange" },
     );
   });
 
   it("should correctly parse an element with a well-formed `indexRange` attribute", () => {
     const element1 = parseXml('<Foo indexRange="0-100" />')[0] as ITNode;
-    expect(parseSegmentURL(element1)).toEqual([{ indexRange: [0, 100] }, []]);
+    expect(parseSegmentURL(element1)).toEqual([
+      { attributes: { indexRange: [0, 100] } },
+      [],
+    ]);
 
     const element2 = parseXml('<Foo indexRange="72-47" />')[0] as ITNode;
-    expect(parseSegmentURL(element2)).toEqual([{ indexRange: [72, 47] }, []]);
+    expect(parseSegmentURL(element2)).toEqual([
+      { attributes: { indexRange: [72, 47] } },
+      [],
+    ]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
@@ -76,45 +88,45 @@ describe("DASH Node Parsers - SegmentURL", () => {
   it("should correctly parse an element with an incorrect `indexRange` attribute", () => {
     const element1 = parseXml('<Foo indexRange="a" />')[0] as ITNode;
     const error1 = new MPDError('`indexRange` property has an unrecognized format "a"');
-    expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
+    expect(parseSegmentURL(element1)).toEqual([{ attributes: {} }, [error1]]);
 
     expect(logWarn).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error1.message,
-      { dashName: "indexRange" },
+      { name: "indexRange" },
     );
 
     const element2 = parseXml('<Foo indexRange="" />')[0] as ITNode;
     const error2 = new MPDError('`indexRange` property has an unrecognized format ""');
-    expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
+    expect(parseSegmentURL(element2)).toEqual([{ attributes: {} }, [error2]]);
 
     expect(logWarn).toHaveBeenCalledTimes(2);
     expect(logWarn).toHaveBeenCalledWith(
       "dash",
       "failed to parse DASH value:",
       error2.message,
-      { dashName: "indexRange" },
+      { name: "indexRange" },
     );
   });
 
   it("should correctly parse an element with a media attribute", () => {
     const element1 = parseXml('<Foo media="a" />')[0] as ITNode;
-    expect(parseSegmentURL(element1)).toEqual([{ media: "a" }, []]);
+    expect(parseSegmentURL(element1)).toEqual([{ attributes: { media: "a" } }, []]);
 
     const element2 = parseXml('<Foo media="" />')[0] as ITNode;
-    expect(parseSegmentURL(element2)).toEqual([{ media: "" }, []]);
+    expect(parseSegmentURL(element2)).toEqual([{ attributes: { media: "" } }, []]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });
 
   it("should correctly parse an element with a index attribute", () => {
     const element1 = parseXml('<Foo index="a" />')[0] as ITNode;
-    expect(parseSegmentURL(element1)).toEqual([{ index: "a" }, []]);
+    expect(parseSegmentURL(element1)).toEqual([{ attributes: { index: "a" } }, []]);
 
     const element2 = parseXml('<Foo index="" />')[0] as ITNode;
-    expect(parseSegmentURL(element2)).toEqual([{ index: "" }, []]);
+    expect(parseSegmentURL(element2)).toEqual([{ attributes: { index: "" } }, []]);
 
     expect(logWarn).not.toHaveBeenCalled();
   });

--- a/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/utils.test.ts
+++ b/tests/unit/src/parsers/manifest/dash/js-parser/node_parsers/utils.test.ts
@@ -155,33 +155,44 @@ describe("dash parser helpers", function () {
   describe("parseScheme", () => {
     it("should correctly parse an element with no known attribute", () => {
       const element1 = parseXml("<Foo />")[0] as ITNode;
-      expect(parseScheme(element1)).toEqual({});
+      expect(parseScheme(element1)).toEqual({
+        attributes: { schemeIdUri: undefined, value: undefined },
+      });
 
       const element2 = parseXml('<Foo test="" />')[0] as ITNode;
-      expect(parseScheme(element2)).toEqual({});
+      expect(parseScheme(element2)).toEqual({
+        attributes: { schemeIdUri: undefined, value: undefined },
+      });
     });
 
     it("should correctly parse an element with a correct schemeIdUri attribute", () => {
       const element1 = parseXml('<Foo schemeIdUri="foobar " />')[0] as ITNode;
-      expect(parseScheme(element1)).toEqual({ schemeIdUri: "foobar " });
+      expect(parseScheme(element1)).toEqual({
+        attributes: { schemeIdUri: "foobar ", value: undefined },
+      });
 
       const element2 = parseXml('<Foo schemeIdUri="" />')[0] as ITNode;
-      expect(parseScheme(element2)).toEqual({ schemeIdUri: "" });
+      expect(parseScheme(element2)).toEqual({
+        attributes: { schemeIdUri: "", value: undefined },
+      });
     });
 
     it("should correctly parse an element with a correct value attribute", () => {
       const element1 = parseXml('<Foo value="foobar " />')[0] as ITNode;
-      expect(parseScheme(element1)).toEqual({ value: "foobar " });
+      expect(parseScheme(element1)).toEqual({
+        attributes: { value: "foobar ", schemeIdUri: undefined },
+      });
 
       const element2 = parseXml('<Foo value="" />')[0] as ITNode;
-      expect(parseScheme(element2)).toEqual({ value: "" });
+      expect(parseScheme(element2)).toEqual({
+        attributes: { value: "", schemeIdUri: undefined },
+      });
     });
 
     it("should correctly parse an element with both attributes", () => {
       const element = parseXml('<Foo schemeIdUri="baz" value="foobar " />')[0] as ITNode;
       expect(parseScheme(element)).toEqual({
-        schemeIdUri: "baz",
-        value: "foobar ",
+        attributes: { schemeIdUri: "baz", value: "foobar " },
       });
     });
   });


### PR DESCRIPTION
## Initial problem: DASH Patch Document

I was looking into the implementation of the "MPD Patch Document", which allows for theoretically more optimal MPD updates by only communicating what changed since the last update.
From what I can see, it relies on a special format indicating that some XML attribute or element is either added, removed or updated compared to the last loaded MPD (also an XML).

Any element or attribute seems to be updateable here, which is a problem I would imagine for most DASH players  as we generally transform a loaded MPD (the original XML document) before using it, often in a new format that looses a lot of information from the original XML, including the original structure (e.g. was a `SegmentTemplate` at the `Period` or at the `Representation` level?).
One of the strategies, seen in the shaka-player, could be to only consider the most sensible subset of properties that are generally updated, but I was a little afraid this led to a insufficient implementation status for the application or packagers, which may need this for things we did not prepare for yet.

Interestingly, the DASH 5th edition specification has the following sentence on that subject:
> To allow for DASH client implementation efficiency, the in-memory MPD need not be stored in full XML structure format, but it must be stored such that all DASH defined identifiers and element order of multiple events of the same type are preserved. See 5.15.3.3 for the XPath addressing modes permitted by this document.

So we have to have a preferably structurally non-destructive and efficient (not re-parsing everything each time and preferably memory-efficient) way to store the previous MPD. 

## Our MPD "Intermediate Representation"

We had already such a format (parsed XML, but with all the original structural information still here), which we called the "MPD intermediate representation", which is outputed by our first pass of our DASH MPD parsers.

The MPD Intermediate Representation is basically the XML format transformed it into a JS Object, with what were semantically dates and numbers transformed into JavaScript's numbers, what were XML elements into objects and so on.

Here we could e.g. keep this object around when we detect that "MPD patching" is possible,

But there were still small modifications compared to the original structure. Minor ones like the `lang` attribute becoming `language` and more major ones like some elements having a special syntax, some children being added to an array and other not etc.

We could also argue that the transformation of the original textual format into numbers (e.g. ISO8601 duration into number of seconds) could be a loss of information, but I cannot think of any case where the format in which an attribute or Element inner content would be important to keep for Patch Documents.

## This proposal

So here I propose just to greatly simplify the output of that first pass:
  - All Elements output an object with at most 3 properties: `children`, `attributes` and `value` (for the stringified inner content)
  - The case and exact naming is kept: elements are now in Pascal cases like in the original XML
  - All children are put in arrays as there may technically be multiple ones when parsing

There are still some exceptions to this: some elements (`SegmentTimeline`, `EventStream`), still have a special syntax for now because it would not be as straigtforward to have this format for them for example.

This work does not even begin to implement PATCH Documents, but I thought that it was a good standalone work anyway, as it makes the first parsing pass much easier to update: just keep the same structure than in the original XML.