### PR TITLE
[PROPOSAL] fix: detect that fetch is native

### DIFF
--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -286,12 +286,16 @@ export default function fetchRequest(
 export function fetchIsSupported(): boolean {
   return (
     typeof globalScope.fetch === "function" &&
-    // Detect if the fetch function has been rewritten.
-    // Polyfill can rewrite this function without a proper implementation
-    // leading to issues.
-    // In this case it's preferable to use XHR over fetch.
+    /**
+     * Detect if the fetch or AbortController function has been rewritten.
+     * Polyfills can rewrite those function without a proper implementation
+     * leading to issues.
+     * In this case it's preferable to use XHR over fetch.
+     * @see https://github.com/TanStack/query/discussions/9049
+     */
     /native code/.test(globalScope.fetch.toString()) &&
     !isNullOrUndefined(_AbortController) &&
+    /native code/.test(_AbortController.toString()) &&
     !isNullOrUndefined(_Headers)
   );
 }

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -284,6 +284,8 @@ export default function fetchRequest(
  * @return {boolean}
  */
 export function fetchIsSupported(): boolean {
+  // Match [native code] and variants with different white space.
+  const nativeCodeRegex = /\[\s*native\s+code\s*\]/;
   return (
     typeof globalScope.fetch === "function" &&
     /**
@@ -293,9 +295,9 @@ export function fetchIsSupported(): boolean {
      * In this case it's preferable to use XHR over fetch.
      * @see https://github.com/TanStack/query/discussions/9049
      */
-    /native code/.test(globalScope.fetch.toString()) &&
+    nativeCodeRegex.test(globalScope.fetch.toString()) &&
     !isNullOrUndefined(_AbortController) &&
-    /native code/.test(_AbortController.toString()) &&
+    nativeCodeRegex.test(_AbortController.toString()) &&
     !isNullOrUndefined(_Headers)
   );
 }

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -289,13 +289,13 @@ export function fetchIsSupported(): boolean {
   return (
     typeof globalScope.fetch === "function" &&
     /**
-     * Detect if the fetch or AbortController function has been rewritten.
+     * Detect if AbortController function has been rewritten.
      * Polyfills can rewrite those function without a proper implementation
      * leading to issues.
-     * In this case it's preferable to use XHR over fetch.
+     * In this case it's preferable to use XHR over fetch, because fetch uses
+     * AbortSignal to cancel requests.
      * @see https://github.com/TanStack/query/discussions/9049
      */
-    nativeCodeRegex.test(globalScope.fetch.toString()) &&
     !isNullOrUndefined(_AbortController) &&
     nativeCodeRegex.test(_AbortController.toString()) &&
     !isNullOrUndefined(_Headers)

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -286,6 +286,11 @@ export default function fetchRequest(
 export function fetchIsSupported(): boolean {
   return (
     typeof globalScope.fetch === "function" &&
+    // Detect if the fetch function has been rewritten.
+    // Polyfill can rewrite this function without a proper implementation
+    // leading to issues.
+    // In this case it's preferable to use XHR over fetch.
+    /native code/.test(globalScope.fetch.toString()) &&
     !isNullOrUndefined(_AbortController) &&
     !isNullOrUndefined(_Headers)
   );


### PR DESCRIPTION
As @peaBerberian noticed, applications can install polyfills that override the fetch method on the window object.
However, in our experience, these polyfill implementations have not been very reliable.

The goal of this PR is to detect whether the fetch method has been polyfilled. If it has been overridden, we fall back to using XHR instead.

This detection uses the toString method, which typically returns [native code] for unmodified native functions.

I'm still unsure whether it's the responsibility of RxPlayer to check for the absence of a polyfill, or if it's up to the application to ensure everything works as expected.