### PR TITLE
[Proposal] Better logs and errors for task cancellation

### DIFF
--- a/src/compat/eme/close_session.ts
+++ b/src/compat/eme/close_session.ts
@@ -33,16 +33,16 @@ import type { IMediaKeySession } from "../browser_compatibility_types";
  * @returns {Promise.<undefined>}
  */
 export default function closeSession(session: IMediaKeySession): Promise<void> {
-  const timeoutCanceller = new TaskCanceller("Close session timeout");
+  const timeoutCanceller = new TaskCanceller("MediaKeySession close timeout");
 
   return Promise.race([
     session.close().then(() => {
-      timeoutCanceller.cancel("MKS close manual");
+      timeoutCanceller.cancel("MediaKeySession close method resolved");
     }),
     // The `closed` promise may resolve, even if `close()` result has not
     // (seen at some point on Firefox).
     session.closed.then(() => {
-      timeoutCanceller.cancel("MKS closed Prom");
+      timeoutCanceller.cancel("MediaKeySession closed property resolved");
     }),
     waitTimeoutAndCheck(),
   ]);

--- a/src/compat/eme/close_session.ts
+++ b/src/compat/eme/close_session.ts
@@ -37,12 +37,12 @@ export default function closeSession(session: IMediaKeySession): Promise<void> {
 
   return Promise.race([
     session.close().then(() => {
-      timeoutCanceller.cancel();
+      timeoutCanceller.cancel("MKS close manual");
     }),
     // The `closed` promise may resolve, even if `close()` result has not
     // (seen at some point on Firefox).
     session.closed.then(() => {
-      timeoutCanceller.cancel();
+      timeoutCanceller.cancel("MKS closed Prom");
     }),
     waitTimeoutAndCheck(),
   ]);

--- a/src/compat/eme/close_session.ts
+++ b/src/compat/eme/close_session.ts
@@ -33,7 +33,7 @@ import type { IMediaKeySession } from "../browser_compatibility_types";
  * @returns {Promise.<undefined>}
  */
 export default function closeSession(session: IMediaKeySession): Promise<void> {
-  const timeoutCanceller = new TaskCanceller();
+  const timeoutCanceller = new TaskCanceller("Close session timeout");
 
   return Promise.race([
     session.close().then(() => {

--- a/src/compat/eme/custom_media_keys/ie11_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/ie11_media_keys.ts
@@ -117,7 +117,7 @@ class IE11MediaKeySession
         this._ss.close();
         this._ss = undefined;
       }
-      this._sessionClosingCanceller.cancel();
+      this._sessionClosingCanceller.cancel("ie11 MKS close");
       resolve();
     });
   }

--- a/src/compat/eme/custom_media_keys/ie11_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/ie11_media_keys.ts
@@ -43,7 +43,7 @@ class IE11MediaKeySession
     this.expiration = NaN;
     this.keyStatuses = new Map();
     this._mk = mk;
-    this._sessionClosingCanceller = new TaskCanceller();
+    this._sessionClosingCanceller = new TaskCanceller("IE11 MKS Closing");
     this.closed = new Promise((resolve) => {
       this._sessionClosingCanceller.signal.register(() =>
         resolve("closed-by-application"),

--- a/src/compat/eme/custom_media_keys/ie11_media_keys.ts
+++ b/src/compat/eme/custom_media_keys/ie11_media_keys.ts
@@ -43,7 +43,7 @@ class IE11MediaKeySession
     this.expiration = NaN;
     this.keyStatuses = new Map();
     this._mk = mk;
-    this._sessionClosingCanceller = new TaskCanceller("IE11 MKS Closing");
+    this._sessionClosingCanceller = new TaskCanceller("IE11 MediaKeySession Closing");
     this.closed = new Promise((resolve) => {
       this._sessionClosingCanceller.signal.register(() =>
         resolve("closed-by-application"),
@@ -117,7 +117,7 @@ class IE11MediaKeySession
         this._ss.close();
         this._ss = undefined;
       }
-      this._sessionClosingCanceller.cancel("ie11 MKS close");
+      this._sessionClosingCanceller.cancel("IE11 MediaKeySession close");
       resolve();
     });
   }

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -195,7 +195,7 @@ function getEstimateReference(
    * This TaskCanceller is used both for restarting estimates with a new
    * configuration and to cancel them altogether.
    */
-  let currentEstimatesCanceller = new TaskCanceller("Current estimates");
+  let currentEstimatesCanceller = new TaskCanceller("ABR " + context.adaptation.type);
   currentEstimatesCanceller.linkToSignal(stopAllEstimates);
 
   // Create `SharedReference` on which estimates will be emitted.
@@ -496,7 +496,7 @@ function getEstimateReference(
   function restartEstimatesProductionFromCurrentConditions(): void {
     const representations = representationsRef.getValue();
     currentEstimatesCanceller.cancel("restart");
-    currentEstimatesCanceller = new TaskCanceller("ARS estimates");
+    currentEstimatesCanceller = new TaskCanceller("ABR " + context.adaptation.type);
     currentEstimatesCanceller.linkToSignal(stopAllEstimates);
     const newRef = createEstimateReference(
       representations,

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -195,7 +195,7 @@ function getEstimateReference(
    * This TaskCanceller is used both for restarting estimates with a new
    * configuration and to cancel them altogether.
    */
-  let currentEstimatesCanceller = new TaskCanceller();
+  let currentEstimatesCanceller = new TaskCanceller("Current estimates");
   currentEstimatesCanceller.linkToSignal(stopAllEstimates);
 
   // Create `SharedReference` on which estimates will be emitted.
@@ -496,7 +496,7 @@ function getEstimateReference(
   function restartEstimatesProductionFromCurrentConditions(): void {
     const representations = representationsRef.getValue();
     currentEstimatesCanceller.cancel();
-    currentEstimatesCanceller = new TaskCanceller();
+    currentEstimatesCanceller = new TaskCanceller("Current estimates");
     currentEstimatesCanceller.linkToSignal(stopAllEstimates);
     const newRef = createEstimateReference(
       representations,

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -495,8 +495,8 @@ function getEstimateReference(
    */
   function restartEstimatesProductionFromCurrentConditions(): void {
     const representations = representationsRef.getValue();
-    currentEstimatesCanceller.cancel();
-    currentEstimatesCanceller = new TaskCanceller("Current estimates");
+    currentEstimatesCanceller.cancel("restart");
+    currentEstimatesCanceller = new TaskCanceller("ARS estimates");
     currentEstimatesCanceller.linkToSignal(stopAllEstimates);
     const newRef = createEstimateReference(
       representations,

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -133,7 +133,7 @@ export default class CmcdDataBuilder {
   public startMonitoringPlayback(
     playbackObserver: IReadOnlyPlaybackObserver<ICmcdDataBuilderPlaybackObservation>,
   ): void {
-    this._canceller?.cancel("cmcd start");
+    this._canceller?.cancel("CmcdDataBuilder start");
     this._canceller = new TaskCanceller("CMCD monitoring");
     this._playbackObserver = playbackObserver;
     playbackObserver.listen(
@@ -151,7 +151,7 @@ export default class CmcdDataBuilder {
    * `stopMonitoringPlayback` call.
    */
   public stopMonitoringPlayback(): void {
-    this._canceller?.cancel("cmcd stop");
+    this._canceller?.cancel("CmcdDataBuilder stop");
     this._canceller = null;
     this._playbackObserver = null;
   }

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -133,7 +133,7 @@ export default class CmcdDataBuilder {
   public startMonitoringPlayback(
     playbackObserver: IReadOnlyPlaybackObserver<ICmcdDataBuilderPlaybackObservation>,
   ): void {
-    this._canceller?.cancel();
+    this._canceller?.cancel("cmcd start");
     this._canceller = new TaskCanceller("CMCD monitoring");
     this._playbackObserver = playbackObserver;
     playbackObserver.listen(
@@ -151,7 +151,7 @@ export default class CmcdDataBuilder {
    * `stopMonitoringPlayback` call.
    */
   public stopMonitoringPlayback(): void {
-    this._canceller?.cancel();
+    this._canceller?.cancel("cmcd stop");
     this._canceller = null;
     this._playbackObserver = null;
   }

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -134,7 +134,7 @@ export default class CmcdDataBuilder {
     playbackObserver: IReadOnlyPlaybackObserver<ICmcdDataBuilderPlaybackObservation>,
   ): void {
     this._canceller?.cancel();
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("CMCD monitoring");
     this._playbackObserver = playbackObserver;
     playbackObserver.listen(
       (obs) => {

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -110,7 +110,7 @@ export default class ContentPreparer {
     throttlers: IRepresentationEstimatorThrottlers,
   ): Promise<IManifest> {
     return new Promise((res, rej) => {
-      this.disposeCurrentContent();
+      this.disposeCurrentContent("new init");
       const contentCanceller = this._contentCanceller;
       const currentMediaSourceCanceller = new TaskCanceller("CP MS");
       this._currentMediaSourceCanceller = currentMediaSourceCanceller;
@@ -222,8 +222,8 @@ export default class ContentPreparer {
         currentMediaSourceCanceller.signal,
       );
 
-      contentCanceller.signal.register(() => {
-        manifestFetcher.dispose();
+      contentCanceller.signal.register((err) => {
+        manifestFetcher.dispose(err.reason);
       });
       manifestFetcher.addEventListener(
         "warning",
@@ -374,9 +374,12 @@ export default class ContentPreparer {
   /**
    * Dispose all resources linked to the currently preopared content if one and
    * stop linking it to this `ContentPreparer`.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public disposeCurrentContent() {
-    this._contentCanceller.cancel("CP dispose");
+  public disposeCurrentContent(reason: string | undefined) {
+    this._contentCanceller.cancel(reason);
     this._contentCanceller = new TaskCanceller("CP");
   }
 }
@@ -516,10 +519,10 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
     hasVideo,
     textSender,
   );
-  cancelSignal.register(() => {
-    segmentSinksStore.disposeAll();
-    textSender?.stop();
-    mediaSourceInterface.dispose();
+  cancelSignal.register((err) => {
+    segmentSinksStore.disposeAll(err.reason);
+    textSender?.stop(err.reason);
+    mediaSourceInterface.dispose(err.reason);
   });
 
   return [mediaSourceInterface, segmentSinksStore, textSender];

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -85,9 +85,9 @@ export default class ContentPreparer {
    */
   constructor({ hasVideo }: { hasVideo: boolean }) {
     this._currentContent = null;
-    this._currentMediaSourceCanceller = new TaskCanceller();
+    this._currentMediaSourceCanceller = new TaskCanceller("CP MS");
     this._hasVideo = hasVideo;
-    const contentCanceller = new TaskCanceller();
+    const contentCanceller = new TaskCanceller("CP");
     this._contentCanceller = contentCanceller;
   }
 
@@ -112,7 +112,7 @@ export default class ContentPreparer {
     return new Promise((res, rej) => {
       this.disposeCurrentContent();
       const contentCanceller = this._contentCanceller;
-      const currentMediaSourceCanceller = new TaskCanceller();
+      const currentMediaSourceCanceller = new TaskCanceller("CP MS");
       this._currentMediaSourceCanceller = currentMediaSourceCanceller;
 
       currentMediaSourceCanceller.linkToSignal(contentCanceller.signal);
@@ -333,7 +333,7 @@ export default class ContentPreparer {
       return Promise.reject(new Error("CP: No content anymore"));
     }
     this._currentContent.trackChoiceSetter.reset();
-    this._currentMediaSourceCanceller = new TaskCanceller();
+    this._currentMediaSourceCanceller = new TaskCanceller("CP MS");
 
     const [mediaSourceInterface, segmentSinksStore, coreTextSender] =
       createMediaSourceInterfaceAndSegmentSinksStore(
@@ -377,7 +377,7 @@ export default class ContentPreparer {
    */
   public disposeCurrentContent() {
     this._contentCanceller.cancel();
-    this._contentCanceller = new TaskCanceller();
+    this._contentCanceller = new TaskCanceller("CP");
   }
 }
 

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -85,9 +85,9 @@ export default class ContentPreparer {
    */
   constructor({ hasVideo }: { hasVideo: boolean }) {
     this._currentContent = null;
-    this._currentMediaSourceCanceller = new TaskCanceller("CP MS");
+    this._currentMediaSourceCanceller = new TaskCanceller("ContentPreparer MediaSource");
     this._hasVideo = hasVideo;
-    const contentCanceller = new TaskCanceller("CP");
+    const contentCanceller = new TaskCanceller("ContentPreparer");
     this._contentCanceller = contentCanceller;
   }
 
@@ -112,7 +112,9 @@ export default class ContentPreparer {
     return new Promise((res, rej) => {
       this.disposeCurrentContent("new init");
       const contentCanceller = this._contentCanceller;
-      const currentMediaSourceCanceller = new TaskCanceller("CP MS");
+      const currentMediaSourceCanceller = new TaskCanceller(
+        "ContentPreparer MediaSource",
+      );
       this._currentMediaSourceCanceller = currentMediaSourceCanceller;
 
       currentMediaSourceCanceller.linkToSignal(contentCanceller.signal);
@@ -328,12 +330,12 @@ export default class ContentPreparer {
   public reloadMediaSource(
     sendMessage: (msg: ICoreMessage, transferables?: Transferable[]) => void,
   ): Promise<void> {
-    this._currentMediaSourceCanceller.cancel("CP MS reload");
+    this._currentMediaSourceCanceller.cancel("ContentPreparer MediaSource reload");
     if (this._currentContent === null) {
       return Promise.reject(new Error("CP: No content anymore"));
     }
     this._currentContent.trackChoiceSetter.reset();
-    this._currentMediaSourceCanceller = new TaskCanceller("CP MS");
+    this._currentMediaSourceCanceller = new TaskCanceller("ContentPreparer MediaSource");
 
     const [mediaSourceInterface, segmentSinksStore, coreTextSender] =
       createMediaSourceInterfaceAndSegmentSinksStore(
@@ -380,7 +382,7 @@ export default class ContentPreparer {
    */
   public disposeCurrentContent(reason: string | undefined) {
     this._contentCanceller.cancel(reason);
-    this._contentCanceller = new TaskCanceller("CP");
+    this._contentCanceller = new TaskCanceller("ContentPreparer");
   }
 }
 

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -328,7 +328,7 @@ export default class ContentPreparer {
   public reloadMediaSource(
     sendMessage: (msg: ICoreMessage, transferables?: Transferable[]) => void,
   ): Promise<void> {
-    this._currentMediaSourceCanceller.cancel();
+    this._currentMediaSourceCanceller.cancel("CP MS reload");
     if (this._currentContent === null) {
       return Promise.reject(new Error("CP: No content anymore"));
     }
@@ -376,7 +376,7 @@ export default class ContentPreparer {
    * stop linking it to this `ContentPreparer`.
    */
   public disposeCurrentContent() {
-    this._contentCanceller.cancel();
+    this._contentCanceller.cancel("CP dispose");
     this._contentCanceller = new TaskCanceller("CP");
   }
 }

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -262,10 +262,13 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
   /**
    * Free all resources used by the `ContentTimeBoundariesObserver` and cancels
    * all recurring processes it performs.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose() {
+  public dispose(reason: string | undefined) {
     this.removeEventListener();
-    this._canceller.cancel("CTBO dispose");
+    this._canceller.cancel(reason ?? "CTBO dispose");
   }
 
   private _addActivelyLoadedPeriod(period: IPeriod, bufferType: IBufferType): void {

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -265,7 +265,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
    */
   public dispose() {
     this.removeEventListener();
-    this._canceller.cancel();
+    this._canceller.cancel("CTBO dispose");
   }
 
   private _addActivelyLoadedPeriod(period: IPeriod, bufferType: IBufferType): void {

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -81,7 +81,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
   ) {
     super();
 
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("Boundaries Observation");
     this._manifest = manifest;
     this._activeStreams = new Map();
     this._allBufferTypes = bufferTypes;

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -268,7 +268,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
    */
   public dispose(reason: string | undefined) {
     this.removeEventListener();
-    this._canceller.cancel(reason ?? "CTBO dispose");
+    this._canceller.cancel(reason ?? "ContentTimeBoundariesObserver dispose");
   }
 
   private _addActivelyLoadedPeriod(period: IPeriod, bufferType: IBufferType): void {

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -129,7 +129,7 @@ export default function initializeCoreEntry(
           }
 
           if (!msg.value.hasVideo) {
-            contentPreparer.disposeCurrentContent("WM init msg");
+            contentPreparer.disposeCurrentContent("Received Init msg");
             contentPreparer = new ContentPreparer({ hasVideo: msg.value.hasVideo });
           }
 
@@ -980,7 +980,7 @@ function loadPreparedContent(
 
   function performMediaSourceReload(payload: INeedsMediaSourceReloadPayload): void {
     if (currentLoadCanceller !== null) {
-      currentLoadCanceller.cancel("WM MS reload");
+      currentLoadCanceller.cancel("WorkerMain MediaSource reload");
       currentLoadCanceller = null;
     }
     const mediaSourceId = contentPreparer.getCurrentContent()?.mediaSource.id;

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -573,12 +573,12 @@ function loadPreparedContent(
       return onMediaSourceReload();
     },
     stop: () => {
-      contentCanceller.cancel();
+      contentCanceller.cancel("ContentHandle stop");
     },
   };
 
   function startLoadingAt(startTime: number): void {
-    currentLoadCanceller?.cancel();
+    currentLoadCanceller?.cancel("Reloading content worker");
     currentLoadCanceller = new TaskCanceller("(Re)Loading Content Worker");
     currentLoadCanceller.linkToSignal(contentCanceller.signal);
 
@@ -980,7 +980,7 @@ function loadPreparedContent(
 
   function performMediaSourceReload(payload: INeedsMediaSourceReloadPayload): void {
     if (currentLoadCanceller !== null) {
-      currentLoadCanceller.cancel();
+      currentLoadCanceller.cancel("WM MS reload");
       currentLoadCanceller = null;
     }
     const mediaSourceId = contentPreparer.getCurrentContent()?.mediaSource.id;
@@ -1010,7 +1010,7 @@ function loadPreparedContent(
     const lastObservation = playbackObservationRef.getValue();
     const newInitialTime = lastObservation.position.getWanted();
     if (currentLoadCanceller !== null) {
-      currentLoadCanceller.cancel();
+      currentLoadCanceller.cancel("MediaSource reload");
       currentLoadCanceller = null;
     }
     const contentId = contentPreparer.getCurrentContent()?.contentId;

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -129,7 +129,7 @@ export default function initializeCoreEntry(
           }
 
           if (!msg.value.hasVideo) {
-            contentPreparer.disposeCurrentContent();
+            contentPreparer.disposeCurrentContent("WM init msg");
             contentPreparer = new ContentPreparer({ hasVideo: msg.value.hasVideo });
           }
 
@@ -208,7 +208,7 @@ export default function initializeCoreEntry(
         if (msg.contentId !== contentPreparer.getCurrentContent()?.contentId) {
           return;
         }
-        contentPreparer.disposeCurrentContent();
+        contentPreparer.disposeCurrentContent("StopContent message");
 
         currentContentHandle?.stop();
         currentContentHandle = null;

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -563,7 +563,7 @@ function loadPreparedContent(
   refs: ICoreReferences,
 ): IContentHandle {
   log.debug("Core", "Loading pepared content.");
-  const contentCanceller = new TaskCanceller();
+  const contentCanceller = new TaskCanceller("Start Content Worker");
 
   let currentLoadCanceller: TaskCanceller | null = null;
 
@@ -579,7 +579,7 @@ function loadPreparedContent(
 
   function startLoadingAt(startTime: number): void {
     currentLoadCanceller?.cancel();
-    currentLoadCanceller = new TaskCanceller();
+    currentLoadCanceller = new TaskCanceller("(Re)Loading Content Worker");
     currentLoadCanceller.linkToSignal(contentCanceller.signal);
 
     /**

--- a/src/core/entry/core_text_displayer_interface.ts
+++ b/src/core/entry/core_text_displayer_interface.ts
@@ -81,23 +81,23 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
       contentId: this._contentId,
       value: null,
     });
-    this._resetCurrentQueue();
+    this._resetCurrentQueue("WTDI reset");
   }
 
   /**
    * @see ITextDisplayerInterface
    */
-  public stop(): void {
+  public stop(reason: string | undefined): void {
     this._messageSender({
       type: CoreMessageType.StopTextDisplayer,
       contentId: this._contentId,
       value: null,
     });
-    this._resetCurrentQueue();
+    this._resetCurrentQueue(reason);
   }
 
-  private _resetCurrentQueue(): void {
-    const error = new CancellationError("WTDI queue", "reset");
+  private _resetCurrentQueue(reason: string | undefined): void {
+    const error = new CancellationError("WTDI queue", reason ?? "reset");
     this._queues.pushTextData.forEach((elt) => {
       elt.reject(error);
     });

--- a/src/core/entry/core_text_displayer_interface.ts
+++ b/src/core/entry/core_text_displayer_interface.ts
@@ -81,7 +81,7 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
       contentId: this._contentId,
       value: null,
     });
-    this._resetCurrentQueue("WTDI reset");
+    this._resetCurrentQueue("WorkerTextDisplayerInterface reset");
   }
 
   /**
@@ -97,7 +97,10 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
   }
 
   private _resetCurrentQueue(reason: string | undefined): void {
-    const error = new CancellationError("WTDI queue", reason ?? "reset");
+    const error = new CancellationError(
+      "WorkerTextDisplayerInterface queue",
+      reason ?? "reset",
+    );
     this._queues.pushTextData.forEach((elt) => {
       elt.reject(error);
     });

--- a/src/core/entry/core_text_displayer_interface.ts
+++ b/src/core/entry/core_text_displayer_interface.ts
@@ -97,7 +97,7 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
   }
 
   private _resetCurrentQueue(): void {
-    const error = new CancellationError("WTDI Reset");
+    const error = new CancellationError("WTDI queue", "reset");
     this._queues.pushTextData.forEach((elt) => {
       elt.reject(error);
     });

--- a/src/core/entry/core_text_displayer_interface.ts
+++ b/src/core/entry/core_text_displayer_interface.ts
@@ -97,7 +97,7 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
   }
 
   private _resetCurrentQueue(): void {
-    const error = new CancellationError();
+    const error = new CancellationError("WTDI Reset");
     this._queues.pushTextData.forEach((elt) => {
       elt.reject(error);
     });

--- a/src/core/entry/create_content_time_boundaries_observer.ts
+++ b/src/core/entry/create_content_time_boundaries_observer.ts
@@ -38,16 +38,16 @@ export default function createContentTimeBoundariesObserver(
   callbacks: IContentTimeBoundariesObserverCallbacks,
   cancelSignal: CancellationSignal,
 ): ContentTimeBoundariesObserver {
-  cancelSignal.register(() => {
-    mediaSource.interruptDurationSetting();
+  cancelSignal.register((err) => {
+    mediaSource.interruptDurationSetting(err.reason);
   });
   const contentTimeBoundariesObserver = new ContentTimeBoundariesObserver(
     manifest,
     streamObserver,
     segmentSinksStore.getBufferTypes(),
   );
-  cancelSignal.register(() => {
-    contentTimeBoundariesObserver.dispose();
+  cancelSignal.register((err) => {
+    contentTimeBoundariesObserver.dispose(err.reason);
   });
   contentTimeBoundariesObserver.addEventListener("warning", (err) =>
     callbacks.onWarning(err),

--- a/src/core/entry/get_thumbnail_data.ts
+++ b/src/core/entry/get_thumbnail_data.ts
@@ -35,6 +35,6 @@ export default async function getThumbnailData(
   }
   return fetchThumbnails(
     { segment: wantedThumbnail, track: thumbnailTrack, period },
-    new TaskCanceller().signal,
+    new TaskCanceller(undefined).signal,
   );
 }

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -120,9 +120,12 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
    *
    * Once `dispose` has been called. This `ManifestFetcher` cannot be relied on
    * anymore.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * cancellation. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose() {
-    this._canceller.cancel("MF dispose");
+  public dispose(reason: string | undefined) {
+    this._canceller.cancel(reason ?? "MF dispose");
     this.removeEventListener();
   }
 
@@ -709,7 +712,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       return;
     }
     this.trigger("error", err);
-    this.dispose();
+    this.dispose("MF fatal err");
   }
 }
 

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -108,7 +108,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     this._pipelines = pipelines.manifest;
     this._transportName = pipelines.transportName;
     this._settings = settings;
-    this._canceller = new TaskCanceller("Manifest Fetcher");
+    this._canceller = new TaskCanceller("ManifestFetcher");
     this._isStarted = false;
     this._isRefreshPending = false;
     this._consecutiveUnsafeMode = 0;
@@ -125,7 +125,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
    * inspection.
    */
   public dispose(reason: string | undefined) {
-    this._canceller.cancel(reason ?? "MF dispose");
+    this._canceller.cancel(reason ?? "ManifestFetcher dispose");
     this.removeEventListener();
   }
 
@@ -472,7 +472,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      * be effectively considered.
      * `nextRefreshCanceller` will allow to cancel every other when one is triggered.
      */
-    const nextRefreshCanceller = new TaskCanceller("MF Refresh");
+    const nextRefreshCanceller = new TaskCanceller("ManifestFetcher refresh handling");
     nextRefreshCanceller.linkToSignal(this._canceller.signal);
 
     /* Function to manually schedule a Manifest refresh */
@@ -489,7 +489,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       );
       const timeoutId = setTimeout(
         () => {
-          nextRefreshCanceller.cancel("MF timeout");
+          nextRefreshCanceller.cancel("manifest request timeout");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh,
             unsafeMode,
@@ -506,7 +506,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     if (manifest.expired !== null) {
       const timeoutId = setTimeout(() => {
         manifest.expired?.then(() => {
-          nextRefreshCanceller.cancel("MF expir");
+          nextRefreshCanceller.cancel("manifest expiration");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh: false,
             unsafeMode: unsafeModeEnabled,
@@ -576,7 +576,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       }
       const timeoutId = setTimeout(
         () => {
-          nextRefreshCanceller.cancel("MF timeout");
+          nextRefreshCanceller.cancel("manifest request timeout");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh: false,
             unsafeMode: unsafeModeEnabled,
@@ -712,7 +712,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       return;
     }
     this.trigger("error", err);
-    this.dispose("MF fatal err");
+    this.dispose("ManifestFetcher fatal err");
   }
 }
 

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -122,7 +122,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
    * anymore.
    */
   public dispose() {
-    this._canceller.cancel();
+    this._canceller.cancel("MF dispose");
     this.removeEventListener();
   }
 
@@ -486,7 +486,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       );
       const timeoutId = setTimeout(
         () => {
-          nextRefreshCanceller.cancel();
+          nextRefreshCanceller.cancel("MF timeout");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh,
             unsafeMode,
@@ -503,7 +503,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     if (manifest.expired !== null) {
       const timeoutId = setTimeout(() => {
         manifest.expired?.then(() => {
-          nextRefreshCanceller.cancel();
+          nextRefreshCanceller.cancel("MF expir");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh: false,
             unsafeMode: unsafeModeEnabled,
@@ -573,7 +573,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
       }
       const timeoutId = setTimeout(
         () => {
-          nextRefreshCanceller.cancel();
+          nextRefreshCanceller.cancel("MF timeout");
           this._triggerNextManifestRefresh(manifest, {
             enablePartialRefresh: false,
             unsafeMode: unsafeModeEnabled,

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -108,7 +108,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     this._pipelines = pipelines.manifest;
     this._transportName = pipelines.transportName;
     this._settings = settings;
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("Manifest Fetcher");
     this._isStarted = false;
     this._isRefreshPending = false;
     this._consecutiveUnsafeMode = 0;
@@ -469,7 +469,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      * be effectively considered.
      * `nextRefreshCanceller` will allow to cancel every other when one is triggered.
      */
-    const nextRefreshCanceller = new TaskCanceller();
+    const nextRefreshCanceller = new TaskCanceller("MF Refresh");
     nextRefreshCanceller.linkToSignal(this._canceller.signal);
 
     /* Function to manually schedule a Manifest refresh */

--- a/src/core/fetchers/segment/__tests__/task_prioritizer.test.ts
+++ b/src/core/fetchers/segment/__tests__/task_prioritizer.test.ts
@@ -37,7 +37,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     });
     let wasInterrupted = 0;
     let wasEnded = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
     const prom = prioritizer
       .create(
         task,
@@ -83,7 +83,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     prioritizer
       .create(
@@ -178,7 +178,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     prioritizer
       .create(
@@ -273,7 +273,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     prioritizer
       .create(
@@ -368,7 +368,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     const prom = prioritizer
       .create(
@@ -472,7 +472,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     const prom = prioritizer
       .create(
@@ -582,7 +582,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     const prom = prioritizer
       .create(
@@ -684,7 +684,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was2Ended = false;
     let was3Interrupted = 0;
     let was3Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     const prom = prioritizer
       .create(
@@ -796,7 +796,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was1Ended = false;
     let was2Interrupted = 0;
     let was2Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     const prom = prioritizer
       .create(
@@ -870,7 +870,7 @@ describe("SegmentFetchers TaskPrioritizer", () => {
     let was1Ended = false;
     let was2Interrupted = 0;
     let was2Ended = false;
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
 
     prioritizer
       .create(

--- a/src/core/fetchers/segment/segment_queue.ts
+++ b/src/core/fetchers/segment/segment_queue.ts
@@ -141,12 +141,12 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     hasInitSegment: boolean,
     reason: string | undefined,
   ): SharedReference<ISegmentQueueItem> {
-    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SQ reset");
+    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SegmentQueue reset");
     const downloadQueue = new SharedReference<ISegmentQueueItem>({
       initSegment: null,
       segmentQueue: [],
     });
-    const currentCanceller = new TaskCanceller("SQ");
+    const currentCanceller = new TaskCanceller("SegmentQueue " + content.adaptation.type);
     currentCanceller.signal.register(() => {
       downloadQueue.finish();
     });
@@ -199,7 +199,10 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
           log.debug("SF", "no more media segment to request. Cancelling queue.", {
             type: content.adaptation.type,
           });
-          this._restartMediaSegmentDownloadingQueue(currentContentInfo, "no more media");
+          this._restartMediaSegmentDownloadingQueue(
+            currentContentInfo,
+            "media segment queue empty",
+          );
           return;
         } else if (currentSegmentRequest === null) {
           // There's no request although there are needed segments: start requests
@@ -207,7 +210,10 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             type: content.adaptation.type,
             queueLength: segmentQueue.length,
           });
-          this._restartMediaSegmentDownloadingQueue(currentContentInfo, "new media");
+          this._restartMediaSegmentDownloadingQueue(
+            currentContentInfo,
+            "media segment queue start",
+          );
           return;
         } else {
           const nextItem = segmentQueue[0];
@@ -218,7 +224,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             });
             this._restartMediaSegmentDownloadingQueue(
               currentContentInfo,
-              "media changed",
+              "next media segment changed",
             );
             return;
           }
@@ -263,7 +269,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
         this._restartInitSegmentDownloadingQueue(
           currentContentInfo,
           next.initSegment,
-          "no init",
+          "init segment queue empty",
         );
       },
       { emitCurrentValue: true, clearSignal: currentCanceller.signal },
@@ -281,7 +287,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
    * inspection.
    */
   public stop(reason: string | undefined) {
-    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SQ stop");
+    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SegmentQueue stop");
     this._currentContentInfo = null;
   }
 
@@ -296,7 +302,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     reason: string | undefined,
   ): void {
     if (contentInfo.mediaSegmentRequest !== null) {
-      contentInfo.mediaSegmentRequest.canceller.cancel(reason ?? "SQ media restart");
+      contentInfo.mediaSegmentRequest.canceller.cancel(
+        reason ?? "SegmentQueue media restart",
+      );
     }
 
     const { downloadQueue, content, initSegmentInfoRef, currentCanceller } = contentInfo;
@@ -317,7 +325,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
         this.trigger("emptyQueue", null);
         return;
       }
-      const canceller = new TaskCanceller("SQ Media");
+      const canceller = new TaskCanceller(
+        "SegmentQueue media segments queue " + content.adaptation.type,
+      );
       const unlinkCanceller =
         currentCanceller === null
           ? noop
@@ -491,13 +501,17 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     const { content, initSegmentInfoRef } = contentInfo;
 
     if (contentInfo.initSegmentRequest !== null) {
-      contentInfo.initSegmentRequest.canceller.cancel(reason ?? "SQ init restart");
+      contentInfo.initSegmentRequest.canceller.cancel(
+        reason ?? "SegmentQueue init restart",
+      );
     }
     if (queuedInitSegment === null) {
       return;
     }
 
-    const canceller = new TaskCanceller("SQ Init");
+    const canceller = new TaskCanceller(
+      "SegmentQueue init segment " + content.adaptation.type,
+    );
     const unlinkCanceller =
       contentInfo.currentCanceller === null
         ? noop

--- a/src/core/fetchers/segment/segment_queue.ts
+++ b/src/core/fetchers/segment/segment_queue.ts
@@ -142,7 +142,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
       initSegment: null,
       segmentQueue: [],
     });
-    const currentCanceller = new TaskCanceller();
+    const currentCanceller = new TaskCanceller("SQ");
     currentCanceller.signal.register(() => {
       downloadQueue.finish();
     });
@@ -299,7 +299,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
         this.trigger("emptyQueue", null);
         return;
       }
-      const canceller = new TaskCanceller();
+      const canceller = new TaskCanceller("SQ Media");
       const unlinkCanceller =
         currentCanceller === null
           ? noop
@@ -475,7 +475,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
       return;
     }
 
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("SQ Init");
     const unlinkCanceller =
       contentInfo.currentCanceller === null
         ? noop

--- a/src/core/fetchers/segment/segment_queue.ts
+++ b/src/core/fetchers/segment/segment_queue.ts
@@ -137,7 +137,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     content: ISegmentQueueContext,
     hasInitSegment: boolean,
   ): SharedReference<ISegmentQueueItem> {
-    this._currentContentInfo?.currentCanceller.cancel();
+    this._currentContentInfo?.currentCanceller.cancel("SQ reset");
     const downloadQueue = new SharedReference<ISegmentQueueItem>({
       initSegment: null,
       segmentQueue: [],
@@ -267,7 +267,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
    * Do nothing if no queue is active.
    */
   public stop() {
-    this._currentContentInfo?.currentCanceller.cancel();
+    this._currentContentInfo?.currentCanceller.cancel("SQ stop");
     this._currentContentInfo = null;
   }
 
@@ -278,7 +278,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     contentInfo: ISegmentQueueContentInfo,
   ): void {
     if (contentInfo.mediaSegmentRequest !== null) {
-      contentInfo.mediaSegmentRequest.canceller.cancel();
+      contentInfo.mediaSegmentRequest.canceller.cancel("SQ media restart");
     }
 
     const { downloadQueue, content, initSegmentInfoRef, currentCanceller } = contentInfo;
@@ -469,7 +469,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     const { content, initSegmentInfoRef } = contentInfo;
 
     if (contentInfo.initSegmentRequest !== null) {
-      contentInfo.initSegmentRequest.canceller.cancel();
+      contentInfo.initSegmentRequest.canceller.cancel("SQ init restart");
     }
     if (queuedInitSegment === null) {
       return;

--- a/src/core/fetchers/segment/segment_queue.ts
+++ b/src/core/fetchers/segment/segment_queue.ts
@@ -129,6 +129,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
    * By setting that value to `false`, you anounce to the `SegmentQueue`
    * that it should not wait for an initialization segment before parsing a
    * media segment.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * reset. Used for debugging matters, especially for debug log
+   * inspection.
    * @returns {Object} - `SharedReference` on which the queue of segment for
    * that content can be communicated and updated. See type for more
    * information.
@@ -136,8 +139,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
   public resetForContent(
     content: ISegmentQueueContext,
     hasInitSegment: boolean,
+    reason: string | undefined,
   ): SharedReference<ISegmentQueueItem> {
-    this._currentContentInfo?.currentCanceller.cancel("SQ reset");
+    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SQ reset");
     const downloadQueue = new SharedReference<ISegmentQueueItem>({
       initSegment: null,
       segmentQueue: [],
@@ -165,7 +169,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
           log.debug("SF", "Media segment can be loaded again, restarting queue.", {
             type: content.adaptation.type,
           });
-          this._restartMediaSegmentDownloadingQueue(currentContentInfo);
+          this._restartMediaSegmentDownloadingQueue(currentContentInfo, "interrupt end");
         }
       },
       { clearSignal: currentCanceller.signal },
@@ -195,7 +199,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
           log.debug("SF", "no more media segment to request. Cancelling queue.", {
             type: content.adaptation.type,
           });
-          this._restartMediaSegmentDownloadingQueue(currentContentInfo);
+          this._restartMediaSegmentDownloadingQueue(currentContentInfo, "no more media");
           return;
         } else if (currentSegmentRequest === null) {
           // There's no request although there are needed segments: start requests
@@ -203,7 +207,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             type: content.adaptation.type,
             queueLength: segmentQueue.length,
           });
-          this._restartMediaSegmentDownloadingQueue(currentContentInfo);
+          this._restartMediaSegmentDownloadingQueue(currentContentInfo, "new media");
           return;
         } else {
           const nextItem = segmentQueue[0];
@@ -212,7 +216,10 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             log.debug("SF", "Next media segment changed, cancelling previous", {
               type: content.adaptation.type,
             });
-            this._restartMediaSegmentDownloadingQueue(currentContentInfo);
+            this._restartMediaSegmentDownloadingQueue(
+              currentContentInfo,
+              "media changed",
+            );
             return;
           }
           if (currentSegmentRequest.priority !== nextItem.priority) {
@@ -253,7 +260,11 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             type: content.adaptation.type,
           });
         }
-        this._restartInitSegmentDownloadingQueue(currentContentInfo, next.initSegment);
+        this._restartInitSegmentDownloadingQueue(
+          currentContentInfo,
+          next.initSegment,
+          "no init",
+        );
       },
       { emitCurrentValue: true, clearSignal: currentCanceller.signal },
     );
@@ -265,20 +276,27 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
    * Stop the currently-active `SegmentQueue`.
    *
    * Do nothing if no queue is active.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * stop. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public stop() {
-    this._currentContentInfo?.currentCanceller.cancel("SQ stop");
+  public stop(reason: string | undefined) {
+    this._currentContentInfo?.currentCanceller.cancel(reason ?? "SQ stop");
     this._currentContentInfo = null;
   }
 
   /**
    * Internal logic performing media segment requests.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * restart. Used for debugging matters, especially for debug log
+   * inspection.
    */
   private _restartMediaSegmentDownloadingQueue(
     contentInfo: ISegmentQueueContentInfo,
+    reason: string | undefined,
   ): void {
     if (contentInfo.mediaSegmentRequest !== null) {
-      contentInfo.mediaSegmentRequest.canceller.cancel("SQ media restart");
+      contentInfo.mediaSegmentRequest.canceller.cancel(reason ?? "SQ media restart");
     }
 
     const { downloadQueue, content, initSegmentInfoRef, currentCanceller } = contentInfo;
@@ -447,7 +465,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
         unlinkCanceller();
         if (!isComplete) {
           isComplete = true;
-          this.stop();
+          this.stop("request err");
           this.trigger("error", error);
         }
       });
@@ -461,15 +479,19 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
    * Internal logic performing initialization segment requests.
    * @param {Object} contentInfo
    * @param {Object} queuedInitSegment
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
   private _restartInitSegmentDownloadingQueue(
     contentInfo: ISegmentQueueContentInfo,
     queuedInitSegment: IQueuedSegment | null,
+    reason: string | undefined,
   ): void {
     const { content, initSegmentInfoRef } = contentInfo;
 
     if (contentInfo.initSegmentRequest !== null) {
-      contentInfo.initSegmentRequest.canceller.cancel("SQ init restart");
+      contentInfo.initSegmentRequest.canceller.cancel(reason ?? "SQ init restart");
     }
     if (queuedInitSegment === null) {
       return;
@@ -529,7 +551,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
       unlinkCanceller();
       if (!isComplete) {
         isComplete = true;
-        this.stop();
+        this.stop("request err");
         this.trigger("error", error);
       }
     });

--- a/src/core/fetchers/segment/task_prioritizer.ts
+++ b/src/core/fetchers/segment/task_prioritizer.ts
@@ -342,7 +342,7 @@ export default class TaskPrioritizer<T> {
     } else if (this._minPendingPriority === task.priority) {
       this._minPendingPriority = Math.min(...this._pendingTasks.map((t) => t.priority));
     }
-    task.interrupter?.cancel("TP interrupt"); // Interrupt at last step because it calls external code
+    task.interrupter?.cancel("TaskPrioritizer interrupt"); // Interrupt at last step because it calls external code
   }
 
   /**

--- a/src/core/fetchers/segment/task_prioritizer.ts
+++ b/src/core/fetchers/segment/task_prioritizer.ts
@@ -94,7 +94,7 @@ export default class TaskPrioritizer<T> {
           reject(err);
         };
 
-        const interrupter = new TaskCanceller();
+        const interrupter = new TaskCanceller(undefined);
         const unlinkInterrupter = interrupter.linkToSignal(cancelSignal);
         newTask.interrupter = interrupter;
         interrupter.signal.register(() => {

--- a/src/core/fetchers/segment/task_prioritizer.ts
+++ b/src/core/fetchers/segment/task_prioritizer.ts
@@ -342,7 +342,7 @@ export default class TaskPrioritizer<T> {
     } else if (this._minPendingPriority === task.priority) {
       this._minPendingPriority = Math.min(...this._pendingTasks.map((t) => t.priority));
     }
-    task.interrupter?.cancel(); // Interrupt at last step because it calls external code
+    task.interrupter?.cancel("TP interrupt"); // Interrupt at last step because it calls external code
   }
 
   /**

--- a/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
+++ b/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
@@ -218,7 +218,7 @@ export default function createThumbnailFetcher(
       }
       pendingRequestsInfo[requestIdx].referenceCount--;
       if (pendingRequestsInfo[requestIdx].referenceCount <= 0) {
-        requestCanceller.cancel();
+        requestCanceller.cancel("Thumbnail request aborted");
         pendingRequestsInfo.splice(requestIdx, 1);
       }
     }

--- a/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
+++ b/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
@@ -143,7 +143,7 @@ export default function createThumbnailFetcher(
      * This is different than `cancellationSignal` which is linked to this call,
      * as several calls might share the same request.
      */
-    const requestCanceller = new TaskCanceller();
+    const requestCanceller = new TaskCanceller("Thumbnail request");
     const fetchPromise = doFetch();
     currRequestInfo = {
       thumbnailContext,

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -307,7 +307,7 @@ export async function scheduleRequestWithCdns<T>(
       return requestCdn(nextWantedCdn);
     }
 
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("Backoff");
     const unlinkCanceller = canceller.linkToSignal(cancellationSignal);
     return new Promise<T>((res, rej) => {
       cdnPrioritizer?.addEventListener(

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -307,7 +307,7 @@ export async function scheduleRequestWithCdns<T>(
       return requestCdn(nextWantedCdn);
     }
 
-    const canceller = new TaskCanceller("Backoff");
+    const canceller = new TaskCanceller("Request Backoff");
     const unlinkCanceller = canceller.linkToSignal(cancellationSignal);
     return new Promise<T>((res, rej) => {
       cdnPrioritizer?.addEventListener(
@@ -321,7 +321,7 @@ export async function scheduleRequestWithCdns<T>(
             return cleanAndReject(prevRequestError);
           }
           if (updatedPrioritaryCdn !== nextWantedCdn) {
-            canceller.cancel("SR new prio CDN");
+            canceller.cancel("new prioritized CDN");
             waitPotentialBackoffAndRequest(updatedPrioritaryCdn, prevRequestError).then(
               cleanAndResolve,
               cleanAndReject,

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -321,7 +321,7 @@ export async function scheduleRequestWithCdns<T>(
             return cleanAndReject(prevRequestError);
           }
           if (updatedPrioritaryCdn !== nextWantedCdn) {
-            canceller.cancel();
+            canceller.cancel("SR new prio CDN");
             waitPotentialBackoffAndRequest(updatedPrioritaryCdn, prevRequestError).then(
               cleanAndResolve,
               cleanAndReject,

--- a/src/core/segment_sinks/implementations/audio_video/audio_video_segment_sink.ts
+++ b/src/core/segment_sinks/implementations/audio_video/audio_video_segment_sink.ts
@@ -254,10 +254,10 @@ export default class AudioVideoSegmentSink extends SegmentSink {
   }
 
   /** @see SegmentSink */
-  public dispose(): void {
+  public dispose(reason: string | undefined): void {
     try {
       log.debug("Stream", "Calling `dispose` on the SourceBufferInterface");
-      this._sourceBuffer.dispose();
+      this._sourceBuffer.dispose(reason);
     } catch (e) {
       log.debug(
         "Stream",

--- a/src/core/segment_sinks/implementations/text/text_segment_sink.ts
+++ b/src/core/segment_sinks/implementations/text/text_segment_sink.ts
@@ -273,7 +273,7 @@ export interface ITextDisplayerInterface {
   /**
    * @see ITextDisplayer
    */
-  stop(): void;
+  stop(reason: string | undefined): void;
 }
 
 /*

--- a/src/core/segment_sinks/implementations/types.ts
+++ b/src/core/segment_sinks/implementations/types.ts
@@ -195,8 +195,11 @@ export abstract class SegmentSink {
    * Dispose of the resources used by this SegmentSink.
    * /!\ You won't be able to use the SegmentSink after calling this
    * function.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public abstract dispose(): void;
+  public abstract dispose(reason: string | undefined): void;
 }
 
 /** Every SegmentSink types. */

--- a/src/core/segment_sinks/segment_sinks_store.ts
+++ b/src/core/segment_sinks/segment_sinks_store.ts
@@ -334,8 +334,11 @@ export default class SegmentSinksStore {
   /**
    * Dispose of the active SegmentSink for the given type.
    * @param {string} bufferType
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public disposeSegmentSink(bufferType: IBufferType): void {
+  public disposeSegmentSink(bufferType: IBufferType, reason: string | undefined): void {
     const memorizedSegmentSink = this._initializedSegmentSinks[bufferType];
     if (isNullOrUndefined(memorizedSegmentSink)) {
       log.warn("Stream", "Trying to dispose a SegmentSink that does not exist", {
@@ -345,17 +348,20 @@ export default class SegmentSinksStore {
     }
 
     log.info("Stream", "Aborting SegmentSink", { bufferType });
-    memorizedSegmentSink.dispose();
+    memorizedSegmentSink.dispose(reason);
     delete this._initializedSegmentSinks[bufferType];
   }
 
   /**
    * Dispose of all SegmentSink created on this SegmentSinksStore.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public disposeAll(): void {
+  public disposeAll(reason: string | undefined): void {
     POSSIBLE_BUFFER_TYPES.forEach((bufferType: IBufferType) => {
       if (this.getStatus(bufferType).type === "initialized") {
-        this.disposeSegmentSink(bufferType);
+        this.disposeSegmentSink(bufferType, reason);
       }
     });
   }

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -68,7 +68,7 @@ export default function AdaptationStream(
   const { manifest, period, adaptation } = content;
 
   /** Allows to cancel everything the `AdaptationStream` is doing. */
-  const adapStreamCanceller = new TaskCanceller();
+  const adapStreamCanceller = new TaskCanceller("AS " + adaptation.type);
   adapStreamCanceller.linkToSignal(parentCancelSignal);
 
   /**
@@ -187,7 +187,7 @@ export default function AdaptationStream(
         newRepIds,
       );
       representationsList.setValueIfChanged(newRepresentations);
-      cancelCurrentStreams = new TaskCanceller();
+      cancelCurrentStreams = new TaskCanceller("AS Reps " + adaptation.type);
       cancelCurrentStreams.linkToSignal(adapStreamCanceller.signal);
       onRepresentationsChoiceChange(val, cancelCurrentStreams.signal).catch((err) => {
         if (
@@ -295,7 +295,9 @@ export default function AdaptationStream(
      * terminating and as such the next one might be immediately created
      * recursively.
      */
-    const repStreamTerminatingCanceller = new TaskCanceller();
+    const repStreamTerminatingCanceller = new TaskCanceller(
+      "AS Reps Recurs " + adaptation.type,
+    );
     repStreamTerminatingCanceller.linkToSignal(fnCancelSignal);
     const { representation } = estimateRef.getValue();
     if (representation === null) {
@@ -412,7 +414,7 @@ export default function AdaptationStream(
     /** Set to `true` if we've encountered an error with this `RepresentationStream` */
     let hasEncounteredError = false;
 
-    const bufferGoalCanceller = new TaskCanceller();
+    const bufferGoalCanceller = new TaskCanceller("AS BG " + adaptation.type);
     bufferGoalCanceller.linkToSignal(fnCancelSignal);
 
     /** Actually built buffer size, in seconds. */

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -332,7 +332,10 @@ export default function AdaptationStream(
             prevRepresentationBitrate: representation.bitrate,
             newRepresentationBitrate: estimate.representation.bitrate,
           });
-          return terminateCurrentStream.setValue({ urgent: true });
+          return terminateCurrentStream.setValue({
+            urgent: true,
+            reason: "Urgent Representation switch",
+          });
         } else {
           log.info("Stream", "slow Representation switch", {
             bufferType: adaptation.type,
@@ -340,7 +343,10 @@ export default function AdaptationStream(
             prevRepresentationBitrate: representation.bitrate,
             newRepresentationBitrate: estimate.representation.bitrate,
           });
-          return terminateCurrentStream.setValue({ urgent: false });
+          return terminateCurrentStream.setValue({
+            urgent: false,
+            reason: "Non-urgent Representation switch",
+          });
         }
       },
       {

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -68,7 +68,7 @@ export default function AdaptationStream(
   const { manifest, period, adaptation } = content;
 
   /** Allows to cancel everything the `AdaptationStream` is doing. */
-  const adapStreamCanceller = new TaskCanceller("AS " + adaptation.type);
+  const adapStreamCanceller = new TaskCanceller("AdaptationStream " + adaptation.type);
   adapStreamCanceller.linkToSignal(parentCancelSignal);
 
   /**
@@ -175,7 +175,7 @@ export default function AdaptationStream(
   content.representations.onUpdate(
     (val) => {
       if (cancelCurrentStreams !== undefined) {
-        cancelCurrentStreams.cancel("AS rep restart");
+        cancelCurrentStreams.cancel("locked representations changed");
       }
       const newRepIds = content.representations.getValue().representationIds;
 
@@ -187,7 +187,9 @@ export default function AdaptationStream(
         newRepIds,
       );
       representationsList.setValueIfChanged(newRepresentations);
-      cancelCurrentStreams = new TaskCanceller("AS Reps " + adaptation.type);
+      cancelCurrentStreams = new TaskCanceller(
+        "AdaptationStream: RepresentationStream Group " + adaptation.type,
+      );
       cancelCurrentStreams.linkToSignal(adapStreamCanceller.signal);
       onRepresentationsChoiceChange(val, cancelCurrentStreams.signal).catch((err) => {
         if (
@@ -196,7 +198,7 @@ export default function AdaptationStream(
         ) {
           return;
         }
-        adapStreamCanceller.cancel("AS rep err");
+        adapStreamCanceller.cancel("RepresentationStream err");
         callbacks.error(err);
       });
     },
@@ -296,7 +298,7 @@ export default function AdaptationStream(
      * recursively.
      */
     const repStreamTerminatingCanceller = new TaskCanceller(
-      "AS Reps Recurs " + adaptation.type,
+      "AdaptationStream: RepresentationStream creation " + adaptation.type,
     );
     repStreamTerminatingCanceller.linkToSignal(fnCancelSignal);
     const { representation } = estimateRef.getValue();
@@ -370,7 +372,7 @@ export default function AdaptationStream(
       inbandEvent: callbacks.inbandEvent,
       warning: callbacks.warning,
       error(err: unknown) {
-        adapStreamCanceller.cancel("AS rep err");
+        adapStreamCanceller.cancel("RepresentationStream err cb");
         callbacks.error(err);
       },
       addedSegment(segmentInfo) {
@@ -380,7 +382,7 @@ export default function AdaptationStream(
         if (repStreamTerminatingCanceller.isUsed()) {
           return; // Already handled
         }
-        repStreamTerminatingCanceller.cancel("AS rep term.");
+        repStreamTerminatingCanceller.cancel("RepresentationStream terminating");
         return recursivelyCreateRepresentationStreams(fnCancelSignal);
       },
     };
@@ -414,7 +416,9 @@ export default function AdaptationStream(
     /** Set to `true` if we've encountered an error with this `RepresentationStream` */
     let hasEncounteredError = false;
 
-    const bufferGoalCanceller = new TaskCanceller("AS BG " + adaptation.type);
+    const bufferGoalCanceller = new TaskCanceller(
+      "AdaptationStream: BufferGoal " + adaptation.type,
+    );
     bufferGoalCanceller.linkToSignal(fnCancelSignal);
 
     /** Actually built buffer size, in seconds. */
@@ -483,7 +487,7 @@ export default function AdaptationStream(
         }
       },
       terminating() {
-        bufferGoalCanceller.cancel("Rep term.");
+        bufferGoalCanceller.cancel("Representation terminating");
         representationStreamCallbacks.terminating();
       },
     });

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -175,7 +175,7 @@ export default function AdaptationStream(
   content.representations.onUpdate(
     (val) => {
       if (cancelCurrentStreams !== undefined) {
-        cancelCurrentStreams.cancel();
+        cancelCurrentStreams.cancel("AS rep restart");
       }
       const newRepIds = content.representations.getValue().representationIds;
 
@@ -196,7 +196,7 @@ export default function AdaptationStream(
         ) {
           return;
         }
-        adapStreamCanceller.cancel();
+        adapStreamCanceller.cancel("AS rep err");
         callbacks.error(err);
       });
     },
@@ -370,7 +370,7 @@ export default function AdaptationStream(
       inbandEvent: callbacks.inbandEvent,
       warning: callbacks.warning,
       error(err: unknown) {
-        adapStreamCanceller.cancel();
+        adapStreamCanceller.cancel("AS rep err");
         callbacks.error(err);
       },
       addedSegment(segmentInfo) {
@@ -380,7 +380,7 @@ export default function AdaptationStream(
         if (repStreamTerminatingCanceller.isUsed()) {
           return; // Already handled
         }
-        repStreamTerminatingCanceller.cancel();
+        repStreamTerminatingCanceller.cancel("AS rep term.");
         return recursivelyCreateRepresentationStreams(fnCancelSignal);
       },
     };
@@ -483,7 +483,7 @@ export default function AdaptationStream(
         }
       },
       terminating() {
-        bufferGoalCanceller.cancel();
+        bufferGoalCanceller.cancel("Rep term.");
         representationStreamCallbacks.terminating();
       },
     });

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -163,7 +163,9 @@ export default function StreamOrchestrator(
     let enableOutOfBoundsCheck = false;
 
     /** Cancels currently created `PeriodStream`s. */
-    let currentCanceller = new TaskCanceller("SO Streams " + bufferType);
+    let currentCanceller = new TaskCanceller(
+      "StreamOrchestrator Streams for " + bufferType,
+    );
     currentCanceller.linkToSignal(orchestratorCancelSignal);
 
     // Restart the current Stream when the wanted time is in another period
@@ -196,8 +198,10 @@ export default function StreamOrchestrator(
           periodList.removeElement(period);
           callbacks.periodStreamCleared({ type: bufferType, manifest, period });
         }
-        currentCanceller.cancel("SO oob");
-        currentCanceller = new TaskCanceller("SO Streams " + bufferType);
+        currentCanceller.cancel("PeriodStream is out of bounds");
+        currentCanceller = new TaskCanceller(
+          "StreamOrchestrator Streams for " + bufferType,
+        );
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
         // As previous callbacks may have performed unknown side-effects, just
@@ -223,7 +227,7 @@ export default function StreamOrchestrator(
           if (orchestratorCancelSignal.isCancelled()) {
             return;
           }
-          currentCanceller.cancel("SO deciph update");
+          currentCanceller.cancel("decipherabilityUpdate event");
           callbacks.error(err);
         });
       },
@@ -265,7 +269,7 @@ export default function StreamOrchestrator(
           callbacks.periodStreamCleared(payload);
         },
         error(err: unknown): void {
-          currentCanceller.cancel("SO err");
+          currentCanceller.cancel("PeriodStream err callback");
           callbacks.error(err);
         },
       };
@@ -360,8 +364,10 @@ export default function StreamOrchestrator(
         callbacks.periodStreamCleared({ type: bufferType, manifest, period });
       }
 
-      currentCanceller.cancel("So deciph upd");
-      currentCanceller = new TaskCanceller("SO Streams " + bufferType);
+      currentCanceller.cancel("decipherability update");
+      currentCanceller = new TaskCanceller(
+        "StreamOrchestrator Streams for " + bufferType,
+      );
       currentCanceller.linkToSignal(orchestratorCancelSignal);
 
       /** Remove from the `SegmentSink` all the concerned time ranges. */
@@ -495,7 +501,9 @@ export default function StreamOrchestrator(
     } | null = null;
 
     /** Emits when the `PeriodStream` linked to `basePeriod` should be destroyed. */
-    const currentStreamCanceller = new TaskCanceller("SO Consecutive " + bufferType);
+    const currentStreamCanceller = new TaskCanceller(
+      "StreamOrchestrator current consecutive Streams " + bufferType,
+    );
     currentStreamCanceller.linkToSignal(cancelSignal);
 
     // Stop current PeriodStream when the current position goes over the end of
@@ -525,7 +533,7 @@ export default function StreamOrchestrator(
             manifest,
             period: basePeriod,
           });
-          currentStreamCanceller.cancel("SO pos above");
+          currentStreamCanceller.cancel("Position ahead of PeriodStream");
         }
       },
       { clearSignal: cancelSignal, includeLastObservation: true },
@@ -568,17 +576,17 @@ export default function StreamOrchestrator(
             manifest,
             period: nextStreamInfo.period,
           });
-          nextStreamInfo.canceller.cancel("SO prev active");
+          nextStreamInfo.canceller.cancel("previous PeriodStream is active");
           nextStreamInfo = null;
         }
         consecutivePeriodStreamCb.streamStatusUpdate(value);
       },
       error(err: unknown): void {
         if (nextStreamInfo !== null) {
-          nextStreamInfo.canceller.cancel("SO err prev");
+          nextStreamInfo.canceller.cancel("previous PeriodStream err");
           nextStreamInfo = null;
         }
-        currentStreamCanceller.cancel("SO err curr");
+        currentStreamCanceller.cancel("PeriodStream err");
         consecutivePeriodStreamCb.error(err);
       },
     };
@@ -608,9 +616,11 @@ export default function StreamOrchestrator(
           manifest,
           period: nextStreamInfo.period,
         });
-        nextStreamInfo.canceller.cancel("SO next recreat");
+        nextStreamInfo.canceller.cancel("PeriodStream recreation");
       }
-      const nextStreamCanceller = new TaskCanceller("SO Next " + bufferType);
+      const nextStreamCanceller = new TaskCanceller(
+        "StreamOrchestrator next PeriodStream " + bufferType,
+      );
       nextStreamCanceller.linkToSignal(cancelSignal);
       nextStreamInfo = { canceller: nextStreamCanceller, period: nextPeriod };
       manageConsecutivePeriodStreams(
@@ -682,7 +692,7 @@ export default function StreamOrchestrator(
                   manifest,
                   period: nextStreamInfo.period,
                 });
-                nextStreamInfo.canceller.cancel("SO next Period changed");
+                nextStreamInfo.canceller.cancel("Next Period changed");
                 nextStreamInfo = null;
               }
             }

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -196,7 +196,7 @@ export default function StreamOrchestrator(
           periodList.removeElement(period);
           callbacks.periodStreamCleared({ type: bufferType, manifest, period });
         }
-        currentCanceller.cancel();
+        currentCanceller.cancel("SO oob");
         currentCanceller = new TaskCanceller("SO Streams " + bufferType);
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
@@ -223,7 +223,7 @@ export default function StreamOrchestrator(
           if (orchestratorCancelSignal.isCancelled()) {
             return;
           }
-          currentCanceller.cancel();
+          currentCanceller.cancel("SO deciph update");
           callbacks.error(err);
         });
       },
@@ -265,7 +265,7 @@ export default function StreamOrchestrator(
           callbacks.periodStreamCleared(payload);
         },
         error(err: unknown): void {
-          currentCanceller.cancel();
+          currentCanceller.cancel("SO err");
           callbacks.error(err);
         },
       };
@@ -360,7 +360,7 @@ export default function StreamOrchestrator(
         callbacks.periodStreamCleared({ type: bufferType, manifest, period });
       }
 
-      currentCanceller.cancel();
+      currentCanceller.cancel("So deciph upd");
       currentCanceller = new TaskCanceller("SO Streams " + bufferType);
       currentCanceller.linkToSignal(orchestratorCancelSignal);
 
@@ -525,7 +525,7 @@ export default function StreamOrchestrator(
             manifest,
             period: basePeriod,
           });
-          currentStreamCanceller.cancel();
+          currentStreamCanceller.cancel("SO pos above");
         }
       },
       { clearSignal: cancelSignal, includeLastObservation: true },
@@ -568,17 +568,17 @@ export default function StreamOrchestrator(
             manifest,
             period: nextStreamInfo.period,
           });
-          nextStreamInfo.canceller.cancel();
+          nextStreamInfo.canceller.cancel("SO prev active");
           nextStreamInfo = null;
         }
         consecutivePeriodStreamCb.streamStatusUpdate(value);
       },
       error(err: unknown): void {
         if (nextStreamInfo !== null) {
-          nextStreamInfo.canceller.cancel();
+          nextStreamInfo.canceller.cancel("SO err prev");
           nextStreamInfo = null;
         }
-        currentStreamCanceller.cancel();
+        currentStreamCanceller.cancel("SO err curr");
         consecutivePeriodStreamCb.error(err);
       },
     };
@@ -608,7 +608,7 @@ export default function StreamOrchestrator(
           manifest,
           period: nextStreamInfo.period,
         });
-        nextStreamInfo.canceller.cancel();
+        nextStreamInfo.canceller.cancel("SO next recreat");
       }
       const nextStreamCanceller = new TaskCanceller("SO Next " + bufferType);
       nextStreamCanceller.linkToSignal(cancelSignal);
@@ -682,7 +682,7 @@ export default function StreamOrchestrator(
                   manifest,
                   period: nextStreamInfo.period,
                 });
-                nextStreamInfo.canceller.cancel();
+                nextStreamInfo.canceller.cancel("SO next Period changed");
                 nextStreamInfo = null;
               }
             }

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -163,7 +163,7 @@ export default function StreamOrchestrator(
     let enableOutOfBoundsCheck = false;
 
     /** Cancels currently created `PeriodStream`s. */
-    let currentCanceller = new TaskCanceller();
+    let currentCanceller = new TaskCanceller("SO Streams " + bufferType);
     currentCanceller.linkToSignal(orchestratorCancelSignal);
 
     // Restart the current Stream when the wanted time is in another period
@@ -197,7 +197,7 @@ export default function StreamOrchestrator(
           callbacks.periodStreamCleared({ type: bufferType, manifest, period });
         }
         currentCanceller.cancel();
-        currentCanceller = new TaskCanceller();
+        currentCanceller = new TaskCanceller("SO Streams " + bufferType);
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
         // As previous callbacks may have performed unknown side-effects, just
@@ -361,7 +361,7 @@ export default function StreamOrchestrator(
       }
 
       currentCanceller.cancel();
-      currentCanceller = new TaskCanceller();
+      currentCanceller = new TaskCanceller("SO Streams " + bufferType);
       currentCanceller.linkToSignal(orchestratorCancelSignal);
 
       /** Remove from the `SegmentSink` all the concerned time ranges. */
@@ -495,7 +495,7 @@ export default function StreamOrchestrator(
     } | null = null;
 
     /** Emits when the `PeriodStream` linked to `basePeriod` should be destroyed. */
-    const currentStreamCanceller = new TaskCanceller();
+    const currentStreamCanceller = new TaskCanceller("SO Consecutive " + bufferType);
     currentStreamCanceller.linkToSignal(cancelSignal);
 
     // Stop current PeriodStream when the current position goes over the end of
@@ -610,7 +610,7 @@ export default function StreamOrchestrator(
         });
         nextStreamInfo.canceller.cancel();
       }
-      const nextStreamCanceller = new TaskCanceller();
+      const nextStreamCanceller = new TaskCanceller("SO Next " + bufferType);
       nextStreamCanceller.linkToSignal(cancelSignal);
       nextStreamInfo = { canceller: nextStreamCanceller, period: nextPeriod };
       manageConsecutivePeriodStreams(

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -125,9 +125,11 @@ export default function PeriodStream(
           return;
         }
 
-        const streamCanceller = new TaskCanceller("PS Adap " + bufferType);
+        const streamCanceller = new TaskCanceller(
+          "PeriodStream: Adaptation choice " + bufferType,
+        );
         streamCanceller.linkToSignal(parentCancelSignal);
-        currentStreamCanceller?.cancel("PS adap update"); // Cancel previously created stream if one
+        currentStreamCanceller?.cancel("PeriodStream: Adaptation update"); // Cancel previously created stream if one
         currentStreamCanceller = streamCanceller;
 
         if (choice === null) {
@@ -192,7 +194,7 @@ export default function PeriodStream(
           (a) => a.id === choice.adaptationId,
         );
         if (adaptation === undefined) {
-          currentStreamCanceller.cancel("PS adap not found");
+          currentStreamCanceller.cancel("PeriodStream: Adaptation not found");
           log.warn("Stream", "Unfound chosen Adaptation choice", {
             adaptationId: choice.adaptationId,
           });
@@ -332,7 +334,7 @@ export default function PeriodStream(
         if (err instanceof CancellationError) {
           return;
         }
-        currentStreamCanceller?.cancel("PS err");
+        currentStreamCanceller?.cancel("PeriodStream err");
         callbacks.error(err);
       });
     },
@@ -381,7 +383,7 @@ export default function PeriodStream(
           `${bufferType} Stream crashed. Aborting it.`,
           error instanceof Error ? error : "",
         );
-        segmentSinksStore.disposeSegmentSink(bufferType, "adap stream err");
+        segmentSinksStore.disposeSegmentSink(bufferType, "AdaptationStream err");
 
         const formattedError = formatError(error, {
           defaultCode: "NONE",

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -125,7 +125,7 @@ export default function PeriodStream(
           return;
         }
 
-        const streamCanceller = new TaskCanceller();
+        const streamCanceller = new TaskCanceller("PS Adap " + bufferType);
         streamCanceller.linkToSignal(parentCancelSignal);
         currentStreamCanceller?.cancel(); // Cancel previously created stream if one
         currentStreamCanceller = streamCanceller;

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -127,7 +127,7 @@ export default function PeriodStream(
 
         const streamCanceller = new TaskCanceller("PS Adap " + bufferType);
         streamCanceller.linkToSignal(parentCancelSignal);
-        currentStreamCanceller?.cancel(); // Cancel previously created stream if one
+        currentStreamCanceller?.cancel("PS adap update"); // Cancel previously created stream if one
         currentStreamCanceller = streamCanceller;
 
         if (choice === null) {
@@ -192,7 +192,7 @@ export default function PeriodStream(
           (a) => a.id === choice.adaptationId,
         );
         if (adaptation === undefined) {
-          currentStreamCanceller.cancel();
+          currentStreamCanceller.cancel("PS adap not found");
           log.warn("Stream", "Unfound chosen Adaptation choice", {
             adaptationId: choice.adaptationId,
           });
@@ -332,7 +332,7 @@ export default function PeriodStream(
         if (err instanceof CancellationError) {
           return;
         }
-        currentStreamCanceller?.cancel();
+        currentStreamCanceller?.cancel("PS err");
         callbacks.error(err);
       });
     },

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -381,7 +381,7 @@ export default function PeriodStream(
           `${bufferType} Stream crashed. Aborting it.`,
           error instanceof Error ? error : "",
         );
-        segmentSinksStore.disposeSegmentSink(bufferType);
+        segmentSinksStore.disposeSegmentSink(bufferType, "adap stream err");
 
         const formattedError = formatError(error, {
           defaultCode: "NONE",

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -158,7 +158,7 @@ export default function RepresentationStream<TSegmentDataType>(
     if (canceller.signal.isCancelled()) {
       return; // ignore post requests-cancellation loading-related errors,
     }
-    canceller.cancel(); // Stop every operations
+    canceller.cancel("SegmentQueue err"); // Stop every operations
     callbacks.error(err);
   });
   segmentQueue.addEventListener("parsedInitSegment", onParsedChunk, canceller.signal);
@@ -290,7 +290,7 @@ export default function RepresentationStream<TSegmentDataType>(
       });
       segmentsToLoadRef.setValue({ initSegment: null, segmentQueue: [] });
       segmentsToLoadRef.finish();
-      canceller.cancel();
+      canceller.cancel("RepresentationStream Urgent Termination");
       callbacks.terminating();
       return;
     } else {
@@ -321,7 +321,7 @@ export default function RepresentationStream<TSegmentDataType>(
           representationBitrate: content.representation.bitrate,
         });
         segmentsToLoadRef.finish();
-        canceller.cancel();
+        canceller.cancel("RepresentationStream non-urgent switch");
         callbacks.terminating();
         return;
       }
@@ -482,7 +482,7 @@ export default function RepresentationStream<TSegmentDataType>(
       },
       err instanceof Error ? err : null,
     );
-    canceller.cancel();
+    canceller.cancel("RepresentationStream fatal buffer err");
     callbacks.error(err);
   }
 }

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -195,7 +195,7 @@ export default function RepresentationStream<TSegmentDataType>(
   const segmentsToLoadRef = segmentQueue.resetForContent(
     content,
     hasInitSegment,
-    "new RepresentationStream in town",
+    "new RepresentationStream linked to SegmentQueue",
   );
 
   canceller.signal.register((err) => {

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -294,7 +294,7 @@ export default function RepresentationStream<TSegmentDataType>(
       });
       segmentsToLoadRef.setValue({ initSegment: null, segmentQueue: [] });
       segmentsToLoadRef.finish();
-      canceller.cancel("RepresentationStream: termination urgent");
+      canceller.cancel(terminateVal.reason);
       callbacks.terminating();
       return;
     } else {
@@ -325,7 +325,7 @@ export default function RepresentationStream<TSegmentDataType>(
           representationBitrate: content.representation.bitrate,
         });
         segmentsToLoadRef.finish();
-        canceller.cancel("RepresentationStream: empty queue + termination");
+        canceller.cancel(terminateVal.reason);
         callbacks.terminating();
         return;
       }

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -102,7 +102,7 @@ export default function RepresentationStream<TSegmentDataType>(
   const bufferType = adaptation.type;
 
   /** `TaskCanceller` stopping operations performed by the `RepresentationStream` */
-  const canceller = new TaskCanceller("RepresentationStream");
+  const canceller = new TaskCanceller("RepresentationStream " + bufferType);
   canceller.linkToSignal(parentCancelSignal);
 
   /** Saved initialization segment state for this representation. */
@@ -158,7 +158,7 @@ export default function RepresentationStream<TSegmentDataType>(
     if (canceller.signal.isCancelled()) {
       return; // ignore post requests-cancellation loading-related errors,
     }
-    canceller.cancel("SegmentQueue err"); // Stop every operations
+    canceller.cancel("RepresentationStream: SegmentQueue err"); // Stop every operations
     callbacks.error(err);
   });
   segmentQueue.addEventListener("parsedInitSegment", onParsedChunk, canceller.signal);
@@ -195,7 +195,7 @@ export default function RepresentationStream<TSegmentDataType>(
   const segmentsToLoadRef = segmentQueue.resetForContent(
     content,
     hasInitSegment,
-    "new RS",
+    "new RepresentationStream in town",
   );
 
   canceller.signal.register((err) => {
@@ -294,7 +294,7 @@ export default function RepresentationStream<TSegmentDataType>(
       });
       segmentsToLoadRef.setValue({ initSegment: null, segmentQueue: [] });
       segmentsToLoadRef.finish();
-      canceller.cancel("RepresentationStream Urgent Termination");
+      canceller.cancel("RepresentationStream: termination urgent");
       callbacks.terminating();
       return;
     } else {
@@ -325,7 +325,7 @@ export default function RepresentationStream<TSegmentDataType>(
           representationBitrate: content.representation.bitrate,
         });
         segmentsToLoadRef.finish();
-        canceller.cancel("RepresentationStream non-urgent switch");
+        canceller.cancel("RepresentationStream: empty queue + termination");
         callbacks.terminating();
         return;
       }
@@ -486,7 +486,7 @@ export default function RepresentationStream<TSegmentDataType>(
       },
       err instanceof Error ? err : null,
     );
-    canceller.cancel("RepresentationStream fatal buffer err");
+    canceller.cancel("RepresentationStream: fatal buffer err");
     callbacks.error(err);
   }
 }

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -192,10 +192,14 @@ export default function RepresentationStream<TSegmentDataType>(
   );
 
   /** Emit the last scheduled downloading queue for segments. */
-  const segmentsToLoadRef = segmentQueue.resetForContent(content, hasInitSegment);
+  const segmentsToLoadRef = segmentQueue.resetForContent(
+    content,
+    hasInitSegment,
+    "new RS",
+  );
 
-  canceller.signal.register(() => {
-    segmentQueue.stop();
+  canceller.signal.register((err) => {
+    segmentQueue.stop(err.reason);
   });
 
   playbackObserver.listen(checkStatus, {

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -102,7 +102,7 @@ export default function RepresentationStream<TSegmentDataType>(
   const bufferType = adaptation.type;
 
   /** `TaskCanceller` stopping operations performed by the `RepresentationStream` */
-  const canceller = new TaskCanceller();
+  const canceller = new TaskCanceller("RepresentationStream");
   canceller.linkToSignal(parentCancelSignal);
 
   /** Saved initialization segment state for this representation. */

--- a/src/core/stream/representation/types.ts
+++ b/src/core/stream/representation/types.ts
@@ -253,6 +253,11 @@ export interface ITerminationOrder {
    * finished.
    */
   urgent: boolean;
+  /**
+   * Human-readable string describing the reason for the change.
+   * This is useful when debugging.
+   */
+  reason: string;
 }
 
 /** Arguments to give to the RepresentationStream. */

--- a/src/experimental/tools/DummyMediaElement/html5.ts
+++ b/src/experimental/tools/DummyMediaElement/html5.ts
@@ -411,7 +411,7 @@ export class DummyMediaElement
     this._src = val;
     this.srcObject = null;
     this._currentContentCanceller?.cancel();
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("DummyMediaElement src");
     this._currentContentCanceller = canceller;
     setTimeout(() => {
       while (this._pendingPlayPromises.length > 0) {
@@ -478,7 +478,7 @@ export class DummyMediaElement
         throw new Error("A DummyMediaElement can only be linked to a DummyMediaSource");
       }
       this._attachedMediaSource = val;
-      this._currentContentCanceller = new TaskCanceller();
+      this._currentContentCanceller = new TaskCanceller("DummyMediaElement srcObject");
       const intervalId = setInterval(() => {
         this._tick();
       }, TICK_INTERVAL);

--- a/src/experimental/tools/DummyMediaElement/html5.ts
+++ b/src/experimental/tools/DummyMediaElement/html5.ts
@@ -410,7 +410,7 @@ export class DummyMediaElement
   public set src(val: string) {
     this._src = val;
     this.srcObject = null;
-    this._currentContentCanceller?.cancel();
+    this._currentContentCanceller?.cancel("Resetting DummyMediaElement src");
     const canceller = new TaskCanceller("DummyMediaElement src");
     this._currentContentCanceller = canceller;
     setTimeout(() => {
@@ -445,7 +445,7 @@ export class DummyMediaElement
   public set srcObject(val: MediaProvider | null) {
     // media element load algorithm
 
-    this._currentContentCanceller?.cancel();
+    this._currentContentCanceller?.cancel("Resetting DummyMediaElement srcObject");
     this._wasLoadedDataSentForCurrentContent = false;
     this._wasPlayPerformedOnCurrentContent = false;
     this.buffered = new TimeRangesWithMetadata();

--- a/src/experimental/tools/DummyMediaElement/mse.ts
+++ b/src/experimental/tools/DummyMediaElement/mse.ts
@@ -164,14 +164,14 @@ export class DummyMediaSource
       sb.updating = false;
       if (sb instanceof DummySourceBuffer) {
         if (sb.currentAppendCanceller !== null) {
-          sb.currentAppendCanceller.cancel();
+          sb.currentAppendCanceller.cancel("Removing DummySourceBuffer");
           sb.currentAppendCanceller = null;
           sb.eventScheduler
             .schedule(sb, "abort", null)
             .then(() => sb.eventScheduler.schedule(sb, "updateend", null))
             .catch(noop);
         }
-        sb.canceller.cancel();
+        sb.canceller.cancel("Removing DummySourceBuffer");
         sb.removed = true;
       }
     }
@@ -629,7 +629,7 @@ export class DummySourceBuffer
     }
 
     if (this.updating) {
-      this.currentAppendCanceller?.cancel();
+      this.currentAppendCanceller?.cancel("Aborting DummySourceBuffer");
       this.currentAppendCanceller = null;
       this.updating = false;
       this.eventScheduler

--- a/src/experimental/tools/DummyMediaElement/mse.ts
+++ b/src/experimental/tools/DummyMediaElement/mse.ts
@@ -369,7 +369,7 @@ export class DummySourceBuffer
     this.onerror = null;
     this.onabort = null;
     this.hasMetadata = false;
-    this.canceller = new TaskCanceller();
+    this.canceller = new TaskCanceller("DummySourceBuffer");
     this.currentAppendCanceller = null;
     this._lastKeyId = null;
     this._callbacks = callbacks;
@@ -485,7 +485,7 @@ export class DummySourceBuffer
 
     this.updating = true;
 
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("DummySourceBuffer append");
     canceller.linkToSignal(this.canceller.signal);
     this.currentAppendCanceller = canceller;
     this.eventScheduler

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -78,7 +78,7 @@ export default class VideoThumbnailLoader {
     const manifest = this._player.__priv_getManifest();
     if (manifest === null) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel("VTL no manifest");
+        this._lastRepresentationInfo.cleaner.cancel("VTL: no manifest");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -94,7 +94,7 @@ export default class VideoThumbnailLoader {
     const content = getTrickModeInfo(time, manifest);
     if (content === null) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel("VTL no trickmode");
+        this._lastRepresentationInfo.cleaner.cancel("VTL: no trickmode");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -109,7 +109,7 @@ export default class VideoThumbnailLoader {
       this._lastRepresentationInfo !== null &&
       !areSameRepresentation(this._lastRepresentationInfo.content, content)
     ) {
-      this._lastRepresentationInfo.cleaner.cancel("VTL diff rep.");
+      this._lastRepresentationInfo.cleaner.cancel("VTL: Representation is different");
       this._lastRepresentationInfo = null;
     }
 
@@ -120,7 +120,7 @@ export default class VideoThumbnailLoader {
 
     if (neededSegments.length === 0) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel("VTL no thumb");
+        this._lastRepresentationInfo.cleaner.cancel("VTL: no segment info");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -166,7 +166,7 @@ export default class VideoThumbnailLoader {
     const loader = loaders[content.manifest.transport];
     if (loader === undefined) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel("VTL no parser");
+        this._lastRepresentationInfo.cleaner.cancel("VTL: no parser");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -180,7 +180,7 @@ export default class VideoThumbnailLoader {
 
     let lastRepInfo: IVideoThumbnailLoaderRepresentationInfo;
     if (this._lastRepresentationInfo === null) {
-      const lastRepInfoCleaner = new TaskCanceller("VTL Rep");
+      const lastRepInfoCleaner = new TaskCanceller("VTL: Representation Info");
       const segmentFetcher = createSegmentFetcher({
         bufferType: "video",
         pipeline: loader.video,
@@ -235,12 +235,14 @@ export default class VideoThumbnailLoader {
 
     abortUnlistedSegmentRequests(lastRepInfo.pendingRequests, neededSegments);
 
-    const currentTaskCanceller = new TaskCanceller("VTL Task");
+    const currentTaskCanceller = new TaskCanceller("VTL: Task");
 
     return lastRepInfo.sourceBuffer
       .catch((err) => {
         if (this._lastRepresentationInfo !== null) {
-          this._lastRepresentationInfo.cleaner.cancel("VTL SB init failure");
+          this._lastRepresentationInfo.cleaner.cancel(
+            "VTL: SourceBuffer initialization failure",
+          );
           this._lastRepresentationInfo = null;
         }
         throw new VideoThumbnailLoaderError(
@@ -272,7 +274,7 @@ export default class VideoThumbnailLoader {
           if (pending !== undefined) {
             promises.push(pending.promise);
           } else {
-            const requestCanceller = new TaskCanceller("VTL Req");
+            const requestCanceller = new TaskCanceller("VTL: Request");
             const unlinkSignal = requestCanceller.linkToSignal(
               lastRepInfo.cleaner.signal,
             );
@@ -327,7 +329,7 @@ export default class VideoThumbnailLoader {
    */
   dispose(): void {
     if (this._lastRepresentationInfo !== null) {
-      this._lastRepresentationInfo.cleaner.cancel("VTL dispose");
+      this._lastRepresentationInfo.cleaner.cancel("VTL: dispose");
       this._lastRepresentationInfo = null;
     }
   }
@@ -382,7 +384,7 @@ function abortUnlistedSegmentRequests(
   pendingRequests
     .filter((req) => !neededSegments.some(({ id }) => id === req.segmentId))
     .forEach((req) => {
-      req.canceller.cancel("VTL abort unlisted");
+      req.canceller.cancel("VTL: abort unlisted segments");
     });
 }
 

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -180,7 +180,7 @@ export default class VideoThumbnailLoader {
 
     let lastRepInfo: IVideoThumbnailLoaderRepresentationInfo;
     if (this._lastRepresentationInfo === null) {
-      const lastRepInfoCleaner = new TaskCanceller();
+      const lastRepInfoCleaner = new TaskCanceller("VTL Rep");
       const segmentFetcher = createSegmentFetcher({
         bufferType: "video",
         pipeline: loader.video,
@@ -235,7 +235,7 @@ export default class VideoThumbnailLoader {
 
     abortUnlistedSegmentRequests(lastRepInfo.pendingRequests, neededSegments);
 
-    const currentTaskCanceller = new TaskCanceller();
+    const currentTaskCanceller = new TaskCanceller("VTL Task");
 
     return lastRepInfo.sourceBuffer
       .catch((err) => {
@@ -272,7 +272,7 @@ export default class VideoThumbnailLoader {
           if (pending !== undefined) {
             promises.push(pending.promise);
           } else {
-            const requestCanceller = new TaskCanceller();
+            const requestCanceller = new TaskCanceller("VTL Req");
             const unlinkSignal = requestCanceller.linkToSignal(
               lastRepInfo.cleaner.signal,
             );

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -78,7 +78,7 @@ export default class VideoThumbnailLoader {
     const manifest = this._player.__priv_getManifest();
     if (manifest === null) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel();
+        this._lastRepresentationInfo.cleaner.cancel("VTL no manifest");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -94,7 +94,7 @@ export default class VideoThumbnailLoader {
     const content = getTrickModeInfo(time, manifest);
     if (content === null) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel();
+        this._lastRepresentationInfo.cleaner.cancel("VTL no trickmode");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -109,7 +109,7 @@ export default class VideoThumbnailLoader {
       this._lastRepresentationInfo !== null &&
       !areSameRepresentation(this._lastRepresentationInfo.content, content)
     ) {
-      this._lastRepresentationInfo.cleaner.cancel();
+      this._lastRepresentationInfo.cleaner.cancel("VTL diff rep.");
       this._lastRepresentationInfo = null;
     }
 
@@ -120,7 +120,7 @@ export default class VideoThumbnailLoader {
 
     if (neededSegments.length === 0) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel();
+        this._lastRepresentationInfo.cleaner.cancel("VTL no thumb");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -166,7 +166,7 @@ export default class VideoThumbnailLoader {
     const loader = loaders[content.manifest.transport];
     if (loader === undefined) {
       if (this._lastRepresentationInfo !== null) {
-        this._lastRepresentationInfo.cleaner.cancel();
+        this._lastRepresentationInfo.cleaner.cancel("VTL no parser");
         this._lastRepresentationInfo = null;
       }
       return Promise.reject(
@@ -240,7 +240,7 @@ export default class VideoThumbnailLoader {
     return lastRepInfo.sourceBuffer
       .catch((err) => {
         if (this._lastRepresentationInfo !== null) {
-          this._lastRepresentationInfo.cleaner.cancel();
+          this._lastRepresentationInfo.cleaner.cancel("VTL SB init failure");
           this._lastRepresentationInfo = null;
         }
         throw new VideoThumbnailLoaderError(
@@ -327,7 +327,7 @@ export default class VideoThumbnailLoader {
    */
   dispose(): void {
     if (this._lastRepresentationInfo !== null) {
-      this._lastRepresentationInfo.cleaner.cancel();
+      this._lastRepresentationInfo.cleaner.cancel("VTL dispose");
       this._lastRepresentationInfo = null;
     }
   }
@@ -382,7 +382,7 @@ function abortUnlistedSegmentRequests(
   pendingRequests
     .filter((req) => !neededSegments.some(({ id }) => id === req.segmentId))
     .forEach((req) => {
-      req.canceller.cancel();
+      req.canceller.cancel("VTL abort unlisted");
     });
 }
 

--- a/src/experimental/tools/createMetaplaylist/get_duration_from_manifest.ts
+++ b/src/experimental/tools/createMetaplaylist/get_duration_from_manifest.ts
@@ -75,7 +75,7 @@ async function getDurationFromManifest(
       timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
       connectionTimeout: config.getCurrent().DEFAULT_CONNECTION_TIMEOUT,
       // We won't cancel
-      cancelSignal: new TaskCanceller().signal,
+      cancelSignal: new TaskCanceller(undefined).signal,
     });
     const { responseData } = response;
     const root = responseData.documentElement;
@@ -116,7 +116,7 @@ async function getDurationFromManifest(
     timeout: config.getCurrent().DEFAULT_REQUEST_TIMEOUT,
     connectionTimeout: config.getCurrent().DEFAULT_CONNECTION_TIMEOUT,
     // We won't cancel
-    cancelSignal: new TaskCanceller().signal,
+    cancelSignal: new TaskCanceller(undefined).signal,
   });
   const { responseData } = response;
   const metaplaylist = JSON.parse(responseData) as IMetaPlaylist;

--- a/src/main_thread/api/__tests__/public_api.test.ts
+++ b/src/main_thread/api/__tests__/public_api.test.ts
@@ -583,7 +583,7 @@ describe("API - Public API", () => {
       });
 
       it("should trigger videoRepresentationChange on representation change", async () => {
-        const taskCanceller = new TaskCanceller();
+        const taskCanceller = new TaskCanceller("Test content");
         const contentInfos: Partial<IPublicApiContentInfos> = {
           contentId: "123",
           originalUrl: undefined,
@@ -637,7 +637,7 @@ describe("API - Public API", () => {
       });
 
       it("should trigger audioRepresentationChange on representation change", async () => {
-        const taskCanceller = new TaskCanceller();
+        const taskCanceller = new TaskCanceller("Test content");
         const contentInfos: Partial<IPublicApiContentInfos> = {
           contentId: "123",
           originalUrl: undefined,

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -450,7 +450,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this.state = "STOPPED";
     this.videoElement = videoElement;
     Player._priv_registerVideoElement(this.videoElement);
-    const destroyCanceller = new TaskCanceller();
+    const destroyCanceller = new TaskCanceller("API Destroy");
     this._destroyCanceller = destroyCanceller;
 
     this._priv_pictureInPictureRef = getPictureOnPictureStateRef(
@@ -808,7 +808,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (features.createDebugElement === null) {
       throw new Error("Feature `DEBUG_ELEMENT` not added to the RxPlayer");
     }
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("API Debug");
     features.createDebugElement(element, this, canceller.signal);
     return {
       dispose() {
@@ -939,7 +939,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const isDirectFile = transport === "directfile";
 
     /** Emit to stop the current content. */
-    const currentContentCanceller = new TaskCanceller();
+    const currentContentCanceller = new TaskCanceller("API Content");
 
     const videoElement = this.videoElement;
 
@@ -1355,7 +1355,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           if (playPauseEventsCanceller !== null) {
             playPauseEventsCanceller.cancel();
           }
-          playPauseEventsCanceller = new TaskCanceller();
+          playPauseEventsCanceller = new TaskCanceller("API Play/Pause");
           playPauseEventsCanceller.linkToSignal(currentContentCanceller.signal);
           if (willAutoPlay !== !videoElement.paused) {
             // paused status is not at the expected value on load: emit event
@@ -1410,7 +1410,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             seekEventsCanceller = null;
           }
         } else if (isLoadedState(this.state)) {
-          seekEventsCanceller = new TaskCanceller();
+          seekEventsCanceller = new TaskCanceller("API Seeks");
           seekEventsCanceller.linkToSignal(currentContentCanceller.signal);
           emitSeekEvents(
             playbackObserver,

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -691,7 +691,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   stop(): void {
     if (this._priv_contentInfos !== null) {
-      this._priv_contentInfos.currentContentCanceller.cancel("stop");
+      this._priv_contentInfos.currentContentCanceller.cancel("API stop");
     }
     this._priv_cleanUpCurrentContentState();
     if (this.state !== PLAYER_STATES.STOPPED) {
@@ -717,7 +717,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     // free resources linked to the Player instance
-    this._destroyCanceller.cancel("destroy");
+    this._destroyCanceller.cancel("API destroy");
 
     this._priv_reloadingMetadata = {};
 
@@ -812,7 +812,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     features.createDebugElement(element, this, canceller.signal);
     return {
       dispose() {
-        canceller.cancel("dispose");
+        canceller.cancel("debug dispose");
       },
     };
   }
@@ -1175,8 +1175,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      */
     playbackObserver.blockSeeking();
 
-    currentContentCanceller.signal.register(() => {
-      playbackObserver.stop();
+    currentContentCanceller.signal.register((err) => {
+      playbackObserver.stop(err.reason);
     });
 
     /** Future `this._priv_contentInfos` related to this content. */
@@ -1297,8 +1297,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       isDirectFile,
       currentContentCanceller.signal,
     );
-    currentContentCanceller.signal.register(() => {
-      initializer.dispose();
+    currentContentCanceller.signal.register((err) => {
+      initializer.dispose(err.reason);
     });
 
     /**

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -691,7 +691,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   stop(): void {
     if (this._priv_contentInfos !== null) {
-      this._priv_contentInfos.currentContentCanceller.cancel();
+      this._priv_contentInfos.currentContentCanceller.cancel("stop");
     }
     this._priv_cleanUpCurrentContentState();
     if (this.state !== PLAYER_STATES.STOPPED) {
@@ -717,7 +717,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     // free resources linked to the Player instance
-    this._destroyCanceller.cancel();
+    this._destroyCanceller.cancel("destroy");
 
     this._priv_reloadingMetadata = {};
 
@@ -812,7 +812,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     features.createDebugElement(element, this, canceller.signal);
     return {
       dispose() {
-        canceller.cancel();
+        canceller.cancel("dispose");
       },
     };
   }
@@ -1343,7 +1343,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
      */
     const triggerPlayPauseEventsWhenReady = (willAutoPlay: boolean) => {
       if (playPauseEventsCanceller !== null) {
-        playPauseEventsCanceller.cancel(); // cancel previous logic
+        playPauseEventsCanceller.cancel("reset"); // cancel previous logic
         playPauseEventsCanceller = null;
       }
       playerStateRef.onUpdate(
@@ -1353,7 +1353,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           }
           stopListeningToStateUpdates();
           if (playPauseEventsCanceller !== null) {
-            playPauseEventsCanceller.cancel();
+            playPauseEventsCanceller.cancel("reset");
           }
           playPauseEventsCanceller = new TaskCanceller("API Play/Pause");
           playPauseEventsCanceller.linkToSignal(currentContentCanceller.signal);
@@ -1406,7 +1406,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
         if (seekEventsCanceller !== null) {
           if (!isLoadedState(this.state)) {
-            seekEventsCanceller.cancel();
+            seekEventsCanceller.cancel("Player State Update");
             seekEventsCanceller = null;
           }
         } else if (isLoadedState(this.state)) {
@@ -3561,7 +3561,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       defaultReason: "An unknown error stopped content playback.",
     });
     formattedError.fatal = true;
-    contentInfos.currentContentCanceller.cancel();
+    contentInfos.currentContentCanceller.cancel("fatal err");
     this._priv_cleanUpCurrentContentState();
     this._priv_currentError = formattedError;
     log.error("API", "The player stopped because of an error", formattedError);

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -450,7 +450,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     this.state = "STOPPED";
     this.videoElement = videoElement;
     Player._priv_registerVideoElement(this.videoElement);
-    const destroyCanceller = new TaskCanceller("API Destroy");
+    const destroyCanceller = new TaskCanceller("API");
     this._destroyCanceller = destroyCanceller;
 
     this._priv_pictureInPictureRef = getPictureOnPictureStateRef(
@@ -808,11 +808,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (features.createDebugElement === null) {
       throw new Error("Feature `DEBUG_ELEMENT` not added to the RxPlayer");
     }
-    const canceller = new TaskCanceller("API Debug");
+    const canceller = new TaskCanceller("API debug element");
     features.createDebugElement(element, this, canceller.signal);
     return {
       dispose() {
-        canceller.cancel("debug dispose");
+        canceller.cancel("API debug dispose");
       },
     };
   }
@@ -939,7 +939,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const isDirectFile = transport === "directfile";
 
     /** Emit to stop the current content. */
-    const currentContentCanceller = new TaskCanceller("API Content");
+    const currentContentCanceller = new TaskCanceller("API current content");
 
     const videoElement = this.videoElement;
 
@@ -1355,7 +1355,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           if (playPauseEventsCanceller !== null) {
             playPauseEventsCanceller.cancel("reset");
           }
-          playPauseEventsCanceller = new TaskCanceller("API Play/Pause");
+          playPauseEventsCanceller = new TaskCanceller("API play/pause events");
           playPauseEventsCanceller.linkToSignal(currentContentCanceller.signal);
           if (willAutoPlay !== !videoElement.paused) {
             // paused status is not at the expected value on load: emit event
@@ -1410,7 +1410,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             seekEventsCanceller = null;
           }
         } else if (isLoadedState(this.state)) {
-          seekEventsCanceller = new TaskCanceller("API Seeks");
+          seekEventsCanceller = new TaskCanceller("API seek events");
           seekEventsCanceller.linkToSignal(currentContentCanceller.signal);
           emitSeekEvents(
             playbackObserver,

--- a/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/get_license.test.ts
@@ -475,7 +475,7 @@ async function checkGetLicense({
               "license-request",
             );
           }
-          contentDecryptor.dispose();
+          contentDecryptor.dispose(undefined);
           res();
         } catch (e) {
           rej(e);

--- a/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/media_key_system_access.test.ts
@@ -1282,7 +1282,7 @@ describe("decrypt - global tests - media key system access", () => {
     const mockRequestMediaKeySystemAccess = vi.fn().mockImplementation(() => {
       return Promise.resolve().then(() => {
         rmksHasBeenCalled = true;
-        contentDecryptor?.dispose();
+        contentDecryptor?.dispose(undefined);
         return Promise.reject("nope");
       });
     });

--- a/src/main_thread/decrypt/__tests__/__global__/media_keys.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/media_keys.test.ts
@@ -140,7 +140,7 @@ describe("decrypt - global tests - media key system access", () => {
             expect(contentDecryptor.getState()).toEqual(
               ContentDecryptorState.WaitingForAttachment,
             );
-            contentDecryptor.dispose();
+            contentDecryptor.dispose(undefined);
           } catch (err) {
             rej(err);
           }
@@ -184,7 +184,7 @@ describe("decrypt - global tests - media key system access", () => {
         }
 
         setTimeout(() => {
-          contentDecryptor1.dispose();
+          contentDecryptor1.dispose(undefined);
           const contentDecryptor2 = new ContentDecryptor(eme, videoElt, ksConfig);
           let receivedStateChange2 = 0;
           contentDecryptor2.addEventListener("error", rej);
@@ -202,7 +202,7 @@ describe("decrypt - global tests - media key system access", () => {
               contentDecryptor2.attach();
               setTimeout(() => {
                 try {
-                  contentDecryptor2.dispose();
+                  contentDecryptor2.dispose(undefined);
                   expect(mockCreateMediaKeys).toHaveBeenCalledTimes(1);
                   res();
                 } catch (err) {
@@ -254,7 +254,7 @@ describe("decrypt - global tests - media key system access", () => {
         }
 
         setTimeout(() => {
-          contentDecryptor1.dispose();
+          contentDecryptor1.dispose(undefined);
           const contentDecryptor2 = new ContentDecryptor(eme, videoElt, ksConfig);
           let receivedStateChange2 = 0;
           contentDecryptor2.addEventListener("error", rej);
@@ -272,7 +272,7 @@ describe("decrypt - global tests - media key system access", () => {
               contentDecryptor2.attach();
               setTimeout(() => {
                 try {
-                  contentDecryptor2.dispose();
+                  contentDecryptor2.dispose(undefined);
                   expect(mockCreateMediaKeys).toHaveBeenCalledTimes(2);
                   res();
                 } catch (err) {
@@ -324,7 +324,7 @@ describe("decrypt - global tests - media key system access", () => {
         }
 
         setTimeout(() => {
-          contentDecryptor1.dispose();
+          contentDecryptor1.dispose(undefined);
           const contentDecryptor2 = new ContentDecryptor(eme, videoElt, ksConfig);
           let receivedStateChange2 = 0;
           contentDecryptor2.addEventListener("error", rej);
@@ -342,7 +342,7 @@ describe("decrypt - global tests - media key system access", () => {
               contentDecryptor2.attach();
               setTimeout(() => {
                 try {
-                  contentDecryptor2.dispose();
+                  contentDecryptor2.dispose(undefined);
                   expect(mockCreateMediaKeys).toHaveBeenCalledTimes(2);
                   res();
                 } catch (err) {

--- a/src/main_thread/decrypt/__tests__/__global__/server_certificate.test.ts
+++ b/src/main_thread/decrypt/__tests__/__global__/server_certificate.test.ts
@@ -67,7 +67,7 @@ describe("decrypt - global tests - server certificate", () => {
             contentDecryptor.attach();
           }, 5);
           setTimeout(() => {
-            contentDecryptor.dispose();
+            contentDecryptor.dispose(undefined);
             expect(mockSetMediaKeys).toHaveBeenCalledTimes(1);
             expect(mockSetServerCertificate).toHaveBeenCalledTimes(1);
             expect(mockCreateSession).not.toHaveBeenCalled();
@@ -121,7 +121,7 @@ describe("decrypt - global tests - server certificate", () => {
     });
     return new Promise<void>((res) => {
       setTimeout(() => {
-        contentDecryptor.dispose();
+        contentDecryptor.dispose(undefined);
         expect(mockSetMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockSetServerCertificate).toHaveBeenCalledTimes(1);
         expect(mockCreateSession).toHaveBeenCalledTimes(1);
@@ -163,7 +163,7 @@ describe("decrypt - global tests - server certificate", () => {
     });
     return new Promise<void>((res) => {
       setTimeout(() => {
-        contentDecryptor.dispose();
+        contentDecryptor.dispose(undefined);
         expect(mockSetMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockSetServerCertificate).toHaveBeenCalledTimes(1);
         expect(mockCreateSession).not.toHaveBeenCalled();
@@ -206,7 +206,7 @@ describe("decrypt - global tests - server certificate", () => {
     });
     return new Promise<void>((res) => {
       setTimeout(() => {
-        contentDecryptor.dispose();
+        contentDecryptor.dispose(undefined);
         expect(mockSetMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockSetServerCertificate).toHaveBeenCalledTimes(1);
         expect(mockCreateSession).not.toHaveBeenCalled();
@@ -264,7 +264,7 @@ describe("decrypt - global tests - server certificate", () => {
     });
     return new Promise<void>((res) => {
       setTimeout(() => {
-        contentDecryptor.dispose();
+        contentDecryptor.dispose(undefined);
         expect(mockSetMediaKeys).toHaveBeenCalledTimes(1);
         expect(mockSetServerCertificate).not.toHaveBeenCalled();
         expect(mockCreateSession).toHaveBeenCalledTimes(1);

--- a/src/main_thread/decrypt/__tests__/find_key_system.test.ts
+++ b/src/main_thread/decrypt/__tests__/find_key_system.test.ts
@@ -187,7 +187,7 @@ describe("find_key_systems - ", () => {
       },
     ];
 
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
     const event1 = await getMediaKeySystemAccess(
       eme,
       mediaElement,
@@ -240,7 +240,7 @@ describe("find_key_systems - ", () => {
       },
     ];
 
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
     const event1 = await getMediaKeySystemAccess(
       eme,
       mediaElement,
@@ -304,7 +304,7 @@ describe("find_key_systems - ", () => {
       },
     ];
 
-    const taskCanceller = new TaskCanceller();
+    const taskCanceller = new TaskCanceller(undefined);
     const event1 = await getMediaKeySystemAccess(
       eme,
       mediaElement,

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -164,7 +164,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
     log.debug("DRM", "Starting ContentDecryptor logic.");
 
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("DRM CD");
     this._currentSessions = [];
     this._canceller = canceller;
     this._initDataQueue = [];

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -352,7 +352,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       isInitDataQueueLocked: undefined,
       data: null,
     };
-    this._canceller.cancel();
+    this._canceller.cancel("CD dispose");
     this.trigger("stateChange", this._stateData.state);
   }
 
@@ -945,7 +945,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       isInitDataQueueLocked: undefined,
       data: null,
     };
-    this._canceller.cancel();
+    this._canceller.cancel("CD err");
     this.trigger("error", formattedErr);
 
     // The previous trigger might have lead to a disposal of the `ContentDecryptor`.

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -343,8 +343,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    *   - abort all operations.
    *
    * Once disposed, a `ContentDecryptor` cannot be used anymore.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose() {
+  public dispose(reason: string | undefined) {
     this.removeEventListener();
     this._stateData = {
       state: ContentDecryptorState.Disposed,
@@ -352,7 +355,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       isInitDataQueueLocked: undefined,
       data: null,
     };
-    this._canceller.cancel("CD dispose");
+    this._canceller.cancel(reason ?? "CD dispose");
     this.trigger("stateChange", this._stateData.state);
   }
 

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -164,7 +164,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
     log.debug("DRM", "Starting ContentDecryptor logic.");
 
-    const canceller = new TaskCanceller("DRM CD");
+    const canceller = new TaskCanceller("ContentDecryptor");
     this._currentSessions = [];
     this._canceller = canceller;
     this._initDataQueue = [];
@@ -355,7 +355,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       isInitDataQueueLocked: undefined,
       data: null,
     };
-    this._canceller.cancel(reason ?? "CD dispose");
+    this._canceller.cancel(reason ?? "ContentDecryptor dispose");
     this.trigger("stateChange", this._stateData.state);
   }
 
@@ -948,7 +948,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       isInitDataQueueLocked: undefined,
       data: null,
     };
-    this._canceller.cancel("CD err");
+    this._canceller.cancel("ContentDecryptor err");
     this.trigger("error", formattedErr);
 
     // The previous trigger might have lead to a disposal of the `ContentDecryptor`.

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -54,18 +54,18 @@ export default function SessionEventsListener(
   const { getLicenseConfig = {} } = keySystemOptions;
 
   /** Allows to manually cancel everything the `SessionEventsListener` is doing. */
-  const manualCanceller = new TaskCanceller("DRM SEL");
+  const manualCanceller = new TaskCanceller("DRM SessionEventListener");
   manualCanceller.linkToSignal(cancelSignal);
 
   if (!isNullOrUndefined(session.closed)) {
     session.closed
-      .then(() => manualCanceller.cancel("MKS closed"))
+      .then(() => manualCanceller.cancel("MediaKeySession closed"))
       .catch((err) => {
         // Should never happen
         if (cancelSignal.isCancelled()) {
           return;
         }
-        manualCanceller.cancel("MKS closed err");
+        manualCanceller.cancel("MediaKeySession closed err");
         callbacks.onError(err);
       });
   }
@@ -73,7 +73,7 @@ export default function SessionEventsListener(
   onKeyError(
     session,
     (evt) => {
-      manualCanceller.cancel("MKS keyerr");
+      manualCanceller.cancel("MediaKeySession keyerr");
       callbacks.onError(
         new EncryptedMediaError("KEY_ERROR", (evt as Event).type, {
           keyStatuses: undefined,
@@ -100,7 +100,7 @@ export default function SessionEventsListener(
         ) {
           return;
         }
-        manualCanceller.cancel("MKS keystatuseschange handling failure");
+        manualCanceller.cancel("MediaKeySession keystatuseschange handling failure");
         callbacks.onError(error);
       }
     },
@@ -141,7 +141,7 @@ export default function SessionEventsListener(
                 mediaKeySystemAccess,
               );
             } catch (err) {
-              manualCanceller.cancel("MKS update failure");
+              manualCanceller.cancel("MediaKeySession update failure");
               callbacks.onError(err);
             }
           }
@@ -150,7 +150,7 @@ export default function SessionEventsListener(
           if (manualCanceller.isUsed()) {
             return;
           }
-          manualCanceller.cancel("MKS license getting failure");
+          manualCanceller.cancel("MediaKeySession license getting failure");
           const formattedError = formatGetLicenseError(err, mediaKeySystemAccess);
 
           if (!isNullOrUndefined(err)) {

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -54,7 +54,7 @@ export default function SessionEventsListener(
   const { getLicenseConfig = {} } = keySystemOptions;
 
   /** Allows to manually cancel everything the `SessionEventsListener` is doing. */
-  const manualCanceller = new TaskCanceller();
+  const manualCanceller = new TaskCanceller("DRM SEL");
   manualCanceller.linkToSignal(cancelSignal);
 
   if (!isNullOrUndefined(session.closed)) {

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -59,13 +59,13 @@ export default function SessionEventsListener(
 
   if (!isNullOrUndefined(session.closed)) {
     session.closed
-      .then(() => manualCanceller.cancel())
+      .then(() => manualCanceller.cancel("MKS closed"))
       .catch((err) => {
         // Should never happen
         if (cancelSignal.isCancelled()) {
           return;
         }
-        manualCanceller.cancel();
+        manualCanceller.cancel("MKS closed err");
         callbacks.onError(err);
       });
   }
@@ -73,7 +73,7 @@ export default function SessionEventsListener(
   onKeyError(
     session,
     (evt) => {
-      manualCanceller.cancel();
+      manualCanceller.cancel("MKS keyerr");
       callbacks.onError(
         new EncryptedMediaError("KEY_ERROR", (evt as Event).type, {
           keyStatuses: undefined,
@@ -100,7 +100,7 @@ export default function SessionEventsListener(
         ) {
           return;
         }
-        manualCanceller.cancel();
+        manualCanceller.cancel("MKS keystatuseschange handling failure");
         callbacks.onError(error);
       }
     },
@@ -141,7 +141,7 @@ export default function SessionEventsListener(
                 mediaKeySystemAccess,
               );
             } catch (err) {
-              manualCanceller.cancel();
+              manualCanceller.cancel("MKS update failure");
               callbacks.onError(err);
             }
           }
@@ -150,7 +150,7 @@ export default function SessionEventsListener(
           if (manualCanceller.isUsed()) {
             return;
           }
-          manualCanceller.cancel();
+          manualCanceller.cancel("MKS license getting failure");
           const formattedError = formatGetLicenseError(err, mediaKeySystemAccess);
 
           if (!isNullOrUndefined(err)) {

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -67,7 +67,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
   constructor(settings: IDirectFileOptions) {
     super();
     this._settings = settings;
-    this._initCanceller = new TaskCanceller();
+    this._initCanceller = new TaskCanceller("Directfile Init");
   }
 
   /**

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -191,7 +191,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
    * Stop content and free all resources linked to this `ContentIntializer`.
    */
   public dispose(): void {
-    this._initCanceller.cancel();
+    this._initCanceller.cancel("Directfile Init dispose");
   }
 
   /**
@@ -199,7 +199,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
    * @param {*} err - The fatal error in question.
    */
   private _onFatalError(err: unknown): void {
-    this._initCanceller.cancel();
+    this._initCanceller.cancel("Directfile Init err");
     this.trigger("error", err);
   }
 

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -136,8 +136,8 @@ export default class DirectFileContentInitializer extends ContentInitializer {
     rebufferingController.addEventListener("warning", (err) =>
       this.trigger("warning", err),
     );
-    cancelSignal.register(() => {
-      rebufferingController.destroy();
+    cancelSignal.register((err) => {
+      rebufferingController.destroy(err.reason);
     });
     rebufferingController.start();
 
@@ -189,9 +189,12 @@ export default class DirectFileContentInitializer extends ContentInitializer {
 
   /**
    * Stop content and free all resources linked to this `ContentIntializer`.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose(): void {
-    this._initCanceller.cancel("Directfile Init dispose");
+  public dispose(reason: string | undefined): void {
+    this._initCanceller.cancel(reason ?? "Directfile Init dispose");
   }
 
   /**

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -151,7 +151,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     super();
     this._settings = settings;
     this._initCanceller = new TaskCanceller("Init");
-    this._currentMediaSourceCanceller = new TaskCanceller("Init MS");
+    this._currentMediaSourceCanceller = new TaskCanceller("Init MediaSource");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     this._currentContentInfo = null;
     this._awaitingRequests = {
@@ -701,7 +701,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             if (sourceBuffer === undefined) {
               return;
             }
-            sourceBuffer.abort("MT worker msg abort SB");
+            sourceBuffer.abort("received AbortSourceBuffer message");
           }
           break;
 
@@ -735,7 +735,9 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             if (mediaSource?.id !== msgData.mediaSourceId) {
               return;
             }
-            mediaSource.interruptDurationSetting("MT interrupt msg");
+            mediaSource.interruptDurationSetting(
+              "received InterrupMediaSourceDurationUpdate message",
+            );
           }
           break;
 
@@ -1183,7 +1185,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               "Received StopTextDisplayer message but no text displayer exists",
             );
           } else {
-            textDisplayer.stop("stop text displayer msg");
+            textDisplayer.stop("received StopTextDisplayer message");
           }
           break;
         }
@@ -1302,7 +1304,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   public dispose(reason: string | undefined): void {
-    this._initCanceller.cancel("Init MT dispose");
+    this._initCanceller.cancel("Init dispose");
     if (this._currentContentInfo !== null) {
       if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
         this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(reason);
@@ -1315,7 +1317,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     if (this._initCanceller.isUsed()) {
       return;
     }
-    this._initCanceller.cancel("Init MT dispose");
+    this._initCanceller.cancel("Init dispose due to fatal Error");
     this.trigger("error", err);
   }
 
@@ -1548,8 +1550,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     position: number,
     autoPlay: boolean,
   ) {
-    this._currentMediaSourceCanceller.cancel("Init MT MS R");
-    this._currentMediaSourceCanceller = new TaskCanceller("Init MS");
+    this._currentMediaSourceCanceller.cancel("Init MediaSource Reload");
+    this._currentMediaSourceCanceller = new TaskCanceller("Init MediaSource");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);
     this.trigger("reloadingMediaSource", { position, autoPlay });

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -1300,7 +1300,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   public dispose(): void {
-    this._initCanceller.cancel();
+    this._initCanceller.cancel("Init MT dispose");
     if (this._currentContentInfo !== null) {
       if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
         this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
@@ -1313,7 +1313,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     if (this._initCanceller.isUsed()) {
       return;
     }
-    this._initCanceller.cancel();
+    this._initCanceller.cancel("Init MT dispose");
     this.trigger("error", err);
   }
 
@@ -1546,7 +1546,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     position: number,
     autoPlay: boolean,
   ) {
-    this._currentMediaSourceCanceller.cancel();
+    this._currentMediaSourceCanceller.cancel("Init MT MS R");
     this._currentMediaSourceCanceller = new TaskCanceller("Init MS");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -365,8 +365,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     } else {
       assert(!this._hasTextBufferFeature());
     }
-    this._initCanceller.signal.register(() => {
-      textDisplayer?.stop();
+    this._initCanceller.signal.register((err) => {
+      textDisplayer?.stop(err.reason);
     });
 
     /** Translate errors coming from the media element into RxPlayer errors. */
@@ -520,7 +520,9 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           }
           if (this._currentContentInfo !== null) {
             if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
-              this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+              this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(
+                "new AttachMediaSource message",
+              );
             }
             this._currentContentInfo.mediaSourceInfo = {
               type: "core",
@@ -699,7 +701,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             if (sourceBuffer === undefined) {
               return;
             }
-            sourceBuffer.abort();
+            sourceBuffer.abort("MT worker msg abort SB");
           }
           break;
 
@@ -733,7 +735,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             if (mediaSource?.id !== msgData.mediaSourceId) {
               return;
             }
-            mediaSource.interruptDurationSetting();
+            mediaSource.interruptDurationSetting("MT interrupt msg");
           }
           break;
 
@@ -775,7 +777,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               return;
             }
             const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
-            mediaSource.dispose();
+            mediaSource.dispose("DisposeMediaSource message");
           }
           break;
 
@@ -1181,7 +1183,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               "Received StopTextDisplayer message but no text displayer exists",
             );
           } else {
-            textDisplayer.stop();
+            textDisplayer.stop("stop text displayer msg");
           }
           break;
         }
@@ -1299,11 +1301,11 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     });
   }
 
-  public dispose(): void {
+  public dispose(reason: string | undefined): void {
     this._initCanceller.cancel("Init MT dispose");
     if (this._currentContentInfo !== null) {
       if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
-        this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+        this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(reason);
       }
       this._currentContentInfo = null;
     }
@@ -1496,8 +1498,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       { clearSignal: cancelSignal },
     );
 
-    cancelSignal.register(() => {
-      contentDecryptor.dispose();
+    cancelSignal.register((err) => {
+      contentDecryptor.dispose(err.reason);
     });
 
     return { statusRef: drmStatusRef, contentDecryptor };
@@ -1690,8 +1692,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     rebufferingController.addEventListener("warning", (err) =>
       this.trigger("warning", err),
     );
-    cancelSignal.register(() => {
-      rebufferingController.destroy();
+    cancelSignal.register((err) => {
+      rebufferingController.destroy(err.reason);
     });
     rebufferingController.start();
     this._currentContentInfo.rebufferingController = rebufferingController;
@@ -1718,8 +1720,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             cancelSignal,
           );
           streamEventsEmitter.start();
-          cancelSignal.register(() => {
-            streamEventsEmitter.stop();
+          cancelSignal.register((err) => {
+            streamEventsEmitter.stop(err.reason);
           });
         }
       },
@@ -1942,7 +1944,9 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                   : undefined,
               );
               if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
-                this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+                this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(
+                  "Attaching new MediaSource",
+                );
               }
               this._currentContentInfo.mediaSourceInfo = {
                 type: "main",
@@ -1976,8 +1980,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                 url = URL.createObjectURL(mediaSource.handle.value);
                 mediaElement.src = url;
               }
-              this._currentMediaSourceCanceller.signal.register(() => {
-                mediaSource.dispose();
+              this._currentMediaSourceCanceller.signal.register((err) => {
+                mediaSource.dispose(err.reason);
                 resetMediaElement(mediaElement, url);
               });
               mediaSourceStatus.setValue(MediaSourceInitializationStatus.Attached);

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -150,8 +150,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   constructor(settings: IInitializeArguments) {
     super();
     this._settings = settings;
-    this._initCanceller = new TaskCanceller();
-    this._currentMediaSourceCanceller = new TaskCanceller();
+    this._initCanceller = new TaskCanceller("Init");
+    this._currentMediaSourceCanceller = new TaskCanceller("Init MS");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     this._currentContentInfo = null;
     this._awaitingRequests = {
@@ -1547,7 +1547,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     autoPlay: boolean,
   ) {
     this._currentMediaSourceCanceller.cancel();
-    this._currentMediaSourceCanceller = new TaskCanceller();
+    this._currentMediaSourceCanceller = new TaskCanceller("Init MS");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);
     this.trigger("reloadingMediaSource", { position, autoPlay });

--- a/src/main_thread/init/types.ts
+++ b/src/main_thread/init/types.ts
@@ -101,8 +101,11 @@ export abstract class ContentInitializer extends EventEmitter<IContentInitialize
    * Stop playing the content linked to this `ContentInitializer` on the
    * `HTMLMediaElement` linked to it and dispose of every resources taken while
    * trying to do so.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * disposal. Might be used for debugging matters, especially for debug log
+   * inspection.
    */
-  public abstract dispose(): void;
+  public abstract dispose(reason: string | undefined): void;
 }
 
 /** Every events emitted by a `ContentInitializer`. */

--- a/src/main_thread/init/utils/create_core_playback_observer.ts
+++ b/src/main_thread/init/utils/create_core_playback_observer.ts
@@ -122,7 +122,7 @@ export default function createCorePlaybackObserver(
     observationRef: IReadOnlySharedReference<IPlaybackObservation>,
     parentObserverCancelSignal: CancellationSignal,
   ): IReadOnlySharedReference<ICorePlaybackObservation> {
-    const canceller = new TaskCanceller("Core PO");
+    const canceller = new TaskCanceller("Core PlaybackObserver");
     canceller.linkToSignal(parentObserverCancelSignal);
     canceller.linkToSignal(fnCancelSignal);
     const newRef = new SharedReference(

--- a/src/main_thread/init/utils/create_core_playback_observer.ts
+++ b/src/main_thread/init/utils/create_core_playback_observer.ts
@@ -122,7 +122,7 @@ export default function createCorePlaybackObserver(
     observationRef: IReadOnlySharedReference<IPlaybackObservation>,
     parentObserverCancelSignal: CancellationSignal,
   ): IReadOnlySharedReference<ICorePlaybackObservation> {
-    const canceller = new TaskCanceller();
+    const canceller = new TaskCanceller("Core PO");
     canceller.linkToSignal(parentObserverCancelSignal);
     canceller.linkToSignal(fnCancelSignal);
     const newRef = new SharedReference(

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -39,7 +39,7 @@ export default function getLoadedReference(
   isDirectfile: boolean,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {
-  const listenCanceller = new TaskCanceller();
+  const listenCanceller = new TaskCanceller("LoadedRef");
   listenCanceller.linkToSignal(cancelSignal);
   const isLoaded = new SharedReference(false, listenCanceller.signal);
   playbackObserver.listen(

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -39,7 +39,7 @@ export default function getLoadedReference(
   isDirectfile: boolean,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<boolean> {
-  const listenCanceller = new TaskCanceller("LoadedRef");
+  const listenCanceller = new TaskCanceller("Loaded Reference update");
   listenCanceller.linkToSignal(cancelSignal);
   const isLoaded = new SharedReference(false, listenCanceller.signal);
   playbackObserver.listen(
@@ -60,7 +60,7 @@ export default function getLoadedReference(
         }
         if (observation.duration > 0) {
           isLoaded.setValue(true);
-          listenCanceller.cancel("Loaded");
+          listenCanceller.cancel("Content Loaded");
           return;
         }
       }
@@ -70,7 +70,7 @@ export default function getLoadedReference(
         if (observation.currentRange !== null || observation.ended) {
           if (!shouldValidateMetadata() || observation.duration > 0) {
             isLoaded.setValue(true);
-            listenCanceller.cancel("Loaded");
+            listenCanceller.cancel("Content Loaded");
             return;
           }
         }

--- a/src/main_thread/init/utils/get_loaded_reference.ts
+++ b/src/main_thread/init/utils/get_loaded_reference.ts
@@ -60,7 +60,7 @@ export default function getLoadedReference(
         }
         if (observation.duration > 0) {
           isLoaded.setValue(true);
-          listenCanceller.cancel();
+          listenCanceller.cancel("Loaded");
           return;
         }
       }
@@ -70,7 +70,7 @@ export default function getLoadedReference(
         if (observation.currentRange !== null || observation.ended) {
           if (!shouldValidateMetadata() || observation.duration > 0) {
             isLoaded.setValue(true);
-            listenCanceller.cancel();
+            listenCanceller.cancel("Loaded");
             return;
           }
         }

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -141,8 +141,8 @@ export default function initializeContentDecryption(
     callbacks.onKeyIdsCompatibilityUpdate(x);
   });
 
-  decryptorCanceller.signal.register(() => {
-    contentDecryptor.dispose();
+  decryptorCanceller.signal.register((err) => {
+    contentDecryptor.dispose(err.reason);
   });
 
   return {

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -66,7 +66,7 @@ export default function initializeContentDecryption(
     return createEmeDisabledReference("EME feature not activated.");
   }
 
-  const decryptorCanceller = new TaskCanceller("CD");
+  const decryptorCanceller = new TaskCanceller("Init: Decryption Capabilities");
   decryptorCanceller.linkToSignal(cancelSignal);
   const drmStatusRef = new SharedReference<IDrmInitializationStatus>(
     {
@@ -125,7 +125,7 @@ export default function initializeContentDecryption(
   });
 
   contentDecryptor.addEventListener("error", (error) => {
-    decryptorCanceller.cancel("CD err");
+    decryptorCanceller.cancel("ContentDecryptor err");
     callbacks.onError(error);
   });
 

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -125,7 +125,7 @@ export default function initializeContentDecryption(
   });
 
   contentDecryptor.addEventListener("error", (error) => {
-    decryptorCanceller.cancel();
+    decryptorCanceller.cancel("CD err");
     callbacks.onError(error);
   });
 

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -66,7 +66,7 @@ export default function initializeContentDecryption(
     return createEmeDisabledReference("EME feature not activated.");
   }
 
-  const decryptorCanceller = new TaskCanceller();
+  const decryptorCanceller = new TaskCanceller("CD");
   decryptorCanceller.linkToSignal(cancelSignal);
   const drmStatusRef = new SharedReference<IDrmInitializationStatus>(
     {

--- a/src/main_thread/init/utils/main_thread_text_displayer_interface.ts
+++ b/src/main_thread/init/utils/main_thread_text_displayer_interface.ts
@@ -53,7 +53,7 @@ export default class MainThreadTextDisplayerInterface implements ITextDisplayerI
   /**
    * @see ITextDisplayerInterface
    */
-  public stop(): void {
-    this._displayer.stop();
+  public stop(reason?: string | undefined): void {
+    this._displayer.stop(reason);
   }
 }

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -92,8 +92,8 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
       this._playbackObserver,
       this._speed,
     );
-    this._canceller.signal.register(() => {
-      playbackRateUpdater.dispose();
+    this._canceller.signal.register((err) => {
+      playbackRateUpdater.dispose(err.reason);
     });
 
     this._playbackObserver.listen(
@@ -333,9 +333,12 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
   /**
    * Stops the `RebufferingController` from montoring stalling situations,
    * forever.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public destroy(): void {
-    this._canceller.cancel("RC destroy");
+  public destroy(reason: string | undefined): void {
+    this._canceller.cancel(reason ?? "RC destroy");
   }
 }
 
@@ -551,9 +554,12 @@ class PlaybackRateUpdater {
    *
    * Consequently, you should call the `dispose` method, when you don't want the
    * `PlaybackRateUpdater` to have an effect anymore.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * cancellation. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose() {
-    this._speedUpdateCanceller.cancel("PRU dispose");
+  public dispose(reason: string | undefined) {
+    this._speedUpdateCanceller.cancel(reason ?? "PRU dispose");
     this._isDisposed = true;
   }
 

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -79,7 +79,7 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
     this._speed = speed;
     this._discontinuitiesStore = [];
     this._isStarted = false;
-    this._canceller = new TaskCanceller("RC");
+    this._canceller = new TaskCanceller("RebufferingController");
   }
 
   public start(): void {
@@ -338,7 +338,7 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
    * inspection.
    */
   public destroy(reason: string | undefined): void {
-    this._canceller.cancel(reason ?? "RC destroy");
+    this._canceller.cancel(reason ?? "RebufferingController destroy");
   }
 }
 
@@ -510,7 +510,7 @@ class PlaybackRateUpdater {
     playbackObserver: IMediaElementPlaybackObserver,
     speed: IReadOnlySharedReference<number>,
   ) {
-    this._speedUpdateCanceller = new TaskCanceller("PRU");
+    this._speedUpdateCanceller = new TaskCanceller("PlaybackRateUpdater speed updates");
     this._isRebuffering = false;
     this._playbackObserver = playbackObserver;
     this._isDisposed = false;
@@ -528,7 +528,7 @@ class PlaybackRateUpdater {
       return;
     }
     this._isRebuffering = true;
-    this._speedUpdateCanceller.cancel("PRU start rebuf");
+    this._speedUpdateCanceller.cancel("start rebuffering");
     log.info("Init", "Pause playback to build buffer");
     this._playbackObserver.setPlaybackRate(0);
   }
@@ -544,7 +544,7 @@ class PlaybackRateUpdater {
       return;
     }
     this._isRebuffering = false;
-    this._speedUpdateCanceller = new TaskCanceller("PRU");
+    this._speedUpdateCanceller = new TaskCanceller("PlaybackRateUpdater speed updates");
     this._updateSpeed();
   }
 
@@ -559,7 +559,7 @@ class PlaybackRateUpdater {
    * inspection.
    */
   public dispose(reason: string | undefined) {
-    this._speedUpdateCanceller.cancel(reason ?? "PRU dispose");
+    this._speedUpdateCanceller.cancel(reason ?? "PlaybackRateUpdater dispose");
     this._isDisposed = true;
   }
 

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -335,7 +335,7 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
    * forever.
    */
   public destroy(): void {
-    this._canceller.cancel();
+    this._canceller.cancel("RC destroy");
   }
 }
 
@@ -525,7 +525,7 @@ class PlaybackRateUpdater {
       return;
     }
     this._isRebuffering = true;
-    this._speedUpdateCanceller.cancel();
+    this._speedUpdateCanceller.cancel("PRU start rebuf");
     log.info("Init", "Pause playback to build buffer");
     this._playbackObserver.setPlaybackRate(0);
   }
@@ -553,7 +553,7 @@ class PlaybackRateUpdater {
    * `PlaybackRateUpdater` to have an effect anymore.
    */
   public dispose() {
-    this._speedUpdateCanceller.cancel();
+    this._speedUpdateCanceller.cancel("PRU dispose");
     this._isDisposed = true;
   }
 

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -79,7 +79,7 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
     this._speed = speed;
     this._discontinuitiesStore = [];
     this._isStarted = false;
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("RC");
   }
 
   public start(): void {
@@ -507,7 +507,7 @@ class PlaybackRateUpdater {
     playbackObserver: IMediaElementPlaybackObserver,
     speed: IReadOnlySharedReference<number>,
   ) {
-    this._speedUpdateCanceller = new TaskCanceller();
+    this._speedUpdateCanceller = new TaskCanceller("PRU");
     this._isRebuffering = false;
     this._playbackObserver = playbackObserver;
     this._isDisposed = false;
@@ -541,7 +541,7 @@ class PlaybackRateUpdater {
       return;
     }
     this._isRebuffering = false;
-    this._speedUpdateCanceller = new TaskCanceller();
+    this._speedUpdateCanceller = new TaskCanceller("PRU");
     this._updateSpeed();
   }
 

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -78,13 +78,13 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
     if (this._canceller !== null) {
       return;
     }
-    this._canceller = new TaskCanceller("SEE");
+    this._canceller = new TaskCanceller("StreamEventsEmitter");
 
     const cancelSignal = this._canceller.signal;
     const playbackObserver = this._playbackObserver;
 
     let isPollingEvents = false;
-    let cancelCurrentPolling = new TaskCanceller("SEE Polling");
+    let cancelCurrentPolling = new TaskCanceller("StreamEventsEmitter Polling");
     cancelCurrentPolling.linkToSignal(cancelSignal);
 
     this._scheduledEventsRef.setValue(refreshScheduledEventsList([], this._manifest));
@@ -93,8 +93,8 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
       ({ length: scheduledEventsLength }) => {
         if (scheduledEventsLength === 0) {
           if (isPollingEvents) {
-            cancelCurrentPolling.cancel("SSE no event");
-            cancelCurrentPolling = new TaskCanceller("SEE Polling");
+            cancelCurrentPolling.cancel("no stream event");
+            cancelCurrentPolling = new TaskCanceller("StreamEventsEmitter Polling");
             cancelCurrentPolling.linkToSignal(cancelSignal);
             isPollingEvents = false;
           }
@@ -154,7 +154,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
    */
   public stop(reason: string | undefined): void {
     if (this._canceller !== null) {
-      this._canceller.cancel(reason ?? "SSE stop");
+      this._canceller.cancel(reason ?? "StreamEventsEmitter stop");
       this._canceller = null;
     }
   }

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -78,13 +78,13 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
     if (this._canceller !== null) {
       return;
     }
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("SEE");
 
     const cancelSignal = this._canceller.signal;
     const playbackObserver = this._playbackObserver;
 
     let isPollingEvents = false;
-    let cancelCurrentPolling = new TaskCanceller();
+    let cancelCurrentPolling = new TaskCanceller("SEE Polling");
     cancelCurrentPolling.linkToSignal(cancelSignal);
 
     this._scheduledEventsRef.setValue(refreshScheduledEventsList([], this._manifest));
@@ -94,7 +94,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
         if (scheduledEventsLength === 0) {
           if (isPollingEvents) {
             cancelCurrentPolling.cancel();
-            cancelCurrentPolling = new TaskCanceller();
+            cancelCurrentPolling = new TaskCanceller("SEE Polling");
             cancelCurrentPolling.linkToSignal(cancelSignal);
             isPollingEvents = false;
           }

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -93,7 +93,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
       ({ length: scheduledEventsLength }) => {
         if (scheduledEventsLength === 0) {
           if (isPollingEvents) {
-            cancelCurrentPolling.cancel();
+            cancelCurrentPolling.cancel("SSE no event");
             cancelCurrentPolling = new TaskCanceller("SEE Polling");
             cancelCurrentPolling.linkToSignal(cancelSignal);
             isPollingEvents = false;
@@ -149,7 +149,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
 
   public stop(): void {
     if (this._canceller !== null) {
-      this._canceller.cancel();
+      this._canceller.cancel("SSE stop");
       this._canceller = null;
     }
   }

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -147,9 +147,14 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
     this._scheduledEventsRef.setValue(refreshScheduledEventsList(prev, man));
   }
 
-  public stop(): void {
+  /**
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * stop. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  public stop(reason: string | undefined): void {
     if (this._canceller !== null) {
-      this._canceller.cancel("SSE stop");
+      this._canceller.cancel(reason ?? "SSE stop");
       this._canceller = null;
     }
   }

--- a/src/main_thread/render_thumbnail.ts
+++ b/src/main_thread/render_thumbnail.ts
@@ -56,13 +56,13 @@ export default async function renderThumbnail(
   let imageUrl: string | undefined;
 
   const olderTaskSameContainer = thumbnailRequestsInfo.pendingRequests.get(container);
-  olderTaskSameContainer?.cancel("thumb same container");
+  olderTaskSameContainer?.cancel("new thumbnail has same container");
 
   thumbnailRequestsInfo.pendingRequests.set(container, canceller);
 
   const onFinished = () => {
     unlinkCanceller();
-    canceller.cancel("thumb finished");
+    canceller.cancel("thumbnail request finished");
     thumbnailRequestsInfo.pendingRequests.delete(container);
 
     // Let's revoke the URL after a round-trip to the event loop just in case

--- a/src/main_thread/render_thumbnail.ts
+++ b/src/main_thread/render_thumbnail.ts
@@ -56,13 +56,13 @@ export default async function renderThumbnail(
   let imageUrl: string | undefined;
 
   const olderTaskSameContainer = thumbnailRequestsInfo.pendingRequests.get(container);
-  olderTaskSameContainer?.cancel();
+  olderTaskSameContainer?.cancel("thumb same container");
 
   thumbnailRequestsInfo.pendingRequests.set(container, canceller);
 
   const onFinished = () => {
     unlinkCanceller();
-    canceller.cancel();
+    canceller.cancel("thumb finished");
     thumbnailRequestsInfo.pendingRequests.delete(container);
 
     // Let's revoke the URL after a round-trip to the event loop just in case

--- a/src/main_thread/render_thumbnail.ts
+++ b/src/main_thread/render_thumbnail.ts
@@ -50,7 +50,7 @@ export default async function renderThumbnail(
   }
 
   const { thumbnailRequestsInfo, currentContentCanceller } = contentInfos;
-  const canceller = new TaskCanceller();
+  const canceller = new TaskCanceller("Render Thumbnail");
   const unlinkCanceller = canceller.linkToSignal(currentContentCanceller.signal);
 
   let imageUrl: string | undefined;

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -110,8 +110,8 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
 
     this._videoElement = videoElement;
     this._textTrackElement = textTrackElement;
-    this._sizeUpdateCanceller = new TaskCanceller();
-    this._subtitlesIntervalCanceller = new TaskCanceller();
+    this._sizeUpdateCanceller = new TaskCanceller("HTD Size");
+    this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
     this._buffer = new TextTrackCuesStore();
     this._currentCues = [];
     this._isAutoRefreshing = false;
@@ -232,7 +232,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       this.refreshSubtitles();
       this._isAutoRefreshing = false;
       this._subtitlesIntervalCanceller.cancel();
-      this._subtitlesIntervalCanceller = new TaskCanceller();
+      this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
     }
     return convertToRanges(this._buffered);
   }
@@ -248,7 +248,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
   public reset(): void {
     log.debug("text", "Resetting HTMLTextDisplayer");
     this.stop();
-    this._subtitlesIntervalCanceller = new TaskCanceller();
+    this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
   }
 
   public stop(): void {
@@ -314,7 +314,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     );
 
     if (proportionalCues.length > 0) {
-      this._sizeUpdateCanceller = new TaskCanceller();
+      this._sizeUpdateCanceller = new TaskCanceller("HTD Size");
       this._sizeUpdateCanceller.linkToSignal(this._subtitlesIntervalCanceller.signal);
       const { TEXT_TRACK_SIZE_CHECKS_INTERVAL } = config.getCurrent();
       // update propertionally-sized elements periodically
@@ -360,7 +360,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     const startAutoRefresh = () => {
       stopAutoRefresh();
       this._isAutoRefreshing = true;
-      autoRefreshCanceller = new TaskCanceller();
+      autoRefreshCanceller = new TaskCanceller("HTD Auto-Refresh");
       autoRefreshCanceller.linkToSignal(cancellationSignal);
       const intervalId = setInterval(
         () => this.refreshSubtitles(),

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -231,7 +231,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     if (this._isAutoRefreshing && this._buffer.isEmpty()) {
       this.refreshSubtitles();
       this._isAutoRefreshing = false;
-      this._subtitlesIntervalCanceller.cancel();
+      this._subtitlesIntervalCanceller.cancel("HTD empty");
       this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
     }
     return convertToRanges(this._buffered);
@@ -260,14 +260,14 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     this._buffer.remove(0, Infinity);
     this._buffered.remove(0, Infinity);
     this._isAutoRefreshing = false;
-    this._subtitlesIntervalCanceller.cancel();
+    this._subtitlesIntervalCanceller.cancel("HTD stop");
   }
 
   /**
    * Remove the current cue from being displayed.
    */
   private _disableCurrentCues(): void {
-    this._sizeUpdateCanceller.cancel();
+    this._sizeUpdateCanceller.cancel("HTD disable curr");
     if (this._currentCues.length > 0) {
       for (const cue of this._currentCues) {
         safelyRemoveChild(this._textTrackElement, cue.element);
@@ -292,7 +292,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     // Remove and re-display everything
     // TODO More intelligent handling
 
-    this._sizeUpdateCanceller.cancel();
+    this._sizeUpdateCanceller.cancel("HTD display");
     for (const cue of this._currentCues) {
       safelyRemoveChild(this._textTrackElement, cue.element);
     }
@@ -353,7 +353,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     const stopAutoRefresh = () => {
       this._isAutoRefreshing = false;
       if (autoRefreshCanceller !== null) {
-        autoRefreshCanceller.cancel();
+        autoRefreshCanceller.cancel("HTD stop auto");
         autoRefreshCanceller = null;
       }
     };

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -110,8 +110,10 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
 
     this._videoElement = videoElement;
     this._textTrackElement = textTrackElement;
-    this._sizeUpdateCanceller = new TaskCanceller("HTD Size");
-    this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
+    this._sizeUpdateCanceller = new TaskCanceller("HTMLTextDisplayer size updates");
+    this._subtitlesIntervalCanceller = new TaskCanceller(
+      "HTMLTextDisplayer subtitles updates",
+    );
     this._buffer = new TextTrackCuesStore();
     this._currentCues = [];
     this._isAutoRefreshing = false;
@@ -231,8 +233,10 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     if (this._isAutoRefreshing && this._buffer.isEmpty()) {
       this.refreshSubtitles();
       this._isAutoRefreshing = false;
-      this._subtitlesIntervalCanceller.cancel("HTD empty");
-      this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
+      this._subtitlesIntervalCanceller.cancel("HTMLTextDisplayer no cue");
+      this._subtitlesIntervalCanceller = new TaskCanceller(
+        "HTMLTextDisplayer subtitles updates",
+      );
     }
     return convertToRanges(this._buffered);
   }
@@ -247,8 +251,10 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
 
   public reset(): void {
     log.debug("text", "Resetting HTMLTextDisplayer");
-    this.stop("HTD reset");
-    this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
+    this.stop("HTMLTextDisplayer reset");
+    this._subtitlesIntervalCanceller = new TaskCanceller(
+      "HTMLTextDisplayer subtitles updates",
+    );
   }
 
   public stop(reason: string | undefined): void {
@@ -294,7 +300,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     // Remove and re-display everything
     // TODO More intelligent handling
 
-    this._sizeUpdateCanceller.cancel("HTD display");
+    this._sizeUpdateCanceller.cancel("HTMLTextDisplayer display");
     for (const cue of this._currentCues) {
       safelyRemoveChild(this._textTrackElement, cue.element);
     }
@@ -316,7 +322,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     );
 
     if (proportionalCues.length > 0) {
-      this._sizeUpdateCanceller = new TaskCanceller("HTD Size");
+      this._sizeUpdateCanceller = new TaskCanceller("HTMLTextDisplayer size updates");
       this._sizeUpdateCanceller.linkToSignal(this._subtitlesIntervalCanceller.signal);
       const { TEXT_TRACK_SIZE_CHECKS_INTERVAL } = config.getCurrent();
       // update propertionally-sized elements periodically
@@ -355,14 +361,16 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     const stopAutoRefresh = () => {
       this._isAutoRefreshing = false;
       if (autoRefreshCanceller !== null) {
-        autoRefreshCanceller.cancel("HTD stop auto");
+        autoRefreshCanceller.cancel("HTMLTextDisplayer stop auto-refresh");
         autoRefreshCanceller = null;
       }
     };
     const startAutoRefresh = () => {
       stopAutoRefresh();
       this._isAutoRefreshing = true;
-      autoRefreshCanceller = new TaskCanceller("HTD Auto-Refresh");
+      autoRefreshCanceller = new TaskCanceller(
+        "HTMLTextDisplayer subtitles auto-refresh",
+      );
       autoRefreshCanceller.linkToSignal(cancellationSignal);
       const intervalId = setInterval(
         () => this.refreshSubtitles(),

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -247,27 +247,29 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
 
   public reset(): void {
     log.debug("text", "Resetting HTMLTextDisplayer");
-    this.stop();
+    this.stop("HTD reset");
     this._subtitlesIntervalCanceller = new TaskCanceller("HTD Sub");
   }
 
-  public stop(): void {
+  public stop(reason: string | undefined): void {
     if (this._subtitlesIntervalCanceller.isUsed()) {
       return;
     }
     log.debug("text", "Stopping HTMLTextDisplayer");
-    this._disableCurrentCues();
+    this._disableCurrentCues(reason ?? "HTD stop");
     this._buffer.remove(0, Infinity);
     this._buffered.remove(0, Infinity);
     this._isAutoRefreshing = false;
-    this._subtitlesIntervalCanceller.cancel("HTD stop");
+    this._subtitlesIntervalCanceller.cancel(reason ?? "HTD stop");
   }
 
   /**
    * Remove the current cue from being displayed.
+   * @param {string} reason - Human-inspectable reason.
+   * Used for debugging matters, especially for debug log inspection.
    */
-  private _disableCurrentCues(): void {
-    this._sizeUpdateCanceller.cancel("HTD disable curr");
+  private _disableCurrentCues(reason: string): void {
+    this._sizeUpdateCanceller.cancel(reason);
     if (this._currentCues.length > 0) {
       for (const cue of this._currentCues) {
         safelyRemoveChild(this._textTrackElement, cue.element);
@@ -376,7 +378,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       this._videoElement,
       () => {
         stopAutoRefresh();
-        this._disableCurrentCues();
+        this._disableCurrentCues("seek");
       },
       cancellationSignal,
     );
@@ -405,7 +407,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     }
     const cues = this._buffer.get(time);
     if (cues.length === 0) {
-      this._disableCurrentCues();
+      this._disableCurrentCues("no cue");
     } else {
       this._displayCues(cues);
     }

--- a/src/main_thread/text_displayer/types.ts
+++ b/src/main_thread/text_displayer/types.ts
@@ -35,8 +35,10 @@ export interface ITextDisplayer {
   getBufferedRanges(): IRange[];
   /**
    * Stop the `ITextDisplayer` from running and using resources.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * stop. Used for debugging matters, especially for debug log inspection.
    */
-  stop(): void;
+  stop(reason: string | undefined): void;
 }
 
 /** Interface describing a timed text media data "chunk". */

--- a/src/main_thread/tracks_store/track_dispatcher.ts
+++ b/src/main_thread/tracks_store/track_dispatcher.ts
@@ -89,7 +89,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
    */
   constructor(adaptationRef: SharedReference<IAdaptationChoice | null | undefined>) {
     super();
-    this._canceller = new TaskCanceller("TD");
+    this._canceller = new TaskCanceller("TrackDispatcher initial");
     this._adaptationRef = adaptationRef;
     this._updateToken = false;
     this._lastEmitted = undefined;
@@ -120,14 +120,14 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
       this._canceller.cancel("track update null");
 
       // has no point but let's still create one for simplicity sake
-      this._canceller = new TaskCanceller("TD");
+      this._canceller = new TaskCanceller("TrackDispatcher null");
       this._lastEmitted = null;
       this._adaptationRef.setValue(null);
       return;
     }
     const { adaptation, switchingMode, relativeResumingPosition } = newTrackInfo;
     this._canceller.cancel("track update");
-    this._canceller = new TaskCanceller("TD");
+    this._canceller = new TaskCanceller("TrackDispatcher " + adaptation.type);
     const reference = this._constructLockedRepresentationsReference(newTrackInfo);
     if (!this._updateToken) {
       return;
@@ -241,7 +241,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
    */
   public dispose(reason: string | undefined): void {
     this.removeEventListener();
-    this._canceller.cancel(reason ?? "TD dispose");
+    this._canceller.cancel(reason ?? "TrackDispatcher dispose");
     this._adaptationRef.finish();
   }
 }

--- a/src/main_thread/tracks_store/track_dispatcher.ts
+++ b/src/main_thread/tracks_store/track_dispatcher.ts
@@ -89,7 +89,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
    */
   constructor(adaptationRef: SharedReference<IAdaptationChoice | null | undefined>) {
     super();
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("TD");
     this._adaptationRef = adaptationRef;
     this._updateToken = false;
     this._lastEmitted = undefined;
@@ -120,14 +120,14 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
       this._canceller.cancel();
 
       // has no point but let's still create one for simplicity sake
-      this._canceller = new TaskCanceller();
+      this._canceller = new TaskCanceller("TD");
       this._lastEmitted = null;
       this._adaptationRef.setValue(null);
       return;
     }
     const { adaptation, switchingMode, relativeResumingPosition } = newTrackInfo;
     this._canceller.cancel();
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("TD");
     const reference = this._constructLockedRepresentationsReference(newTrackInfo);
     if (!this._updateToken) {
       return;

--- a/src/main_thread/tracks_store/track_dispatcher.ts
+++ b/src/main_thread/tracks_store/track_dispatcher.ts
@@ -117,7 +117,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
         return;
       }
       this._updateToken = false;
-      this._canceller.cancel();
+      this._canceller.cancel("track update null");
 
       // has no point but let's still create one for simplicity sake
       this._canceller = new TaskCanceller("TD");
@@ -126,7 +126,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
       return;
     }
     const { adaptation, switchingMode, relativeResumingPosition } = newTrackInfo;
-    this._canceller.cancel();
+    this._canceller.cancel("track update");
     this._canceller = new TaskCanceller("TD");
     const reference = this._constructLockedRepresentationsReference(newTrackInfo);
     if (!this._updateToken) {
@@ -238,7 +238,7 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
    */
   public dispose(): void {
     this.removeEventListener();
-    this._canceller.cancel();
+    this._canceller.cancel("TD dispose");
     this._adaptationRef.finish();
   }
 }

--- a/src/main_thread/tracks_store/track_dispatcher.ts
+++ b/src/main_thread/tracks_store/track_dispatcher.ts
@@ -235,10 +235,13 @@ export default class TrackDispatcher extends EventEmitter<ITrackDispatcherEvent>
   /**
    * Free the resources (e.g. `Manifest` event listeners) linked to this
    * `TrackDispatcher`.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose(): void {
+  public dispose(reason: string | undefined): void {
     this.removeEventListener();
-    this._canceller.cancel("TD dispose");
+    this._canceller.cancel(reason ?? "TD dispose");
     this._adaptationRef.finish();
   }
 }

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -487,7 +487,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         bufferType,
         periodId: period.id,
       });
-      periodObj[bufferType].dispatcher.dispose("TD double add");
+      periodObj[bufferType].dispatcher.dispose("TrackDispatcher double add issue");
     }
 
     const dispatcher = new TrackDispatcher(adaptationRef);
@@ -757,7 +757,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       return;
     }
 
-    choiceItem.dispatcher.dispose("TD ref removal");
+    choiceItem.dispatcher.dispose("TrackDispatcher reference removal");
     choiceItem.dispatcher = null;
     if (isPeriodItemRemovable(periodObj)) {
       this._removePeriodObject(periodIndex);
@@ -835,11 +835,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     log.debug("Track", "Resetting Period Objects");
     for (let i = this._storedPeriodInfo.length - 1; i >= 0; i--) {
       const storedObj = this._storedPeriodInfo[i];
-      storedObj.audio.dispatcher?.dispose("TD reset");
+      storedObj.audio.dispatcher?.dispose("TrackDispatcher reset");
       storedObj.audio.dispatcher = null;
-      storedObj.video.dispatcher?.dispose("TD reset");
+      storedObj.video.dispatcher?.dispose("TrackDispatcher reset");
       storedObj.video.dispatcher = null;
-      storedObj.text.dispatcher?.dispose("TD reset");
+      storedObj.text.dispatcher?.dispose("TrackDispatcher reset");
       storedObj.text.dispatcher = null;
       if (!storedObj.inManifest) {
         this._removePeriodObject(i);

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -487,7 +487,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         bufferType,
         periodId: period.id,
       });
-      periodObj[bufferType].dispatcher.dispose();
+      periodObj[bufferType].dispatcher.dispose("TD double add");
     }
 
     const dispatcher = new TrackDispatcher(adaptationRef);
@@ -757,7 +757,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       return;
     }
 
-    choiceItem.dispatcher.dispose();
+    choiceItem.dispatcher.dispose("TD ref removal");
     choiceItem.dispatcher = null;
     if (isPeriodItemRemovable(periodObj)) {
       this._removePeriodObject(periodIndex);
@@ -835,11 +835,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     log.debug("Track", "Resetting Period Objects");
     for (let i = this._storedPeriodInfo.length - 1; i >= 0; i--) {
       const storedObj = this._storedPeriodInfo[i];
-      storedObj.audio.dispatcher?.dispose();
+      storedObj.audio.dispatcher?.dispose("TD reset");
       storedObj.audio.dispatcher = null;
-      storedObj.video.dispatcher?.dispose();
+      storedObj.video.dispatcher?.dispose("TD reset");
       storedObj.video.dispatcher = null;
-      storedObj.text.dispatcher?.dispose();
+      storedObj.text.dispatcher?.dispose("TD reset");
       storedObj.text.dispatcher = null;
       if (!storedObj.inManifest) {
         this._removePeriodObject(i);

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -178,7 +178,7 @@ export default class MainMediaSourceInterface
   public stopEndOfStream() {
     if (this._endOfStreamCanceller !== null) {
       log.debug("mse", "resume-stream order received.");
-      this._endOfStreamCanceller.cancel();
+      this._endOfStreamCanceller.cancel("MSI stop EOS");
       this._endOfStreamCanceller = null;
     }
   }
@@ -186,7 +186,7 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public dispose() {
     this.sourceBuffers.forEach((s) => s.dispose());
-    this._canceller.cancel();
+    this._canceller.cancel("MSI dispose");
     resetMediaSource(this._mediaSource);
   }
 }
@@ -361,7 +361,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   }
 
   private _emptyCurrentQueue(): void {
-    const error = new CancellationError("SBI empty");
+    const error = new CancellationError("SBI empty", "empty");
     if (this._currentOperations.length > 0) {
       this._currentOperations.forEach((op) => {
         op.reject(error);

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -160,8 +160,8 @@ export default class MainMediaSourceInterface
   }
 
   /** @see IMediaSourceInterface */
-  public interruptDurationSetting() {
-    this._durationUpdater.stopUpdating();
+  public interruptDurationSetting(reason: string | undefined) {
+    this._durationUpdater.stopUpdating(reason);
   }
 
   /** @see IMediaSourceInterface */
@@ -184,9 +184,9 @@ export default class MainMediaSourceInterface
   }
 
   /** @see IMediaSourceInterface */
-  public dispose() {
-    this.sourceBuffers.forEach((s) => s.dispose());
-    this._canceller.cancel("MSI dispose");
+  public dispose(reason: string | undefined) {
+    this.sourceBuffers.forEach((s) => s.dispose(reason));
+    this._canceller.cancel(reason ?? "MSI dispose");
     resetMediaSource(this._mediaSource);
   }
 }
@@ -290,7 +290,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   }
 
   /** @see ISourceBufferInterface */
-  public abort(): void {
+  public abort(reason: string | undefined): void {
     try {
       this._sourceBuffer.abort();
     } catch (err) {
@@ -300,17 +300,17 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
         err instanceof Error ? err : "Unknown Error",
       );
     }
-    this._emptyCurrentQueue();
+    this._emptyCurrentQueue(reason);
   }
 
   /** @see ISourceBufferInterface */
-  public dispose(): void {
+  public dispose(reason: string | undefined): void {
     try {
       this._sourceBuffer.abort();
     } catch (_) {
       // we don't care
     }
-    this._emptyCurrentQueue();
+    this._emptyCurrentQueue(reason);
   }
 
   private _onError(evt: Event) {
@@ -360,8 +360,13 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     this._performNextOperation();
   }
 
-  private _emptyCurrentQueue(): void {
-    const error = new CancellationError("SBI empty", "empty");
+  /**
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * action. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  private _emptyCurrentQueue(reason: string | undefined): void {
+    const error = new CancellationError("SBI queue", reason);
     if (this._currentOperations.length > 0) {
       this._currentOperations.forEach((op) => {
         op.reject(error);

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -85,7 +85,7 @@ export default class MainMediaSourceInterface
     super();
     this.id = id;
     this.sourceBuffers = [];
-    this._canceller = new TaskCanceller("MSI Main");
+    this._canceller = new TaskCanceller("MainMediaSourceInterface");
 
     if (isNullOrUndefined(MediaSource_)) {
       throw new MediaError(
@@ -167,7 +167,9 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public maintainEndOfStream() {
     if (this._endOfStreamCanceller === null) {
-      this._endOfStreamCanceller = new TaskCanceller("MSI EOS");
+      this._endOfStreamCanceller = new TaskCanceller(
+        "MainMediaSourceInterface EndOfStream",
+      );
       this._endOfStreamCanceller.linkToSignal(this._canceller.signal);
       log.debug("mse", "end-of-stream order received.");
       maintainEndOfStream(this._mediaSource, this._endOfStreamCanceller.signal);
@@ -178,7 +180,7 @@ export default class MainMediaSourceInterface
   public stopEndOfStream() {
     if (this._endOfStreamCanceller !== null) {
       log.debug("mse", "resume-stream order received.");
-      this._endOfStreamCanceller.cancel("MSI stop EOS");
+      this._endOfStreamCanceller.cancel("MediaSourceInterface stopEndOfStream");
       this._endOfStreamCanceller = null;
     }
   }
@@ -186,7 +188,7 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public dispose(reason: string | undefined) {
     this.sourceBuffers.forEach((s) => s.dispose(reason));
-    this._canceller.cancel(reason ?? "MSI dispose");
+    this._canceller.cancel(reason ?? "MainMediaSourceInterface dispose");
     resetMediaSource(this._mediaSource);
   }
 }
@@ -231,7 +233,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   constructor(sbType: SourceBufferType, codec: string, sourceBuffer: ISourceBuffer) {
     this.type = sbType;
     this.codec = codec;
-    this._canceller = new TaskCanceller("SBI Main");
+    this._canceller = new TaskCanceller("MainSourceBufferInterface " + sbType);
     this._sourceBuffer = sourceBuffer;
     this._operationQueue = [];
     this._currentOperations = [];
@@ -366,7 +368,10 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
    * inspection.
    */
   private _emptyCurrentQueue(reason: string | undefined): void {
-    const error = new CancellationError("SBI queue", reason);
+    const error = new CancellationError(
+      "MainSourceBufferInterface queue " + this.type,
+      reason,
+    );
     if (this._currentOperations.length > 0) {
       this._currentOperations.forEach((op) => {
         op.reject(error);
@@ -557,12 +562,17 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     const sourceBuffer = this._sourceBuffer;
     const { codec, timestampOffset, appendWindow = [] } = params;
     if (codec !== undefined && codec !== this.codec) {
-      log.debug("mse", "updating codec", { prevCodec: this.codec, newCodec: codec });
+      log.debug("mse", "updating codec", {
+        type: this.type,
+        prevCodec: this.codec,
+        newCodec: codec,
+      });
       const hasUpdatedSourceBufferType = tryToChangeSourceBufferType(sourceBuffer, codec);
       if (hasUpdatedSourceBufferType) {
         this.codec = codec;
       } else {
         log.debug("mse", "could not update codec", {
+          type: this.type,
           prevCodec: this.codec,
           newCodec: codec,
         });
@@ -575,6 +585,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     ) {
       const newTimestampOffset = timestampOffset;
       log.debug("mse", "updating timestampOffset", {
+        type: this.type,
         codec,
         prevTimestampOffset: sourceBuffer.timestampOffset,
         newTimestampOffset,
@@ -585,6 +596,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     if (appendWindow[0] === undefined) {
       if (sourceBuffer.appendWindowStart > 0) {
         log.debug("mse", "re-setting `appendWindowStart`", {
+          type: this.type,
           prevWindowStart: sourceBuffer.appendWindowStart,
         });
         sourceBuffer.appendWindowStart = 0;
@@ -593,12 +605,14 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       if (appendWindow[0] >= sourceBuffer.appendWindowEnd) {
         const newWindowEnd = appendWindow[0] + 1;
         log.debug("mse", "pre-updating `appendWindowEnd`", {
+          type: this.type,
           prevWindowEnd: sourceBuffer.appendWindowEnd,
           newWindowEnd,
         });
         sourceBuffer.appendWindowEnd = newWindowEnd;
       }
       log.debug("mse", "setting `appendWindowStart`", {
+        type: this.type,
         appendWindowStart: appendWindow[0],
       });
       sourceBuffer.appendWindowStart = appendWindow[0];
@@ -607,12 +621,14 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     if (appendWindow[1] === undefined) {
       if (sourceBuffer.appendWindowEnd !== Infinity) {
         log.debug("mse", "re-setting `appendWindowEnd`", {
+          type: this.type,
           prevWindowStart: sourceBuffer.appendWindowStart,
         });
         sourceBuffer.appendWindowEnd = Infinity;
       }
     } else if (appendWindow[1] !== sourceBuffer.appendWindowEnd) {
       log.debug("mse", "setting `appendWindowEnd`", {
+        type: this.type,
         prevWindowEnd: sourceBuffer.appendWindowEnd,
         newWindowEnd: appendWindow[1],
       });

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -85,7 +85,7 @@ export default class MainMediaSourceInterface
     super();
     this.id = id;
     this.sourceBuffers = [];
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("MSI Main");
 
     if (isNullOrUndefined(MediaSource_)) {
       throw new MediaError(
@@ -167,7 +167,7 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public maintainEndOfStream() {
     if (this._endOfStreamCanceller === null) {
-      this._endOfStreamCanceller = new TaskCanceller();
+      this._endOfStreamCanceller = new TaskCanceller("MSI EOS");
       this._endOfStreamCanceller.linkToSignal(this._canceller.signal);
       log.debug("mse", "end-of-stream order received.");
       maintainEndOfStream(this._mediaSource, this._endOfStreamCanceller.signal);
@@ -231,7 +231,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   constructor(sbType: SourceBufferType, codec: string, sourceBuffer: ISourceBuffer) {
     this.type = sbType;
     this.codec = codec;
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("SBI Main");
     this._sourceBuffer = sourceBuffer;
     this._operationQueue = [];
     this._currentOperations = [];
@@ -361,7 +361,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   }
 
   private _emptyCurrentQueue(): void {
-    const error = new CancellationError();
+    const error = new CancellationError("SBI empty");
     if (this._currentOperations.length > 0) {
       this._currentOperations.forEach((op) => {
         op.reject(error);

--- a/src/mse/types.ts
+++ b/src/mse/types.ts
@@ -89,16 +89,24 @@ export interface ISourceBufferInterface {
    * @returns {Promise.<Array.<Object>>}
    */
   remove(start: number, end: number): Promise<IRange[]>;
-  /** Abort all operations pending on the `SourceBuffer`. */
-  abort(): void;
+  /**
+   * Abort all operations pending on the `SourceBuffer`.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * abort. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  abort(reason: string | undefined): void;
   /**
    * Abort all operations pending on the `SourceBuffer` AND free up all
    * resources taken by the `ISourceBufferInterface`.
    *
    * The `ISourceBufferInterface` implementation might not be usable after
    * this call, it should mostly be called for clean-up.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  dispose(): void;
+  dispose(reason: string | undefined): void;
   /**
    * Returns the current range of buffered data, or `undefined` if this is not
    * obtainable synchronously.
@@ -247,8 +255,11 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
   /**
    * Interrupt a duration update background task previously started through
    * a `setDuration` call.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * interrupt. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  interruptDurationSetting(): void;
+  interruptDurationSetting(reason: string | undefined): void;
 
   /**
    * Signal to the `IMediaSourceInterface` that all media segments until the
@@ -272,8 +283,11 @@ export interface IMediaSourceInterface extends EventEmitter<IMediaSourceInterfac
   /**
    * Free all resources taken by the `IMediaSourceInterface`, including all its
    * inner `ISourceBufferInterface` objects.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  dispose(): void;
+  dispose(reason: string | undefined): void;
 
   /**
    * Only set for `IMediaSourceInterface` objects which cannot rely on

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -82,13 +82,13 @@ export default function triggerEndOfStream(
 
   log.debug("mse", "Waiting SourceBuffers to be updated before calling endOfStream.");
 
-  const innerCanceller = new TaskCanceller("EOS inner");
+  const innerCanceller = new TaskCanceller("EndOfStream current iteration");
   innerCanceller.linkToSignal(cancelSignal);
   for (const sourceBuffer of updatingSourceBuffers) {
     onSourceBufferUpdate(
       sourceBuffer,
       () => {
-        innerCanceller.cancel("SB update");
+        innerCanceller.cancel("SourceBuffer update");
         triggerEndOfStream(mediaSource, cancelSignal);
       },
       innerCanceller.signal,
@@ -98,7 +98,7 @@ export default function triggerEndOfStream(
   onRemoveSourceBuffers(
     sourceBuffers,
     () => {
-      innerCanceller.cancel("SB remove");
+      innerCanceller.cancel("SourceBuffer remove");
       triggerEndOfStream(mediaSource, cancelSignal);
     },
     innerCanceller.signal,
@@ -115,14 +115,14 @@ export function maintainEndOfStream(
   mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): void {
-  let endOfStreamCanceller = new TaskCanceller("EOS");
+  let endOfStreamCanceller = new TaskCanceller("EndOfStream");
   endOfStreamCanceller.linkToSignal(cancelSignal);
   onSourceOpen(
     mediaSource,
     () => {
       log.debug("mse", "MediaSource re-opened while end-of-stream is active");
-      endOfStreamCanceller.cancel("MS re-opened");
-      endOfStreamCanceller = new TaskCanceller("EOS");
+      endOfStreamCanceller.cancel("MediaSource re-opened");
+      endOfStreamCanceller = new TaskCanceller("EndOfStream");
       endOfStreamCanceller.linkToSignal(cancelSignal);
       triggerEndOfStream(mediaSource, endOfStreamCanceller.signal);
     },

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -82,7 +82,7 @@ export default function triggerEndOfStream(
 
   log.debug("mse", "Waiting SourceBuffers to be updated before calling endOfStream.");
 
-  const innerCanceller = new TaskCanceller();
+  const innerCanceller = new TaskCanceller("EOS inner");
   innerCanceller.linkToSignal(cancelSignal);
   for (const sourceBuffer of updatingSourceBuffers) {
     onSourceBufferUpdate(
@@ -115,14 +115,14 @@ export function maintainEndOfStream(
   mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): void {
-  let endOfStreamCanceller = new TaskCanceller();
+  let endOfStreamCanceller = new TaskCanceller("EOS");
   endOfStreamCanceller.linkToSignal(cancelSignal);
   onSourceOpen(
     mediaSource,
     () => {
       log.debug("mse", "MediaSource re-opened while end-of-stream is active");
       endOfStreamCanceller.cancel();
-      endOfStreamCanceller = new TaskCanceller();
+      endOfStreamCanceller = new TaskCanceller("EOS");
       endOfStreamCanceller.linkToSignal(cancelSignal);
       triggerEndOfStream(mediaSource, endOfStreamCanceller.signal);
     },

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -88,7 +88,7 @@ export default function triggerEndOfStream(
     onSourceBufferUpdate(
       sourceBuffer,
       () => {
-        innerCanceller.cancel();
+        innerCanceller.cancel("SB update");
         triggerEndOfStream(mediaSource, cancelSignal);
       },
       innerCanceller.signal,
@@ -98,7 +98,7 @@ export default function triggerEndOfStream(
   onRemoveSourceBuffers(
     sourceBuffers,
     () => {
-      innerCanceller.cancel();
+      innerCanceller.cancel("SB remove");
       triggerEndOfStream(mediaSource, cancelSignal);
     },
     innerCanceller.signal,
@@ -121,7 +121,7 @@ export function maintainEndOfStream(
     mediaSource,
     () => {
       log.debug("mse", "MediaSource re-opened while end-of-stream is active");
-      endOfStreamCanceller.cancel();
+      endOfStreamCanceller.cancel("MS re-opened");
       endOfStreamCanceller = new TaskCanceller("EOS");
       endOfStreamCanceller.linkToSignal(cancelSignal);
       triggerEndOfStream(mediaSource, endOfStreamCanceller.signal);

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -76,7 +76,9 @@ export default class MediaSourceDurationUpdater {
     if (this._currentMediaSourceDurationUpdateCanceller !== null) {
       this._currentMediaSourceDurationUpdateCanceller.cancel();
     }
-    this._currentMediaSourceDurationUpdateCanceller = new TaskCanceller();
+    this._currentMediaSourceDurationUpdateCanceller = new TaskCanceller(
+      "MediaSource Duration Update",
+    );
 
     const mediaSource = this._mediaSource;
     const currentSignal = this._currentMediaSourceDurationUpdateCanceller.signal;
@@ -86,7 +88,7 @@ export default class MediaSourceDurationUpdater {
     );
 
     /** TaskCanceller triggered each time the MediaSource switches to and from "open". */
-    let msOpenStatusCanceller = new TaskCanceller();
+    let msOpenStatusCanceller = new TaskCanceller("MS Duration Update Open Listener");
     msOpenStatusCanceller.linkToSignal(currentSignal);
     isMediaSourceOpened.onUpdate(onMediaSourceOpenedStatusChanged, {
       emitCurrentValue: true,
@@ -98,20 +100,22 @@ export default class MediaSourceDurationUpdater {
       if (!isMediaSourceOpened.getValue()) {
         return;
       }
-      msOpenStatusCanceller = new TaskCanceller();
+      msOpenStatusCanceller = new TaskCanceller(
+        undefined /* we do not care for logs here */,
+      );
       msOpenStatusCanceller.linkToSignal(currentSignal);
       const areSourceBuffersUpdating = createSourceBuffersUpdatingReference(
         mediaSource.sourceBuffers,
         msOpenStatusCanceller.signal,
       );
       /** TaskCanceller triggered each time SourceBuffers' updating status changes */
-      let sourceBuffersUpdatingCanceller = new TaskCanceller();
+      let sourceBuffersUpdatingCanceller = new TaskCanceller(undefined);
       sourceBuffersUpdatingCanceller.linkToSignal(msOpenStatusCanceller.signal);
 
       return areSourceBuffersUpdating.onUpdate(
         (areUpdating) => {
           sourceBuffersUpdatingCanceller.cancel();
-          sourceBuffersUpdatingCanceller = new TaskCanceller();
+          sourceBuffersUpdatingCanceller = new TaskCanceller(undefined);
           sourceBuffersUpdatingCanceller.linkToSignal(msOpenStatusCanceller.signal);
           if (areUpdating) {
             return;

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -74,7 +74,7 @@ export default class MediaSourceDurationUpdater {
    */
   public updateDuration(newDuration: number, isRealEndKnown: boolean): void {
     if (this._currentMediaSourceDurationUpdateCanceller !== null) {
-      this._currentMediaSourceDurationUpdateCanceller.cancel("reset mdu");
+      this._currentMediaSourceDurationUpdateCanceller.cancel("manual duration update");
     }
     this._currentMediaSourceDurationUpdateCanceller = new TaskCanceller(
       "MediaSource Duration Update",
@@ -88,7 +88,9 @@ export default class MediaSourceDurationUpdater {
     );
 
     /** TaskCanceller triggered each time the MediaSource switches to and from "open". */
-    let msOpenStatusCanceller = new TaskCanceller("MS Duration Update Open Listener");
+    let msOpenStatusCanceller = new TaskCanceller(
+      undefined /* we do not care for logs here */,
+    );
     msOpenStatusCanceller.linkToSignal(currentSignal);
     isMediaSourceOpened.onUpdate(onMediaSourceOpenedStatusChanged, {
       emitCurrentValue: true,
@@ -96,7 +98,7 @@ export default class MediaSourceDurationUpdater {
     });
 
     function onMediaSourceOpenedStatusChanged() {
-      msOpenStatusCanceller.cancel("ms opened");
+      msOpenStatusCanceller.cancel("MediaSource open status changed");
       if (!isMediaSourceOpened.getValue()) {
         return;
       }
@@ -114,7 +116,7 @@ export default class MediaSourceDurationUpdater {
 
       return areSourceBuffersUpdating.onUpdate(
         (areUpdating) => {
-          sourceBuffersUpdatingCanceller.cancel("sb status update");
+          sourceBuffersUpdatingCanceller.cancel("SourceBuffer status update");
           sourceBuffersUpdatingCanceller = new TaskCanceller(undefined);
           sourceBuffersUpdatingCanceller.linkToSignal(msOpenStatusCanceller.signal);
           if (areUpdating) {

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -135,10 +135,13 @@ export default class MediaSourceDurationUpdater {
 
   /**
    * Abort the last duration-setting operation and free its resources.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * stop. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public stopUpdating() {
+  public stopUpdating(reason: string | undefined) {
     if (this._currentMediaSourceDurationUpdateCanceller !== null) {
-      this._currentMediaSourceDurationUpdateCanceller.cancel("stop MSDU");
+      this._currentMediaSourceDurationUpdateCanceller.cancel(reason ?? "stop MSDU");
       this._currentMediaSourceDurationUpdateCanceller = null;
     }
   }

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -74,7 +74,7 @@ export default class MediaSourceDurationUpdater {
    */
   public updateDuration(newDuration: number, isRealEndKnown: boolean): void {
     if (this._currentMediaSourceDurationUpdateCanceller !== null) {
-      this._currentMediaSourceDurationUpdateCanceller.cancel();
+      this._currentMediaSourceDurationUpdateCanceller.cancel("reset mdu");
     }
     this._currentMediaSourceDurationUpdateCanceller = new TaskCanceller(
       "MediaSource Duration Update",
@@ -96,7 +96,7 @@ export default class MediaSourceDurationUpdater {
     });
 
     function onMediaSourceOpenedStatusChanged() {
-      msOpenStatusCanceller.cancel();
+      msOpenStatusCanceller.cancel("ms opened");
       if (!isMediaSourceOpened.getValue()) {
         return;
       }
@@ -114,7 +114,7 @@ export default class MediaSourceDurationUpdater {
 
       return areSourceBuffersUpdating.onUpdate(
         (areUpdating) => {
-          sourceBuffersUpdatingCanceller.cancel();
+          sourceBuffersUpdatingCanceller.cancel("sb status update");
           sourceBuffersUpdatingCanceller = new TaskCanceller(undefined);
           sourceBuffersUpdatingCanceller.linkToSignal(msOpenStatusCanceller.signal);
           if (areUpdating) {
@@ -138,7 +138,7 @@ export default class MediaSourceDurationUpdater {
    */
   public stopUpdating() {
     if (this._currentMediaSourceDurationUpdateCanceller !== null) {
-      this._currentMediaSourceDurationUpdateCanceller.cancel();
+      this._currentMediaSourceDurationUpdateCanceller.cancel("stop MSDU");
       this._currentMediaSourceDurationUpdateCanceller = null;
     }
   }

--- a/src/mse/worker_media_source_interface.ts
+++ b/src/mse/worker_media_source_interface.ts
@@ -153,8 +153,13 @@ export default class WorkerMediaSourceInterface
     });
   }
 
-  public dispose() {
-    this.sourceBuffers.forEach((s) => s.dispose());
+  /**
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  public dispose(reason: string | undefined) {
+    this.sourceBuffers.forEach((s) => s.dispose(reason));
     this._canceller.cancel("dispose WMSI");
     this._messageSender({
       type: CoreMessageType.DisposeMediaSource,
@@ -362,9 +367,14 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
     });
   }
 
-  public dispose(): void {
+  /**
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  public dispose(reason: string | undefined): void {
     this.abort();
-    this._canceller.cancel("dispose WSBI");
+    this._canceller.cancel(reason ?? "dispose WSBI");
   }
 
   public getBuffered(): undefined {

--- a/src/mse/worker_media_source_interface.ts
+++ b/src/mse/worker_media_source_interface.ts
@@ -67,7 +67,7 @@ export default class WorkerMediaSourceInterface
     super();
     this.id = id;
     this.sourceBuffers = [];
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("MSI");
     this.readyState = "closed";
     this._messageSender = messageSender;
 
@@ -226,7 +226,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   ) {
     this.type = sbType;
     this.codec = codec;
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("SBI");
     this._mediaSourceId = mediaSourceId;
     this._queuedOperations = [];
     this._pendingOperations = new Map();
@@ -250,7 +250,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   ): void {
     const formattedErr =
       error.errorName === "CancellationError"
-        ? new CancellationError()
+        ? new CancellationError("Pending SBI Operation")
         : new SourceBufferError(error.errorName, error.message, error.isBufferFull);
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
@@ -260,7 +260,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
       mapElt.reject(formattedErr);
     }
 
-    const cancellationError = new CancellationError();
+    const cancellationError = new CancellationError("Queued SBI Operation");
     for (const operation of this._queuedOperations) {
       operation.reject(cancellationError);
     }

--- a/src/mse/worker_media_source_interface.ts
+++ b/src/mse/worker_media_source_interface.ts
@@ -67,7 +67,7 @@ export default class WorkerMediaSourceInterface
     super();
     this.id = id;
     this.sourceBuffers = [];
-    this._canceller = new TaskCanceller("MSI");
+    this._canceller = new TaskCanceller("WorkerMediaSourceInterface");
     this.readyState = "closed";
     this._messageSender = messageSender;
 
@@ -160,7 +160,7 @@ export default class WorkerMediaSourceInterface
    */
   public dispose(reason: string | undefined) {
     this.sourceBuffers.forEach((s) => s.dispose(reason));
-    this._canceller.cancel("dispose WMSI");
+    this._canceller.cancel("WorkerMediaSourceInterface dispose");
     this._messageSender({
       type: CoreMessageType.DisposeMediaSource,
       mediaSourceId: this.id,
@@ -231,7 +231,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   ) {
     this.type = sbType;
     this.codec = codec;
-    this._canceller = new TaskCanceller("SBI");
+    this._canceller = new TaskCanceller("WorkerSourceBufferInterface " + sbType);
     this._mediaSourceId = mediaSourceId;
     this._queuedOperations = [];
     this._pendingOperations = new Map();
@@ -241,7 +241,9 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   public onOperationSuccess(operationId: string, ranges: IRange[]): void {
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
-      log.warn("mse", "unknown SourceBuffer operation succeeded");
+      log.warn("mse", "unknown SourceBuffer operation succeeded", {
+        type: this.type,
+      });
     } else {
       this._pendingOperations.delete(operationId);
       mapElt.resolve(ranges);
@@ -255,18 +257,23 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   ): void {
     const formattedErr =
       error.errorName === "CancellationError"
-        ? new CancellationError("Pending SBI Operation", "SBI Failure")
+        ? new CancellationError("Pending SBI Operation " + this.type, "SBI Failure")
         : new SourceBufferError(error.errorName, error.message, error.isBufferFull);
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
-      log.info("mse", "unknown SourceBuffer operation failed", formattedErr);
+      log.info(
+        "mse",
+        "unknown SourceBuffer operation failed",
+        { type: this.type },
+        formattedErr,
+      );
     } else {
       this._pendingOperations.delete(operationId);
       mapElt.reject(formattedErr);
     }
 
     const cancellationError = new CancellationError(
-      "Queued SBI Operation",
+      "Queued SBI Operation " + this.type,
       "SBI failure",
     );
     for (const operation of this._queuedOperations) {
@@ -374,7 +381,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
    */
   public dispose(reason: string | undefined): void {
     this.abort();
-    this._canceller.cancel(reason ?? "dispose WSBI");
+    this._canceller.cancel(reason ?? "WorkerSourceBufferInterface dispose");
   }
 
   public getBuffered(): undefined {

--- a/src/mse/worker_media_source_interface.ts
+++ b/src/mse/worker_media_source_interface.ts
@@ -155,7 +155,7 @@ export default class WorkerMediaSourceInterface
 
   public dispose() {
     this.sourceBuffers.forEach((s) => s.dispose());
-    this._canceller.cancel();
+    this._canceller.cancel("dispose WMSI");
     this._messageSender({
       type: CoreMessageType.DisposeMediaSource,
       mediaSourceId: this.id,
@@ -250,7 +250,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   ): void {
     const formattedErr =
       error.errorName === "CancellationError"
-        ? new CancellationError("Pending SBI Operation")
+        ? new CancellationError("Pending SBI Operation", "SBI Failure")
         : new SourceBufferError(error.errorName, error.message, error.isBufferFull);
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
@@ -260,7 +260,10 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
       mapElt.reject(formattedErr);
     }
 
-    const cancellationError = new CancellationError("Queued SBI Operation");
+    const cancellationError = new CancellationError(
+      "Queued SBI Operation",
+      "SBI failure",
+    );
     for (const operation of this._queuedOperations) {
       operation.reject(cancellationError);
     }
@@ -361,7 +364,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
 
   public dispose(): void {
     this.abort();
-    this._canceller.cancel();
+    this._canceller.cancel("dispose WSBI");
   }
 
   public getBuffered(): undefined {

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -214,7 +214,7 @@ export default class PlaybackObserver {
    * more needed to avoid unnecessarily leaking resources.
    */
   public stop() {
-    this._canceller.cancel();
+    this._canceller.cancel("stop pbo");
   }
 
   /**

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -212,9 +212,12 @@ export default class PlaybackObserver {
    *
    * Note that it is important to call stop once the `PlaybackObserver` is no
    * more needed to avoid unnecessarily leaking resources.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * stop. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public stop() {
-    this._canceller.cancel("stop pbo");
+  public stop(reason: string | undefined) {
+    this._canceller.cancel(reason ?? "stop pbo");
   }
 
   /**

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -160,7 +160,7 @@ export default class PlaybackObserver {
     this._mediaElementRef = new SharedReference<IMediaElement | null>(null);
     this._withMediaSource = options.withMediaSource;
     this._lowLatencyMode = options.lowLatencyMode;
-    this._canceller = new TaskCanceller();
+    this._canceller = new TaskCanceller("PlaybackObserver");
     this._expectedSeekingPosition = null;
     this._pendingSeek = null;
     this._isSeekBlocked = false;

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -160,7 +160,7 @@ export default class PlaybackObserver {
     this._mediaElementRef = new SharedReference<IMediaElement | null>(null);
     this._withMediaSource = options.withMediaSource;
     this._lowLatencyMode = options.lowLatencyMode;
-    this._canceller = new TaskCanceller("PlaybackObserver");
+    this._canceller = new TaskCanceller("MediaElementPlaybackObserver");
     this._expectedSeekingPosition = null;
     this._pendingSeek = null;
     this._isSeekBlocked = false;
@@ -217,7 +217,7 @@ export default class PlaybackObserver {
    * inspection.
    */
   public stop(reason: string | undefined) {
-    this._canceller.cancel(reason ?? "stop pbo");
+    this._canceller.cancel(reason ?? "MediaElementPlaybackObserver stop");
   }
 
   /**

--- a/src/tools/TextTrackRenderer/text_track_renderer.ts
+++ b/src/tools/TextTrackRenderer/text_track_renderer.ts
@@ -106,8 +106,11 @@ export default class TextTrackRenderer {
    * Dispose of most ressources taken by the TextTrackRenderer.
    * /!\ The TextTrackRenderer will be unusable after this method has been
    * called.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public dispose(): void {
-    this._displayer.stop();
+  public dispose(reason: string | undefined): void {
+    this._displayer.stop(reason);
   }
 }

--- a/src/transports/dash/integrity_checks.ts
+++ b/src/transports/dash/integrity_checks.ts
@@ -19,7 +19,7 @@ export function addSegmentIntegrityChecks<T>(
 ): ISegmentLoader<T> {
   return (url, context, loaderOptions, initialCancelSignal, callbacks) => {
     return new Promise((resolve, reject) => {
-      const requestCanceller = new TaskCanceller();
+      const requestCanceller = new TaskCanceller("integrity checks");
       const unlinkCanceller = requestCanceller.linkToSignal(initialCancelSignal);
       requestCanceller.signal.register(reject);
 

--- a/src/transports/dash/integrity_checks.ts
+++ b/src/transports/dash/integrity_checks.ts
@@ -34,7 +34,7 @@ export function addSegmentIntegrityChecks<T>(
             cleanUpCancellers();
 
             // Cancel the request
-            requestCanceller.cancel();
+            requestCanceller.cancel("Integrity check failed");
 
             // Reject with thrown error
             reject(err);

--- a/src/transports/dash/integrity_checks.ts
+++ b/src/transports/dash/integrity_checks.ts
@@ -19,7 +19,7 @@ export function addSegmentIntegrityChecks<T>(
 ): ISegmentLoader<T> {
   return (url, context, loaderOptions, initialCancelSignal, callbacks) => {
     return new Promise((resolve, reject) => {
-      const requestCanceller = new TaskCanceller("integrity checks");
+      const requestCanceller = new TaskCanceller("Segment integrity checks");
       const unlinkCanceller = requestCanceller.linkToSignal(initialCancelSignal);
       requestCanceller.signal.register(reject);
 

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -28,7 +28,7 @@ import noop from "./noop";
  * To do that, the code which might ask for cancellation have to create a new
  * `TaskCanceller`:
  * ```js
- * const canceller = new TaskCanceller();
+ * const canceller = new TaskCanceller("my Task");
  * ```
  *
  * And has to provide its associated `CancellationSignal` to the code running
@@ -69,7 +69,7 @@ import noop from "./noop";
  *    // expected that the same Error instance is used when rejecting Promises.
  *    function onCancellation(error : CancellationError) {
  *      // abort asynchronous task
- *      myCancellableTask.cancel();
+ *      myCancellableTask.cancel(error.reason);
  *
  *      // In this example, reject the current pending Promise
  *      reject(CancellationError);
@@ -100,7 +100,7 @@ import noop from "./noop";
  * (even before the signal was given) and listen to possible CancellationErrors
  * to know when it was cancelled.
  * ```js
- * const canceller = new TaskCanceller();
+ * const canceller = new TaskCanceller("my Task");
  *
  * runAsyncTask(canceller.signal)
  *   .then(() => { console.log("Task succeeded!"); )
@@ -111,7 +111,7 @@ import noop from "./noop";
  *        console.log("Task failed:", err);
  *      }
  *   });
- * canceller.cancel(); // Cancel the task, calling registered callbacks
+ * canceller.cancel("Stopping"); // Cancel the task, calling registered callbacks
  * ```
  * @class TaskCanceller
  */
@@ -177,8 +177,8 @@ export default class TaskCanceller {
    * @returns {Function}
    */
   public linkToSignal(signal: CancellationSignal): () => void {
-    const unregister = signal.register(() => {
-      this.cancel();
+    const unregister = signal.register((error) => {
+      this.cancel(error.reason);
     });
     this.signal.register(unregister);
     return unregister;
@@ -189,18 +189,16 @@ export default class TaskCanceller {
    * `CancellationSignal` (its `signal` property) that a task should be aborted.
    *
    * Once called the `TaskCanceller` is permanently triggered.
-   *
-   * An optional CancellationError can be given in argument for when this
-   * cancellation is actually triggered as a chain reaction from a previous
-   * cancellation.
-   * @param {Error} [srcError]
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * cancellation. Used for debugging matters, especially for debug log
+   * inspection.
    */
-  public cancel(srcError?: CancellationError): void {
+  public cancel(reason: string | undefined): void {
     if (this._isUsed) {
       return;
     }
     this._isUsed = true;
-    const cancellationError = srcError ?? new CancellationError(this._taskName);
+    const cancellationError = new CancellationError(this._taskName, reason);
     this._trigger(cancellationError);
   }
 
@@ -346,6 +344,8 @@ export type ICancellationListener = (error: CancellationError) => void;
 export class CancellationError extends Error {
   public readonly name: "CancellationError";
 
+  public readonly reason: string | undefined;
+
   /**
    * Create a `CancellationError`
    * @param {string|undefined} taskName - Choosen descriptive "name" for the
@@ -356,21 +356,29 @@ export class CancellationError extends Error {
    * RxPlayer maintainer easier to easily trace which task we're talking
    * about.
    */
-  constructor(taskName: string | undefined) {
-    const message =
+  constructor(taskName: string | undefined, reason: string | undefined) {
+    let message =
       taskName !== undefined
         ? `"${taskName}" task cancelled.`
         : "This task was cancelled.";
-    super(message);
-
-    if (taskName !== undefined) {
-      log.debug("utils", `task cancellation: "${taskName}"`);
+    if (reason !== undefined) {
+      message += " Reason: " + reason;
     }
+    super(message);
 
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, CancellationError.prototype);
 
     this.name = "CancellationError";
+    this.reason = reason;
+
+    if (taskName !== undefined) {
+      log.debug(
+        "utils",
+        `task cancellation: "${taskName}"` +
+          (reason === undefined ? "" : ` - Reason: "${reason}"`),
+      );
+    }
   }
 }
 

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -28,7 +28,7 @@ import noop from "./noop";
  * To do that, the code which might ask for cancellation have to create a new
  * `TaskCanceller`:
  * ```js
- * const canceller = new TaskCanceller("my Task");
+ * const canceller = new TaskCanceller("my example task");
  * ```
  *
  * And has to provide its associated `CancellationSignal` to the code running
@@ -100,7 +100,7 @@ import noop from "./noop";
  * (even before the signal was given) and listen to possible CancellationErrors
  * to know when it was cancelled.
  * ```js
- * const canceller = new TaskCanceller("my Task");
+ * const canceller = new TaskCanceller("my async task");
  *
  * runAsyncTask(canceller.signal)
  *   .then(() => { console.log("Task succeeded!"); )
@@ -111,7 +111,9 @@ import noop from "./noop";
  *        console.log("Task failed:", err);
  *      }
  *   });
- * canceller.cancel("Stopping"); // Cancel the task, calling registered callbacks
+ *
+ * // Cancel the task (with a given reason), calling registered callbacks
+ * canceller.cancel("I changed my mind");
  * ```
  * @class TaskCanceller
  */
@@ -133,18 +135,21 @@ export default class TaskCanceller {
    */
   private _trigger: (error: CancellationError) => void;
 
+  /** Description for this task, if communicated. */
   private _taskName: string | undefined;
 
   /**
    * Creates a new `TaskCanceller`, with its own `CancellationSignal` created
-   * as its `signal` provide.
-   * You can then pass this property to async task you wish to be cancellable.
-   * @param {string|undefined} taskName - Choosen descriptive "name" for the
-   * task, that will be added to the linked `CancellationError`'s message
-   * if/when thrown. The idea is that `TaskCanceller`-linked bugs are very hard
-   * to trace. By adding a descriptive string for the task, it makes the job of
-   * the RxPlayer maintainer easier to easily trace which task we're talking
-   * about.
+   * as its `signal` property.
+   * You can then pass this `signal` property to async task you wish to be
+   * cancellable.
+   * @param {string|undefined} taskName - Descriptive "name" for the task you
+   * want to make cancellable. This is used for debugging purposes: this string
+   * will be linked to the thrown `CancellationError` (and will be logged) if
+   * the task is ever cancelled, making cancellation-related issues much easier
+   * to trace.
+   * By setting it to `undefined`, you indicate that this task does not need
+   * those supplementary debug information and does not need to be logged.
    */
   constructor(taskName: string | undefined) {
     const [trigger, register] = createCancellationFunctions();
@@ -189,9 +194,10 @@ export default class TaskCanceller {
    * `CancellationSignal` (its `signal` property) that a task should be aborted.
    *
    * Once called the `TaskCanceller` is permanently triggered.
-   * @param {string | undefined} reason - Human-inspectable reason behind the
-   * cancellation. Used for debugging matters, especially for debug log
-   * inspection.
+   * @param {string | undefined} reason - Human-readable reason that led to the
+   * cancellation of this task. This is used for debugging matters: the reason
+   * will be linked to the corresponding `CancellationError` instance.
+   * `undefined` if you don't want to give a reason.
    */
   public cancel(reason: string | undefined): void {
     if (this._isUsed) {
@@ -344,17 +350,22 @@ export type ICancellationListener = (error: CancellationError) => void;
 export class CancellationError extends Error {
   public readonly name: "CancellationError";
 
+  /**
+   * Human-readable reason for the cancellation.
+   * `undefined` if no reason was given.
+   */
   public readonly reason: string | undefined;
 
   /**
    * Create a `CancellationError`
-   * @param {string|undefined} taskName - Choosen descriptive "name" for the
-   * task linked to that `CancellationError`, that will be added to this
-   * instance's error `message`.
-   * The idea is that `TaskCanceller`-linked bugs are very hard to trace.
-   * By adding a descriptive string for the task, it makes the job of the
-   * RxPlayer maintainer easier to easily trace which task we're talking
-   * about.
+   * @param {string|undefined} taskName - Descriptive "name" for the task you
+   * just cancelled. This is used for debugging purposes: this string
+   *  will both be logged and be inserted in this `CancellationError`'s
+   *  `message` property.
+   * By setting it to `undefined`, you indicate that this task does not need
+   * those supplementary debug information and does not need to be logged.
+   * @param {string|undefined} reason - Human-readable reason for the
+   * cancellation.
    */
   constructor(taskName: string | undefined, reason: string | undefined) {
     let message =

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -133,15 +133,24 @@ export default class TaskCanceller {
    */
   private _trigger: (error: CancellationError) => void;
 
+  private _taskName: string | undefined;
+
   /**
    * Creates a new `TaskCanceller`, with its own `CancellationSignal` created
    * as its `signal` provide.
    * You can then pass this property to async task you wish to be cancellable.
+   * @param {string|undefined} taskName - Choosen descriptive "name" for the
+   * task, that will be added to the linked `CancellationError`'s message
+   * if/when thrown. The idea is that `TaskCanceller`-linked bugs are very hard
+   * to trace. By adding a descriptive string for the task, it makes the job of
+   * the RxPlayer maintainer easier to easily trace which task we're talking
+   * about.
    */
-  constructor() {
+  constructor(taskName: string | undefined) {
     const [trigger, register] = createCancellationFunctions();
     this._isUsed = false;
     this._trigger = trigger;
+    this._taskName = taskName;
     this.signal = new CancellationSignal(register);
   }
 
@@ -191,7 +200,7 @@ export default class TaskCanceller {
       return;
     }
     this._isUsed = true;
-    const cancellationError = srcError ?? new CancellationError();
+    const cancellationError = srcError ?? new CancellationError(this._taskName);
     this._trigger(cancellationError);
   }
 
@@ -337,9 +346,27 @@ export type ICancellationListener = (error: CancellationError) => void;
 export class CancellationError extends Error {
   public readonly name: "CancellationError";
 
-  constructor() {
-    const message = "This task was cancelled.";
+  /**
+   * Create a `CancellationError`
+   * @param {string|undefined} taskName - Choosen descriptive "name" for the
+   * task linked to that `CancellationError`, that will be added to this
+   * instance's error `message`.
+   * The idea is that `TaskCanceller`-linked bugs are very hard to trace.
+   * By adding a descriptive string for the task, it makes the job of the
+   * RxPlayer maintainer easier to easily trace which task we're talking
+   * about.
+   */
+  constructor(taskName: string | undefined) {
+    const message =
+      taskName !== undefined
+        ? `"${taskName}" task cancelled.`
+        : "This task was cancelled.";
     super(message);
+
+    if (taskName !== undefined) {
+      log.debug("utils", `task cancellation: "${taskName}"`);
+    }
+
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
     Object.setPrototypeOf(this, CancellationError.prototype);
 


### PR DESCRIPTION
Includes #1665 

**TL;DR:** This PR proposes that we provide both a human-targeted "name" for each cancellable task (e.g. `"segment request"`) and a reason if/when we cancel it (e.g. `"most needed segment changed"`).
At cancellation, the corresponding `CancellationError` will have both of them in its `message` property and a log will be produced, in our theoretical case:
```
TC: "segment request" cancellation. Reason: "most needed segment changed"
```

Here's a demo with those new logs. I load a new content, and then filter the `TC:` namespace in the console to better see the impact (you can pause to see if those logs make sense to you). I insist in the end on the large number of task cancellations due to an `"API stop"` (I stopped the content), which is the main inconvenient of this proposal (no biggie though IMO): 

https://github.com/user-attachments/assets/d0750528-3e6f-4409-81fe-3fbf97a880a0

The goal is to have a better debugging experience, especially around cancellation mechanisms.

Context: `CancellationError` have a generic error `message`
-----------------------------------------------------------

The `TaskCanceller` is our homemade abstraction to handle task cancellation (its API is similar to the `AbortController` web API).
With it, when a cancellable task is cancelled, it usually will throw or reject a special `CancellationError` `Error` with the message `"This task was cancelled"`.

The thrown message is very generic and could be thrown by any place in the code, making debugging when starting from a `CancellationError` hard.

Note that those errors should never be seen by the application: we try to internally handle all of those. Though we've seen some very rare cases where they have "leaked".
We've had (maybe once or twice, so not that frequent) reported cases where such errors has been seen by other developers in some impossible-to-reproduce scenario, in which case it's hard to understand what happened.

More frequent are cases where we are debugging strange behavior linked to task cancellation (or the absence of it), here also we could do much better by improving on a TaskCanceller's tracing.

Solution: indicate unique name for each task and log it
-------------------------------------------------------

So basically what I'm proposing here is to encourage RxPlayer maintainers to declare a unique "name" for a task when creating either a `TaskCanceller` or a `CancellationError`, and to in the same spirit give a `"reason"` when/if cancelling that task.

Those will be indicated in the corresponding `CancellationError`'s message.

More interestingly, I now log cases where a `CancellationError` is instantiated (and not thrown! As it is easier to write :/). This leads to more logs, but it's IMO more informative on what goes on inside the RxPlayer.

The downside is that a lot of cancellations are done when stopping or reloading a content, leading to a good majority of uninteresting logs (unless we're trying to find a leak - which funnily enough happened while doing this!) when those actions are performed. This also adds more arguments for the few outsiders which tell us that we output too much logs in debug mode!