### PR TITLE
Fix running of the Edge browser on the CI.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript": "5.8.3",
         "typescript-eslint": "^8.35.0",
         "vitest": "3.2.4",
-        "webdriverio": "9.16.2"
+        "webdriverio": "^9.18.1"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
-      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
+      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1058,7 +1058,7 @@
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
         "semver": "^7.7.2",
-        "tar-fs": "^3.0.8",
+        "tar-fs": "^3.1.0",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -1892,15 +1892,15 @@
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.16.2.tgz",
-      "integrity": "sha512-a7zDSNzpGgkb6mWrg9GWPmvh/sZFzaf86/iBjCv+n2DTY0+8v8NLruRQmWuCaQAlLVhM3XAqmB+fWLqxDhdvOA==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.18.0.tgz",
+      "integrity": "sha512-fN+Z7SkKjb0u3UUMSxMN4d+CCZQKZhm/tx3eX7Rv+3T78LtpOjlesBYQ7Ax3tQ3tp8hgEo+CoOXU0jHEYubFrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "9.16.2",
+        "@wdio/logger": "9.18.0",
         "@wdio/types": "9.16.2",
-        "@wdio/utils": "9.16.2",
+        "@wdio/utils": "9.18.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
         "import-meta-resolve": "^4.0.0"
@@ -1910,15 +1910,16 @@
       }
     },
     "node_modules/@wdio/logger": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.16.2.tgz",
-      "integrity": "sha512-6A1eVpNPToWupLIo8CXStth4HJGTfxKsAiKtwE0xQFKyDM8uPTm3YO3Nf15vCSHbmsncbYVEo7QrUwRUEB4YUg==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
       },
       "engines": {
@@ -1972,22 +1973,23 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.16.2.tgz",
-      "integrity": "sha512-bsRdEUXUTYvznXH/Z+p6HDzHSjMI6I6bnu8WXWTeDDDyqybWK5D8cbZvs8A/kMmGXoz1GZkSBHxy4Z5NTg8OQg==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.18.0.tgz",
+      "integrity": "sha512-M+QH05FUw25aFXZfjb+V16ydKoURgV61zeZrMjQdW2aAiks3F5iiI9pgqYT5kr1kHZcMy8gawGqQQ+RVfKYscQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.16.2",
+        "@wdio/logger": "9.18.0",
         "@wdio/types": "9.16.2",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.1",
+        "edgedriver": "^6.1.2",
         "geckodriver": "^5.0.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
@@ -1997,9 +1999,9 @@
       }
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.7.62",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.62.tgz",
-      "integrity": "sha512-OaLvZ8j4gCkLn048ypkZu29KX30r8/OfFF2w4Jo5WXFr+J04J+lzJ5TKZBVgFXhlvSkqNFQdfnY1Q8TMTCyBVA==",
+      "version": "2.7.64",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.64.tgz",
+      "integrity": "sha512-x6BDiDTKeZWbeHgHlVzV1sqReGuz4b1R4cVStUDua8OSq4bRreZeiJKPFFlvJs67FvCnetq33aYb/XH73EQhdA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2401,9 +2403,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
-      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -3318,9 +3320,9 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.1.tgz",
-      "integrity": "sha512-/dM/PoBf22Xg3yypMWkmRQrBKEnSyNaZ7wHGCT9+qqT14izwtFT+QvdR89rjNkMfXwW+bSFoqOfbcvM+2Cyc7w==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.2.tgz",
+      "integrity": "sha512-UvFqd/IR81iPyWMcxXbUNi+xKWR7JjfoHjfuwjqsj9UHQKn80RpQmS0jf+U25IPi+gKVPcpOSKm0XkqgGMq4zQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3329,7 +3331,7 @@
         "@zip.js/zip.js": "^2.7.53",
         "decamelize": "^6.0.0",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^4.5.0",
+        "fast-xml-parser": "^5.0.8",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
         "node-fetch": "^3.3.2",
