### PR TITLE
fix: check that ec-3 codec is supported when encrypted

### DIFF
--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -877,7 +877,11 @@ const DEFAULT_CONFIG = {
    * Defined in order of importance (first will be tested first etc.)
    * @type {Array.<string>}
    */
-  EME_DEFAULT_AUDIO_CODECS: ['audio/mp4;codecs="mp4a.40.2"', "audio/webm;codecs=opus"],
+  EME_DEFAULT_AUDIO_CODECS: [
+    'audio/mp4;codecs="mp4a.40.2"',
+    '"audio/webm;codecs="opus"',
+    'audio/mp4; codecs="ec-3"',
+  ],
 
   /**
    * Robustnesses used in the {audio,video}Capabilities of the

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -879,8 +879,8 @@ const DEFAULT_CONFIG = {
    */
   EME_DEFAULT_AUDIO_CODECS: [
     'audio/mp4;codecs="mp4a.40.2"',
-    '"audio/webm;codecs="opus"',
-    'audio/mp4; codecs="ec-3"',
+    'audio/webm;codecs="opus"',
+    'audio/mp4;codecs="ec-3"',
   ],
 
   /**

--- a/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/defaultCodecFinder.test.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/__tests__/probers/defaultCodecFinder.test.ts
@@ -78,7 +78,7 @@ describe("MediaCapabilitiesProber probers - findDefaultAudioCodec", () => {
   it("should find default audio codec", async () => {
     const mockIsTypeSupported = vi.fn((codec: string) => {
       return (
-        codec === 'audio/mp4;codecs="mp4a.40.2"' || codec === "audio/webm;codecs=opus"
+        codec === 'audio/mp4;codecs="mp4a.40.2"' || codec === 'audio/webm;codecs="opus"'
       );
     });
     vi.doMock("../../../../../compat/browser_compatibility_types", () => ({

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/defaultCodecsFinder.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/defaultCodecsFinder.ts
@@ -51,7 +51,7 @@ export function findDefaultVideoCodec(): string {
  * @returns {string}
  */
 export function findDefaultAudioCodec(): string {
-  const audioCodecs = ['audio/mp4;codecs="mp4a.40.2"', "audio/webm;codecs=opus"];
+  const audioCodecs = ['audio/mp4;codecs="mp4a.40.2"', 'audio/webm;codecs="opus"'];
   if (
     isNullOrUndefined(MediaSource_) ||
     typeof MediaSource_.isTypeSupported !== "function"

--- a/src/main_thread/decrypt/__tests__/__global__/utils.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/utils.ts
@@ -15,7 +15,8 @@ export const defaultKSConfig: MediaKeySystemConfiguration[] = [
   {
     audioCapabilities: [
       { contentType: 'audio/mp4;codecs="mp4a.40.2"' },
-      { contentType: "audio/webm;codecs=opus" },
+      { contentType: 'audio/webm;codecs="opus"' },
+      { contentType: 'audio/mp4;codecs="ec-3"' },
     ],
     distinctiveIdentifier: "optional" as const,
     initDataTypes: ["cenc"] as const,
@@ -38,9 +39,11 @@ export const defaultPRRecommendationKSConfig: MediaKeySystemConfiguration[] = [
   {
     audioCapabilities: [
       { robustness: "3000", contentType: 'audio/mp4;codecs="mp4a.40.2"' },
-      { robustness: "3000", contentType: "audio/webm;codecs=opus" },
+      { robustness: "3000", contentType: 'audio/webm;codecs="opus"' },
+      { robustness: "3000", contentType: 'audio/mp4;codecs="ec-3"' },
       { robustness: "2000", contentType: 'audio/mp4;codecs="mp4a.40.2"' },
-      { robustness: "2000", contentType: "audio/webm;codecs=opus" },
+      { robustness: "2000", contentType: 'audio/webm;codecs="opus"' },
+      { robustness: "2000", contentType: 'audio/mp4;codecs="ec-3"' },
     ],
     distinctiveIdentifier: "optional" as const,
     initDataTypes: ["cenc"] as const,
@@ -79,7 +82,8 @@ export const defaultWidevineConfig: MediaKeySystemConfiguration[] = (() => {
   const audioCapabilities = flatMap(ROBUSTNESSES, (robustness) => {
     return [
       { contentType: 'audio/mp4;codecs="mp4a.40.2"', robustness },
-      { contentType: "audio/webm;codecs=opus", robustness },
+      { contentType: 'audio/webm;codecs="opus"', robustness },
+      { contentType: 'audio/mp4;codecs="ec-3"', robustness },
     ];
   });
   return [{ ...defaultKSConfig[0], audioCapabilities, videoCapabilities }];

--- a/src/main_thread/decrypt/__tests__/find_key_system.test.ts
+++ b/src/main_thread/decrypt/__tests__/find_key_system.test.ts
@@ -106,7 +106,7 @@ describe("find_key_systems - ", () => {
         robustness: "HW_SECURE_ALL",
       },
       {
-        contentType: "audio/webm;codecs=opus",
+        contentType: 'audio/webm;codecs="opus"',
         robustness: "HW_SECURE_ALL",
       },
       {
@@ -114,7 +114,7 @@ describe("find_key_systems - ", () => {
         robustness: "HW_SECURE_DECODE",
       },
       {
-        contentType: "audio/webm;codecs=opus",
+        contentType: 'audio/webm;codecs="opus"',
         robustness: "HW_SECURE_DECODE",
       },
       {
@@ -122,7 +122,7 @@ describe("find_key_systems - ", () => {
         robustness: "HW_SECURE_CRYPTO",
       },
       {
-        contentType: "audio/webm;codecs=opus",
+        contentType: 'audio/webm;codecs="opus"',
         robustness: "HW_SECURE_CRYPTO",
       },
       {
@@ -130,7 +130,7 @@ describe("find_key_systems - ", () => {
         robustness: "SW_SECURE_DECODE",
       },
       {
-        contentType: "audio/webm;codecs=opus",
+        contentType: 'audio/webm;codecs="opus"',
         robustness: "SW_SECURE_DECODE",
       },
       {
@@ -138,7 +138,7 @@ describe("find_key_systems - ", () => {
         robustness: "SW_SECURE_CRYPTO",
       },
       {
-        contentType: "audio/webm;codecs=opus",
+        contentType: 'audio/webm;codecs="opus"',
         robustness: "SW_SECURE_CRYPTO",
       },
     ],

--- a/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
+++ b/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
@@ -1,0 +1,281 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import type {
+  IManifestMetadata,
+  IPeriodMetadata,
+  IAdaptationMetadata,
+  IRepresentationMetadata,
+} from "../../../../manifest";
+import { ManifestMetadataFormat } from "../../../../manifest";
+
+import type { IContentProtections } from "../../../../parsers/manifest";
+import { updateManifestCodecSupport } from "../update_manifest_codec_support";
+import ContentDecryptor from "../../../decrypt";
+import sleep from "../../../../utils/sleep";
+
+function generateFakeManifestWithRepresentations(
+  videoRepresentations: IRepresentationMetadata[],
+  audioRepresentations: IRepresentationMetadata[],
+): IManifestMetadata {
+  const videoAdaptation: IAdaptationMetadata = {
+    id: "adaptation1",
+    representations: videoRepresentations,
+    type: "video",
+    supportStatus: {
+      isDecipherable: true,
+      hasSupportedCodec: undefined,
+      hasCodecWithUndefinedSupport: true,
+    },
+  };
+
+  const audioAdaptation: IAdaptationMetadata = {
+    id: "adaptation2",
+    representations: audioRepresentations,
+    type: "audio",
+    supportStatus: {
+      isDecipherable: true,
+      hasSupportedCodec: undefined,
+      hasCodecWithUndefinedSupport: true,
+    },
+  };
+
+  const period: IPeriodMetadata = {
+    adaptations: {
+      video: [videoAdaptation],
+      audio: [audioAdaptation],
+    },
+    id: "period1",
+    start: 0,
+    streamEvents: [],
+  };
+
+  const manifest: IManifestMetadata = {
+    id: "manifest1",
+    isDynamic: false,
+    isLive: false,
+    timeBounds: {
+      minimumSafePosition: 0,
+      timeshiftDepth: null,
+      maximumTimeData: {
+        isLinear: false,
+        livePosition: 0,
+        maximumSafePosition: 10,
+        time: 10,
+      },
+    },
+    periods: [period],
+    availabilityStartTime: 0,
+    isLastPeriodKnown: true,
+    manifestFormat: ManifestMetadataFormat.MetadataObject,
+    uris: [],
+  };
+
+  return manifest;
+}
+
+beforeAll(() => {
+  // Mock the `compat` module and override the export of _MediaSource
+  vi.mock("../../../../compat/browser_compatibility_types", () => ({
+    MediaSource_: class {
+      static isTypeSupported(type) {
+        // Mocked behavior: always return true for all codecs and false for vp9
+        return !type.includes("vp9");
+      }
+    },
+  }));
+
+  // Mock EME APIs
+  vi.mock("../../../../compat/eme/eme-api-implementation", () => ({
+    default: {
+      requestMediaKeySystemAccess: function (
+        keyType: string,
+        config: MediaKeySystemConfiguration[],
+      ) {
+        return {
+          keySystem: keyType,
+          getConfiguration: () => ({
+            ...config[0],
+            videoCapabilities: [
+              // Notice that all other codecs such as hevc are not listed in the videoCapabilities
+              // meanings that the EME implementation does not support them.
+              {
+                contentType: 'video/mp4;codecs="avc1.4d401e"',
+                robustness: "HW_SECURE_ALL",
+              },
+            ],
+            audioCapabilities: [
+              // Notice that all other codecs such as ec-3 are not listed in the audioCapabilities
+              // meanings that the EME implementation does not support them.
+              {
+                contentType: 'audio/mp4;codecs="mp4a.40.2"',
+                robustness: "HW_SECURE_ALL",
+              },
+            ],
+          }),
+          createMediaKeys: () => Promise.resolve({}),
+        };
+      },
+      onEncrypted: (
+        _target: unknown,
+        _listener: (evt: unknown) => void,
+        _cancelSignal: unknown,
+      ) => {
+        return;
+      },
+      setMediaKeys: (
+        _mediaElement: HTMLMediaElement,
+        _mediaKeys: unknown,
+      ): Promise<unknown> => {
+        return Promise.resolve();
+      },
+    },
+  }));
+});
+describe("init - utils - updateManifestCodecSupport", () => {
+  it("should return the codecs with result true/false if it's supported by the device", () => {
+    const representationAVC: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation1",
+      uniqueId: "representation1",
+      codecs: ["avc1.4d401e"],
+      mimeType: "video/mp4",
+      isSupported: undefined,
+    };
+
+    const representationHEVC: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation2",
+      uniqueId: "representation2",
+      codecs: ["hvc1.2.4.L153.B0"],
+      mimeType: "video/mp4",
+      isSupported: undefined,
+    };
+
+    const representationVP9: IRepresentationMetadata = {
+      bitrate: 3000,
+      id: "representation3",
+      uniqueId: "representation3",
+      codecs: ["vp9"],
+      mimeType: "video/mp4",
+      isSupported: undefined,
+    };
+
+    const representationMP4A: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation4",
+      uniqueId: "representation4",
+      codecs: ["mp4a.40.2"],
+      mimeType: "audio/mp4",
+      isSupported: undefined,
+    };
+
+    const representationEC3: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation5",
+      uniqueId: "representation5",
+      codecs: ["ec-3"],
+      mimeType: "audio/mp4",
+      isSupported: undefined,
+    };
+
+    const manifest = generateFakeManifestWithRepresentations(
+      [representationAVC, representationHEVC, representationVP9],
+      [representationMP4A, representationEC3],
+    );
+
+    const video = document.createElement("video");
+    const keySystem1 = {
+      type: "com.widevine.alpha",
+      getLicense: () => {
+        return new Uint8Array([]);
+      },
+    };
+    const contentDecryptor = new ContentDecryptor(video, [keySystem1]);
+    updateManifestCodecSupport(manifest, contentDecryptor);
+    expect(representationAVC.isSupported).toBe(true);
+    expect(representationHEVC.isSupported).toBe(true);
+    expect(representationVP9.isSupported).toBe(false); // Not Supported by MSE
+    expect(representationMP4A.isSupported).toBe(true);
+    expect(representationEC3.isSupported).toBe(true);
+  });
+
+  it("should take into consideration the supported codecs by the CDM", async () => {
+    /**
+     * While HEVC codec is supported by the browser, in this example the CDM
+     * does not support it. Overral the codec should be considered as unsupported.
+     */
+    const fakeContentProtection: IContentProtections = {
+      keyIds: [new Uint8Array([1, 2, 3])],
+      initData: [],
+    };
+    const encryptedRepresentationAVC: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation1",
+      uniqueId: "representation1",
+      codecs: ["avc1.4d401e"],
+      mimeType: "video/mp4",
+      contentProtections: fakeContentProtection,
+    };
+
+    const encryptedRepresentationHEVC: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation2",
+      uniqueId: "representation2",
+      codecs: ["hvc1.2.4.L153.B0"],
+      mimeType: "video/mp4",
+      contentProtections: fakeContentProtection,
+    };
+
+    const encryptedRepresentationVP9: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation3",
+      uniqueId: "representation3",
+      codecs: ["vp9"],
+      mimeType: "video/mp4",
+      contentProtections: fakeContentProtection,
+    };
+
+    const encryptedRepresentationMP4A: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation4",
+      uniqueId: "representation4",
+      codecs: ["mp4a.40.2"],
+      mimeType: "audio/mp4",
+      contentProtections: fakeContentProtection,
+    };
+
+    const encryptedRepresentationEC3: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation5",
+      uniqueId: "representation5",
+      codecs: ["ec-3"],
+      mimeType: "audio/mp4",
+      contentProtections: fakeContentProtection,
+    };
+
+    const manifest = generateFakeManifestWithRepresentations(
+      [
+        encryptedRepresentationAVC,
+        encryptedRepresentationHEVC,
+        encryptedRepresentationVP9,
+      ],
+      [encryptedRepresentationMP4A, encryptedRepresentationEC3],
+    );
+
+    const keySystem1 = {
+      type: "com.widevine.alpha",
+      getLicense: () => {
+        return new Uint8Array([]);
+      },
+    };
+    const video = document.createElement("video");
+    const contentDecryptor = new ContentDecryptor(video, [keySystem1]);
+    await sleep(100);
+    contentDecryptor.attach();
+    updateManifestCodecSupport(manifest, contentDecryptor);
+    expect(encryptedRepresentationAVC.isSupported).toBe(true);
+    expect(encryptedRepresentationHEVC.isSupported).toBe(false); // Not supported by EME
+    expect(encryptedRepresentationVP9.isSupported).toBe(false); // Not supported by MSE
+    expect(encryptedRepresentationMP4A.isSupported).toBe(true);
+    expect(encryptedRepresentationEC3.isSupported).toBe(false); // Not supported by EME
+  });
+});

--- a/src/utils/__tests__/are_codecs_compatible.test.ts
+++ b/src/utils/__tests__/are_codecs_compatible.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from "vitest";
-import areCodecsCompatible from "../are_codecs_compatible";
+import areCodecsCompatible, { parseCodec } from "../are_codecs_compatible";
+
+describe("parseCodec", () => {
+  it("should return audio/mp4 and mp4a.42.2", () => {
+    const { mimeType, codecs } = parseCodec('audio/mp4;codecs="mp4a.42.2"');
+    expect(mimeType).toBe("audio/mp4");
+    expect(codecs).toBe("mp4a.42.2");
+  });
+
+  it("should return video/mp4 and avc1.64001f", () => {
+    const { mimeType, codecs } = parseCodec('video/mp4;codecs="avc1.64001f"');
+    expect(mimeType).toBe("video/mp4");
+    expect(codecs).toBe("avc1.64001f");
+  });
+
+  it("should return audio/mp4 and ec-3", () => {
+    const { mimeType, codecs } = parseCodec('audio/mp4;codecs="ec-3"');
+    expect(mimeType).toBe("audio/mp4");
+    expect(codecs).toBe("ec-3");
+  });
+});
 
 describe("are_codecs_compatible", () => {
   it("should return false as one is different from the other", () => {

--- a/src/utils/are_codecs_compatible.ts
+++ b/src/utils/are_codecs_compatible.ts
@@ -54,7 +54,7 @@ export function parseCodec(unparsedCodec: string): { mimeType: string; codecs: s
   codecs = codecs.substring(LENGTH_OF_CODEC_PREFIX);
   // remove the leading and trailing quote
   if (codecs[0] === '"') {
-    codecs = codecs.substring(1, codecs.length - 2);
+    codecs = codecs.substring(1, codecs.length - 1);
   }
 
   return { mimeType, codecs };


### PR DESCRIPTION
Some devices (such as meta quest 3) does not support ec-3 codec when the content is encrypted.
We already have a mechanism to verify that a codec is supported with EME APIs. 
I have added the ec-3 codec to the list of codec to check by default.