### PR TITLE
Few logic tweaks after issues seen with new integration tests

### DIFF
--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -31,7 +31,6 @@ import CdnPrioritizer from "../../fetchers/cdn_prioritizer";
 import createThumbnailFetcher from "../../fetchers/thumbnails/thumbnail_fetcher";
 import type { IThumbnailFetcher } from "../../fetchers/thumbnails/thumbnail_fetcher";
 import SegmentSinksStore from "../../segment_sinks";
-import type { INeedsMediaSourceReloadPayload } from "../../stream";
 import FreezeResolver from "../common/FreezeResolver";
 import { limitVideoResolution, throttleVideoBitrate } from "./globals";
 import sendMessage, { formatErrorForSender } from "./send_message";
@@ -325,30 +324,18 @@ export default class ContentPreparer {
   }
 
   /**
-   * If there is a prepared content right now, performs the destructive
-   * "reloading" strategy: dispose of its `MediaSource` (and of its
-   * `SourceBuffer`) and recreate one.
+   * Signal the ContentPreparer that the MediaSource is "reloading".
    *
    * The returned Promise resolves when it restarts being ready.
-   * @param {Object} reloadInfo
    * @returns {Promise}
    */
-  public reloadMediaSource(reloadInfo: INeedsMediaSourceReloadPayload): Promise<void> {
+  public reloadMediaSource(): Promise<void> {
     this._currentMediaSourceCanceller.cancel();
     if (this._currentContent === null) {
       return Promise.reject(new Error("CP: No content anymore"));
     }
     this._currentContent.trackChoiceSetter.reset();
     this._currentMediaSourceCanceller = new TaskCanceller();
-
-    sendMessage(
-      {
-        type: WorkerMessageType.ReloadingMediaSource,
-        contentId: this._currentContent.contentId,
-        value: reloadInfo,
-      },
-      [],
-    );
 
     const [mediaSourceInterface, segmentSinksStore, workerTextSender] =
       createMediaSourceInterfaceAndSegmentSinksStore(

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -70,6 +70,8 @@ export default function initializeWorkerMain() {
    */
   let currentLoadedContentTaskCanceller: TaskCanceller | null = null;
 
+  let currentContentHandle: IContentHandle | null = null;
+
   // Initialize Manually a `DashWasmParser` and add the feature.
   // TODO allow worker-side feature-switching? Not sure how
   const dashWasmParser = new DashWasmParser();
@@ -136,6 +138,7 @@ export default function initializeWorkerMain() {
           currentLoadedContentTaskCanceller = null;
         }
 
+        // XXX TODO: Move inside loadOrReloadPreparedContent
         const currentCanceller = new TaskCanceller();
         const currentContentObservationRef =
           new SharedReference<IWorkerPlaybackObservation>(
@@ -149,7 +152,7 @@ export default function initializeWorkerMain() {
           currentContentObservationRef.finish();
         });
         log.debug("WP: Loading new pepared content.");
-        loadOrReloadPreparedContent(
+        currentContentHandle = loadOrReloadPreparedContent(
           msg.value,
           contentPreparer,
           currentContentObservationRef,
@@ -195,6 +198,16 @@ export default function initializeWorkerMain() {
         if (currentLoadedContentTaskCanceller !== null) {
           currentLoadedContentTaskCanceller.cancel();
           currentLoadedContentTaskCanceller = null;
+        }
+        break;
+
+      case MainThreadMessageType.TriggerMediaSourceReload:
+        {
+          const preparedContent = contentPreparer.getCurrentContent();
+          if (msg.mediaSourceId !== preparedContent?.mediaSource.id) {
+            return;
+          }
+          currentContentHandle?.reload(msg.value);
         }
         break;
 
@@ -485,12 +498,16 @@ interface IBufferingInitializationInformation {
   onCodecSwitch: "continue" | "reload";
 }
 
+interface IContentHandle {
+  reload: (payload: INeedsMediaSourceReloadPayload) => void;
+}
+
 function loadOrReloadPreparedContent(
   val: IBufferingInitializationInformation,
   contentPreparer: ContentPreparer,
   playbackObservationRef: IReadOnlySharedReference<IWorkerPlaybackObservation>,
   parentCancelSignal: CancellationSignal,
-) {
+): IContentHandle {
   log.debug("WP: Loading prepared content");
   const currentLoadCanceller = new TaskCanceller();
   currentLoadCanceller.linkToSignal(parentCancelSignal);
@@ -516,7 +533,7 @@ function loadOrReloadPreparedContent(
       contentId: undefined,
       value: formatErrorForSender(error),
     });
-    return;
+    throw error;
   }
   const {
     contentId,
@@ -559,7 +576,7 @@ function loadOrReloadPreparedContent(
       contentId,
       value: formatErrorForSender(error),
     });
-    return;
+    throw error;
   }
 
   const playbackObserver = new WorkerPlaybackObserver(
@@ -614,6 +631,12 @@ function loadOrReloadPreparedContent(
     handleStreamOrchestratorCallbacks(),
     currentLoadCanceller.signal,
   );
+
+  return {
+    reload: (payload: INeedsMediaSourceReloadPayload): void => {
+      return handleMediaSourceReload(payload);
+    },
+  };
 
   /**
    * Returns Object handling the callbacks from a `StreamOrchestrator`, which

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -190,13 +190,13 @@ export default function initializeWorkerMain() {
         playbackObservationRef = null;
         break;
 
-      case MainThreadMessageType.TriggerMediaSourceReload:
+      case MainThreadMessageType.MediaSourceReload:
         {
           const preparedContent = contentPreparer.getCurrentContent();
           if (msg.mediaSourceId !== preparedContent?.mediaSource.id) {
             return;
           }
-          currentContentHandle?.reload(msg.value);
+          currentContentHandle?.signalMediaSourceReload();
         }
         break;
 
@@ -488,7 +488,12 @@ interface ILoadingContentParameters {
 }
 
 interface IContentHandle {
-  reload: (payload: INeedsMediaSourceReloadPayload) => void;
+  /**
+   * Callback to call if a "MediaSource reload" was triggered by an external
+   * component (e.g. main thread).
+   */
+  signalMediaSourceReload: () => void;
+  /** Callback to call to stop the content and free all its related resources. */
   stop: () => void;
 }
 
@@ -505,8 +510,8 @@ function loadPreparedContent(
 
   startLoadingAt(val.initialTime);
   return {
-    reload: (payload: INeedsMediaSourceReloadPayload): void => {
-      return handleMediaSourceReload(payload);
+    signalMediaSourceReload: (): void => {
+      return onMediaSourceReload();
     },
     stop: () => {
       contentCanceller.cancel();
@@ -562,7 +567,7 @@ function loadPreparedContent(
           handleFreezeResolution(freezeResolution, {
             contentId,
             manifest,
-            handleMediaSourceReload,
+            handleMediaSourceReload: performMediaSourceReload,
             enableRepresentationAvoidance,
           });
         }
@@ -826,7 +831,7 @@ function loadPreparedContent(
         },
 
         needsMediaSourceReload(payload: INeedsMediaSourceReloadPayload) {
-          handleMediaSourceReload(payload);
+          performMediaSourceReload(payload);
         },
 
         needsDecipherabilityFlush() {
@@ -914,13 +919,15 @@ function loadPreparedContent(
     }
   }
 
-  function handleMediaSourceReload(payload: INeedsMediaSourceReloadPayload) {
-    // TODO more precize one day?
-    const lastObservation = playbackObservationRef.getValue();
-    const newInitialTime = lastObservation.position.getWanted();
+  function performMediaSourceReload(payload: INeedsMediaSourceReloadPayload): void {
     if (currentLoadCanceller !== null) {
       currentLoadCanceller.cancel();
       currentLoadCanceller = null;
+    }
+    const mediaSourceId = contentPreparer.getCurrentContent()?.mediaSource.id;
+    if (mediaSourceId === undefined) {
+      log.warn("WP: Cannot reload MediaSource: no MediaSource currently.");
+      return;
     }
     log.debug(
       "WP: Reloading MediaSource",
@@ -928,8 +935,29 @@ function loadPreparedContent(
       payload.minimumPosition,
       payload.maximumPosition,
     );
+
+    sendMessage(
+      {
+        type: WorkerMessageType.ReloadingMediaSource,
+        mediaSourceId,
+        value: payload,
+      },
+      [],
+    );
+    onMediaSourceReload();
+  }
+
+  function onMediaSourceReload(): void {
+    // TODO more precize one day?
+    const lastObservation = playbackObservationRef.getValue();
+    const newInitialTime = lastObservation.position.getWanted();
+    if (currentLoadCanceller !== null) {
+      currentLoadCanceller.cancel();
+      currentLoadCanceller = null;
+    }
+    log.debug("WP: Reloading MediaSource");
     const contentId = contentPreparer.getCurrentContent()?.contentId;
-    contentPreparer.reloadMediaSource(payload).then(
+    contentPreparer.reloadMediaSource().then(
       () => {
         log.info("WP: MediaSource Reloaded, loading content again", newInitialTime);
         startLoadingAt(newInitialTime);

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -26,7 +26,6 @@ import { scaleTimestamp } from "../../../utils/monotonic_timestamp";
 import objectAssign from "../../../utils/object_assign";
 import type { IReadOnlySharedReference } from "../../../utils/reference";
 import SharedReference from "../../../utils/reference";
-import type { CancellationSignal } from "../../../utils/task_canceller";
 import TaskCanceller from "../../../utils/task_canceller";
 import type {
   INeedsMediaSourceReloadPayload,
@@ -57,19 +56,16 @@ export default function initializeWorkerMain() {
    */
   let isInitialized = false;
   /**
-   * Abstraction allowing to load contents (fetching its manifest as
-   * well as creating and reloading its MediaSource).
+   * Abstraction allowing to prepare contents (fetching its manifest as
+   * well as creating and reloading its MediaSource) for playback.
    *
    * Creating a default one which may change on initialization.
    */
   let contentPreparer = new ContentPreparer({ hasVideo: true });
-
   /**
-   * Abort all operations relative to the currently loaded content.
-   * `null` when there's no loaded content currently or when it is reloaidng.
+   * Object allowing to control the lifecycle of the current content (stop/reload etc.).
+   * `null` if there's no content loaded currently.
    */
-  let currentLoadedContentTaskCanceller: TaskCanceller | null = null;
-
   let currentContentHandle: IContentHandle | null = null;
 
   // Initialize Manually a `DashWasmParser` and add the feature.
@@ -133,13 +129,10 @@ export default function initializeWorkerMain() {
         if (msg.contentId !== preparedContent?.contentId) {
           return;
         }
-        if (currentLoadedContentTaskCanceller !== null) {
-          currentLoadedContentTaskCanceller.cancel();
-          currentLoadedContentTaskCanceller = null;
-        }
 
-        // XXX TODO: Move inside loadOrReloadPreparedContent
-        const currentCanceller = new TaskCanceller();
+        currentContentHandle?.stop();
+        playbackObservationRef?.finish();
+
         const currentContentObservationRef =
           new SharedReference<IWorkerPlaybackObservation>(
             objectAssign(msg.value.initialObservation, {
@@ -147,16 +140,10 @@ export default function initializeWorkerMain() {
             }),
           );
         playbackObservationRef = currentContentObservationRef;
-        currentLoadedContentTaskCanceller = currentCanceller;
-        currentLoadedContentTaskCanceller.signal.register(() => {
-          currentContentObservationRef.finish();
-        });
-        log.debug("WP: Loading new pepared content.");
-        currentContentHandle = loadOrReloadPreparedContent(
+        currentContentHandle = loadPreparedContent(
           msg.value,
           contentPreparer,
           currentContentObservationRef,
-          currentCanceller.signal,
         );
         break;
       }
@@ -195,10 +182,12 @@ export default function initializeWorkerMain() {
           return;
         }
         contentPreparer.disposeCurrentContent();
-        if (currentLoadedContentTaskCanceller !== null) {
-          currentLoadedContentTaskCanceller.cancel();
-          currentLoadedContentTaskCanceller = null;
-        }
+
+        currentContentHandle?.stop();
+        currentContentHandle = null;
+
+        playbackObservationRef?.finish();
+        playbackObservationRef = null;
         break;
 
       case MainThreadMessageType.TriggerMediaSourceReload:
@@ -480,7 +469,7 @@ function updateGlobalReference(msg: IReferenceUpdateMessage): void {
   }
 }
 
-interface IBufferingInitializationInformation {
+interface ILoadingContentParameters {
   /** The start time at which we should play, in seconds. */
   initialTime: number;
   /**
@@ -500,404 +489,429 @@ interface IBufferingInitializationInformation {
 
 interface IContentHandle {
   reload: (payload: INeedsMediaSourceReloadPayload) => void;
+  stop: () => void;
 }
 
-function loadOrReloadPreparedContent(
-  val: IBufferingInitializationInformation,
+function loadPreparedContent(
+  val: ILoadingContentParameters,
   contentPreparer: ContentPreparer,
   playbackObservationRef: IReadOnlySharedReference<IWorkerPlaybackObservation>,
-  parentCancelSignal: CancellationSignal,
 ): IContentHandle {
   log.debug("WP: Loading prepared content");
-  const currentLoadCanceller = new TaskCanceller();
-  currentLoadCanceller.linkToSignal(parentCancelSignal);
 
-  /**
-   * Stores last discontinuity update sent to the worker for each Period and type
-   * combinations, at least until the corresponding `PeriodStreamCleared`
-   * message.
-   *
-   * This is an optimization to avoid sending too much discontinuity messages to
-   * the main thread when it is not needed because nothing changed.
-   */
-  const lastSentDiscontinuitiesStore: Map<
-    Period,
-    Map<ITrackType, IDiscontinuityUpdateWorkerMessagePayload>
-  > = new Map();
+  const contentCanceller = new TaskCanceller();
 
-  const preparedContent = contentPreparer.getCurrentContent();
-  if (preparedContent === null || preparedContent.manifest === null) {
-    const error = new OtherError("NONE", "Loading content when none is prepared");
-    sendMessage({
-      type: WorkerMessageType.Error,
-      contentId: undefined,
-      value: formatErrorForSender(error),
-    });
-    throw error;
-  }
-  const {
-    contentId,
-    cmcdDataBuilder,
-    enableRepresentationAvoidance,
-    manifest,
-    mediaSource,
-    representationEstimator,
-    segmentSinksStore,
-    segmentQueueCreator,
-  } = preparedContent;
-  const { drmSystemId, enableFastSwitching, initialTime, onCodecSwitch } = val;
+  let currentLoadCanceller: TaskCanceller | null = null;
 
-  playbackObservationRef.onUpdate(
-    (observation) => {
-      synchronizeSegmentSinksOnObservation(observation, segmentSinksStore);
-      const freezeResolution =
-        preparedContent.freezeResolver.onNewObservation(observation);
-      if (freezeResolution !== null) {
-        handleFreezeResolution(freezeResolution, {
-          contentId,
-          manifest,
-          handleMediaSourceReload,
-          enableRepresentationAvoidance,
-        });
-      }
-    },
-    { clearSignal: currentLoadCanceller.signal },
-  );
-
-  const initialPeriod =
-    manifest.getPeriodForTime(initialTime) ?? manifest.getNextPeriod(initialTime);
-  if (initialPeriod === undefined) {
-    const error = new MediaError(
-      "MEDIA_STARTING_TIME_NOT_FOUND",
-      "Wanted starting time not found in the Manifest.",
-    );
-    sendMessage({
-      type: WorkerMessageType.Error,
-      contentId,
-      value: formatErrorForSender(error),
-    });
-    throw error;
-  }
-
-  const playbackObserver = new WorkerPlaybackObserver(
-    playbackObservationRef,
-    contentId,
-    sendMessage,
-    currentLoadCanceller.signal,
-  );
-  cmcdDataBuilder?.startMonitoringPlayback(playbackObserver);
-  currentLoadCanceller.signal.register(() => {
-    cmcdDataBuilder?.stopMonitoringPlayback();
-  });
-
-  const contentTimeBoundariesObserver = createContentTimeBoundariesObserver(
-    manifest,
-    mediaSource,
-    playbackObserver,
-    segmentSinksStore,
-    {
-      onWarning: (err: IPlayerError) =>
-        sendMessage({
-          type: WorkerMessageType.Warning,
-          contentId,
-          value: formatErrorForSender(err),
-        }),
-      onPeriodChanged: (period: Period) => {
-        sendMessage({
-          type: WorkerMessageType.ActivePeriodChanged,
-          contentId,
-          value: { periodId: period.id },
-        });
-      },
-    },
-    currentLoadCanceller.signal,
-  );
-
-  StreamOrchestrator(
-    { initialPeriod, manifest },
-    playbackObserver,
-    representationEstimator,
-    segmentSinksStore,
-    segmentQueueCreator,
-    {
-      wantedBufferAhead,
-      maxVideoBufferSize,
-      maxBufferAhead,
-      maxBufferBehind,
-      drmSystemId,
-      enableFastSwitching,
-      onCodecSwitch,
-    },
-    handleStreamOrchestratorCallbacks(),
-    currentLoadCanceller.signal,
-  );
-
+  startLoadingAt(val.initialTime);
   return {
     reload: (payload: INeedsMediaSourceReloadPayload): void => {
       return handleMediaSourceReload(payload);
     },
+    stop: () => {
+      contentCanceller.cancel();
+    },
   };
 
-  /**
-   * Returns Object handling the callbacks from a `StreamOrchestrator`, which
-   * are basically how it communicates about events.
-   * @returns {Object}
-   */
-  function handleStreamOrchestratorCallbacks(): IStreamOrchestratorCallbacks {
-    return {
-      needsBufferFlush(payload) {
-        sendMessage({
-          type: WorkerMessageType.NeedsBufferFlush,
-          contentId,
-          value: payload,
-        });
-      },
+  function startLoadingAt(startTime: number): void {
+    currentLoadCanceller?.cancel();
+    currentLoadCanceller = new TaskCanceller();
+    currentLoadCanceller.linkToSignal(contentCanceller.signal);
 
-      streamStatusUpdate(value) {
-        sendDiscontinuityUpdateIfNeeded(value);
+    /**
+     * Stores last discontinuity update sent to the worker for each Period and type
+     * combinations, at least until the corresponding `PeriodStreamCleared`
+     * message.
+     *
+     * This is an optimization to avoid sending too much discontinuity messages to
+     * the main thread when it is not needed because nothing changed.
+     */
+    const lastSentDiscontinuitiesStore: Map<
+      Period,
+      Map<ITrackType, IDiscontinuityUpdateWorkerMessagePayload>
+    > = new Map();
 
-        // If the status for the last Period indicates that segments are all loaded
-        // or on the contrary that the loading resumed, announce it to the
-        // ContentTimeBoundariesObserver.
-        if (
-          manifest.isLastPeriodKnown &&
-          value.period.id === manifest.periods[manifest.periods.length - 1].id
-        ) {
-          const hasFinishedLoadingLastPeriod =
-            value.hasFinishedLoading || value.isEmptyStream;
-          if (hasFinishedLoadingLastPeriod) {
-            contentTimeBoundariesObserver.onLastSegmentFinishedLoading(value.bufferType);
-          } else {
-            contentTimeBoundariesObserver.onLastSegmentLoadingResume(value.bufferType);
-          }
-        }
-      },
+    const preparedContent = contentPreparer.getCurrentContent();
+    if (preparedContent === null || preparedContent.manifest === null) {
+      const error = new OtherError("NONE", "Loading content when none is prepared");
+      sendMessage({
+        type: WorkerMessageType.Error,
+        contentId: undefined,
+        value: formatErrorForSender(error),
+      });
+      throw error;
+    }
+    const {
+      contentId,
+      cmcdDataBuilder,
+      enableRepresentationAvoidance,
+      manifest,
+      mediaSource,
+      representationEstimator,
+      segmentSinksStore,
+      segmentQueueCreator,
+    } = preparedContent;
+    const { drmSystemId, enableFastSwitching, onCodecSwitch } = val;
 
-      needsManifestRefresh() {
-        contentPreparer.scheduleManifestRefresh({
-          enablePartialRefresh: true,
-          canUseUnsafeMode: true,
-        });
-      },
-
-      manifestMightBeOufOfSync() {
-        const { OUT_OF_SYNC_MANIFEST_REFRESH_DELAY } = config.getCurrent();
-        contentPreparer.scheduleManifestRefresh({
-          enablePartialRefresh: false,
-          canUseUnsafeMode: false,
-          delay: OUT_OF_SYNC_MANIFEST_REFRESH_DELAY,
-        });
-      },
-
-      lockedStream(payload) {
-        sendMessage({
-          type: WorkerMessageType.LockedStream,
-          contentId,
-          value: {
-            periodId: payload.period.id,
-            bufferType: payload.bufferType,
-          },
-        });
-      },
-
-      adaptationChange(value) {
-        contentTimeBoundariesObserver.onAdaptationChange(
-          value.type,
-          value.period,
-          value.adaptation,
-        );
-        if (currentLoadCanceller.signal.isCancelled()) {
-          return;
-        }
-        sendMessage({
-          type: WorkerMessageType.AdaptationChanged,
-          contentId,
-          value: {
-            adaptationId: value.adaptation?.id ?? null,
-            periodId: value.period.id,
-            type: value.type,
-          },
-        });
-      },
-
-      representationChange(value) {
-        contentTimeBoundariesObserver.onRepresentationChange(value.type, value.period);
-        if (currentLoadCanceller.signal.isCancelled()) {
-          return;
-        }
-        sendMessage({
-          type: WorkerMessageType.RepresentationChanged,
-          contentId,
-          value: {
-            adaptationId: value.adaptation.id,
-            representationId: value.representation?.id ?? null,
-            periodId: value.period.id,
-            type: value.type,
-          },
-        });
-      },
-
-      inbandEvent(value) {
-        sendMessage({
-          type: WorkerMessageType.InbandEvent,
-          contentId,
-          value,
-        });
-      },
-
-      warning(value) {
-        sendMessage({
-          type: WorkerMessageType.Warning,
-          contentId,
-          value: formatErrorForSender(value),
-        });
-      },
-
-      periodStreamReady(value) {
-        if (preparedContent === null) {
-          return;
-        }
-        preparedContent.trackChoiceSetter.addTrackSetter(
-          value.period.id,
-          value.type,
-          value.adaptationRef,
-        );
-        sendMessage({
-          type: WorkerMessageType.PeriodStreamReady,
-          contentId,
-          value: { periodId: value.period.id, bufferType: value.type },
-        });
-      },
-
-      periodStreamCleared(value) {
-        if (preparedContent === null) {
-          return;
-        }
-
-        const periodDiscontinuitiesStore = lastSentDiscontinuitiesStore.get(value.period);
-        if (periodDiscontinuitiesStore !== undefined) {
-          periodDiscontinuitiesStore.delete(value.type);
-          if (periodDiscontinuitiesStore.size === 0) {
-            lastSentDiscontinuitiesStore.delete(value.period);
-          }
-        }
-
-        contentTimeBoundariesObserver.onPeriodCleared(value.type, value.period);
-        preparedContent.trackChoiceSetter.removeTrackSetter(value.period.id, value.type);
-        sendMessage({
-          type: WorkerMessageType.PeriodStreamCleared,
-          contentId,
-          value: { periodId: value.period.id, bufferType: value.type },
-        });
-      },
-
-      bitrateEstimateChange(payload) {
-        if (preparedContent !== null) {
-          preparedContent.cmcdDataBuilder?.updateThroughput(
-            payload.type,
-            payload.bitrate,
-          );
-        }
-
-        // TODO for low-latency contents it is __VERY__ frequent.
-        // Considering this is only for an unimportant undocumented API, we may
-        // throttle such messages. (e.g. max one per 2 seconds for each type?).
-        sendMessage({
-          type: WorkerMessageType.BitrateEstimateChange,
-          contentId,
-          value: {
-            bitrate: payload.bitrate,
-            bufferType: payload.type,
-          },
-        });
-      },
-
-      needsMediaSourceReload(payload: INeedsMediaSourceReloadPayload) {
-        handleMediaSourceReload(payload);
-      },
-
-      needsDecipherabilityFlush() {
-        sendMessage({
-          type: WorkerMessageType.NeedsDecipherabilityFlush,
-          contentId,
-          value: null,
-        });
-      },
-
-      encryptionDataEncountered(values) {
-        for (const value of values) {
-          const originalContent = value.content;
-          const content = { ...originalContent };
-          if (content.manifest instanceof Manifest) {
-            content.manifest = content.manifest.getMetadataSnapshot();
-          }
-          if (content.period instanceof Period) {
-            content.period = content.period.getMetadataSnapshot();
-          }
-          if (content.adaptation instanceof Adaptation) {
-            content.adaptation = content.adaptation.getMetadataSnapshot();
-          }
-          if (content.representation instanceof Representation) {
-            content.representation = content.representation.getMetadataSnapshot();
-          }
-          sendMessage({
-            type: WorkerMessageType.EncryptionDataEncountered,
+    playbackObservationRef.onUpdate(
+      (observation) => {
+        synchronizeSegmentSinksOnObservation(observation, segmentSinksStore);
+        const freezeResolution =
+          preparedContent.freezeResolver.onNewObservation(observation);
+        if (freezeResolution !== null) {
+          handleFreezeResolution(freezeResolution, {
             contentId,
-            value: {
-              keyIds: value.keyIds,
-              values: value.values,
-              content,
-              type: value.type,
-            },
+            manifest,
+            handleMediaSourceReload,
+            enableRepresentationAvoidance,
           });
         }
       },
+      { clearSignal: currentLoadCanceller.signal },
+    );
 
-      error(error: unknown) {
-        sendMessage({
-          type: WorkerMessageType.Error,
-          contentId,
-          value: formatErrorForSender(error),
-        });
+    const initialPeriod =
+      manifest.getPeriodForTime(startTime) ?? manifest.getNextPeriod(startTime);
+    if (initialPeriod === undefined) {
+      const error = new MediaError(
+        "MEDIA_STARTING_TIME_NOT_FOUND",
+        "Wanted starting time not found in the Manifest.",
+      );
+      sendMessage({
+        type: WorkerMessageType.Error,
+        contentId,
+        value: formatErrorForSender(error),
+      });
+      throw error;
+    }
+
+    const playbackObserver = new WorkerPlaybackObserver(
+      playbackObservationRef,
+      contentId,
+      sendMessage,
+      currentLoadCanceller.signal,
+    );
+    cmcdDataBuilder?.startMonitoringPlayback(playbackObserver);
+    currentLoadCanceller.signal.register(() => {
+      cmcdDataBuilder?.stopMonitoringPlayback();
+    });
+
+    const contentTimeBoundariesObserver = createContentTimeBoundariesObserver(
+      manifest,
+      mediaSource,
+      playbackObserver,
+      segmentSinksStore,
+      {
+        onWarning: (err: IPlayerError) =>
+          sendMessage({
+            type: WorkerMessageType.Warning,
+            contentId,
+            value: formatErrorForSender(err),
+          }),
+        onPeriodChanged: (period: Period) => {
+          sendMessage({
+            type: WorkerMessageType.ActivePeriodChanged,
+            contentId,
+            value: { periodId: period.id },
+          });
+        },
       },
-    };
-  }
+      currentLoadCanceller.signal,
+    );
 
-  function sendDiscontinuityUpdateIfNeeded(value: IStreamStatusPayload): void {
-    const { imminentDiscontinuity } = value;
-    let periodMap = lastSentDiscontinuitiesStore.get(value.period);
-    const sentObjInfo = periodMap?.get(value.bufferType);
-    if (sentObjInfo !== undefined) {
-      if (sentObjInfo.discontinuity === null) {
-        if (imminentDiscontinuity === null) {
+    StreamOrchestrator(
+      { initialPeriod, manifest },
+      playbackObserver,
+      representationEstimator,
+      segmentSinksStore,
+      segmentQueueCreator,
+      {
+        wantedBufferAhead,
+        maxVideoBufferSize,
+        maxBufferAhead,
+        maxBufferBehind,
+        drmSystemId,
+        enableFastSwitching,
+        onCodecSwitch,
+      },
+      handleStreamOrchestratorCallbacks(),
+      currentLoadCanceller.signal,
+    );
+
+    /**
+     * Returns Object handling the callbacks from a `StreamOrchestrator`, which
+     * are basically how it communicates about events.
+     * @returns {Object}
+     */
+    function handleStreamOrchestratorCallbacks(): IStreamOrchestratorCallbacks {
+      return {
+        needsBufferFlush(payload) {
+          sendMessage({
+            type: WorkerMessageType.NeedsBufferFlush,
+            contentId,
+            value: payload,
+          });
+        },
+
+        streamStatusUpdate(value) {
+          sendDiscontinuityUpdateIfNeeded(value);
+
+          // If the status for the last Period indicates that segments are all loaded
+          // or on the contrary that the loading resumed, announce it to the
+          // ContentTimeBoundariesObserver.
+          if (
+            manifest.isLastPeriodKnown &&
+            value.period.id === manifest.periods[manifest.periods.length - 1].id
+          ) {
+            const hasFinishedLoadingLastPeriod =
+              value.hasFinishedLoading || value.isEmptyStream;
+            if (hasFinishedLoadingLastPeriod) {
+              contentTimeBoundariesObserver.onLastSegmentFinishedLoading(
+                value.bufferType,
+              );
+            } else {
+              contentTimeBoundariesObserver.onLastSegmentLoadingResume(value.bufferType);
+            }
+          }
+        },
+
+        needsManifestRefresh() {
+          contentPreparer.scheduleManifestRefresh({
+            enablePartialRefresh: true,
+            canUseUnsafeMode: true,
+          });
+        },
+
+        manifestMightBeOufOfSync() {
+          const { OUT_OF_SYNC_MANIFEST_REFRESH_DELAY } = config.getCurrent();
+          contentPreparer.scheduleManifestRefresh({
+            enablePartialRefresh: false,
+            canUseUnsafeMode: false,
+            delay: OUT_OF_SYNC_MANIFEST_REFRESH_DELAY,
+          });
+        },
+
+        lockedStream(payload) {
+          sendMessage({
+            type: WorkerMessageType.LockedStream,
+            contentId,
+            value: {
+              periodId: payload.period.id,
+              bufferType: payload.bufferType,
+            },
+          });
+        },
+
+        adaptationChange(value) {
+          contentTimeBoundariesObserver.onAdaptationChange(
+            value.type,
+            value.period,
+            value.adaptation,
+          );
+          if (
+            currentLoadCanceller === null ||
+            currentLoadCanceller.signal.isCancelled()
+          ) {
+            return;
+          }
+          sendMessage({
+            type: WorkerMessageType.AdaptationChanged,
+            contentId,
+            value: {
+              adaptationId: value.adaptation?.id ?? null,
+              periodId: value.period.id,
+              type: value.type,
+            },
+          });
+        },
+
+        representationChange(value) {
+          contentTimeBoundariesObserver.onRepresentationChange(value.type, value.period);
+          if (
+            currentLoadCanceller === null ||
+            currentLoadCanceller.signal.isCancelled()
+          ) {
+            return;
+          }
+          sendMessage({
+            type: WorkerMessageType.RepresentationChanged,
+            contentId,
+            value: {
+              adaptationId: value.adaptation.id,
+              representationId: value.representation?.id ?? null,
+              periodId: value.period.id,
+              type: value.type,
+            },
+          });
+        },
+
+        inbandEvent(value) {
+          sendMessage({
+            type: WorkerMessageType.InbandEvent,
+            contentId,
+            value,
+          });
+        },
+
+        warning(value) {
+          sendMessage({
+            type: WorkerMessageType.Warning,
+            contentId,
+            value: formatErrorForSender(value),
+          });
+        },
+
+        periodStreamReady(value) {
+          if (preparedContent === null) {
+            return;
+          }
+          preparedContent.trackChoiceSetter.addTrackSetter(
+            value.period.id,
+            value.type,
+            value.adaptationRef,
+          );
+          sendMessage({
+            type: WorkerMessageType.PeriodStreamReady,
+            contentId,
+            value: { periodId: value.period.id, bufferType: value.type },
+          });
+        },
+
+        periodStreamCleared(value) {
+          if (preparedContent === null) {
+            return;
+          }
+
+          const periodDiscontinuitiesStore = lastSentDiscontinuitiesStore.get(
+            value.period,
+          );
+          if (periodDiscontinuitiesStore !== undefined) {
+            periodDiscontinuitiesStore.delete(value.type);
+            if (periodDiscontinuitiesStore.size === 0) {
+              lastSentDiscontinuitiesStore.delete(value.period);
+            }
+          }
+
+          contentTimeBoundariesObserver.onPeriodCleared(value.type, value.period);
+          preparedContent.trackChoiceSetter.removeTrackSetter(
+            value.period.id,
+            value.type,
+          );
+          sendMessage({
+            type: WorkerMessageType.PeriodStreamCleared,
+            contentId,
+            value: { periodId: value.period.id, bufferType: value.type },
+          });
+        },
+
+        bitrateEstimateChange(payload) {
+          if (preparedContent !== null) {
+            preparedContent.cmcdDataBuilder?.updateThroughput(
+              payload.type,
+              payload.bitrate,
+            );
+          }
+
+          // TODO for low-latency contents it is __VERY__ frequent.
+          // Considering this is only for an unimportant undocumented API, we may
+          // throttle such messages. (e.g. max one per 2 seconds for each type?).
+          sendMessage({
+            type: WorkerMessageType.BitrateEstimateChange,
+            contentId,
+            value: {
+              bitrate: payload.bitrate,
+              bufferType: payload.type,
+            },
+          });
+        },
+
+        needsMediaSourceReload(payload: INeedsMediaSourceReloadPayload) {
+          handleMediaSourceReload(payload);
+        },
+
+        needsDecipherabilityFlush() {
+          sendMessage({
+            type: WorkerMessageType.NeedsDecipherabilityFlush,
+            contentId,
+            value: null,
+          });
+        },
+
+        encryptionDataEncountered(values) {
+          for (const value of values) {
+            const originalContent = value.content;
+            const content = { ...originalContent };
+            if (content.manifest instanceof Manifest) {
+              content.manifest = content.manifest.getMetadataSnapshot();
+            }
+            if (content.period instanceof Period) {
+              content.period = content.period.getMetadataSnapshot();
+            }
+            if (content.adaptation instanceof Adaptation) {
+              content.adaptation = content.adaptation.getMetadataSnapshot();
+            }
+            if (content.representation instanceof Representation) {
+              content.representation = content.representation.getMetadataSnapshot();
+            }
+            sendMessage({
+              type: WorkerMessageType.EncryptionDataEncountered,
+              contentId,
+              value: {
+                keyIds: value.keyIds,
+                values: value.values,
+                content,
+                type: value.type,
+              },
+            });
+          }
+        },
+
+        error(error: unknown) {
+          sendMessage({
+            type: WorkerMessageType.Error,
+            contentId,
+            value: formatErrorForSender(error),
+          });
+        },
+      };
+    }
+
+    function sendDiscontinuityUpdateIfNeeded(value: IStreamStatusPayload): void {
+      const { imminentDiscontinuity } = value;
+      let periodMap = lastSentDiscontinuitiesStore.get(value.period);
+      const sentObjInfo = periodMap?.get(value.bufferType);
+      if (sentObjInfo !== undefined) {
+        if (sentObjInfo.discontinuity === null) {
+          if (imminentDiscontinuity === null) {
+            return;
+          }
+        } else if (
+          imminentDiscontinuity !== null &&
+          sentObjInfo.discontinuity.start === imminentDiscontinuity.start &&
+          sentObjInfo.discontinuity.end === imminentDiscontinuity.end
+        ) {
           return;
         }
-      } else if (
-        imminentDiscontinuity !== null &&
-        sentObjInfo.discontinuity.start === imminentDiscontinuity.start &&
-        sentObjInfo.discontinuity.end === imminentDiscontinuity.end
-      ) {
-        return;
       }
-    }
 
-    if (periodMap === undefined) {
-      periodMap = new Map();
-      lastSentDiscontinuitiesStore.set(value.period, periodMap);
-    }
+      if (periodMap === undefined) {
+        periodMap = new Map();
+        lastSentDiscontinuitiesStore.set(value.period, periodMap);
+      }
 
-    const msgObj = {
-      periodId: value.period.id,
-      bufferType: value.bufferType,
-      discontinuity: value.imminentDiscontinuity,
-      position: value.position,
-    };
-    periodMap.set(value.bufferType, msgObj);
-    sendMessage({
-      type: WorkerMessageType.DiscontinuityUpdate,
-      contentId,
-      value: msgObj,
-    });
+      const msgObj = {
+        periodId: value.period.id,
+        bufferType: value.bufferType,
+        discontinuity: value.imminentDiscontinuity,
+        position: value.position,
+      };
+      periodMap.set(value.bufferType, msgObj);
+      sendMessage({
+        type: WorkerMessageType.DiscontinuityUpdate,
+        contentId,
+        value: msgObj,
+      });
+    }
   }
 
   function handleMediaSourceReload(payload: INeedsMediaSourceReloadPayload) {
@@ -906,6 +920,7 @@ function loadOrReloadPreparedContent(
     const newInitialTime = lastObservation.position.getWanted();
     if (currentLoadCanceller !== null) {
       currentLoadCanceller.cancel();
+      currentLoadCanceller = null;
     }
     log.debug(
       "WP: Reloading MediaSource",
@@ -913,20 +928,11 @@ function loadOrReloadPreparedContent(
       payload.minimumPosition,
       payload.maximumPosition,
     );
+    const contentId = contentPreparer.getCurrentContent()?.contentId;
     contentPreparer.reloadMediaSource(payload).then(
       () => {
-        log.info("WP: MediaSource Reloaded, loading content again");
-        loadOrReloadPreparedContent(
-          {
-            initialTime: newInitialTime,
-            drmSystemId: val.drmSystemId,
-            enableFastSwitching: val.enableFastSwitching,
-            onCodecSwitch: val.onCodecSwitch,
-          },
-          contentPreparer,
-          playbackObservationRef,
-          parentCancelSignal,
-        );
+        log.info("WP: MediaSource Reloaded, loading content again", newInitialTime);
+        startLoadingAt(newInitialTime);
       },
       (err: unknown) => {
         if (TaskCanceller.isCancellationError(err)) {

--- a/src/core/stream/orchestrator/get_time_ranges_for_content.ts
+++ b/src/core/stream/orchestrator/get_time_ranges_for_content.ts
@@ -20,8 +20,8 @@ import type {
   IPeriodMetadata,
   IRepresentationMetadata,
 } from "../../../manifest";
-import type { IRange } from "../../../utils/ranges";
-import type { SegmentSink } from "../../segment_sinks";
+import { insertInto, type IRange } from "../../../utils/ranges";
+import { SegmentSinkOperation, type SegmentSink } from "../../segment_sinks";
 
 /**
  * Returns the buffered ranges which hold the given content.
@@ -41,8 +41,10 @@ export default function getTimeRangesForContent(
   if (contents.length === 0) {
     return [];
   }
-  const accumulator: IRange[] = [];
+  const ranges: IRange[] = [];
   const inventory = segmentSink.getLastKnownInventory();
+
+  const pendingOperations = segmentSink.getPendingOperations();
 
   for (const chunk of inventory) {
     const hasContent = contents.some((content) => {
@@ -59,16 +61,36 @@ export default function getTimeRangesForContent(
         return [{ start: 0, end: Number.MAX_VALUE }];
       }
 
-      const previousLastElement = accumulator[accumulator.length - 1];
+      const previousLastElement = ranges[ranges.length - 1];
       if (
         previousLastElement !== undefined &&
         previousLastElement.end === bufferedStart
       ) {
         previousLastElement.end = bufferedEnd;
       } else {
-        accumulator.push({ start: bufferedStart, end: bufferedEnd });
+        ranges.push({ start: bufferedStart, end: bufferedEnd });
       }
     }
   }
-  return accumulator;
+
+  for (const operation of pendingOperations) {
+    if (operation.type !== SegmentSinkOperation.Push) {
+      continue;
+    }
+    const pushInfo = operation.value;
+    const hasContent = contents.some((content) => {
+      return (
+        pushInfo.inventoryInfos.period.id === content.period.id &&
+        pushInfo.inventoryInfos.adaptation.id === content.adaptation.id &&
+        pushInfo.inventoryInfos.representation.id === content.representation.id
+      );
+    });
+    if (hasContent) {
+      insertInto(ranges, {
+        start: pushInfo.inventoryInfos.start,
+        end: pushInfo.inventoryInfos.end,
+      });
+    }
+  }
+  return ranges;
 }

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -739,13 +739,13 @@ export interface INeedsMediaSourceReloadPayload {
    * `timeOffset` is before `minimumPosition`, then we will reload at
    * `minimumPosition`  instead.
    */
-  minimumPosition: number | undefined;
+  minimumPosition?: number | undefined;
   /**
    * If defined and if the new position obtained after relying on
    * `timeOffset` is after `maximumPosition`, then we will reload at
    * `maximumPosition`  instead.
    */
-  maximumPosition: number | undefined;
+  maximumPosition?: number | undefined;
 }
 
 /** Payload for the `lockedStream` callback. */

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -179,7 +179,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       contentId,
       contentDecryptor: null,
       manifest: null,
-      mainThreadMediaSource: null,
+      mediaSourceInfo: null,
       rebufferingController: null,
       streamEventsEmitter: null,
       initialTime: undefined,
@@ -382,7 +382,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         mediaElement,
         lastContentProtection,
         mediaSourceStatus,
-        () => reloadMediaSource(0, undefined, undefined),
+        () => triggerMediaSourceReload(0, undefined, undefined),
         this._initCanceller.signal,
       );
     const contentInfo = this._currentContentInfo;
@@ -415,6 +415,44 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       },
       { emitCurrentValue: true, clearSignal: this._initCanceller.signal },
     );
+
+    /**
+     * Callback allowing to signal the core that it should reload the `MediaSource` now.
+     * @param {number} deltaPosition - Position you want to seek to after
+     * reloading, as a delta in seconds from the last polled playing position.
+     * @param {number|undefined} minimumPosition - If set, minimum time bound
+     * in seconds after `deltaPosition` has been applied.
+     * @param {number|undefined} maximumPosition - If set, minimum time bound
+     * in seconds after `deltaPosition` has been applied.
+     */
+    const triggerMediaSourceReload = (
+      deltaPosition: number,
+      minimumPosition: number | undefined,
+      maximumPosition: number | undefined,
+    ): void => {
+      const reloadingContentInfo = this._currentContentInfo;
+      if (reloadingContentInfo === null) {
+        log.warn("MTCI: Asked to reload when no content is loaded.");
+        return;
+      }
+      if (
+        reloadingContentInfo === null ||
+        reloadingContentInfo.mediaSourceInfo === null
+      ) {
+        log.warn("MTCI: Asked to reload when no MediaSource is active.");
+        return;
+      }
+
+      const mediaSourceId =
+        reloadingContentInfo.mediaSourceInfo.type === "main"
+          ? reloadingContentInfo.mediaSourceInfo.mediaSource.id
+          : reloadingContentInfo.mediaSourceInfo.mediaSourceId;
+      sendMessage(this._settings.worker, {
+        type: MainThreadMessageType.TriggerMediaSourceReload,
+        mediaSourceId,
+        value: { minimumPosition, maximumPosition, timeOffset: deltaPosition },
+      });
+    };
 
     /**
      * Callback allowing to reload the current content.
@@ -467,6 +505,16 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           if (this._currentContentInfo?.contentId !== msgData.contentId) {
             return;
           }
+          if (this._currentContentInfo !== null) {
+            if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
+              this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+            }
+            this._currentContentInfo.mediaSourceInfo = {
+              type: "core",
+              mediaSourceId: msgData.mediaSourceId,
+            };
+          }
+
           const mediaSourceLink = msgData.value;
           mediaSourceStatus.onUpdate(
             (currStatus, stopListening) => {
@@ -522,12 +570,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.AddSourceBuffer:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             mediaSource.addSourceBuffer(
               msgData.value.sourceBufferType,
               msgData.value.codec,
@@ -538,12 +587,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.SourceBufferAppend:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             const sourceBuffer = arrayFind(
               mediaSource.sourceBuffers,
               (s) => s.type === msgData.sourceBufferType,
@@ -580,12 +630,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.SourceBufferRemove:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             const sourceBuffer = arrayFind(
               mediaSource.sourceBuffers,
               (s) => s.type === msgData.sourceBufferType,
@@ -622,12 +673,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.AbortSourceBuffer:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             const sourceBuffer = arrayFind(
               mediaSource.sourceBuffers,
               (s) => s.type === msgData.sourceBufferType,
@@ -642,12 +694,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.UpdateMediaSourceDuration:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             if (mediaSource?.id !== msgData.mediaSourceId) {
               return;
             }
@@ -658,12 +711,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.InterruptMediaSourceDurationUpdate:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            const mediaSource = this._currentContentInfo.mainThreadMediaSource;
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
             if (mediaSource?.id !== msgData.mediaSourceId) {
               return;
             }
@@ -674,36 +728,42 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         case WorkerMessageType.EndOfStream:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            this._currentContentInfo.mainThreadMediaSource.maintainEndOfStream();
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
+            mediaSource.maintainEndOfStream();
           }
           break;
 
         case WorkerMessageType.InterruptEndOfStream:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            this._currentContentInfo.mainThreadMediaSource.stopEndOfStream();
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
+            mediaSource.stopEndOfStream();
           }
           break;
 
         case WorkerMessageType.DisposeMediaSource:
           {
             if (
-              this._currentContentInfo?.mainThreadMediaSource?.id !==
-              msgData.mediaSourceId
+              this._currentContentInfo?.mediaSourceInfo?.type !== "main" ||
+              this._currentContentInfo.mediaSourceInfo.mediaSource.id !==
+                msgData.mediaSourceId
             ) {
               return;
             }
-            this._currentContentInfo.mainThreadMediaSource.dispose();
+            const { mediaSource } = this._currentContentInfo.mediaSourceInfo;
+            mediaSource.dispose();
           }
           break;
 
@@ -1131,7 +1191,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
 
             const keySystem = getKeySystemConfiguration(mediaElement);
             if (shouldReloadMediaSourceOnDecipherabilityUpdate(keySystem?.[0])) {
-              reloadMediaSource(0, undefined, undefined);
+              triggerMediaSourceReload(0, undefined, undefined);
             } else {
               const lastObservation = playbackObserver.getReference().getValue();
 
@@ -1213,7 +1273,9 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
   public dispose(): void {
     this._initCanceller.cancel();
     if (this._currentContentInfo !== null) {
-      this._currentContentInfo.mainThreadMediaSource?.dispose();
+      if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
+        this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+      }
       this._currentContentInfo = null;
     }
   }
@@ -1541,7 +1603,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       return null;
     }
 
-    const { manifest, mainThreadMediaSource: mediaSource } = this._currentContentInfo;
+    const { manifest, mediaSourceInfo } = this._currentContentInfo;
     const { speed } = this._settings;
     const { initialTime, autoPlay, mediaElement, textDisplayer, playbackObserver } =
       parameters;
@@ -1566,7 +1628,8 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         autoPlay,
         initialPlayPerformed,
         manifest,
-        mediaSource,
+        mediaSource:
+          mediaSourceInfo?.type === "main" ? mediaSourceInfo.mediaSource : null,
         speed,
         textDisplayer,
       },
@@ -1842,7 +1905,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             if (currStatus === MediaSourceInitializationStatus.AttachNow) {
               stopListening();
               const mediaSource = new MainMediaSourceInterface(mediaSourceId);
-              this._currentContentInfo.mainThreadMediaSource = mediaSource;
+              if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
+                this._currentContentInfo.mediaSourceInfo.mediaSource.dispose();
+              }
+              this._currentContentInfo.mediaSourceInfo = {
+                type: "main",
+                mediaSource,
+              };
               mediaSource.addEventListener("mediaSourceOpen", () => {
                 sendMessage(worker, {
                   type: MainThreadMessageType.MediaSourceReadyStateChange,
@@ -1915,7 +1984,17 @@ export interface IMultiThreadContentInitializerContentInfos {
    *
    * `null` if no MediaSource is currently created for the content.
    */
-  mainThreadMediaSource: MainMediaSourceInterface | null;
+  mediaSourceInfo:
+    | {
+        type: "main";
+        mediaSource: MainMediaSourceInterface;
+      }
+    | {
+        type: "core";
+        mediaSourceId: string;
+      }
+    | null;
+
   /**
    * Current `RebufferingController` linked to the content, allowing to
    * detect and handle rebuffering situations.

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -382,7 +382,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
         mediaElement,
         lastContentProtection,
         mediaSourceStatus,
-        () => triggerMediaSourceReload(0, undefined, undefined),
+        () => notifyAndStartMediaSourceReload(0, undefined, undefined),
         this._initCanceller.signal,
       );
     const contentInfo = this._currentContentInfo;
@@ -417,7 +417,8 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     );
 
     /**
-     * Callback allowing to signal the core that it should reload the `MediaSource` now.
+     * Reset directly (synchronously) the current `MediaSource` and signal to
+     * the core that we did so.
      * @param {number} deltaPosition - Position you want to seek to after
      * reloading, as a delta in seconds from the last polled playing position.
      * @param {number|undefined} minimumPosition - If set, minimum time bound
@@ -425,7 +426,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
      * @param {number|undefined} maximumPosition - If set, minimum time bound
      * in seconds after `deltaPosition` has been applied.
      */
-    const triggerMediaSourceReload = (
+    const notifyAndStartMediaSourceReload = (
       deltaPosition: number,
       minimumPosition: number | undefined,
       maximumPosition: number | undefined,
@@ -448,14 +449,18 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           ? reloadingContentInfo.mediaSourceInfo.mediaSource.id
           : reloadingContentInfo.mediaSourceInfo.mediaSourceId;
       sendMessage(this._settings.worker, {
-        type: MainThreadMessageType.TriggerMediaSourceReload,
+        type: MainThreadMessageType.MediaSourceReload,
         mediaSourceId,
-        value: { minimumPosition, maximumPosition, timeOffset: deltaPosition },
+        value: null,
       });
+      reloadMediaSource(deltaPosition, minimumPosition, maximumPosition);
     };
 
     /**
-     * Callback allowing to reload the current content.
+     * Reset directly (synchronously) the current `MediaSource`.
+     *
+     * It is assumed that `core` already knows about this action. If not, call
+     * `notifyAndStartMediaSourceReload` instead.
      * @param {number} deltaPosition - Position you want to seek to after
      * reloading, as a delta in seconds from the last polled playing position.
      * @param {number|undefined} minimumPosition - If set, minimum time bound
@@ -1171,10 +1176,19 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
 
         case WorkerMessageType.ReloadingMediaSource:
           {
-            if (this._currentContentInfo?.contentId !== msgData.contentId) {
+            if (
+              this._currentContentInfo === null ||
+              this._currentContentInfo.mediaSourceInfo === null
+            ) {
               return;
             }
-
+            const mediaSourceId =
+              this._currentContentInfo.mediaSourceInfo.type === "main"
+                ? this._currentContentInfo.mediaSourceInfo.mediaSource.id
+                : this._currentContentInfo.mediaSourceInfo.mediaSourceId;
+            if (mediaSourceId !== msgData.mediaSourceId) {
+              return;
+            }
             reloadMediaSource(
               msgData.value.timeOffset,
               msgData.value.minimumPosition,
@@ -1191,7 +1205,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
 
             const keySystem = getKeySystemConfiguration(mediaElement);
             if (shouldReloadMediaSourceOnDecipherabilityUpdate(keySystem?.[0])) {
-              triggerMediaSourceReload(0, undefined, undefined);
+              notifyAndStartMediaSourceReload(0, undefined, undefined);
             } else {
               const lastObservation = playbackObserver.getReference().getValue();
 

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -151,7 +151,7 @@ export default function performInitialSeekAndPlay(
               waitForSeekable();
             }
           },
-          { includeLastObservation: true, clearSignal: cancelSignal },
+          { includeLastObservation: false, clearSignal: cancelSignal },
         );
       }
 
@@ -197,7 +197,7 @@ export default function performInitialSeekAndPlay(
             }
             waitForPlayable();
           },
-          { includeLastObservation: true, clearSignal: cancelSignal },
+          { includeLastObservation: false, clearSignal: cancelSignal },
         );
       }
 

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -439,15 +439,16 @@ export interface ISerializedPlaybackObservation {
   fullyLoaded: boolean;
 }
 
+/**
+ * Sent when the main thread had to "reload" the media source.
+ * The worker should understand that this MediaSource won't be used anymore.
+ */
 export interface ITriggerMediaSourceReloadMainMessage {
-  type: MainThreadMessageType.TriggerMediaSourceReload;
+  type: MainThreadMessageType.MediaSourceReload;
   /** Identify the MediaSource concerned by this message. */
   mediaSourceId: string;
-  value: {
-    timeOffset: number;
-    minimumPosition?: number | undefined;
-    maximumPosition?: number | undefined;
-  };
+  /** No message is necessary. */
+  value: null;
 }
 
 /**
@@ -600,7 +601,7 @@ export const enum MainThreadMessageType {
   PrepareContent = "prepare",
   ReferenceUpdate = "ref-update",
   RepresentationUpdate = "rep-update",
-  TriggerMediaSourceReload = "trig-ms-reload",
+  MediaSourceReload = "ms-reload",
   SourceBufferError = "sb-error",
   SourceBufferSuccess = "sb-success",
   StartPreparedContent = "start",
@@ -853,7 +854,8 @@ export interface IUpdatePlaybackRateWorkerMessage {
 
 export interface IReloadingMediaSourceWorkerMessage {
   type: WorkerMessageType.ReloadingMediaSource;
-  contentId: string;
+  /** Identify the MediaSource concerned by this message. */
+  mediaSourceId: string;
   value: {
     timeOffset: number;
     minimumPosition?: number | undefined;

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -439,6 +439,17 @@ export interface ISerializedPlaybackObservation {
   fullyLoaded: boolean;
 }
 
+export interface ITriggerMediaSourceReloadMainMessage {
+  type: MainThreadMessageType.TriggerMediaSourceReload;
+  /** Identify the MediaSource concerned by this message. */
+  mediaSourceId: string;
+  value: {
+    timeOffset: number;
+    minimumPosition?: number | undefined;
+    maximumPosition?: number | undefined;
+  };
+}
+
 /**
  * Sent when the SourceBuffer linked to the given `mediaSourceId` and
  * `SourceBufferType`, running on the main thread, succeeded to perform the last
@@ -589,6 +600,7 @@ export const enum MainThreadMessageType {
   PrepareContent = "prepare",
   ReferenceUpdate = "ref-update",
   RepresentationUpdate = "rep-update",
+  TriggerMediaSourceReload = "trig-ms-reload",
   SourceBufferError = "sb-error",
   SourceBufferSuccess = "sb-success",
   StartPreparedContent = "start",
@@ -610,6 +622,7 @@ export type IMainThreadMessage =
   | IPlaybackObservationMessage
   | IDecipherabilityStatusChangedMessage
   | IUpdateContentUrlsMessage
+  | ITriggerMediaSourceReloadMainMessage
   | ISourceBufferErrorMainMessage
   | ISourceBufferOperationSuccessMainMessage
   | ITrackUpdateMessage
@@ -691,7 +704,7 @@ export interface IWarningWorkerMessage {
 export interface IAttachMediaSourceWorkerMessage {
   type: WorkerMessageType.AttachMediaSource;
   contentId: string | undefined;
-  mediaSourceId: string | undefined;
+  mediaSourceId: string;
   value: IAttachMediaSourceWorkerMessagePayload;
 }
 


### PR DESCRIPTION
While rebasing #1645 on the recent `dev` base now with many DRM integration tests, I noticed several tests failing.

After inspection, I think many of those have roots in problematic logic even on `dev`:

1. beee1b8f5e1fcac6ca3a4f1e5959b21cca320d3a: When a `keystatuseschange` event is received  from a `MediaKeySession`, we previously looked at the content of the `SourceBuffer` to know if it is necessary to reload or not. Now we also consider pending SourceBuffer operations, which may not have yet been pushed.

    The drawback could be some false positives where we would reload due to the fact that undecipherable data is planned to be pushed even when we'll abort those operations anyway.
    
    The advantage is no (or close to none) false negatives where we end up with undecipherable data in the buffer (that the `FreezeResolver` end-up detecting when buffering on it  - to then reload, just much later).
    
2. 459ca30f8e95b1176a494ae2ccc0dfdc1787277a: Previously a "MediaSource reloading" logic could start on `/core/` (e.g. codec switch, freeze resolving etc.) or on `/main_thread/` (e.g. issues linked to DRM). I found this very hard to think about and was not even sure how it all worked when encountering a failing test...

     I simplified the architecture by now always go through `src/core` to indicate the content should be reloaded, adding the `TriggerMediaSourceReload` message if the issue was initially seen on `main_thread` (going `main_thread -> core`).

5. 5c9d8081553afe97c41b88f86b059c00c819096c: Is a supplementary commit cleaning-up the implem of the previous point. I isolated this one in its own commit as it has a huge diff due to an indentation change.

6.  31e47f913ecac59307d333c81dbe2ee93ab776cc: Wait for at least one playback observation to be emitted in `perform_initial_seek_and_play`. The previous code relied potentially on the last emitted observation but this one could be stale (e.g. from before a RELOADING step).

Note that I did not detect any bugs currently with those beside on the future #1645 work, but looking at the code, I still think those were problematic logic previously.