### PR TITLE
Fix persistent session loading when content has no key id

### DIFF
--- a/src/main_thread/decrypt/utils/persistent_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/persistent_sessions_store.ts
@@ -255,7 +255,7 @@ export default class PersistentSessionsStore {
       if (entry.initDataType === initData.type) {
         switch (entry.version) {
           case 4:
-            if (initData.keyIds !== undefined) {
+            if (Array.isArray(initData.keyIds) && initData.keyIds.length > 0) {
               const foundCompatible = initData.keyIds.every((keyId) => {
                 const keyIdB64 = bytesToBase64(keyId);
                 for (const entryKid of entry.keyIds) {


### PR DESCRIPTION
We saw issues with some contents from a partner using persistent licenses.

After investigations, I noticed that the stored metadata linked to persisted licences could be corrupted if key ids are not known in advance through the Manifest nor through segments.

Thankfully this is a very rare occurence, itself happening also only in the rare scenario where persisted sessions are used - but we did actually saw it with some contents from a partner (an italian one).

---

The root cause was due to a simple JS gotcha: the result of an Array's `every` method (which returns `true` if all elements from an array follow the given predicate) when the array it is applied to is empty.

Turns out it returns `true` (it even kind of makes sense when you think hard about it :p!).

Yet we were using it in the following type of condition:
```js
if (currentKeyIds !== undefined) {
  const isCurrentPersistentLicenseCompatible = currentKeyIds.every(keyId => {
    return storedEntry.keyIds.includes(keyId);
  });
}
```

So here, if `currentKeyIds` is defined but empty, it would return `true` for any `storedEntry`, even ones linked to a license that do not apply to the current content.

Note that we have a valid fallback in cases where keyIds are unknown, which is to check whole PSSH instead.
Here we should go through this strategy instead - but we didn't consider the "empty keyIds array" as equivalent to "no known key id". Now we do.

Also a more efficient solution could also be to tell those partners to just advertise their key id like everybody else - which also leads to more performance-linked tricks elsewhere. Though we already tried that with no success :/