### PR TITLE
Improve on freeze resolution, especially for encrypted contents

### DIFF
--- a/src/core/main/common/FreezeResolver.ts
+++ b/src/core/main/common/FreezeResolver.ts
@@ -220,12 +220,12 @@ export default class FreezeResolver {
     /** If set to `true`, we consider playback "frozen" */
     const isFrozen =
       freezing !== null ||
-      // When rebuffering, `freezing` might be not set as we're actively pausing
-      // playback. Yet, rebuffering occurences can also be abnormal, such as
-      // when enough buffer is constructed but with a low readyState (those are
-      // generally decryption issues).
-      (rebuffering !== null &&
-        readyState === 1 &&
+      // When rebuffering or loading the content, `freezing` might be not
+      // set as we're actively pausing playback.
+      // Yet, rebuffering occurences can also be abnormal, such as when enough
+      // buffer is constructed but with a low readyState (those are generally
+      // decryption issues).
+      (readyState === 1 &&
         (bufferGap >= MINIMUM_BUFFER_GAP_AT_READY_STATE_1_BEFORE_FREEZING ||
           fullyLoaded));
 
@@ -302,6 +302,17 @@ export default class FreezeResolver {
     const bufferGap = normalizeBufferGap(observation.bufferGap);
     const rebufferingForTooLong =
       rebuffering !== null && now - rebuffering.timestamp > FREEZING_FOR_TOO_LONG_DELAY;
+
+    const hasUndecipherableSegments = haveBuffersUndecipherableData(
+      this._segmentSinksStore,
+    );
+    if (hasUndecipherableSegments === true) {
+      log.warn("FR: we have undecipherable segments left in the buffer, reloading");
+      this._decipherabilityFreezeStartingTimestamp = null;
+      this._ignoreFreezeUntil = now + MINIMUM_TIME_BETWEEN_FREEZE_HANDLING;
+      return { type: "reload", value: null };
+    }
+
     const frozenForTooLong =
       freezing !== null && now - freezing.timestamp > FREEZING_FOR_TOO_LONG_DELAY;
 
@@ -322,29 +333,7 @@ export default class FreezeResolver {
       getMonotonicTimeStamp() - this._decipherabilityFreezeStartingTimestamp >
         FREEZING_FOR_TOO_LONG_DELAY;
 
-    let hasOnlyDecipherableSegments = true;
-    let isClear = true;
-    for (const ttype of ["audio", "video"] as const) {
-      const status = this._segmentSinksStore.getStatus(ttype);
-      if (status.type === "initialized") {
-        for (const segment of status.value.getLastKnownInventory()) {
-          const { representation } = segment.infos;
-          if (representation.decipherable === false) {
-            log.warn("FR: we have undecipherable segments left in the buffer, reloading");
-            this._decipherabilityFreezeStartingTimestamp = null;
-            this._ignoreFreezeUntil = now + MINIMUM_TIME_BETWEEN_FREEZE_HANDLING;
-            return { type: "reload", value: null };
-          } else if (representation.contentProtections !== undefined) {
-            isClear = false;
-            if (representation.decipherable !== true) {
-              hasOnlyDecipherableSegments = false;
-            }
-          }
-        }
-      }
-    }
-
-    if (shouldHandleDecipherabilityFreeze && !isClear && hasOnlyDecipherableSegments) {
+    if (shouldHandleDecipherabilityFreeze && hasUndecipherableSegments === false) {
       log.warn(
         "FR: we are frozen despite only having decipherable " +
           "segments left in the buffer, reloading",
@@ -522,6 +511,39 @@ export default class FreezeResolver {
       }
     }
   }
+}
+
+/**
+ * Check the audio and video buffers for decipherability information.
+ * @param {SegmentSinksStore} segmentSinksStore - Interface to obtain the
+ * current segment sinks.
+ * @returns {boolean|undefined} - Returns check result:
+ * -  If `true`, the buffer contains data known to be undecipherable.
+ * - If `false`, the buffer is either [thought to be] unencrypted or all data in
+ *   it are known to be decipherable.
+ * - If `undefined`, we don't know yet the decryption status of some of the data
+ *   containes in the buffer.
+ */
+function haveBuffersUndecipherableData(
+  segmentSinksStore: SegmentSinksStore,
+): boolean | undefined {
+  let hasOnlyDecipherableSegments = true;
+  for (const ttype of ["audio", "video"] as const) {
+    const status = segmentSinksStore.getStatus(ttype);
+    if (status.type === "initialized") {
+      for (const segment of status.value.getLastKnownInventory()) {
+        const { representation } = segment.infos;
+        if (representation.decipherable === false) {
+          return true;
+        } else if (representation.contentProtections !== undefined) {
+          if (representation.decipherable !== true) {
+            hasOnlyDecipherableSegments = false;
+          }
+        }
+      }
+    }
+  }
+  return hasOnlyDecipherableSegments ? false : undefined;
 }
 
 /**

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -696,11 +696,7 @@ function getRebufferingStatus({
     position: prevTime,
   } = previousObservation;
 
-  const canSwitchToRebuffering =
-    readyState >= 1 &&
-    observationEvent !== "loadedmetadata" &&
-    prevRebuffering === null &&
-    !(fullyLoaded || ended);
+  const canSwitchToRebuffering = prevRebuffering === null && !(fullyLoaded || ended);
 
   let rebufferEndPosition: number | null | undefined = null;
   let shouldRebuffer: boolean | undefined;


### PR DESCRIPTION
We just had a new issue on a very specific french device since a middleware update from its vendors which seems to trigger just the right set of conditions to lead to an infinite rebuffering undetected by our freeze-resolving heuristics.

Basically what happens is:

1.  We push some encrypted content in the buffer

2.  we then have the result from the license request: the data is not actually decipherable, we need thus to fallback from it

3.  By checking the buffer at this right instant, we do not see the corresponding segments yet, so we continue

4.  The segments are finally registered by the browser, still non-decipherable.

5.  Due to a complex chain of events (linked to the timings of the first "media observations" which are regular polling of media properties), our freeze-resolving logic - whose roles include unblocking that situation - doesn't trigger a reload in that instance.

    This is a consequence to the media observations done at the start of the content where we do not at any point consider the content as `rebuffering`, yet we are `paused` because the content is not yet started. In that specific scenario, we're neither "freezing" (because we're paused), nor "rebuffering" (because of the chain of events in question) and so currently our Freeze Resolver just thinks we are paused, consider the fact that we're not playing normal, and call it a day.

---

The real issue was IMO the fact that our `FreezeResolver` didn't consider the "not-yet-loaded" case, just assuming that `rebuffering` catched all cases of unwanted "pause" situations.

The real cases are more complex.

I updated several aspects of the logic:

-  In the `FreezeResolver`: We now do not care now if we are "rebuffering" or not, as long as we a `1` readyState but a lot of data in the buffer, we run heuristics to detect what the problem might be.

-  In the `FreezeResolver`: We check if we have segments known to be undecipherable **even** if we just began stalling playback. We should never have known-to-be undecipherable segments in the buffer, period.

-  In the `MediaElementPlaybackObserver`: I relaxed a lot the rules to consider a rebuffering.

   I don't get why we excluded `readyState` `0` nor why we treated the `loadedmetadata` event as special here. This "I don't get why" may be a recipe for regressions due to subtle device quirks but I take the risk in the name of code readability :P

Only one of those are needed in the encoutered case, but I consider both to be better form.