### PR TITLE
feat: add disableAudioTrack API

### DIFF
--- a/demo/scripts/controllers/knobs/AudioTrack.tsx
+++ b/demo/scripts/controllers/knobs/AudioTrack.tsx
@@ -34,27 +34,33 @@ function AudioTrackKnob({
       return [["Not available"], 0];
     }
     return [
-      availableAudioTracks.map((audioTrack) => {
-        return (
-          translateAudioTrackCode(audioTrack.normalized) +
-          (audioTrack.audioDescription ? " " + AUDIO_DESCRIPTION_ICON : "")
-        );
-      }),
+      ["no audio track"].concat(
+        availableAudioTracks.map((audioTrack) => {
+          return (
+            translateAudioTrackCode(audioTrack.normalized) +
+            (audioTrack.audioDescription ? " " + AUDIO_DESCRIPTION_ICON : "")
+          );
+        }),
+      ),
 
       currentAudioTrack
-        ? Math.max(findAudioTrackIndex(currentAudioTrack, availableAudioTracks), 0)
+        ? 1 + Math.max(findAudioTrackIndex(currentAudioTrack, availableAudioTracks), 0)
         : 0,
     ];
   }, [availableAudioTracks, currentAudioTrack]);
 
   const onAudioTrackChange = React.useCallback(
     ({ index }: { index: number }) => {
-      const track = availableAudioTracks[index];
-      if (track !== undefined) {
-        player.actions.setAudioTrack(track);
+      if (index > 0) {
+        const track = availableAudioTracks[index - 1];
+        if (track !== undefined) {
+          player.actions.setAudioTrack(track);
+        } else {
+          // eslint-disable-next-line no-console
+          console.error("Error: audio track not found");
+        }
       } else {
-        // eslint-disable-next-line no-console
-        console.error("Error: audio track not found");
+        player.actions.disableAudioTrack();
       }
     },
     [availableAudioTracks, player],
@@ -62,10 +68,10 @@ function AudioTrackKnob({
 
   return (
     <Knob
-      name="Audio AudioTrack"
+      name="Audio Track"
       ariaLabel="Update the audio track"
       className={className}
-      disabled={availableAudioTracks.length < 2}
+      disabled={availableAudioTracks.length < 1}
       onChange={onAudioTrackChange}
       options={options}
       selected={{ index: selectedIndex, value: undefined }}

--- a/demo/scripts/modules/player/index.ts
+++ b/demo/scripts/modules/player/index.ts
@@ -419,6 +419,10 @@ const PlayerModule = declareModule(
         player.disableVideoTrack();
       },
 
+      disableAudioTrack() {
+        player.disableAudioTrack();
+      },
+
       setTextTrack(track: ITextTrack) {
         player.setTextTrack(track.id as string);
       },

--- a/doc/Getting_Started/Tutorials/Selecting_a_Track.md
+++ b/doc/Getting_Started/Tutorials/Selecting_a_Track.md
@@ -437,11 +437,12 @@ subtitles or closed captions appearing on the screen.
 You could also want to disable the video track, which is a trick often used to reduce the
 network bandwidth used by a content.
 
-You can disable respectively the current text track and the current video track by calling
-those methods:
+You can disable respectively the current text track, the current video track and the
+current audio track by calling those methods:
 
 - [`disableTextTrack`](../../api/Track_Selection/disableTextTrack.md)
 - [`disableVideoTrack`](../../api/Track_Selection/disableVideoTrack.md)
+- [`disableAudioTrack`](../../api/Track_Selection/disableAudioTrack.md)
 
 However, like for selecting a track, this only concerns the current content being played.
 When playing a new content or even when just switching to another part of the content with

--- a/doc/api/Player_Events.md
+++ b/doc/api/Player_Events.md
@@ -797,8 +797,8 @@ The payload for this event is an object with the following properties:
     update it.
 
     This event is the direct consequence of calling `setAudioTrack`, `setTextTrack`,
-    `setVideoTrack`, `disableTextTrack` or `disableVideoTrack`, so it corresponds to track
-    updates you should already be aware of.
+    `setVideoTrack`, `disableTextTrack`, `disableVideoTrack` or `disableAudioTrack`, so it
+    corresponds to track updates you should already be aware of.
 
   - `"trickmode-enabled"`: The track is being updated because the application wanted to
     enable video trickmode tracks (usually by setting the `preferTrickModeTracks` option

--- a/doc/api/Track_Selection/disableAudioTrack.md
+++ b/doc/api/Track_Selection/disableAudioTrack.md
@@ -1,0 +1,37 @@
+# disableAudioTrack
+
+## Description
+
+Disable the current audio track, if one.
+
+Might enter in `RELOADING` state for a short period after calling this API.
+
+You can also disable the audio track for another Period by calling `disableAudioTrack`
+with the corresponding Period's id in argument. Such id can be obtained through the
+`getAvailablePeriods` method, the `newAvailablePeriods` event or the `periodChange` event.
+
+```js
+// example: disabling the audio track for all Periods
+const periods = rxPlayer.getAvailablePeriods();
+for (const period of periods) {
+  rxPlayer.disableAudioTrack(period.id);
+}
+```
+
+Note that disabling the audio track if there's no video track currently selected currently
+will lead to a [`NO_AUDIO_VIDEO_TRACKS` player error](../Player_Errors.md).
+
+## Syntax
+
+```js
+// Disable the current audio track
+player.disableAudioTrack();
+
+// Disable the audio track for a specific Period
+player.disableAudioTrack(periodId);
+```
+
+- **arguments**:
+  1.  _periodId_ `string|undefined`: The `id` of the Period for which you want to disable
+      the audio track. If not defined, the audio track of the currently-playing Period
+      will be disabled.

--- a/doc/api/Track_Selection/disableVideoTrack.md
+++ b/doc/api/Track_Selection/disableVideoTrack.md
@@ -18,6 +18,9 @@ for (const period of periods) {
 }
 ```
 
+Note that disabling the video track if there's no audio track currently selected currently
+will lead to a [`NO_AUDIO_VIDEO_TRACKS` player error](../Player_Errors.md).
+
 <div class="warning">
 This option may have no effect in <i>DirectFile</i> mode (see <a
 href="../Loading_a_Content.md#transport">loadVideo options</a>).

--- a/doc/reference/API_Reference.md
+++ b/doc/reference/API_Reference.md
@@ -288,6 +288,9 @@ events and so on.
 - [`disableVideoTrack`](../api/Track_Selection/disableVideoTrack.md): Disable the current
   video track.
 
+- [`disableAudioTrack`](../api/Track_Selection/disableAudioTrack.md): Disable the current
+  audio track.
+
 - [`getVideoRepresentation`](../api/Representation_Selection/getVideoRepresentation.md):
   Returns the currently-loading video Representation.
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2403,6 +2403,23 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     );
   }
 
+  /**
+   * Disable audio track for the current content.
+   * @param {string|undefined} [periodId]
+   */
+  disableAudioTrack(periodId?: string | undefined): void {
+    if (this._priv_contentInfos === null) {
+      return;
+    }
+    const { isDirectFile, mediaElementTracksStore } = this._priv_contentInfos;
+    if (isDirectFile && mediaElementTracksStore !== null) {
+      return mediaElementTracksStore.disableAudioTrack();
+    }
+    return this._priv_callTracksStoreGetterSetter(periodId, undefined, (tcm, periodRef) =>
+      tcm.disableTrack(periodRef, "audio"),
+    );
+  }
+
   lockAudioRepresentations(arg: string[] | ILockedAudioRepresentationsSettings): void {
     if (this._priv_contentInfos === null) {
       throw new Error("No content loaded");

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2708,6 +2708,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       onTracksNotPlayableForType: {
         audio: contentInfos.onAudioTracksNotPlayable,
         video: contentInfos.onVideoTracksNotPlayable,
+        text: "continue",
       },
     });
     contentInfos.tracksStore = tracksStore;

--- a/src/main_thread/tracks_store/media_element_tracks_store.ts
+++ b/src/main_thread/tracks_store/media_element_tracks_store.ts
@@ -212,9 +212,10 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
    * MediaElementTracksStore's API(s).
    * Allows to "lock on" a track, to be sure that choice will be kept even
    * through audio track list updates, as long as it is still available.
+   * `null` if the audio track was disabled.
    * `undefined` if the audio track was not manually set.
    */
-  private _audioTrackLockedOn: ICompatAudioTrack | undefined;
+  private _audioTrackLockedOn: ICompatAudioTrack | undefined | null;
 
   /**
    * Last text track manually set active through the corresponding
@@ -320,6 +321,14 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
   public disableVideoTrack(): void {
     disableVideoTracks(this._videoTracks);
     this._videoTrackLockedOn = null;
+  }
+
+  /**
+   * Disable the currently-active audio track, if one.
+   */
+  public disableAudioTrack(): void {
+    disableAudioTracks(this._audioTracks);
+    this._audioTrackLockedOn = null;
   }
 
   /**
@@ -807,5 +816,17 @@ function disableVideoTracks(videoTracks: Array<{ nativeTrack: ICompatVideoTrack 
   for (let i = 0; i < videoTracks.length; i++) {
     const { nativeTrack } = videoTracks[i];
     nativeTrack.selected = false;
+  }
+}
+
+/**
+ * Disable all audio track elements in the given array from showing.
+ * Note that browser need to support that use case, which they often do not.
+ * @param {Array.<Object>} audioTracks
+ */
+function disableAudioTracks(audioTracks: Array<{ nativeTrack: ICompatAudioTrack }>) {
+  for (let i = 0; i < audioTracks.length; i++) {
+    const { nativeTrack } = audioTracks[i];
+    nativeTrack.enabled = false;
   }
 }

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -107,6 +107,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   private onTracksNotPlayableForType: {
     audio: "error" | "continue";
     video: "error" | "continue";
+    text: "error" | "continue";
   };
 
   constructor(args: {
@@ -115,6 +116,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     onTracksNotPlayableForType: {
       audio: "error" | "continue";
       video: "error" | "continue";
+      text: "error" | "continue";
     };
   }) {
     super();
@@ -491,7 +493,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     periodObj[bufferType].dispatcher = dispatcher;
 
     dispatcher.addEventListener("noPlayableRepresentation", () => {
-      this.onNoPlayableRepresentation(period, bufferType);
+      this.handleMissingOrUnplayableTrack(period, bufferType, false);
     });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
@@ -519,10 +521,6 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         },
       ]);
 
-      for (const eventToEmit of periodObj.noPlayableTrackEventToDispatch) {
-        this.trigger("noPlayableTrack", eventToEmit);
-      }
-
       if (this._isDisposed) {
         return;
       }
@@ -547,130 +545,180 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   }
 
   /**
-   * Handle the noPlayableRepresentation event, trigger an error if no fallback is possible.
-   * and can trigger event "noPlayableTrack"
-   * @param period - The period that has no playable representation
-   * @param trackType - The media type that is not playable
+   * Throws an error if neither audio nor video tracks are selected for the given period.
+   *
+   * This indicates that the application or user has not selected any tracks for playback,
+   * which is considered an invalid state.
+   *
+   * @param {object} period - The period to check for selected tracks.
+   * @returns {void}
+   * @throws {erorr} If no audio or video tracks are set for the period.
    */
-  private onNoPlayableRepresentation(
+  private throwIfTracksAreNotSetForPeriod(period: IPeriodMetadata): void {
+    const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+    if (periodItem !== undefined) {
+      const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
+        (ttype) => periodItem[ttype].storedSettings === null,
+      );
+      if (hasNoTrackAtAll) {
+        const err = new MediaError(
+          "NO_AUDIO_VIDEO_TRACKS",
+          "No audio and no video tracks are set.",
+        );
+        this.trigger("error", err);
+        this.dispose();
+      }
+    }
+  }
+
+  /**
+   * Handles the case when no playable representations are available, or when no initial track has been set,
+   * for a given period and track type (e.g., `'video'` or `'audio'`).
+   *
+   * It attempts to fall back to another available track.
+   *
+   * If no fallback tracks are available, the function may either:
+   * - Throw an error
+   * - Continue playback by disabling the affected media type (audio/video)
+   *
+   * The behavior depends on how the `onVideoTracksNotPlayable` and `onAudioTracksNotPlayable` options are configured.
+   *
+   * @param {Object} period - The period object containing the adaptations.
+   * @param {string} trackType - The type of media track (e.g., `'video'` or `'audio'`) that became unplayable.
+   *@param {boolean} isInitialSelection - Indicates if this occurs during initial track selection.
+   * @returns {void}
+   */
+  private handleMissingOrUnplayableTrack(
     period: IPeriodMetadata,
     trackType: ITrackType,
-  ): Array<{
-    trackType: ITrackType;
-    period: IPeriod;
-  }> {
-    const noPlayableTrackToTrigger = [];
+    isInitialSelection: boolean,
+  ): void {
+    const { fallbackTrack, noSourceMedia } = getFallbackTrack(period, trackType);
+    const typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
+    if (typeInfo === undefined) {
+      log.warn(`TS: Could not find period periodId=${period.id}`);
+      return;
+    }
+    const initialStoredSettings = typeInfo.storedSettings;
+    const hasStoredSettingsChanged = (): boolean => {
+      return typeInfo.storedSettings !== initialStoredSettings;
+    };
 
-    const periodHasAdaptationForType =
-      period.adaptations[trackType] !== undefined &&
-      period.adaptations[trackType].length > 0;
-    if (!periodHasAdaptationForType) {
+    if (fallbackTrack !== null) {
+      let switchingMode: "direct" | "seamless" | "reload";
+      if (trackType === "audio") {
+        switchingMode = this._defaultAudioTrackSwitchingMode;
+      } else if (trackType === "text") {
+        switchingMode = "direct";
+      } else {
+        switchingMode = "reload";
+      }
+
+      const storedSettings = {
+        adaptation: fallbackTrack,
+        switchingMode,
+        lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
+      };
+      typeInfo.storedSettings = storedSettings;
+
+      if (!isInitialSelection) {
+        // "trackUpdate" events are not sent for the initial track.
+        // See documentation: #Player_Events.md, section ###trackUpdate
+        this.trigger("trackUpdate", {
+          period: toExposedPeriod(period),
+          trackType,
+          reason: "no-playable-representation",
+        });
+      }
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+
+      // Check again that no track change occurred in the meantime
+      if (typeInfo.storedSettings === storedSettings) {
+        typeInfo.dispatcher?.updateTrack(storedSettings);
+      }
+    } else if (fallbackTrack === null && !noSourceMedia) {
+      this.trigger("noPlayableTrack", {
+        trackType,
+        period: { id: period.id, start: period.start, end: period.end },
+      });
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+
+      const fallbackBehavior = this.onTracksNotPlayableForType[trackType];
+      if (hasStoredSettingsChanged()) {
+        // The previous "noPlayableTrack" event might have caused changes,
+        // so we re-check to see if the selected track has been updated.
+        // If it has, we exit early because the API consumer likely adjusted the settings,
+        // and throwing an error now would be out of sync with their changes.
+      } else if (fallbackBehavior === "continue") {
+        log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
+        typeInfo.storedSettings = null;
+        if (!isInitialSelection) {
+          // "trackUpdate" events are not sent for the initial track.
+          // See documentation: #Player_Events.md, section ###trackUpdate
+          this.trigger("trackUpdate", {
+            period: toExposedPeriod(period),
+            trackType,
+            reason: "no-playable-representation",
+          });
+        }
+        if (typeInfo.storedSettings !== null || this._isDisposed) {
+          // The previous "trackUpdate" event might have caused changes,
+          // so we re-check to see if the selected track has been updated.
+          // If it has, we exit early because the API consumer likely adjusted the settings,
+          // and throwing an error now would be out of sync with their changes.
+        } else {
+          typeInfo.dispatcher?.updateTrack(null);
+        }
+      } else if (fallbackBehavior === "error") {
+        const noRepErr = new MediaError(
+          "NO_PLAYABLE_REPRESENTATION",
+          `No ${trackType} Representation can be played`,
+          { tracks: undefined },
+        );
+        this.trigger("error", noRepErr);
+      }
+    } else if (fallbackTrack === null && noSourceMedia) {
       log.debug(
         `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
       );
-      return [];
-    }
-
-    const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
-    if (
-      firstPlayableAdaptation === undefined &&
-      (trackType === "text" || this.onTracksNotPlayableForType[trackType] === "continue")
-    ) {
-      // audio or video is not playable, but let's continue the playback without audio
-      // or without video because of the option was set to "continue".
-      log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
-      noPlayableTrackToTrigger.push({
-        trackType,
-        period: { id: period.id, start: period.start, end: period.end },
-      });
-      // The previous event trigger could have had side-effects, so we
-      // re-check if we're still mostly in the same state
-      if (this._isDisposed) {
-        return []; // Someone disposed the `TracksStore` on the previous side-effect
+      typeInfo.storedSettings = null;
+      if (!isInitialSelection) {
+        // "trackUpdate" events are not sent for the initial track.
+        // See documentation: #Player_Events.md, section ###trackUpdate
+        this.trigger("trackUpdate", {
+          period: toExposedPeriod(period),
+          trackType,
+          reason: "no-playable-representation",
+        });
       }
-    } else if (firstPlayableAdaptation === undefined) {
-      const noRepErr = new MediaError(
-        "NO_PLAYABLE_REPRESENTATION",
-        `No ${trackType} Representation can be played`,
-        { tracks: undefined },
-      );
-      noPlayableTrackToTrigger.push({
-        trackType,
-        period: { id: period.id, start: period.start, end: period.end },
-      });
-      // The previous event trigger could have had side-effects, so we
-      // re-check if we're still mostly in the same state
-      if (this._isDisposed) {
-        return []; // Someone disposed the `TracksStore` on the previous side-effect
+      if (typeInfo.storedSettings !== null || this._isDisposed) {
+        // The previous "trackUpdate" event might have caused changes,
+        // so we re-check to see if the selected track has been updated.
+        // If it has, we exit early because the API consumer likely adjusted the settings,
+        // and throwing an error now would be out of sync with their changes.
+      } else {
+        typeInfo.dispatcher?.updateTrack(null);
       }
-      this.trigger("error", noRepErr);
-      this.dispose();
-      return [];
     }
-    let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
-    if (isNullOrUndefined(typeInfo)) {
-      return noPlayableTrackToTrigger;
-    }
-    const selectedAdaptation = getPeriodItem(this._storedPeriodInfo, period.id)?.[
-      trackType
-    ]?.storedSettings;
-    if (selectedAdaptation === null) {
-      // The track type has been explicitly disabled, there is no need to select
-      // a new track as a fallback.
-      return noPlayableTrackToTrigger;
-    }
-
-    const switchingMode =
-      trackType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload";
-    const storedSettings =
-      firstPlayableAdaptation !== undefined
-        ? {
-            adaptation: firstPlayableAdaptation,
-            switchingMode,
-            lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(
-              null,
-            ),
-          }
-        : null;
-    typeInfo.storedSettings = storedSettings;
-
-    this.trigger("trackUpdate", {
-      period: toExposedPeriod(period),
-      trackType,
-      reason: "no-playable-representation",
-    });
 
     // The previous event trigger could have had side-effects, so we
     // re-check if we're still mostly in the same state
     if (this._isDisposed) {
-      return []; // Someone disposed the `TracksStore` on the previous side-effect
-    }
-    typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
-    if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
-      return noPlayableTrackToTrigger;
+      return; // Someone disposed the `TracksStore` on the previous side-effect
     }
 
-    // Check that we're not both disabling audio and video here
-    if (storedSettings === null) {
-      const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
-      if (periodItem !== undefined) {
-        const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
-          (ttype) => periodItem[ttype].storedSettings === null,
-        );
-        if (hasNoTrackAtAll) {
-          const err = new MediaError(
-            "NO_AUDIO_VIDEO_TRACKS",
-            "No audio and no video tracks are set.",
-          );
-          this.trigger("error", err);
-          this.dispose();
-          return [];
-        }
-      }
+    if (trackType !== "text") {
+      // Allow missing text tracks; only enforce for audio/video
+      this.throwIfTracksAreNotSetForPeriod(period);
     }
-
-    typeInfo.dispatcher?.updateTrack(storedSettings);
-    return noPlayableTrackToTrigger;
   }
 
   /**
@@ -1477,9 +1525,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       )[0];
       if (audioAdaptation === undefined) {
         trackStorePeriod.audio.storedSettings = null;
-        trackStorePeriod.noPlayableTrackEventToDispatch.push(
-          ...this.onNoPlayableRepresentation(period, "audio"),
-        );
+        this.handleMissingOrUnplayableTrack(period, "audio", true);
         if (this._isDisposed) {
           return;
         }
@@ -1495,9 +1541,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         getSupportedAdaptations(period, "video")[0];
       if (baseVideoAdaptation === undefined) {
         trackStorePeriod.video.storedSettings = null;
-        trackStorePeriod.noPlayableTrackEventToDispatch.push(
-          ...this.onNoPlayableRepresentation(period, "video"),
-        );
+        this.handleMissingOrUnplayableTrack(period, "video", true);
         if (this._isDisposed) {
           return;
         }
@@ -1561,13 +1605,6 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     for (const trackStorePeriod of toDispatchTrack) {
       if (!trackStorePeriod.isPeriodAdvertised) {
         continue;
-      }
-
-      if (trackStorePeriod.noPlayableTrackEventToDispatch.length > 0) {
-        for (const noPlayableTrackEvent of trackStorePeriod.noPlayableTrackEventToDispatch) {
-          this.trigger("noPlayableTrack", noPlayableTrackEvent);
-        }
-        trackStorePeriod.noPlayableTrackEventToDispatch = [];
       }
 
       const bufferTypes: ITrackType[] = ["audio", "video", "text"];
@@ -1667,12 +1704,44 @@ function generatePeriodInfo(
     audio: { storedSettings: undefined, dispatcher: null },
     video: { storedSettings: undefined, dispatcher: null },
     text: { storedSettings: undefined, dispatcher: null },
-    noPlayableTrackEventToDispatch: [],
   };
 }
 
 function toExposedPeriod(p: IPeriodMetadata): IPeriod {
   return { start: p.start, end: p.end, id: p.id };
+}
+
+/**
+ * Retrieves a fallback track for the given period and track type.
+ *
+ * This function is used when the current track becomes unavailable,
+ * and a fallback track must be selected based on the period and media type.
+ *
+ * @param {Object} period - The period object that contains information about the available tracks.
+ * @param {string} trackType - The type of media track to fallback to (e.g., "audio", "video", "text").
+ * @returns {object|null} A fallback track matching the type, or `null` if none is available.
+ */
+function getFallbackTrack(
+  period: IPeriodMetadata,
+  trackType: ITrackType,
+): {
+  fallbackTrack: IAdaptationMetadata | null;
+  noSourceMedia: boolean;
+} {
+  const periodHasAdaptationForType =
+    period.adaptations[trackType] !== undefined &&
+    period.adaptations[trackType].length > 0;
+  if (!periodHasAdaptationForType) {
+    return {
+      fallbackTrack: null,
+      noSourceMedia: true,
+    };
+  }
+  const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
+  return {
+    fallbackTrack: firstPlayableAdaptation ?? null,
+    noSourceMedia: false,
+  };
 }
 
 function findFirstPlayableAdaptation(
@@ -1733,16 +1802,6 @@ export interface ITSPeriodObject {
    * If `true`, this object was since cleaned-up.
    */
   isRemoved: boolean;
-
-  /**
-   * NoPlayableTrack events that should be emitted when the period has been advertised.
-   *
-   * This ensure the events relates to a period that was communicated via the public API.
-   */
-  noPlayableTrackEventToDispatch: Array<{
-    trackType: ITrackType;
-    period: IPeriod;
-  }>;
 }
 
 /**

--- a/tests/integration/scenarios/audio_video_not_supported.test.js
+++ b/tests/integration/scenarios/audio_video_not_supported.test.js
@@ -180,6 +180,49 @@ describe("Content with video or audio not supported", function () {
     );
   });
 
+  it("should trigger an error if the video is not supported and the audio is disabled", async function () {
+    player.setWantedBufferAhead(15);
+    const { url, transport } = manifestVideoNotSupportedInfos;
+    let playerError;
+    let noPlayableTrackEvent;
+    player.addEventListener("error", (err) => {
+      playerError = err;
+    });
+    player.addEventListener("noPlayableTrack", (event) => {
+      noPlayableTrackEvent = event;
+    });
+    player.loadVideo({
+      url,
+      transport,
+      autoPlay: true,
+      onVideoTracksNotPlayable: "continue",
+    });
+    await waitForState(player, "PLAYING", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+    ]);
+    expect(noPlayableTrackEvent).not.toBe(undefined);
+    expect(noPlayableTrackEvent.trackType).toBe("video");
+
+    const waitStopped = waitForState(player, "STOPPED", [
+      "LOADING",
+      "LOADED",
+      "BUFFERING",
+      "SEEKING",
+      "RELOADING",
+      "PLAYING",
+    ]);
+    player.disableAudioTrack();
+    await waitStopped;
+    expect(playerError).not.toBe(undefined);
+    expect(playerError.message).toBe(
+      "NO_AUDIO_VIDEO_TRACKS: No audio and no video tracks are set.",
+    );
+  });
+
   it("should trigger an error if audio only content is not supported", async function () {
     player.setWantedBufferAhead(15);
     const { url, transport } = manifestAudioOnlyInfos;

--- a/tests/integration/scenarios/dash_multi-track.test.js
+++ b/tests/integration/scenarios/dash_multi-track.test.js
@@ -140,6 +140,11 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     expect(currentVideoTrack).to.equal(null);
   }
 
+  function checkNoAudioTrack() {
+    const currentAudioTrack = player.getAudioTrack();
+    expect(currentAudioTrack).to.equal(null);
+  }
+
   function checkVideoTrack(codecRules, isSignInterpreted) {
     const currentVideoTrack = player.getVideoTrack();
 
@@ -225,18 +230,23 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
       const videoTrackPreference = videoTrackPreferences[i];
 
       if (audioTrackPreference !== undefined) {
-        const availableAudioTracks = player.getAvailableAudioTracks(period.id);
-        expect(availableAudioTracks).not.to.be.empty;
-        const wantedAudioTrack = chooseWantedAudioTrack(
-          availableAudioTracks,
-          audioTrackPreference,
-        );
-        if (wantedAudioTrack !== undefined) {
-          player.setAudioTrack({
-            trackId: wantedAudioTrack.id,
-            periodId: period.id,
-          });
-          expect(player.getAudioTrack(period.id).id).to.equal(wantedAudioTrack.id);
+        if (audioTrackPreference === null) {
+          player.disableAudioTrack(period.id);
+          expect(player.getAudioTrack(period.id)).to.equal(null);
+        } else {
+          const availableAudioTracks = player.getAvailableAudioTracks(period.id);
+          expect(availableAudioTracks).not.to.be.empty;
+          const wantedAudioTrack = chooseWantedAudioTrack(
+            availableAudioTracks,
+            audioTrackPreference,
+          );
+          if (wantedAudioTrack !== undefined) {
+            player.setAudioTrack({
+              trackId: wantedAudioTrack.id,
+              periodId: period.id,
+            });
+            expect(player.getAudioTrack(period.id).id).to.equal(wantedAudioTrack.id);
+          }
         }
       }
 
@@ -399,6 +409,22 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     checkAudioTrack("fr", "fra", true);
     checkNoTextTrack();
     checkNoVideoTrack();
+  });
+
+  it("should allow the initial disabling of the audio tracks", async () => {
+    player.addEventListener("newAvailablePeriods", () => {
+      updateTracks([null, null], [], []);
+    });
+    await loadContent();
+    checkNoAudioTrack();
+    checkNoTextTrack();
+    checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
+
+    await goToSecondPeriod();
+    checkNoAudioTrack();
+    checkNoTextTrack();
+    checkVideoTrack({ all: false, test: /avc1\.42C014/ }, undefined);
+    checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);
   });
 
   it("setting the current track should not be persisted between Periods", async () => {

--- a/tests/integration/scenarios/drm_base.js
+++ b/tests/integration/scenarios/drm_base.js
@@ -25,7 +25,11 @@ describe("DRM: Basic use cases", function () {
       ...opts,
     });
     if (isNullOrUndefined(error)) {
-      await waitForPlayerState(player, "LOADED", ["LOADING"]);
+      try {
+        await waitForPlayerState(player, "LOADED", ["LOADING"]);
+      } catch (err) {
+        throw player.getError() ?? err;
+      }
       expect(player.getError()).toBeNull();
     } else {
       await waitForPlayerState(player, "STOPPED", ["LOADING"]);
@@ -687,5 +691,49 @@ describe("DRM: Basic use cases", function () {
     );
     expect(player.getAudioRepresentation().id).toEqual("15-585f233f");
     expect(player.getError()).toBeNull();
+  });
+
+  it("should let a time window for an audio track reset if no license for video can be fetched while audio is disabled", async function () {
+    const noPlayableTracksReceived = [];
+    player.addEventListener("newAvailablePeriods", (periods) => {
+      expect(player.getVideoTrack(periods[0].id)).not.toBeNull();
+      player.disableAudioTrack(periods[0].id);
+    });
+    player.addEventListener("noPlayableTrack", (npt) => {
+      noPlayableTracksReceived.push(npt);
+      const period = player.getAvailablePeriods()[0];
+      player.setAudioTrack({
+        periodId: period.id,
+        trackId: player.getAvailableAudioTracks(period.id)[0].id,
+      });
+    });
+    await loadEncryptedContent({
+      onVideoTracksNotPlayable: "continue",
+      keySystems: [
+        {
+          type: "com.microsoft.playready",
+          onKeyOutputRestricted: "fallback",
+          getLicense: generateGetLicenseForFakeLicense({
+            failingKeyIds: {
+              "90953e096cb249a3a2607a5fefead499": {
+                fallbackOnLastTry: true,
+              },
+              "80399bf58a2140148053e27e748e98c0": {
+                fallbackOnLastTry: true,
+              },
+              "80399bf58a2140148053e27e748e98c1": {
+                fallbackOnLastTry: true,
+              },
+            },
+          }),
+        },
+      ],
+    });
+    expect(player.getAvailableVideoTracks()).toEqual([]);
+    expect(noPlayableTracksReceived.length).toEqual(1);
+    expect(noPlayableTracksReceived[0].trackType).toEqual("video");
+    expect(noPlayableTracksReceived[0].period.id).toEqual(
+      player.getAvailablePeriods()[0].id,
+    );
   });
 });


### PR DESCRIPTION
We previously never added the `disableAudioTrack` API for two reasons:

1. It's often much less needed than a `disableTextTrack` API and than a `disableVideoTrack` API (second one for "audio-only")

2. It was unclear what behavior the RxPlayer should have if both audio and video were disabled

Since @Florent-Bouisset work on the new `onAudioTracksNotPlayable` / `onVideoTracksNotPlayable` options however, we do have a concrete way to deal with the absence of both audio and video: the `noPlayableTrack` event and `NO_AUDIO_VIDEO_TRACKS` error.

So now that there's no real barrier to add that API, I'm adding it.

---

This does not seem to really be needed right now by the different applications we work with, I just wanted to add that API now because it facilitates the writing of edge-cases-tests: I especially wanted to add a test for a pretty rare situation where there's no audio/video selected yet we're fallbacking from all of the other types' (video/audio) tracks due to DRM constraints.

I'm doing this now because now that advanced DRM integration tests are merged, we can begin to add tests for all those advanced edge cases scenarios to ensure we're keeping them under control.