### PR TITLE
Pin versions of non-github gh-action dependenceis

### DIFF
--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -58,7 +58,7 @@ jobs:
         id: npm-pack
 
       - name: Upload archive to release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@04733e069f2d7f7f0b4aebc4fbdbce8613b03ccd
         id: upload-action
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud_analysis.yml
+++ b/.github/workflows/sonarcloud_analysis.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@0303d6b62e310685c0e34d0b9cde218036885c4d
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
We had news of some compromised github actions last friday (https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised).

Even if we do not use those actions, and even if it was promptly detected, it reveals some flaws of the gh-actions dependencies system: versions indicated in config files actually correspond to tags which can be retroactively updated at any time.

As such, some people on the internet (appeal to authority: maximum ;p) are recommending referencing hash instead of the github-recommended way of relying on some version number (which appears to just be a git tag behind the hood? - It's a little confusing because there's appear to have some semver capabilities here which isn't a requirement of git tags). Though it doesn't seem ""perfect"" either (some people talk about e.g. SHA-1 collisions done maliciously, though others state that from the current status of SHA-1 collision, targeting a specific hash - without doing some detectable things like multi-GB files - does not seem possible for now) it appears to be a more secure way of handling those dependencies.

I've only done so for the actions not under the `actions` organization (as I guess those are controlled by Github in which we can put more trust?):

  - `svenstaro/upload-release-action`: It was used to auto-publish some builds so we can test pre-relases easily.

    I've pinned it to their last release (which we already tested a lot as it was done beginning of last year)

  - `SonarSource/sonarqube-scan-action`: The last action we relied on was deprecated so I updated it and relied on their last version here.

Relying on tags emulating versions have some advantages, like relying on future patch versions automatically so we lose that.