### PR TITLE
fix: some subtitle missed on multiple period assets

### DIFF
--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -168,7 +168,9 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       while (i >= 0 && cues[i].start >= appendWindowEnd) {
         i--;
       }
-      cues.splice(i, cues.length);
+
+      const deleteCount = cues.length - 1 - i;
+      cues.splice(i, deleteCount);
 
       i = cues.length - 1;
       while (i >= 0 && cues[i].end > appendWindowEnd) {

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -169,8 +169,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
         i--;
       }
 
-      const deleteCount = cues.length - 1 - i;
-      cues.splice(i, deleteCount);
+      cues.splice(i + 1, cues.length);
 
       i = cues.length - 1;
       while (i >= 0 && cues[i].end > appendWindowEnd) {

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -168,7 +168,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       while (i >= 0 && cues[i].start >= appendWindowEnd) {
         i--;
       }
-
+      // cues[i] is the last cue we want to keep, remove from i + 1
       cues.splice(i + 1, cues.length);
 
       i = cues.length - 1;


### PR DESCRIPTION
This PR fixes the issue: #1655 

Root cause of this issue is `cues.splice` been called incorrectly, it ment to remove the cues that start time after window end, but current implementation removes the last cue even all cues start time are before window end.

For details: https://github.com/canalplus/rx-player/issues/1655#issuecomment-3022460548