### PR TITLE
Narrow down startAt.fromLivePosition option to only apply on live stream

### DIFF
--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -191,13 +191,12 @@ either:
   - for VoD contents, it is the difference between the starting position and the end
     position of the content.
 
-- **fromLivePosition** relative position relative to the content's live edge (for live
-  contents, it is the position that is intended to be broadcasted at the current time) if
-  it makes sense, in seconds. Should be a negative number.
+- **fromLivePosition** position relative to the content's live edge (i.e. the position
+  that is intended to be broadcast at the current time) if it makes sense, in seconds.
+  Should be a negative number.
 
   If the live edge is unknown or if it does not make sense for the current content (for
-  example, it won't make sense for a VoD content), that setting repeats the same behavior
-  than **fromLastPosition**.
+  example, it won't make sense for VoD content), this setting is ignored.
 
 - **percentage** (`Number`): percentage of the wanted position. `0` being the minimum
   position possible (0 for static content, buffer depth for dynamic contents) and `100`

--- a/src/main_thread/init/utils/get_initial_time.ts
+++ b/src/main_thread/init/utils/get_initial_time.ts
@@ -93,6 +93,8 @@ export default function getInitialTime(
   if (!isNullOrUndefined(startAt)) {
     const min = getMinimumSafePosition(manifest);
     const max = getMaximumSafePosition(manifest);
+    const livePosition = getLivePosition(manifest);
+
     if (!isNullOrUndefined(startAt.position)) {
       log.debug("Init: using startAt.minimumPosition");
       return Math.max(Math.min(startAt.position, max), min);
@@ -110,9 +112,12 @@ export default function getInitialTime(
       log.debug("Init: using startAt.fromLastPosition");
       const { fromLastPosition } = startAt;
       return fromLastPosition >= 0 ? max : Math.max(min, max + fromLastPosition);
-    } else if (!isNullOrUndefined(startAt.fromLivePosition) && manifest.isLive) {
+    } else if (
+      !isNullOrUndefined(startAt.fromLivePosition) &&
+      livePosition !== undefined &&
+      manifest.isLive
+    ) {
       log.debug("Init: using startAt.fromLivePosition");
-      const livePosition = getLivePosition(manifest) ?? max;
       const { fromLivePosition } = startAt;
       return fromLivePosition >= 0
         ? livePosition

--- a/src/main_thread/init/utils/get_initial_time.ts
+++ b/src/main_thread/init/utils/get_initial_time.ts
@@ -110,7 +110,7 @@ export default function getInitialTime(
       log.debug("Init: using startAt.fromLastPosition");
       const { fromLastPosition } = startAt;
       return fromLastPosition >= 0 ? max : Math.max(min, max + fromLastPosition);
-    } else if (!isNullOrUndefined(startAt.fromLivePosition)) {
+    } else if (!isNullOrUndefined(startAt.fromLivePosition) && manifest.isLive) {
       log.debug("Init: using startAt.fromLivePosition");
       const livePosition = getLivePosition(manifest) ?? max;
       const { fromLivePosition } = startAt;


### PR DESCRIPTION
`startAt.fromLivePosition` makes users think of the options only suitable for live stream, but from reading the code, it's actually not, this PR is to make this option only works on live stream. 