### PR TITLE
fix(firefox): check extensibly Playready DRMs support before using them

### DIFF
--- a/src/compat/can_rely_on_request_media_key_system_access.ts
+++ b/src/compat/can_rely_on_request_media_key_system_access.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isEdgeChromium } from "./browser_detection";
+import { isEdgeChromium, isFirefox } from "./browser_detection";
 
 /**
  * This functions tells if the RxPlayer can trust the browser when it has
@@ -31,11 +31,17 @@ import { isEdgeChromium } from "./browser_detection";
  *   'generateRequest' on 'MediaKeySession': Failed to create MF PR CdmSession".
  *   In this particular case, the work-around was to consider recommendation.3000 as not supported
  *   and try another keySystem.
+ *
+ * - On Firefox v.137:
+ *   Similar issue with requestMediaKeySystemAccess that resolves correctly with
+ *   'com.microsoft.playready.recommendation.3000' but fail at the `createMediaKeys``
+ *   step with error `WMFCDMProxy: Init: WMFCDM init error`
+ *
  * @param keySystem - The key system in use.
  * @returns {boolean}
  */
 export function canRelyOnRequestMediaKeySystemAccess(keySystem: string): boolean {
-  if (isEdgeChromium && keySystem.indexOf("playready") !== -1) {
+  if ((isEdgeChromium || isFirefox) && keySystem.indexOf("playready") !== -1) {
     return false;
   }
   return true;


### PR DESCRIPTION
Firefox has recently launched Playready support, some devices announces they support Playready through `requestMediaKeySystemAccess` but then throw an error on `createMediaKeys` step.

To fix, check extensibly the whole DRM workflow.

----
Here is the support matrix of a device that use playready:


![drm](https://github.com/user-attachments/assets/d41a209c-87c5-4d09-9f56-2cc9420ecb87)
