### PR TITLE
Fix minor memory leak when switching RepresentationStream through ABR

### DIFF
--- a/src/core/stream/representation/utils/push_init_segment.ts
+++ b/src/core/stream/representation/utils/push_init_segment.ts
@@ -62,9 +62,6 @@ export default async function pushInitSegment<T>(
   },
   cancelSignal: CancellationSignal,
 ): Promise<IStreamEventAddedSegmentPayload | null> {
-  if (cancelSignal.cancellationError !== null) {
-    throw cancelSignal.cancellationError;
-  }
   const codec = content.representation.getMimeTypeString();
   const data: IPushedChunkData<T> = {
     initSegmentUniqueId,

--- a/src/core/stream/representation/utils/push_media_segment.ts
+++ b/src/core/stream/representation/utils/push_media_segment.ts
@@ -68,9 +68,6 @@ export default async function pushMediaSegment<T>(
   if (parsedSegment.chunkData === null) {
     return null;
   }
-  if (cancelSignal.cancellationError !== null) {
-    throw cancelSignal.cancellationError;
-  }
   const { chunkData, chunkInfos, chunkOffset, chunkSize, appendWindow } = parsedSegment;
   const codec = content.representation.getMimeTypeString();
   const { APPEND_WINDOW_SECURITIES } = config.getCurrent();


### PR DESCRIPTION
I was working on a refacto proposal for better debugging capabilities (incoming!) and while working on it, that work actually detected a leak: a `RepresentationStream`'s own `TaskCanceller` is still listened to even if we decide to switch the Representation since. It was only cleared once either the content was stopped or some other situations (a track change, AdaptationStream aborted due to a Period change, a reload etc.).

While debugging a content, I saw that the amount of `TaskCanceller` aborted when stopping the content was actually equal to the number of quality switches through ABR - instead of the one per Period-type combination that I would have expected.

This should be relatively minor, I don't even think that it is actually visible to end customers even long term (multiple hours, a day etc.), but it is still a leak as we don't really need to keep that `TaskCanceller` alive once a `RepresentationStream` finished its business.

---

The fix was not straightforward though, as there was a reason we did not want to cancel the `TaskCanceller` as soon as the Representation changed: if at that time a segment was loaded but not yet pushed, we have no problem (and even prefer) with the fact that the `RepresentationStream` can continue to push that segment to the buffers.

I ended up declaring a single `TaskCanceller` for a `RepresentationStream`, yet by being careful as to not let it impact segment pushing.