### PR TITLE
Avoid error log when stopping a stream with a pending GC buffer removal

### DIFF
--- a/src/core/segment_sinks/garbage_collector.ts
+++ b/src/core/segment_sinks/garbage_collector.ts
@@ -21,6 +21,7 @@ import type { IRange } from "../../utils/ranges";
 import { getInnerAndOuterRanges } from "../../utils/ranges";
 import type { IReadOnlySharedReference } from "../../utils/reference";
 import type { CancellationSignal } from "../../utils/task_canceller";
+import TaskCanceller from "../../utils/task_canceller";
 import type { IStreamOrchestratorPlaybackObservation } from "../stream";
 import type { SegmentSink } from "./implementations";
 
@@ -80,6 +81,9 @@ export default function BufferGarbageCollector(
       maxBufferAhead.getValue(),
       cancellationSignal,
     ).catch((e) => {
+      if (cancellationSignal.isCancelled() && TaskCanceller.isCancellationError(e)) {
+        return;
+      }
       const errMsg = e instanceof Error ? e.message : "Unknown error";
       log.error("Could not run BufferGarbageCollector:", errMsg);
     });


### PR DESCRIPTION
Fixes #1668

Basically, if an application stopped playback while buffer-removal due to `maxBufferAhead` / `maxBufferBehind` options were set, an error log would be outputed:
```
Could not run BufferGarbageCollector: This task was cancelled.
```

This log in this case is unnecessary (the behavior is normal and wanted) and its verbosity could make people think there was an issue.