### PR TITLE
[v3] DRM: Fix `KEY_UPDATE_ERROR` by not translating it into a `KEY_LOAD_ERROR`

### DIFF
--- a/src/core/decrypt/session_events_listener.ts
+++ b/src/core/decrypt/session_events_listener.ts
@@ -106,23 +106,23 @@ export default function SessionEventsListener(
         () => runGetLicense(message, messageType),
         backoffOptions,
         manualCanceller.signal,
-      )
-        .then((licenseObject) => {
+      ).then(
+        async (licenseObject) => {
           if (manualCanceller.isUsed()) {
-            return Promise.resolve();
+            return;
           }
           if (isNullOrUndefined(licenseObject)) {
             log.info("DRM: No license given, skipping session.update");
           } else {
             try {
-              return updateSessionWithMessage(session, licenseObject);
+              await updateSessionWithMessage(session, licenseObject);
             } catch (err) {
               manualCanceller.cancel();
               callbacks.onError(err);
             }
           }
-        })
-        .catch((err: unknown) => {
+        },
+        (err: unknown) => {
           if (manualCanceller.isUsed()) {
             return;
           }
@@ -141,7 +141,8 @@ export default function SessionEventsListener(
             }
           }
           callbacks.onError(formattedError);
-        });
+        },
+      );
     },
     manualCanceller.signal,
   );


### PR DESCRIPTION
This is a backport of #1670 for the v3