### PR TITLE
fix(DRM): renew the mediaKeySystemAccess on Edge and Firefox when using a Playready keySystem.

### DIFF
--- a/src/compat/__tests__/should_renew_media_key_system_access.test.ts
+++ b/src/compat/__tests__/should_renew_media_key_system_access.test.ts
@@ -10,23 +10,27 @@ describe("compat - shouldRenewMediaKeySystemAccess", () => {
     vi.doMock("../browser_detection", () => {
       return {
         isIE11: false,
+        isEdgeChromium: false,
+        isFirefox: false,
       };
     });
     const shouldRenewMediaKeySystemAccess = (
       await vi.importActual("../should_renew_media_key_system_access")
     ).default as typeof IShouldRenewMediaKeySystemAccess;
-    expect(shouldRenewMediaKeySystemAccess()).toBe(false);
+    expect(shouldRenewMediaKeySystemAccess("com.microsoft.playready")).toBe(false);
   });
 
   it("should return true if we are on IE11", async () => {
     vi.doMock("../browser_detection", () => {
       return {
         isIE11: true,
+        isEdgeChromium: false,
+        isFirefox: false,
       };
     });
     const shouldRenewMediaKeySystemAccess = (
       await vi.importActual("../should_renew_media_key_system_access")
     ).default as typeof IShouldRenewMediaKeySystemAccess;
-    expect(shouldRenewMediaKeySystemAccess()).toBe(true);
+    expect(shouldRenewMediaKeySystemAccess("com.microsoft.playready")).toBe(true);
   });
 });

--- a/src/compat/should_renew_media_key_system_access.ts
+++ b/src/compat/should_renew_media_key_system_access.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { isIE11 } from "./browser_detection";
+import { isIE11, isEdgeChromium, isFirefox } from "./browser_detection";
 
 /**
  * Returns true if the current target require the MediaKeySystemAccess to be
  * renewed on each content.
  * @returns {Boolean}
  */
-export default function shouldRenewMediaKeySystemAccess(): boolean {
-  return isIE11;
+export default function shouldRenewMediaKeySystemAccess(keySystem: string): boolean {
+  return keySystem.indexOf("playready") !== -1 && (isIE11 || isEdgeChromium || isFirefox);
 }

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -488,7 +488,7 @@ export default function getMediaKeySystemAccess(
       // Check if the current `MediaKeySystemAccess` created cannot be reused here
       if (
         currentState !== null &&
-        !shouldRenewMediaKeySystemAccess() &&
+        !shouldRenewMediaKeySystemAccess(currentState.mediaKeySystemAccess.keySystem) &&
         // TODO: Do it with MediaKeySystemAccess.prototype.keySystem instead?
         keyType === currentState.mediaKeySystemAccess.keySystem &&
         eme.implementation === currentState.emeImplementation.implementation &&


### PR DESCRIPTION
Edge and Firefox browsers tends to crash when reusing the `mediaKeySystemAccess` object when switching between different contents while using Playready DRMs.
I propose to recreate the `mediaKeySystemAccess` when switching content on those device to mitigate the issues.
This would have the disadvantage of not having a session cache for temporary licence, but It would improve the stability.