### PR TITLE
Allow application to reset an audio/video track when fallbacking from all the others' one

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2708,6 +2708,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       onTracksNotPlayableForType: {
         audio: contentInfos.onAudioTracksNotPlayable,
         video: contentInfos.onVideoTracksNotPlayable,
+        text: "continue",
       },
     });
     contentInfos.tracksStore = tracksStore;

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -107,6 +107,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   private onTracksNotPlayableForType: {
     audio: "error" | "continue";
     video: "error" | "continue";
+    text: "error" | "continue";
   };
 
   constructor(args: {
@@ -115,6 +116,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     onTracksNotPlayableForType: {
       audio: "error" | "continue";
       video: "error" | "continue";
+      text: "error" | "continue";
     };
   }) {
     super();
@@ -597,20 +599,24 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       log.warn(`TS: Could not find period periodId=${period.id}`);
       return;
     }
-    if (trackType === "text") {
-      // we don't care for text fallback
-      return;
-    }
     const initialStoredSettings = typeInfo.storedSettings;
     const hasStoredSettingsChanged = (): boolean => {
       return typeInfo.storedSettings !== initialStoredSettings;
     };
 
     if (fallbackTrack !== null) {
+      let switchingMode: "direct" | "seamless" | "reload";
+      if (trackType === "audio") {
+        switchingMode = this._defaultAudioTrackSwitchingMode;
+      } else if (trackType === "text") {
+        switchingMode = "direct";
+      } else {
+        switchingMode = "reload";
+      }
+
       const storedSettings = {
         adaptation: fallbackTrack,
-        switchingMode:
-          trackType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload",
+        switchingMode,
         lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
       };
       typeInfo.storedSettings = storedSettings;
@@ -629,7 +635,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       if (this._isDisposed) {
         return; // Someone disposed the `TracksStore` on the previous side-effect
       }
-      typeInfo.dispatcher?.updateTrack(storedSettings);
+
+      // Check again that no track change occurred in the meantime
+      if (typeInfo.storedSettings === storedSettings) {
+        typeInfo.dispatcher?.updateTrack(storedSettings);
+      }
     } else if (fallbackTrack === null && !noSourceMedia) {
       this.trigger("noPlayableTrack", {
         trackType,
@@ -640,6 +650,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       if (this._isDisposed) {
         return; // Someone disposed the `TracksStore` on the previous side-effect
       }
+
       const fallbackBehavior = this.onTracksNotPlayableForType[trackType];
       if (hasStoredSettingsChanged()) {
         // The previous "noPlayableTrack" event might have caused changes,
@@ -703,7 +714,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     if (this._isDisposed) {
       return; // Someone disposed the `TracksStore` on the previous side-effect
     }
-    this.throwIfTracksAreNotSetForPeriod(period);
+
+    if (trackType !== "text") {
+      // Allow missing text tracks; only enforce for audio/video
+      this.throwIfTracksAreNotSetForPeriod(period);
+    }
   }
 
   /**

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -624,6 +624,11 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
           reason: "no-playable-representation",
         });
       }
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
       typeInfo.dispatcher?.updateTrack(storedSettings);
     } else if (fallbackTrack === null && !noSourceMedia) {
       this.trigger("noPlayableTrack", {
@@ -637,8 +642,10 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       }
       const fallbackBehavior = this.onTracksNotPlayableForType[trackType];
       if (hasStoredSettingsChanged()) {
-        // The previous "noPlayableTrack" event trigger could have had side-effects, so we
-        // re-check if we're still mostly in the same state
+        // The previous "noPlayableTrack" event might have caused changes,
+        // so we re-check to see if the selected track has been updated.
+        // If it has, we exit early because the API consumer likely adjusted the settings,
+        // and throwing an error now would be out of sync with their changes.
       } else if (fallbackBehavior === "continue") {
         log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
         typeInfo.storedSettings = null;
@@ -650,6 +657,14 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
             trackType,
             reason: "no-playable-representation",
           });
+        }
+        if (typeInfo.storedSettings !== null || this._isDisposed) {
+          // The previous "trackUpdate" event might have caused changes,
+          // so we re-check to see if the selected track has been updated.
+          // If it has, we exit early because the API consumer likely adjusted the settings,
+          // and throwing an error now would be out of sync with their changes.
+        } else {
+          typeInfo.dispatcher?.updateTrack(null);
         }
       } else if (fallbackBehavior === "error") {
         const noRepErr = new MediaError(
@@ -663,8 +678,24 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       log.debug(
         `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
       );
-      // No source media was found for this track type in the period (e.g., no audio at all).
-      // This is expected, so continue playback without this type.
+      typeInfo.storedSettings = null;
+      if (!isInitialSelection) {
+        // "trackUpdate" events are not sent for the initial track.
+        // See documentation: #Player_Events.md, section ###trackUpdate
+        this.trigger("trackUpdate", {
+          period: toExposedPeriod(period),
+          trackType,
+          reason: "no-playable-representation",
+        });
+      }
+      if (typeInfo.storedSettings !== null || this._isDisposed) {
+        // The previous "trackUpdate" event might have caused changes,
+        // so we re-check to see if the selected track has been updated.
+        // If it has, we exit early because the API consumer likely adjusted the settings,
+        // and throwing an error now would be out of sync with their changes.
+      } else {
+        typeInfo.dispatcher?.updateTrack(null);
+      }
     }
 
     // The previous event trigger could have had side-effects, so we

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -491,10 +491,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     periodObj[bufferType].dispatcher = dispatcher;
 
     dispatcher.addEventListener("noPlayableRepresentation", () => {
-      const events = this.onNoPlayableRepresentation(period, bufferType);
-      for (const event of events) {
-        this.trigger("noPlayableTrack", event);
-      }
+      this.onNoPlayableRepresentation(period, bufferType);
     });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
@@ -522,10 +519,6 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         },
       ]);
 
-      for (const eventToEmit of periodObj.noPlayableTrackEventToDispatch) {
-        this.trigger("noPlayableTrack", eventToEmit);
-      }
-
       if (this._isDisposed) {
         return;
       }
@@ -550,134 +543,126 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   }
 
   /**
-   * Handle the noPlayableRepresentation event, trigger an error if no fallback is possible.
-   * and can trigger event "noPlayableTrack"
-   * @param period - The period that has no playable representation
-   * @param trackType - The media type that is not playable
+   * Throws an error if neither audio nor video tracks are selected for the given period.
+   *
+   * This indicates that the application or user has not selected any tracks for playback,
+   * which is considered an invalid state.
+   *
+   * @param {object} period - The period to check for selected tracks.
+   * @returns {void}
+   * @throws {erorr} If no audio or video tracks are set for the period.
+   */
+  private throwIfTracksAreNotSetForPeriod(period: IPeriodMetadata): void {
+    const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+    if (periodItem !== undefined) {
+      const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
+        (ttype) => periodItem[ttype].storedSettings === null,
+      );
+      if (hasNoTrackAtAll) {
+        const err = new MediaError(
+          "NO_AUDIO_VIDEO_TRACKS",
+          "No audio and no video tracks are set.",
+        );
+        this.trigger("error", err);
+        this.dispose();
+      }
+    }
+  }
+
+  /**
+   * Handles the case when no playable representations are available for a given media adaptation.
+   *
+   * This event handler is triggered when all representations in an adaptation (e.g., a video or audio track)
+   * are determined to be unplayable. It attempts to fall back to another available track.
+   *
+   * If no fallback tracks are available, the function may either:
+   * - Throw an error
+   * - Continue playback by disabling the affected media type (audio/video)
+   *
+   * The behavior depends on how the `onVideoTracksNotPlayable` and `onAudioTracksNotPlayable` options are configured.
+   *
+   * @param {Object} period - The period object containing the adaptations.
+   * @param {string} trackType - The type of media track (e.g., `'video'` or `'audio'`) that became unplayable.
+   * @returns {void}
    */
   private onNoPlayableRepresentation(
     period: IPeriodMetadata,
     trackType: ITrackType,
-  ): Array<{
-    trackType: ITrackType;
-    period: IPeriod;
-  }> {
-    const noPlayableTrackToTrigger = [];
+  ): void {
+    const { fallbackTrack, noSourceMedia } = getFallbackTrack(period, trackType);
+    const typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
+    if (typeInfo === undefined) {
+      log.warn(`TS: Could not find period periodId=${period.id}`);
+      return;
+    }
+    if (trackType === "text") {
+      // we don't care for text fallback
+      return;
+    }
+    const initialStoredSettings = typeInfo.storedSettings;
+    const hasStoredSettingsChanged = (): boolean => {
+      return typeInfo.storedSettings !== initialStoredSettings;
+    };
 
-    const periodHasAdaptationForType =
-      period.adaptations[trackType] !== undefined &&
-      period.adaptations[trackType].length > 0;
-    if (!periodHasAdaptationForType) {
+    if (fallbackTrack !== null) {
+      const storedSettings = {
+        adaptation: fallbackTrack,
+        switchingMode:
+          trackType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload",
+        lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(null),
+      };
+      typeInfo.storedSettings = storedSettings;
+
+      this.trigger("trackUpdate", {
+        period: toExposedPeriod(period),
+        trackType,
+        reason: "no-playable-representation",
+      });
+      typeInfo.dispatcher?.updateTrack(storedSettings);
+    } else if (fallbackTrack === null && !noSourceMedia) {
+      this.trigger("noPlayableTrack", {
+        trackType,
+        period: { id: period.id, start: period.start, end: period.end },
+      });
+      // The previous event trigger could have had side-effects, so we
+      // re-check if we're still mostly in the same state
+      if (this._isDisposed) {
+        return; // Someone disposed the `TracksStore` on the previous side-effect
+      }
+      const fallbackBehavior = this.onTracksNotPlayableForType[trackType];
+      if (hasStoredSettingsChanged()) {
+        // The previous "noPlayableTrack" event trigger could have had side-effects, so we
+        // re-check if we're still mostly in the same state
+      } else if (fallbackBehavior === "continue") {
+        log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
+        typeInfo.storedSettings = null;
+        this.trigger("trackUpdate", {
+          period: toExposedPeriod(period),
+          trackType,
+          reason: "no-playable-representation",
+        });
+      } else if (fallbackBehavior === "error") {
+        const noRepErr = new MediaError(
+          "NO_PLAYABLE_REPRESENTATION",
+          `No ${trackType} Representation can be played`,
+          { tracks: undefined },
+        );
+        this.trigger("error", noRepErr);
+      }
+    } else if (fallbackTrack === null && noSourceMedia) {
       log.debug(
         `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
       );
-      return [];
+      // No source media was found for this track type in the period (e.g., no audio at all).
+      // This is expected, so continue playback without this type.
     }
-
-    const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
-    if (
-      firstPlayableAdaptation === undefined &&
-      (trackType === "text" || this.onTracksNotPlayableForType[trackType] === "continue")
-    ) {
-      // audio or video is not playable, but let's continue the playback without audio
-      // or without video because of the option was set to "continue".
-      log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
-      noPlayableTrackToTrigger.push({
-        trackType,
-        period: { id: period.id, start: period.start, end: period.end },
-      });
-      // The previous event trigger could have had side-effects, so we
-      // re-check if we're still mostly in the same state
-      if (this._isDisposed) {
-        return []; // Someone disposed the `TracksStore` on the previous side-effect
-      }
-    } else if (firstPlayableAdaptation === undefined) {
-      const noRepErr = new MediaError(
-        "NO_PLAYABLE_REPRESENTATION",
-        `No ${trackType} Representation can be played`,
-        { tracks: undefined },
-      );
-      noPlayableTrackToTrigger.push({
-        trackType,
-        period: { id: period.id, start: period.start, end: period.end },
-      });
-      // The previous event trigger could have had side-effects, so we
-      // re-check if we're still mostly in the same state
-      if (this._isDisposed) {
-        return []; // Someone disposed the `TracksStore` on the previous side-effect
-      }
-      this.trigger("error", noRepErr);
-      this.dispose();
-      return [];
-    }
-    let typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
-    if (isNullOrUndefined(typeInfo)) {
-      return noPlayableTrackToTrigger;
-    }
-    const selectedAdaptation = getPeriodItem(this._storedPeriodInfo, period.id)?.[
-      trackType
-    ]?.storedSettings;
-    if (selectedAdaptation === null) {
-      // The track type has been explicitly disabled, there is no need to select
-      // a new track as a fallback.
-      return noPlayableTrackToTrigger;
-    }
-
-    const switchingMode =
-      trackType === "audio" ? this._defaultAudioTrackSwitchingMode : "reload";
-    const storedSettings =
-      firstPlayableAdaptation !== undefined
-        ? {
-            adaptation: firstPlayableAdaptation,
-            switchingMode,
-            lockedRepresentations: new SharedReference<IRepresentationsChoice | null>(
-              null,
-            ),
-          }
-        : null;
-    typeInfo.storedSettings = storedSettings;
-
-    this.trigger("trackUpdate", {
-      period: toExposedPeriod(period),
-      trackType,
-      reason: "no-playable-representation",
-    });
 
     // The previous event trigger could have had side-effects, so we
     // re-check if we're still mostly in the same state
     if (this._isDisposed) {
-      return []; // Someone disposed the `TracksStore` on the previous side-effect
+      return; // Someone disposed the `TracksStore` on the previous side-effect
     }
-    typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
-    if (isNullOrUndefined(typeInfo) || typeInfo.storedSettings !== storedSettings) {
-      return noPlayableTrackToTrigger;
-    }
-
-    // Check that we're not both disabling audio and video here
-    // Use a setTimeout(..., 0) to let a time window for an audio/video track switch when
-    // receiving a "noPlayableTrack" event
-    setTimeout(() => {
-      if (storedSettings === null) {
-        const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
-        if (periodItem !== undefined) {
-          const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
-            (ttype) => periodItem[ttype].storedSettings === null,
-          );
-          if (hasNoTrackAtAll) {
-            const err = new MediaError(
-              "NO_AUDIO_VIDEO_TRACKS",
-              "No audio and no video tracks are set.",
-            );
-            this.trigger("error", err);
-            this.dispose();
-            return [];
-          }
-        }
-      }
-    }, 0);
-
-    typeInfo.dispatcher?.updateTrack(storedSettings);
-    return noPlayableTrackToTrigger;
+    this.throwIfTracksAreNotSetForPeriod(period);
   }
 
   /**
@@ -1484,9 +1469,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       )[0];
       if (audioAdaptation === undefined) {
         trackStorePeriod.audio.storedSettings = null;
-        trackStorePeriod.noPlayableTrackEventToDispatch.push(
-          ...this.onNoPlayableRepresentation(period, "audio"),
-        );
+        this.onNoPlayableRepresentation(period, "audio");
         if (this._isDisposed) {
           return;
         }
@@ -1502,9 +1485,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         getSupportedAdaptations(period, "video")[0];
       if (baseVideoAdaptation === undefined) {
         trackStorePeriod.video.storedSettings = null;
-        trackStorePeriod.noPlayableTrackEventToDispatch.push(
-          ...this.onNoPlayableRepresentation(period, "video"),
-        );
+        this.onNoPlayableRepresentation(period, "video");
         if (this._isDisposed) {
           return;
         }
@@ -1568,13 +1549,6 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     for (const trackStorePeriod of toDispatchTrack) {
       if (!trackStorePeriod.isPeriodAdvertised) {
         continue;
-      }
-
-      if (trackStorePeriod.noPlayableTrackEventToDispatch.length > 0) {
-        for (const noPlayableTrackEvent of trackStorePeriod.noPlayableTrackEventToDispatch) {
-          this.trigger("noPlayableTrack", noPlayableTrackEvent);
-        }
-        trackStorePeriod.noPlayableTrackEventToDispatch = [];
       }
 
       const bufferTypes: ITrackType[] = ["audio", "video", "text"];
@@ -1674,12 +1648,44 @@ function generatePeriodInfo(
     audio: { storedSettings: undefined, dispatcher: null },
     video: { storedSettings: undefined, dispatcher: null },
     text: { storedSettings: undefined, dispatcher: null },
-    noPlayableTrackEventToDispatch: [],
   };
 }
 
 function toExposedPeriod(p: IPeriodMetadata): IPeriod {
   return { start: p.start, end: p.end, id: p.id };
+}
+
+/**
+ * Retrieves a fallback track for the given period and track type.
+ *
+ * This function is used when the current track becomes unavailable,
+ * and a fallback track must be selected based on the period and media type.
+ *
+ * @param {Object} period - The period object that contains information about the available tracks.
+ * @param {string} trackType - The type of media track to fallback to (e.g., "audio", "video", "text").
+ * @returns {object|null} A fallback track matching the type, or `null` if none is available.
+ */
+function getFallbackTrack(
+  period: IPeriodMetadata,
+  trackType: ITrackType,
+): {
+  fallbackTrack: IAdaptationMetadata | null;
+  noSourceMedia: boolean;
+} {
+  const periodHasAdaptationForType =
+    period.adaptations[trackType] !== undefined &&
+    period.adaptations[trackType].length > 0;
+  if (!periodHasAdaptationForType) {
+    return {
+      fallbackTrack: null,
+      noSourceMedia: true,
+    };
+  }
+  const firstPlayableAdaptation = findFirstPlayableAdaptation(period, trackType);
+  return {
+    fallbackTrack: firstPlayableAdaptation ?? null,
+    noSourceMedia: false,
+  };
 }
 
 function findFirstPlayableAdaptation(
@@ -1740,16 +1746,6 @@ export interface ITSPeriodObject {
    * If `true`, this object was since cleaned-up.
    */
   isRemoved: boolean;
-
-  /**
-   * NoPlayableTrack events that should be emitted when the period has been advertised.
-   *
-   * This ensure the events relates to a period that was communicated via the public API.
-   */
-  noPlayableTrackEventToDispatch: Array<{
-    trackType: ITrackType;
-    period: IPeriod;
-  }>;
 }
 
 /**

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -491,7 +491,10 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     periodObj[bufferType].dispatcher = dispatcher;
 
     dispatcher.addEventListener("noPlayableRepresentation", () => {
-      this.onNoPlayableRepresentation(period, bufferType);
+      const events = this.onNoPlayableRepresentation(period, bufferType);
+      for (const event of events) {
+        this.trigger("noPlayableTrack", event);
+      }
     });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
@@ -651,23 +654,27 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     }
 
     // Check that we're not both disabling audio and video here
-    if (storedSettings === null) {
-      const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
-      if (periodItem !== undefined) {
-        const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
-          (ttype) => periodItem[ttype].storedSettings === null,
-        );
-        if (hasNoTrackAtAll) {
-          const err = new MediaError(
-            "NO_AUDIO_VIDEO_TRACKS",
-            "No audio and no video tracks are set.",
+    // Use a setTimeout(..., 0) to let a time window for an audio/video track switch when
+    // receiving a "noPlayableTrack" event
+    setTimeout(() => {
+      if (storedSettings === null) {
+        const periodItem = getPeriodItem(this._storedPeriodInfo, period.id);
+        if (periodItem !== undefined) {
+          const hasNoTrackAtAll = ["audio" as const, "video" as const].every(
+            (ttype) => periodItem[ttype].storedSettings === null,
           );
-          this.trigger("error", err);
-          this.dispose();
-          return [];
+          if (hasNoTrackAtAll) {
+            const err = new MediaError(
+              "NO_AUDIO_VIDEO_TRACKS",
+              "No audio and no video tracks are set.",
+            );
+            this.trigger("error", err);
+            this.dispose();
+            return [];
+          }
         }
       }
-    }
+    }, 0);
 
     typeInfo.dispatcher?.updateTrack(storedSettings);
     return noPlayableTrackToTrigger;

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -491,7 +491,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     periodObj[bufferType].dispatcher = dispatcher;
 
     dispatcher.addEventListener("noPlayableRepresentation", () => {
-      this.onNoPlayableRepresentation(period, bufferType);
+      this.handleMissingOrUnplayableTrack(period, bufferType, false);
     });
     dispatcher.addEventListener("noPlayableLockedRepresentation", () => {
       // TODO check that it doesn't already lead to segment loading or MediaSource
@@ -570,10 +570,10 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   }
 
   /**
-   * Handles the case when no playable representations are available for a given media adaptation.
+   * Handles the case when no playable representations are available, or when no initial track has been set,
+   * for a given period and track type (e.g., `'video'` or `'audio'`).
    *
-   * This event handler is triggered when all representations in an adaptation (e.g., a video or audio track)
-   * are determined to be unplayable. It attempts to fall back to another available track.
+   * It attempts to fall back to another available track.
    *
    * If no fallback tracks are available, the function may either:
    * - Throw an error
@@ -583,11 +583,13 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    *
    * @param {Object} period - The period object containing the adaptations.
    * @param {string} trackType - The type of media track (e.g., `'video'` or `'audio'`) that became unplayable.
+   *@param {boolean} isInitialSelection - Indicates if this occurs during initial track selection.
    * @returns {void}
    */
-  private onNoPlayableRepresentation(
+  private handleMissingOrUnplayableTrack(
     period: IPeriodMetadata,
     trackType: ITrackType,
+    isInitialSelection: boolean,
   ): void {
     const { fallbackTrack, noSourceMedia } = getFallbackTrack(period, trackType);
     const typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
@@ -613,11 +615,15 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       };
       typeInfo.storedSettings = storedSettings;
 
-      this.trigger("trackUpdate", {
-        period: toExposedPeriod(period),
-        trackType,
-        reason: "no-playable-representation",
-      });
+      if (!isInitialSelection) {
+        // "trackUpdate" events are not sent for the initial track.
+        // See documentation: #Player_Events.md, section ###trackUpdate
+        this.trigger("trackUpdate", {
+          period: toExposedPeriod(period),
+          trackType,
+          reason: "no-playable-representation",
+        });
+      }
       typeInfo.dispatcher?.updateTrack(storedSettings);
     } else if (fallbackTrack === null && !noSourceMedia) {
       this.trigger("noPlayableTrack", {
@@ -636,11 +642,15 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       } else if (fallbackBehavior === "continue") {
         log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
         typeInfo.storedSettings = null;
-        this.trigger("trackUpdate", {
-          period: toExposedPeriod(period),
-          trackType,
-          reason: "no-playable-representation",
-        });
+        if (!isInitialSelection) {
+          // "trackUpdate" events are not sent for the initial track.
+          // See documentation: #Player_Events.md, section ###trackUpdate
+          this.trigger("trackUpdate", {
+            period: toExposedPeriod(period),
+            trackType,
+            reason: "no-playable-representation",
+          });
+        }
       } else if (fallbackBehavior === "error") {
         const noRepErr = new MediaError(
           "NO_PLAYABLE_REPRESENTATION",
@@ -1469,7 +1479,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       )[0];
       if (audioAdaptation === undefined) {
         trackStorePeriod.audio.storedSettings = null;
-        this.onNoPlayableRepresentation(period, "audio");
+        this.handleMissingOrUnplayableTrack(period, "audio", true);
         if (this._isDisposed) {
           return;
         }
@@ -1485,7 +1495,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         getSupportedAdaptations(period, "video")[0];
       if (baseVideoAdaptation === undefined) {
         trackStorePeriod.video.storedSettings = null;
-        this.onNoPlayableRepresentation(period, "video");
+        this.handleMissingOrUnplayableTrack(period, "video", true);
         if (this._isDisposed) {
           return;
         }

--- a/tests/integration/scenarios/drm_base.js
+++ b/tests/integration/scenarios/drm_base.js
@@ -694,7 +694,6 @@ describe("DRM: Basic use cases", function () {
   });
 
   it("should let a time window for an audio track reset if no license for video can be fetched while audio is disabled", async function () {
-    lockLowestBitrates(player);
     const noPlayableTracksReceived = [];
     player.addEventListener("newAvailablePeriods", (periods) => {
       expect(player.getVideoTrack(periods[0].id)).not.toBeNull();
@@ -708,7 +707,6 @@ describe("DRM: Basic use cases", function () {
         trackId: player.getAvailableAudioTracks(period.id)[0].id,
       });
     });
-    // RxPlayer.LogLevel = "DEBUG";
     await loadEncryptedContent({
       onVideoTracksNotPlayable: "continue",
       keySystems: [

--- a/tests/integration/scenarios/drm_base.js
+++ b/tests/integration/scenarios/drm_base.js
@@ -693,7 +693,7 @@ describe("DRM: Basic use cases", function () {
     expect(player.getError()).toBeNull();
   });
 
-  it.only("should let a time window for an audio track reset if no license for video can be fetched while audio is disabled", async function () {
+  it("should let a time window for an audio track reset if no license for video can be fetched while audio is disabled", async function () {
     lockLowestBitrates(player);
     const noPlayableTracksReceived = [];
     player.addEventListener("newAvailablePeriods", (periods) => {
@@ -708,7 +708,7 @@ describe("DRM: Basic use cases", function () {
         trackId: player.getAvailableAudioTracks(period.id)[0].id,
       });
     });
-    RxPlayer.LogLevel = "DEBUG";
+    // RxPlayer.LogLevel = "DEBUG";
     await loadEncryptedContent({
       onVideoTracksNotPlayable: "continue",
       keySystems: [
@@ -732,7 +732,7 @@ describe("DRM: Basic use cases", function () {
       ],
     });
     expect(player.getAvailableVideoTracks()).toEqual([]);
-    expect(noPlayableTracksReceived).toEqual(1);
+    expect(noPlayableTracksReceived.length).toEqual(1);
     expect(noPlayableTracksReceived[0].trackType).toEqual("video");
     expect(noPlayableTracksReceived[0].period.id).toEqual(
       player.getAvailablePeriods()[0].id,

--- a/tests/integration/scenarios/drm_base.js
+++ b/tests/integration/scenarios/drm_base.js
@@ -25,7 +25,11 @@ describe("DRM: Basic use cases", function () {
       ...opts,
     });
     if (isNullOrUndefined(error)) {
-      await waitForPlayerState(player, "LOADED", ["LOADING"]);
+      try {
+        await waitForPlayerState(player, "LOADED", ["LOADING"]);
+      } catch (err) {
+        throw player.getError() ?? err;
+      }
       expect(player.getError()).toBeNull();
     } else {
       await waitForPlayerState(player, "STOPPED", ["LOADING"]);
@@ -687,5 +691,51 @@ describe("DRM: Basic use cases", function () {
     );
     expect(player.getAudioRepresentation().id).toEqual("15-585f233f");
     expect(player.getError()).toBeNull();
+  });
+
+  it.only("should let a time window for an audio track reset if no license for video can be fetched while audio is disabled", async function () {
+    lockLowestBitrates(player);
+    const noPlayableTracksReceived = [];
+    player.addEventListener("newAvailablePeriods", (periods) => {
+      expect(player.getVideoTrack(periods[0].id)).not.toBeNull();
+      player.disableAudioTrack(periods[0].id);
+    });
+    player.addEventListener("noPlayableTrack", (npt) => {
+      noPlayableTracksReceived.push(npt);
+      const period = player.getAvailablePeriods()[0];
+      player.setAudioTrack({
+        periodId: period.id,
+        trackId: player.getAvailableAudioTracks(period.id)[0].id,
+      });
+    });
+    RxPlayer.LogLevel = "DEBUG";
+    await loadEncryptedContent({
+      onVideoTracksNotPlayable: "continue",
+      keySystems: [
+        {
+          type: "com.microsoft.playready",
+          onKeyOutputRestricted: "fallback",
+          getLicense: generateGetLicenseForFakeLicense({
+            failingKeyIds: {
+              "90953e096cb249a3a2607a5fefead499": {
+                fallbackOnLastTry: true,
+              },
+              "80399bf58a2140148053e27e748e98c0": {
+                fallbackOnLastTry: true,
+              },
+              "80399bf58a2140148053e27e748e98c1": {
+                fallbackOnLastTry: true,
+              },
+            },
+          }),
+        },
+      ],
+    });
+    expect(player.getAvailableVideoTracks()).toEqual([]);
+    expect(noPlayableTracksReceived).toEqual(1);
+    expect(noPlayableTracksReceived[0].trackType).toEqual("video");
+    expect(noPlayableTracksReceived[0].period.id).toEqual(
+      player.getAvailablePeriods()[0].id,
+    );
   });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -96,8 +96,10 @@ export default defineConfig({
     globals: false,
     reporters: "dot",
     include: [
-      // integration tests
-      "tests/integration/scenarios/**/drm_base.[jt]s?(x)",
+      "tests/integration/scenarios/**/*.[jt]s?(x)",
+      "tests/integration/**/*.test.[jt]s?(x)",
+      // memory tests
+      "tests/memory/**/*.[jt]s?(x)",
     ],
     globalSetup: "tests/globalSetup.mjs",
     browser: getBrowserConfig(process.env.BROWSER_CONFIG ?? "chrome"),

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -96,6 +96,7 @@ export default defineConfig({
     globals: false,
     reporters: "dot",
     include: [
+      // integration tests
       "tests/integration/scenarios/**/*.[jt]s?(x)",
       "tests/integration/**/*.test.[jt]s?(x)",
       // memory tests

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -97,10 +97,7 @@ export default defineConfig({
     reporters: "dot",
     include: [
       // integration tests
-      "tests/integration/scenarios/**/*.[jt]s?(x)",
-      "tests/integration/**/*.test.[jt]s?(x)",
-      // memory tests
-      "tests/memory/**/*.[jt]s?(x)",
+      "tests/integration/scenarios/**/drm_base.[jt]s?(x)",
     ],
     globalSetup: "tests/globalSetup.mjs",
     browser: getBrowserConfig(process.env.BROWSER_CONFIG ?? "chrome"),


### PR DESCRIPTION
Based on #1715

This commit shows an issue that can arise in the very rare scenario where:

1. An application decides to load a content with no audio track (could be also with no video track).

2. We fallback for some reason from all video tracks (or audio tracks if it's video that has been disabled in `1.`) - in the test here this is due to the impossibility to fetch their licenses.

3. We should here receive a `noPlayableTrack` event indicating that no video track is playable, allowing us to re-set our audio choice to still be able to play something **BEFORE** the `NO_AUDIO_VIDEO_TRACKS` error that arises when no video nor audio is selected.

   However we don't here, we receive directly a `NO_AUDIO_VIDEO_TRACKS` error and stop playback.