### PR TITLE
Add information on key system to an `EncryptedMediaError`

### DIFF
--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -395,8 +395,8 @@ They have the following properties:
   Note that it is not set for some errors for which it wouldn't make sense, such as for
   `EncryptedMediaError` instances with the `code` `MEDIA_IS_ENCRYPTED_ERROR`.
 
-- `mediaKeySystemConfiguration` (`MediaKeySystemAccessConfiguration | undefined`): If
-  known, the
+- `keySystemConfiguration` (`MediaKeySystemAccessConfiguration | undefined`): If known,
+  the
   [`MediaKeySystemAccessConfiguration`](https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess/getConfiguration)
   of the `MediaKeySystemAccess` that encountered the error. This might be useful to for
   example be able to check the key system's robustness (e.g. PlayReady SL3000 vs SL2000,

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -382,11 +382,34 @@ the following properties:
 Those errors are linked to the "Encrypted Media Extensions" API. They concern various
 DRM-related problems.
 
-They all have a `type` property equal to `"ENCRYPTED_MEDIA_ERROR"`.
+They have the following properties:
 
-When its code is set to `KEY_STATUS_CHANGE_ERROR`, an ENCRYPTED_MEDIA_ERROR generally also
-have a `keyStatuses` property, which is documented in the corresponding
-`KEY_STATUS_CHANGE_ERROR` code explanation below.
+- `type` (`string`): Equal to `"ENCRYPTED_MEDIA_ERROR"`.
+
+- `keySystem` (`string | undefined`): If known, the
+  [`keySystem`](https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess/keySystem)
+  of the `MediaKeySystemAccess` that encountered the error. This might be useful to check
+  e.g. if the error was encountered while relying on PlayReady, Widevine or other
+  indentified technologies.
+
+  Note that it is not set for some errors for which it wouldn't make sense, such as for
+  `EncryptedMediaError` instances with the `code` `MEDIA_IS_ENCRYPTED_ERROR`.
+
+- `mediaKeySystemConfiguration` (`MediaKeySystemAccessConfiguration | undefined`): If
+  known, the
+  [`MediaKeySystemAccessConfiguration`](https://developer.mozilla.org/en-US/docs/Web/API/MediaKeySystemAccess/getConfiguration)
+  of the `MediaKeySystemAccess` that encountered the error. This might be useful to for
+  example be able to check the key system's robustness (e.g. PlayReady SL3000 vs SL2000,
+  or Widevine L3 vs L1) when the Error was encountered.
+
+  Note that it is not set for some errors for which it wouldn't make sense, such as for
+  `EncryptedMediaError` instances with the `code` `MEDIA_IS_ENCRYPTED_ERROR`.
+
+- `keyStatuses` (`Array.<Object>`): Only set for `EncryptedMediaError` instances which
+  have the `code` `KEY_STATUS_CHANGE_ERROR`.
+
+  This corresponds to the corresponding statuses. More information in the code's
+  documentation below.
 
 #### codes
 

