### PR TITLE
fix: prevent unnecessary resources usage by inactive worker

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -490,10 +490,22 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         );
       }
 
-      // if the user already attach worker before
+      // check if the user already attach worker before
       // terminate the previous worker to release the resources
       if (this._priv_worker !== null) {
-        this._priv_worker.terminate();
+        if (this.__priv_isPlaying()) {
+          log.warn(
+            "API: Cannot attach a new worker while a content is playing, please stop the player first.",
+          );
+          return rej(
+            new WorkerInitializationError(
+              "SETUP_ERROR",
+              "Cannot attach a new worker while a content is playing",
+            ),
+          );
+        } else {
+          this._priv_worker.terminate();
+        }
       }
 
       if (typeof workerSettings.workerUrl === "string") {
@@ -838,6 +850,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       );
     }
     return renderThumbnail(this._priv_contentInfos, options);
+  }
+
+  /**
+   * Get the player is currently playing
+   */
+  private __priv_isPlaying(): boolean {
+    return !["ENDED", "STOPPED"].includes(this.state);
   }
 
   /**

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -489,6 +489,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           new WorkerInitializationError("INCOMPATIBLE_ERROR", "Worker unavailable"),
         );
       }
+
+      // if the user already attach worker before
+      // terminate the previous worker to release the resources
+      if (this._priv_worker !== null) {
+        this._priv_worker.terminate();
+      }
+
       if (typeof workerSettings.workerUrl === "string") {
         this._priv_worker = new Worker(workerSettings.workerUrl);
       } else {

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -493,7 +493,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       // check if the user already attach worker before
       // terminate the previous worker to release the resources
       if (this._priv_worker !== null) {
-        if (this.__priv_isPlaying()) {
+        if (this.state !== "STOPPED") {
           log.warn(
             "API: Cannot attach a new worker while a content is playing, please stop the player first.",
           );
@@ -850,13 +850,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       );
     }
     return renderThumbnail(this._priv_contentInfos, options);
-  }
-
-  /**
-   * Get the player is currently playing
-   */
-  private __priv_isPlaying(): boolean {
-    return !["ENDED", "STOPPED"].includes(this.state);
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR addresses a potential resource management issue when `player.attachWorker()` is called multiple times without properly disposing of the previous player instance.

## Context

In our current usage pattern, we initialize and load a new player like this:

```js
function setup () {
   const player = new RxPlayer(...);
   player.attachWorker(...);
   player.loadVideo(...);
}

function destroy() {
   player.stop();

   if (!licenseCacheEnabled) {
      player.dispose();
   }
}
```

If licenseCacheEnabled is true, we skip calling `player.dispose()`, but still invoke `attachWorker()` every time a new asset is played. This can result in multiple Web Workers being created, which may lead to unnecessary resource usage over time.

## Motivation
Although calling attachWorker() multiple times without disposing of the previous instance is technically a misuse, it could easily happen in real-world scenarios. Adding safeguards in the player to avoid creating redundant workers can help make the library more robust and user-friendly.

## Proposed Change
This PR adds a check to ensure that the previous worker is been terminated when there's a new worker attached, helping prevent unintended resource leaks from inactive workers.