### PR TITLE
DRM: Fix `KEY_UPDATE_ERROR` by not translating it into a `KEY_LOAD_ERROR`

### DIFF
--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -111,23 +111,23 @@ export default function SessionEventsListener(
         () => runGetLicense(message, messageType),
         backoffOptions,
         manualCanceller.signal,
-      )
-        .then((licenseObject) => {
+      ).then(
+        async (licenseObject) => {
           if (manualCanceller.isUsed()) {
-            return Promise.resolve();
+            return;
           }
           if (isNullOrUndefined(licenseObject)) {
             log.info("DRM: No license given, skipping session.update");
           } else {
             try {
-              return updateSessionWithMessage(session, licenseObject);
+              await updateSessionWithMessage(session, licenseObject);
             } catch (err) {
               manualCanceller.cancel();
               callbacks.onError(err);
             }
           }
-        })
-        .catch((err: unknown) => {
+        },
+        (err: unknown) => {
           if (manualCanceller.isUsed()) {
             return;
           }
@@ -148,7 +148,8 @@ export default function SessionEventsListener(
             }
           }
           callbacks.onError(formattedError);
-        });
+        },
+      );
     },
     manualCanceller.signal,
   );


### PR DESCRIPTION
We had kind of a dumb mistake where an error arising at license-communication time was falsely categorized as an error at license-fetching time.

This is because we inadvertently also catched errors from the `MediaKeySession.prototype.update` EME call where we only intended to catch errors at the higher-up `getLicense` (the RxPlayer API) level.

The fix to that issue is relatively straigtforward.