### PR TITLE
[MultiThread] Fix error not being thrown on manifest update

### DIFF
--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -250,6 +250,11 @@ export default class ContentPreparer {
       manifestFetcher.addEventListener(
         "error",
         (err: unknown) => {
+          sendMessage({
+            type: WorkerMessageType.Error,
+            contentId,
+            value: formatErrorForSender(err),
+          });
           rej(err);
         },
         contentCanceller.signal,


### PR DESCRIPTION
Fixes #1651

We had an issue in multithreading mode where we would not trigger an error (and stop playback) if a Manifest request failed in all its attempt unless it was the first manifest request.

The reason was simple: we didn't link a `ManifestFetcher`'s `error` event to an actual RxPlayer error. It worked for the initial request because it leads to the rejection of our internal initial-loading promise with that error.