@@ -4294,9 +4296,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "dev": true,
       "funding": [
         {
@@ -4306,7 +4308,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4669,9 +4671,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4933,9 +4935,9 @@
       "license": "MIT"
     },
     "node_modules/htmlfy": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.6.7.tgz",
-      "integrity": "sha512-r8hRd+oIM10lufovN+zr3VKPTYEIvIwqXGucidh2XQufmiw6sbUXFUFjWlfjo3AnefIDTyzykVzQ8IUVuT1peQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
+      "integrity": "sha512-xWROBw9+MEGwxpotll0h672KCaLrKKiCYzsyN8ZgL9cQbVumFnyvsk2JqiB9ELAV1GLj1GG/jxZUjV9OZZi/yQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6100,6 +6102,13 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -7054,6 +7063,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7245,6 +7264,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -7286,29 +7325,29 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
-      "integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^2.12.2"
+        "type-fest": "^4.31.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=12.20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7516,9 +7555,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.5.tgz",
-      "integrity": "sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.6.tgz",
+      "integrity": "sha512-pe4Y2yzru68lXCb38aAqRf5gvN8YdjP1lok5o0J7BOHljkyCGKVz7H3vpVIXKD27rj2giOJ7DwVyk/GWrPHDWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7916,9 +7955,9 @@
       "license": "MIT"
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "dev": true,
       "funding": [
         {
@@ -8661,21 +8700,22 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.16.2.tgz",
-      "integrity": "sha512-T7QKqD+N0hfvrxq/am5wqdOuyOy7F2tGS7X2f/7jyhrxSPG6Q0cNkSt4gCwla+q3nDMivCP0QIPc7mAVSx5AYQ==",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.18.0.tgz",
+      "integrity": "sha512-07lC4FLj45lHJo0FvLjUp5qkjzEGWJWKGsxLoe9rQ2Fg88iYsqgr9JfSj8qxHpazBaBd+77+ZtpmMZ2X2D1Zuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.16.2",
-        "@wdio/logger": "9.16.2",
+        "@wdio/config": "9.18.0",
+        "@wdio/logger": "9.18.0",
         "@wdio/protocols": "9.16.2",
         "@wdio/types": "9.16.2",
-        "@wdio/utils": "9.16.2",
+        "@wdio/utils": "9.18.0",
         "deepmerge-ts": "^7.0.3",
-        "undici": "^6.20.1",
+        "https-proxy-agent": "^7.0.6",
+        "undici": "^6.21.3",
         "ws": "^8.8.0"
       },
       "engines": {
@@ -8683,27 +8723,27 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.16.2",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.16.2.tgz",
-      "integrity": "sha512-aRcfBZyY+OFqz2DI0ZYmMahGlH3h/clAXXOQSFN5QfrHG4Cjuo5xy3lq4tVfszjEJ813+wwC4HJLbgDmMrPXkA==",
+      "version": "9.18.1",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.18.1.tgz",
+      "integrity": "sha512-b9aVtmi5+BUkae+SfJlajjKcVWqhMP+HdxpW2B3MlAtvYG2MRpwXkR34yvRIh5IYVMnR5tyUi5knDlJUGOPHPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.16.2",
-        "@wdio/logger": "9.16.2",
+        "@wdio/config": "9.18.0",
+        "@wdio/logger": "9.18.0",
         "@wdio/protocols": "9.16.2",
         "@wdio/repl": "9.16.2",
         "@wdio/types": "9.16.2",
-        "@wdio/utils": "9.16.2",
+        "@wdio/utils": "9.18.0",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
         "grapheme-splitter": "^1.0.4",
-        "htmlfy": "^0.6.0",
+        "htmlfy": "^0.8.1",
         "is-plain-obj": "^4.1.0",
         "jszip": "^3.10.1",
         "lodash.clonedeep": "^4.5.0",
@@ -8711,9 +8751,9 @@
         "query-selector-shadow-dom": "^1.0.1",
         "resq": "^1.11.0",
         "rgb2hex": "0.2.5",
-        "serialize-error": "^11.0.3",
+        "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.16.2"
+        "webdriver": "9.18.0"
       },
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "typescript": "5.8.3",
     "typescript-eslint": "^8.35.0",
     "vitest": "3.2.4",
-    "webdriverio": "9.16.2"
+    "webdriverio": "^9.18.1"
   },
   "scripts-list": {
     " INFO ": "---- This field is read by the `list` npm script and allows to guide you through the RxPlayer's npm scripts ----",


### PR DESCRIPTION
The integration tests fail in the CI since a few days (first seen wednesday) when it's turn to run the Edge browser.

As the error looks like that:
```
2025-07-18T09:33:55.879Z ERROR edgedriver: Failed to download Edgedriver: request to https://msedgedriver.azureedge.net/138.0.3351.77/edgedriver_linux64.zip failed, reason: getaddrinfo ENOTFOUND msedgedriver.azureedge.net, trying alternative download URL...
2025-07-18T09:33:56.681Z ERROR edgedriver: Failed to download Edgedriver: request to https://msedgedriver.azureedge.net/138.0.3351.77/edgedriver_linux64.zip failed, reason: getaddrinfo ENOTFOUND msedgedriver.azureedge.net, trying alternative download URL...
```

It seems to be due to some stale URL when retrieving "edgedriver", so I guess something to do with webdriverio (the dependency we use to be able to run our tests on actual browser implems) and its dependencies. _Note: we don't even need what edgedriver [seems to be about](https://learn.microsoft.com/en-us/microsoft-edge/webdriver/?tabs=c-sharp), we just want to run some static page with JS in various browsers. For now, none of our tests interact with the browser beside running some JS on it._

It seems to be linked to the https://github.com/webdriverio-community/node-edgedriver/issues/500 issue, which has been fixed here https://github.com/webdriverio-community/node-edgedriver/pull/501 very recently.

That `edgedriver` is a transitive dependency of `webdriverio`:
```
└─┬ webdriverio@9.18.1
  └─┬ @wdio/utils@9.18.0
    └── edgedriver@6.1.2
```

Here I just updated webdriverio as a whole anyway.