### PR TITLE
[Proposal] Make Performance test report HTML and to be collapsed by default

### DIFF
--- a/.github/workflows/perfs.yml
+++ b/.github/workflows/perfs.yml
@@ -49,8 +49,5 @@ jobs:
               repo: context.repo.repo,
               // TODO: generate comment header inside the report file instead of here for better portability?
               // We should already have access to the sha1 through `git` and the destination branch through the command line arguments.
-              body: "Automated performance checks have been performed on commit " +
-                    "\`${{github.event.pull_request.head.sha}}\` with the base branch \`${{github.base_ref}}\`.\n\n" +
-                    fileContent +
-                    "\n\n If you want to skip performance checks for latter commits, add the `skip-performance-checks` label to this Pull Request.",
+              body: fileContent,
             })


### PR DESCRIPTION
Issue: performance tests results produce too much noise on PR
-------------------------------------------------------------

We recently decided to perform performance tests (which check for performance regressions) on all Pull Requests each time a push occurs on it.

Those performance tests post a message detailling the results when complete. The idea is to better see the impact for each tested scenario: a monothreaded content loading, a multithreaded one, a seek etc. - including when tests pass.

However, we generally have very long review time in the RxPlayer team :D. It's not unheard of to stay in review phases for weeks, months or even sometimes years (!), time during which we continue developing/maintaining those branches and pushing, re-triggering the tests!

The issue is not running the tests multiple times, nor it is really the review times, the problem we now have is that after a while, we end up with a huge part of a Pull Request summary dedicated to performance tests results.

Current solution: HTML `<details>` element
------------------------------------------

This PR tries to reduce this issue by relying on the `<details>` HTML element, which results in a collapsed message.

The idea is that results are still posted each time, but the table summarizing results is now collapsed inside the comment.

To profit from this, I decided that our performance tests now produce HTML reports instead of markdown ones. Technically, markdown specs like CommonMark do support HTML inside, but at that point I though it would be more compatible to only produce HTML.

The inconvenients are:

  - HTML is less readable than markdown. To alleviate this, I tried to make HTML as readable as possible by "playing" with line breaks and spaces.

  - We now have a function producing mardown tables (for stdout) and another producing HTML tables (for the file report).

    This doesn't bother me too much though.

Example of a report file:
----------------------------------

```html
<div>
  <p>
    ✅ Automated performance checks have passed on commit <code>03e35b1813682181628c1be6600f708af1d7f9f9</code> with the base branch <code>dev</code>
  </p>
  <details>
    <summary>Details</summary>

<h2>Performance tests 1st run output</h2>

<p>No significative change in performance for tests:</p>

<table role="table">
  <thead>
    <tr>
      <th>Name</th>
      <th>Mean</th>
      <th>Median</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>loading</td>
      <td>25.38ms -> 26.58ms (-0.206ms, z: 1.32017)</td>
      <td>37.35ms -> 37.20ms</td>
    </tr>
    <tr>
      <td>seeking</td>
      <td>650.91ms -> 551.65ms (100.268ms, z: 1.00650)</td>
      <td>1517.85ms -> 1519.05ms</td>
    </tr>
    <tr>
      <td>audio-track-reload</td>
      <td>27.33ms -> 27.96ms (0.368ms, z: 0.94101)</td>
      <td>41.65ms -> 42.25ms</td>
    </tr>
    <tr>
      <td>cold loading multithread</td>
      <td>44.48ms -> 44.67ms (0.808ms, z: 2.58518)</td>
      <td>66.85ms -> 65.55ms</td>
    </tr>
    <tr>
      <td>seeking multithread</td>
      <td>210.72ms -> 291.74ms (-80.020ms, z: 0.05170)</td>
      <td>15.65ms -> 17.20ms</td>
    </tr>
    <tr>
      <td>audio-track-reload multithread</td>
      <td>24.44ms -> 25.68ms (-0.238ms, z: 0.09996)</td>
      <td>36.70ms -> 37.60ms</td>
    </tr>
    <tr>
      <td>hot loading multithread</td>
      <td>23.28ms -> 23.57ms (0.706ms, z: 2.53348)</td>
      <td>35.50ms -> 35.05ms</td>
    </tr>
  </tbody>
</table>

  </details>
</div>
```

Which gives as a comment:

---

<div>
  <p>
    ✅ Automated performance checks have passed on commit <code>03e35b1813682181628c1be6600f708af1d7f9f9</code> with the base branch <code>dev</code>
  </p>
  <details>
    <summary>Details</summary>
    <h2>Performance tests 1st run output</h2>

<p>No significative change in performance for tests:</p>

<table role="table">
  <thead>
    <tr>
      <th>Name</th>
      <th>Mean</th>
      <th>Median</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>loading</td>
      <td>25.38ms -> 26.58ms (-0.206ms, z: 1.32017)</td>
      <td>37.35ms -> 37.20ms</td>
    </tr>
    <tr>
      <td>seeking</td>
      <td>650.91ms -> 551.65ms (100.268ms, z: 1.00650)</td>
      <td>1517.85ms -> 1519.05ms</td>
    </tr>
    <tr>
      <td>audio-track-reload</td>
      <td>27.33ms -> 27.96ms (0.368ms, z: 0.94101)</td>
      <td>41.65ms -> 42.25ms</td>
    </tr>
    <tr>
      <td>cold loading multithread</td>
      <td>44.48ms -> 44.67ms (0.808ms, z: 2.58518)</td>
      <td>66.85ms -> 65.55ms</td>
    </tr>
    <tr>
      <td>seeking multithread</td>
      <td>210.72ms -> 291.74ms (-80.020ms, z: 0.05170)</td>
      <td>15.65ms -> 17.20ms</td>
    </tr>
    <tr>
      <td>audio-track-reload multithread</td>
      <td>24.44ms -> 25.68ms (-0.238ms, z: 0.09996)</td>
      <td>36.70ms -> 37.60ms</td>
    </tr>
    <tr>
      <td>hot loading multithread</td>
      <td>23.28ms -> 23.57ms (0.706ms, z: 2.53348)</td>
      <td>35.50ms -> 35.05ms</td>
    </tr>
  </tbody>
</table>

  </details>
</div>

---