### PR TITLE
Fix: microsoft edge some codecs are not supported by MSE in worker

### DIFF
--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -291,7 +291,7 @@ export default class ContentPreparer {
           ];
           for (const adaptation of checkedAdaptations) {
             for (const representation of adaptation.representations) {
-              const codec = representation.codecs[0];
+              const codec = `${representation.mimeType};codecs="${representation.codecs[0]}"`;
               if (codecsMap.has(codec)) {
                 representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
               } else {

--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -1,7 +1,9 @@
+import { MediaSource_ } from "../../../compat/browser_compatibility_types";
 import features from "../../../features";
 import log from "../../../log";
 import type { IManifest, IManifestMetadata } from "../../../manifest";
 import { createRepresentationFilterFromFnString } from "../../../manifest";
+import type Manifest from "../../../manifest/classes";
 import type { IMediaSourceInterface } from "../../../mse";
 import MainMediaSourceInterface from "../../../mse/main_media_source_interface";
 import WorkerMediaSourceInterface from "../../../mse/worker_media_source_interface";
@@ -13,6 +15,7 @@ import { WorkerMessageType } from "../../../multithread_types";
 import type { IPlayerError } from "../../../public_types";
 import assert from "../../../utils/assert";
 import idGenerator from "../../../utils/id_generator";
+import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import objectAssign from "../../../utils/object_assign";
 import type {
   CancellationError,
@@ -270,6 +273,37 @@ export default class ContentPreparer {
       );
       manifestFetcher.start();
 
+      /**
+       * Set Representation.isCodecSupportedInWebWorker to true or false
+       * If the codec is supported in the current context.
+       * If MSE in worker is not available, the attribute is not set.
+       */
+      function updateCodecSupportInWorkerMode(manifestToUpdate: Manifest) {
+        if (isNullOrUndefined(MediaSource_)) {
+          return;
+        }
+
+        const codecsMap = new Map<string, boolean>();
+        for (const period of manifestToUpdate.periods) {
+          const checkedAdaptations = [
+            ...(period.adaptations.video ?? []),
+            ...(period.adaptations.audio ?? []),
+          ];
+          for (const adaptation of checkedAdaptations) {
+            for (const representation of adaptation.representations) {
+              const codec = representation.codecs[0];
+              if (codecsMap.has(codec)) {
+                representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
+              } else {
+                const supported = MediaSource_.isTypeSupported(codec);
+                representation.isCodecSupportedInWebWorker = supported;
+                codecsMap.set(codec, supported);
+              }
+            }
+          }
+        }
+      }
+
       function checkIfReadyAndValidate() {
         if (
           manifest === null ||
@@ -278,7 +312,7 @@ export default class ContentPreparer {
         ) {
           return;
         }
-
+        updateCodecSupportInWorkerMode(manifest);
         const sentManifest = manifest.getMetadataSnapshot();
         manifest.addEventListener(
           "manifestUpdate",

--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -273,37 +273,6 @@ export default class ContentPreparer {
       );
       manifestFetcher.start();
 
-      /**
-       * Set Representation.isCodecSupportedInWebWorker to true or false
-       * If the codec is supported in the current context.
-       * If MSE in worker is not available, the attribute is not set.
-       */
-      function updateCodecSupportInWorkerMode(manifestToUpdate: Manifest) {
-        if (isNullOrUndefined(MediaSource_)) {
-          return;
-        }
-
-        const codecsMap = new Map<string, boolean>();
-        for (const period of manifestToUpdate.periods) {
-          const checkedAdaptations = [
-            ...(period.adaptations.video ?? []),
-            ...(period.adaptations.audio ?? []),
-          ];
-          for (const adaptation of checkedAdaptations) {
-            for (const representation of adaptation.representations) {
-              const codec = `${representation.mimeType};codecs="${representation.codecs[0]}"`;
-              if (codecsMap.has(codec)) {
-                representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
-              } else {
-                const supported = MediaSource_.isTypeSupported(codec);
-                representation.isCodecSupportedInWebWorker = supported;
-                codecsMap.set(codec, supported);
-              }
-            }
-          }
-        }
-      }
-
       function checkIfReadyAndValidate() {
         if (
           manifest === null ||
@@ -567,4 +536,35 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
   });
 
   return [mediaSourceInterface, segmentSinksStore, textSender];
+}
+
+/**
+ * Set Representation.isCodecSupportedInWebWorker to true or false
+ * If the codec is supported in the current context.
+ * If MSE in worker is not available, the attribute is not set.
+ */
+function updateCodecSupportInWorkerMode(manifestToUpdate: Manifest) {
+  if (isNullOrUndefined(MediaSource_)) {
+    return;
+  }
+
+  const codecsMap = new Map<string, boolean>();
+  for (const period of manifestToUpdate.periods) {
+    const checkedAdaptations = [
+      ...(period.adaptations.video ?? []),
+      ...(period.adaptations.audio ?? []),
+    ];
+    for (const adaptation of checkedAdaptations) {
+      for (const representation of adaptation.representations) {
+        const codec = `${representation.mimeType};codecs="${representation.codecs[0]}"`;
+        if (codecsMap.has(codec)) {
+          representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
+        } else {
+          const supported = MediaSource_.isTypeSupported(codec);
+          representation.isCodecSupportedInWebWorker = supported;
+          codecsMap.set(codec, supported);
+        }
+      }
+    }
+  }
 }

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1413,7 +1413,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       const updatedCodecs = updateManifestCodecSupport(
         manifest,
         this._currentContentInfo?.contentDecryptor ?? null,
-        this._settings.worker && hasMseInWorker,
+        hasMseInWorker,
       );
       if (updatedCodecs.length > 0) {
         sendMessage(this._settings.worker, {

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,4 +1,5 @@
 import type { IMediaElement } from "../../compat/browser_compatibility_types";
+import hasMseInWorker from "../../compat/has_mse_in_worker";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store";
@@ -1412,6 +1413,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       const updatedCodecs = updateManifestCodecSupport(
         manifest,
         this._currentContentInfo?.contentDecryptor ?? null,
+        this._settings.worker && hasMseInWorker,
       );
       if (updatedCodecs.length > 0) {
         sendMessage(this._settings.worker, {

--- a/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
+++ b/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
@@ -193,7 +193,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
       },
     };
     const contentDecryptor = new ContentDecryptor(video, [keySystem1]);
-    updateManifestCodecSupport(manifest, contentDecryptor);
+    updateManifestCodecSupport(manifest, contentDecryptor, true);
     expect(representationAVC.isSupported).toBe(true);
     expect(representationHEVC.isSupported).toBe(true);
     expect(representationVP9.isSupported).toBe(false); // Not Supported by MSE
@@ -274,7 +274,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
     const contentDecryptor = new ContentDecryptor(video, [keySystem1]);
     await sleep(100);
     contentDecryptor.attach();
-    updateManifestCodecSupport(manifest, contentDecryptor);
+    updateManifestCodecSupport(manifest, contentDecryptor, true);
     expect(encryptedRepresentationAVC.isSupported).toBe(true);
     expect(encryptedRepresentationHEVC.isSupported).toBe(false); // Not supported by EME
     expect(encryptedRepresentationVP9.isSupported).toBe(false); // Not supported by MSE
@@ -318,7 +318,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
 
     const video = document.createElement("video");
     const contentDecryptor = new ContentDecryptor(video, []);
-    updateManifestCodecSupport(manifest, contentDecryptor);
+    updateManifestCodecSupport(manifest, contentDecryptor, true);
     expect(representationAVC.isSupported).toBe(true);
     expect(representationHEVC.isSupported).toBe(false); // not supported with MSE in worker
     expect(representationMP4A.isSupported).toBe(true);

--- a/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
+++ b/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
@@ -281,4 +281,46 @@ describe("init - utils - updateManifestCodecSupport", () => {
     expect(encryptedRepresentationMP4A.isSupported).toBe(true);
     expect(encryptedRepresentationEC3.isSupported).toBe(false); // Not supported by EME
   });
+
+  it("should update to false if the codec is not usable with MSE in worker", () => {
+    const representationAVC: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation1",
+      uniqueId: "representation1",
+      codecs: ["avc1.4d401e"],
+      mimeType: "video/mp4",
+      isSupported: undefined,
+      isCodecSupportedInWebWorker: undefined,
+    };
+    const representationHEVC: IRepresentationMetadata = {
+      bitrate: 2000,
+      id: "representation2",
+      uniqueId: "representation2",
+      codecs: ["hvc1.2.4.L153.B0"],
+      mimeType: "video/mp4",
+      isSupported: undefined,
+      isCodecSupportedInWebWorker: false,
+    };
+
+    const representationMP4A: IRepresentationMetadata = {
+      bitrate: 1000,
+      id: "representation4",
+      uniqueId: "representation4",
+      codecs: ["mp4a.40.2"],
+      mimeType: "audio/mp4",
+      isSupported: undefined,
+      isCodecSupportedInWebWorker: true,
+    };
+    const manifest = generateFakeManifestWithRepresentations(
+      [representationAVC, representationHEVC],
+      [representationMP4A],
+    );
+
+    const video = document.createElement("video");
+    const contentDecryptor = new ContentDecryptor(video, []);
+    updateManifestCodecSupport(manifest, contentDecryptor);
+    expect(representationAVC.isSupported).toBe(true);
+    expect(representationHEVC.isSupported).toBe(false); // not supported with MSE in worker
+    expect(representationMP4A.isSupported).toBe(true);
+  });
 });

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -131,6 +131,11 @@ export function updateManifestCodecSupport(
       let hasSupportedCodec: boolean = false;
       let hasCodecWithUndefinedSupport: boolean = false;
       adaptation.representations.forEach((representation) => {
+        if (representation.isCodecSupportedInWebWorker === false) {
+          representation.isSupported = false;
+          return;
+        }
+
         if (representation.isSupported !== undefined) {
           if (representation.isSupported) {
             hasSupportedCodec = true;

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -63,6 +63,7 @@ export function getCodecsWithUnknownSupport(
 export function updateManifestCodecSupport(
   manifest: IManifestMetadata,
   contentDecryptor: ContentDecryptor | null,
+  isPlayingWithMSEinWorker: boolean,
 ): ICodecSupportInfo[] {
   const codecSupportMap: Map<
     string,
@@ -131,7 +132,10 @@ export function updateManifestCodecSupport(
       let hasSupportedCodec: boolean = false;
       let hasCodecWithUndefinedSupport: boolean = false;
       adaptation.representations.forEach((representation) => {
-        if (representation.isCodecSupportedInWebWorker === false) {
+        if (
+          representation.isCodecSupportedInWebWorker === false &&
+          isPlayingWithMSEinWorker
+        ) {
           representation.isSupported = false;
           return;
         }

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -56,9 +56,10 @@ export function getCodecsWithUnknownSupport(
  * Because probing for codec support is always synchronous in the main thread,
  * calling this function ensures that support is now known.
  *
- * @param {Object} manifest
- * @param {Object|null} contentDecryptor
- * @returns {boolean}
+ * @param {Object} manifest - The manifest to update
+ * @param {Object|null} contentDecryptor - The current content decryptor
+ * @param {boolean} isPlayingWithMSEinWorker - True if WebWorker is used with MSE in worker
+ * @returns {Array.<Object>}
  */
 export function updateManifestCodecSupport(
   manifest: IManifestMetadata,

--- a/src/manifest/classes/representation.ts
+++ b/src/manifest/classes/representation.ts
@@ -121,7 +121,6 @@ class Representation implements IRepresentationMetadata {
    * `Manifest` methods for this.
    */
   public shouldBeAvoided: boolean;
-
   /** If the codec is supported with MSE in worker */
   public isCodecSupportedInWebWorker: boolean | undefined;
 

--- a/src/manifest/classes/representation.ts
+++ b/src/manifest/classes/representation.ts
@@ -122,6 +122,9 @@ class Representation implements IRepresentationMetadata {
    */
   public shouldBeAvoided: boolean;
 
+  /** If the codec is supported with MSE in worker */
+  public isCodecSupportedInWebWorker: boolean | undefined;
+
   /**
    * @param {Object} args
    * @param {string} trackType
@@ -484,6 +487,7 @@ class Representation implements IRepresentationMetadata {
       hdrInfo: this.hdrInfo,
       contentProtections: this.contentProtections,
       decipherable: this.decipherable,
+      isCodecSupportedInWebWorker: this.isCodecSupportedInWebWorker,
     };
   }
 }

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -488,4 +488,6 @@ export interface IRepresentationMetadata {
   decipherable?: boolean | undefined;
   /** Encryption information for this Representation. */
   contentProtections?: IContentProtections | undefined;
+  /** If the codec is supported with MSE in worker */
+  isCodecSupportedInWebWorker?: boolean | undefined;
 }


### PR DESCRIPTION
We were reported a bug on Microsoft Edge where the player tried to play a content with HEVC codec but the MSE API failed to `addSourceBuffer` in a WebWorker.
The browser was supposed to handle HEVC because the API `MediaSource.isTypeSupported` returned `true`.
But calling this same API from a WebWorker returned `false`.

It is not clear if it is a Microsoft Edge limitation or a browser bug.
The fix is to test the codec support in the context of the WebWorker (only if it has MSE in worker).
