### PR TITLE
[MULTI_THREAD] Communicate to `/init` whether we're relying on MSE-in-worker

### DIFF
--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -80,17 +80,10 @@ export default class ContentPreparer {
   private _currentMediaSourceCanceller: TaskCanceller;
 
   /** @see constructor */
-  private _hasMseInWorker: boolean;
-
-  /** @see constructor */
   private _hasVideo: boolean;
 
   /**
    * @param {Object} capabilities
-   * @param {boolean} capabilities.hasMseInWorker - If `true`, the current
-   * environment has access to MediaSource API in a WebWorker context (so,
-   * here).
-   * If `false`, we have to go through the main thread to rely on all MSE API.
    * @param {boolean} capabilities.hasVideo - If `true`, we're playing on an
    * element which has video capabilities.
    * If `false`, we're only able to play audio, optionally with subtitles.
@@ -98,17 +91,10 @@ export default class ContentPreparer {
    * Typically this boolean is `true` for `<video>` HTMLElement and `false` for
    * `<audio>` HTMLElement.
    */
-  constructor({
-    hasMseInWorker,
-    hasVideo,
-  }: {
-    hasMseInWorker: boolean;
-    hasVideo: boolean;
-  }) {
+  constructor({ hasVideo }: { hasVideo: boolean }) {
     this._currentContent = null;
     this._currentMediaSourceCanceller = new TaskCanceller();
     this._hasVideo = hasVideo;
-    this._hasMseInWorker = hasMseInWorker;
     const contentCanceller = new TaskCanceller();
     this._contentCanceller = contentCanceller;
   }
@@ -136,8 +122,14 @@ export default class ContentPreparer {
 
       currentMediaSourceCanceller.linkToSignal(contentCanceller.signal);
 
-      const { contentId, url, hasText, transportOptions, enableRepresentationAvoidance } =
-        context;
+      const {
+        contentId,
+        url,
+        hasText,
+        transportOptions,
+        useMseInWorker,
+        enableRepresentationAvoidance,
+      } = context;
       let manifest: IManifest | null = null;
 
       // TODO better way
@@ -200,7 +192,7 @@ export default class ContentPreparer {
         createMediaSourceInterfaceAndSegmentSinksStore(
           contentId,
           {
-            hasMseInWorker: this._hasMseInWorker,
+            useMseInWorker,
             hasVideo: this._hasVideo,
             hasText,
           },
@@ -221,6 +213,7 @@ export default class ContentPreparer {
         fetchThumbnailData,
         workerTextSender,
         trackChoiceSetter,
+        useMseInWorker,
       };
       mediaSource.addEventListener(
         "mediaSourceOpen",
@@ -361,7 +354,7 @@ export default class ContentPreparer {
       createMediaSourceInterfaceAndSegmentSinksStore(
         this._currentContent.contentId,
         {
-          hasMseInWorker: this._hasMseInWorker,
+          useMseInWorker: this._currentContent.useMseInWorker,
           hasVideo: this._hasVideo,
           hasText: this._currentContent.workerTextSender !== null,
         },
@@ -466,12 +459,18 @@ export interface IPreparedContentData {
    * track.
    */
   trackChoiceSetter: TrackChoiceSetter;
+  /**
+   * If `true`, MSE API should be used in the core part of the RxPlayer (in the
+   * WebWorker).
+   * If `false`, they should be relied on on main thread.
+   */
+  useMseInWorker: boolean;
 }
 
 /**
  * @param {string} contentId
  * @param {Object} capabilities
- * @param {boolean} capabilities.hasMseInWorker
+ * @param {boolean} capabilities.useMseInWorker
  * @param {boolean} capabilities.hasVideo
  * @param {boolean} capabilities.hasText
  * @param {Object} cancelSignal
@@ -480,14 +479,14 @@ export interface IPreparedContentData {
 function createMediaSourceInterfaceAndSegmentSinksStore(
   contentId: string,
   capabilities: {
-    hasMseInWorker: boolean;
+    useMseInWorker: boolean;
     hasVideo: boolean;
     hasText: boolean;
   },
   cancelSignal: CancellationSignal,
 ): [IMediaSourceInterface, SegmentSinksStore, WorkerTextDisplayerInterface | null] {
   let mediaSourceInterface: IMediaSourceInterface;
-  if (capabilities.hasMseInWorker) {
+  if (capabilities.useMseInWorker) {
     const mainMediaSource = new MainMediaSourceInterface(generateMediaSourceId());
     mediaSourceInterface = mainMediaSource;
 

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -62,10 +62,7 @@ export default function initializeWorkerMain() {
    *
    * Creating a default one which may change on initialization.
    */
-  let contentPreparer = new ContentPreparer({
-    hasMseInWorker: false,
-    hasVideo: true,
-  });
+  let contentPreparer = new ContentPreparer({ hasVideo: true });
 
   /**
    * Abort all operations relative to the currently loaded content.
@@ -109,12 +106,9 @@ export default function initializeWorkerMain() {
           });
         }
 
-        if (!msg.value.hasVideo || msg.value.hasMseInWorker) {
+        if (!msg.value.hasVideo) {
           contentPreparer.disposeCurrentContent();
-          contentPreparer = new ContentPreparer({
-            hasMseInWorker: msg.value.hasMseInWorker,
-            hasVideo: msg.value.hasVideo,
-          });
+          contentPreparer = new ContentPreparer({ hasVideo: msg.value.hasVideo });
         }
 
         sendMessage({ type: WorkerMessageType.InitSuccess, value: null });

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -549,7 +549,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           date: Date.now(),
           timestamp: getMonotonicTimeStamp(),
           hasVideo: this.videoElement?.nodeName.toLowerCase() === "video",
-          hasMseInWorker,
         },
       });
       log.addEventListener(
@@ -1068,6 +1067,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           textTrackOptions,
           worker: this._priv_worker,
           url,
+          useMseInWorker: hasMseInWorker,
         });
       }
     } else {

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1,5 +1,4 @@
 import type { IMediaElement } from "../../compat/browser_compatibility_types";
-import hasMseInWorker from "../../compat/has_mse_in_worker";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data";
 import shouldReloadMediaSourceOnDecipherabilityUpdate from "../../compat/should_reload_media_source_on_decipherability_update";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store";
@@ -170,7 +169,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       return;
     }
     const contentId = generateContentId();
-    const { adaptiveOptions, transportOptions, worker } = this._settings;
+    const { adaptiveOptions, transportOptions, useMseInWorker, worker } = this._settings;
     const { wantedBufferAhead, maxVideoBufferSize, maxBufferAhead, maxBufferBehind } =
       this._settings.bufferOptions;
     const initialVideoBitrate = adaptiveOptions.initialBitrates.video;
@@ -185,6 +184,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       initialTime: undefined,
       autoPlay: undefined,
       initialPlayPerformed: null,
+      useMseInWorker,
     };
     sendMessage(worker, {
       type: MainThreadMessageType.PrepareContent,
@@ -202,6 +202,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           lowLatencyMode: this._settings.lowLatencyMode,
         },
         segmentRetryOptions: this._settings.segmentRequestOptions,
+        useMseInWorker,
       },
     });
     this._initCanceller.signal.register(() => {
@@ -1413,7 +1414,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       const updatedCodecs = updateManifestCodecSupport(
         manifest,
         this._currentContentInfo?.contentDecryptor ?? null,
-        hasMseInWorker,
+        this._currentContentInfo?.useMseInWorker ?? false,
       );
       if (updatedCodecs.length > 0) {
         sendMessage(this._settings.worker, {
@@ -1947,11 +1948,28 @@ export interface IMultiThreadContentInitializerContentInfos {
    * Set to `null` when those considerations are not taken.
    */
   contentDecryptor: IContentDecryptor | null;
+  /**
+   * If `true`, MSE API should be used in the core part of the RxPlayer (in the
+   * WebWorker).
+   * If `false`, they should be relied on on main thread.
+   */
+  useMseInWorker: boolean;
 }
 
 /** Arguments to give to the `InitializeOnMediaSource` function. */
 export interface IInitializeArguments {
+  /** WebWorker inside which the core code runs. */
   worker: Worker;
+  /**
+   * If `true`, MSE API should be used in the core part of the RxPlayer (in the
+   * WebWorker).
+   * If `false`, they should be relied on on main thread.
+   *
+   * This might depend on both browser capabilities and preferences. It is
+   * assumed that the caller perform all those checks, the `ContentInitializer`
+   * won't check again the validity of this value.
+   */
+  useMseInWorker: boolean;
   /** Options concerning the ABR logic. */
   adaptiveOptions: IAdaptiveRepresentationSelectorArguments;
   /** `true` if we should play when loaded. */

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -56,14 +56,6 @@ export interface IInitMessage {
      * elements (`<audio>` tags).
      */
     hasVideo: boolean;
-    /**
-     * If `true` the current platform exposes Media Source extensions (MSE) API
-     * in a WebWorker environment.
-     *
-     * If `false`, every MSE API has to be called on the main thread, usually
-     * by messages posted by the WebWorker.
-     */
-    hasMseInWorker: boolean;
     /** Initial logging level that should be set. */
     logLevel: ILoggerLevel;
     /** Intitial logger's log format that should be set. */
@@ -148,6 +140,16 @@ export interface IContentInitializationData {
   manifestRetryOptions: Omit<IManifestFetcherSettings, "cmcdDataBuilder">;
   /** Options relative to the fetching of media segments. */
   segmentRetryOptions: ISegmentQueueCreatorBackoffOptions;
+  /**
+   * If `true`, MSE API should be used in the core part of the RxPlayer (in the
+   * WebWorker).
+   * If `false`, they should be relied on on main thread.
+   *
+   * This might depend on both browser capabilities and preferences. It is
+   * assumed that the caller perform all those checks, the core won't check
+   * again the validity of this value.
+   */
+  useMseInWorker: boolean;
 }
 
 export interface ILogLevelUpdateMessage {


### PR DESCRIPTION
Built on #1664 (the PR, not the other thing).

While exchanging in that PR with @Florent-Bouisset, we noticed that the choice of whether we rely on mse-in-worker was done by the Public API part of the code, which then directly told our WebWorker to use that feature without telling any other part of the code.

However, that PR brought the need to have that information inside the `ContentInitializer` - so that it knows whether a given codec is supported (for cases, only seen on Edge for now, where codec support is different depending on if MSE is relied on inside a worker or on main thread).

Even without this, I thought that our `ContentInitializer`, as a global controlling module, should probably architecturally be in the know of whether MSE API are called in-worker or in-main-thread.

So I propose this modification, where the information on whether mse-in-worker should be used is both communicated to the `ContentInitializer`, but is also set per-content (we don't need that, but it's actually both simpler and more powerful that way so why not).

This also opens the way for an API to control this, but I did not add one for now.