### PR TITLE
Fix: set autoplay attribute ondirectfile

### DIFF
--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -268,6 +268,11 @@ export function setAutoplay(
   autoplay: boolean,
   cancellationSignal: CancellationSignal,
 ) {
+  if (!autoplay) {
+    // If autoplay option is set to false, don't touch to `autoplay`
+    // videoElement attribute.
+    return;
+  }
   const autoplayPreviousValue = mediaElement.autoplay;
   cancellationSignal.register(() => {
     /**
@@ -277,7 +282,7 @@ export function setAutoplay(
      */
     mediaElement.autoplay = autoplayPreviousValue;
   });
-  mediaElement.disableRemotePlayback = autoplay;
+  mediaElement.autoplay = autoplay;
 }
 
 /**

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -93,6 +93,11 @@ export default class DirectFileContentInitializer extends ContentInitializer {
 
     clearElementSrc(mediaElement);
 
+    // Set the autoplay attribute on the mediaElement.
+    // On Apple devices, the native HLS player needs autoplay to be set
+    // in order to start buffering,which is required for our API's autoplay to work.
+    mediaElement.autoplay = this._settings.autoPlay;
+
     const { statusRef: drmInitRef } = initializeContentDecryption(
       mediaElement,
       keySystems,

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -29,6 +29,7 @@ import assert from "../../utils/assert";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import noop from "../../utils/noop";
 import type { IReadOnlySharedReference } from "../../utils/reference";
+import type { CancellationSignal } from "../../utils/task_canceller";
 import TaskCanceller from "../../utils/task_canceller";
 import { ContentInitializer } from "./types";
 import type { IInitialTimeOptions } from "./utils/get_initial_time";
@@ -96,7 +97,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
     // Set the autoplay attribute on the mediaElement.
     // On Apple devices, the native HLS player needs autoplay to be set
     // in order to start buffering,which is required for our API's autoplay to work.
-    mediaElement.autoplay = this._settings.autoPlay;
+    setAutoplay(mediaElement, this._settings.autoPlay, cancelSignal);
 
     const { statusRef: drmInitRef } = initializeContentDecryption(
       mediaElement,
@@ -252,6 +253,31 @@ export default class DirectFileContentInitializer extends ContentInitializer {
         }
       });
   }
+}
+
+/**
+ * Set autoplay value on the mediaElement.
+ *
+ * @param {HTMLElement} mediaElement - The media element whose `autoplay`
+ * attribute will be modified.
+ * @param {CancellationSignal} cancellationSignal - The signal that, when triggered,
+ * restores the `autoplay` attribute to its original value.
+ */
+export function setAutoplay(
+  mediaElement: IMediaElement,
+  autoplay: boolean,
+  cancellationSignal: CancellationSignal,
+) {
+  const autoplayPreviousValue = mediaElement.autoplay;
+  cancellationSignal.register(() => {
+    /**
+     * Restore the `autoplay` attribute to its previous value.
+     * This ensures that the media element's state is the same as it was before
+     * calling `RxPlayer.loadVideo` in the application.
+     */
+    mediaElement.autoplay = autoplayPreviousValue;
+  });
+  mediaElement.disableRemotePlayback = autoplay;
 }
 
 /**

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -274,6 +274,7 @@ export function setAutoplay(
     return;
   }
   const autoplayPreviousValue = mediaElement.autoplay;
+  mediaElement.autoplay = autoplay;
   cancellationSignal.register(() => {
     /**
      * Restore the `autoplay` attribute to its previous value.
@@ -282,7 +283,6 @@ export function setAutoplay(
      */
     mediaElement.autoplay = autoplayPreviousValue;
   });
-  mediaElement.autoplay = autoplay;
 }
 
 /**


### PR DESCRIPTION
When using direct file options to load content on devices like Safari—which allows loading HLS playlists directly through the player—we’re encountering an issue where playback does not start buffering unless the `autoplay` attribute is set on the video element.

With the RxPlayer, we typically avoid setting the autoplay attribute because we want to manage playback start ourselves, based on heuristics like buffer size. 

The proposed PR slightly adjusts this behavior, but only for the directFile case, to ensure compatibility with Safari while preserving the custom autoplay logic in other scenarios. Maybe we want to limit that workaround to specific device with device detection, this is still to be determined.