--- a/src/errors/__tests__/encrypted_media_error.test.ts
+++ b/src/errors/__tests__/encrypted_media_error.test.ts
@@ -4,13 +4,21 @@ import EncryptedMediaError from "../encrypted_media_error";
 describe("errors - EncryptedMediaError", () => {
   it("should format an EncryptedMediaError", () => {
     const reason = "test";
-    const encryptedMediaError = new EncryptedMediaError("KEY_LOAD_TIMEOUT", reason);
+    const encryptedMediaError = new EncryptedMediaError(
+      "MEDIA_IS_ENCRYPTED_ERROR",
+      reason,
+      {
+        keyStatuses: undefined,
+        mediaKeySystemAccessConfiguration: undefined,
+        keySystem: undefined,
+      },
+    );
     expect(encryptedMediaError).toBeInstanceOf(Error);
     expect(encryptedMediaError.name).toBe("EncryptedMediaError");
     expect(encryptedMediaError.type).toBe("ENCRYPTED_MEDIA_ERROR");
-    expect(encryptedMediaError.code).toBe("KEY_LOAD_TIMEOUT");
+    expect(encryptedMediaError.code).toBe("MEDIA_IS_ENCRYPTED_ERROR");
     expect(encryptedMediaError.fatal).toBe(false);
-    expect(encryptedMediaError.message).toBe("KEY_LOAD_TIMEOUT: test");
+    expect(encryptedMediaError.message).toBe("MEDIA_IS_ENCRYPTED_ERROR: test");
   });
 
   it("should be able to set it as fatal", () => {
@@ -18,6 +26,11 @@ describe("errors - EncryptedMediaError", () => {
     const encryptedMediaError = new EncryptedMediaError(
       "INCOMPATIBLE_KEYSYSTEMS",
       reason,
+      {
+        keyStatuses: undefined,
+        mediaKeySystemAccessConfiguration: undefined,
+        keySystem: undefined,
+      },
     );
     encryptedMediaError.fatal = true;
     expect(encryptedMediaError).toBeInstanceOf(Error);

--- a/src/errors/__tests__/encrypted_media_error.test.ts
+++ b/src/errors/__tests__/encrypted_media_error.test.ts
@@ -9,7 +9,7 @@ describe("errors - EncryptedMediaError", () => {
       reason,
       {
         keyStatuses: undefined,
-        mediaKeySystemAccessConfiguration: undefined,
+        keySystemConfiguration: undefined,
         keySystem: undefined,
       },
     );
@@ -28,7 +28,7 @@ describe("errors - EncryptedMediaError", () => {
       reason,
       {
         keyStatuses: undefined,
-        mediaKeySystemAccessConfiguration: undefined,
+        keySystemConfiguration: undefined,
         keySystem: undefined,
       },
     );

--- a/src/errors/__tests__/is_known_error.test.ts
+++ b/src/errors/__tests__/is_known_error.test.ts
@@ -33,7 +33,15 @@ describe("Errors - isKnownError", () => {
   });
 
   it("should return true for an EncryptedMediaError", () => {
-    const encryptedMediaError = new EncryptedMediaError("KEY_UPDATE_ERROR", "toto");
+    const encryptedMediaError = new EncryptedMediaError(
+      "INCOMPATIBLE_KEYSYSTEMS",
+      "toto",
+      {
+        keyStatuses: undefined,
+        mediaKeySystemAccessConfiguration: undefined,
+        keySystem: undefined,
+      },
+    );
     expect(isKnownError(encryptedMediaError)).toBe(true);
   });
 });

--- a/src/errors/__tests__/is_known_error.test.ts
+++ b/src/errors/__tests__/is_known_error.test.ts
@@ -38,7 +38,7 @@ describe("Errors - isKnownError", () => {
       "toto",
       {
         keyStatuses: undefined,
-        mediaKeySystemAccessConfiguration: undefined,
+        keySystemConfiguration: undefined,
         keySystem: undefined,
       },
     );

--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -30,7 +30,7 @@ export default class EncryptedMediaError extends Error {
   public readonly type: "ENCRYPTED_MEDIA_ERROR";
   public readonly code: IEncryptedMediaErrorCode;
   public readonly keyStatuses: IEncryptedMediaErrorKeyStatusObject[] | undefined;
-  public readonly mediaKeySystemConfiguration: MediaKeySystemConfiguration | undefined;
+  public readonly keySystemConfiguration: MediaKeySystemConfiguration | undefined;
   public readonly keySystem: string | undefined;
   public fatal: boolean;
   private _originalMessage: string;
@@ -44,7 +44,7 @@ export default class EncryptedMediaError extends Error {
     reason: string,
     supplementaryInfos: {
       keyStatuses: IEncryptedMediaErrorKeyStatusObject[];
-      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration;
+      keySystemConfiguration: MediaKeySystemConfiguration;
       keySystem: string;
     },
   );
@@ -59,7 +59,7 @@ export default class EncryptedMediaError extends Error {
     reason: string,
     supplementaryInfos: {
       keyStatuses: undefined;
-      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration;
+      keySystemConfiguration: MediaKeySystemConfiguration;
       keySystem: string;
     },
   );
@@ -68,7 +68,7 @@ export default class EncryptedMediaError extends Error {
     reason: string,
     supplementaryInfos: {
       keyStatuses: undefined;
-      mediaKeySystemAccessConfiguration: undefined;
+      keySystemConfiguration: undefined;
       keySystem: undefined;
     },
   );
@@ -77,7 +77,7 @@ export default class EncryptedMediaError extends Error {
     reason: string,
     supplementaryInfos: {
       keyStatuses: IEncryptedMediaErrorKeyStatusObject[] | undefined;
-      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration | undefined;
+      keySystemConfiguration: MediaKeySystemConfiguration | undefined;
       keySystem: string | undefined;
     },
   ) {
@@ -93,8 +93,7 @@ export default class EncryptedMediaError extends Error {
     this.fatal = false;
 
     this.keyStatuses = supplementaryInfos.keyStatuses;
-    this.mediaKeySystemConfiguration =
-      supplementaryInfos.mediaKeySystemAccessConfiguration;
+    this.keySystemConfiguration = supplementaryInfos.keySystemConfiguration;
     this.keySystem = supplementaryInfos.keySystem;
   }
 
@@ -110,7 +109,7 @@ export default class EncryptedMediaError extends Error {
       code: this.code,
       reason: this._originalMessage,
       keyStatuses: this.keyStatuses,
-      mediaKeySystemConfiguration: this.mediaKeySystemConfiguration,
+      keySystemConfiguration: this.keySystemConfiguration,
       keySystem: this.keySystem,
     };
   }
@@ -126,6 +125,6 @@ export interface ISerializedEncryptedMediaError {
         keyId: ArrayBuffer;
       }>
     | undefined;
-  mediaKeySystemConfiguration: MediaKeySystemConfiguration | undefined;
+  keySystemConfiguration: MediaKeySystemConfiguration | undefined;
   keySystem: string | undefined;
 }

--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -29,7 +29,9 @@ export default class EncryptedMediaError extends Error {
   public readonly name: "EncryptedMediaError";
   public readonly type: "ENCRYPTED_MEDIA_ERROR";
   public readonly code: IEncryptedMediaErrorCode;
-  public readonly keyStatuses?: IEncryptedMediaErrorKeyStatusObject[];
+  public readonly keyStatuses: IEncryptedMediaErrorKeyStatusObject[] | undefined;
+  public readonly mediaKeySystemConfiguration: MediaKeySystemConfiguration | undefined;
+  public readonly keySystem: string | undefined;
   public fatal: boolean;
   private _originalMessage: string;
 
@@ -40,18 +42,44 @@ export default class EncryptedMediaError extends Error {
   constructor(
     code: "KEY_STATUS_CHANGE_ERROR",
     reason: string,
-    supplementaryInfos: { keyStatuses: IEncryptedMediaErrorKeyStatusObject[] },
+    supplementaryInfos: {
+      keyStatuses: IEncryptedMediaErrorKeyStatusObject[];
+      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration;
+      keySystem: string;
+    },
   );
   constructor(
-    code: Omit<IEncryptedMediaErrorCode, "KEY_STATUS_CHANGE_ERROR">,
+    code: Omit<
+      IEncryptedMediaErrorCode,
+      | "KEY_STATUS_CHANGE_ERROR"
+      | "INCOMPATIBLE_KEYSYSTEMS"
+      | "INVALID_KEY_SYSTEM"
+      | "MEDIA_IS_ENCRYPTED_ERROR"
+    >,
     reason: string,
+    supplementaryInfos: {
+      keyStatuses: undefined;
+      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration;
+      keySystem: string;
+    },
+  );
+  constructor(
+    code: "INCOMPATIBLE_KEYSYSTEMS" | "INVALID_KEY_SYSTEM" | "MEDIA_IS_ENCRYPTED_ERROR",
+    reason: string,
+    supplementaryInfos: {
+      keyStatuses: undefined;
+      mediaKeySystemAccessConfiguration: undefined;
+      keySystem: undefined;
+    },
   );
   constructor(
     code: IEncryptedMediaErrorCode,
     reason: string,
-    supplementaryInfos?:
-      | { keyStatuses?: IEncryptedMediaErrorKeyStatusObject[] | undefined }
-      | undefined,
+    supplementaryInfos: {
+      keyStatuses: IEncryptedMediaErrorKeyStatusObject[] | undefined;
+      mediaKeySystemAccessConfiguration: MediaKeySystemConfiguration | undefined;
+      keySystem: string | undefined;
+    },
   ) {
     super(errorMessage(code, reason));
     // @see https://stackoverflow.com/questions/41102060/typescript-extending-error-class
@@ -64,9 +92,10 @@ export default class EncryptedMediaError extends Error {
     this._originalMessage = reason;
     this.fatal = false;
 
-    if (typeof supplementaryInfos?.keyStatuses === "string") {
-      this.keyStatuses = supplementaryInfos.keyStatuses;
-    }
+    this.keyStatuses = supplementaryInfos.keyStatuses;
+    this.mediaKeySystemConfiguration =
+      supplementaryInfos.mediaKeySystemAccessConfiguration;
+    this.keySystem = supplementaryInfos.keySystem;
   }
 
   /**
@@ -81,6 +110,8 @@ export default class EncryptedMediaError extends Error {
       code: this.code,
       reason: this._originalMessage,
       keyStatuses: this.keyStatuses,
+      mediaKeySystemConfiguration: this.mediaKeySystemConfiguration,
+      keySystem: this.keySystem,
     };
   }
 }
@@ -95,4 +126,6 @@ export interface ISerializedEncryptedMediaError {
         keyId: ArrayBuffer;
       }>
     | undefined;
+  mediaKeySystemConfiguration: MediaKeySystemConfiguration | undefined;
+  keySystem: string | undefined;
 }

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -300,7 +300,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
         const { serverCertificate } = options;
         if (!isNullOrUndefined(serverCertificate)) {
-          const resSsc = await setServerCertificate(mediaKeys, serverCertificate);
+          const resSsc = await setServerCertificate(
+            mediaKeys,
+            serverCertificate,
+            mediaKeySystemAccess,
+          );
           if (resSsc.type === "error") {
             this.trigger("warning", resSsc.value);
           }
@@ -584,7 +588,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     SessionEventsListener(
       mediaKeySession,
       options,
-      mediaKeySystemAccess.keySystem,
+      mediaKeySystemAccess,
       {
         onKeyUpdate: (value: IKeyUpdateValue): void => {
           const linkedKeys = getKeyIdsLinkedToSession(
@@ -715,6 +719,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         throw new EncryptedMediaError(
           "KEY_GENERATE_REQUEST_ERROR",
           error instanceof Error ? error.toString() : "Unknown error",
+          {
+            keyStatuses: undefined,
+            mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            keySystem: mediaKeySystemAccess.keySystem,
+          },
         );
       }
     }

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -721,7 +721,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
           error instanceof Error ? error.toString() : "Unknown error",
           {
             keyStatuses: undefined,
-            mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
             keySystem: mediaKeySystemAccess.keySystem,
           },
         );

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -463,6 +463,11 @@ export default function getMediaKeySystemAccess(
         "No key system compatible with your wanted " +
           "configuration has been found in the current " +
           "browser.",
+        {
+          keyStatuses: undefined,
+          mediaKeySystemAccessConfiguration: undefined,
+          keySystem: undefined,
+        },
       );
     }
 

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -465,7 +465,7 @@ export default function getMediaKeySystemAccess(
           "browser.",
         {
           keyStatuses: undefined,
-          mediaKeySystemAccessConfiguration: undefined,
+          keySystemConfiguration: undefined,
           keySystem: undefined,
         },
       );

--- a/src/main_thread/decrypt/get_media_keys.ts
+++ b/src/main_thread/decrypt/get_media_keys.ts
@@ -159,7 +159,7 @@ async function createMediaKeys(
       error instanceof Error ? error.message : "Unknown error when creating MediaKeys.";
     throw new EncryptedMediaError("CREATE_MEDIA_KEYS_ERROR", message, {
       keyStatuses: undefined,
-      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
       keySystem: mediaKeySystemAccess.keySystem,
     });
   }

--- a/src/main_thread/decrypt/get_media_keys.ts
+++ b/src/main_thread/decrypt/get_media_keys.ts
@@ -157,6 +157,10 @@ async function createMediaKeys(
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unknown error when creating MediaKeys.";
-    throw new EncryptedMediaError("CREATE_MEDIA_KEYS_ERROR", message);
+    throw new EncryptedMediaError("CREATE_MEDIA_KEYS_ERROR", message, {
+      keyStatuses: undefined,
+      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystem: mediaKeySystemAccess.keySystem,
+    });
   }
 }

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -77,7 +77,7 @@ export default function SessionEventsListener(
       callbacks.onError(
         new EncryptedMediaError("KEY_ERROR", (evt as Event).type, {
           keyStatuses: undefined,
-          mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+          keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
           keySystem: mediaKeySystemAccess.keySystem,
         }),
       );
@@ -287,7 +287,7 @@ function formatGetLicenseError(
       "The license server took too much time to " + "respond.",
       {
         keyStatuses: undefined,
-        mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+        keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
         keySystem: mediaKeySystemAccess.keySystem,
       },
     );
@@ -298,7 +298,7 @@ function formatGetLicenseError(
     "An error occured when calling `getLicense`.",
     {
       keyStatuses: undefined,
-      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
       keySystem: mediaKeySystemAccess.keySystem,
     },
   );
@@ -332,7 +332,7 @@ async function updateSessionWithMessage(
     const reason = error instanceof Error ? error.toString() : "`session.update` failed";
     throw new EncryptedMediaError("KEY_UPDATE_ERROR", reason, {
       keyStatuses: undefined,
-      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
       keySystem: mediaKeySystemAccess.keySystem,
     });
   }

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { IMediaKeySession } from "../../compat/browser_compatibility_types";
+import type {
+  IMediaKeySession,
+  IMediaKeySystemAccess,
+} from "../../compat/browser_compatibility_types";
 import {
   onKeyError,
   onKeyMessage,
@@ -35,14 +38,15 @@ import checkKeyStatuses from "./utils/check_key_statuses";
  * depending on the configuration given.
  * @param {MediaKeySession} session - The MediaKeySession concerned.
  * @param {Object} keySystemOptions - The key system options.
- * @param {String} keySystem - The configuration keySystem used for deciphering
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the linked `MediaKeys` instance.
  * @param {Object} callbacks
  * @param {Object} cancelSignal
  */
 export default function SessionEventsListener(
   session: IMediaKeySession,
   keySystemOptions: IKeySystemOption,
-  keySystem: string,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
   callbacks: ISessionEventListenerCallbacks,
   cancelSignal: CancellationSignal,
 ): void {
@@ -70,7 +74,13 @@ export default function SessionEventsListener(
     session,
     (evt) => {
       manualCanceller.cancel();
-      callbacks.onError(new EncryptedMediaError("KEY_ERROR", (evt as Event).type));
+      callbacks.onError(
+        new EncryptedMediaError("KEY_ERROR", (evt as Event).type, {
+          keyStatuses: undefined,
+          mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+          keySystem: mediaKeySystemAccess.keySystem,
+        }),
+      );
     },
     manualCanceller.signal,
   );
@@ -120,7 +130,11 @@ export default function SessionEventsListener(
             log.info("DRM: No license given, skipping session.update");
           } else {
             try {
-              await updateSessionWithMessage(session, licenseObject);
+              await updateSessionWithMessage(
+                session,
+                licenseObject,
+                mediaKeySystemAccess,
+              );
             } catch (err) {
               manualCanceller.cancel();
               callbacks.onError(err);
@@ -132,7 +146,7 @@ export default function SessionEventsListener(
             return;
           }
           manualCanceller.cancel();
-          const formattedError = formatGetLicenseError(err);
+          const formattedError = formatGetLicenseError(err, mediaKeySystemAccess);
 
           if (!isNullOrUndefined(err)) {
             const { fallbackOnLastTry } = err as {
@@ -170,7 +184,7 @@ export default function SessionEventsListener(
     const { warning, blacklistedKeyIds, whitelistedKeyIds } = checkKeyStatuses(
       session,
       keySystemOptions,
-      keySystem,
+      mediaKeySystemAccess,
     );
     if (warning !== undefined) {
       callbacks.onWarning(warning);
@@ -237,7 +251,8 @@ export default function SessionEventsListener(
         error instanceof GetLicenseTimeoutError ||
         isNullOrUndefined(error) ||
         (error as { noRetry?: boolean }).noRetry !== true,
-      onRetry: (error: unknown) => callbacks.onWarning(formatGetLicenseError(error)),
+      onRetry: (error: unknown) =>
+        callbacks.onWarning(formatGetLicenseError(error, mediaKeySystemAccess)),
     };
   }
 }
@@ -257,19 +272,35 @@ export interface ISessionEventListenerCallbacks {
  * Format an error returned by a `getLicense` call to a proper form as defined
  * by the RxPlayer's API.
  * @param {*} error
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the linked `MediaKeys` instance.
+ * This parameter is mainly useful for error generation.
  * @returns {Error}
  */
-function formatGetLicenseError(error: unknown): IPlayerError {
+function formatGetLicenseError(
+  error: unknown,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
+): IPlayerError {
   if (error instanceof GetLicenseTimeoutError) {
     return new EncryptedMediaError(
       "KEY_LOAD_TIMEOUT",
       "The license server took too much time to " + "respond.",
+      {
+        keyStatuses: undefined,
+        mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+        keySystem: mediaKeySystemAccess.keySystem,
+      },
     );
   }
 
   const err = new EncryptedMediaError(
     "KEY_LOAD_ERROR",
     "An error occured when calling `getLicense`.",
+    {
+      keyStatuses: undefined,
+      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystem: mediaKeySystemAccess.keySystem,
+    },
   );
   if (
     !isNullOrUndefined(error) &&
@@ -284,18 +315,26 @@ function formatGetLicenseError(error: unknown): IPlayerError {
  * Call MediaKeySession.update with the given `message`, if defined.
  * @param {MediaKeySession} session
  * @param {ArrayBuffer|TypedArray|null} message
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the linked `MediaKeys` instance.
+ * This parameter is mainly useful for error generation.
  * @returns {Promise}
  */
 async function updateSessionWithMessage(
   session: IMediaKeySession,
   message: BufferSource,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
 ): Promise<void> {
   log.info("DRM: Updating MediaKeySession with message");
   try {
     await session.update(message);
   } catch (error) {
     const reason = error instanceof Error ? error.toString() : "`session.update` failed";
-    throw new EncryptedMediaError("KEY_UPDATE_ERROR", reason);
+    throw new EncryptedMediaError("KEY_UPDATE_ERROR", reason, {
+      keyStatuses: undefined,
+      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystem: mediaKeySystemAccess.keySystem,
+    });
   }
   log.info("DRM: MediaKeySession update succeeded.");
 }

--- a/src/main_thread/decrypt/set_server_certificate.ts
+++ b/src/main_thread/decrypt/set_server_certificate.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { IMediaKeys } from "../../compat/browser_compatibility_types";
+import type {
+  IMediaKeys,
+  IMediaKeySystemAccess,
+} from "../../compat/browser_compatibility_types";
 import { EncryptedMediaError, isKnownError } from "../../errors";
 import log from "../../log";
 import type { IPlayerError } from "../../public_types";
@@ -32,11 +35,15 @@ import ServerCertificateStore from "./utils/server_certificate_store";
  *
  * @param {MediaKeys} mediaKeys
  * @param {ArrayBuffer} serverCertificate
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the `MediaKeys` instance provided.
+ * This parameter is mainly useful for error generation.
  * @returns {Promise}
  */
 async function setServerCertificate(
   mediaKeys: IMediaKeys,
   serverCertificate: BufferSource,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
 ): Promise<unknown> {
   try {
     const res = await mediaKeys.setServerCertificate(serverCertificate);
@@ -51,7 +58,11 @@ async function setServerCertificate(
     );
     const reason =
       error instanceof Error ? error.toString() : "`setServerCertificate` error";
-    throw new EncryptedMediaError("LICENSE_SERVER_CERTIFICATE_ERROR", reason);
+    throw new EncryptedMediaError("LICENSE_SERVER_CERTIFICATE_ERROR", reason, {
+      keyStatuses: undefined,
+      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystem: mediaKeySystemAccess.keySystem,
+    });
   }
 }
 
@@ -60,11 +71,15 @@ async function setServerCertificate(
  * and complete.
  * @param {MediaKeys} mediaKeys
  * @param {ArrayBuffer} serverCertificate
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the `MediaKeys` instance provided.
+ * This parameter is mainly useful for error generation.
  * @returns {Promise.<Object>}
  */
 export default async function trySettingServerCertificate(
   mediaKeys: IMediaKeys,
   serverCertificate: BufferSource,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
 ): Promise<
   | { type: "success"; value: unknown }
   | { type: "already-has-one" }
@@ -90,7 +105,11 @@ export default async function trySettingServerCertificate(
   // Calling `prepare` allow to invalidate temporarily that status.
   ServerCertificateStore.prepare(mediaKeys);
   try {
-    const result = await setServerCertificate(mediaKeys, serverCertificate);
+    const result = await setServerCertificate(
+      mediaKeys,
+      serverCertificate,
+      mediaKeySystemAccess,
+    );
     ServerCertificateStore.set(mediaKeys, serverCertificate);
     return { type: "success", value: result };
   } catch (error) {
@@ -99,6 +118,11 @@ export default async function trySettingServerCertificate(
       : new EncryptedMediaError(
           "LICENSE_SERVER_CERTIFICATE_ERROR",
           "Unknown error when setting the server certificate.",
+          {
+            keyStatuses: undefined,
+            mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            keySystem: mediaKeySystemAccess.keySystem,
+          },
         );
     return { type: "error" as const, value: formattedErr };
   }

--- a/src/main_thread/decrypt/set_server_certificate.ts
+++ b/src/main_thread/decrypt/set_server_certificate.ts
@@ -60,7 +60,7 @@ async function setServerCertificate(
       error instanceof Error ? error.toString() : "`setServerCertificate` error";
     throw new EncryptedMediaError("LICENSE_SERVER_CERTIFICATE_ERROR", reason, {
       keyStatuses: undefined,
-      mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
       keySystem: mediaKeySystemAccess.keySystem,
     });
   }
@@ -120,7 +120,7 @@ export default async function trySettingServerCertificate(
           "Unknown error when setting the server certificate.",
           {
             keyStatuses: undefined,
-            mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
             keySystem: mediaKeySystemAccess.keySystem,
           },
         );

--- a/src/main_thread/decrypt/utils/check_key_statuses.ts
+++ b/src/main_thread/decrypt/utils/check_key_statuses.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { IMediaKeySession } from "../../../compat/browser_compatibility_types";
+import type {
+  IMediaKeySession,
+  IMediaKeySystemAccess,
+} from "../../../compat/browser_compatibility_types";
 import getUUIDKidFromKeyStatusKID from "../../../compat/eme/get_uuid_kid_from_keystatus_kid";
 import { EncryptedMediaError } from "../../../errors";
 import log from "../../../log";
@@ -79,13 +82,14 @@ type IKeyStatusesForEach = (
  * @param {MediaKeySession} session - The MediaKeySession from which the keys
  * will be checked.
  * @param {Object} options
- * @param {String} keySystem - The configuration keySystem used for deciphering
+ * @param {MediaKeySystemAccess} mediaKeySystemAccess - The
+ * `MediaKeySystemAccess` that produced the linked `MediaKeys` instance.
  * @returns {Object} - Warnings to send, whitelisted and blacklisted key ids.
  */
 export default function checkKeyStatuses(
   session: IMediaKeySession,
   options: IKeyStatusesCheckingOptions,
-  keySystem: string,
+  mediaKeySystemAccess: IMediaKeySystemAccess,
 ): {
   warning: EncryptedMediaError | undefined;
   blacklistedKeyIds: Uint8Array[];
@@ -107,7 +111,10 @@ export default function checkKeyStatuses(
         ];
       })();
 
-      const keyId = getUUIDKidFromKeyStatusKID(keySystem, new Uint8Array(keyStatusKeyId));
+      const keyId = getUUIDKidFromKeyStatusKID(
+        mediaKeySystemAccess.keySystem,
+        new Uint8Array(keyStatusKeyId),
+      );
 
       const keyStatusObj = { keyId: keyId.buffer, keyStatus };
 
@@ -120,7 +127,11 @@ export default function checkKeyStatuses(
           const error = new EncryptedMediaError(
             "KEY_STATUS_CHANGE_ERROR",
             `A decryption key expired (${bytesToHex(keyId)})`,
-            { keyStatuses: [keyStatusObj, ...badKeyStatuses] },
+            {
+              keyStatuses: [keyStatusObj, ...badKeyStatuses],
+              keySystem: mediaKeySystemAccess.keySystem,
+              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            },
           );
 
           if (onKeyExpiration === "error" || onKeyExpiration === undefined) {
@@ -153,7 +164,11 @@ export default function checkKeyStatuses(
           const error = new EncryptedMediaError(
             "KEY_STATUS_CHANGE_ERROR",
             `A "${keyStatus}" status has been encountered (${bytesToHex(keyId)})`,
-            { keyStatuses: [keyStatusObj, ...badKeyStatuses] },
+            {
+              keyStatuses: [keyStatusObj, ...badKeyStatuses],
+              keySystem: mediaKeySystemAccess.keySystem,
+              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            },
           );
           switch (onKeyInternalError) {
             case undefined:
@@ -185,7 +200,11 @@ export default function checkKeyStatuses(
           const error = new EncryptedMediaError(
             "KEY_STATUS_CHANGE_ERROR",
             `A "${keyStatus}" status has been encountered (${bytesToHex(keyId)})`,
-            { keyStatuses: [keyStatusObj, ...badKeyStatuses] },
+            {
+              keyStatuses: [keyStatusObj, ...badKeyStatuses],
+              keySystem: mediaKeySystemAccess.keySystem,
+              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+            },
           );
           switch (onKeyOutputRestricted) {
             case undefined:
@@ -223,7 +242,11 @@ export default function checkKeyStatuses(
     warning = new EncryptedMediaError(
       "KEY_STATUS_CHANGE_ERROR",
       "One or several problematic key statuses have been encountered",
-      { keyStatuses: badKeyStatuses },
+      {
+        keyStatuses: badKeyStatuses,
+        keySystem: mediaKeySystemAccess.keySystem,
+        mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+      },
     );
   }
   return { warning, blacklistedKeyIds, whitelistedKeyIds };

--- a/src/main_thread/decrypt/utils/check_key_statuses.ts
+++ b/src/main_thread/decrypt/utils/check_key_statuses.ts
@@ -130,7 +130,7 @@ export default function checkKeyStatuses(
             {
               keyStatuses: [keyStatusObj, ...badKeyStatuses],
               keySystem: mediaKeySystemAccess.keySystem,
-              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+              keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
             },
           );
 
@@ -167,7 +167,7 @@ export default function checkKeyStatuses(
             {
               keyStatuses: [keyStatusObj, ...badKeyStatuses],
               keySystem: mediaKeySystemAccess.keySystem,
-              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+              keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
             },
           );
           switch (onKeyInternalError) {
@@ -203,7 +203,7 @@ export default function checkKeyStatuses(
             {
               keyStatuses: [keyStatusObj, ...badKeyStatuses],
               keySystem: mediaKeySystemAccess.keySystem,
-              mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+              keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
             },
           );
           switch (onKeyOutputRestricted) {
@@ -245,7 +245,7 @@ export default function checkKeyStatuses(
       {
         keyStatuses: badKeyStatuses,
         keySystem: mediaKeySystemAccess.keySystem,
-        mediaKeySystemAccessConfiguration: mediaKeySystemAccess.getConfiguration(),
+        keySystemConfiguration: mediaKeySystemAccess.getConfiguration(),
       },
     );
   }

--- a/src/main_thread/decrypt/utils/media_keys_attacher.ts
+++ b/src/main_thread/decrypt/utils/media_keys_attacher.ts
@@ -257,8 +257,7 @@ async function attachMediaKeys(
       "Could not attach the MediaKeys to the media element: " + errMessage,
       {
         keyStatuses: undefined,
-        mediaKeySystemAccessConfiguration:
-          mediaKeysInfo.mediaKeySystemAccess.getConfiguration(),
+        keySystemConfiguration: mediaKeysInfo.mediaKeySystemAccess.getConfiguration(),
         keySystem: mediaKeysInfo.mediaKeySystemAccess.keySystem,
       },
     );

--- a/src/main_thread/decrypt/utils/media_keys_attacher.ts
+++ b/src/main_thread/decrypt/utils/media_keys_attacher.ts
@@ -255,6 +255,12 @@ async function attachMediaKeys(
     throw new EncryptedMediaError(
       "MEDIA_KEYS_ATTACHMENT_ERROR",
       "Could not attach the MediaKeys to the media element: " + errMessage,
+      {
+        keyStatuses: undefined,
+        mediaKeySystemAccessConfiguration:
+          mediaKeysInfo.mediaKeySystemAccess.getConfiguration(),
+        keySystem: mediaKeysInfo.mediaKeySystemAccess.keySystem,
+      },
     );
   }
 }

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1246,7 +1246,11 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             return;
           }
           stopListening();
-          const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg);
+          const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg, {
+            keyStatuses: undefined,
+            mediaKeySystemAccessConfiguration: undefined,
+            keySystem: undefined,
+          });
           this._onFatalError(err);
         },
         { clearSignal: cancelSignal },
@@ -2103,13 +2107,14 @@ function formatWorkerError(sentError: ISentError): IPlayerError {
         tracks: sentError.tracks,
       });
     case "EncryptedMediaError":
-      if (sentError.code === "KEY_STATUS_CHANGE_ERROR") {
-        return new EncryptedMediaError(sentError.code, sentError.reason, {
-          keyStatuses: sentError.keyStatuses ?? [],
-        });
-      } else {
-        return new EncryptedMediaError(sentError.code, sentError.reason);
-      }
+      // We assume that everything have already been checked Worker-side here
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      return new EncryptedMediaError(sentError.code, sentError.reason, {
+        keyStatuses: sentError.keyStatuses,
+        mediaKeySystemAccessConfiguration: sentError.mediaKeySystemConfiguration,
+        keySystem: sentError.keySystem,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any);
     case "OtherError":
       return new OtherError(sentError.code, sentError.reason);
   }

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -1248,7 +1248,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           stopListening();
           const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg, {
             keyStatuses: undefined,
-            mediaKeySystemAccessConfiguration: undefined,
+            keySystemConfiguration: undefined,
             keySystem: undefined,
           });
           this._onFatalError(err);
@@ -2111,7 +2111,7 @@ function formatWorkerError(sentError: ISentError): IPlayerError {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return new EncryptedMediaError(sentError.code, sentError.reason, {
         keyStatuses: sentError.keyStatuses,
-        mediaKeySystemAccessConfiguration: sentError.mediaKeySystemConfiguration,
+        keySystemConfiguration: sentError.keySystemConfiguration,
         keySystem: sentError.keySystem,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any);

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -155,7 +155,11 @@ export default function initializeContentDecryption(
       value: EncryptedMediaError;
     };
   } {
-    const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg);
+    const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg, {
+      keyStatuses: undefined,
+      mediaKeySystemAccessConfiguration: undefined,
+      keySystem: undefined,
+    });
     const ref = new SharedReference({
       initializationState: { type: "initialized" as const, value: null },
       drmSystemId: undefined,

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -157,7 +157,7 @@ export default function initializeContentDecryption(
   } {
     const err = new EncryptedMediaError("MEDIA_IS_ENCRYPTED_ERROR", errMsg, {
       keyStatuses: undefined,
-      mediaKeySystemAccessConfiguration: undefined,
+      keySystemConfiguration: undefined,
       keySystem: undefined,
     });
     const ref = new SharedReference({


### PR DESCRIPTION
We worked with an application that wished, for resilience reasons, to be able to switch from a key system to another (e.g. widevine to playready) when specific encryption errors occured and when both key systems were available.

Previously they used our `getKeySystemConfiguration` API to know about the current key system used.

But when processing an error, it might be too late (e.g. the key system linked to the RxPlayer might already has been reset due to the error) or too soon (the issue happened before we could confirm the current key system through that API).

Because it seems logical to me as an API, I propose here to add the fields `keySystem` (the name/RDN of the key system as advertised by `MediaKeySystemAccess.prototype.keySystem`) and `mediaKeySystemConfiguration` (the configuration as advertised by the `MediaKeySystemAccess.prototype.getConfiguration()`) on all `EncryptedMediaError` instances when it is known (so on all errors but `INVALID_KEY_SYSTEM`, `INCOMPATIBLE_KEY_SYSTEMS` and `MEDIA_IS_ENCRYPTED` errors as they all happen before the `MediaKeySystemAccess` has been obtained).

Consequently, an application can then write code like:

```js
player.addEventListener("error", (error) => {
  if (error.type === "ENCRYPTED_MEDIA_ERROR") {
    const { keySystem } = error;
    if (keySystem !== undefined && keySystem.indexOf("playready") >= 0) {
      // we were having the issue while using playready
    }
  }
});
```