### PR TITLE
[Proposal] formalize logs

### DIFF
--- a/src/compat/__tests__/change_source_buffer_type.test.ts
+++ b/src/compat/__tests__/change_source_buffer_type.test.ts
@@ -33,6 +33,7 @@ describe("Compat - tryToChangeSourceBufferType", () => {
     expect(tryToChangeSourceBufferType(fakeSourceBuffer, "toto")).toBe(false);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith(
+      "mse",
       "Could not call 'changeType' on the given SourceBuffer:",
       err,
     );

--- a/src/compat/__tests__/clear_element_src.test.ts
+++ b/src/compat/__tests__/clear_element_src.test.ts
@@ -120,7 +120,8 @@ describe("Compat - clearElementSrc", () => {
     expect(spyRemoveChild).toHaveBeenCalledTimes(2);
     expect(mockLogWarn).toHaveBeenCalledTimes(2);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "Compat: Could not remove text track child from element.",
+      "media",
+      "Could not remove text track child from element.",
     );
   });
 

--- a/src/compat/__tests__/make_vtt_cue.test.ts
+++ b/src/compat/__tests__/make_vtt_cue.test.ts
@@ -58,7 +58,14 @@ describe("Compat - makeVTTCue", () => {
     const result = makeCue(12, 10, "toto");
     expect(result).toBeNull();
     expect(mockLog.warn).toHaveBeenCalledTimes(1);
-    expect(mockLog.warn).toHaveBeenCalledWith("Compat: Invalid cue times: 12 - 10");
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      "text",
+      "Invalid cue times: start after end.",
+      {
+        endTime: 10,
+        startTime: 12,
+      },
+    );
   });
 
   it("should create a new VTT Cue in other cases", async () => {

--- a/src/compat/__tests__/remove_cue.test.ts
+++ b/src/compat/__tests__/remove_cue.test.ts
@@ -171,7 +171,8 @@ describe("compat - removeCue", () => {
     expect(fakeTrack.mode).toBe("showing");
     expect(mocks.logWarn).toHaveBeenCalledTimes(1);
     expect(mocks.logWarn).toHaveBeenCalledWith(
-      "Compat: Could not remove cue from text track.",
+      "text",
+      "Could not remove cue from text track.",
     );
     expect(mockRemoveCue).toHaveBeenCalledTimes(1);
     expect(mockRemoveCue).toHaveBeenLastCalledWith(fakeCue);
@@ -196,7 +197,8 @@ describe("compat - removeCue", () => {
     expect(fakeTrack.mode).toBe("showing");
     expect(mocks.logWarn).toHaveBeenCalledTimes(1);
     expect(mocks.logWarn).toHaveBeenCalledWith(
-      "Compat: Could not remove cue from text track.",
+      "text",
+      "Could not remove cue from text track.",
     );
     expect(mockRemoveCue).toHaveBeenCalledTimes(1);
     expect(mockRemoveCue).toHaveBeenLastCalledWith({ id: "1" });

--- a/src/compat/browser_version.ts
+++ b/src/compat/browser_version.ts
@@ -26,7 +26,10 @@ import EnvDetector from "./env_detector";
  */
 function getFirefoxVersion(): number | null {
   if (EnvDetector.browser !== EnvDetector.BROWSERS.Firefox) {
-    log.warn("Compat: Can't access Firefox version on no firefox browser.");
+    log.warn(
+      "utils",
+      "getFirefoxVersion: Can't access Firefox version. Not a firefox browser.",
+    );
     return null;
   }
   const userAgent = navigator.userAgent;

--- a/src/compat/change_source_buffer_type.ts
+++ b/src/compat/change_source_buffer_type.ts
@@ -58,6 +58,7 @@ export default function tryToChangeSourceBufferType(
       sourceBuffer.changeType(codec);
     } catch (e) {
       log.warn(
+        "mse",
         "Could not call 'changeType' on the given SourceBuffer:",
         e instanceof Error ? e : "",
       );

--- a/src/compat/clear_element_src.ts
+++ b/src/compat/clear_element_src.ts
@@ -41,7 +41,7 @@ export default function clearElementSrc(element: IMediaElement): void {
           try {
             element.removeChild(childNodes[j]);
           } catch (_err) {
-            log.warn("Compat: Could not remove text track child from element.");
+            log.warn("media", "Could not remove text track child from element.");
           }
         }
       }

--- a/src/compat/eme/close_session.ts
+++ b/src/compat/eme/close_session.ts
@@ -69,7 +69,7 @@ export default function closeSession(session: IMediaKeySession): Promise<void> {
         err instanceof Error
           ? err.message
           : "Unknown error made it impossible to close the session";
-      log.error(`DRM: ${message}`);
+      log.error(`DRM`, "Error made it impossible to close the session", `${message}`);
     }
   }
 

--- a/src/compat/eme/generate_key_request.ts
+++ b/src/compat/eme/generate_key_request.ts
@@ -47,7 +47,7 @@ import { PSSH_TO_INTEGER } from "./constants";
  * @returns {Uint8Array} - Initialization data, patched
  */
 export function patchInitData(initData: Uint8Array): Uint8Array {
-  log.info("Compat: Trying to move CENC PSSH from init data at the end of it.");
+  log.info("DRM", "Trying to move CENC PSSH from init data at the end of it.");
   let foundCencV1 = false;
   let concatenatedCencs = new Uint8Array();
   let resInitData = new Uint8Array();
@@ -58,13 +58,13 @@ export function patchInitData(initData: Uint8Array): Uint8Array {
       initData.length < offset + 8 ||
       be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
     ) {
-      log.warn("Compat: unrecognized initialization data. Cannot patch it.");
+      log.warn("DRM", "unrecognized initialization data. Cannot patch it.");
       throw new Error("Compat: unrecognized initialization data. Cannot patch it.");
     }
 
     const len = be4toi(new Uint8Array(initData), offset);
     if (offset + len > initData.length) {
-      log.warn("Compat: unrecognized initialization data. Cannot patch it.");
+      log.warn("DRM", "unrecognized initialization data. Cannot patch it.");
       throw new Error("Compat: unrecognized initialization data. Cannot patch it.");
     }
 
@@ -90,20 +90,21 @@ export function patchInitData(initData: Uint8Array): Uint8Array {
     ) {
       const cencOffsets = getNextBoxOffsets(currentPSSH);
       const version = cencOffsets === null ? undefined : currentPSSH[cencOffsets[1]];
-      log.info("Compat: CENC PSSH found with version", version);
+      log.info("DRM", "CENC PSSH found with version", version);
       if (version === undefined) {
-        log.warn("Compat: could not read version of CENC PSSH");
+        log.warn("DRM", "could not read version of CENC PSSH");
       } else if (foundCencV1 === (version === 1)) {
         // Either `concatenatedCencs` only contains v1 or does not contain any
         concatenatedCencs = concat(concatenatedCencs, currentPSSH);
       } else if (version === 1) {
         log.warn(
-          "Compat: cenc version 1 encountered, " + "removing every other cenc pssh box.",
+          "DRM",
+          "cenc version 1 encountered, " + "removing every other cenc pssh box.",
         );
         concatenatedCencs = currentPSSH;
         foundCencV1 = true;
       } else {
-        log.warn("Compat: filtering out cenc pssh box with wrong version", version);
+        log.warn("DRM", "filtering out cenc pssh box with wrong version", version);
       }
     } else {
       resInitData = concat(resInitData, currentPSSH);
@@ -112,7 +113,7 @@ export function patchInitData(initData: Uint8Array): Uint8Array {
   }
 
   if (offset !== initData.length) {
-    log.warn("Compat: unrecognized initialization data. Cannot patch it.");
+    log.warn("DRM", "unrecognized initialization data. Cannot patch it.");
     throw new Error("Compat: unrecognized initialization data. Cannot patch it.");
   }
   return concat(resInitData, concatenatedCencs);
@@ -133,7 +134,7 @@ export default function generateKeyRequest(
   initializationDataType: string | undefined,
   initializationData: Uint8Array,
 ): Promise<unknown> {
-  log.debug("Compat: Calling generateRequest on the MediaKeySession");
+  log.debug("DRM", "Calling generateRequest on the MediaKeySession");
   let patchedInit: Uint8Array;
   try {
     patchedInit = patchInitData(initializationData);
@@ -152,7 +153,8 @@ export default function generateKeyRequest(
     // Retry with a default "cenc" value for initialization data type if
     // we're in that condition.
     log.warn(
-      "Compat: error while calling `generateRequest` with an empty " +
+      "DRM",
+      "error while calling `generateRequest` with an empty " +
         'initialization data type. Retrying with a default "cenc" value.',
       error,
     );

--- a/src/compat/eme/get_init_data.ts
+++ b/src/compat/eme/get_init_data.ts
@@ -76,13 +76,13 @@ function getInitializationDataValues(
       initData.length < offset + 8 ||
       be4toi(initData, offset + 4) !== PSSH_TO_INTEGER
     ) {
-      log.warn("Compat: Unrecognized initialization data. Use as is.");
+      log.warn("DRM", "Unrecognized initialization data. Use as is.");
       return [{ systemId: undefined, data: initData }];
     }
 
     const len = be4toi(new Uint8Array(initData), offset);
     if (offset + len > initData.length) {
-      log.warn("Compat: Unrecognized initialization data. Use as is.");
+      log.warn("DRM", "Unrecognized initialization data. Use as is.");
       return [{ systemId: undefined, data: initData }];
     }
     const currentPSSH = initData.subarray(offset, offset + len);
@@ -94,7 +94,7 @@ function getInitializationDataValues(
       // event (but not when the corresponding segment has been pushed to the
       // SourceBuffer).
       // We prefer filtering them out, to avoid further issues.
-      log.warn("Compat: Duplicated PSSH found in initialization data, removing it.");
+      log.warn("DRM", "Duplicated PSSH found in initialization data, removing it.");
     } else {
       result.push(currentItem);
     }
@@ -102,7 +102,7 @@ function getInitializationDataValues(
   }
 
   if (offset !== initData.length) {
-    log.warn("Compat: Unrecognized initialization data. Use as is.");
+    log.warn("DRM", "Unrecognized initialization data. Use as is.");
     return [{ systemId: undefined, data: initData }];
   }
   return result;
@@ -151,7 +151,7 @@ export default function getInitData(
 ): IEncryptedEventData | null {
   const { initData, initDataType, forceSessionRecreation } = encryptedEvent;
   if (isNullOrUndefined(initData)) {
-    log.warn("Compat: No init data found on media encrypted event.");
+    log.warn("DRM", "No init data found on media encrypted event.");
     return null;
   }
 

--- a/src/compat/eme/load_session.ts
+++ b/src/compat/eme/load_session.ts
@@ -36,7 +36,7 @@ export default async function loadSession(
   session: IMediaKeySession,
   sessionId: string,
 ): Promise<boolean> {
-  log.info("DRM: Load persisted session", sessionId);
+  log.info("DRM", "Load persisted session", { sessionId });
   const isLoaded = await session.load(sessionId);
 
   if (!isLoaded || session.keyStatuses.size > 0) {

--- a/src/compat/eme/set_media_keys.ts
+++ b/src/compat/eme/set_media_keys.ts
@@ -18,18 +18,20 @@ export function setMediaKeys(
   const prom = emeImplementation
     .setMediaKeys(mediaElement, mediaKeys)
     .then(() => {
-      log.info("Compat: MediaKeys updated with success");
+      log.info("DRM", "MediaKeys updated with success");
     })
     .catch((err) => {
       if (mediaKeys === null) {
         log.error(
-          "Compat: Could not reset MediaKeys",
+          "DRM",
+          "Could not reset MediaKeys",
           err instanceof Error ? err : "Unknown Error",
         );
         return;
       }
       log.error(
-        "Compat: Could not update MediaKeys",
+        "DRM",
+        "Could not update MediaKeys",
         err instanceof Error ? err : "Unknown Error",
       );
       throw err;

--- a/src/compat/event_listeners.ts
+++ b/src/compat/event_listeners.ts
@@ -160,7 +160,8 @@ function createCompatibleEventListener(
         });
       } else {
         log.warn(
-          `compat: element ${element.tagName}` +
+          "utils",
+          `element ${element.tagName}` +
             " does not support any of these events: " +
             prefixedEvents.join(", "),
         );

--- a/src/compat/is_codec_supported.ts
+++ b/src/compat/is_codec_supported.ts
@@ -42,7 +42,7 @@ const supportMap: Map<string, boolean> = new Map();
 export default function isCodecSupported(mimeType: string): boolean {
   if (isNullOrUndefined(MediaSource_)) {
     if (isWorker) {
-      log.error("Compat: Cannot request codec support in a worker without MSE.");
+      log.error("mse", "Cannot request codec support in a worker without MSE.");
     }
     return false;
   }

--- a/src/compat/make_vtt_cue.ts
+++ b/src/compat/make_vtt_cue.ts
@@ -36,7 +36,7 @@ export default function makeCue(
   if (startTime >= endTime) {
     // IE/Edge will throw in this case.
     // See issue #501
-    log.warn(`Compat: Invalid cue times: ${startTime} - ${endTime}`);
+    log.warn("text", `Invalid cue times: start after end.`, { startTime, endTime });
     return null;
   }
 

--- a/src/compat/on_height_width_change.ts
+++ b/src/compat/on_height_width_change.ts
@@ -90,7 +90,7 @@ export default function onHeightWidthChange(
   if (_ResizeObserver !== undefined) {
     const resizeObserver = new _ResizeObserver((entries) => {
       if (entries.length === 0) {
-        log.error("Compat: Resized but no observed element.");
+        log.error("utils", "Resized but no observed element.");
         return;
       }
 

--- a/src/compat/remove_cue.ts
+++ b/src/compat/remove_cue.ts
@@ -58,7 +58,7 @@ export default function removeCue(
     try {
       track.removeCue(cue as TextTrackCue);
     } catch (_err) {
-      log.warn("Compat: Could not remove cue from text track.");
+      log.warn("text", "Could not remove cue from text track.");
     }
     track.mode = trackMode;
     return;
@@ -66,6 +66,6 @@ export default function removeCue(
   try {
     track.removeCue(cue as TextTrackCue);
   } catch (_err) {
-    log.warn("Compat: Could not remove cue from text track.");
+    log.warn("text", "Could not remove cue from text track.");
   }
 }

--- a/src/core/adaptive/__tests__/buffer_based_chooser.test.ts
+++ b/src/core/adaptive/__tests__/buffer_based_chooser.test.ts
@@ -87,7 +87,8 @@ describe("BufferBasedChooser", () => {
     expect(bbc.getLastEstimate()).toEqual(10);
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith(
-      "ABR: Current Bitrate not found in the calculated levels",
+      "ABR",
+      "Current Bitrate not found in the calculated levels",
     );
   });
 

--- a/src/core/adaptive/adaptive_representation_selector.ts
+++ b/src/core/adaptive/adaptive_representation_selector.ts
@@ -129,7 +129,7 @@ export default function createAdaptiveRepresentationSelector(
   function _getBandwidthEstimator(bufferType: IBufferType): BandwidthEstimator {
     const originalBandwidthEstimator = bandwidthEstimators[bufferType];
     if (isNullOrUndefined(originalBandwidthEstimator)) {
-      log.debug("ABR: Creating new BandwidthEstimator for ", bufferType);
+      log.debug("ABR", "Creating new BandwidthEstimator", { bufferType });
       const bandwidthEstimator = new BandwidthEstimator();
       bandwidthEstimators[bufferType] = bandwidthEstimator;
       return bandwidthEstimator;
@@ -426,11 +426,10 @@ function getEstimateReference(
         chosenRepFromGuessMode !== null &&
         chosenRepFromGuessMode.bitrate > currentBestBitrate
       ) {
-        log.debug(
-          "ABR: Choosing representation with guess-based estimation.",
-          chosenRepFromGuessMode.bitrate,
-          chosenRepFromGuessMode.id,
-        );
+        log.debug("ABR", "new guess-based estimate", {
+          bitrate: chosenRepFromGuessMode.bitrate,
+          representation: chosenRepFromGuessMode.id,
+        });
         prevEstimate.update(
           chosenRepFromGuessMode,
           bandwidthEstimate,
@@ -445,11 +444,10 @@ function getEstimateReference(
           knownStableBitrate,
         };
       } else if (chosenRepFromBufferSize !== null) {
-        log.debug(
-          "ABR: Choosing representation with buffer-based estimation.",
-          chosenRepFromBufferSize.bitrate,
-          chosenRepFromBufferSize.id,
-        );
+        log.debug("ABR", "new buffer-based estimate", {
+          bitrate: chosenRepFromBufferSize.bitrate,
+          representation: chosenRepFromBufferSize.id,
+        });
         prevEstimate.update(
           chosenRepFromBufferSize,
           bandwidthEstimate,
@@ -467,11 +465,10 @@ function getEstimateReference(
           knownStableBitrate,
         };
       } else {
-        log.debug(
-          "ABR: Choosing representation with bandwidth estimation.",
-          chosenRepFromBandwidth.bitrate,
-          chosenRepFromBandwidth.id,
-        );
+        log.debug("ABR", "new bandwidth estimate", {
+          bitrate: chosenRepFromBandwidth.bitrate,
+          representation: chosenRepFromBandwidth.id,
+        });
         prevEstimate.update(
           chosenRepFromBandwidth,
           bandwidthEstimate,

--- a/src/core/adaptive/buffer_based_chooser.ts
+++ b/src/core/adaptive/buffer_based_chooser.ts
@@ -121,7 +121,8 @@ export default class BufferBasedChooser {
     this._lastUnsuitableQualityTimestamp = undefined;
     this._blockRaiseDelay = MINIMUM_BLOCK_RAISE_DELAY;
     log.debug(
-      "ABR: Steps for buffer based chooser.",
+      "ABR",
+      "Steps for buffer based chooser.",
       this._levelsMap
         .map((l, i) => `bufferLevel: ${l}, bitrate: ${bitrates[i]}`)
         .join(" ,"),
@@ -155,7 +156,7 @@ export default class BufferBasedChooser {
     }
 
     if (currentBitrateIndex < 0 || bitrates.length !== bufferLevels.length) {
-      log.info("ABR: Current Bitrate not found in the calculated levels");
+      log.info("ABR", "Current Bitrate not found in the calculated levels");
       this._currentEstimate = bitrates[0];
       return;
     }
@@ -181,16 +182,20 @@ export default class BufferBasedChooser {
           : now - this._lastUnsuitableQualityTimestamp;
       if (timeSincePrev < this._blockRaiseDelay + STABILITY_CHECK_DELAY) {
         const newDelay = this._blockRaiseDelay + RAISE_BLOCKING_DELAY_INCREMENT;
-        this._blockRaiseDelay = Math.min(newDelay, MAXIMUM_BLOCK_RAISE_DELAY);
         log.debug(
-          "ABR: Incrementing blocking raise in BufferBasedChooser due " +
+          "ABR",
+          "Incrementing blocking raise in BufferBasedChooser due " +
             "to unstable quality",
-          this._blockRaiseDelay,
+          { prevDelay: this._blockRaiseDelay, newDelay },
         );
+        this._blockRaiseDelay = Math.min(newDelay, MAXIMUM_BLOCK_RAISE_DELAY);
       } else {
         const newDelay = this._blockRaiseDelay - RAISE_BLOCKING_DELAY_DECREMENT;
+        log.debug("ABR", "Lowering quality in BufferBasedChooser", {
+          prevDelay: this._blockRaiseDelay,
+          newDelay,
+        });
         this._blockRaiseDelay = Math.max(MINIMUM_BLOCK_RAISE_DELAY, newDelay);
-        log.debug("ABR: Lowering quality in BufferBasedChooser", this._blockRaiseDelay);
       }
       this._lastUnsuitableQualityTimestamp = now;
       // Security if multiple bitrates are equal, we now take the first one
@@ -227,7 +232,9 @@ export default class BufferBasedChooser {
     if (nextIndex !== undefined) {
       const nextBufferLevel = bufferLevels[nextIndex];
       if (bufferGap >= nextBufferLevel) {
-        log.debug("ABR: Raising quality in BufferBasedChooser", bitrates[nextIndex]);
+        log.debug("ABR", "Raising quality in BufferBasedChooser", {
+          bitrate: bitrates[nextIndex],
+        });
         this._currentEstimate = bitrates[nextIndex];
         return;
       }

--- a/src/core/adaptive/guess_based_chooser.ts
+++ b/src/core/adaptive/guess_based_chooser.ts
@@ -136,7 +136,12 @@ export default class GuessBasedChooser {
     // If we reached here, we're currently already in guessing mode
 
     if (this._isLastGuessValidated(lastChosenRep, incomingBestBitrate, scoreData)) {
-      log.debug("ABR: Guessed Representation validated", lastChosenRep.bitrate);
+      log.debug("ABR", "Guessed Representation validated", {
+        chosenBitrate: lastChosenRep.bitrate,
+        otherAbrAlgosBitrate: incomingBestBitrate,
+        scoreData: scoreData?.score,
+        scoreConfidence: scoreData?.confidenceLevel,
+      });
       this._lastMaintanableBitrate = lastChosenRep.bitrate;
       this._consecutiveWrongGuesses = 0;
     }
@@ -282,7 +287,7 @@ function getNextRepresentation(
     ({ id }) => id === currentRepresentation.id,
   );
   if (index < 0) {
-    log.error("ABR: Current Representation not found.");
+    log.error("ABR", "Current Representation not found.");
     return null;
   }
 
@@ -311,7 +316,7 @@ function getPreviousRepresentation(
     ({ id }) => id === currentRepresentation.id,
   );
   if (index < 0) {
-    log.error("ABR: Current Representation not found.");
+    log.error("ABR", "Current Representation not found.");
     return null;
   }
 

--- a/src/core/adaptive/network_analyzer.ts
+++ b/src/core/adaptive/network_analyzer.ts
@@ -344,17 +344,25 @@ export default class NetworkAnalyzer {
       realBufferGap + position.getWanted() < duration - ABR_STARVATION_DURATION_DELTA
     ) {
       if (!this._inStarvationMode && realBufferGap <= localConf.starvationGap) {
-        log.info("ABR: enter starvation mode.");
+        log.info("ABR", "enter starvation mode.", {
+          buffergap: realBufferGap,
+          enterStarvation: localConf.starvationGap,
+        });
         this._inStarvationMode = true;
       } else if (
         this._inStarvationMode &&
         realBufferGap >= localConf.outOfStarvationGap
       ) {
-        log.info("ABR: exit starvation mode.");
+        log.info("ABR", "exit starvation mode.", {
+          bufferGap: realBufferGap,
+          outOfStarvation: localConf.starvationGap,
+        });
         this._inStarvationMode = false;
       }
     } else if (this._inStarvationMode) {
-      log.info("ABR: exit starvation mode.");
+      log.info("ABR", "exit starvation mode.", {
+        bufferGap: realBufferGap,
+      });
       this._inStarvationMode = false;
     }
 
@@ -371,7 +379,9 @@ export default class NetworkAnalyzer {
       );
 
       if (bandwidthEstimate !== undefined) {
-        log.info("ABR: starvation mode emergency estimate:", bandwidthEstimate);
+        log.info("ABR", "starvation mode emergency estimate:", {
+          bandwidth: bandwidthEstimate,
+        });
         bandwidthEstimator.reset();
         newBitrateCeil = isNullOrUndefined(currentRepresentation)
           ? bandwidthEstimate

--- a/src/core/adaptive/utils/pending_requests_store.ts
+++ b/src/core/adaptive/utils/pending_requests_store.ts
@@ -57,7 +57,7 @@ export default class PendingRequestsStore {
       if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
         throw new Error("ABR: progress for a request not added");
       }
-      log.warn("ABR: progress for a request not added");
+      log.warn("ABR", "progress for a request not added", { requestId: progress.id });
       return;
     }
     request.progress.push(progress);
@@ -72,7 +72,7 @@ export default class PendingRequestsStore {
       if ((__ENVIRONMENT__.CURRENT_ENV as number) === (__ENVIRONMENT__.DEV as number)) {
         throw new Error("ABR: can't remove unknown request");
       }
-      log.warn("ABR: can't remove unknown request");
+      log.warn("ABR", "can't remove unknown request", { requestId: id });
     }
     delete this._currentRequests[id];
   }

--- a/src/core/adaptive/utils/representation_score_calculator.ts
+++ b/src/core/adaptive/utils/representation_score_calculator.ts
@@ -118,7 +118,9 @@ export default class RepresentationScoreCalculator {
       currentEWMA.getEstimate() > 1 &&
       this._lastRepresentationWithGoodScore !== representation
     ) {
-      log.debug("ABR: New last stable representation", representation.bitrate);
+      log.debug("ABR", "New last stable representation", {
+        bitrate: representation.bitrate,
+      });
       this._lastRepresentationWithGoodScore = representation;
     }
   }

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -444,7 +444,7 @@ export default class CmcdDataBuilder {
       if (headers.status[headers.status.length - 1] === ",") {
         headers.status = headers.status.substring(0, headers.status.length - 1);
       }
-      log.debug("CMCD: proposing headers payload");
+      log.debug("CMCD", "proposing headers payload");
       return {
         type: "headers",
         value: {
@@ -462,7 +462,9 @@ export default class CmcdDataBuilder {
       queryStringPayload = queryStringPayload.substring(0, queryStringPayload.length - 1);
     }
     queryStringPayload = encodeURIComponent(queryStringPayload);
-    log.debug("CMCD: proposing query string payload", queryStringPayload);
+    log.debug("CMCD", "proposing query string payload", {
+      queryString: queryStringPayload,
+    });
     return {
       type: "query",
       value: [["CMCD", queryStringPayload]],

--- a/src/core/fetchers/manifest/manifest_fetcher.ts
+++ b/src/core/fetchers/manifest/manifest_fetcher.ts
@@ -378,7 +378,7 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
      */
     function finish(manifest: Manifest): IManifestFetcherParsedResult {
       const parsingTime = getMonotonicTimeStamp() - parsingTimeStart;
-      log.info(`MF: Manifest parsed in ${parsingTime}ms`);
+      log.info("MF", `Manifest parsed in ${parsingTime}ms`);
 
       return { manifest, sendingTime, receivedTime, parsingTime };
     }
@@ -547,9 +547,9 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
           regularRefreshDelay * 6,
         );
         log.info(
-          "MUS: Manifest update rythm is too frequent. Postponing next request.",
-          regularRefreshDelay,
-          actualRefreshInterval,
+          "MF",
+          "Manifest update rythm is too frequent. Postponing next request.",
+          { regularRefreshDelay, newRefreshDelay: actualRefreshInterval },
         );
       } else if (totalUpdateTime >= (manifest.lifetime * 1000) / 10) {
         // If Manifest updating time is very long relative to its lifetime,
@@ -564,11 +564,10 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
           // performance seems to have been abysmal one time.
           regularRefreshDelay * 6,
         );
-        log.info(
-          "MUS: Manifest took too long to parse. Postponing next request",
-          actualRefreshInterval,
-          actualRefreshInterval,
-        );
+        log.info("MF", "Manifest took too long to parse. Postponing next request", {
+          regularRefreshDelay,
+          newRefreshDelay: actualRefreshInterval,
+        });
       } else {
         actualRefreshInterval = regularRefreshDelay;
       }
@@ -618,13 +617,15 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
     if (unsafeMode) {
       this._consecutiveUnsafeMode += 1;
       log.info(
-        'Init: Refreshing the Manifest in "unsafeMode" for the ' +
+        "MF",
+        'Refreshing the Manifest in "unsafeMode" for the ' +
           String(this._consecutiveUnsafeMode) +
           " consecutive time.",
       );
     } else if (this._consecutiveUnsafeMode > 0) {
       log.info(
-        'Init: Not parsing the Manifest in "unsafeMode" anymore after ' +
+        "MF",
+        'Not parsing the Manifest in "unsafeMode" anymore after ' +
           String(this._consecutiveUnsafeMode) +
           " consecutive times.",
       );
@@ -656,7 +657,8 @@ export default class ManifestFetcher extends EventEmitter<IManifestFetcherEvent>
           } catch (e) {
             const message = e instanceof Error ? e.message : "unknown error";
             log.warn(
-              `MUS: Attempt to update Manifest failed: ${message}`,
+              "MF",
+              `Attempt to update Manifest failed: ${message}`,
               "Re-downloading the Manifest fully",
             );
             const { FAILED_PARTIAL_UPDATE_MANIFEST_REFRESH_DELAY } = config.getCurrent();

--- a/src/core/fetchers/segment/prioritized_segment_fetcher.ts
+++ b/src/core/fetchers/segment/prioritized_segment_fetcher.ts
@@ -78,7 +78,7 @@ export default function applyPrioritizerToSegmentFetcher<TSegmentDataType>(
     updatePriority(task: Promise<void>, priority: number): void {
       const correspondingTask = taskHandlers.get(task);
       if (correspondingTask === undefined) {
-        log.warn("Fetchers: Cannot update the priority of a request: task not found.");
+        log.warn("SF", "Cannot update the priority of a request: task not found.");
         return;
       }
       prioritizer.updatePriority(correspondingTask, priority);

--- a/src/core/fetchers/segment/segment_fetcher.ts
+++ b/src/core/fetchers/segment/segment_fetcher.ts
@@ -204,12 +204,12 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>({
     // Retrieve from cache if it exists
     const cached = cache !== undefined ? cache.get(content) : null;
     if (cached !== null) {
-      log.debug("SF: Found wanted segment in cache", segmentIdString);
+      log.debug("SF", "Found wanted segment in cache", segmentIdString);
       fetcherCallbacks.onChunk(generateParserFunction(cached, false));
       return Promise.resolve();
     }
 
-    log.debug("SF: Beginning request", segmentIdString);
+    log.debug("SF", "Beginning request", segmentIdString);
     eventListeners.onRequestBegin?.({
       requestTimestamp: getTimestamp(),
       id: requestId,
@@ -237,7 +237,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>({
         fetcherCallbacks.onChunk(generateParserFunction(res.resultData, false));
       }
 
-      log.debug("SF: Segment request ended with success", segmentIdString);
+      log.debug("SF", "Segment request ended with success", segmentIdString);
       fetcherCallbacks.onAllChunksReceived();
 
       if (res.resultType !== "segment-created") {
@@ -258,10 +258,10 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>({
       cancellationSignal.deregister(onCancellation);
       requestInfo = null;
       if (err instanceof CancellationError) {
-        log.debug("SF: Segment request aborted", segmentIdString);
+        log.debug("SF", "Segment request aborted", segmentIdString);
         throw err;
       }
-      log.debug("SF: Segment request failed", segmentIdString);
+      log.debug("SF", "Segment request failed", segmentIdString);
       eventListeners.onRequestEnd?.({ id: requestId });
       throw errorSelector(err);
     }
@@ -270,7 +270,7 @@ export default function createSegmentFetcher<TLoadedFormat, TSegmentDataType>({
       if (requestInfo !== undefined) {
         return; // Request already terminated
       }
-      log.debug("SF: Segment request cancelled", segmentIdString);
+      log.debug("SF", "Segment request cancelled", segmentIdString);
       requestInfo = null;
       eventListeners.onRequestEnd?.({ id: requestId });
     }

--- a/src/core/fetchers/segment/segment_queue.ts
+++ b/src/core/fetchers/segment/segment_queue.ts
@@ -162,10 +162,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
     this.isMediaSegmentQueueInterrupted.onUpdate(
       (val) => {
         if (!val) {
-          log.debug(
-            "SQ: Media segment can be loaded again, restarting queue.",
-            content.adaptation.type,
-          );
+          log.debug("SF", "Media segment can be loaded again, restarting queue.", {
+            type: content.adaptation.type,
+          });
           this._restartMediaSegmentDownloadingQueue(currentContentInfo);
         }
       },
@@ -193,40 +192,36 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
             // There's nothing to load but there's already no request pending.
             return;
           }
-          log.debug(
-            "SQ: no more media segment to request. Cancelling queue.",
-            content.adaptation.type,
-          );
+          log.debug("SF", "no more media segment to request. Cancelling queue.", {
+            type: content.adaptation.type,
+          });
           this._restartMediaSegmentDownloadingQueue(currentContentInfo);
           return;
         } else if (currentSegmentRequest === null) {
           // There's no request although there are needed segments: start requests
-          log.debug(
-            "SQ: Media segments now need to be requested. Starting queue.",
-            content.adaptation.type,
-            segmentQueue.length,
-          );
+          log.debug("SF", "Media segments now need to be requested. Starting queue.", {
+            type: content.adaptation.type,
+            queueLength: segmentQueue.length,
+          });
           this._restartMediaSegmentDownloadingQueue(currentContentInfo);
           return;
         } else {
           const nextItem = segmentQueue[0];
           if (currentSegmentRequest.segment.id !== nextItem.segment.id) {
             // The most important request if for another segment, request it
-            log.debug(
-              "SQ: Next media segment changed, cancelling previous",
-              content.adaptation.type,
-            );
+            log.debug("SF", "Next media segment changed, cancelling previous", {
+              type: content.adaptation.type,
+            });
             this._restartMediaSegmentDownloadingQueue(currentContentInfo);
             return;
           }
           if (currentSegmentRequest.priority !== nextItem.priority) {
             // The priority of the most important request has changed, update it
-            log.debug(
-              "SQ: Priority of next media segment changed, updating",
-              content.adaptation.type,
-              currentSegmentRequest.priority,
-              nextItem.priority,
-            );
+            log.debug("SF", "Priority of next media segment changed, updating", {
+              type: content.adaptation.type,
+              prevPriority: currentSegmentRequest.priority,
+              newPriority: nextItem.priority,
+            });
             this._segmentFetcher.updatePriority(
               currentSegmentRequest.request,
               nextItem.priority,
@@ -254,10 +249,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
           return;
         }
         if (next.initSegment === null) {
-          log.debug(
-            "SQ: no more init segment to request. Cancelling queue.",
-            content.adaptation.type,
-          );
+          log.debug("SF", "no more init segment to request. Cancelling queue.", {
+            type: content.adaptation.type,
+          });
         }
         this._restartInitSegmentDownloadingQueue(currentContentInfo, next.initSegment);
       },
@@ -291,7 +285,7 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
 
     const recursivelyRequestSegments = (): void => {
       if (this.isMediaSegmentQueueInterrupted.getValue()) {
-        log.debug("SQ: Segment fetching postponed because it cannot stream now.");
+        log.debug("SF", "Segment fetching postponed because it cannot stream now.");
         return;
       }
       const { segmentQueue } = downloadQueue.getValue();
@@ -378,11 +372,10 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
            * restarted later.
            */
           beforeInterrupted() {
-            log.info(
-              "SQ: segment request interrupted temporarly.",
-              segment.id,
-              segment.time,
-            );
+            log.info("SF", "segment request interrupted temporarly.", {
+              segmentId: segment.id,
+              segmentTime: segment.time,
+            });
           },
 
           /**
@@ -504,7 +497,9 @@ export default class SegmentQueue<T> extends EventEmitter<ISegmentQueueEvent<T>>
           this.trigger("requestRetry", { segment, error: err });
         },
         beforeInterrupted: () => {
-          log.info("SQ: init segment request interrupted temporarly.", segment.id);
+          log.info("SF", "init segment request interrupted temporarly.", {
+            segmentId: segment.id,
+          });
         },
         beforeEnded: () => {
           unlinkCanceller();

--- a/src/core/fetchers/segment/task_prioritizer.ts
+++ b/src/core/fetchers/segment/task_prioritizer.ts
@@ -37,7 +37,7 @@ export default class TaskPrioritizer<T> {
 
     if (this._prioritySteps.high >= this._prioritySteps.low) {
       throw new Error(
-        "TP: the max high level priority should be given a lower" +
+        "The max high level priority should be given a lower" +
           "priority number than the min low priority.",
       );
     }
@@ -227,7 +227,7 @@ export default class TaskPrioritizer<T> {
     }
     const pendingTasksIndex = _findTaskIndex(promise, this._pendingTasks);
     if (pendingTasksIndex < 0) {
-      log.warn("TP: request to update the priority of a non-existent task");
+      log.warn("SF", "request to update the priority of a non-existent task");
       return;
     }
 
@@ -315,7 +315,7 @@ export default class TaskPrioritizer<T> {
    */
   private _findAndRunWaitingQueueTask(index: number): boolean {
     if (index >= this._waitingQueue.length || index < 0) {
-      log.warn("TP : Tried to start a non existing task");
+      log.warn("SF", "Tried to start a non existing task");
       return false;
     }
     const task = this._waitingQueue.splice(index, 1)[0];
@@ -330,7 +330,7 @@ export default class TaskPrioritizer<T> {
   private _interruptPendingTask(task: IPrioritizerTask<T>): void {
     const pendingTasksIndex = _findTaskIndex(task.taskFn, this._pendingTasks);
     if (pendingTasksIndex < 0) {
-      log.warn("TP: Interrupting a non-existent pending task. Aborting...");
+      log.warn("SF", "Interrupting a non-existent pending task. Aborting...");
       return;
     }
 

--- a/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
+++ b/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
@@ -98,7 +98,9 @@ export default function createThumbnailFetcher(
     });
 
     if (pendingInfo !== undefined) {
-      log.debug("TF: Requesting same thumbnail than the pending one");
+      log.debug("Thumbnails", "Requesting same thumbnail than the pending one", {
+        time: thumbnailContext.segment.time,
+      });
       currRequestInfo = pendingInfo;
       currRequestInfo.referenceCount++;
 
@@ -165,7 +167,7 @@ export default function createThumbnailFetcher(
     }
 
     async function doFetch() {
-      log.debug("TF: Beginning thumbnail request", thumbnail.time);
+      log.debug("Thumbnails", "Beginning thumbnail request", { time: thumbnail.time });
       let res;
       try {
         res = await scheduleRequestWithCdns(
@@ -180,15 +182,17 @@ export default function createThumbnailFetcher(
           return Promise.reject(cancellationSignal.cancellationError);
         }
 
-        log.debug("TF: Thumbnail request ended with success", thumbnail.time);
+        log.debug("Thumbnails", "Thumbnail request ended with success", {
+          time: thumbnail.time,
+        });
         cancellationSignal.deregister(onCancellation);
       } catch (err) {
         cancellationSignal.deregister(onCancellation);
         if (err instanceof CancellationError) {
-          log.debug("TF: Thumbnail request aborted", thumbnail.time);
+          log.debug("Thumbnails", "Thumbnail request aborted", { time: thumbnail.time });
           throw err;
         }
-        log.debug("TF: Thumbnail request failed", thumbnail.time);
+        log.debug("Thumbnails", "Thumbnail request failed", { time: thumbnail.time });
         throw errorSelector(err);
       }
 
@@ -207,7 +211,7 @@ export default function createThumbnailFetcher(
     }
 
     function onCancellation() {
-      log.debug("TF: Thumbnail request cancelled", thumbnail.time);
+      log.debug("Thumbnails", "Thumbnail request cancelled", { time: thumbnail.time });
       const requestIdx = pendingRequestsInfo.indexOf(currRequestInfo);
       if (requestIdx < 0) {
         return;
@@ -241,7 +245,14 @@ export default function createThumbnailFetcher(
      */
     function onRetry(err: unknown): void {
       const formattedErr = errorSelector(err);
-      log.warn("TF: Thumbnail request retry ", thumbnail.time, formattedErr);
+      log.warn(
+        "Thumbnails",
+        "Thumbnail request retry ",
+        {
+          time: thumbnail.time,
+        },
+        formattedErr,
+      );
     }
   };
 }

--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -162,7 +162,7 @@ export async function scheduleRequestWithCdns<T>(
   const { baseDelay, maxDelay, maxRetry, onRetry } = options;
 
   if (cdns !== null && cdns.length === 0) {
-    log.warn("Fetchers: no CDN given to `scheduleRequestWithCdns`.");
+    log.warn("utils", "No CDN given to `scheduleRequestWithCdns`.");
   }
 
   const missedAttempts: Map<ICdnMetadata | null, ICdnAttemptMetadata> = new Map();

--- a/src/core/main/common/FreezeResolver.ts
+++ b/src/core/main/common/FreezeResolver.ts
@@ -235,7 +235,10 @@ export default class FreezeResolver {
     }
 
     const freezingTs = freezing?.timestamp ?? rebuffering?.timestamp ?? null;
-    log.info("FR: Freeze detected", freezingTs, now - (freezingTs ?? now));
+    log.info("Freeze", "Freeze detected", {
+      freezeStart: freezingTs,
+      timeFrozen: now - (freezingTs ?? now),
+    });
 
     /**
      * If `true`, we recently tried to "flush" to unstuck playback but playback
@@ -268,7 +271,7 @@ export default class FreezeResolver {
         timestamp: now,
         position: freezingPosition + UNFREEZING_DELTA_POSITION,
       };
-      log.debug("FR: trying to flush to un-freeze");
+      log.debug("Freeze", "Trying to flush to un-freeze");
 
       this._decipherabilityFreezeStartingTimestamp = null;
       this._ignoreFreezeUntil = now + MINIMUM_TIME_BETWEEN_FREEZE_HANDLING;
@@ -307,7 +310,7 @@ export default class FreezeResolver {
       this._segmentSinksStore,
     );
     if (hasUndecipherableData === true) {
-      log.warn("FR: we have undecipherable segments left in the buffer, reloading");
+      log.warn("Freeze", "we have undecipherable segments left in the buffer, reloading");
       this._decipherabilityFreezeStartingTimestamp = null;
       this._ignoreFreezeUntil = now + MINIMUM_TIME_BETWEEN_FREEZE_HANDLING;
       return { type: "reload", value: null };
@@ -324,7 +327,7 @@ export default class FreezeResolver {
     if (!hasDecipherabilityFreezePotential) {
       this._decipherabilityFreezeStartingTimestamp = null;
     } else if (this._decipherabilityFreezeStartingTimestamp === null) {
-      log.debug("FR: Start of a potential decipherability freeze detected");
+      log.debug("Freeze", "Start of a potential decipherability freeze detected");
       this._decipherabilityFreezeStartingTimestamp = now;
     }
 
@@ -339,7 +342,8 @@ export default class FreezeResolver {
       hasUndecipherableData === false
     ) {
       log.warn(
-        "FR: we are frozen despite only having decipherable " +
+        "Freeze",
+        "we are frozen despite only having decipherable " +
           "segments left in the buffer, reloading",
       );
       this._decipherabilityFreezeStartingTimestamp = null;
@@ -361,7 +365,8 @@ export default class FreezeResolver {
    */
   private _getStrategyIfFlushingFails(freezingPosition: number): IFreezeResolution {
     log.warn(
-      "FR: A recent flush seemed to have no effect on freeze, checking for transitions",
+      "Freeze",
+      "A recent flush seemed to have no effect on freeze, checking for transitions",
     );
 
     /** Contains Representation we might want to avoid after the following algorithm */
@@ -427,7 +432,8 @@ export default class FreezeResolver {
         previousRepresentationEntry.segment === null
       ) {
         log.debug(
-          "FR: Freeze when beginning to play a content, try avoiding this quality",
+          "Freeze",
+          "Freeze when beginning to play a content, try avoiding this quality",
         );
         toAvoid.push({
           adaptation: currentSegment.infos.adaptation,
@@ -438,16 +444,15 @@ export default class FreezeResolver {
         currentSegment.infos.period.id !==
         previousRepresentationEntry.segment.infos.period.id
       ) {
-        log.debug("FR: Freeze when switching Period, reloading");
+        log.debug("Freeze", "Freeze when switching Period, reloading");
         return { type: "reload", value: null };
       } else if (
         currentSegment.infos.representation.uniqueId !==
         previousRepresentationEntry.segment.infos.representation.uniqueId
       ) {
-        log.warn(
-          "FR: Freeze when switching Representation, avoiding",
-          currentSegment.infos.representation.bitrate,
-        );
+        log.warn("Freeze", "Freeze when switching Representation, avoiding", {
+          bitrate: currentSegment.infos.representation.bitrate,
+        });
         toAvoid.push({
           adaptation: currentSegment.infos.adaptation,
           period: currentSegment.infos.period,
@@ -459,7 +464,7 @@ export default class FreezeResolver {
     if (toAvoid.length > 0) {
       return { type: "avoid-representations", value: toAvoid };
     } else {
-      log.debug("FR: Reloading because flush doesn't work");
+      log.debug("Freeze", "Reloading because flush doesn't work");
       return { type: "reload", value: null };
     }
   }

--- a/src/core/main/common/create_content_time_boundaries_observer.ts
+++ b/src/core/main/common/create_content_time_boundaries_observer.ts
@@ -59,7 +59,7 @@ export default function createContentTimeBoundariesObserver(
     mediaSource.setDuration(evt.endingPosition, evt.isEnd);
   });
   contentTimeBoundariesObserver.addEventListener("endOfStream", () => {
-    log.debug("Init: end-of-stream order received.");
+    log.debug("mse", "Start applying end-of-stream order.");
     mediaSource.maintainEndOfStream();
   });
   contentTimeBoundariesObserver.addEventListener("resumeStream", () => {

--- a/src/core/main/worker/content_preparer.ts
+++ b/src/core/main/worker/content_preparer.ts
@@ -240,7 +240,7 @@ export default class ContentPreparer {
         "manifestReady",
         (man: IManifest) => {
           if (manifest !== null) {
-            log.warn("WP: Multiple `manifestReady` events, ignoring");
+            log.warn("Core", "Multiple `manifestReady` events, ignoring");
             return;
           }
           manifest = man;

--- a/src/core/main/worker/send_message.ts
+++ b/src/core/main/worker/send_message.ts
@@ -6,7 +6,7 @@ export default function sendMessage(
   msg: IWorkerMessage,
   transferables?: Transferable[],
 ): void {
-  log.debug("<--- Sending to Main:", msg.type);
+  log.debug("M<--C", "Sending message", { name: msg.type });
   if (transferables === undefined) {
     postMessage(msg);
   } else {

--- a/src/core/main/worker/track_choice_setter.ts
+++ b/src/core/main/worker/track_choice_setter.ts
@@ -68,7 +68,7 @@ export default class TrackChoiceSetter {
       this._refs.set(periodId, obj);
     }
     if (obj[bufferType] !== undefined) {
-      log.warn("WP: Track for periodId already declared", periodId, bufferType);
+      log.warn("Track", "Track for periodId already declared", { periodId, bufferType });
       obj[bufferType]?.trackReference.finish();
       obj[bufferType]?.representations.finish();
     }
@@ -106,7 +106,10 @@ export default class TrackChoiceSetter {
   ): boolean {
     const ref = this._refs.get(periodId)?.[bufferType];
     if (ref === undefined) {
-      log.debug("WP: Setting track for inexistent periodId", periodId, bufferType);
+      log.debug("Track", "Setting track for inexistent periodId", {
+        periodId,
+        bufferType,
+      });
       return false;
     }
     if (isNullOrUndefined(choice)) {
@@ -136,12 +139,18 @@ export default class TrackChoiceSetter {
   ): boolean {
     const ref = this._refs.get(periodId)?.[bufferType];
     if (ref === undefined) {
-      log.debug("WP: Setting track for inexistent periodId", periodId, bufferType);
+      log.debug("Track", "Setting track for inexistent periodId", {
+        periodId,
+        bufferType,
+      });
       return false;
     }
     const val = ref.trackReference.getValue();
     if (isNullOrUndefined(val) || val.adaptationId !== adaptationId) {
-      log.debug("WP: Desynchronized Adaptation id", val?.adaptationId, adaptationId);
+      log.debug("Track", "Desynchronized Adaptation id", {
+        oldId: val?.adaptationId,
+        newId: adaptationId,
+      });
       return false;
     }
     ref.representations.setValue(choice);
@@ -152,11 +161,10 @@ export default class TrackChoiceSetter {
     const obj = this._refs.get(periodId);
     const ref = obj?.[bufferType];
     if (obj === undefined || ref === undefined) {
-      log.debug(
-        "WP: Removing track setter for inexistent periodId",
+      log.debug("Track", "Removing track setter for inexistent periodId", {
         periodId,
         bufferType,
-      );
+      });
       return false;
     }
     ref.trackReference.finish();

--- a/src/core/main/worker/worker_main.ts
+++ b/src/core/main/worker/worker_main.ts
@@ -81,10 +81,10 @@ export default function initializeWorkerMain() {
   let playbackObservationRef: SharedReference<IWorkerPlaybackObservation> | null = null;
 
   globalScope.onmessageerror = (_msg: MessageEvent) => {
-    log.error("MTCI: Error when receiving message from main thread.");
+    log.error("Core", "Error when receiving message from main thread.");
   };
   onmessage = function (e: MessageEvent<IMainThreadMessage>) {
-    log.debug("Worker: received message", e.data.type);
+    log.debug("Core", "received message", { name: e.data.type });
 
     const msg = e.data;
     switch (msg.type) {
@@ -100,7 +100,7 @@ export default function initializeWorkerMain() {
         if (msg.value.dashWasmUrl !== undefined && dashWasmParser.isCompatible()) {
           dashWasmParser.initialize({ wasmUrl: msg.value.dashWasmUrl }).catch((err) => {
             const error = err instanceof Error ? err.toString() : "Unknown Error";
-            log.error("Worker: Could not initialize DASH_WASM parser", error);
+            log.error("Core", "Could not initialize DASH_WASM parser", error);
           });
         }
 
@@ -211,13 +211,16 @@ export default function initializeWorkerMain() {
           (s) => s.type === msg.sourceBufferType,
         );
         if (sourceBuffer === undefined) {
-          log.info("WP: Success for an unknown SourceBuffer", msg.sourceBufferType);
+          log.info("Core", "Success for an unknown SourceBuffer", {
+            sourceBufferType: msg.sourceBufferType,
+          });
           return;
         }
         if (sourceBuffer.onOperationSuccess === undefined) {
           log.warn(
-            "WP: A SourceBufferInterface with MSE performed a cross-thread operation",
-            msg.sourceBufferType,
+            "Core",
+            "A SourceBufferInterface with MSE performed a cross-thread operation",
+            { sourceBufferType: msg.sourceBufferType },
           );
           return;
         }
@@ -236,13 +239,18 @@ export default function initializeWorkerMain() {
           (s) => s.type === msg.sourceBufferType,
         );
         if (sourceBuffer === undefined) {
-          log.info("WP: Error for an unknown SourceBuffer", msg.sourceBufferType);
+          log.info("Core", "Error for an unknown SourceBuffer", {
+            sourceBufferType: msg.sourceBufferType,
+          });
           return;
         }
         if (sourceBuffer.onOperationFailure === undefined) {
           log.warn(
-            "WP: A SourceBufferInterface with MSE performed a cross-thread operation",
-            msg.sourceBufferType,
+            "Core",
+            "A SourceBufferInterface with MSE performed a cross-thread operation",
+            {
+              sourceBufferType: msg.sourceBufferType,
+            },
           );
           return;
         }
@@ -257,7 +265,8 @@ export default function initializeWorkerMain() {
         }
         if (preparedContent.mediaSource.onMediaSourceReadyStateChanged === undefined) {
           log.warn(
-            "WP: A MediaSourceInterface with MSE performed a cross-thread operation",
+            "Core",
+            "A MediaSourceInterface with MSE performed a cross-thread operation",
           );
           return;
         }
@@ -355,7 +364,7 @@ export default function initializeWorkerMain() {
           return;
         }
         if (preparedContent.workerTextSender === null) {
-          log.error("WP: Added text track but text track aren't enabled");
+          log.error("Core", "Added text track but text track aren't enabled");
           return;
         }
         preparedContent.workerTextSender.onPushedTrackSuccess(msg.value.ranges);
@@ -368,7 +377,7 @@ export default function initializeWorkerMain() {
           return;
         }
         if (preparedContent.workerTextSender === null) {
-          log.error("WP: Added text track but text track aren't enabled");
+          log.error("Core", "Added text track but text track aren't enabled");
           return;
         }
         preparedContent.workerTextSender.onPushedTrackError(new Error(msg.value.message));
@@ -381,7 +390,7 @@ export default function initializeWorkerMain() {
           return;
         }
         if (preparedContent.workerTextSender === null) {
-          log.error("WP: Removed text track but text track aren't enabled");
+          log.error("Core", "Removed text track but text track aren't enabled");
           return;
         }
         preparedContent.workerTextSender.onRemoveSuccess(msg.value.ranges);
@@ -394,7 +403,7 @@ export default function initializeWorkerMain() {
           return;
         }
         if (preparedContent.workerTextSender === null) {
-          log.error("WP: Removed text track but text track aren't enabled");
+          log.error("Core", "Removed text track but text track aren't enabled");
           return;
         }
         preparedContent.workerTextSender.onRemoveError(new Error(msg.value.message));
@@ -502,8 +511,7 @@ function loadPreparedContent(
   contentPreparer: ContentPreparer,
   playbackObservationRef: IReadOnlySharedReference<IWorkerPlaybackObservation>,
 ): IContentHandle {
-  log.debug("WP: Loading prepared content");
-
+  log.debug("Core", "Loading pepared content.");
   const contentCanceller = new TaskCanceller();
 
   let currentLoadCanceller: TaskCanceller | null = null;
@@ -926,15 +934,14 @@ function loadPreparedContent(
     }
     const mediaSourceId = contentPreparer.getCurrentContent()?.mediaSource.id;
     if (mediaSourceId === undefined) {
-      log.warn("WP: Cannot reload MediaSource: no MediaSource currently.");
+      log.warn("Core", "Cannot reload MediaSource: no MediaSource currently.");
       return;
     }
-    log.debug(
-      "WP: Reloading MediaSource",
-      payload.timeOffset,
-      payload.minimumPosition,
-      payload.maximumPosition,
-    );
+    log.debug("Core", "Reloading MediaSource", {
+      timeOffset: payload.timeOffset,
+      minimumPosition: payload.minimumPosition,
+      maximumPosition: payload.maximumPosition,
+    });
 
     sendMessage(
       {
@@ -955,16 +962,17 @@ function loadPreparedContent(
       currentLoadCanceller.cancel();
       currentLoadCanceller = null;
     }
-    log.debug("WP: Reloading MediaSource");
     const contentId = contentPreparer.getCurrentContent()?.contentId;
     contentPreparer.reloadMediaSource().then(
       () => {
-        log.info("WP: MediaSource Reloaded, loading content again", newInitialTime);
+        log.info("Core", "MediaSource Reloaded, loading content again", {
+          newInitialTime,
+        });
         startLoadingAt(newInitialTime);
       },
       (err: unknown) => {
         if (TaskCanceller.isCancellationError(err)) {
-          log.info("WP: A reloading operation was cancelled");
+          log.info("Core", "A reloading operation was cancelled");
           return;
         }
         sendMessage({
@@ -987,7 +995,7 @@ function updateLoggerLevel(
   } else {
     // Here we force the log format to "standard" as the full formatting will be
     // performed on main thread.
-    log.setLevel(logLevel, "standard", (levelStr, logs) => {
+    log.setLevel(logLevel, "standard", (levelStr, namespace, logs) => {
       const sentLogs = logs.map((e) => {
         if (e instanceof Error) {
           return formatErrorForSender(e);
@@ -998,6 +1006,7 @@ function updateLoggerLevel(
       postMessage({
         type: WorkerMessageType.LogMessage,
         value: {
+          namespace,
           logLevel: levelStr,
           logs: sentLogs,
         },
@@ -1058,7 +1067,7 @@ function handleFreezeResolution(
 ): void {
   switch (freezeResolution.type) {
     case "reload": {
-      log.info("WP: Planning reload due to freeze");
+      log.info("Core", "Planning reload due to freeze");
       handleMediaSourceReload({
         timeOffset: 0,
         minimumPosition: 0,
@@ -1067,7 +1076,7 @@ function handleFreezeResolution(
       break;
     }
     case "flush": {
-      log.info("WP: Flushing buffer due to freeze");
+      log.info("Core", "Flushing buffer due to freeze");
       sendMessage({
         type: WorkerMessageType.NeedsBufferFlush,
         contentId,
@@ -1079,7 +1088,7 @@ function handleFreezeResolution(
       break;
     }
     case "avoid-representations": {
-      log.info("WP: Planning Representation avoidance due to freeze");
+      log.info("Core", "Planning Representation avoidance due to freeze");
       const content = freezeResolution.value;
       if (enableRepresentationAvoidance) {
         manifest.addRepresentationsToAvoid(content);

--- a/src/core/main/worker/worker_text_displayer_interface.ts
+++ b/src/core/main/worker/worker_text_displayer_interface.ts
@@ -112,7 +112,7 @@ export default class WorkerTextDisplayerInterface implements ITextDisplayerInter
   public onPushedTrackSuccess(ranges: IRange[]): void {
     const element = this._queues.pushTextData.shift();
     if (element === undefined) {
-      log.error("WMS: pushTextData success for inexistant operation");
+      log.error("text", "pushTextData success for inexistant operation");
       return;
     }
     element.resolve(ranges);
@@ -124,7 +124,7 @@ export default class WorkerTextDisplayerInterface implements ITextDisplayerInter
   public onPushedTrackError(err: Error): void {
     const element = this._queues.pushTextData.shift();
     if (element === undefined) {
-      log.error("WMS: pushTextData error for inexistant operation");
+      log.error("text", "pushTextData error for inexistant operation");
       return;
     }
     element.reject(err);
@@ -136,7 +136,7 @@ export default class WorkerTextDisplayerInterface implements ITextDisplayerInter
   public onRemoveSuccess(ranges: IRange[]): void {
     const element = this._queues.remove.shift();
     if (element === undefined) {
-      log.error("WMS: remove success for inexistant operation");
+      log.error("text", "remove success for inexistant operation");
       return;
     }
     element.resolve(ranges);
@@ -148,7 +148,7 @@ export default class WorkerTextDisplayerInterface implements ITextDisplayerInter
   public onRemoveError(err: Error): void {
     const element = this._queues.pushTextData.shift();
     if (element === undefined) {
-      log.error("WMS: pushTextData error for inexistant operation");
+      log.error("text", "pushTextData error for inexistant operation");
       return;
     }
     element.reject(err);

--- a/src/core/segment_sinks/garbage_collector.ts
+++ b/src/core/segment_sinks/garbage_collector.ts
@@ -85,7 +85,7 @@ export default function BufferGarbageCollector(
         return;
       }
       const errMsg = e instanceof Error ? e.message : "Unknown error";
-      log.error("Could not run BufferGarbageCollector:", errMsg);
+      log.error("Stream", "Could not run BufferGarbageCollector:", errMsg);
     });
   }
   maxBufferBehind.onUpdate(clean, { clearSignal: cancellationSignal });
@@ -191,7 +191,10 @@ async function clearBuffer(
 
   for (const range of cleanedupRanges) {
     if (range.start < range.end) {
-      log.debug("GC: cleaning range from SegmentSink", range.start, range.end);
+      log.debug("Stream", "cleaning range from SegmentSink", {
+        start: range.start,
+        end: range.end,
+      });
       if (cancellationSignal.cancellationError !== null) {
         throw cancellationSignal.cancellationError;
       }

--- a/src/core/segment_sinks/implementations/audio_video/audio_video_segment_sink.ts
+++ b/src/core/segment_sinks/implementations/audio_video/audio_video_segment_sink.ts
@@ -90,7 +90,7 @@ export default class AudioVideoSegmentSink extends SegmentSink {
     mediaSource: IMediaSourceInterface,
   ) {
     super();
-    log.info("AVSB: calling `mediaSource.addSourceBuffer`", codec);
+    log.info("Stream", "calling `mediaSource.addSourceBuffer`", { codec });
     const sourceBuffer = mediaSource.addSourceBuffer(bufferType, codec);
 
     this.bufferType = bufferType;
@@ -139,11 +139,7 @@ export default class AudioVideoSegmentSink extends SegmentSink {
    */
   public async pushChunk(infos: IPushChunkInfos<unknown>): Promise<IRange[]> {
     assertDataIsBufferSource(infos.data.chunk);
-    log.debug(
-      "AVSB: receiving order to push data to the SourceBuffer",
-      this.bufferType,
-      getLoggableSegmentId(infos.inventoryInfos),
-    );
+    log.debug("Stream", "queuing push order", getLoggableSegmentId(infos.inventoryInfos));
     const dataToPush = this._getActualDataToPush(
       infos.data as IPushedChunkData<BufferSource>,
     );
@@ -170,11 +166,7 @@ export default class AudioVideoSegmentSink extends SegmentSink {
     const promise = Promise.all(
       dataToPush.map((data) => {
         const { codec, timestampOffset, appendWindow } = infos.data;
-        log.debug(
-          "AVSB: pushing segment",
-          this.bufferType,
-          getLoggableSegmentId(infos.inventoryInfos),
-        );
+        log.debug("Stream", "now pushing", getLoggableSegmentId(infos.inventoryInfos));
         return this._sourceBuffer.appendBuffer(data, {
           codec,
           timestampOffset,
@@ -211,12 +203,11 @@ export default class AudioVideoSegmentSink extends SegmentSink {
 
   /** @see SegmentSink */
   public async removeBuffer(start: number, end: number): Promise<IRange[]> {
-    log.debug(
-      "AVSB: receiving order to remove data from the SourceBuffer",
-      this.bufferType,
+    log.debug("Stream", "queuing remove order", {
+      bufferType: this.bufferType,
       start,
       end,
-    );
+    });
     const promise = this._sourceBuffer.remove(start, end);
     this._addToOperationQueue(promise, {
       type: SegmentSinkOperation.Remove,
@@ -265,12 +256,13 @@ export default class AudioVideoSegmentSink extends SegmentSink {
   /** @see SegmentSink */
   public dispose(): void {
     try {
-      log.debug("AVSB: Calling `dispose` on the SourceBufferInterface");
+      log.debug("Stream", "Calling `dispose` on the SourceBufferInterface");
       this._sourceBuffer.dispose();
     } catch (e) {
       log.debug(
-        `AVSB: Failed to dispose a ${this.bufferType} SourceBufferInterface:`,
-        e instanceof Error ? e : "",
+        "Stream",
+        `Failed to dispose a ${this.bufferType} SourceBufferInterface:`,
+        e instanceof Error ? e : "Unknown Error",
       );
     }
   }

--- a/src/core/segment_sinks/implementations/text/text_segment_sink.ts
+++ b/src/core/segment_sinks/implementations/text/text_segment_sink.ts
@@ -28,7 +28,7 @@ export default class TextSegmentSink extends SegmentSink {
    * @param {Object} textDisplayerSender
    */
   constructor(textDisplayerSender: ITextDisplayerInterface) {
-    log.debug("HTSB: Creating TextSegmentSink");
+    log.debug("Stream", "Creating TextSegmentSink");
     super();
     this.bufferType = "text";
     this._sender = textDisplayerSender;
@@ -40,14 +40,18 @@ export default class TextSegmentSink extends SegmentSink {
    * @param {string} uniqueId
    */
   public declareInitSegment(uniqueId: string): void {
-    log.warn("HTSB: Declaring initialization segment for  Text SegmentSink", uniqueId);
+    log.warn("Stream", "Declaring initialization segment for  Text SegmentSink", {
+      uniqueId,
+    });
   }
 
   /**
    * @param {string} uniqueId
    */
   public freeInitSegment(uniqueId: string): void {
-    log.warn("HTSB: Freeing initialization segment for  Text SegmentSink", uniqueId);
+    log.warn("Stream", "Freeing initialization segment for  Text SegmentSink", {
+      uniqueId,
+    });
   }
 
   /**
@@ -125,7 +129,7 @@ export default class TextSegmentSink extends SegmentSink {
   }
 
   public dispose(): void {
-    log.debug("HTSB: Disposing TextSegmentSink");
+    log.debug("Stream", "Disposing TextSegmentSink");
     this._sender.reset();
   }
 

--- a/src/core/segment_sinks/inventory/segment_inventory.ts
+++ b/src/core/segment_sinks/inventory/segment_inventory.ts
@@ -17,7 +17,7 @@
 import config from "../../../config";
 import log from "../../../log";
 import type { IAdaptation, ISegment, IPeriod, IRepresentation } from "../../../manifest";
-import { areSameContent } from "../../../manifest";
+import { areSameContent, getLoggableSegmentId } from "../../../manifest";
 import isNullOrUndefined from "../../../utils/is_null_or_undefined";
 import getMonotonicTimeStamp from "../../../utils/monotonic_timestamp";
 import type { IRange } from "../../../utils/ranges";
@@ -224,7 +224,8 @@ export default class SegmentInventory {
     if (log.hasLevel("DEBUG")) {
       const prettyPrintedRanges = ranges.map((r) => `${r.start}-${r.end}`).join(",");
       log.debug(
-        `SI: synchronizing ${bufferType ?? "unknown"} buffered ranges:`,
+        "SI",
+        `synchronizing ${bufferType ?? "unknown"} buffered ranges:`,
         prettyPrintedRanges,
       );
     }
@@ -240,12 +241,11 @@ export default class SegmentInventory {
       const rangeStart = ranges[i].start;
       const rangeEnd = ranges[i].end;
       if (rangeEnd - rangeStart < MINIMUM_SEGMENT_SIZE) {
-        log.warn(
-          "SI: skipped range when synchronizing because it was too small",
-          bufferType,
+        log.warn("SI", "skipped range when synchronizing because it was too small", {
+          t: bufferType,
           rangeStart,
           rangeEnd,
-        );
+        });
         continue;
       }
 
@@ -276,7 +276,9 @@ export default class SegmentInventory {
           end: lastDeletedSegment.bufferedEnd ?? lastDeletedSegment.end,
           precizeEnd: lastDeletedSegment.precizeEnd,
         };
-        log.debug(`SI: ${numberOfSegmentToDelete} segments GCed.`, bufferType);
+        log.debug("SI", `${numberOfSegmentToDelete} segments GCed.`, {
+          t: bufferType,
+        });
         const removed = inventory.splice(indexBefore, numberOfSegmentToDelete);
         for (const seg of removed) {
           if (
@@ -358,12 +360,11 @@ export default class SegmentInventory {
               // `start` is in that scenario more "trustable" than `end`.
               prevSegment.bufferedEnd = thisSegment.start;
             }
-            log.debug(
-              "SI: calculating buffered end of contiguous segment",
-              bufferType,
-              prevSegment.bufferedEnd,
-              prevSegment.end,
-            );
+            log.debug("SI", "calculating buffered end of contiguous segment", {
+              t: bufferType,
+              prevSegmentBufferedEnd: prevSegment.bufferedEnd,
+              pse: prevSegment.end,
+            });
           }
 
           thisSegment.bufferedStart = prevSegment.bufferedEnd;
@@ -391,9 +392,9 @@ export default class SegmentInventory {
         const segmentInfo = inventory[i];
         if (now - segmentInfo.insertionTs >= SEGMENT_SYNCHRONIZATION_DELAY) {
           log.debug(
-            "SI: A segment at the end has been completely GCed",
-            bufferType,
-            `${segmentInfo.start}-${segmentInfo.end}`,
+            "SI",
+            "A segment at the end has been completely GCed",
+            getLoggableSegmentId(segmentInfo.infos),
           );
           if (
             segmentInfo.bufferedStart === undefined &&
@@ -408,8 +409,10 @@ export default class SegmentInventory {
       }
     }
     if (bufferType !== undefined && log.hasLevel("DEBUG")) {
+      // TODO: Do not log if it did not change?
       log.debug(
-        `SI: current ${bufferType} inventory timeline:\n` +
+        "SI",
+        `current ${bufferType} inventory timeline:\n` +
           prettyPrintInventory(this._inventory),
       );
     }
@@ -445,12 +448,11 @@ export default class SegmentInventory {
 
     const bufferType = adaptation.type;
     if (start >= end) {
-      log.warn(
-        "SI: Invalid chunked inserted: starts before it ends",
-        bufferType,
+      log.warn("SI", "Invalid chunked inserted: starts before it ends", {
+        t: bufferType,
         start,
         end,
-      );
+      });
       return;
     }
 
@@ -486,12 +488,11 @@ export default class SegmentInventory {
           //   prevSegment  : |------|
           //   newSegment   :          |======|
           //   ===>         : |------| |======|
-          log.debug(
-            "SI: Pushing segment strictly after previous one.",
-            bufferType,
-            start,
-            segmentI.end,
-          );
+          log.debug("SI", "Pushing segment strictly after previous one.", {
+            t: bufferType,
+            pse: segmentI.end,
+            ss: start,
+          });
           this._inventory.splice(i + 1, 0, newSegment);
 
           i += 2; // Go to segment immediately after newSegment
@@ -505,12 +506,12 @@ export default class SegmentInventory {
               //   newSegment   :        |======|
               //   nextSegment  :            |----|
               //   ===>         : |------|======|-|
-              log.debug(
-                "SI: Segment pushed updates the start of the next one",
-                bufferType,
-                newSegment.end,
-                inventory[i].start,
-              );
+              log.debug("SI", "Segment pushed updates the start of the next one", {
+                t: bufferType,
+                pss: inventory[i].start,
+                ss: start,
+                se: end,
+              });
               inventory[i].start = newSegment.end;
               inventory[i].bufferedStart = undefined;
               inventory[i].precizeStart =
@@ -531,14 +532,13 @@ export default class SegmentInventory {
             //   newSegment   :        |======|
             //   nextSegment  :          |----|
             //   ===>         : |------|======|
-            log.debug(
-              "SI: Segment pushed removes the next one",
-              bufferType,
-              start,
-              end,
-              inventory[i].start,
-              inventory[i].end,
-            );
+            log.debug("SI", "Segment pushed removes the next one", {
+              t: bufferType,
+              ss: start,
+              se: end,
+              pss: inventory[i].start,
+              pse: inventory[i].end,
+            });
             inventory.splice(i, 1);
           }
           return;
@@ -556,13 +556,13 @@ export default class SegmentInventory {
               //  prevSegment  : |-------|
               //  newSegment   : |==========|
               //  ===>         : |==========|
-              log.debug(
-                "SI: Segment pushed replace another one",
-                bufferType,
-                start,
-                end,
-                segmentI.end,
-              );
+              log.debug("SI", "Segment pushed replace another one", {
+                t: bufferType,
+                ss: start,
+                se: end,
+                pss: segmentI.start,
+                pse: segmentI.end,
+              });
               this._inventory.splice(i, 1, newSegment);
               i += 1; // Go to segment immediately after newSegment
               while (i < inventory.length && inventory[i].start < newSegment.end) {
@@ -574,12 +574,13 @@ export default class SegmentInventory {
                   //   newSegment   : |======|
                   //   nextSegment  :      |----|
                   //   ===>         : |======|--|
-                  log.debug(
-                    "SI: Segment pushed updates the start of the next one",
-                    bufferType,
-                    newSegment.end,
-                    inventory[i].start,
-                  );
+                  log.debug("SI", "Segment pushed updates the start of the next one", {
+                    t: bufferType,
+                    ss: start,
+                    se: end,
+                    pss: inventory[i].start,
+                    pse: inventory[i].end,
+                  });
                   inventory[i].start = newSegment.end;
                   inventory[i].bufferedStart = undefined;
                   inventory[i].precizeStart =
@@ -598,14 +599,13 @@ export default class SegmentInventory {
                 //   newSegment   : |======|
                 //   nextSegment  :   |----|
                 //   ===>         : |======|
-                log.debug(
-                  "SI: Segment pushed removes the next one",
-                  bufferType,
-                  start,
-                  end,
-                  inventory[i].start,
-                  inventory[i].end,
-                );
+                log.debug("SI", "Segment pushed removes the next one", {
+                  t: bufferType,
+                  ss: start,
+                  se: end,
+                  pss: inventory[i].start,
+                  pse: inventory[i].end,
+                });
                 inventory.splice(i, 1);
               }
               return;
@@ -619,13 +619,12 @@ export default class SegmentInventory {
               //  prevSegment  : |------------|
               //  newSegment   : |==========|
               //  ===>         : |==========|-|
-              log.debug(
-                "SI: Segment pushed ends before another with the same start",
-                bufferType,
-                start,
-                end,
-                segmentI.end,
-              );
+              log.debug("SI", "Segment pushed ends before another with the same start", {
+                t: bufferType,
+                ss: start,
+                se: end,
+                pse: segmentI.end,
+              });
               inventory.splice(i, 0, newSegment);
               segmentI.start = newSegment.end;
               segmentI.bufferedStart = undefined;
@@ -646,14 +645,13 @@ export default class SegmentInventory {
               //  prevSegment  : |-------|
               //  newSegment   :    |====|
               //  ===>         : |--|====|
-              log.debug(
-                "SI: Segment pushed updates end of previous one",
-                bufferType,
-                start,
-                end,
-                segmentI.start,
-                segmentI.end,
-              );
+              log.debug("SI", "Segment pushed updates end of previous one", {
+                t: bufferType,
+                ss: start,
+                se: end,
+                pss: segmentI.start,
+                pse: segmentI.end,
+              });
               this._inventory.splice(i + 1, 0, newSegment);
               segmentI.end = newSegment.start;
               segmentI.bufferedEnd = undefined;
@@ -668,12 +666,12 @@ export default class SegmentInventory {
                   //   newSegment   : |======|
                   //   nextSegment  :      |----|
                   //   ===>         : |======|--|
-                  log.debug(
-                    "SI: Segment pushed updates the start of the next one",
-                    bufferType,
-                    newSegment.end,
-                    inventory[i].start,
-                  );
+                  log.debug("SI", "Segment pushed updates the start of the next one", {
+                    t: bufferType,
+                    ss: start,
+                    se: end,
+                    pss: inventory[i].start,
+                  });
                   inventory[i].start = newSegment.end;
                   inventory[i].bufferedStart = undefined;
                   inventory[i].precizeStart =
@@ -692,14 +690,13 @@ export default class SegmentInventory {
                 //   newSegment   : |======|
                 //   nextSegment  :   |----|
                 //   ===>         : |======|
-                log.debug(
-                  "SI: Segment pushed removes the next one",
-                  bufferType,
-                  start,
-                  end,
-                  inventory[i].start,
-                  inventory[i].end,
-                );
+                log.debug("SI", "Segment pushed removes the next one", {
+                  t: bufferType,
+                  ss: start,
+                  se: end,
+                  pss: inventory[i].start,
+                  pse: inventory[i].end,
+                });
                 inventory.splice(i, 1);
               }
               return;
@@ -712,14 +709,13 @@ export default class SegmentInventory {
               //  prevSegment  : |---------|
               //  newSegment   :    |====|
               //  ===>         : |--|====|-|
-              log.warn(
-                "SI: Segment pushed is contained in a previous one",
-                bufferType,
-                start,
-                end,
-                segmentI.start,
-                segmentI.end,
-              );
+              log.warn("SI", "Segment pushed is contained in a previous one", {
+                t: bufferType,
+                ss: start,
+                se: end,
+                pss: segmentI.start,
+                pse: segmentI.end,
+              });
               const nextSegment = {
                 status: segmentI.status,
                 insertionTs: segmentI.insertionTs,
@@ -758,7 +754,7 @@ export default class SegmentInventory {
     const firstSegment = this._inventory[0];
     if (firstSegment === undefined) {
       // we do not have any segment yet
-      log.debug("SI: first segment pushed", bufferType, start, end);
+      log.debug("SI", "first segment pushed", { t: bufferType, ss: start, se: end });
       this._inventory.push(newSegment);
       return;
     }
@@ -775,13 +771,12 @@ export default class SegmentInventory {
       //  firstSegment :        |----|
       //  newSegment   : |====|
       //  ===>         : |====| |----|
-      log.debug(
-        "SI: Segment pushed comes before all previous ones",
-        bufferType,
-        start,
-        end,
-        firstSegment.start,
-      );
+      log.debug("SI", "Segment pushed comes before all previous ones", {
+        t: bufferType,
+        ss: start,
+        se: end,
+        pss: firstSegment.start,
+      });
       this._inventory.splice(0, 0, newSegment);
     } else if (firstSegment.end <= end) {
       // Our segment is bigger, replace the first
@@ -796,13 +791,16 @@ export default class SegmentInventory {
       //  newSegment   : |=======|
       //  ===>         : |=======|
       log.debug(
-        "SI: Segment pushed starts before and completely " +
+        "SI",
+        "Segment pushed starts before and completely " +
           "recovers the previous first one",
-        bufferType,
-        start,
-        end,
-        firstSegment.start,
-        firstSegment.end,
+        {
+          t: bufferType,
+          ss: start,
+          se: end,
+          pss: firstSegment.start,
+          pse: firstSegment.end,
+        },
       );
       this._inventory.splice(0, 1, newSegment);
       while (inventory.length > 1 && inventory[1].start < newSegment.end) {
@@ -814,12 +812,13 @@ export default class SegmentInventory {
           //   newSegment   : |======|
           //   nextSegment  :      |----|
           //   ===>         : |======|--|
-          log.debug(
-            "SI: Segment pushed updates the start of the next one",
-            bufferType,
-            newSegment.end,
-            inventory[1].start,
-          );
+          log.debug("SI", "Segment pushed updates the start of the next one", {
+            t: bufferType,
+            ss: start,
+            se: end,
+            pss: inventory[1].start,
+            pse: inventory[1].end,
+          });
           inventory[1].start = newSegment.end;
           inventory[1].bufferedStart = undefined;
           inventory[1].precizeStart = newSegment.precizeEnd;
@@ -837,14 +836,13 @@ export default class SegmentInventory {
         //   newSegment   : |======|
         //   nextSegment  :   |----|
         //   ===>         : |======|
-        log.debug(
-          "SI: Segment pushed removes the next one",
-          bufferType,
-          start,
-          end,
-          inventory[1].start,
-          inventory[1].end,
-        );
+        log.debug("SI", "Segment pushed removes the next one", {
+          t: bufferType,
+          ss: start,
+          se: end,
+          pss: inventory[1].start,
+          pse: inventory[1].end,
+        });
         inventory.splice(1, 1);
       }
       return;
@@ -856,14 +854,12 @@ export default class SegmentInventory {
       //  firstSegment :    |------|
       //  newSegment   : |======|
       //  ===>         : |======|--|
-      log.debug(
-        "SI: Segment pushed start of the next one",
-        bufferType,
-        start,
-        end,
-        firstSegment.start,
-        firstSegment.end,
-      );
+      log.debug("SI", "Segment pushed start of the next one", bufferType, {
+        ss: start,
+        se: end,
+        pss: firstSegment.start,
+        pse: firstSegment.end,
+      });
       firstSegment.start = end;
       firstSegment.bufferedStart = undefined;
       firstSegment.precizeStart = newSegment.precizeEnd;
@@ -899,10 +895,9 @@ export default class SegmentInventory {
           splitted = true;
           if (resSegments.length === 1) {
             log.warn(
-              "SI: Completed Segment is splitted.",
-              content.segment.id,
-              content.segment.time,
-              content.segment.end,
+              "SI",
+              "Completed Segment is splitted.",
+              getLoggableSegmentId(content),
             );
             resSegments[0].splitted = true;
           }
@@ -939,11 +934,7 @@ export default class SegmentInventory {
     }
 
     if (resSegments.length === 0) {
-      log.warn(
-        "SI: Completed Segment not found",
-        content.segment.id,
-        content.segment.time,
-      );
+      log.warn("SI", "Completed Segment not found", getLoggableSegmentId(content));
     } else {
       for (const seg of resSegments) {
         if (seg.bufferedStart !== undefined && seg.bufferedEnd !== undefined) {
@@ -956,11 +947,10 @@ export default class SegmentInventory {
         } else {
           // TODO FIXME There might be a false positive here when the
           // `SEGMENT_SYNCHRONIZATION_DELAY` config value is at play
-          log.debug(
-            "SI: buffered range not known after sync. Skipping history.",
-            seg.start,
-            seg.end,
-          );
+          log.debug("SI", "buffered range not known after sync. Skipping history.", {
+            ss: seg.start,
+            se: seg.end,
+          });
         }
       }
     }
@@ -1074,12 +1064,11 @@ function guessBufferedStartFromRangeStart(
   } = config.getCurrent();
   if (firstSegmentInRange.bufferedStart !== undefined) {
     if (firstSegmentInRange.bufferedStart < rangeStart) {
-      log.debug(
-        "SI: Segment partially GCed at the start",
-        bufferType,
-        firstSegmentInRange.bufferedStart,
-        rangeStart,
-      );
+      log.debug("SI", "Segment partially GCed at the start", {
+        t: bufferType,
+        firstsbs: firstSegmentInRange.bufferedStart,
+        rs: rangeStart,
+      });
       firstSegmentInRange.bufferedStart = rangeStart;
     }
     if (
@@ -1090,11 +1079,10 @@ function guessBufferedStartFromRangeStart(
       firstSegmentInRange.precizeStart = true;
     }
   } else if (firstSegmentInRange.precizeStart) {
-    log.debug(
-      "SI: buffered start is precize start",
-      bufferType,
-      firstSegmentInRange.start,
-    );
+    log.debug("SI", "buffered start is precize start", {
+      t: bufferType,
+      firstss: firstSegmentInRange.start,
+    });
     firstSegmentInRange.bufferedStart = firstSegmentInRange.start;
   } else if (
     lastDeletedSegmentInfos !== null &&
@@ -1103,13 +1091,12 @@ function guessBufferedStartFromRangeStart(
       firstSegmentInRange.start - lastDeletedSegmentInfos.end <=
         MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE)
   ) {
-    log.debug(
-      "SI: buffered start is end of previous segment",
-      bufferType,
-      rangeStart,
-      firstSegmentInRange.start,
-      lastDeletedSegmentInfos.end,
-    );
+    log.debug("SI", "buffered start is end of previous segment", {
+      t: bufferType,
+      rs: rangeStart,
+      firstss: firstSegmentInRange.start,
+      lastdelse: lastDeletedSegmentInfos.end,
+    });
     firstSegmentInRange.bufferedStart = lastDeletedSegmentInfos.end;
     if (bufferedStartLooksCoherent(firstSegmentInRange)) {
       firstSegmentInRange.start = lastDeletedSegmentInfos.end;
@@ -1124,33 +1111,30 @@ function guessBufferedStartFromRangeStart(
       firstSegmentInRange.start - rangeStart >= MISSING_DATA_TRIGGER_SYNC_DELAY &&
       now - firstSegmentInRange.insertionTs < SEGMENT_SYNCHRONIZATION_DELAY
     ) {
-      log.debug(
-        "SI: Ignored bufferedStart synchronization",
-        bufferType,
-        rangeStart,
-        firstSegmentInRange.start,
-        now - firstSegmentInRange.insertionTs,
-      );
+      log.debug("SI", "Ignored bufferedStart synchronization", {
+        t: bufferType,
+        rs: rangeStart,
+        firstss: firstSegmentInRange.start,
+        delta: now - firstSegmentInRange.insertionTs,
+      });
       return;
     }
-    log.debug(
-      "SI: found true buffered start",
-      bufferType,
-      rangeStart,
-      firstSegmentInRange.start,
-    );
+    log.debug("SI", "found true buffered start", {
+      t: bufferType,
+      rs: rangeStart,
+      firstss: firstSegmentInRange.start,
+    });
     firstSegmentInRange.bufferedStart = rangeStart;
     if (bufferedStartLooksCoherent(firstSegmentInRange)) {
       firstSegmentInRange.start = rangeStart;
       firstSegmentInRange.precizeStart = true;
     }
   } else if (rangeStart < firstSegmentInRange.start) {
-    log.debug(
-      "SI: range start too far from expected start",
-      bufferType,
-      rangeStart,
-      firstSegmentInRange.start,
-    );
+    log.debug("SI", "range start too far from expected start", {
+      t: bufferType,
+      rs: rangeStart,
+      firstss: firstSegmentInRange.start,
+    });
     firstSegmentInRange.bufferedStart = firstSegmentInRange.start;
   } else {
     const now = getMonotonicTimeStamp();
@@ -1158,21 +1142,19 @@ function guessBufferedStartFromRangeStart(
       firstSegmentInRange.start - rangeStart >= MISSING_DATA_TRIGGER_SYNC_DELAY &&
       now - firstSegmentInRange.insertionTs < SEGMENT_SYNCHRONIZATION_DELAY
     ) {
-      log.debug(
-        "SI: Ignored bufferedStart synchronization",
-        bufferType,
-        rangeStart,
-        firstSegmentInRange.start,
-        now - firstSegmentInRange.insertionTs,
-      );
+      log.debug("SI", "Ignored bufferedStart synchronization", {
+        t: bufferType,
+        rs: rangeStart,
+        firstss: firstSegmentInRange.start,
+        delta: now - firstSegmentInRange.insertionTs,
+      });
       return;
     }
-    log.debug(
-      "SI: Segment appears immediately garbage collected at the start",
-      bufferType,
-      rangeStart,
-      firstSegmentInRange.start,
-    );
+    log.debug("SI", "Segment appears immediately garbage collected at the start", {
+      t: bufferType,
+      rs: rangeStart,
+      firstss: firstSegmentInRange.start,
+    });
     firstSegmentInRange.bufferedStart = rangeStart;
   }
 }
@@ -1196,12 +1178,11 @@ function guessBufferedEndFromRangeEnd(
   } = config.getCurrent();
   if (lastSegmentInRange.bufferedEnd !== undefined) {
     if (lastSegmentInRange.bufferedEnd > rangeEnd) {
-      log.debug(
-        "SI: Segment partially GCed at the end",
-        bufferType,
-        lastSegmentInRange.bufferedEnd,
-        rangeEnd,
-      );
+      log.debug("SI", "Segment partially GCed at the end", {
+        t: bufferType,
+        lastsbe: lastSegmentInRange.bufferedEnd,
+        re: rangeEnd,
+      });
       lastSegmentInRange.bufferedEnd = rangeEnd;
     }
     if (
@@ -1213,7 +1194,10 @@ function guessBufferedEndFromRangeEnd(
       lastSegmentInRange.end = rangeEnd;
     }
   } else if (lastSegmentInRange.precizeEnd) {
-    log.debug("SI: buffered end is precize end", bufferType, lastSegmentInRange.end);
+    log.debug("SI", "buffered end is precize end", {
+      t: bufferType,
+      lastse: lastSegmentInRange.end,
+    });
     lastSegmentInRange.bufferedEnd = lastSegmentInRange.end;
   } else if (
     rangeEnd - lastSegmentInRange.end <= MAX_MANIFEST_BUFFERED_START_END_DIFFERENCE ||
@@ -1224,33 +1208,30 @@ function guessBufferedEndFromRangeEnd(
       rangeEnd - lastSegmentInRange.end >= MISSING_DATA_TRIGGER_SYNC_DELAY &&
       now - lastSegmentInRange.insertionTs < SEGMENT_SYNCHRONIZATION_DELAY
     ) {
-      log.debug(
-        "SI: Ignored bufferedEnd synchronization",
-        bufferType,
-        rangeEnd,
-        lastSegmentInRange.end,
-        now - lastSegmentInRange.insertionTs,
-      );
+      log.debug("SI", "Ignored bufferedEnd synchronization", {
+        t: bufferType,
+        re: rangeEnd,
+        lastse: lastSegmentInRange.end,
+        delta: now - lastSegmentInRange.insertionTs,
+      });
       return;
     }
-    log.debug(
-      "SI: found true buffered end",
-      bufferType,
-      rangeEnd,
-      lastSegmentInRange.end,
-    );
+    log.debug("SI", "found true buffered end", {
+      t: bufferType,
+      re: rangeEnd,
+      lastse: lastSegmentInRange.end,
+    });
     lastSegmentInRange.bufferedEnd = rangeEnd;
     if (bufferedEndLooksCoherent(lastSegmentInRange)) {
       lastSegmentInRange.end = rangeEnd;
       lastSegmentInRange.precizeEnd = true;
     }
   } else if (rangeEnd > lastSegmentInRange.end) {
-    log.debug(
-      "SI: range end too far from expected end",
-      bufferType,
-      rangeEnd,
-      lastSegmentInRange.end,
-    );
+    log.debug("SI", "range end too far from expected end", {
+      t: bufferType,
+      re: rangeEnd,
+      lastse: lastSegmentInRange.end,
+    });
     lastSegmentInRange.bufferedEnd = lastSegmentInRange.end;
   } else {
     const now = getMonotonicTimeStamp();
@@ -1258,21 +1239,19 @@ function guessBufferedEndFromRangeEnd(
       rangeEnd - lastSegmentInRange.end >= MISSING_DATA_TRIGGER_SYNC_DELAY &&
       now - lastSegmentInRange.insertionTs < SEGMENT_SYNCHRONIZATION_DELAY
     ) {
-      log.debug(
-        "SI: Ignored bufferedEnd synchronization",
-        bufferType,
-        rangeEnd,
-        lastSegmentInRange.end,
-        now - lastSegmentInRange.insertionTs,
-      );
+      log.debug("SI", "Ignored bufferedEnd synchronization", {
+        t: bufferType,
+        re: rangeEnd,
+        lastse: lastSegmentInRange.end,
+        delta: now - lastSegmentInRange.insertionTs,
+      });
       return;
     }
-    log.debug(
-      "SI: Segment appears immediately garbage collected at the end",
-      bufferType,
-      lastSegmentInRange.bufferedEnd,
-      rangeEnd,
-    );
+    log.debug("SI", "Segment appears immediately garbage collected at the end", {
+      t: bufferType,
+      lastsbe: lastSegmentInRange.bufferedEnd,
+      re: rangeEnd,
+    });
     lastSegmentInRange.bufferedEnd = rangeEnd;
   }
 }

--- a/src/core/segment_sinks/segment_sinks_store.ts
+++ b/src/core/segment_sinks/segment_sinks_store.ts
@@ -249,7 +249,7 @@ export default class SegmentSinksStore {
   public disableSegmentSink(bufferType: IBufferType): void {
     const currentValue = this._initializedSegmentSinks[bufferType];
     if (currentValue === null) {
-      log.warn(`SBS: The ${bufferType} SegmentSink was already disabled.`);
+      log.warn("Stream", `The ${bufferType} SegmentSink was already disabled.`);
       return;
     }
     if (currentValue !== undefined) {
@@ -283,17 +283,18 @@ export default class SegmentSinksStore {
           memorizedSegmentSink.codec !== codec
         ) {
           log.warn(
-            "SB: Reusing native SegmentSink with codec",
+            "Stream",
+            "Reusing native SegmentSink with codec",
             memorizedSegmentSink.codec,
             "for codec",
             codec,
           );
         } else {
-          log.info("SB: Reusing native SegmentSink with codec", codec);
+          log.info("Stream", "Reusing native SegmentSink with codec", codec);
         }
         return memorizedSegmentSink;
       }
-      log.info("SB: Adding native SegmentSink with codec", codec);
+      log.info("Stream", "Adding native SegmentSink with codec", codec);
       const sourceBufferType =
         bufferType === "audio" ? SourceBufferType.Audio : SourceBufferType.Video;
       const nativeSegmentSink = new AudioVideoSegmentSink(
@@ -308,13 +309,13 @@ export default class SegmentSinksStore {
     }
 
     if (!isNullOrUndefined(memorizedSegmentSink)) {
-      log.info("SB: Reusing a previous custom SegmentSink for the type", bufferType);
+      log.info("Stream", "Reusing a previous custom SegmentSink", { bufferType });
       return memorizedSegmentSink;
     }
 
     let segmentSink: TextSegmentSink;
     if (bufferType === "text") {
-      log.info("SB: Creating a new text SegmentSink");
+      log.info("Stream", "Creating a new text SegmentSink");
       if (this._textInterface === null) {
         throw new Error("HTML Text track feature not activated");
       }
@@ -323,7 +324,7 @@ export default class SegmentSinksStore {
       return segmentSink;
     }
 
-    log.error("SB: Unknown buffer type:", bufferType);
+    log.error("Stream", "Unknown buffer type:", { bufferType });
     throw new MediaError(
       "BUFFER_TYPE_UNKNOWN",
       "The player wants to create a SegmentSink " + "of an unknown type.",
@@ -337,11 +338,13 @@ export default class SegmentSinksStore {
   public disposeSegmentSink(bufferType: IBufferType): void {
     const memorizedSegmentSink = this._initializedSegmentSinks[bufferType];
     if (isNullOrUndefined(memorizedSegmentSink)) {
-      log.warn("SB: Trying to dispose a SegmentSink that does not exist");
+      log.warn("Stream", "Trying to dispose a SegmentSink that does not exist", {
+        bufferType,
+      });
       return;
     }
 
-    log.info("SB: Aborting SegmentSink", bufferType);
+    log.info("Stream", "Aborting SegmentSink", { bufferType });
     memorizedSegmentSink.dispose();
     delete this._initializedSegmentSinks[bufferType];
   }

--- a/src/core/stream/adaptation/adaptation_stream.ts
+++ b/src/core/stream/adaptation/adaptation_stream.ts
@@ -121,7 +121,8 @@ export default function AdaptationStream(
       const observationCanStream = observation.canStream ?? true;
       if (isMediaSegmentQueueInterrupted.getValue() === observationCanStream) {
         log.debug(
-          "Stream: isMediaSegmentQueueInterrupted updated to",
+          "Stream",
+          "isMediaSegmentQueueInterrupted updated to",
           !observationCanStream,
         );
         isMediaSegmentQueueInterrupted.setValue(!observationCanStream);
@@ -156,7 +157,9 @@ export default function AdaptationStream(
         return;
       }
       previouslyEmittedBitrate = bitrate;
-      log.debug(`Stream: new ${adaptation.type} bitrate estimate`, bitrate);
+      log.debug("Stream", `new ${adaptation.type} bitrate estimate received from ABR`, {
+        bitrate,
+      });
       callbacks.bitrateEstimateChange({ type: adaptation.type, bitrate });
     },
     { emitCurrentValue: true, clearSignal: adapStreamCanceller.signal },
@@ -319,10 +322,20 @@ export default function AdaptationStream(
           return;
         }
         if (estimate.urgent) {
-          log.info("Stream: urgent Representation switch", adaptation.type);
+          log.info("Stream", "urgent Representation switch", {
+            bufferType: adaptation.type,
+            estimateBitrate: estimate.bitrate,
+            prevRepresentationBitrate: representation.bitrate,
+            newRepresentationBitrate: estimate.representation.bitrate,
+          });
           return terminateCurrentStream.setValue({ urgent: true });
         } else {
-          log.info("Stream: slow Representation switch", adaptation.type);
+          log.info("Stream", "slow Representation switch", {
+            bufferType: adaptation.type,
+            estimateBitrate: estimate.bitrate,
+            prevRepresentationBitrate: representation.bitrate,
+            newRepresentationBitrate: estimate.representation.bitrate,
+          });
           return terminateCurrentStream.setValue({ urgent: false });
         }
       },
@@ -413,12 +426,11 @@ export default function AdaptationStream(
 
     const maxBufferSize =
       adaptation.type === "video" ? maxVideoBufferSize : new SharedReference(Infinity);
-    log.info(
-      "Stream: changing representation",
-      adaptation.type,
-      representation.id,
-      representation.bitrate,
-    );
+    log.info("Stream", "changing representation", {
+      bufferType: adaptation.type,
+      representationId: representation.id,
+      representationBitrate: representation.bitrate,
+    });
     const updatedCallbacks = objectAssign({}, representationStreamCallbacks, {
       error(err: Error) {
         if (hasEncounteredError) {
@@ -428,7 +440,7 @@ export default function AdaptationStream(
           //
           // That could mean that we're hiding legitimate issues but handling
           // multiple of those errors at once is too hard a task for now.
-          log.warn("Stream: Ignoring RepresentationStream error", err);
+          log.warn("Stream", "Ignoring RepresentationStream error", err);
           return;
         }
         hasEncounteredError = true;
@@ -439,11 +451,11 @@ export default function AdaptationStream(
         if (formattedError.code !== "BUFFER_FULL_ERROR") {
           representationStreamCallbacks.error(err);
         } else {
-          log.warn(
-            "Stream: received BUFFER_FULL_ERROR",
-            adaptation.type,
-            representation.bitrate,
-          );
+          log.warn("Stream", "received BUFFER_FULL_ERROR", {
+            bufferType: adaptation.type,
+
+            representationBitrate: representation.bitrate,
+          });
           const wba = wantedBufferAhead.getValue();
           const lastBufferGoalRatio = bufferGoalRatioMap.get(representation.id) ?? 1;
           // 70%, 49%, 34.3%, 24%, 16.81%, 11.76%, 8.24% and 5.76%

--- a/src/core/stream/orchestrator/get_time_ranges_for_content.ts
+++ b/src/core/stream/orchestrator/get_time_ranges_for_content.ts
@@ -57,7 +57,10 @@ export default function getTimeRangesForContent(
     if (hasContent) {
       const { bufferedStart, bufferedEnd } = chunk;
       if (bufferedStart === undefined || bufferedEnd === undefined) {
-        log.warn("SO: No buffered start or end found from a segment.");
+        log.warn("Stream", "No buffered start or end found from a segment.", {
+          bufferType: chunk.infos.adaptation.type,
+          segmentStart: chunk.infos.segment.time,
+        });
         return [{ start: 0, end: Number.MAX_VALUE }];
       }
 

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -176,9 +176,9 @@ export default function StreamOrchestrator(
         }
 
         log.info(
-          "Stream: Destroying all PeriodStreams due to out of bounds situation",
-          bufferType,
-          time,
+          "Stream",
+          "Destroying all PeriodStreams due to out of bounds situation",
+          { bufferType, time },
         );
         enableOutOfBoundsCheck = false;
         while (periodList.length() > 0) {
@@ -193,7 +193,7 @@ export default function StreamOrchestrator(
         const nextPeriod =
           manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
         if (nextPeriod === undefined) {
-          log.warn("Stream: The wanted position is not found in the Manifest.");
+          log.warn("Stream", "The wanted position is not found in the Manifest.");
           enableOutOfBoundsCheck = true;
           return;
         }
@@ -340,10 +340,9 @@ export default function StreamOrchestrator(
       // load and push segments.
       enableOutOfBoundsCheck = false;
 
-      log.info(
-        "Stream: Destroying all PeriodStreams for decipherability matters",
+      log.info("Stream", "Destroying all PeriodStreams for decipherability matters", {
         bufferType,
-      );
+      });
       while (periodList.length() > 0) {
         const period = periodList.get(periodList.length() - 1);
         periodList.removeElement(period);
@@ -443,7 +442,10 @@ export default function StreamOrchestrator(
     },
     cancelSignal: CancellationSignal,
   ): void {
-    log.info("Stream: Creating new Stream for", bufferType, basePeriod.start);
+    log.info("Stream", "Creating new PeriodStream", {
+      bufferType,
+      periodStart: basePeriod.start,
+    });
 
     /**
      * Contains properties linnked to the next chronological `PeriodStream` that
@@ -472,11 +474,14 @@ export default function StreamOrchestrator(
             return;
           }
           log.info(
-            "Stream: Destroying PeriodStream as the current playhead moved above it",
-            bufferType,
-            basePeriod.start,
-            position.getWanted(),
-            basePeriod.end,
+            "Stream",
+            "Destroying PeriodStream as the current playhead moved above it",
+            {
+              bufferType,
+              periodStart: basePeriod.start,
+              periodEnd: basePeriod.end,
+              position: position.getWanted(),
+            },
           );
           stopListeningObservations();
           consecutivePeriodStreamCb.periodStreamCleared({
@@ -514,9 +519,13 @@ export default function StreamOrchestrator(
         } else if (nextStreamInfo !== null) {
           // current Stream is active, destroy next Stream if created
           log.info(
-            "Stream: Destroying next PeriodStream due to current one being active",
-            bufferType,
-            nextStreamInfo.period.start,
+            "Stream",
+            "Destroying next PeriodStream due to current one being active",
+            {
+              bufferType,
+              periodStart: basePeriod.start,
+              nextPeriodStart: nextStreamInfo.period.start,
+            },
           );
           consecutivePeriodStreamCb.periodStreamCleared({
             type: bufferType,
@@ -551,10 +560,12 @@ export default function StreamOrchestrator(
           return;
         }
         log.warn(
-          "Stream: Creating next `PeriodStream` while one was already created.",
-          bufferType,
-          nextPeriod.id,
-          nextStreamInfo.period.id,
+          "Stream",
+          "Creating next `PeriodStream` while one was already created.",
+          {
+            bufferType,
+            nextPeriodStart: nextPeriod.start,
+          },
         );
         consecutivePeriodStreamCb.periodStreamCleared({
           type: bufferType,
@@ -623,9 +634,12 @@ export default function StreamOrchestrator(
                 nextStreamInfo.period.id !== newNextPeriod.id
               ) {
                 log.warn(
-                  "Stream: Destroying next PeriodStream due to new one being added",
-                  bufferType,
-                  nextStreamInfo.period.start,
+                  "Stream",
+                  "Destroying next PeriodStream due to new one being added",
+                  {
+                    bufferType,
+                    nextPeriodStart: nextStreamInfo.period.start,
+                  },
                 );
                 consecutivePeriodStreamCb.periodStreamCleared({
                   type: bufferType,

--- a/src/core/stream/period/period_stream.ts
+++ b/src/core/stream/period/period_stream.ts
@@ -132,17 +132,27 @@ export default function PeriodStream(
 
         if (choice === null) {
           // Current type is disabled for that Period
-          log.info(`Stream: Set no ${bufferType} Adaptation. P:`, period.start);
+          log.info(`Stream`, `Set no Adaptation`, {
+            periodStart: period.start,
+            bufferType,
+          });
           const segmentSinkStatus = segmentSinksStore.getStatus(bufferType);
 
           if (segmentSinkStatus.type === "initialized") {
-            log.info(`Stream: Clearing previous ${bufferType} SegmentSink`);
+            log.info(`Stream`, `Clearing previous SegmentSink`, {
+              periodStart: period.start,
+              bufferType,
+            });
             if (SegmentSinksStore.isNative(bufferType)) {
               return askForMediaSourceReload(0, true, streamCanceller.signal);
             } else {
               const periodEnd = period.end ?? Infinity;
               if (period.start > periodEnd) {
-                log.warn("Stream: Can't free buffer: period's start is after its end");
+                log.warn("Stream", "Can't free buffer: period's start is after its end", {
+                  periodStart: period.start,
+                  periodEnd,
+                  bufferType,
+                });
               } else {
                 await segmentSinkStatus.value.removeBuffer(period.start, periodEnd);
                 if (streamCanceller.isUsed()) {
@@ -183,7 +193,9 @@ export default function PeriodStream(
         );
         if (adaptation === undefined) {
           currentStreamCanceller.cancel();
-          log.warn("Stream: Unfound chosen Adaptation choice", choice.adaptationId);
+          log.warn("Stream", "Unfound chosen Adaptation choice", {
+            adaptationId: choice.adaptationId,
+          });
           return;
         }
 
@@ -253,11 +265,11 @@ export default function PeriodStream(
         );
 
         const { representations } = choice;
-        log.info(
-          `Stream: Updating ${bufferType} adaptation`,
-          `A: ${adaptation.id}`,
-          `P: ${period.start}`,
-        );
+        log.info(`Stream`, `Updating adaptation`, {
+          bufferType: adaptation.type,
+          periodStart: period.start,
+          adaptationId: adaptation.id,
+        });
 
         callbacks.adaptationChange({ type: bufferType, adaptation, period });
         if (streamCanceller.isUsed()) {
@@ -365,7 +377,8 @@ export default function PeriodStream(
       // to continue playing without any subtitles
       if (!SegmentSinksStore.isNative(bufferType)) {
         log.error(
-          `Stream: ${bufferType} Stream crashed. Aborting it.`,
+          `Stream`,
+          `${bufferType} Stream crashed. Aborting it.`,
           error instanceof Error ? error : "",
         );
         segmentSinksStore.disposeSegmentSink(bufferType);
@@ -389,7 +402,8 @@ export default function PeriodStream(
         );
       }
       log.error(
-        `Stream: ${bufferType} Stream crashed. Stopping playback.`,
+        `Stream`,
+        `${bufferType} Stream crashed. Stopping playback.`,
         error instanceof Error ? error : "",
       );
       callbacks.error(error);
@@ -456,7 +470,7 @@ function createOrReuseSegmentSink(
 ): SegmentSink {
   const segmentSinkStatus = segmentSinksStore.getStatus(bufferType);
   if (segmentSinkStatus.type === "initialized") {
-    log.info("Stream: Reusing a previous SegmentSink for the type", bufferType);
+    log.info("Stream", "Reusing a previous SegmentSink for the type", { bufferType });
     return segmentSinkStatus.value;
   }
   const codec = getFirstDeclaredMimeType(adaptation);
@@ -564,7 +578,12 @@ function createEmptyAdaptationStream(
     const wba = wantedBufferAhead.getValue();
     const position = observation.position.getWanted();
     if (period.end !== undefined && position + wba >= period.end) {
-      log.debug('Stream: full "empty" AdaptationStream', bufferType);
+      log.debug("Stream", 'full "empty" AdaptationStream', {
+        bufferType,
+        periodEnd: period.end,
+        position,
+        wantedBufferAhead: wba,
+      });
       hasFinishedLoading = true;
     }
     callbacks.streamStatusUpdate({

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -90,11 +90,13 @@ export default function RepresentationStream<TSegmentDataType>(
   callbacks: IRepresentationStreamCallbacks,
   parentCancelSignal: CancellationSignal,
 ): void {
-  log.debug(
-    "Stream: Creating RepresentationStream",
-    content.adaptation.type,
-    content.representation.bitrate,
-  );
+  log.debug("Stream", "Creating RepresentationStream", {
+    periodStart: content.period.start,
+    bufferType: content.adaptation.type,
+    adaptationId: content.adaptation.id,
+    representationBitrate: content.representation.bitrate,
+    mimeType: content.representation.getMimeTypeString(),
+  });
   const { period, adaptation, representation } = content;
   const { bufferGoal, maxBufferSize, drmSystemId, fastSwitchThreshold } = options;
   const bufferType = adaptation.type;
@@ -243,11 +245,18 @@ export default function RepresentationStream<TSegmentDataType>(
     // Add initialization segment if required
     if (!representation.index.isInitialized()) {
       if (initSegmentState.segment === null) {
-        log.warn("Stream: Uninitialized index without an initialization segment");
+        log.warn("Stream", "Uninitialized index without an initialization segment", {
+          bufferType,
+          representationBitrate: content.representation.bitrate,
+        });
       } else if (initSegmentState.isLoaded) {
         log.warn(
-          "Stream: Uninitialized index with an already loaded " +
-            "initialization segment",
+          "Stream",
+          "Uninitialized index with an already loaded " + "initialization segment",
+          {
+            bufferType,
+            representationBitrate: content.representation.bitrate,
+          },
         );
       } else {
         const wantedStart = observation.position.getWanted();
@@ -275,7 +284,10 @@ export default function RepresentationStream<TSegmentDataType>(
         segmentQueue: neededSegments,
       });
     } else if (terminateVal.urgent) {
-      log.debug("Stream: Urgent switch, terminate now.", bufferType);
+      log.debug("Stream", "Urgent switch, terminate now.", {
+        bufferType,
+        representationBitrate: content.representation.bitrate,
+      });
       segmentsToLoadRef.setValue({ initSegment: null, segmentQueue: [] });
       segmentsToLoadRef.finish();
       canceller.cancel();
@@ -304,7 +316,10 @@ export default function RepresentationStream<TSegmentDataType>(
         segmentQueue: nextQueue,
       });
       if (nextQueue.length === 0 && nextInit === null) {
-        log.debug("Stream: No request left, terminate", bufferType);
+        log.debug("Stream", "No request left, terminate", {
+          bufferType,
+          representationBitrate: content.representation.bitrate,
+        });
         segmentsToLoadRef.finish();
         canceller.cancel();
         callbacks.terminating();
@@ -459,9 +474,12 @@ export default function RepresentationStream<TSegmentDataType>(
       return;
     }
     log.warn(
-      "Stream: Received fatal buffer error",
-      adaptation.type,
-      representation.bitrate,
+      "Stream",
+      "Received fatal buffer error",
+      {
+        bufferType,
+        representationBitrate: content.representation.bitrate,
+      },
       err instanceof Error ? err : null,
     );
     canceller.cancel();

--- a/src/core/stream/representation/utils/append_segment_to_buffer.ts
+++ b/src/core/stream/representation/utils/append_segment_to_buffer.ts
@@ -69,7 +69,7 @@ export default async function appendSegmentToBuffer<T>(
     const { position } = playbackObserver.getReference().getValue();
     const currentPos = position.getWanted();
     try {
-      log.warn("Stream: Running garbage collector");
+      log.warn("Stream", "Running garbage collector");
       const start = Math.max(currentPos - 5, 0);
       const end = currentPos + bufferGoal.getValue() + 12;
       if (start > 0) {

--- a/src/core/stream/representation/utils/check_for_discontinuity.ts
+++ b/src/core/stream/representation/utils/check_for_discontinuity.ts
@@ -116,11 +116,11 @@ export default function checkForDiscontinuity(
     ) {
       return null;
     }
-    log.debug(
-      "RS: current discontinuity encountered",
-      adaptation.type,
-      nextBufferedSegment.bufferedStart,
-    );
+    log.debug("Stream", "current discontinuity encountered", {
+      bufferType: adaptation.type,
+      nextSegmentTime: nextBufferedSegment.bufferedStart,
+      checkStartTime: checkedRange.start,
+    });
     return { start: undefined, end: discontinuityEnd };
   }
 
@@ -152,7 +152,11 @@ export default function checkForDiscontinuity(
       }
       const start = segmentInfoBeforeHole.bufferedEnd as number;
       const end = segmentInfoAfterHole.bufferedStart as number;
-      log.debug("RS: future discontinuity encountered", adaptation.type, start, end);
+      log.debug("Stream", "future discontinuity encountered", {
+        bufferType: adaptation.type,
+        discontinuityStart: start,
+        discontinuityEnd: end,
+      });
       return { start, end };
     }
   }
@@ -181,10 +185,13 @@ export default function checkForDiscontinuity(
           lastSegment.bufferedEnd < period.end
         ) {
           log.debug(
-            "RS: discontinuity encountered at the end of the current period",
-            adaptation.type,
-            lastSegment.bufferedEnd,
-            period.end,
+            "Stream",
+            "discontinuity encountered at the end of the current period",
+            {
+              bufferType: adaptation.type,
+              segmentsEndTimeFromPeriod: lastSegment.bufferedEnd,
+              periodEnd: period.end,
+            },
           );
           return { start: lastSegment.bufferedEnd, end: null };
         }
@@ -274,7 +281,7 @@ function getIndexOfFirstDiscontinuityBetweenChunks(
   startFromIndex: number,
 ): number | null {
   if (startFromIndex <= 0) {
-    log.error("RS: Asked to check a discontinuity before the first chunk.");
+    log.error("Stream", "Asked to check a discontinuity before the first chunk.");
     return null;
   }
   for (let bufIdx = startFromIndex; bufIdx < bufferedChunks.length; bufIdx++) {

--- a/src/core/stream/representation/utils/get_needed_segments.ts
+++ b/src/core/stream/representation/utils/get_needed_segments.ts
@@ -256,15 +256,18 @@ export default function getNeededSegments({
         beforeLastTimeItWasPushed.buffered === null
       ) {
         log.warn(
-          "Stream: Segment GCed multiple times in a row, ignoring it.",
+          "Stream",
+          "Segment GCed multiple times in a row, ignoring it.",
           "If this happens a lot and lead to unpleasant experience, please " +
             " check your device's available memory. If it's low when this message " +
             "is emitted, you might want to update the RxPlayer's settings (" +
             "`maxBufferAhead`, `maxVideoBufferSize` etc.) so less memory is used " +
-            "by regular media data buffering." +
-            adaptation.type,
-          representation.id,
-          segment.time,
+            "by regular media data buffering.",
+          {
+            bufferType: adaptation.type,
+            representationId: representation.id,
+            segmentTime: segment.time,
+          },
         );
         return false;
       }
@@ -451,11 +454,10 @@ function doesStartSeemGarbageCollected(
     maximumStartTime < currentSeg.bufferedStart &&
     currentSeg.bufferedStart - currentSeg.start > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT
   ) {
-    log.info(
-      "Stream: The start of the wanted segment has been garbage collected",
-      currentSeg.start,
-      currentSeg.bufferedStart,
-    );
+    log.info("Stream", "The start of the wanted segment has been garbage collected", {
+      segmentStart: currentSeg.start,
+      currentStartInBuffer: currentSeg.bufferedStart,
+    });
     return true;
   }
 
@@ -496,11 +498,10 @@ function doesEndSeemGarbageCollected(
     minimumEndTime > currentSeg.bufferedEnd &&
     currentSeg.end - currentSeg.bufferedEnd > MAX_TIME_MISSING_FROM_COMPLETE_SEGMENT
   ) {
-    log.info(
-      "Stream: The end of the wanted segment has been garbage collected",
-      currentSeg.end,
-      currentSeg.bufferedEnd,
-    );
+    log.info("Stream", "The end of the wanted segment has been garbage collected", {
+      segmentEnd: currentSeg.end,
+      currentEndInBuffer: currentSeg.bufferedEnd,
+    });
     return true;
   }
 
@@ -648,22 +649,20 @@ function filterOutGCedSegments(
       ) {
         return false;
       }
-      log.debug(
-        "Stream: skipping segment gc-ed at the start",
-        currentSeg.start,
-        currentSeg.bufferedStart,
-      );
+      log.debug("Stream", "skipping segment gc-ed at the start", {
+        segmentStart: currentSeg.start,
+        currentStartInBuffer: currentSeg.bufferedStart,
+      });
     }
     if (doesEndSeemGarbageCollected(currentSeg, nextSeg, neededRange.end)) {
       lazySegmentHistory = lazySegmentHistory ?? getBufferedHistory(currentSeg.infos);
       if (shouldReloadSegmentGCedAtTheEnd(lazySegmentHistory, currentSeg.bufferedEnd)) {
         return false;
       }
-      log.debug(
-        "Stream: skipping segment gc-ed at the end",
-        currentSeg.end,
-        currentSeg.bufferedEnd,
-      );
+      log.debug("Stream", "skipping segment gc-ed at the end", {
+        segmentEnd: currentSeg.end,
+        currentEndInBuffer: currentSeg.bufferedEnd,
+      });
     }
     return true;
   });

--- a/src/experimental/tools/VideoThumbnailLoader/load_and_push_segment.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/load_and_push_segment.ts
@@ -67,7 +67,7 @@ export default function loadAndPushSegment(
         return;
       },
       onRetry(error) {
-        log.warn("Retrying segment request", error);
+        log.warn("VideoThumbnailLoader", "Retrying segment request", error);
       },
     },
     cancelSignal,

--- a/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
@@ -53,7 +53,7 @@ export default function prepareSourceBuffer(
     const oldSrc = isNonEmptyString(videoElement.src) ? videoElement.src : null;
     resetMediaElement(videoElement, oldSrc);
 
-    log.info("Init: Creating MediaSource");
+    log.info("VideoThumbnailLoader", "Creating MediaSource");
     const mediaSource = new MainMediaSourceInterface(generateMediaSourceId());
     if (mediaSource.handle.type === "handle") {
       videoElement.srcObject = mediaSource.handle.value;
@@ -63,7 +63,11 @@ export default function prepareSourceBuffer(
     } else {
       const objectURL = URL.createObjectURL(mediaSource.handle.value);
 
-      log.info("Init: Attaching MediaSource URL to the media element", objectURL);
+      log.info(
+        "VideoThumbnailLoader",
+        "Attaching MediaSource URL to the media element",
+        objectURL,
+      );
       videoElement.src = objectURL;
       cleanUpSignal.register(() => {
         resetMediaElement(videoElement, objectURL);

--- a/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/video_thumbnail_loader.ts
@@ -150,13 +150,14 @@ export default class VideoThumbnailLoader {
 
     if (neededSegments.length === 0) {
       this._videoElement.currentTime = time;
-      log.debug("VTL: Thumbnails already loaded.", time);
+      log.debug("VideoThumbnailLoader", "Thumbnails already loaded.", time);
       return Promise.resolve(time);
     }
 
     if (log.hasLevel("DEBUG")) {
       log.debug(
-        "VTL: Found thumbnail for time",
+        "VideoThumbnailLoader",
+        "Found thumbnail for time",
         time,
         neededSegments.map((s) => `start: ${s.time} - end: ${s.end}`).join(", "),
       );
@@ -250,7 +251,7 @@ export default class VideoThumbnailLoader {
       .then(async (sourceBufferInterface) => {
         abortUnlistedSegmentRequests(lastRepInfo.pendingRequests, neededSegments);
 
-        log.debug("VTL: Removing buffer around time.", time);
+        log.debug("VideoThumbnailLoader", "Removing buffer around time.", time);
         await removeBufferAroundTime(
           this._videoElement,
           sourceBufferInterface,

--- a/src/experimental/tools/mediaCapabilitiesProber/api.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/api.ts
@@ -86,11 +86,14 @@ const mediaCapabilitiesProber = {
         const initData = generatePlayReadyInitData(DUMMY_PLAY_READY_HEADER);
         await session.generateRequest("cenc", initData);
         session.close().catch(() => {
-          log.warn("DRM: Failed to close the dummy session");
+          log.warn("MediaCapabilitiesProber", "Failed to close the dummy session");
         });
         return mksa.getConfiguration();
       } catch (err) {
-        log.debug("DRM: KeySystemAccess was granted but it is not usable");
+        log.debug(
+          "MediaCapabilitiesProber",
+          "KeySystemAccess was granted but it is not usable",
+        );
         return Promise.reject(
           new Error(
             "Failed to generare a license-request with this keySystem: " +
@@ -165,7 +168,7 @@ const mediaCapabilitiesProber = {
       }
     } catch (err) {
       const error = err instanceof Error ? err : new Error("Unknown error");
-      log.error("MCP: probeContentType failed", error);
+      log.error("MediaCapabilitiesProber", "probeContentType failed", error);
     }
 
     try {

--- a/src/experimental/tools/mediaCapabilitiesProber/probers/HDCPPolicy.ts
+++ b/src/experimental/tools/mediaCapabilitiesProber/probers/HDCPPolicy.ts
@@ -63,7 +63,10 @@ export default async function probeHDCPPolicy(
 
   const mediaKeys = await mediaKeysSystemAccess.createMediaKeys();
   if (!("getStatusForPolicy" in mediaKeys)) {
-    log.error("MCP: `MediaKeys.prototype.getStatusForPolicy` API is not available");
+    log.error(
+      "MediaCapabilitiesProber",
+      "`MediaKeys.prototype.getStatusForPolicy` API is not available",
+    );
     throw new Error("MediaKeys.prototype.getStatusForPolicy` API is not available");
   }
   const result = await (

--- a/src/main_thread/api/__tests__/option_utils.test.ts
+++ b/src/main_thread/api/__tests__/option_utils.test.ts
@@ -699,6 +699,7 @@ describe("API - parseLoadVideoOptions", () => {
     });
     expect(logWarnMock).toHaveBeenCalledTimes(1);
     expect(logWarnMock).toHaveBeenCalledWith(
+      "API",
       "The `defaultAudioTrackSwitchingMode` loadVideo option must match one of " +
         `the following strategy name:
 - \`seamless\`
@@ -766,6 +767,7 @@ describe("API - parseLoadVideoOptions", () => {
     });
     expect(logWarnMock).toHaveBeenCalledTimes(1);
     expect(logWarnMock).toHaveBeenCalledWith(
+      "API",
       "The `onCodecSwitch` loadVideo option must match one " +
         `of the following string:
 - \`continue\`
@@ -1071,7 +1073,8 @@ If badly set, continue will be used as default`,
 
     expect(logWarnMock).toHaveBeenCalledTimes(1);
     expect(logWarnMock).toHaveBeenCalledWith(
-      "API: You have set a textTrackElement " +
+      "API",
+      "You have set a textTrackElement " +
         'without being in an "html" textTrackMode. It will be ignored.',
     );
   });

--- a/src/main_thread/api/option_utils.ts
+++ b/src/main_thread/api/option_utils.ts
@@ -383,6 +383,7 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     !arrayIncludes(["seamless", "direct", "reload"], defaultAudioTrackSwitchingMode)
   ) {
     log.warn(
+      "API",
       "The `defaultAudioTrackSwitchingMode` loadVideo option must match one of " +
         "the following strategy name:\n" +
         "- `seamless`\n" +
@@ -397,6 +398,7 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     : options.onCodecSwitch;
   if (!arrayIncludes(["continue", "reload"], onCodecSwitch)) {
     log.warn(
+      "API",
       "The `onCodecSwitch` loadVideo option must match one of " +
         "the following string:\n" +
         "- `continue`\n" +
@@ -415,6 +417,7 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     : options.onAudioTracksNotPlayable;
   if (!arrayIncludes(["continue", "error"], onAudioTracksNotPlayable)) {
     log.warn(
+      "API",
       "The `onAudioTracksNotPlayable` loadVideo option must match one of " +
         "the following string:\n" +
         "- `continue`\n" +
@@ -433,6 +436,7 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     : options.onVideoTracksNotPlayable;
   if (!arrayIncludes(["continue", "error"], onVideoTracksNotPlayable)) {
     log.warn(
+      "API",
       "The `onVideoTracksNotPlayable` loadVideo option must match one of " +
         "the following string:\n" +
         "- `continue`\n" +
@@ -466,7 +470,8 @@ function parseLoadVideoOptions(options: ILoadVideoOptions): IParsedLoadVideoOpti
     }
   } else if (!isNullOrUndefined(options.textTrackElement)) {
     log.warn(
-      "API: You have set a textTrackElement without being in " +
+      "API",
+      "You have set a textTrackElement without being in " +
         'an "html" textTrackMode. It will be ignored.',
     );
   }

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -521,7 +521,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   public attachWorker(workerSettings: IWorkerSettings): Promise<void> {
     return new Promise((res, rej) => {
       if (!hasWorkerApi()) {
-        log.warn("API: Cannot rely on a WebWorker: Worker API unavailable");
+        log.warn("API", "Cannot rely on a WebWorker: Worker API unavailable");
         return rej(
           new WorkerInitializationError("INCOMPATIBLE_ERROR", "Worker unavailable"),
         );
@@ -532,7 +532,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (this._priv_worker !== null) {
         if (this.state !== "STOPPED") {
           log.warn(
-            "API: Cannot attach a new worker while a content is playing, please stop the player first.",
+            "API",
+            "Cannot attach a new worker while a content is playing, please stop the player first.",
           );
           return rej(
             new WorkerInitializationError(
@@ -559,7 +560,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           this._priv_worker = null;
         }
         log.error(
-          "API: Unexpected worker error",
+          "API",
+          "Unexpected worker error",
           evt.error instanceof Error ? evt.error : undefined,
         );
         rej(
@@ -572,7 +574,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       const handleInitMessages = (msg: MessageEvent) => {
         const msgData = msg.data as unknown as IWorkerMessage;
         if (msgData.type === WorkerMessageType.InitError) {
-          log.warn("API: Processing InitError worker message: detaching worker");
+          log.warn("API", "Processing InitError worker message: detaching worker");
           if (this._priv_worker !== null) {
             this._priv_worker.removeEventListener("message", handleInitMessages);
             this._priv_worker.terminate();
@@ -585,7 +587,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             ),
           );
         } else if (msgData.type === WorkerMessageType.InitSuccess) {
-          log.info("API: InitSuccess received from worker.");
+          log.info("API", "InitSuccess received from worker.");
           if (this._priv_worker !== null) {
             this._priv_worker.removeEventListener("message", handleInitMessages);
           }
@@ -594,7 +596,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       };
       this._priv_worker.addEventListener("message", handleInitMessages);
 
-      log.debug("---> Sending To Worker:", MainThreadMessageType.Init);
+      log.debug("M-->C", "Sending message", { name: MainThreadMessageType.Init });
       this._priv_worker.postMessage({
         type: MainThreadMessageType.Init,
         value: {
@@ -613,7 +615,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           if (this._priv_worker === null) {
             return;
           }
-          log.debug("---> Sending To Worker:", MainThreadMessageType.LogLevelUpdate);
+          log.debug("M-->C", "Sending message", {
+            name: MainThreadMessageType.LogLevelUpdate,
+          });
           this._priv_worker.postMessage({
             type: MainThreadMessageType.LogLevelUpdate,
             value: {
@@ -630,7 +634,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         if (this._priv_worker === null) {
           return;
         }
-        log.debug("---> Sending To Worker:", MainThreadMessageType.ConfigUpdate);
+        log.debug("M-->C", "Sending message:", {
+          name: MainThreadMessageType.ConfigUpdate,
+        });
         this._priv_worker.postMessage({
           type: MainThreadMessageType.ConfigUpdate,
           value: updates,
@@ -706,7 +712,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       // free resources used for decryption management
       disposeDecryptionResources(this.videoElement).catch((err: unknown) => {
         const message = err instanceof Error ? err.message : "Unknown error";
-        log.error("API: Could not dispose decryption resources: " + message);
+        log.error("API", "Could not dispose decryption resources: " + message);
       });
     }
 
@@ -730,7 +736,10 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    */
   loadVideo(opts: ILoadVideoOptions): void {
     const options = parseLoadVideoOptions(opts);
-    log.info("API: Calling loadvideo", options.url, options.transport);
+    log.info("API", "Calling loadvideo", {
+      url: options.url,
+      transport: options.transport,
+    });
     this._priv_reloadingMetadata = { options };
     this._priv_initializeContentPlayback(options);
     this._priv_lastAutoPlay = options.autoPlay;
@@ -840,7 +849,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     } else if (periodId !== undefined) {
       period = arrayFind(manifest.periods, (p) => p.id === periodId);
       if (period === undefined) {
-        log.error("API: getAvailableThumbnailTracks: periodId not found");
+        log.error("API", "getAvailableThumbnailTracks: periodId not found", { periodId });
         return [];
       }
     } else {
@@ -958,7 +967,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (this._priv_throttleVideoBitrateWhenHidden) {
         if (!relyOnVideoVisibilityAndSize) {
           log.warn(
-            "API: Can't apply throttleVideoBitrateWhenHidden because " +
+            "API",
+            "Can't apply throttleVideoBitrateWhenHidden because " +
               "browser can't be trusted for visibility.",
           );
         } else {
@@ -977,7 +987,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (this._priv_videoResolutionLimit === "videoElement") {
         if (!relyOnVideoVisibilityAndSize) {
           log.warn(
-            "API: Can't apply videoResolutionLimit because browser can't be " +
+            "API",
+            "Can't apply videoResolutionLimit because browser can't be " +
               "trusted for video size.",
           );
         } else {
@@ -1052,7 +1063,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
             ? createRepresentationFilterFromFnString(options.representationFilter)
             : options.representationFilter;
 
-        log.info("API: Initializing MediaSource mode in the main thread");
+        log.info("API", "Initializing MediaSource mode in the main thread");
         const transportPipelines = transportFn({
           lowLatencyMode,
           checkMediaSegmentIntegrity,
@@ -1096,7 +1107,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         }
         assert(typeof options.representationFilter !== "function");
         useWorker = true;
-        log.info("API: Initializing MediaSource mode in a WebWorker");
+        log.info("API", "Initializing MediaSource mode in a WebWorker");
         const transportOptions = {
           lowLatencyMode,
           checkMediaSegmentIntegrity,
@@ -1138,7 +1149,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         throw new Error("No URL for a DirectFile content");
       }
 
-      log.info("API: Initializing DirectFile mode in the main thread");
+      log.info("API", "Initializing DirectFile mode in the main thread");
       mediaElementTracksStore = this._priv_initializeMediaElementTracksStore(
         currentContentCanceller.signal,
       );
@@ -1188,7 +1199,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
         defaultCode: "NONE",
         defaultReason: "An unknown error happened.",
       });
-      log.warn("API: Sending warning:", formattedError);
+      log.warn("API", "Sending warning:", formattedError);
       this.trigger("warning", formattedError);
     });
     initializer.addEventListener("reloadingMediaSource", (payload) => {
@@ -1877,7 +1888,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (positionWanted === undefined) {
       throw new Error("invalid time given");
     }
-    log.info("API: API Seek to", positionWanted);
+    log.info("API", "API seekTo", { positionWanted });
     this.videoElement.currentTime = positionWanted;
     return positionWanted;
   }
@@ -2684,7 +2695,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
    * Reset all state properties relative to a playing content.
    */
   private _priv_cleanUpCurrentContentState(): void {
-    log.debug("Locking `contentLock` to clean-up the current content.");
+    log.debug("API", "Locking `contentLock` to clean-up the current content.");
 
     // lock playback of new contents while cleaning up is pending
     this._priv_contentLock.setValue(true);
@@ -2699,7 +2710,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const freeUpContentLock = () => {
       if (this.videoElement !== null) {
         // If not disposed
-        log.debug("Unlocking `contentLock`. Next content can begin.");
+        log.debug("API", "Unlocking `contentLock`. Next content can begin.");
         this._priv_contentLock.setValue(false);
       }
     };
@@ -2707,12 +2718,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (!isNullOrUndefined(this.videoElement)) {
       clearOnStop(this.videoElement).then(
         () => {
-          log.debug("API: DRM session cleaned-up with success!");
+          log.debug("API", "DRM session cleaned-up with success!");
           freeUpContentLock();
         },
         (err: unknown) => {
           log.error(
-            "API: An error arised when trying to clean-up the DRM session:" +
+            "API",
+            "An error arised when trying to clean-up the DRM session:" +
               (err instanceof Error ? err.toString() : "Unknown Error"),
           );
           freeUpContentLock();
@@ -3012,7 +3024,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       case "audio":
       case "text":
         if (isNullOrUndefined(tracksStore)) {
-          log.error(`API: TracksStore not instanciated for a new ${type} period`);
+          log.error("API", `TracksStore not instanciated for a new ${type} period`);
           adaptationRef.setValue(null);
         } else {
           tracksStore.addTrackReference(type, period, adaptationRef);
@@ -3250,7 +3262,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
   private _priv_setPlayerState(newState: IPlayerState): void {
     if (this.state !== newState) {
       this.state = newState;
-      log.info("API: playerStateChange event", newState);
+      log.info("API", "playerStateChange event", { newState });
       this.trigger("playerStateChange", newState);
     }
   }
@@ -3406,7 +3418,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       this._priv_contentInfos === null ||
       this._priv_contentInfos.tracksStore === null
     ) {
-      log.warn("API: Trying to call track API too soon");
+      log.warn("API", "Trying to call track API too soon");
       return defaultValue;
     }
     const { tracksStore } = this._priv_contentInfos;
@@ -3503,7 +3515,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     contentInfos.currentContentCanceller.cancel();
     this._priv_cleanUpCurrentContentState();
     this._priv_currentError = formattedError;
-    log.error("API: The player stopped because of an error", formattedError);
+    log.error("API", "The player stopped because of an error", formattedError);
     this._priv_setPlayerState(PLAYER_STATES.STOPPED);
 
     // TODO This condition is here because the eventual callback called when the

--- a/src/main_thread/decrypt/clear_on_stop.ts
+++ b/src/main_thread/decrypt/clear_on_stop.ts
@@ -27,9 +27,9 @@ import MediaKeysAttacher from "./utils/media_keys_attacher";
  * @returns {Promise}
  */
 export default async function clearOnStop(mediaElement: IMediaElement): Promise<unknown> {
-  log.info("DRM: Clearing-up DRM session.");
+  log.info("DRM", "Clearing-up DRM session.");
   if (shouldUnsetMediaKeys()) {
-    log.info("DRM: disposing current MediaKeys.");
+    log.info("DRM", "disposing current MediaKeys.");
     return disposeDecryptionResources(mediaElement);
   }
 
@@ -38,12 +38,11 @@ export default async function clearOnStop(mediaElement: IMediaElement): Promise<
     currentState !== null &&
     currentState.keySystemOptions.closeSessionsOnStop === true
   ) {
-    log.info("DRM: closing all current sessions.");
+    log.info("DRM", "closing all current sessions.");
     return currentState.loadedSessionsStore.closeAllSessions();
   }
-  log.info(
-    "DRM: Nothing to clear. Returning right away. No state =",
-    currentState === null,
-  );
+  log.info("DRM", "Nothing to clear. Returning right away.", {
+    noState: currentState === null,
+  });
   return Promise.resolve();
 }

--- a/src/main_thread/decrypt/content_decryptor.ts
+++ b/src/main_thread/decrypt/content_decryptor.ts
@@ -162,7 +162,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   ) {
     super();
 
-    log.debug("DRM: Starting ContentDecryptor logic.");
+    log.debug("DRM", "Starting ContentDecryptor logic.");
 
     const canceller = new TaskCanceller();
     this._currentSessions = [];
@@ -181,7 +181,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     this._eme.onEncrypted(
       mediaElement,
       (evt) => {
-        log.debug("DRM: Encrypted event received from media element.");
+        log.debug("DRM", "Encrypted event received from media element.");
         const initData = getInitData(evt);
         if (initData !== null) {
           this.onInitializationData(initData);
@@ -213,7 +213,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
         this.systemId = systemId;
         if (this._stateData.state === ContentDecryptorState.Initializing) {
-          log.debug("DRM: Waiting for attachment.");
+          log.debug("DRM", "Waiting for attachment.");
           this._stateData = {
             state: ContentDecryptorState.WaitingForAttachment,
             isInitDataQueueLocked: true,
@@ -256,7 +256,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     } else if (
       this._stateData.isMediaKeysAttached !== MediaKeyAttachmentStatus.NotAttached
     ) {
-      log.warn("DRM: ContentDecryptor's `attach` method called more than once.");
+      log.warn("DRM", "ContentDecryptor's `attach` method called more than once.");
       return;
     }
 
@@ -266,7 +266,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     const shouldDisableLock = options.disableMediaKeysAttachmentLock === true;
 
     if (shouldDisableLock) {
-      log.debug("DRM: disabling MediaKeys attachment lock. Ready for content");
+      log.debug("DRM", "disabling MediaKeys attachment lock. Ready for content");
       this._stateData = {
         state: ContentDecryptorState.ReadyForContent,
         isInitDataQueueLocked: true,
@@ -291,7 +291,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       keySystemOptions: options,
     };
 
-    log.debug("DRM: Attaching current MediaKeys");
+    log.debug("DRM", "Attaching current MediaKeys");
     MediaKeysAttacher.attach(mediaElement, stateToAttach)
       .then(async () => {
         if (this._isStopped()) {
@@ -370,7 +370,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   public isCodecSupported(mimeType: string, codec: string): boolean | undefined {
     if (this._stateData.state === ContentDecryptorState.Initializing) {
       log.error(
-        "DRM: Asking for codec support while the ContentDecryptor is still initializing",
+        "DRM",
+        "Asking for codec support while the ContentDecryptor is still initializing",
       );
       return undefined;
     }
@@ -378,7 +379,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       this._stateData.state === ContentDecryptorState.Error ||
       this._stateData.state === ContentDecryptorState.Disposed
     ) {
-      log.error("DRM: Asking for codec support while the ContentDecryptor is disposed");
+      log.error("DRM", "Asking for codec support while the ContentDecryptor is disposed");
     }
     return isCompatibleCodecSupported(mimeType, codec, this._supportedCodecWhenEncrypted);
   }
@@ -428,7 +429,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
   ): Promise<void> {
     if (log.hasLevel("DEBUG")) {
       log.debug(
-        "DRM: processing init data",
+        "DRM",
+        "processing init data",
         initializationData.content?.adaptation.type,
         initializationData.content?.representation.bitrate,
         (initializationData.keyIds ?? []).map((k) => bytesToHex(k)).join(", "),
@@ -457,10 +459,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         const keyIds = initializationData.keyIds;
         if (keyIds === undefined) {
           if (initializationData.content === undefined) {
-            log.warn("DRM: Unable to fallback from a non-decipherable quality.");
+            log.warn("DRM", "Unable to fallback from a non-decipherable quality.");
           } else {
             log.debug(
-              "DRM: Blacklisting new init data (due to singleLicensePer content policy)",
+              "DRM",
+              "Blacklisting new init data (due to singleLicensePer content policy)",
             );
             this.trigger("blackListProtectionData", initializationData);
           }
@@ -469,11 +472,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
         firstCreatedSession.record.associateKeyIds(keyIds);
         if (initializationData.content === undefined) {
-          log.warn("DRM: Unable to fallback from a non-decipherable quality.");
+          log.warn("DRM", "Unable to fallback from a non-decipherable quality.");
         } else {
           if (log.hasLevel("DEBUG")) {
             const hexKids = keyIds.reduce((acc, kid) => `${acc}, ${bytesToHex(kid)}`, "");
-            log.debug("DRM: Blacklisting new key ids", hexKids);
+            log.debug("DRM", "Blacklisting new key ids", hexKids);
           }
           this.trigger("keyIdsCompatibilityUpdate", {
             whitelistedKeyIds: [],
@@ -516,7 +519,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
             }
             if (log.hasLevel("DEBUG")) {
               log.debug(
-                "DRM: Session already created for",
+                "DRM",
+                "Session already created for",
                 bytesToHex(kid),
                 'under singleLicensePer "periods" policy',
               );
@@ -643,7 +647,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         },
         onError: (err: unknown): void => {
           if (err instanceof DecommissionedSessionError) {
-            log.warn("DRM: A session's closing condition has been triggered");
+            log.warn("DRM", "A session's closing condition has been triggered");
             this._lockInitDataQueue();
             const indexOf = this._currentSessions.indexOf(sessionInfo);
             if (indexOf >= 0) {
@@ -661,7 +665,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
               .closeSession(mediaKeySession)
               .catch((e) => {
                 const closeError = e instanceof Error ? e : "unknown error";
-                log.warn("DRM: failed to close expired session", closeError);
+                log.warn("DRM", "failed to close expired session", closeError);
               })
               .then(() => this._unlockInitDataQueue())
               .catch((retryError) => this._onFatalError(retryError));
@@ -679,7 +683,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
           sessionInfo.blacklistedSessionError = err;
 
           if (initializationData.content !== undefined) {
-            log.info("DRM: blacklisting Representations based on protection data.");
+            log.info("DRM", "blacklisting Representations based on protection data.");
             this.trigger("blackListProtectionData", initializationData);
           }
 
@@ -774,13 +778,15 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
         initializationData.content === undefined
       ) {
         log.error(
-          "DRM: This initialization data has already been blacklisted " +
+          "DRM",
+          "This initialization data has already been blacklisted " +
             "but the current content is not known.",
         );
         return true;
       } else {
         log.info(
-          "DRM: This initialization data has already been blacklisted. " +
+          "DRM",
+          "This initialization data has already been blacklisted. " +
             "Blacklisting the related content.",
         );
         this.trigger("blackListProtectionData", initializationData);
@@ -828,11 +834,12 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
 
       if (isUndecipherable) {
         if (initializationData.content === undefined) {
-          log.error("DRM: Cannot forbid key id, the content is unknown.");
+          log.error("DRM", "Cannot forbid key id, the content is unknown.");
           return true;
         }
         log.info(
-          "DRM: Current initialization data is linked to blacklisted keys. " +
+          "DRM",
+          "Current initialization data is linked to blacklisted keys. " +
             "Marking Representations as not decipherable",
         );
         this.trigger("keyIdsCompatibilityUpdate", {
@@ -850,7 +857,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     const entry = stores.loadedSessionsStore.reuse(initializationData);
     if (entry !== null) {
       // TODO update decipherability to `true` if not?
-      log.debug("DRM: Init data already processed. Skipping it.");
+      log.debug("DRM", "Init data already processed. Skipping it.");
       return true;
     }
 
@@ -859,10 +866,11 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     // Remove from `this._currentSessions` and start again.
     const indexOf = this._currentSessions.indexOf(compatibleSessionInfo);
     if (indexOf === -1) {
-      log.error("DRM: Unable to remove processed init data: not found.");
+      log.error("DRM", "Unable to remove processed init data: not found.");
     } else {
       log.debug(
-        "DRM: A session from a processed init data is not available " +
+        "DRM",
+        "A session from a processed init data is not available " +
           "anymore. Re-processing it.",
       );
       this._currentSessions.splice(indexOf, 1);
@@ -888,7 +896,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
       stores.loadedSessionsStore
         .closeSession(entry.mediaKeySession)
         .catch(() =>
-          log.error("DRM: Cannot close the session from the loaded session store"),
+          log.error("DRM", "Cannot close the session from the loaded session store"),
         );
     }
 
@@ -906,7 +914,8 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
     const indexOf = this._currentSessions.indexOf(compatibleSessionInfo);
     if (indexOf !== -1) {
       log.debug(
-        "DRM: A session from a processed init is removed due to forceSessionRecreation policy.",
+        "DRM",
+        "A session from a processed init is removed due to forceSessionRecreation policy.",
       );
       this._currentSessions.splice(indexOf, 1);
     }
@@ -991,7 +1000,7 @@ export default class ContentDecryptor extends EventEmitter<IContentDecryptorEven
    */
   private _unlockInitDataQueue(): void {
     if (this._stateData.isMediaKeysAttached !== MediaKeyAttachmentStatus.Attached) {
-      log.error("DRM: Trying to unlock in the wrong state");
+      log.error("DRM", "Trying to unlock in the wrong state");
       return;
     }
     this._stateData.isInitDataQueueLocked = false;
@@ -1055,7 +1064,8 @@ export function getMissingKnownKeyIds(
   const missingKeyIds = getMissingKeyIds(allKnownKeyIds, newKeyIds);
   if (missingKeyIds.length > 0 && log.hasLevel("DEBUG")) {
     log.debug(
-      "DRM: KeySessionRecord's keys missing in the license, blacklisting them",
+      "DRM",
+      "KeySessionRecord's keys missing in the license, blacklisting them",
       missingKeyIds.map((m) => bytesToHex(m)).join(", "),
     );
   }
@@ -1082,7 +1092,8 @@ export function getMissingInitDataKeyIds(
 
   if (missingKeyIds.length > 0 && log.hasLevel("DEBUG")) {
     log.debug(
-      "DRM: init data keys missing in the license, blacklisting them",
+      "DRM",
+      "init data keys missing in the license, blacklisting them",
       missingKeyIds.map((m) => bytesToHex(m)).join(", "),
     );
   }

--- a/src/main_thread/decrypt/create_or_load_session.ts
+++ b/src/main_thread/decrypt/create_or_load_session.ts
@@ -56,7 +56,9 @@ export default async function createOrLoadSession(
   if (entry !== null) {
     previousLoadedSession = entry.mediaKeySession;
     if (isSessionUsable(previousLoadedSession)) {
-      log.info("DRM: Reuse loaded session", previousLoadedSession.sessionId);
+      log.info("DRM", "Reuse loaded session", {
+        sessionId: previousLoadedSession.sessionId,
+      });
       return {
         type: MediaKeySessionLoadingType.LoadedOpenSession,
         value: {

--- a/src/main_thread/decrypt/create_session.ts
+++ b/src/main_thread/decrypt/create_session.ts
@@ -52,7 +52,8 @@ export default function createSession(
     return createTemporarySession(loadedSessionsStore, initData);
   } else if (persistentSessionsStore === null) {
     log.warn(
-      "DRM: Cannot create persistent MediaKeySession, " +
+      "DRM",
+      "Cannot create persistent MediaKeySession, " +
         "PersistentSessionsStore not created.",
     );
     return createTemporarySession(loadedSessionsStore, initData);
@@ -76,7 +77,7 @@ function createTemporarySession(
   loadedSessionsStore: LoadedSessionsStore,
   initData: IProcessedProtectionData,
 ): Promise<INewSessionCreatedEvent> {
-  log.info("DRM: Creating a new temporary session");
+  log.info("DRM", "Creating a new temporary session");
   const entry = loadedSessionsStore.createSession(initData, "temporary");
   return Promise.resolve({
     type: MediaKeySessionLoadingType.Created,
@@ -102,7 +103,7 @@ async function createAndTryToRetrievePersistentSession(
   if (cancelSignal.cancellationError !== null) {
     throw cancelSignal.cancellationError;
   }
-  log.info("DRM: Creating persistent MediaKeySession");
+  log.info("DRM", "Creating persistent MediaKeySession");
 
   const entry = loadedSessionsStore.createSession(initData, "persistent-license");
   const storedEntry = persistentSessionsStore.getAndReuse(initData);
@@ -116,7 +117,9 @@ async function createAndTryToRetrievePersistentSession(
       storedEntry.sessionId,
     );
     if (!hasLoadedSession) {
-      log.warn("DRM: No data stored for the loaded session");
+      log.warn("DRM", "No data stored for the loaded session", {
+        sessionId: storedEntry.sessionId,
+      });
       persistentSessionsStore.delete(storedEntry.sessionId);
 
       // The EME specification is kind of implicit about it but it seems from my
@@ -132,7 +135,7 @@ async function createAndTryToRetrievePersistentSession(
 
     if (hasLoadedSession && isSessionUsable(entry.mediaKeySession)) {
       persistentSessionsStore.add(initData, initData.keyIds, entry.mediaKeySession);
-      log.info("DRM: Succeeded to load persistent session.");
+      log.info("DRM", "Succeeded to load persistent session.");
       return {
         type: MediaKeySessionLoadingType.LoadedPersistentSession,
         value: entry,
@@ -140,11 +143,12 @@ async function createAndTryToRetrievePersistentSession(
     }
 
     // Unusable persistent session: recreate a new session from scratch.
-    log.warn("DRM: Previous persistent session not usable anymore.");
+    log.warn("DRM", "Previous persistent session not usable anymore.");
     return recreatePersistentSession();
   } catch (err) {
     log.warn(
-      "DRM: Unable to load persistent session: " +
+      "DRM",
+      "Unable to load persistent session: " +
         (err instanceof Error ? err.toString() : "Unknown Error"),
     );
     return recreatePersistentSession();
@@ -159,7 +163,7 @@ async function createAndTryToRetrievePersistentSession(
     if (cancelSignal.cancellationError !== null) {
       throw cancelSignal.cancellationError;
     }
-    log.info("DRM: Removing previous persistent session.");
+    log.info("DRM", "Removing previous persistent session.");
     const persistentEntry = persistentSessionsStore.get(initData);
     if (persistentEntry !== null) {
       persistentSessionsStore.delete(persistentEntry.sessionId);

--- a/src/main_thread/decrypt/find_key_system.ts
+++ b/src/main_thread/decrypt/find_key_system.ts
@@ -419,7 +419,7 @@ export default function getMediaKeySystemAccess(
   keySystemsConfigs: IKeySystemOption[],
   cancelSignal: CancellationSignal,
 ): Promise<IFoundMediaKeySystemAccessEvent> {
-  log.info("DRM: Searching for compatible MediaKeySystemAccess");
+  log.info("DRM", "Searching for compatible MediaKeySystemAccess");
   /** Array of set keySystems for this content. */
   const keySystemsType: IKeySystemType[] = keySystemsConfigs.reduce(
     (arr: IKeySystemType[], keySystemOptions) => {
@@ -482,10 +482,11 @@ export default function getMediaKeySystemAccess(
 
     const keySystemConfigurations = buildKeySystemConfigurations(chosenType);
 
-    log.debug(
-      `DRM: Request keysystem access ${keyType},` +
-        `${index + 1} of ${keySystemsType.length}`,
-    );
+    log.debug(`DRM`, `Request keysystem access`, {
+      keyType,
+      index,
+      length: keySystemsType.length,
+    });
 
     let keySystemAccess;
     const currentState = await MediaKeysAttacher.getAttachedMediaKeysState(mediaElement);
@@ -504,7 +505,7 @@ export default function getMediaKeySystemAccess(
           currentState.askedConfiguration,
         )
       ) {
-        log.info("DRM: Found cached compatible keySystem");
+        log.info("DRM", "Found cached compatible keySystem");
         return Promise.resolve({
           type: "reuse-media-key-system-access" as const,
           value: {
@@ -521,7 +522,11 @@ export default function getMediaKeySystemAccess(
 
       try {
         keySystemAccess = await testKeySystem(eme, keyType, [keySystemConfiguration]);
-        log.info("DRM: Found compatible keysystem", keyType, index + 1);
+        log.info("DRM", "Found compatible keysystem", {
+          keyType,
+          index,
+          configIndex: configIdx,
+        });
         return {
           type: "create-media-key-system-access" as const,
           value: {
@@ -535,7 +540,11 @@ export default function getMediaKeySystemAccess(
           },
         };
       } catch (_) {
-        log.debug("DRM: Rejected access to keysystem", keyType, index + 1, configIdx);
+        log.debug("DRM", "Rejected access to keysystem", {
+          keyType,
+          index,
+          configIndex: configIdx,
+        });
         if (cancelSignal.cancellationError !== null) {
           throw cancelSignal.cancellationError;
         }
@@ -570,10 +579,10 @@ export async function testKeySystem(
       const initData = generatePlayReadyInitData(DUMMY_PLAY_READY_HEADER);
       await session.generateRequest("cenc", initData);
       session.close().catch(() => {
-        log.warn("DRM: Failed to close the dummy session");
+        log.warn("DRM", "Failed to close the dummy session");
       });
     } catch (err) {
-      log.debug("DRM: KeySystemAccess was granted but it is not usable");
+      log.debug("DRM", "KeySystemAccess was granted but it is not usable");
       throw err;
     }
   }

--- a/src/main_thread/decrypt/get_media_keys.ts
+++ b/src/main_thread/decrypt/get_media_keys.ts
@@ -47,7 +47,7 @@ function createPersistentSessionsStorage(
     return null;
   }
 
-  log.debug("DRM: Set the given license storage");
+  log.debug("DRM", "Set the given license storage");
   return new PersistentSessionsStore(persistentLicenseConfig);
 }
 
@@ -110,7 +110,7 @@ export default async function getMediaKeysInfos(
     currentState !== null &&
     evt.type === "reuse-media-key-system-access"
   ) {
-    log.debug("DRM: Reusing already created MediaKeys");
+    log.debug("DRM", "Reusing already created MediaKeys");
     const { mediaKeys, loadedSessionsStore } = currentState;
 
     // We might just rely on the currently attached MediaKeys instance.
@@ -133,7 +133,7 @@ export default async function getMediaKeysInfos(
   }
 
   const mediaKeys = await createMediaKeys(mediaKeySystemAccess);
-  log.info("DRM: MediaKeys created with success");
+  log.info("DRM", "MediaKeys created with success");
   const loadedSessionsStore = new LoadedSessionsStore(mediaKeys);
   return {
     mediaKeys,
@@ -154,7 +154,7 @@ export default async function getMediaKeysInfos(
 async function createMediaKeys(
   mediaKeySystemAccess: IMediaKeySystemAccess,
 ): Promise<IMediaKeys> {
-  log.info("DRM: Calling createMediaKeys on the MediaKeySystemAccess");
+  log.info("DRM", "Calling createMediaKeys on the MediaKeySystemAccess");
   try {
     const mediaKeys = await mediaKeySystemAccess.createMediaKeys();
     return mediaKeys;

--- a/src/main_thread/decrypt/init_media_keys.ts
+++ b/src/main_thread/decrypt/init_media_keys.ts
@@ -51,7 +51,7 @@ export default async function initMediaKeys(
     mediaKeys !== mediaElement.mediaKeys;
 
   if (shouldDisableOldMediaKeys) {
-    log.debug("DRM: Disabling old MediaKeys");
+    log.debug("DRM", "Disabling old MediaKeys");
     await MediaKeysAttacher.clearMediaKeys(mediaElement);
   }
   return mediaKeysInfo;

--- a/src/main_thread/decrypt/session_events_listener.ts
+++ b/src/main_thread/decrypt/session_events_listener.ts
@@ -50,7 +50,7 @@ export default function SessionEventsListener(
   callbacks: ISessionEventListenerCallbacks,
   cancelSignal: CancellationSignal,
 ): void {
-  log.info("DRM: Binding session events", session.sessionId);
+  log.info("DRM", "Binding session events", { sessionId: session.sessionId });
   const { getLicenseConfig = {} } = keySystemOptions;
 
   /** Allows to manually cancel everything the `SessionEventsListener` is doing. */
@@ -88,7 +88,9 @@ export default function SessionEventsListener(
   onKeyStatusesChange(
     session,
     () => {
-      log.info("DRM: keystatuseschange event received", session.sessionId);
+      log.info("DRM", "keystatuseschange event received", {
+        sessionId: session.sessionId,
+      });
       try {
         checkAndHandleCurrentKeyStatuses();
       } catch (error) {
@@ -114,7 +116,10 @@ export default function SessionEventsListener(
         ? messageEvent.messageType
         : "license-request";
 
-      log.info(`DRM: Received message event, type ${messageType}`, session.sessionId);
+      log.info(`DRM`, `Received message event`, {
+        messageType,
+        sessionId: session.sessionId,
+      });
 
       const backoffOptions = getLicenseBackoffOptions(getLicenseConfig.retry);
       retryPromiseWithBackoff(
@@ -127,7 +132,7 @@ export default function SessionEventsListener(
             return;
           }
           if (isNullOrUndefined(licenseObject)) {
-            log.info("DRM: No license given, skipping session.update");
+            log.info("DRM", "No license given, skipping session.update");
           } else {
             try {
               await updateSessionWithMessage(
@@ -154,7 +159,8 @@ export default function SessionEventsListener(
             };
             if (fallbackOnLastTry === true) {
               log.warn(
-                "DRM: Last `getLicense` attempt failed. " +
+                "DRM",
+                "Last `getLicense` attempt failed. " +
                   "Blacklisting the current session.",
               );
               callbacks.onError(new BlacklistedSessionError(formattedError));
@@ -168,7 +174,7 @@ export default function SessionEventsListener(
     manualCanceller.signal,
   );
 
-  log.info("DRM: transmitting current keystatuses", session.sessionId);
+  log.info("DRM", "transmitting current keystatuses", { sessionId: session.sessionId });
   checkAndHandleCurrentKeyStatuses();
   return;
   /**
@@ -202,7 +208,7 @@ export default function SessionEventsListener(
     let timeoutId: number | undefined;
     return new Promise<BufferSource | null>((res, rej) => {
       try {
-        log.debug("DRM: Calling `getLicense`", messageType);
+        log.debug("DRM", "Calling `getLicense`", { messageType });
         const getLicense = keySystemOptions.getLicense(message, messageType);
         const getLicenseTimeout = isNullOrUndefined(getLicenseConfig.timeout)
           ? 10 * 1000
@@ -325,7 +331,7 @@ async function updateSessionWithMessage(
   message: BufferSource,
   mediaKeySystemAccess: IMediaKeySystemAccess,
 ): Promise<void> {
-  log.info("DRM: Updating MediaKeySession with message");
+  log.info("DRM", "Updating MediaKeySession with message");
   try {
     await session.update(message);
   } catch (error) {
@@ -336,7 +342,7 @@ async function updateSessionWithMessage(
       keySystem: mediaKeySystemAccess.keySystem,
     });
   }
-  log.info("DRM: MediaKeySession update succeeded.");
+  log.info("DRM", "MediaKeySession update succeeded.");
 }
 
 /** Information on key ids linked to a MediaKeySession. */

--- a/src/main_thread/decrypt/set_server_certificate.ts
+++ b/src/main_thread/decrypt/set_server_certificate.ts
@@ -53,7 +53,8 @@ async function setServerCertificate(
     return res;
   } catch (error) {
     log.warn(
-      "DRM: mediaKeys.setServerCertificate returned an error",
+      "DRM",
+      "mediaKeys.setServerCertificate returned an error",
       error instanceof Error ? error : "",
     );
     const reason =
@@ -87,18 +88,19 @@ export default async function trySettingServerCertificate(
   | { type: "error"; value: IPlayerError }
 > {
   if (ServerCertificateStore.hasOne(mediaKeys) === true) {
-    log.info("DRM: The MediaKeys already has a server certificate, skipping...");
+    log.info("DRM", "The MediaKeys already has a server certificate, skipping...");
     return { type: "already-has-one" };
   }
   if (typeof mediaKeys.setServerCertificate !== "function") {
     log.warn(
-      "DRM: Could not set the server certificate." +
+      "DRM",
+      "Could not set the server certificate." +
         " mediaKeys.setServerCertificate is not a function",
     );
     return { type: "method-not-implemented" };
   }
 
-  log.info("DRM: Setting server certificate on the MediaKeys");
+  log.info("DRM", "Setting server certificate on the MediaKeys");
   // Because of browser errors, or a user action that can lead to interrupting
   // server certificate setting, we might be left in a status where we don't
   // know if we attached the server certificate or not.

--- a/src/main_thread/decrypt/utils/__tests__/clean_old_stored_persistent_info.test.ts
+++ b/src/main_thread/decrypt/utils/__tests__/clean_old_stored_persistent_info.test.ts
@@ -74,9 +74,12 @@ async function checkRemoved(
   expect(mockDeleteLast).toHaveBeenCalledWith(numberToRemove);
   expect(mockLogInfo).toHaveBeenCalledTimes(1);
   expect(mockLogInfo).toHaveBeenCalledWith(
-    "DRM: Too many stored persistent sessions," + " removing some.",
-    persistentSessionsStore.getLength(),
-    numberToRemove,
+    "DRM",
+    "Too many stored persistent sessions, removing some.",
+    {
+      numberOfPersistentSessions: persistentSessionsStore.getLength(),
+      toDelete: numberToRemove,
+    },
   );
   vi.resetModules();
 }

--- a/src/main_thread/decrypt/utils/check_key_statuses.ts
+++ b/src/main_thread/decrypt/utils/check_key_statuses.ts
@@ -119,7 +119,7 @@ export default function checkKeyStatuses(
       const keyStatusObj = { keyId: keyId.buffer, keyStatus };
 
       if (log.hasLevel("DEBUG")) {
-        log.debug(`DRM: key status update (${bytesToHex(keyId)}): ${keyStatus}`);
+        log.debug(`DRM`, `key status update`, { keyId: bytesToHex(keyId), keyStatus });
       }
 
       switch (keyStatus) {

--- a/src/main_thread/decrypt/utils/clean_old_loaded_sessions.ts
+++ b/src/main_thread/decrypt/utils/clean_old_loaded_sessions.ts
@@ -33,7 +33,10 @@ export default async function cleanOldLoadedSessions(
   if (limit < 0 || limit >= loadedSessionsStore.getLength()) {
     return;
   }
-  log.info("DRM: LSS cache limit exceeded", limit, loadedSessionsStore.getLength());
+  log.info("DRM", "LSS cache limit exceeded", {
+    limit,
+    length: loadedSessionsStore.getLength(),
+  });
   const proms: Array<Promise<unknown>> = [];
   const entries = loadedSessionsStore.getAll().slice(); // clone
   const toDelete = entries.length - limit;

--- a/src/main_thread/decrypt/utils/clean_old_stored_persistent_info.ts
+++ b/src/main_thread/decrypt/utils/clean_old_stored_persistent_info.ts
@@ -41,10 +41,9 @@ export default function cleanOldStoredPersistentInfo(
   }
   const numberOfPersistentSessions = persistentSessionsStore.getLength();
   const toDelete = numberOfPersistentSessions - limit;
-  log.info(
-    "DRM: Too many stored persistent sessions, removing some.",
+  log.info("DRM", "Too many stored persistent sessions, removing some.", {
     numberOfPersistentSessions,
     toDelete,
-  );
+  });
   persistentSessionsStore.deleteOldSessions(toDelete);
 }

--- a/src/main_thread/decrypt/utils/is_session_usable.ts
+++ b/src/main_thread/decrypt/utils/is_session_usable.ts
@@ -37,29 +37,30 @@ export default function isSessionUsable(loadedSession: IMediaKeySession): boolea
   });
 
   if (keyStatuses.length <= 0) {
-    log.debug(
-      "DRM: isSessionUsable: MediaKeySession given has an empty keyStatuses",
-      loadedSession.sessionId,
-    );
+    log.debug("DRM", "isSessionUsable: MediaKeySession given has an empty keyStatuses", {
+      sessionId: loadedSession.sessionId,
+    });
     return false;
   }
 
   if (arrayIncludes(keyStatuses, "expired")) {
-    log.debug(
-      "DRM: isSessionUsable: MediaKeySession given has an expired key",
-      loadedSession.sessionId,
-    );
+    log.debug("DRM", "isSessionUsable: MediaKeySession given has an expired key", {
+      sessionId: loadedSession.sessionId,
+    });
     return false;
   }
 
   if (arrayIncludes(keyStatuses, "internal-error")) {
     log.debug(
-      "DRM: isSessionUsable: MediaKeySession given has a key with an " + "internal-error",
-      loadedSession.sessionId,
+      "DRM",
+      "isSessionUsable: MediaKeySession given has a key with an " + "internal-error",
+      { sessionId: loadedSession.sessionId },
     );
     return false;
   }
 
-  log.debug("DRM: isSessionUsable: MediaKeySession is usable", loadedSession.sessionId);
+  log.debug("DRM", "isSessionUsable: MediaKeySession is usable", {
+    sessionId: loadedSession.sessionId,
+  });
   return true;
 }

--- a/src/main_thread/decrypt/utils/loaded_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/loaded_sessions_store.ts
@@ -61,7 +61,7 @@ export default class LoadedSessionsStore {
     sessionType: MediaKeySessionType,
   ): IStoredSessionEntry {
     const keySessionRecord = new KeySessionRecord(initData);
-    log.debug("DRM-LSS: calling `createSession`", sessionType);
+    log.debug("DRM", "calling `createSession`", { sessionType });
     const mediaKeySession = this._mediaKeys.createSession(sessionType);
     const entry = {
       mediaKeySession,
@@ -74,10 +74,9 @@ export default class LoadedSessionsStore {
     if (!isNullOrUndefined(mediaKeySession.closed)) {
       mediaKeySession.closed
         .then(() => {
-          log.info(
-            "DRM-LSS: session was closed, removing it.",
-            mediaKeySession.sessionId,
-          );
+          log.info("DRM", "session was closed, removing it.", {
+            sessionId: mediaKeySession.sessionId,
+          });
           const index = this.getIndex(keySessionRecord);
           if (index >= 0 && this._storage[index].mediaKeySession === mediaKeySession) {
             this._storage.splice(index, 1);
@@ -85,12 +84,15 @@ export default class LoadedSessionsStore {
         })
         .catch((e: unknown) => {
           // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          log.warn(`DRM-LSS: MediaKeySession.closed rejected: ${e}`);
+          log.warn("DRM", `MediaKeySession.closed rejected: ${e}`);
         });
     }
 
     this._storage.push({ ...entry });
-    log.debug("DRM-LSS: MediaKeySession added", entry.sessionType, this._storage.length);
+    log.debug("DRM", "MediaKeySession added", {
+      sessionType: entry.sessionType,
+      currentlyLoaded: this._storage.length,
+    });
     return entry;
   }
 
@@ -112,11 +114,10 @@ export default class LoadedSessionsStore {
       if (stored.keySessionRecord.isCompatibleWith(initializationData)) {
         this._storage.splice(i, 1);
         this._storage.push(stored);
-        log.debug(
-          "DRM-LSS: Reusing session:",
-          stored.mediaKeySession.sessionId,
-          stored.sessionType,
-        );
+        log.debug("DRM", "Reusing session:", {
+          sessionId: stored.mediaKeySession.sessionId,
+          sessionType: stored.sessionType,
+        });
         return { ...stored };
       }
     }
@@ -167,7 +168,8 @@ export default class LoadedSessionsStore {
     }
     if (entry === undefined) {
       log.error(
-        "DRM-LSS: generateRequest error. No MediaKeySession found with " +
+        "DRM",
+        "generateRequest error. No MediaKeySession found with " +
           "the given initData and initDataType",
       );
       return generateKeyRequest(
@@ -227,7 +229,8 @@ export default class LoadedSessionsStore {
     }
     if (entry === undefined) {
       log.error(
-        "DRM-LSS: loadPersistentSession error. No MediaKeySession found with " +
+        "DRM",
+        "loadPersistentSession error. No MediaKeySession found with " +
           "the given initData and initDataType",
       );
       return loadSession(mediaKeySession, sessionId);
@@ -279,7 +282,8 @@ export default class LoadedSessionsStore {
     }
     if (entry === undefined) {
       log.warn(
-        "DRM-LSS: No MediaKeySession found with " + "the given initData and initDataType",
+        "DRM",
+        "No MediaKeySession found with " + "the given initData and initDataType",
       );
       return Promise.resolve(false);
     }
@@ -310,7 +314,9 @@ export default class LoadedSessionsStore {
    */
   public async closeAllSessions(): Promise<void> {
     const allEntries = this._storage;
-    log.debug("DRM-LSS: Closing all current MediaKeySessions", allEntries.length);
+    log.debug("DRM", "Closing all current MediaKeySessions", {
+      numberOfEntries: allEntries.length,
+    });
 
     // re-initialize the storage, so that new interactions with the
     // `LoadedSessionsStore` do not rely on MediaKeySessions we're in the
@@ -342,10 +348,9 @@ export default class LoadedSessionsStore {
     for (let i = this._storage.length - 1; i >= 0; i--) {
       const stored = this._storage[i];
       if (stored.mediaKeySession === mediaKeySession) {
-        log.debug(
-          "DRM-LSS: Removing session without closing it",
-          mediaKeySession.sessionId,
-        );
+        log.debug("DRM", "Removing session without closing it", {
+          sessionId: mediaKeySession.sessionId,
+        });
         this._storage.splice(i, 1);
         return true;
       }
@@ -495,15 +500,22 @@ export interface IStoredSessionEntry {
 async function safelyCloseMediaKeySession(
   mediaKeySession: IMediaKeySession,
 ): Promise<void> {
-  log.debug("DRM: Trying to close a MediaKeySession", mediaKeySession.sessionId);
+  const sessionId = mediaKeySession.sessionId;
+  log.debug("DRM", "Trying to close a MediaKeySession", {
+    sessionId,
+  });
   try {
     await closeSession(mediaKeySession);
-    log.debug("DRM: Succeeded to close MediaKeySession");
+    log.debug("DRM", "Succeeded to close MediaKeySession", {
+      sessionId,
+    });
     return;
   } catch (err: unknown) {
     log.error(
-      "DRM: Could not close MediaKeySession: " +
+      "DRM",
+      "Could not close MediaKeySession: " +
         (err instanceof Error ? err.toString() : "Unknown error"),
+      { sessionId },
     );
     return;
   }

--- a/src/main_thread/decrypt/utils/media_keys_attacher.ts
+++ b/src/main_thread/decrypt/utils/media_keys_attacher.ts
@@ -204,12 +204,13 @@ async function awaitMediaKeysAttachment(
   if (isNullOrUndefined(promise)) {
     return;
   }
-  log.info("DRM: Awaiting previous MediaKeys attachment operation");
+  log.info("DRM", "Awaiting previous MediaKeys attachment operation");
   try {
     await previousState.pendingTask;
   } catch (err) {
     log.info(
-      "DRM: previous MediaKeys attachment operation failed",
+      "DRM",
+      "previous MediaKeys attachment operation failed",
       err instanceof Error ? err : "Unknown error",
     );
   }
@@ -237,19 +238,19 @@ async function attachMediaKeys(
     await closeAllSessions;
 
     if (mediaElement.mediaKeys === mediaKeysInfo.mediaKeys) {
-      log.debug("DRM: Right MediaKeys already set");
+      log.debug("DRM", "Right MediaKeys already set");
       return;
     }
   }
 
-  log.info("DRM: Attaching MediaKeys to the media element");
+  log.info("DRM", "Attaching MediaKeys to the media element");
   try {
     await setMediaKeys(
       mediaKeysInfo.emeImplementation,
       mediaElement,
       mediaKeysInfo.mediaKeys,
     );
-    log.info("DRM: MediaKeys attached with success");
+    log.info("DRM", "MediaKeys attached with success");
   } catch (err) {
     const errMessage = err instanceof Error ? err.toString() : "Unknown Error";
     throw new EncryptedMediaError(
@@ -282,7 +283,7 @@ async function clearMediaKeys(
     return;
   }
 
-  log.info("DRM: Disposing of the current MediaKeys");
+  log.info("DRM", "Disposing of the current MediaKeys");
   const { loadedSessionsStore } = previousState.mediaKeysState;
   await loadedSessionsStore.closeAllSessions();
   return setMediaKeys(previousState.mediaKeysState.emeImplementation, mediaElement, null);

--- a/src/main_thread/decrypt/utils/persistent_sessions_store.ts
+++ b/src/main_thread/decrypt/utils/persistent_sessions_store.ts
@@ -72,7 +72,8 @@ export default class PersistentSessionsStore {
       this._entries = entries;
     } catch (e) {
       log.warn(
-        "DRM-PSS: Could not get entries from license storage",
+        "DRM",
+        "Persistent store: Could not get entries from license storage",
         e instanceof Error ? e : "",
       );
       this.dispose();
@@ -138,7 +139,7 @@ export default class PersistentSessionsStore {
     session: IMediaKeySession,
   ): void {
     if (isNullOrUndefined(session) || !isNonEmptyString(session.sessionId)) {
-      log.warn("DRM-PSS: Invalid Persisten Session given.");
+      log.warn("DRM", "Persistent Store: Invalid Persisten Session given.");
       return;
     }
     const { sessionId } = session;
@@ -150,10 +151,10 @@ export default class PersistentSessionsStore {
       if (entryVersion >= currVersion && sessionId === currentEntry.sessionId) {
         return;
       }
-      log.info("DRM-PSS: Updating session info.", sessionId);
+      log.info("DRM", "Persistent Store: Updating session info.", { sessionId });
       this._entries.splice(currentIndex, 1);
     } else {
-      log.info("DRM-PSS: Add new session", sessionId);
+      log.info("DRM", "Persistent Store: Add new session", { sessionId });
     }
 
     const storedValues = prepareValuesForStore(initData.values.getFormattedValues());
@@ -190,17 +191,22 @@ export default class PersistentSessionsStore {
       }
     }
     if (index === -1) {
-      log.warn("DRM-PSS: initData to delete not found.");
+      log.warn(
+        "DRM",
+        "Persistent Store: initData to delete not found in persistent store.",
+      );
       return;
     }
     const entry = this._entries[index];
-    log.warn("DRM-PSS: Delete session from store", entry.sessionId);
+    log.warn("DRM", "Persistent Store: Delete session from persistent store", {
+      sessionId: entry.sessionId,
+    });
     this._entries.splice(index, 1);
     this._save();
   }
 
   public deleteOldSessions(sessionsToDelete: number): void {
-    log.info(`DRM-PSS: Deleting last ${sessionsToDelete} sessions.`);
+    log.info("DRM", "Persistent Store: Deleting last sessions.", { sessionsToDelete });
     if (sessionsToDelete <= 0) {
       return;
     }
@@ -208,7 +214,8 @@ export default class PersistentSessionsStore {
       this._entries.splice(0, sessionsToDelete);
     } else {
       log.warn(
-        "DRM-PSS: Asked to remove more information that it contains",
+        "DRM",
+        "Persistent Store: Asked to remove more information that it contains",
         sessionsToDelete,
         this._entries.length,
       );
@@ -262,20 +269,26 @@ export default class PersistentSessionsStore {
                   if (typeof entryKid === "string") {
                     if (keyIdB64 === entryKid) {
                       log.debug(
-                        "DRM: PSS: Found wanted kid stored on entry",
-                        `i=${i}`,
-                        `key-id=${keyIdB64}`,
-                        `session-id=${entry.sessionId}`,
+                        "DRM",
+                        "Persistent Store: Found wanted kid stored on entry",
+                        {
+                          index: i,
+                          keyId: keyIdB64,
+                          sessionId: entry.sessionId,
+                        },
                       );
                       return true;
                     }
                   } else if (areArraysOfNumbersEqual(entryKid.initData, keyId)) {
                     if (log.hasLevel("DEBUG")) {
                       log.debug(
-                        "DRM: PSS: Found wanted kid stored on entry",
-                        `i=${i}`,
-                        `key-id=${bytesToBase64(entryKid.initData)}`,
-                        `session-id=${entry.sessionId}`,
+                        "DRM",
+                        "Persistent Store: Found wanted kid stored on entry",
+                        {
+                          index: i,
+                          keyId: keyIdB64,
+                          sessionId: entry.sessionId,
+                        },
                       );
                     }
                     return true;
@@ -284,20 +297,22 @@ export default class PersistentSessionsStore {
                 return false;
               });
               if (foundCompatible) {
-                log.debug(
-                  "DRM: PSS: Found compatible entry of v4",
-                  `i=${i}`,
-                  `session-id=${entry.sessionId}`,
-                );
+                log.debug("DRM", "Persistent Store: Found compatible entry of v4", {
+                  index: i,
+                  sessionId: entry.sessionId,
+                });
                 return i;
               }
             } else {
               const formatted = initData.values.getFormattedValues();
               if (areInitializationValuesCompatible(formatted, entry.values)) {
                 log.debug(
-                  "DRM: PSS: Found compatible entry of v4 without init data",
-                  `i=${i}`,
-                  `session-id=${entry.sessionId}`,
+                  "DRM",
+                  "Persistent Store: Found compatible entry of v4 without init data",
+                  {
+                    index: i,
+                    sessionId: entry.sessionId,
+                  },
                 );
                 return i;
               }
@@ -308,9 +323,12 @@ export default class PersistentSessionsStore {
             const formatted = initData.values.getFormattedValues();
             if (areInitializationValuesCompatible(formatted, entry.values)) {
               log.debug(
-                "DRM: PSS: Found compatible entry of v3 - same values",
-                `i=${i}`,
-                `session-id=${entry.sessionId}`,
+                "DRM",
+                "Persistent Store: Found compatible entry of v3 - same values",
+                {
+                  index: i,
+                  sessionId: entry.sessionId,
+                },
               );
               return i;
             }
@@ -328,15 +346,19 @@ export default class PersistentSessionsStore {
                     : entry.initData.initData;
                 if (areArraysOfNumbersEqual(decodedInitData, concatInitData)) {
                   log.debug(
-                    "DRM: PSS: Found compatible entry of v2 - same concatenated init data",
-                    `i=${i}`,
-                    `session-id=${entry.sessionId}`,
+                    "DRM",
+                    "Persistent Store: Found compatible entry of v2 - same concatenated init data",
+                    {
+                      index: i,
+                      sessionId: entry.sessionId,
+                    },
                   );
                   return i;
                 }
               } catch (e) {
                 log.warn(
-                  "DRM-PSS: Could not decode initialization data.",
+                  "DRM",
+                  "Persistent Store: Could not decode initialization data.",
                   e instanceof Error ? e : "",
                 );
               }
@@ -354,18 +376,24 @@ export default class PersistentSessionsStore {
                 // ugly unreadable logic for a very very minor possibility.
                 // Just consider that it is a match based on the hash.
                 log.debug(
-                  "DRM: PSS: Found compatible entry of v1 - same hash only",
-                  `i=${i}`,
-                  `hash=${concatHash}`,
-                  `session-id=${entry.sessionId}`,
+                  "DRM",
+                  "Persistent Store: Found compatible entry of v1 - same hash only",
+                  {
+                    index: i,
+                    sessionId: entry.sessionId,
+                    hash: concatHash,
+                  },
                 );
                 return i;
               } else if (areArraysOfNumbersEqual(entry.initData, concatInitData)) {
                 log.debug(
-                  "DRM: PSS: Found compatible entry of v1 - same hash and initData",
-                  `i=${i}`,
-                  `hash=${concatHash}`,
-                  `session-id=${entry.sessionId}`,
+                  "DRM",
+                  "Persistent Store: Found compatible entry of v1 - same hash and initData",
+                  {
+                    index: i,
+                    sessionId: entry.sessionId,
+                    hash: concatHash,
+                  },
                 );
                 return i;
               }
@@ -377,10 +405,13 @@ export default class PersistentSessionsStore {
             const { initDataHash: concatHash } = getConcatenatedInitDataInfo();
             if (entry.initData === concatHash) {
               log.debug(
-                "DRM: PSS: Found compatible entry - same hash only",
-                `i=${i}`,
-                `hash=${concatHash}`,
-                `session-id=${entry.sessionId}`,
+                "DRM",
+                "Persistent Store: Found compatible entry - same hash only",
+                {
+                  index: i,
+                  sessionId: entry.sessionId,
+                  hash: concatHash,
+                },
               );
               return i;
             }
@@ -399,7 +430,11 @@ export default class PersistentSessionsStore {
       this._storage.save(this._entries);
     } catch (e) {
       const err = e instanceof Error ? e : undefined;
-      log.warn("DRM-PSS: Could not save MediaKeySession information", err);
+      log.warn(
+        "DRM",
+        "Persistent Store: Could not save MediaKeySession information",
+        err,
+      );
     }
   }
 }

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -149,10 +149,12 @@ export default class DirectFileContentInitializer extends ContentInitializer {
         stopListeningToDrmUpdates();
 
         // Start everything! (Just put the URL in the element's src).
-        log.info("Setting URL to HTMLMediaElement", url);
+        log.info("Init", "Setting URL to HTMLMediaElement", { url });
         mediaElement.src = url;
         cancelSignal.register(() => {
-          log.info("Init: Removing directfile src from media element", mediaElement.src);
+          log.info("Init", "Removing directfile src from media element", {
+            src: mediaElement.src,
+          });
           clearElementSrc(mediaElement);
         });
 
@@ -214,9 +216,9 @@ export default class DirectFileContentInitializer extends ContentInitializer {
     const cancelSignal = this._initCanceller.signal;
     const { autoPlay, startAt } = this._settings;
     const initialTime = () => {
-      log.debug("Init: Calculating initial time");
+      log.debug("Init", "Calculating initial time");
       const initTime = getDirectFileInitialTime(mediaElement, startAt);
-      log.debug("Init: Initial time calculated:", initTime);
+      log.debug("Init", "Initial time calculated", { initialTime: initTime });
       return initTime;
     };
     performInitialSeekAndPlay(
@@ -320,7 +322,8 @@ function getDirectFileInitialTime(
       }
     }
     log.warn(
-      "Init: startAt.fromLastPosition set but no known duration, " +
+      "Init",
+      "startAt.fromLastPosition set but no known duration, " +
         "it may be too soon to seek",
     );
     return undefined;
@@ -329,8 +332,8 @@ function getDirectFileInitialTime(
       mediaElement.seekable.length > 0 ? mediaElement.seekable.end(0) : duration;
     if (isNullOrUndefined(livePosition)) {
       log.warn(
-        "Init: startAt.fromLivePosition set but no known live position, " +
-          "beginning at 0.",
+        "Init",
+        "startAt.fromLivePosition set but no known live position, " + "beginning at 0.",
       );
       return 0;
     }
@@ -338,7 +341,8 @@ function getDirectFileInitialTime(
   } else if (!isNullOrUndefined(startAt.percentage)) {
     if (isNullOrUndefined(duration) || !isFinite(duration)) {
       log.warn(
-        "Init: startAt.percentage set but no known duration, " + "beginning at 0.",
+        "Init",
+        "startAt.percentage set but no known duration, " + "beginning at 0.",
       );
       return 0;
     }

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -440,9 +440,9 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       initCanceller.signal,
     );
 
-    log.debug("Init: Calculating initial time");
+    log.debug("Init", "Calculating initial time");
     const initialTime = getInitialTime(manifest, lowLatencyMode, startAt);
-    log.debug("Init: Initial time calculated:", initialTime);
+    log.debug("Init", "Initial time calculated", { initialTime });
 
     /** Choose the right "Representation" for a given "Adaptation". */
     const representationEstimator = AdaptiveRepresentationSelector(adaptiveOptions);
@@ -992,7 +992,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           } else if (self._decryptionCapabilities.status === "uninitialized") {
             // Should never happen
             log.error(
-              "Init: received encryption data without known decryption capabilities",
+              "Init",
+              "received encryption data without known decryption capabilities",
             );
             return;
           }
@@ -1432,12 +1433,12 @@ function handleFreezeResolution(
 ): void {
   switch (freezeResolution.type) {
     case "reload": {
-      log.info("Init: Planning reload due to freeze");
+      log.info("Init", "Planning reload due to freeze");
       triggerReload();
       break;
     }
     case "flush": {
-      log.info("Init: Flushing buffer due to freeze");
+      log.info("Init", "Flushing buffer due to freeze");
       const observation = playbackObserver.getReference().getValue();
       const currentTime = observation.position.isAwaitingFuturePosition()
         ? observation.position.getWanted()

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -217,7 +217,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       return;
     }
     this._queuedWorkerMessages = [];
-    log.debug("MTCI: addEventListener prepare buffering worker messages");
+    log.debug("Init", "addEventListener prepare buffering worker messages");
     const onmessage = (evt: MessageEvent): void => {
       const msgData = evt.data as unknown as IWorkerMessage;
       const type = msgData.type;
@@ -243,16 +243,16 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             case "NONE":
               break;
             case "ERROR":
-              log.error(...formatted);
+              log.error(msgData.value.namespace, ...formatted);
               break;
             case "WARNING":
-              log.warn(...formatted);
+              log.warn(msgData.value.namespace, ...formatted);
               break;
             case "INFO":
-              log.info(...formatted);
+              log.info(msgData.value.namespace, ...formatted);
               break;
             case "DEBUG":
-              log.debug(...formatted);
+              log.debug(msgData.value.namespace, ...formatted);
               break;
             default:
               assertUnreachable(msgData.value.logLevel);
@@ -268,11 +268,11 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     };
     this._settings.worker.addEventListener("message", onmessage);
     const onmessageerror = (_msg: MessageEvent) => {
-      log.error("MTCI: Error when receiving message from worker.");
+      log.error("Init", "Error when receiving message from worker.");
     };
     this._settings.worker.addEventListener("messageerror", onmessageerror);
     this._initCanceller.signal.register(() => {
-      log.debug("MTCI: removeEventListener prepare for worker message");
+      log.debug("Init", "removeEventListener prepare for worker message");
       this._settings.worker.removeEventListener("message", onmessage);
       this._settings.worker.removeEventListener("messageerror", onmessageerror);
     });
@@ -433,14 +433,14 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     ): void => {
       const reloadingContentInfo = this._currentContentInfo;
       if (reloadingContentInfo === null) {
-        log.warn("MTCI: Asked to reload when no content is loaded.");
+        log.warn("Init", "Asked to reload when no content is loaded.");
         return;
       }
       if (
         reloadingContentInfo === null ||
         reloadingContentInfo.mediaSourceInfo === null
       ) {
-        log.warn("MTCI: Asked to reload when no MediaSource is active.");
+        log.warn("Init", "Asked to reload when no MediaSource is active.");
         return;
       }
 
@@ -475,7 +475,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     ): void => {
       const reloadingContentInfo = this._currentContentInfo;
       if (reloadingContentInfo === null) {
-        log.warn("MTCI: Asked to reload when no content is loaded.");
+        log.warn("Init", "Asked to reload when no content is loaded.");
         return;
       }
       const lastObservation = playbackObserver.getReference().getValue();
@@ -525,7 +525,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             (currStatus, stopListening) => {
               if (currStatus === MediaSourceInitializationStatus.AttachNow) {
                 stopListening();
-                log.info("MTCI: Attaching MediaSource URL to the media element");
+                log.info("media", "Attaching MediaSource URL to the media element");
                 if (mediaSourceLink.type === "handle") {
                   mediaElement.srcObject = mediaSourceLink.value;
                   this._currentMediaSourceCanceller.signal.register(() => {
@@ -919,7 +919,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           }
           const manifest = this._currentContentInfo?.manifest;
           if (isNullOrUndefined(manifest)) {
-            log.error("MTCI: Manifest update but no Manifest loaded");
+            log.error("Init", "Manifest update but no Manifest loaded");
             return;
           }
 
@@ -1077,7 +1077,9 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             (p) => p.id === msgData.value.periodId,
           );
           if (period === undefined) {
-            log.warn("MTCI: Discontinuity's Period not found", msgData.value.periodId);
+            log.warn("Init", "Discontinuity's Period not found", {
+              periodId: msgData.value.periodId,
+            });
             return;
           }
           this._currentContentInfo.rebufferingController?.updateDiscontinuityInfo({
@@ -1094,7 +1096,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
             return;
           }
           if (textDisplayer === null) {
-            log.warn("Init: Received AddTextData message but no text displayer exists");
+            log.warn("text", "Received AddTextData message but no text displayer exists");
           } else {
             try {
               const ranges = textDisplayer.pushTextData(msgData.value);
@@ -1121,7 +1123,8 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           }
           if (textDisplayer === null) {
             log.warn(
-              "Init: Received RemoveTextData message but no text displayer exists",
+              "text",
+              "Received RemoveTextData message but no text displayer exists",
             );
           } else {
             try {
@@ -1152,7 +1155,8 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           }
           if (textDisplayer === null) {
             log.warn(
-              "Init: Received ResetTextDisplayer message but no text displayer exists",
+              "text",
+              "Received ResetTextDisplayer message but no text displayer exists",
             );
           } else {
             textDisplayer.reset();
@@ -1166,7 +1170,8 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           }
           if (textDisplayer === null) {
             log.warn(
-              "Init: Received StopTextDisplayer message but no text displayer exists",
+              "text",
+              "Received StopTextDisplayer message but no text displayer exists",
             );
           } else {
             textDisplayer.stop();
@@ -1232,7 +1237,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
           if (sinkObj !== undefined) {
             sinkObj.resolve(msgData.value.segmentSinkMetrics);
           } else {
-            log.error("MTCI: Failed to send segment sink store update");
+            log.error("Init", "Failed to send segment sink store update");
           }
           break;
         }
@@ -1259,7 +1264,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
               tObj.resolve(msgData.value.data);
             }
           } else {
-            log.error("MTCI: Failed to send segment sink store update");
+            log.error("Init", "Failed to send segment sink store update");
           }
           break;
         }
@@ -1268,10 +1273,12 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       }
     };
 
-    log.debug("MTCI: addEventListener for worker message");
+    log.debug("Init", "addEventListener for worker message");
     if (this._queuedWorkerMessages !== null) {
       const bufferedMessages = this._queuedWorkerMessages.slice();
-      log.debug("MTCI: Processing buffered messages", bufferedMessages.length);
+      log.debug("Init", "Processing buffered messages", {
+        ammount: bufferedMessages.length,
+      });
       for (const message of bufferedMessages) {
         onmessage(message);
       }
@@ -1279,7 +1286,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     }
     this._settings.worker.addEventListener("message", onmessage);
     this._initCanceller.signal.register(() => {
-      log.debug("MTCI: removeEventListener for worker message");
+      log.debug("Init", "removeEventListener for worker message");
       this._settings.worker.removeEventListener("message", onmessage);
     });
   }
@@ -1356,7 +1363,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     if (emeApi === null) {
       return createEmeDisabledReference("EME API not available on the current page.");
     }
-    log.debug("MTCI: Creating ContentDecryptor");
+    log.debug("Init", "Creating ContentDecryptor");
     const contentDecryptor = new ContentDecryptor(emeApi, mediaElement, keySystems);
     const drmStatusRef = new SharedReference<IDrmInitializationStatus>(
       {
@@ -1609,11 +1616,11 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       return null;
     }
     if (this._currentContentInfo === null) {
-      log.error("MTCI: Setting up modules without a contentId");
+      log.error("Init", "Setting up modules without a contentId");
       return null;
     }
     if (this._currentContentInfo.manifest === null) {
-      log.error("MTCI: Setting up modules without a loaded Manifest");
+      log.error("Init", "Setting up modules without a loaded Manifest");
       return null;
     }
 
@@ -1836,13 +1843,13 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     }
 
     const { contentId, manifest } = this._currentContentInfo;
-    log.debug("MTCI: Calculating initial time");
+    log.debug("Init", "Calculating initial time");
     const initialTime = getInitialTime(
       manifest,
       this._settings.lowLatencyMode,
       this._settings.startAt,
     );
-    log.debug("MTCI: Initial time calculated:", initialTime);
+    log.debug("Init", "Initial time calculated", { initialTime });
     const { enableFastSwitching, onCodecSwitch } = this._settings.bufferOptions;
     const corePlaybackObserver = this._setUpModulesOnNewMediaSource(
       {
@@ -1906,7 +1913,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
     worker: Worker,
   ): void {
     if (this._currentContentInfo?.contentId !== msg.contentId) {
-      log.info("MTCI: Ignoring MediaSource attachment due to wrong `contentId`");
+      log.info("Init", "Ignoring MediaSource attachment due to wrong `contentId`");
     } else {
       const { mediaSourceId } = msg;
       try {

--- a/src/main_thread/init/send_message.ts
+++ b/src/main_thread/init/send_message.ts
@@ -6,7 +6,7 @@ export default function sendMessage(
   msg: IMainThreadMessage,
   transferables?: Transferable[],
 ): void {
-  log.debug("---> Sending to Worker:", msg.type);
+  log.debug("M-->C", "Sending message", { name: msg.type });
   if (transferables === undefined) {
     worker.postMessage(msg);
   } else {

--- a/src/main_thread/init/utils/create_media_source.ts
+++ b/src/main_thread/init/utils/create_media_source.ts
@@ -41,17 +41,18 @@ export function resetMediaElement(
   mediaSourceURL: string | null,
 ): void {
   if (mediaSourceURL !== null && mediaElement.src === mediaSourceURL) {
-    log.info("Init: Clearing HTMLMediaElement's src");
+    log.info("media", "Clearing HTMLMediaElement's src");
     clearElementSrc(mediaElement);
   }
 
   if (mediaSourceURL !== null) {
     try {
-      log.debug("Init: Revoking previous URL");
+      log.debug("media", "Revoking previous URL");
       URL.revokeObjectURL(mediaSourceURL);
     } catch (e) {
       log.warn(
-        "Init: Error while revoking the media source URL",
+        "media",
+        "Error while revoking the media source URL",
         e instanceof Error ? e : "",
       );
     }
@@ -144,12 +145,14 @@ export default function openMediaSource(
     mediaSource.addEventListener(
       "mediaSourceOpen",
       () => {
-        log.info("Init: MediaSource opened");
+        log.info("mse", "MediaSource opened");
         resolve(mediaSource);
       },
       unlinkSignal,
     );
-    log.info("MTCI: Attaching MediaSource URL to the media element");
+    log.info("media", "Attaching MediaSource URL to the media element", {
+      handleType: mediaSource.handle.type,
+    });
     if (mediaSource.handle.type === "handle") {
       mediaElement.srcObject = mediaSource.handle.value;
       unlinkSignal.register(() => {

--- a/src/main_thread/init/utils/get_initial_time.ts
+++ b/src/main_thread/init/utils/get_initial_time.ts
@@ -94,32 +94,58 @@ export default function getInitialTime(
     const min = getMinimumSafePosition(manifest);
     const max = getMaximumSafePosition(manifest);
     if (!isNullOrUndefined(startAt.position)) {
-      log.debug("Init: using startAt.minimumPosition");
+      log.debug("Init", "Initial Position: using startAt.position", {
+        position: startAt.position,
+        min,
+        max,
+      });
       return Math.max(Math.min(startAt.position, max), min);
     } else if (!isNullOrUndefined(startAt.wallClockTime)) {
-      log.debug("Init: using startAt.wallClockTime");
       const ast =
         manifest.availabilityStartTime === undefined ? 0 : manifest.availabilityStartTime;
       const position = startAt.wallClockTime - ast;
+      log.debug("Init", "Initial Position: using startAt.wallClockTime", {
+        wallClockTime: startAt.wallClockTime,
+        wallClockOffset: ast,
+        deOffseted: position,
+        min,
+        max,
+      });
       return Math.max(Math.min(position, max), min);
     } else if (!isNullOrUndefined(startAt.fromFirstPosition)) {
-      log.debug("Init: using startAt.fromFirstPosition");
       const { fromFirstPosition } = startAt;
+      log.debug("Init", "Initial Position: using startAt.fromFirstPosition", {
+        fromFirstPosition,
+        min,
+        max,
+      });
       return fromFirstPosition <= 0 ? min : Math.min(max, min + fromFirstPosition);
     } else if (!isNullOrUndefined(startAt.fromLastPosition)) {
-      log.debug("Init: using startAt.fromLastPosition");
       const { fromLastPosition } = startAt;
+      log.debug("Init", "Initial Position: using startAt.fromLastPosition", {
+        fromLastPosition,
+        min,
+        max,
+      });
       return fromLastPosition >= 0 ? max : Math.max(min, max + fromLastPosition);
     } else if (!isNullOrUndefined(startAt.fromLivePosition)) {
-      log.debug("Init: using startAt.fromLivePosition");
       const livePosition = getLivePosition(manifest) ?? max;
       const { fromLivePosition } = startAt;
+      log.debug("Init", "Initial Position: using startAt.fromLivePosition", {
+        fromLivePosition,
+        livePosition,
+        min,
+      });
       return fromLivePosition >= 0
         ? livePosition
         : Math.max(min, livePosition + fromLivePosition);
     } else if (!isNullOrUndefined(startAt.percentage)) {
-      log.debug("Init: using startAt.percentage");
       const { percentage } = startAt;
+      log.debug("Init", "Initial Position: using startAt.percentage", {
+        percentage,
+        min,
+        max,
+      });
       if (percentage > 100) {
         return max;
       } else if (percentage < 0) {
@@ -140,30 +166,41 @@ export default function getInitialTime(
 
     if (clockOffset === undefined) {
       log.info(
-        "Init: no clock offset found for a live content, " +
+        "Init",
+        "no clock offset found for a live content, " +
           "starting close to maximum available position",
+        { maximumPosition },
       );
       liveTime = maximumPosition;
     } else {
-      log.info(
-        "Init: clock offset found for a live content, " +
-          "checking if we can start close to it",
-      );
       const ast =
         manifest.availabilityStartTime === undefined ? 0 : manifest.availabilityStartTime;
       const clockRelativeLiveTime = (getMonotonicTimeStamp() + clockOffset) / 1000 - ast;
       liveTime = Math.min(maximumPosition, clockRelativeLiveTime);
+      log.info(
+        "Init",
+        "clock offset found for a live content, " +
+          "checking if we can start close to it",
+        {
+          wallClockOffset: ast,
+          clockRelativeLiveTime,
+          liveTime,
+        },
+      );
     }
     const diffFromLiveTime =
       suggestedPresentationDelay ??
       (lowLatencyMode ? DEFAULT_LIVE_GAP.LOW_LATENCY : DEFAULT_LIVE_GAP.DEFAULT);
-    log.debug(
-      `Init: ${liveTime} defined as the live time, applying a live gap` +
-        ` of ${diffFromLiveTime}`,
-    );
+    log.debug("Init", "Initial Position: Applying gap from live time", {
+      liveTime,
+      diffFromLiveTime,
+      minimumPosition,
+    });
     return Math.max(liveTime - diffFromLiveTime, minimumPosition);
   }
 
-  log.info("Init: starting at the minimum available position:", minimumPosition);
+  log.info("Init", "Initial Position: starting at the minimum available position", {
+    minimumPosition,
+  });
   return minimumPosition;
 }

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -232,11 +232,12 @@ export default function performInitialSeekAndPlay(
        * Might also send warnings if minor issues arise.
        */
       function onPlayable() {
-        log.info("Init: Can begin to play content");
+        log.info("Init", "Can begin to play content");
         if (!mustAutoPlay) {
           if (mediaElement.autoplay) {
             log.warn(
-              "Init: autoplay is enabled on HTML media element. " +
+              "Init",
+              "autoplay is enabled on HTML media element. " +
                 "Media will play as soon as possible.",
             );
           }
@@ -249,7 +250,8 @@ export default function performInitialSeekAndPlay(
           // restart the video from the start, which is not wanted in most cases.
           // returning "skipped" prevents the call to play() and fix the issue
           log.warn(
-            "Init: autoplay is enabled but the video is ended. " +
+            "Init",
+            "autoplay is enabled but the video is ended. " +
               "Skipping autoplay to prevent video to start again",
           );
           initialPlayPerformed.setValue(true);
@@ -283,7 +285,8 @@ export default function performInitialSeekAndPlay(
             if (playError instanceof Error && playError.name === "NotAllowedError") {
               // auto-play was probably prevented.
               log.warn(
-                "Init: Media element can't play." +
+                "Init",
+                "Media element can't play." +
                   " It may be due to browser auto-play policies.",
               );
 

--- a/src/main_thread/init/utils/initialize_content_decryption.ts
+++ b/src/main_thread/init/utils/initialize_content_decryption.ts
@@ -83,7 +83,7 @@ export default function initializeContentDecryption(
     return createEmeDisabledReference("EME API not available on the current page.");
   }
 
-  log.debug("Init: Creating ContentDecryptor");
+  log.debug("Init", "Creating ContentDecryptor");
   const contentDecryptor = new ContentDecryptor(emeApi, mediaElement, keySystems);
 
   const onStateChange = (state: ContentDecryptorState) => {

--- a/src/main_thread/init/utils/rebuffering_controller.ts
+++ b/src/main_thread/init/utils/rebuffering_controller.ts
@@ -148,7 +148,14 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
 
         if (position.isAwaitingFuturePosition()) {
           playbackRateUpdater.stopRebuffering();
-          log.debug("Init: let rebuffering happen as we're awaiting a future position");
+          log.debug(
+            "Init",
+            "let rebuffering happen as we're awaiting a future position",
+            {
+              wantedPosition: position.getWanted(),
+              lastPolledPosition: position.getPolled(),
+            },
+          );
         } else {
           playbackRateUpdater.startRebuffering();
         }
@@ -191,17 +198,15 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
           if (skippableDiscontinuity !== null) {
             const realSeekTime = skippableDiscontinuity + 0.001;
             if (realSeekTime <= targetTime) {
-              log.info(
-                "Init: position to seek already reached, no seeking",
+              log.info("Init", "position to seek already reached, no seeking", {
                 targetTime,
                 realSeekTime,
-              );
+              });
             } else {
-              log.warn(
-                "SA: skippable discontinuity found in the stream",
-                position.getPolled(),
+              log.warn("Init", "skippable discontinuity found in the stream", {
+                lastPolledPosition: position.getPolled(),
                 realSeekTime,
-              );
+              });
               this._playbackObserver.setCurrentTime(realSeekTime);
               this.trigger(
                 "warning",
@@ -233,12 +238,11 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
         ) {
           const seekTo = positionBlockedAt + nextBufferRangeGap + EPSILON;
           if (targetTime < seekTo) {
-            log.warn(
-              "Init: discontinuity encountered inferior to the threshold",
+            log.warn("Init", "discontinuity encountered inferior to the threshold", {
               positionBlockedAt,
               seekTo,
               BUFFER_DISCONTINUITY_THRESHOLD,
-            );
+            });
             this._playbackObserver.setCurrentTime(seekTo);
             this.trigger(
               "warning",
@@ -318,7 +322,8 @@ export default class RebufferingController extends EventEmitter<IRebufferingCont
       Math.abs(rebufferingPos - lockedPeriodStart) < 1
     ) {
       log.warn(
-        "Init: rebuffering because of a future locked stream.\n" +
+        "Init",
+        "rebuffering because of a future locked stream.\n" +
           "Trying to unlock by seeking to the next Period",
       );
       this._playbackObserver.setCurrentTime(lockedPeriodStart + 0.001);
@@ -367,14 +372,16 @@ function findSeekableDiscontinuity(
           if (nextPeriod !== null) {
             discontinuityEnd = nextPeriod.start + EPSILON;
           } else {
-            log.warn("Init: discontinuity at Period's end but no next Period");
+            log.warn("Init", "discontinuity at Period's end but no next Period", {
+              periodId: period.id,
+            });
           }
         } else if (stalledPosition < end + EPSILON) {
           discontinuityEnd = end + EPSILON;
         }
       }
       if (discontinuityEnd !== undefined) {
-        log.info("Init: discontinuity found", stalledPosition, discontinuityEnd);
+        log.info("Init", "discontinuity found", { stalledPosition, discontinuityEnd });
         maxDiscontinuityEnd =
           maxDiscontinuityEnd !== null && maxDiscontinuityEnd > discontinuityEnd
             ? maxDiscontinuityEnd
@@ -519,7 +526,7 @@ class PlaybackRateUpdater {
     }
     this._isRebuffering = true;
     this._speedUpdateCanceller.cancel();
-    log.info("Init: Pause playback to build buffer");
+    log.info("Init", "Pause playback to build buffer");
     this._playbackObserver.setPlaybackRate(0);
   }
 
@@ -553,7 +560,7 @@ class PlaybackRateUpdater {
   private _updateSpeed() {
     this._speed.onUpdate(
       (lastSpeed) => {
-        log.info("Init: Resume playback speed", lastSpeed);
+        log.info("Init", "Resume playback speed", { newSpeed: lastSpeed });
         this._playbackObserver.setPlaybackRate(lastSpeed);
       },
       {

--- a/src/main_thread/text_displayer/html/html_parsers.ts
+++ b/src/main_thread/text_displayer/html/html_parsers.ts
@@ -26,14 +26,14 @@ export default function parseTextTrackToElements(
   },
   timestampOffset: number,
 ): IHTMLCue[] {
-  log.debug("HTSB: Finding parser for html text tracks:", type);
+  log.debug("text", "Finding parser for html text tracks:", { type });
   const parser = features.htmlTextTracksParsers[type];
 
   if (typeof parser !== "function") {
     throw new Error("no parser found for the given text track");
   }
-  log.debug("HTSB: Parser found, parsing...");
+  log.debug("text", "Parser found, parsing...", { type });
   const parsed = parser(data, context, timestampOffset);
-  log.debug("HTTB: Parsed successfully!", parsed.length);
+  log.debug("text", "Parsed successfully!", { length: parsed.length });
   return parsed;
 }

--- a/src/main_thread/text_displayer/html/html_text_displayer.ts
+++ b/src/main_thread/text_displayer/html/html_text_displayer.ts
@@ -25,7 +25,7 @@ function safelyRemoveChild(element: Element, child: Element) {
   try {
     element.removeChild(child);
   } catch (_error) {
-    log.warn("HTD: Can't remove text track: not in the element.");
+    log.warn("text", "Can't remove text track: not in the element.");
   }
 }
 
@@ -105,7 +105,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
    * @param {HTMLElement} textTrackElement
    */
   constructor(videoElement: IMediaElement, textTrackElement: HTMLElement) {
-    log.debug("HTD: Creating HTMLTextDisplayer");
+    log.debug("text", "Creating HTMLTextDisplayer");
     this._buffered = new ManualTimeRanges();
 
     this._videoElement = videoElement;
@@ -123,7 +123,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
    * @returns {Object}
    */
   public pushTextData(infos: ITextDisplayerData): IRange[] {
-    log.debug("HTD: Appending new html text tracks");
+    log.debug("text", "Appending new html text tracks");
     const { timestampOffset, appendWindow, chunk } = infos;
     if (chunk === null) {
       return convertToRanges(this._buffered);
@@ -183,10 +183,10 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       start = Math.max(appendWindowStart, startTime);
     } else {
       if (cues.length <= 0) {
-        log.warn("HTD: Current text tracks have no cues nor start time. Aborting");
+        log.warn("text", "Current text tracks have no cues nor start time. Aborting");
         return convertToRanges(this._buffered);
       }
-      log.warn("HTD: No start time given. Guessing from cues.");
+      log.warn("text", "No start time given. Guessing from cues.");
       start = cues[0].start;
     }
 
@@ -195,16 +195,17 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
       end = Math.min(appendWindowEnd, endTime);
     } else {
       if (cues.length <= 0) {
-        log.warn("HTD: Current text tracks have no cues nor end time. Aborting");
+        log.warn("text", "Current text tracks have no cues nor end time. Aborting");
         return convertToRanges(this._buffered);
       }
-      log.warn("HTD: No end time given. Guessing from cues.");
+      log.warn("text", "No end time given. Guessing from cues.");
       end = cues[cues.length - 1].end;
     }
 
     if (end <= start) {
       log.warn(
-        "HTD: Invalid text track appended: ",
+        "text",
+        "Invalid text track appended: ",
         "the start time is inferior or equal to the end time.",
       );
       return convertToRanges(this._buffered);
@@ -224,7 +225,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
    * @returns {Object}
    */
   public removeBuffer(start: number, end: number): IRange[] {
-    log.debug("HTD: Removing html text track data", start, end);
+    log.debug("text", "Removing html text track data", { start, end });
     this._buffer.remove(start, end);
     this._buffered.remove(start, end);
     if (this._isAutoRefreshing && this._buffer.isEmpty()) {
@@ -245,7 +246,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
   }
 
   public reset(): void {
-    log.debug("HTD: Resetting HTMLTextDisplayer");
+    log.debug("text", "Resetting HTMLTextDisplayer");
     this.stop();
     this._subtitlesIntervalCanceller = new TaskCanceller();
   }
@@ -254,7 +255,7 @@ export default class HTMLTextDisplayer implements ITextDisplayer {
     if (this._subtitlesIntervalCanceller.isUsed()) {
       return;
     }
-    log.debug("HTD: Stopping HTMLTextDisplayer");
+    log.debug("text", "Stopping HTMLTextDisplayer");
     this._disableCurrentCues();
     this._buffer.remove(0, Infinity);
     this._buffered.remove(0, Infinity);

--- a/src/main_thread/text_displayer/native/native_parsers.ts
+++ b/src/main_thread/text_displayer/native/native_parsers.ts
@@ -21,15 +21,15 @@ export default function parseTextTrackToCues(
   },
   timestampOffset: number,
 ): Array<ICompatVTTCue | TextTrackCue> {
-  log.debug("NTSB: Finding parser for native text tracks:", type);
+  log.debug("text", "Finding parser for native text tracks:", { type });
   const parser = features.nativeTextTracksParsers[type];
 
   if (typeof parser !== "function") {
     throw new Error("no parser found for the given text track");
   }
 
-  log.debug("NTSB: Parser found, parsing...");
+  log.debug("text", "Parser found, parsing...", { type });
   const parsed = parser(data, context, timestampOffset);
-  log.debug("NTSB: Parsed successfully!", parsed.length);
+  log.debug("text", "Parsed successfully!", { length: parsed.length });
   return parsed;
 }

--- a/src/main_thread/text_displayer/native/native_text_displayer.ts
+++ b/src/main_thread/text_displayer/native/native_text_displayer.ts
@@ -29,7 +29,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
    * @param {HTMLMediaElement} videoElement
    */
   constructor(videoElement: IMediaElement) {
-    log.debug("NTD: Creating NativeTextDisplayer");
+    log.debug("text", "Creating NativeTextDisplayer");
     const { track, trackElement } = addTextTrack(videoElement);
     this._buffered = new ManualTimeRanges();
     this._videoElement = videoElement;
@@ -43,7 +43,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
    * @returns {Object}
    */
   public pushTextData(infos: ITextDisplayerData): IRange[] {
-    log.debug("NTD: Appending new native text tracks");
+    log.debug("text", "Appending new native text tracks");
     if (infos.chunk === null) {
       return convertToRanges(this._buffered);
     }
@@ -99,10 +99,10 @@ export default class NativeTextDisplayer implements ITextDisplayer {
       start = Math.max(appendWindowStart, startTime);
     } else {
       if (cues.length <= 0) {
-        log.warn("NTD: Current text tracks have no cues nor start time. Aborting");
+        log.warn("text", "Current text tracks have no cues nor start time. Aborting");
         return convertToRanges(this._buffered);
       }
-      log.warn("NTD: No start time given. Guessing from cues.");
+      log.warn("text", "No start time given. Guessing from cues.");
       start = cues[0].startTime;
     }
 
@@ -111,16 +111,17 @@ export default class NativeTextDisplayer implements ITextDisplayer {
       end = Math.min(appendWindowEnd, endTime);
     } else {
       if (cues.length <= 0) {
-        log.warn("NTD: Current text tracks have no cues nor end time. Aborting");
+        log.warn("text", "Current text tracks have no cues nor end time. Aborting");
         return convertToRanges(this._buffered);
       }
-      log.warn("NTD: No end time given. Guessing from cues.");
+      log.warn("text", "No end time given. Guessing from cues.");
       end = cues[cues.length - 1].endTime;
     }
 
     if (end <= start) {
       log.warn(
-        "NTD: Invalid text track appended: ",
+        "text",
+        "Invalid text track appended: ",
         "the start time is inferior or equal to the end time.",
       );
       return convertToRanges(this._buffered);
@@ -168,13 +169,13 @@ export default class NativeTextDisplayer implements ITextDisplayer {
   }
 
   public reset(): void {
-    log.debug("NTD: Aborting NativeTextDisplayer");
+    log.debug("text", "Aborting NativeTextDisplayer");
     this._removeData(0, Infinity);
     this._clearTrackElement();
   }
 
   public stop(): void {
-    log.debug("NTD: Aborting NativeTextDisplayer");
+    log.debug("text", "Aborting NativeTextDisplayer");
     this._removeData(0, Infinity);
     const { _trackElement, _videoElement } = this;
 
@@ -182,7 +183,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
       try {
         _videoElement.removeChild(_trackElement);
       } catch (_e) {
-        log.warn("NTD: Can't remove track element from the video");
+        log.warn("text", "Can't remove track element from the video");
       }
     }
 
@@ -194,7 +195,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
   }
 
   private _removeData(start: number, end: number): void {
-    log.debug("NTD: Removing native text track data", start, end);
+    log.debug("text", "Removing native text track data", { start, end });
     const track = this._track;
     const cues = track.cues;
     if (cues !== null) {
@@ -216,7 +217,7 @@ export default class NativeTextDisplayer implements ITextDisplayer {
       try {
         _videoElement.removeChild(_trackElement);
       } catch (_e) {
-        log.warn("NTD: Can't remove track element from the video");
+        log.warn("text", "Can't remove track element from the video");
       }
     }
 

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -348,7 +348,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       return;
     }
 
-    log.warn(`TS: Chosen ${type} Adaptation not available anymore`);
+    log.warn(`Track`, `Chosen ${type} Adaptation not available anymore`);
 
     if (type === "video") {
       periodInfo.video.storedSettings = this.getDefaultStoredSettingsForAdaptation(
@@ -465,7 +465,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     period: IPeriodMetadata,
     adaptationRef: SharedReference<IAdaptationChoice | null | undefined>,
   ): void {
-    log.debug("TS: Adding Track Reference", bufferType, period.id);
+    log.debug("Track", "Adding Track Reference", { bufferType, periodId: period.id });
     let periodObj = getPeriodItem(this._storedPeriodInfo, period.id);
     if (periodObj === undefined) {
       // The Period has not yet been added.
@@ -483,9 +483,10 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     }
 
     if (periodObj[bufferType].dispatcher !== null) {
-      log.error(
-        `TS: Subject already added for ${bufferType} ` + `and Period ${period.start}`,
-      );
+      log.error(`Track`, `Subject already added for type and Period`, {
+        bufferType,
+        periodId: period.id,
+      });
       periodObj[bufferType].dispatcher.dispose();
     }
 
@@ -596,7 +597,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     const { fallbackTrack, noSourceMedia } = getFallbackTrack(period, trackType);
     const typeInfo = getPeriodItem(this._storedPeriodInfo, period.id)?.[trackType];
     if (typeInfo === undefined) {
-      log.warn(`TS: Could not find period periodId=${period.id}`);
+      log.warn("Track", "Could not find period", { periodId: period.id });
       return;
     }
     const initialStoredSettings = typeInfo.storedSettings;
@@ -658,7 +659,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         // If it has, we exit early because the API consumer likely adjusted the settings,
         // and throwing an error now would be out of sync with their changes.
       } else if (fallbackBehavior === "continue") {
-        log.warn(`TS: No playable ${trackType}, continuing without ${trackType}`);
+        log.warn("Track", `No playable ${trackType}, continuing without ${trackType}`);
         typeInfo.storedSettings = null;
         if (!isInitialSelection) {
           // "trackUpdate" events are not sent for the initial track.
@@ -687,7 +688,8 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       }
     } else if (fallbackTrack === null && noSourceMedia) {
       log.debug(
-        `TS: The period does not have adaptation for ${trackType} there is no track to choose`,
+        `Track`,
+        `The period does not have adaptation for ${trackType} there is no track to choose`,
       );
       typeInfo.storedSettings = null;
       if (!isInitialSelection) {
@@ -731,7 +733,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     bufferType: "audio" | "text" | "video",
     periodId: string,
   ): void {
-    log.debug("TS: Removing Track Reference", bufferType, periodId);
+    log.debug("Track", "Removing Track Reference", { bufferType, periodId });
     let periodIndex;
     for (let i = 0; i < this._storedPeriodInfo.length; i++) {
       const periodI = this._storedPeriodInfo[i];
@@ -741,17 +743,17 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
       }
     }
     if (periodIndex === undefined) {
-      log.warn(`TS: ${bufferType} not found for period`, periodId);
+      log.warn(`Track`, `type not found for period`, { bufferType, periodId });
       return;
     }
 
     const periodObj = this._storedPeriodInfo[periodIndex];
     const choiceItem = periodObj[bufferType];
     if (choiceItem?.dispatcher === null) {
-      log.warn(
-        `TS: TrackDispatcher already removed for ${bufferType} ` +
-          `and Period ${periodId}`,
-      );
+      log.warn(`Track`, `TrackDispatcher already removed for type and Period`, {
+        bufferType,
+        periodId,
+      });
       return;
     }
 
@@ -830,7 +832,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
    * You might want to call this API when restarting playback.
    */
   public resetPeriodObjects(): void {
-    log.debug("TS: Resetting Period Objects");
+    log.debug("Track", "Resetting Period Objects");
     for (let i = this._storedPeriodInfo.length - 1; i >= 0; i--) {
       const storedObj = this._storedPeriodInfo[i];
       storedObj.audio.dispatcher?.dispose();
@@ -1471,7 +1473,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
         return r.id === repId;
       });
       if (foundRep === undefined) {
-        log.warn("API: Wanted locked Representation not found.");
+        log.warn("Track", "Wanted locked Representation not found.");
       } else {
         acc.push(foundRep.id);
       }

--- a/src/manifest/classes/__tests__/update_period_in_place.test.ts
+++ b/src/manifest/classes/__tests__/update_period_in_place.test.ts
@@ -725,7 +725,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      "Manifest: 1 new Adaptations found when merging.",
+      "manifest",
+      "1 new Adaptations found when merging.",
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     mockLog.mockRestore();
@@ -822,7 +823,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      "Manifest: 1 new Adaptations found when merging.",
+      "manifest",
+      "1 new Adaptations found when merging.",
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     mockLog.mockRestore();
@@ -924,7 +926,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      'Manifest: Adaptation "ada-video-2" not found when merging.',
+      "manifest",
+      'Adaptation "ada-video-2" not found when merging.',
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     mockLog.mockRestore();
@@ -1026,7 +1029,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      'Manifest: Adaptation "ada-video-2" not found when merging.',
+      "manifest",
+      'Adaptation "ada-video-2" not found when merging.',
     );
     expect(oldPeriod.adaptations.video).toHaveLength(2);
     mockLog.mockRestore();
@@ -1115,7 +1119,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     });
     expect(mockLog).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith(
-      "Manifest: 1 new Representations found when merging.",
+      "manifest",
+      "1 new Representations found when merging.",
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(2);
     mockLog.mockRestore();
@@ -1204,7 +1209,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     });
     expect(mockLog).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith(
-      "Manifest: 1 new Representations found when merging.",
+      "manifest",
+      "1 new Representations found when merging.",
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(2);
     mockLog.mockRestore();
@@ -1292,7 +1298,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     });
     expect(mockLog).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith(
-      'Manifest: Representation "rep-video-2" not found when merging.',
+      "manifest",
+      'Representation "rep-video-2" not found when merging.',
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
     mockLog.mockRestore();
@@ -1380,7 +1387,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     });
     expect(mockLog).toHaveBeenCalledTimes(1);
     expect(mockLog).toHaveBeenCalledWith(
-      'Manifest: Representation "rep-video-2" not found when merging.',
+      "manifest",
+      'Representation "rep-video-2" not found when merging.',
     );
     expect(oldVideoAdaptation1.representations).toHaveLength(1);
     mockLog.mockRestore();
@@ -1463,7 +1471,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      "Manifest: 1 new Thumbnail tracks found when merging.",
+      "manifest",
+      "1 new Thumbnail tracks found when merging.",
     );
     expect(oldPeriod.thumbnailTracks).toHaveLength(2);
     mockLog.mockRestore();
@@ -1546,7 +1555,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      "Manifest: 1 new Thumbnail tracks found when merging.",
+      "manifest",
+      "1 new Thumbnail tracks found when merging.",
     );
     expect(oldPeriod.thumbnailTracks).toHaveLength(2);
     mockLog.mockRestore();
@@ -1621,7 +1631,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      'Manifest: ThumbnailTrack "thumb-2" not found when merging.',
+      "manifest",
+      'ThumbnailTrack "thumb-2" not found when merging.',
     );
     expect(oldPeriod.thumbnailTracks).toHaveLength(1);
     mockLog.mockRestore();
@@ -1696,7 +1707,8 @@ describe("Manifest - updatePeriodInPlace", () => {
     expect(mockLog).toHaveBeenCalled();
     expect(mockLog).toHaveBeenNthCalledWith(
       1,
-      'Manifest: ThumbnailTrack "thumb-2" not found when merging.',
+      "manifest",
+      'ThumbnailTrack "thumb-2" not found when merging.',
     );
     expect(oldPeriod.thumbnailTracks).toHaveLength(1);
     mockLog.mockRestore();

--- a/src/manifest/classes/adaptation.ts
+++ b/src/manifest/classes/adaptation.ts
@@ -213,6 +213,7 @@ export default class Adaptation implements IAdaptationMetadata {
         }
       } else {
         log.debug(
+          "manifest",
           "Filtering Representation due to representationFilter",
           this.type,
           `Adaptation: ${this.id}`,

--- a/src/manifest/classes/manifest.ts
+++ b/src/manifest/classes/manifest.ts
@@ -763,6 +763,7 @@ function updateDeciperability(
             adaptation.supportStatus.isDecipherable = undefined;
           }
           log.debug(
+            "manifest",
             `Decipherability changed for "${representation.id}"`,
             `(${representation.bitrate})`,
             String(representation.decipherable),

--- a/src/manifest/classes/representation.ts
+++ b/src/manifest/classes/representation.ts
@@ -24,6 +24,7 @@ import type {
 import type { ITrackType, IHDRInformation } from "../../public_types";
 import areArraysOfNumbersEqual from "../../utils/are_arrays_of_numbers_equal";
 import idGenerator from "../../utils/id_generator";
+import { bytesToHex } from "../../utils/string_parsing";
 import type codecSupportCache from "./codec_support_cache";
 import type { IRepresentationIndex } from "./representation_index";
 
@@ -401,7 +402,9 @@ class Representation implements IRepresentationMetadata {
           }
         }
         if (!foundKeyId) {
-          log.warn("Manifest: found unanounced key id.");
+          log.warn("manifest", "found unanounced key id.", {
+            keyId: bytesToHex(keyId),
+          });
           keyIds.push(keyId);
         }
       }
@@ -422,7 +425,9 @@ class Representation implements IRepresentationMetadata {
                 // go to next dataToAdd
                 break;
               } else {
-                log.warn("Manifest: different init data for the same system ID");
+                log.warn("manifest", "different init data for the same system ID", {
+                  systemId: dataToAdd.systemId,
+                });
               }
             }
           }

--- a/src/manifest/classes/representation_index/static.ts
+++ b/src/manifest/classes/representation_index/static.ts
@@ -152,7 +152,10 @@ export default class StaticRepresentationIndex implements IRepresentationIndex {
   }
 
   initialize(): void {
-    log.error("A `StaticRepresentationIndex` does not need to be initialized");
+    log.error(
+      "manifest",
+      "A `StaticRepresentationIndex` does not need to be initialized",
+    );
   }
 
   /**
@@ -174,14 +177,17 @@ export default class StaticRepresentationIndex implements IRepresentationIndex {
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `StaticRepresentationIndex`");
+    log.warn(
+      "manifest",
+      "Cannot add predicted segments to a `StaticRepresentationIndex`",
+    );
   }
 
   _replace(): void {
-    log.warn("Tried to replace a static RepresentationIndex");
+    log.warn("manifest", "Tried to replace a static RepresentationIndex");
   }
 
   _update(): void {
-    log.warn("Tried to update a static RepresentationIndex");
+    log.warn("manifest", "Tried to update a static RepresentationIndex");
   }
 }

--- a/src/manifest/classes/update_period_in_place.ts
+++ b/src/manifest/classes/update_period_in_place.ts
@@ -59,9 +59,8 @@ export default function updatePeriodInPlace(
 
     if (newThumbnailTrackIdx === -1) {
       log.warn(
-        'Manifest: ThumbnailTrack "' +
-          oldThumbnailTracks[j].id +
-          '" not found when merging.',
+        "manifest",
+        'ThumbnailTrack "' + oldThumbnailTracks[j].id + '" not found when merging.',
       );
       const [removed] = oldThumbnailTracks.splice(j, 1);
       j--;
@@ -100,8 +99,8 @@ export default function updatePeriodInPlace(
 
   if (newThumbnailTracks.length > 0) {
     log.warn(
-      `Manifest: ${newThumbnailTracks.length} new Thumbnail tracks ` +
-        "found when merging.",
+      "manifest",
+      `${newThumbnailTracks.length} new Thumbnail tracks ` + "found when merging.",
     );
     res.addedThumbnailTracks.push(
       ...newThumbnailTracks.map((t) => ({
@@ -131,7 +130,8 @@ export default function updatePeriodInPlace(
 
     if (newAdaptationIdx === -1) {
       log.warn(
-        'Manifest: Adaptation "' + oldAdaptations[j].id + '" not found when merging.',
+        "manifest",
+        'Adaptation "' + oldAdaptations[j].id + '" not found when merging.',
       );
       const [removed] = oldAdaptations.splice(j, 1);
       j--;
@@ -164,8 +164,8 @@ export default function updatePeriodInPlace(
 
         if (newRepresentationIdx === -1) {
           log.warn(
-            `Manifest: Representation "${oldRepresentations[k].id}" ` +
-              "not found when merging.",
+            "manifest",
+            `Representation "${oldRepresentations[k].id}" ` + "not found when merging.",
           );
           const [removed] = oldRepresentations.splice(k, 1);
           k--;
@@ -184,8 +184,8 @@ export default function updatePeriodInPlace(
 
       if (newRepresentations.length > 0) {
         log.warn(
-          `Manifest: ${newRepresentations.length} new Representations ` +
-            "found when merging.",
+          "manifest",
+          `${newRepresentations.length} new Representations ` + "found when merging.",
         );
         oldAdaptation.representations.push(...newRepresentations);
         addedRepresentations.push(
@@ -196,7 +196,8 @@ export default function updatePeriodInPlace(
   }
   if (newAdaptations.length > 0) {
     log.warn(
-      `Manifest: ${newAdaptations.length} new Adaptations ` + "found when merging.",
+      "manifest",
+      `${newAdaptations.length} new Adaptations ` + "found when merging.",
     );
     for (const adap of newAdaptations) {
       const prevAdaps = oldPeriod.adaptations[adap.type];

--- a/src/manifest/classes/update_periods.ts
+++ b/src/manifest/classes/update_periods.ts
@@ -82,7 +82,7 @@ export function replacePeriods(
   }
 
   if (firstUnhandledPeriodIdx > oldPeriods.length) {
-    log.error("Manifest: error when updating Periods");
+    log.error("manifest", "error when updating Periods");
     return res;
   }
   if (firstUnhandledPeriodIdx < oldPeriods.length) {
@@ -210,7 +210,7 @@ export function updatePeriods(
     } else {
       if (indexOfNewPeriod > prevIndexOfNewPeriod) {
         // Some old periods were not found: remove
-        log.warn("Manifest: old Periods not found in new when updating, removing");
+        log.warn("manifest", "old Periods not found in new when updating, removing");
         const removed = oldPeriods.splice(
           prevIndexOfNewPeriod,
           indexOfNewPeriod - prevIndexOfNewPeriod,
@@ -242,7 +242,7 @@ export function updatePeriods(
   }
 
   if (prevIndexOfNewPeriod < oldPeriods.length) {
-    log.warn("Manifest: Ending Periods not found in new when updating, removing");
+    log.warn("manifest", "Ending Periods not found in new when updating, removing");
     const removed = oldPeriods.splice(
       prevIndexOfNewPeriod,
       oldPeriods.length - prevIndexOfNewPeriod,

--- a/src/manifest/classes/utils.ts
+++ b/src/manifest/classes/utils.ts
@@ -49,23 +49,24 @@ export function areSameContent(
  * @param {Object} content
  * @returns {string|null|undefined}
  */
-export function getLoggableSegmentId(
-  content: IBufferedChunkInfos | null | undefined,
-): string {
+export function getLoggableSegmentId(content: IBufferedChunkInfos | null | undefined): {
+  t: string;
+  p: string;
+  a: string;
+  r: string;
+  ss: number | null;
+  se: number | null;
+} | null {
   if (isNullOrUndefined(content)) {
-    return "";
+    return null;
   }
   const { period, adaptation, representation, segment } = content;
-  let segmentString;
-  if (segment.isInit) {
-    segmentString = "init";
-  } else if (segment.complete) {
-    segmentString = `${segment.time}-${segment.duration}`;
-  } else {
-    segmentString = `${segment.time}`;
-  }
-  return (
-    `${adaptation.type} P: ${period.id} A: ${adaptation.id} ` +
-    `R: ${representation.id} S: ${segmentString}`
-  );
+  return {
+    t: adaptation.type[0],
+    p: period.id,
+    a: adaptation.id,
+    r: representation.id,
+    ss: segment.isInit ? null : segment.time,
+    se: segment.isInit || !segment.complete ? null : segment.end,
+  };
 }

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -94,7 +94,7 @@ export default class MainMediaSourceInterface
       );
     }
 
-    log.info("Init: Creating MediaSource");
+    log.info("mse", "Creating MediaSource");
     const mediaSource =
       forcedMediaSource !== undefined ? new forcedMediaSource() : new MediaSource_();
     const handle = (mediaSource as unknown as { handle: MediaProvider }).handle;
@@ -169,7 +169,7 @@ export default class MainMediaSourceInterface
     if (this._endOfStreamCanceller === null) {
       this._endOfStreamCanceller = new TaskCanceller();
       this._endOfStreamCanceller.linkToSignal(this._canceller.signal);
-      log.debug("Init: end-of-stream order received.");
+      log.debug("mse", "end-of-stream order received.");
       maintainEndOfStream(this._mediaSource, this._endOfStreamCanceller.signal);
     }
   }
@@ -177,7 +177,7 @@ export default class MainMediaSourceInterface
   /** @see IMediaSourceInterface */
   public stopEndOfStream() {
     if (this._endOfStreamCanceller !== null) {
-      log.debug("Init: resume-stream order received.");
+      log.debug("mse", "resume-stream order received.");
       this._endOfStreamCanceller.cancel();
       this._endOfStreamCanceller = null;
     }
@@ -250,7 +250,9 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
   public appendBuffer(
     ...args: Parameters<ISourceBufferInterface["appendBuffer"]>
   ): Promise<IRange[]> {
-    log.debug("SBI: receiving order to push data to the SourceBuffer", this.type);
+    log.debug("mse", "receiving order to push data to the SourceBuffer", {
+      type: this.type,
+    });
     return this._addToQueue({
       operationName: SbiOperationName.Push,
       params: args,
@@ -259,12 +261,11 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
 
   /** @see ISourceBufferInterface */
   public remove(start: number, end: number): Promise<IRange[]> {
-    log.debug(
-      "SBI: receiving order to remove data from the SourceBuffer",
-      this.type,
+    log.debug("mse", "receiving order to remove data from the SourceBuffer", {
+      type: this.type,
       start,
       end,
-    );
+    });
     return this._addToQueue({
       operationName: SbiOperationName.Remove,
       params: [start, end],
@@ -277,9 +278,12 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       return convertToRanges(this._sourceBuffer.buffered);
     } catch (err) {
       log.error(
+        "mse",
         "Failed to get buffered time range of SourceBuffer",
-        this.type,
-        err instanceof Error ? err : null,
+        {
+          type: this.type,
+        },
+        err instanceof Error ? err : "Unknown Error",
       );
       return [];
     }
@@ -290,7 +294,11 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     try {
       this._sourceBuffer.abort();
     } catch (err) {
-      log.debug("Init: Failed to abort SourceBuffer:", err instanceof Error ? err : null);
+      log.debug(
+        "mse",
+        "Failed to abort SourceBuffer:",
+        err instanceof Error ? err : "Unknown Error",
+      );
     }
     this._emptyCurrentQueue();
   }
@@ -317,7 +325,7 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     const currentOps = this._currentOperations;
     this._currentOperations = [];
     if (currentOps.length === 0) {
-      log.error("SBI: error for an unknown operation", error);
+      log.error("mse", "error for an unknown operation", error);
     } else {
       const rejected = new SourceBufferError(
         error.name,
@@ -465,10 +473,9 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
           }
         }
         if (toConcat.length > 1) {
-          log.info(
-            `MMSI: Merging ${toConcat.length} segments together for perf`,
-            this.type,
-          );
+          log.info("mse", `: Merging ${toConcat.length} segments together for perf`, {
+            type: this.type,
+          });
           segmentData = concat(...toConcat);
         }
       }
@@ -510,7 +517,11 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       // TODO merge contiguous removes?
       this._currentOperations = [nextElem];
       const [start, end] = nextElem.params;
-      log.debug("SBI: removing data from SourceBuffer", this.type, start, end);
+      log.debug("mse", "removing data from SourceBuffer", {
+        type: this.type,
+        start,
+        end,
+      });
       try {
         this._sourceBuffer.remove(start, end);
       } catch (err) {
@@ -541,12 +552,15 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
     const sourceBuffer = this._sourceBuffer;
     const { codec, timestampOffset, appendWindow = [] } = params;
     if (codec !== undefined && codec !== this.codec) {
-      log.debug("SBI: updating codec", codec);
+      log.debug("mse", "updating codec", { prevCodec: this.codec, newCodec: codec });
       const hasUpdatedSourceBufferType = tryToChangeSourceBufferType(sourceBuffer, codec);
       if (hasUpdatedSourceBufferType) {
         this.codec = codec;
       } else {
-        log.debug("SBI: could not update codec", codec, this.codec);
+        log.debug("mse", "could not update codec", {
+          prevCodec: this.codec,
+          newCodec: codec,
+        });
       }
     }
 
@@ -555,40 +569,51 @@ export class MainSourceBufferInterface implements ISourceBufferInterface {
       sourceBuffer.timestampOffset !== timestampOffset
     ) {
       const newTimestampOffset = timestampOffset;
-      log.debug(
-        "SBI: updating timestampOffset",
+      log.debug("mse", "updating timestampOffset", {
         codec,
-        sourceBuffer.timestampOffset,
+        prevTimestampOffset: sourceBuffer.timestampOffset,
         newTimestampOffset,
-      );
+      });
       sourceBuffer.timestampOffset = newTimestampOffset;
     }
 
     if (appendWindow[0] === undefined) {
       if (sourceBuffer.appendWindowStart > 0) {
-        log.debug("SBI: re-setting `appendWindowStart` to `0`");
+        log.debug("mse", "re-setting `appendWindowStart`", {
+          prevWindowStart: sourceBuffer.appendWindowStart,
+        });
         sourceBuffer.appendWindowStart = 0;
       }
     } else if (appendWindow[0] !== sourceBuffer.appendWindowStart) {
       if (appendWindow[0] >= sourceBuffer.appendWindowEnd) {
-        const newTmpEnd = appendWindow[0] + 1;
-        log.debug("SBI: pre-updating `appendWindowEnd`", newTmpEnd);
-        sourceBuffer.appendWindowEnd = newTmpEnd;
+        const newWindowEnd = appendWindow[0] + 1;
+        log.debug("mse", "pre-updating `appendWindowEnd`", {
+          prevWindowEnd: sourceBuffer.appendWindowEnd,
+          newWindowEnd,
+        });
+        sourceBuffer.appendWindowEnd = newWindowEnd;
       }
-      log.debug("SBI: setting `appendWindowStart`", appendWindow[0]);
+      log.debug("mse", "setting `appendWindowStart`", {
+        appendWindowStart: appendWindow[0],
+      });
       sourceBuffer.appendWindowStart = appendWindow[0];
     }
 
     if (appendWindow[1] === undefined) {
       if (sourceBuffer.appendWindowEnd !== Infinity) {
-        log.debug("SBI: re-setting `appendWindowEnd` to `Infinity`");
+        log.debug("mse", "re-setting `appendWindowEnd`", {
+          prevWindowStart: sourceBuffer.appendWindowStart,
+        });
         sourceBuffer.appendWindowEnd = Infinity;
       }
     } else if (appendWindow[1] !== sourceBuffer.appendWindowEnd) {
-      log.debug("SBI: setting `appendWindowEnd`", appendWindow[1]);
+      log.debug("mse", "setting `appendWindowEnd`", {
+        prevWindowEnd: sourceBuffer.appendWindowEnd,
+        newWindowEnd: appendWindow[1],
+      });
       sourceBuffer.appendWindowEnd = appendWindow[1];
     }
-    log.debug("SBI: pushing segment", this.type);
+    log.debug("mse", "pushing segment", { type: this.type });
     sourceBuffer.appendBuffer(data);
   }
 }
@@ -600,21 +625,21 @@ function resetMediaSource(mediaSource: IMediaSource): void {
       const sourceBuffer = sourceBuffers[i];
       try {
         if (readyState === "open") {
-          log.info("Init: Aborting SourceBuffer before removing");
+          log.info("mse", "Aborting SourceBuffer before removing");
           try {
             sourceBuffer.abort();
           } catch (_) {
             // We actually don't care at all when resetting
           }
         }
-        log.info("Init: Removing SourceBuffer from mediaSource");
+        log.info("mse", "Removing SourceBuffer from mediaSource");
         mediaSource.removeSourceBuffer(sourceBuffer);
       } catch (_) {
         // We actually don't care at all when resetting
       }
     }
     if (sourceBuffers.length > 0) {
-      log.info("Init: Not all SourceBuffers could have been removed.");
+      log.info("mse", "Not all SourceBuffers could have been removed.");
     }
   }
 }

--- a/src/mse/utils/end_of_stream.ts
+++ b/src/mse/utils/end_of_stream.ts
@@ -57,9 +57,9 @@ export default function triggerEndOfStream(
   mediaSource: IMediaSource,
   cancelSignal: CancellationSignal,
 ): void {
-  log.debug("Init: Trying to call endOfStream");
+  log.debug("mse", "Trying to call endOfStream");
   if (mediaSource.readyState !== "open") {
-    log.debug("Init: MediaSource not open, cancel endOfStream");
+    log.debug("mse", "MediaSource not open, cancel endOfStream");
     return;
   }
 
@@ -67,11 +67,12 @@ export default function triggerEndOfStream(
   const updatingSourceBuffers = getUpdatingSourceBuffers(sourceBuffers);
 
   if (updatingSourceBuffers.length === 0) {
-    log.info("Init: Triggering end of stream");
+    log.info("mse", "Triggering end of stream");
     try {
       mediaSource.endOfStream();
     } catch (err) {
       log.error(
+        "mse",
         "Unable to call endOfStream",
         err instanceof Error ? err : new Error("Unknown error"),
       );
@@ -79,7 +80,7 @@ export default function triggerEndOfStream(
     return;
   }
 
-  log.debug("Init: Waiting SourceBuffers to be updated before calling endOfStream.");
+  log.debug("mse", "Waiting SourceBuffers to be updated before calling endOfStream.");
 
   const innerCanceller = new TaskCanceller();
   innerCanceller.linkToSignal(cancelSignal);
@@ -119,7 +120,7 @@ export function maintainEndOfStream(
   onSourceOpen(
     mediaSource,
     () => {
-      log.debug("Init: MediaSource re-opened while end-of-stream is active");
+      log.debug("mse", "MediaSource re-opened while end-of-stream is active");
       endOfStreamCanceller.cancel();
       endOfStreamCanceller = new TaskCanceller();
       endOfStreamCanceller.linkToSignal(cancelSignal);

--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -182,11 +182,14 @@ function setMediaSourceDuration(
     // Keep the duration that was set at that time as a security.
     if (maxBufferedEnd < mediaSource.duration) {
       try {
-        log.info("Init: Updating duration to what is currently buffered", maxBufferedEnd);
+        log.info("mse", "Updating duration to what is currently buffered", {
+          maxBufferedEnd,
+        });
         mediaSource.duration = maxBufferedEnd;
       } catch (err) {
         log.warn(
-          "Duration Updater: Can't update duration on the MediaSource.",
+          "mse",
+          "Can't update duration on the MediaSource.",
           err instanceof Error ? err : "",
         );
         return MediaSourceDurationUpdateStatus.Failed;
@@ -196,16 +199,17 @@ function setMediaSourceDuration(
   } else {
     const oldDuration = mediaSource.duration;
     try {
-      log.info("Init: Updating duration", newDuration);
+      log.info("mse", "Updating duration", { newDuration });
       mediaSource.duration = newDuration;
       if (mediaSource.readyState === "open" && !isFinite(newDuration)) {
         const maxSeekable = getMaximumLiveSeekablePosition(duration);
-        log.info("Init: calling `mediaSource.setLiveSeekableRange`", maxSeekable);
+        log.info("mse", "calling `mediaSource.setLiveSeekableRange`", { maxSeekable });
         mediaSource.setLiveSeekableRange(0, maxSeekable);
       }
     } catch (err) {
       log.warn(
-        "Duration Updater: Can't update duration on the MediaSource.",
+        "mse",
+        "Can't update duration on the MediaSource.",
         err instanceof Error ? err : "",
       );
       return MediaSourceDurationUpdateStatus.Failed;
@@ -303,7 +307,7 @@ function createMediaSourceOpenReference(
   onSourceOpen(
     mediaSource,
     () => {
-      log.debug("Init: Reacting to MediaSource open in duration updater");
+      log.debug("mse", "Reacting to MediaSource open in duration updater");
       isMediaSourceOpen.setValueIfChanged(true);
     },
     cancelSignal,
@@ -311,7 +315,7 @@ function createMediaSourceOpenReference(
   onSourceEnded(
     mediaSource,
     () => {
-      log.debug("Init: Reacting to MediaSource ended in duration updater");
+      log.debug("mse", "Reacting to MediaSource ended in duration updater");
       isMediaSourceOpen.setValueIfChanged(false);
     },
     cancelSignal,
@@ -319,7 +323,7 @@ function createMediaSourceOpenReference(
   onSourceClose(
     mediaSource,
     () => {
-      log.debug("Init: Reacting to MediaSource close in duration updater");
+      log.debug("mse", "Reacting to MediaSource close in duration updater");
       isMediaSourceOpen.setValueIfChanged(false);
     },
     cancelSignal,

--- a/src/mse/worker_media_source_interface.ts
+++ b/src/mse/worker_media_source_interface.ts
@@ -236,7 +236,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
   public onOperationSuccess(operationId: string, ranges: IRange[]): void {
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
-      log.warn("SBI: unknown SourceBuffer operation succeeded");
+      log.warn("mse", "unknown SourceBuffer operation succeeded");
     } else {
       this._pendingOperations.delete(operationId);
       mapElt.resolve(ranges);
@@ -254,7 +254,7 @@ export class WorkerSourceBufferInterface implements ISourceBufferInterface {
         : new SourceBufferError(error.errorName, error.message, error.isBufferFull);
     const mapElt = this._pendingOperations.get(operationId);
     if (mapElt === undefined) {
-      log.info("SBI: unknown SourceBuffer operation failed", formattedErr);
+      log.info("mse", "unknown SourceBuffer operation failed", formattedErr);
     } else {
       this._pendingOperations.delete(operationId);
       mapElt.reject(formattedErr);

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -31,7 +31,7 @@ import type {
 import type { IFreezingStatus, IRebufferingStatus } from "./playback_observer";
 import type { ICmcdOptions, ITrackType } from "./public_types";
 import type { IThumbnailResponse, ITransportOptions } from "./transports";
-import type { ILogFormat, ILoggerLevel } from "./utils/logger";
+import type { ILogFormat, ILoggerLevel, ILogNamespace } from "./utils/logger";
 import type { IRange } from "./utils/ranges";
 
 /**
@@ -947,6 +947,7 @@ export interface IResetTextDisplayerWorkerMessage {
 export interface ILogMessageWorkerMessage {
   type: WorkerMessageType.LogMessage;
   value: {
+    namespace: ILogNamespace;
     logLevel: ILoggerLevel;
     logs: Array<boolean | string | number | ISentError | null | undefined>;
   };

--- a/src/parsers/containers/isobmff/get_box.ts
+++ b/src/parsers/containers/isobmff/get_box.ts
@@ -221,8 +221,7 @@ function getUuidContent(
  *
  * `null` if no box is found.
  * @param {Uint8Array} buf - the isobmff data
- * @param {Number} boxName - the 4-letter 'name' of the box as a 4 byte integer
- * generated from encoding the corresponding ASCII in big endian.
+ * @returns {Array.<number>|null}
  */
 function getNextBoxOffsets(
   buf: Uint8Array,
@@ -235,7 +234,7 @@ function getNextBoxOffsets(
   | null {
   const len = buf.length;
   if (len < 8) {
-    log.warn("ISOBMFF: box inferior to 8 bytes, cannot find offsets");
+    log.warn("isobmff", "box inferior to 8 bytes, cannot find offsets");
     return null;
   }
   let lastOffset = 0;
@@ -249,7 +248,7 @@ function getNextBoxOffsets(
     boxSize = len;
   } else if (boxSize === 1) {
     if (lastOffset + 8 > len) {
-      log.warn("ISOBMFF: box too short, cannot find offsets");
+      log.warn("isobmff", "box too short, cannot find offsets");
       return null;
     }
     boxSize = be8toi(buf, lastOffset);

--- a/src/parsers/containers/isobmff/take_pssh_out.ts
+++ b/src/parsers/containers/isobmff/take_pssh_out.ts
@@ -50,7 +50,7 @@ export default function takePSSHOut(data: Uint8Array): IISOBMFFPSSHInfo[] {
       psshOffsets = getBoxOffsets(moov, 0x70737368 /* pssh */);
     } catch (e) {
       const err = e instanceof Error ? e : "";
-      log.warn("Error while removing PSSH from ISOBMFF", err);
+      log.warn("isobmff", "Error while removing PSSH from ISOBMFF", err);
       return psshBoxes;
     }
     if (psshOffsets === null) {
@@ -85,7 +85,7 @@ export function getPsshSystemID(
   initialDataOffset: number,
 ): string | undefined {
   if (buff[initialDataOffset] > 1) {
-    log.warn("ISOBMFF: un-handled PSSH version");
+    log.warn("isobmff", "un-handled PSSH version");
     return undefined;
   }
   const offset = initialDataOffset + 4; /* version + flags */

--- a/src/parsers/containers/isobmff/utils.ts
+++ b/src/parsers/containers/isobmff/utils.ts
@@ -556,7 +556,7 @@ function parseEmsgBoxes(buffer: Uint8Array): IEMSG[] | undefined {
 
     const version = emsg[0];
     if (version !== 0) {
-      log.warn("ISOBMFF: EMSG version " + version.toString() + " not supported.");
+      log.warn("isobmff", "EMSG version " + version.toString() + " not supported.");
     } else {
       let position = 4; // skip version + flags
 

--- a/src/parsers/containers/matroska/utils.ts
+++ b/src/parsers/containers/matroska/utils.ts
@@ -257,11 +257,15 @@ function getEBMLID(
 ): { length: number; value: number } | null {
   const length = getLength(buffer, offset);
   if (length === undefined) {
-    log.warn("webm: unrepresentable length");
+    log.warn("webm", "unrepresentable length");
     return null;
   }
   if (offset + length > buffer.length) {
-    log.warn("webm: impossible length");
+    log.warn("webm", "impossible length", {
+      offset,
+      length,
+      bufferLength: buffer.length,
+    });
     return null;
   }
 
@@ -278,11 +282,15 @@ function getEBMLValue(
 ): { length: number; value: number } | null {
   const length = getLength(buffer, offset);
   if (length === undefined) {
-    log.warn("webm: unrepresentable length");
+    log.warn("webm", "unrepresentable length");
     return null;
   }
   if (offset + length > buffer.length) {
-    log.warn("webm: impossible length");
+    log.warn("webm", "impossible length", {
+      offset,
+      length,
+      bufferLength: buffer.length,
+    });
     return null;
   }
 

--- a/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/flatten_overlapping_period.test.ts
@@ -32,7 +32,10 @@ describe("flattenOverlappingPeriods", function () {
     expect(flattenPeriods[1].id).toBe("3");
 
     expect(mockLog).toHaveBeenCalledTimes(1);
-    expect(mockLog).toHaveBeenCalledWith("DASH: Updating overlapping Periods.", 60, 60);
+    expect(mockLog).toHaveBeenCalledWith("dash", "Updating overlapping Periods.", {
+      lastStart: 60,
+      newStart: 60,
+    });
     mockLog.mockRestore();
   });
 
@@ -60,7 +63,10 @@ describe("flattenOverlappingPeriods", function () {
     expect(flattenPeriods[2].id).toBe("3");
 
     expect(mockLog).toHaveBeenCalledTimes(1);
-    expect(mockLog).toHaveBeenCalledWith("DASH: Updating overlapping Periods.", 60, 90);
+    expect(mockLog).toHaveBeenCalledWith("dash", "Updating overlapping Periods.", {
+      lastStart: 60,
+      newStart: 90,
+    });
     mockLog.mockRestore();
   });
 
@@ -85,8 +91,14 @@ describe("flattenOverlappingPeriods", function () {
     expect(flattenPeriods[1].id).toBe("3");
 
     expect(mockLog).toHaveBeenCalledTimes(2);
-    expect(mockLog).toHaveBeenCalledWith("DASH: Updating overlapping Periods.", 60, 50);
-    expect(mockLog).toHaveBeenCalledWith("DASH: Updating overlapping Periods.", 0, 50);
+    expect(mockLog).toHaveBeenCalledWith("dash", "Updating overlapping Periods.", {
+      lastStart: 60,
+      newStart: 50,
+    });
+    expect(mockLog).toHaveBeenCalledWith("dash", "Updating overlapping Periods.", {
+      lastStart: 0,
+      newStart: 50,
+    });
     mockLog.mockRestore();
   });
 

--- a/src/parsers/manifest/dash/common/__tests__/get_clock_offset.test.ts
+++ b/src/parsers/manifest/dash/common/__tests__/get_clock_offset.test.ts
@@ -33,15 +33,16 @@ describe("DASH Parser - getClockOffset", () => {
 
     expect(getClockOffset("2018/412/13")).toEqual(undefined);
     expect(mockWarn).toHaveBeenCalledTimes(1);
-    expect(mockWarn).toHaveBeenCalledWith(
-      "DASH Parser: Invalid clock received: ",
-      "2018/412/13",
-    );
+    expect(mockWarn).toHaveBeenCalledWith("dash", "Invalid clock received", {
+      clock: "2018/412/13",
+    });
     mockWarn.mockReset();
 
     expect(getClockOffset("foo")).toEqual(undefined);
     expect(mockWarn).toHaveBeenCalledTimes(1);
-    expect(mockWarn).toHaveBeenCalledWith("DASH Parser: Invalid clock received: ", "foo");
+    expect(mockWarn).toHaveBeenCalledWith("dash", "Invalid clock received", {
+      clock: "foo",
+    });
     mockWarn.mockReset();
   });
 });

--- a/src/parsers/manifest/dash/common/content_protection_parser.ts
+++ b/src/parsers/manifest/dash/common/content_protection_parser.ts
@@ -144,7 +144,7 @@ export default class ContentProtectionParser {
     if (referenced === undefined) {
       // Referenced ContentProtection not found, exit
       if (force) {
-        log.warn("DASH: forcing the parsing of a referencing ContentProtection");
+        log.warn("dash", "forcing the parsing of a referencing ContentProtection");
         parseContentProtection(representation, contentProt);
       }
       return false;

--- a/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
+++ b/src/parsers/manifest/dash/common/flatten_overlapping_periods.ts
@@ -57,11 +57,10 @@ export default function flattenOverlappingPeriods(
       lastFlattenedPeriod.duration === undefined ||
       lastFlattenedPeriod.start + lastFlattenedPeriod.duration > parsedPeriod.start
     ) {
-      log.warn(
-        "DASH: Updating overlapping Periods.",
-        lastFlattenedPeriod?.start,
-        parsedPeriod.start,
-      );
+      log.warn("dash", "Updating overlapping Periods.", {
+        lastStart: lastFlattenedPeriod?.start,
+        newStart: parsedPeriod.start,
+      });
       lastFlattenedPeriod.duration = parsedPeriod.start - lastFlattenedPeriod.start;
       lastFlattenedPeriod.end = parsedPeriod.start;
       if (lastFlattenedPeriod.duration > 0) {

--- a/src/parsers/manifest/dash/common/get_clock_offset.ts
+++ b/src/parsers/manifest/dash/common/get_clock_offset.ts
@@ -33,7 +33,7 @@ import getMonotonicTimeStamp from "../../../../utils/monotonic_timestamp";
 export default function getClockOffset(serverClock: string): number | undefined {
   const httpOffset = Date.parse(serverClock) - getMonotonicTimeStamp();
   if (isNaN(httpOffset)) {
-    log.warn("DASH Parser: Invalid clock received: ", serverClock);
+    log.warn("dash", "Invalid clock received", { clock: serverClock });
     return undefined;
   }
   return httpOffset;

--- a/src/parsers/manifest/dash/common/indexes/base.ts
+++ b/src/parsers/manifest/dash/common/indexes/base.ts
@@ -430,7 +430,7 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `BaseRepresentationIndex`");
+    log.warn("dash", "Cannot add predicted segments to a `BaseRepresentationIndex`");
   }
 
   /**
@@ -469,6 +469,6 @@ export default class BaseRepresentationIndex implements IRepresentationIndex {
   }
 
   _update(): void {
-    log.error("Base RepresentationIndex: Cannot update a SegmentList");
+    log.error("dash", "Base RepresentationIndex: Cannot update a SegmentList");
   }
 }

--- a/src/parsers/manifest/dash/common/indexes/list.ts
+++ b/src/parsers/manifest/dash/common/indexes/list.ts
@@ -341,11 +341,11 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
   }
 
   initialize(): void {
-    log.error("A `ListRepresentationIndex` does not need to be initialized");
+    log.error("dash", "A `ListRepresentationIndex` does not need to be initialized");
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `ListRepresentationIndex`");
+    log.warn("dash", "Cannot add predicted segments to a `ListRepresentationIndex`");
   }
 
   /**
@@ -375,6 +375,6 @@ export default class ListRepresentationIndex implements IRepresentationIndex {
   }
 
   _update(): void {
-    log.error("A `ListRepresentationIndex` cannot be updated");
+    log.error("dash", "A `ListRepresentationIndex` cannot be updated");
   }
 }

--- a/src/parsers/manifest/dash/common/indexes/template.ts
+++ b/src/parsers/manifest/dash/common/indexes/template.ts
@@ -500,11 +500,11 @@ export default class TemplateRepresentationIndex implements IRepresentationIndex
   }
 
   initialize(): void {
-    log.error("A `TemplateRepresentationIndex` does not need to be initialized");
+    log.error("dash", "A `TemplateRepresentationIndex` does not need to be initialized");
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `TemplateRepresentationIndex`");
+    log.warn("dash", "Cannot add predicted segments to a `TemplateRepresentationIndex`");
   }
 
   /**

--- a/src/parsers/manifest/dash/common/indexes/timeline/__tests__/parse_s_element.test.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/__tests__/parse_s_element.test.ts
@@ -27,18 +27,30 @@ function testNumberAttribute(attributeName: string, variableName?: string): void
     const element1 = parseXml(`<S ${attributeName}="toto" />`)[0] as ITNode;
     expect(parseSElementNode(element1)).toEqual({});
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("toto")`);
+    expect(spyLog).toHaveBeenCalledWith(
+      "dash",
+      `invalid ${attributeName} value for <S> element`,
+      { val: "toto" },
+    );
 
     const element2 = parseXml(`<S ${attributeName}="PT5M" />`)[0] as ITNode;
     expect(parseSElementNode(element2)).toEqual({});
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("PT5M")`);
+    expect(spyLog).toHaveBeenCalledWith(
+      "dash",
+      `invalid ${attributeName} value for <S> element`,
+      { val: "PT5M" },
+    );
 
     const element3 = parseXml(`<S ${attributeName}="" />`)[0] as ITNode;
 
     expect(parseSElementNode(element3)).toEqual({});
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenCalledWith(`DASH: invalid ${attributeName} ("")`);
+    expect(spyLog).toHaveBeenCalledWith(
+      "dash",
+      `invalid ${attributeName} value for <S> element`,
+      { val: "" },
+    );
     spyLog.mockRestore();
   });
 }

--- a/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_previous_timeline.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/construct_timeline_from_previous_timeline.ts
@@ -30,7 +30,7 @@ export default function constructTimelineFromPreviousTimeline(
   // Find first index in both timeline where a common segment is found.
   const commonStartInfo = findFirstCommonStartTime(prevTimeline, newElements);
   if (commonStartInfo === null) {
-    log.warn('DASH: Cannot perform "based" update. Common segment not found.');
+    log.warn("dash", 'Cannot perform "based" update. Common segment not found.');
     return constructTimelineFromElements(newElements);
   }
   const {
@@ -44,7 +44,7 @@ export default function constructTimelineFromPreviousTimeline(
   const numberCommonEltGuess = prevTimeline.length - prevSegmentsIdx;
   const lastCommonEltNewEltsIdx = numberCommonEltGuess + newElementsIdx - 1;
   if (lastCommonEltNewEltsIdx >= newElements.length) {
-    log.info('DASH: Cannot perform "based" update. New timeline too short');
+    log.info("dash", 'Cannot perform "based" update. New timeline too short');
     return constructTimelineFromElements(newElements);
   }
 
@@ -59,7 +59,8 @@ export default function constructTimelineFromPreviousTimeline(
 
   if (repeatNumberInNewElements > 0 && newElementsIdx !== 0) {
     log.info(
-      'DASH: Cannot perform "based" update. ' + "The new timeline has a different form.",
+      "dash",
+      'Cannot perform "based" update. ' + "The new timeline has a different form.",
     );
     return constructTimelineFromElements(newElements);
   }
@@ -73,7 +74,8 @@ export default function constructTimelineFromPreviousTimeline(
     prevLastElement.repeatCount > newRepeatCountOffseted
   ) {
     log.info(
-      'DASH: Cannot perform "based" update. ' +
+      "dash",
+      'Cannot perform "based" update. ' +
         "The new timeline has a different form at the beginning.",
     );
     return constructTimelineFromElements(newElements);

--- a/src/parsers/manifest/dash/common/indexes/timeline/convert_element_to_index_segment.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/convert_element_to_index_segment.ts
@@ -68,6 +68,6 @@ export default function convertElementsToIndexSegment(
       repeatCount: repeatCount === undefined ? 0 : repeatCount,
     };
   }
-  log.warn('DASH: A "S" Element could not have been parsed.');
+  log.warn("dash", 'A "S" Element could not have been parsed.');
   return null;
 }

--- a/src/parsers/manifest/dash/common/indexes/timeline/parse_s_element.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/parse_s_element.ts
@@ -50,7 +50,7 @@ export function parseSElementNode(root: ITNode): IParsedS {
       case "t": {
         const start = parseInt(attributeVal, 10);
         if (isNaN(start)) {
-          log.warn(`DASH: invalid t ("${attributeVal}")`);
+          log.warn("dash", "invalid t value for <S> element", { val: attributeVal });
         } else {
           parsedS.start = start;
         }
@@ -59,7 +59,7 @@ export function parseSElementNode(root: ITNode): IParsedS {
       case "d": {
         const duration = parseInt(attributeVal, 10);
         if (isNaN(duration)) {
-          log.warn(`DASH: invalid d ("${attributeVal}")`);
+          log.warn("dash", "invalid d value for <S> element", { val: attributeVal });
         } else {
           parsedS.duration = duration;
         }
@@ -68,7 +68,7 @@ export function parseSElementNode(root: ITNode): IParsedS {
       case "r": {
         const repeatCount = parseInt(attributeVal, 10);
         if (isNaN(repeatCount)) {
-          log.warn(`DASH: invalid r ("${attributeVal}")`);
+          log.warn("dash", "invalid r value for <S> element", { val: attributeVal });
         } else {
           parsedS.repeatCount = repeatCount;
         }

--- a/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
+++ b/src/parsers/manifest/dash/common/indexes/timeline/timeline_representation_index.ts
@@ -768,11 +768,11 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
   }
 
   initialize(): void {
-    log.error("A `TimelineRepresentationIndex` does not need to be initialized");
+    log.error("dash", "A `TimelineRepresentationIndex` does not need to be initialized");
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `TimelineRepresentationIndex`");
+    log.warn("dash", "Cannot add predicted segments to a `TimelineRepresentationIndex`");
   }
 
   /**
@@ -868,7 +868,7 @@ export default class TimelineRepresentationIndex implements IRepresentationIndex
       if (this._index.timeline !== null) {
         return this._index.timeline;
       }
-      log.error("DASH: Timeline already lazily parsed.");
+      log.error("dash", "Timeline already lazily parsed.");
       return [];
     }
 

--- a/src/parsers/manifest/dash/common/infer_adaptation_type.ts
+++ b/src/parsers/manifest/dash/common/infer_adaptation_type.ts
@@ -75,7 +75,7 @@ export function getThumbnailAdaptationSetInfo(
     thumbnailProp.value === undefined ||
     !tilesRegex.test(thumbnailProp.value)
   ) {
-    log.warn("DASH: Invalid thumbnails Representation, no tile-related information");
+    log.warn("dash", "Invalid thumbnails Representation, no tile-related information");
     return null;
   }
   const match = thumbnailProp.value.match(tilesRegex) as RegExpMatchArray;

--- a/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
+++ b/src/parsers/manifest/dash/common/parse_adaptation_sets.ts
@@ -472,7 +472,7 @@ export default function parseAdaptationSets(
             mergedInto[0].closedCaption === parsedAdaptationSet.closedCaption &&
             mergedInto[0].language === parsedAdaptationSet.language
           ) {
-            log.info('DASH Parser: merging "switchable" AdaptationSets', originalID, id);
+            log.info("dash", 'merging "switchable" AdaptationSets', { originalID, id });
             mergedInto[0].representations.push(...parsedAdaptationSet.representations);
             mergedInto[1] = {
               priority: Math.max(priority, mergedInto[1].priority),
@@ -556,7 +556,7 @@ function createThumbnailTracks(
     const representation = representations[i];
     if (representation !== undefined) {
       if (representation.mimeType === undefined) {
-        log.warn("DASH: Invalid thumbnails Representation, no mime-type");
+        log.warn("dash", "Invalid thumbnails Representation, no mime-type");
         continue;
       }
       const tileInfo = getThumbnailAdaptationSetInfo(
@@ -567,11 +567,11 @@ function createThumbnailTracks(
         continue;
       }
       if (representation.height === undefined) {
-        log.warn("DASH: Invalid thumbnails Representation, no height information");
+        log.warn("dash", "Invalid thumbnails Representation, no height information");
         continue;
       }
       if (representation.width === undefined) {
-        log.warn("DASH: Invalid thumbnails Representation, no width information");
+        log.warn("dash", "Invalid thumbnails Representation, no width information");
         continue;
       }
 
@@ -583,7 +583,7 @@ function createThumbnailTracks(
       if (targetDuration !== undefined && targetDuration.isPrecize) {
         segmentDuration = targetDuration.duration;
       } else {
-        log.warn("DASH: Cannot produce duration estimate for thumbnail track");
+        log.warn("dash", "Cannot produce duration estimate for thumbnail track");
       }
 
       tracks.push({

--- a/src/parsers/manifest/dash/common/parse_mpd.ts
+++ b/src/parsers/manifest/dash/common/parse_mpd.ts
@@ -168,7 +168,8 @@ export default function parseMpdIr(
               if (!responseDataClock.success) {
                 warnings.push(responseDataClock.error);
                 log.warn(
-                  "DASH Parser: Error on fetching the clock ressource",
+                  "dash",
+                  "Error on fetching the clock ressource",
                   responseDataClock.error,
                 );
                 return parseMpdIr(mpdIR, args, warnings, true);
@@ -349,7 +350,7 @@ function parseCompleteIntermediateRepresentation(
       finalMaximumSafePosition = maximumSafePosition;
     } else {
       if (externalClockOffset === undefined) {
-        log.warn("DASH Parser: use system clock to define maximum position");
+        log.warn("dash", "use system clock to define maximum position");
         finalMaximumSafePosition = Date.now() / 1000 - availabilityStartTime;
       } else {
         const serverTime = getMonotonicTimeStamp() + externalClockOffset;

--- a/src/parsers/manifest/dash/common/parse_periods.ts
+++ b/src/parsers/manifest/dash/common/parse_periods.ts
@@ -88,8 +88,10 @@ export default function parsePeriods(
 
     let periodID: string;
     if (isNullOrUndefined(periodIR.attributes.id)) {
-      log.warn("DASH: No usable id found in the Period. Generating one.");
       periodID = "gen-dash-period-" + generatePeriodID();
+      log.warn("dash", "No usable id found in the Period. Generating one.", {
+        periodId: periodID,
+      });
     } else {
       periodID = periodIR.attributes.id;
     }
@@ -231,8 +233,8 @@ function guessLastPositionFromClock(
     const now = Date.now() / 1000;
     if (now >= minimumTime) {
       log.warn(
-        "DASH Parser: no clock synchronization mechanism found." +
-          " Using the system clock instead.",
+        "dash",
+        "no clock synchronization mechanism found. Using the system clock instead.",
       );
       const lastPosition = now - context.availabilityStartTime;
       const positionTime = getMonotonicTimeStamp() / 1000;
@@ -326,7 +328,8 @@ function generateStreamEvents(
           };
         } catch (err) {
           log.error(
-            "DASH: Error while parsing event-stream:",
+            "dash",
+            "Error while parsing event-stream:",
             err instanceof Error ? err.message : "Unknown error",
           );
         }

--- a/src/parsers/manifest/dash/common/parse_representations.ts
+++ b/src/parsers/manifest/dash/common/parse_representations.ts
@@ -185,7 +185,7 @@ export default function parseRepresentations(
     // Find bitrate
     let representationBitrate: number;
     if (representation.attributes.bitrate === undefined) {
-      log.warn("DASH: No usable bitrate found in the Representation.");
+      log.warn("dash", "No usable bitrate found in the Representation.");
       representationBitrate = 0;
     } else {
       representationBitrate = representation.attributes.bitrate;

--- a/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/ContentProtection.ts
@@ -41,7 +41,7 @@ function parseContentProtectionChildren(
       if (content !== null && content.length > 0) {
         const [toUint8Array, error] = parseBase64(content, "cenc:pssh");
         if (error !== null) {
-          log.warn(error.message);
+          log.warn("dash", "Content protection parsing failure", error.message);
           warnings.push(error);
         }
         if (toUint8Array !== null) {

--- a/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/AdaptationSet.test.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/AdaptationSet.test.ts
@@ -46,7 +46,13 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
       [error1],
     ]);
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      1,
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: attributeName },
+    );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error2 = new MPDError(
@@ -60,7 +66,13 @@ function testBooleanAttribute(attributeName: string, variableName?: string): voi
       [error2],
     ]);
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      2,
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: attributeName },
+    );
     spyLog.mockRestore();
   });
 }
@@ -138,7 +150,13 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      1,
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: attributeName },
+    );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(`\`${attributeName}\` property is invalid: "PT5M"`);
@@ -148,7 +166,13 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      2,
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: attributeName },
+    );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(`\`${attributeName}\` property is invalid: ""`);
@@ -159,7 +183,13 @@ function testMaybeDividedNumber(attributeName: string, variableName?: string): v
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      3,
+      "dash",
+      "failed to parse DASH value:",
+      error3.message,
+      { dashName: attributeName },
+    );
     spyLog.mockRestore();
   });
 }
@@ -210,7 +240,13 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      1,
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: attributeName },
+    );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(`\`${attributeName}\` property is invalid: "PT5M"`);
@@ -220,7 +256,13 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      2,
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: attributeName },
+    );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(`\`${attributeName}\` property is invalid: ""`);
@@ -231,7 +273,13 @@ function testFloatAttribute(attributeName: string, variableName?: string): void 
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      3,
+      "dash",
+      "failed to parse DASH value:",
+      error3.message,
+      { dashName: attributeName },
+    );
     spyLog.mockRestore();
   });
 }
@@ -284,7 +332,13 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      1,
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: attributeName },
+    );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(
@@ -296,7 +350,13 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      2,
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: attributeName },
+    );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(
@@ -309,7 +369,13 @@ function testIntegerAttribute(attributeName: string, variableName?: string): voi
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      3,
+      "dash",
+      "failed to parse DASH value:",
+      error3.message,
+      { dashName: attributeName },
+    );
     spyLog.mockRestore();
   });
 }
@@ -365,7 +431,13 @@ function testNumberOrBooleanAttribute(
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(1);
-    expect(spyLog).toHaveBeenNthCalledWith(1, error1.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      1,
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: attributeName },
+    );
 
     const element2 = parseXml(`<AdaptationSet ${attributeName}="PT5M" />`)[0] as ITNode;
     const error2 = new MPDError(
@@ -377,7 +449,13 @@ function testNumberOrBooleanAttribute(
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(2);
-    expect(spyLog).toHaveBeenNthCalledWith(2, error2.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      2,
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: attributeName },
+    );
 
     const element3 = parseXml(`<AdaptationSet ${attributeName}="" />`)[0] as ITNode;
     const error3 = new MPDError(
@@ -390,7 +468,14 @@ function testNumberOrBooleanAttribute(
     ]);
 
     expect(spyLog).toHaveBeenCalledTimes(3);
-    expect(spyLog).toHaveBeenNthCalledWith(3, error3.message);
+    expect(spyLog).toHaveBeenNthCalledWith(
+      3,
+      "dash",
+      "failed to parse DASH value:",
+      error3.message,
+      { dashName: attributeName },
+    );
+
     spyLog.mockRestore();
   });
 

--- a/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/Initialization.test.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/Initialization.test.ts
@@ -56,14 +56,24 @@ describe("DASH Node Parsers - Initialization", () => {
     expect(parseInitialization(element1)).toEqual([{}, [error1]]);
 
     expect(mockLog).toHaveBeenCalledTimes(1);
-    expect(mockLog).toHaveBeenCalledWith(error1.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: "range" },
+    );
 
     const element2 = parseXml('<Foo range="" />')[0] as ITNode;
     const error2 = new MPDError('`range` property has an unrecognized format ""');
     expect(parseInitialization(element2)).toEqual([{}, [error2]]);
 
     expect(mockLog).toHaveBeenCalledTimes(2);
-    expect(mockLog).toHaveBeenCalledWith(error2.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: "range" },
+    );
 
     mockLog.mockRestore();
   });

--- a/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/SegmentURL.test.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/__tests__/SegmentURL.test.ts
@@ -56,14 +56,24 @@ describe("DASH Node Parsers - SegmentURL", () => {
     expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
 
     expect(mockLog).toHaveBeenCalledTimes(1);
-    expect(mockLog).toHaveBeenCalledWith(error1.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: "mediaRange" },
+    );
 
     const element2 = parseXml('<Foo mediaRange="" />')[0] as ITNode;
     const error2 = new MPDError('`mediaRange` property has an unrecognized format ""');
     expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
 
     expect(mockLog).toHaveBeenCalledTimes(2);
-    expect(mockLog).toHaveBeenCalledWith(error2.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: "mediaRange" },
+    );
 
     mockLog.mockRestore();
   });
@@ -100,14 +110,24 @@ describe("DASH Node Parsers - SegmentURL", () => {
     expect(parseSegmentURL(element1)).toEqual([{}, [error1]]);
 
     expect(mockLog).toHaveBeenCalledTimes(1);
-    expect(mockLog).toHaveBeenCalledWith(error1.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error1.message,
+      { dashName: "indexRange" },
+    );
 
     const element2 = parseXml('<Foo indexRange="" />')[0] as ITNode;
     const error2 = new MPDError('`indexRange` property has an unrecognized format ""');
     expect(parseSegmentURL(element2)).toEqual([{}, [error2]]);
 
     expect(mockLog).toHaveBeenCalledTimes(2);
-    expect(mockLog).toHaveBeenCalledWith(error2.message);
+    expect(mockLog).toHaveBeenCalledWith(
+      "dash",
+      "failed to parse DASH value:",
+      error2.message,
+      { dashName: "indexRange" },
+    );
 
     mockLog.mockRestore();
   });

--- a/src/parsers/manifest/dash/js-parser/node_parsers/utils.ts
+++ b/src/parsers/manifest/dash/js-parser/node_parsers/utils.ts
@@ -321,10 +321,8 @@ function ValueParser<T>(dest: T, warnings: Error[]) {
   /**
    * Parse a single value and add it to the `dest` objects.
    * If an error arised while parsing, add it at the end of the `warnings` array.
-   * @param {string} objKey - The key which will be added to the `dest` object.
    * @param {string} val - The value found in the MPD which we should parse.
    * @param {Function} parsingFn - The parsing function adapted for this value.
-   * @param {string} displayName - The name of the key as it appears in the MPD.
    * This is used only in error formatting,
    */
   return function (
@@ -344,7 +342,9 @@ function ValueParser<T>(dest: T, warnings: Error[]) {
   ): void {
     const [parsingResult, parsingError] = parser(val, dashName);
     if (parsingError !== null) {
-      log.warn(parsingError.message);
+      log.warn("dash", "failed to parse DASH value:", parsingError.message, {
+        dashName,
+      });
       warnings.push(parsingError);
     }
 

--- a/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
+++ b/src/parsers/manifest/dash/wasm-parser/ts/dash-wasm-parser.ts
@@ -186,6 +186,7 @@ export default class DashWasmParser {
           objectUrl = null;
         }
         log.warn(
+          "dash",
           "Unable to call `instantiateStreaming` on WASM",
           e instanceof Error ? e : "",
         );
@@ -210,7 +211,7 @@ export default class DashWasmParser {
       })
       .catch((err: Error) => {
         const message = err instanceof Error ? err.toString() : "Unknown error";
-        log.warn("DW: Could not create DASH-WASM parser:", message);
+        log.warn("dash", "Could not create DASH-WASM parser:", message);
         this.status = "failure";
         throw err;
       });
@@ -268,11 +269,11 @@ export default class DashWasmParser {
       const arr = new Uint8Array(linearMemory.buffer, ptr, len);
       if (evt === CustomEventType.Error) {
         const decoded = textDecoder.decode(arr);
-        log.warn("WASM Error Event:", decoded);
+        log.warn("dash", "WASM Error Event:", decoded);
         self._warnings.push(new Error(decoded));
       } else if (evt === CustomEventType.Log) {
         const decoded = textDecoder.decode(arr);
-        log.warn("WASM Log Event:", decoded);
+        log.warn("dash", "WASM Log Event:", decoded);
       }
     }
 

--- a/src/parsers/manifest/local/representation_index.ts
+++ b/src/parsers/manifest/local/representation_index.ts
@@ -195,11 +195,11 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
   }
 
   initialize(): void {
-    log.error("A `LocalRepresentationIndex` does not need to be initialized");
+    log.error("dash", "A `LocalRepresentationIndex` does not need to be initialized");
   }
 
   addPredictedSegments(): void {
-    log.warn("Cannot add predicted segments to a `LocalRepresentationIndex`");
+    log.warn("dash", "Cannot add predicted segments to a `LocalRepresentationIndex`");
   }
 
   /**
@@ -249,7 +249,8 @@ export default class LocalRepresentationIndex implements IRepresentationIndex {
         if (currSegment.time + currSegment.duration > newIndexStart) {
           // the new Manifest overlaps a previous segment (weird). Remove the latter.
           log.warn(
-            "Local RepresentationIndex: Manifest update removed" + " previous segments",
+            "dash",
+            "Local RepresentationIndex: Manifest update removed previous segments",
           );
           return insertNewIndexAtPosition(i);
         }

--- a/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
+++ b/src/parsers/manifest/metaplaylist/metaplaylist_parser.ts
@@ -227,7 +227,8 @@ function createManifest(
               if (currentRepresentation.codecs.length > 1) {
                 if (currentRepresentation.codecs.length > 2) {
                   log.warn(
-                    "MP: MetaPlaylist relying on more than 2 groups of " +
+                    "metaplaylist",
+                    "MetaPlaylist relying on more than 2 groups of " +
                       "codecs with retro-compatibility",
                   );
                 }

--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -189,7 +189,9 @@ function createSmoothStreamingParser(
           (fourCC !== undefined && MIME_TYPES[fourCC] === undefined) ||
           codecPrivateData === undefined
         ) {
-          log.warn("Smooth parser: Unsupported audio codec. Ignoring quality level.");
+          log.warn("smooth", "Unsupported audio codec. Ignoring quality level.", {
+            fourCC,
+          });
           return null;
         }
 
@@ -225,7 +227,9 @@ function createSmoothStreamingParser(
           (fourCC !== undefined && MIME_TYPES[fourCC] === undefined) ||
           codecPrivateData === undefined
         ) {
-          log.warn("Smooth parser: Unsupported video codec. Ignoring quality level.");
+          log.warn("smooth", "Unsupported video codec. Ignoring quality level.", {
+            fourCC,
+          });
           return null;
         }
 
@@ -259,7 +263,7 @@ function createSmoothStreamingParser(
       }
 
       default:
-        log.error("Smooth Parser: Unrecognized StreamIndex type: " + streamType);
+        log.error("smooth", "Unrecognized StreamIndex type: " + streamType);
         return null;
     }
   }
@@ -293,7 +297,7 @@ function createSmoothStreamingParser(
       throw new Error("StreamIndex without type.");
     }
     if (!arrayIncludes(SUPPORTED_ADAPTATIONS_TYPE, typeAttribute)) {
-      log.warn("Smooth Parser: Unrecognized adaptation type:", typeAttribute);
+      log.warn("smooth", "Unrecognized adaptation type:", typeAttribute);
     }
     const adaptationType = typeAttribute as IAdaptationType;
 

--- a/src/parsers/manifest/smooth/representation_index.ts
+++ b/src/parsers/manifest/smooth/representation_index.ts
@@ -544,7 +544,7 @@ export default class SmoothRepresentationIndex implements IRepresentationIndex {
   }
 
   initialize(): void {
-    log.error("A `SmoothRepresentationIndex` does not need to be initialized");
+    log.error("smooth", "A `SmoothRepresentationIndex` does not need to be initialized");
   }
 
   /**

--- a/src/parsers/manifest/smooth/shared_smooth_segment_timeline.ts
+++ b/src/parsers/manifest/smooth/shared_smooth_segment_timeline.ts
@@ -149,8 +149,8 @@ export default class SharedSmoothSegmentTimeline {
         const rangeDuration = newEnd - oldTimelineRange.start;
         if (rangeDuration === 0) {
           log.warn(
-            "Smooth Parser: a discontinuity detected in the previous manifest" +
-              " has been resolved.",
+            "smooth",
+            "a discontinuity detected in the previous manifest" + " has been resolved.",
           );
           this.timeline = this.timeline.concat(oldTimeline.slice(i));
           return;
@@ -187,15 +187,15 @@ export default class SharedSmoothSegmentTimeline {
    * Add segments to a `SharedSmoothSegmentTimeline` that were predicted to come
    * after `currentSegment`.
    * @param {Array.<Object>} nextSegments - The segment information parsed.
-   * @param {Object} segment - Information on the segment which contained that
-   * new segment information.
+   * @param {Object} currentSegment - Information on the segment which contained
+   * that new segment information.
    */
   public addPredictedSegments(
     nextSegments: Array<{ duration: number; time: number; timescale: number }>,
     currentSegment: ISegment,
   ): void {
     if (currentSegment.privateInfos?.smoothMediaSegment === undefined) {
-      log.warn("Smooth Parser: should only encounter SmoothRepresentationIndex");
+      log.warn("smooth", "should only encounter SmoothRepresentationIndex");
       return;
     }
 

--- a/src/parsers/manifest/utils/__tests__/update_segment_timeline.test.ts
+++ b/src/parsers/manifest/utils/__tests__/update_segment_timeline.test.ts
@@ -330,7 +330,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
     mockLogWarn?.mockClear();
 
@@ -355,7 +356,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
     mockLogWarn?.mockClear();
 
@@ -372,7 +374,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
   });
 
@@ -399,7 +402,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
     mockLogWarn?.mockClear();
 
@@ -424,7 +428,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
     mockLogWarn?.mockClear();
 
@@ -437,7 +442,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed previous segments",
+      "utils",
+      "Manifest update removed previous segments",
     );
   });
 
@@ -465,7 +471,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
     ]);
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: Manifest update removed all previous segments",
+      "utils",
+      "Manifest update removed all previous segments",
     );
   });
 
@@ -523,7 +530,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      'RepresentationIndex: The new index is "bigger" than the previous one',
+      "utils",
+      'The new index is "bigger" than the previous one',
     );
 
     mockLogWarn?.mockClear();
@@ -550,7 +558,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      'RepresentationIndex: The new index is "bigger" than the previous one',
+      "utils",
+      'The new index is "bigger" than the previous one',
     );
   });
 
@@ -575,7 +584,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: The new index is older than the previous one",
+      "utils",
+      "The new index is older than the previous one",
     );
 
     mockLogWarn?.mockClear();
@@ -600,7 +610,8 @@ describe("Manifest Parsers utils - updateSegmentTimeline", () => {
 
     expect(mockLogWarn).toHaveBeenCalledTimes(1);
     expect(mockLogWarn).toHaveBeenCalledWith(
-      "RepresentationIndex: The new index is older than the previous one",
+      "utils",
+      "The new index is older than the previous one",
     );
 
     mockLogWarn?.mockClear();

--- a/src/parsers/manifest/utils/check_manifest_ids.ts
+++ b/src/parsers/manifest/utils/check_manifest_ids.ts
@@ -31,7 +31,7 @@ export default function checkManifestIDs(manifest: IParsedManifest): void {
   manifest.periods.forEach((period) => {
     const periodID = period.id;
     if (arrayIncludes(periodIDS, periodID)) {
-      log.warn("Two periods with the same ID found. Updating.");
+      log.warn("utils", "Two periods with the same ID found. Updating.", { periodID });
       const newID = periodID + "-dup";
       period.id = newID;
       checkManifestIDs(manifest);
@@ -49,7 +49,9 @@ export default function checkManifestIDs(manifest: IParsedManifest): void {
       adaptationsForType.forEach((adaptation) => {
         const adaptationID = adaptation.id;
         if (arrayIncludes(adaptationIDs, adaptationID)) {
-          log.warn("Two adaptations with the same ID found. Updating.", adaptationID);
+          log.warn("utils", "Two adaptations with the same ID found. Updating.", {
+            adaptationID,
+          });
           const newID = adaptationID + "-dup";
           adaptation.id = newID;
           checkManifestIDs(manifest);
@@ -61,10 +63,9 @@ export default function checkManifestIDs(manifest: IParsedManifest): void {
         adaptation.representations.forEach((representation) => {
           const representationID = representation.id;
           if (arrayIncludes(representationIDs, representationID)) {
-            log.warn(
-              "Two representations with the same ID found. Updating.",
+            log.warn("utils", "Two representations with the same ID found. Updating.", {
               representationID,
-            );
+            });
             const newID = `${representationID}-dup`;
             representation.id = newID;
             checkManifestIDs(manifest);

--- a/src/parsers/manifest/utils/get_maximum_positions.ts
+++ b/src/parsers/manifest/utils/get_maximum_positions.ts
@@ -64,7 +64,8 @@ export default function getMaximumPosition(periods: IParsedPeriod[]): {
         (firstVideoAdaptationFromPeriod !== undefined && maximumVideoPosition === null)
       ) {
         log.info(
-          "Parser utils: found Period with no segment. ",
+          "utils",
+          "found Period with no segment. ",
           "Going to previous one to calculate last position",
         );
         return { safe: undefined, unsafe: undefined };

--- a/src/parsers/manifest/utils/get_minimum_position.ts
+++ b/src/parsers/manifest/utils/get_minimum_position.ts
@@ -61,7 +61,8 @@ export default function getMinimumPosition(periods: IParsedPeriod[]): number | u
         (firstVideoAdaptationFromPeriod !== undefined && minimumVideoPosition === null)
       ) {
         log.info(
-          "Parser utils: found Period with no segment. ",
+          "utils",
+          "found Period with no segment. ",
           "Going to next one to calculate first position",
         );
         return undefined;

--- a/src/parsers/manifest/utils/update_segment_timeline.ts
+++ b/src/parsers/manifest/utils/update_segment_timeline.ts
@@ -71,7 +71,7 @@ export default function updateSegmentTimeline(
       if (currElt.start + currElt.duration > newIndexStart) {
         // The new Manifest overlaps a previous segment (weird)
         // In that improbable case, we'll just completely replace segments
-        log.warn("RepresentationIndex: Manifest update removed all previous segments");
+        log.warn("utils", "Manifest update removed all previous segments");
         oldTimeline.splice(0, prevTimelineLength, ...newTimeline);
         return true;
       } else if (currElt.repeatCount === undefined || currElt.repeatCount <= 0) {
@@ -104,7 +104,7 @@ export default function updateSegmentTimeline(
         oldTimeline[i].repeatCount = newRepeatCount;
         return false;
       }
-      log.warn("RepresentationIndex: Manifest update removed previous segments");
+      log.warn("utils", "Manifest update removed previous segments");
       oldTimeline[i].repeatCount = Math.floor(newCurrRepeat);
 
       // put it after this one
@@ -120,11 +120,11 @@ export default function updateSegmentTimeline(
   const newLastElt = newTimeline[newTimeline.length - 1];
   if (prevLastElt.repeatCount !== undefined && prevLastElt.repeatCount < 0) {
     if (prevLastElt.start > newLastElt.start) {
-      log.warn("RepresentationIndex: The new index is older than the previous one");
+      log.warn("utils", "The new index is older than the previous one");
       return false;
     } else {
       // the new has more depth
-      log.warn('RepresentationIndex: The new index is "bigger" than the previous one');
+      log.warn("utils", 'The new index is "bigger" than the previous one');
       oldTimeline.splice(0, prevTimelineLength, ...newTimeline);
       return true;
     }
@@ -134,12 +134,12 @@ export default function updateSegmentTimeline(
   const newLastTime =
     newLastElt.start + newLastElt.duration * (newLastElt.repeatCount + 1);
   if (prevLastTime >= newLastTime) {
-    log.warn("RepresentationIndex: The new index is older than the previous one");
+    log.warn("utils", "The new index is older than the previous one");
     return false;
   }
 
   // the new one has more depth. full update
-  log.warn('RepresentationIndex: The new index is "bigger" than the previous one');
+  log.warn("utils", 'The new index is "bigger" than the previous one');
   oldTimeline.splice(0, prevTimelineLength, ...newTimeline);
   return true;
 }

--- a/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
+++ b/src/parsers/texttracks/ttml/__tests__/resolve_styles_inheritance.test.ts
@@ -180,7 +180,8 @@ describe("resolve_styles_inheritance", () => {
 
     expect(logWarnMock).toHaveBeenNthCalledWith(
       1,
-      "TTML Parser: infinite style inheritance loop avoided",
+      "ttml",
+      "infinite style inheritance loop avoided",
     );
     expect(logWarnMock).toHaveBeenCalledTimes(1);
     logWarnMock.mockReset();
@@ -215,11 +216,13 @@ describe("resolve_styles_inheritance", () => {
     ]);
     expect(logWarnMock).toHaveBeenNthCalledWith(
       1,
-      "TTML Parser: infinite style inheritance loop avoided",
+      "ttml",
+      "infinite style inheritance loop avoided",
     );
     expect(logWarnMock).toHaveBeenNthCalledWith(
       2,
-      "TTML Parser: infinite style inheritance loop avoided",
+      "ttml",
+      "infinite style inheritance loop avoided",
     );
     expect(logWarnMock).toHaveBeenCalledTimes(2);
   });
@@ -244,10 +247,9 @@ describe("resolve_styles_inheritance", () => {
       { id: "2", style: { titi: "tito", teta: "tutu" }, extendsStyles: [] },
       { id: "3", style: { tata: "toto", tota: "tutu" }, extendsStyles: [] },
     ]);
-    expect(logWarnMock).toHaveBeenNthCalledWith(
-      1,
-      "TTML Parser: unknown style inheritance: 6",
-    );
+    expect(logWarnMock).toHaveBeenNthCalledWith(1, "ttml", "unknown style inheritance", {
+      id: "6",
+    });
     expect(logWarnMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/parsers/texttracks/ttml/get_parameters.ts
+++ b/src/parsers/texttracks/ttml/get_parameters.ts
@@ -48,12 +48,16 @@ export default function getParameters(tt: Element): ITTParameters {
   if (parsedCellResolution !== null) {
     const extractedData = CELL_RESOLUTION_REGEXP.exec(parsedCellResolution);
     if (extractedData === null || extractedData.length < 3) {
-      log.warn("TTML Parser: Invalid cellResolution");
+      log.warn("ttml", "Invalid cellResolution", {
+        cellResolution: parsedCellResolution,
+      });
     } else {
       const columns = parseInt(extractedData[1], 10);
       const rows = parseInt(extractedData[2], 10);
       if (isNaN(columns) || isNaN(rows)) {
-        log.warn("TTML Parser: Invalid cellResolution");
+        log.warn("ttml", "Invalid cellResolution", {
+          cellResolution: parsedCellResolution,
+        });
       } else {
         cellResolution = { columns, rows };
       }

--- a/src/parsers/texttracks/ttml/html/apply_extent.ts
+++ b/src/parsers/texttracks/ttml/html/apply_extent.ts
@@ -41,7 +41,7 @@ export default function applyExtent(element: HTMLElement, extent: string): void 
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-width", firstExtent[1]);
     } else {
-      log.warn("TTML Parser: unhandled extent unit:", firstExtent[2]);
+      log.warn("ttml", "unhandled extent unit", { unit: firstExtent[2] });
     }
 
     if (secondExtent[2] === "px" || secondExtent[2] === "%" || secondExtent[2] === "em") {
@@ -50,7 +50,7 @@ export default function applyExtent(element: HTMLElement, extent: string): void 
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-height", secondExtent[1]);
     } else {
-      log.warn("TTML Parser: unhandled extent unit:", secondExtent[2]);
+      log.warn("ttml", "unhandled extent unit", { unit: secondExtent[2] });
     }
   }
 }

--- a/src/parsers/texttracks/ttml/html/apply_font_size.ts
+++ b/src/parsers/texttracks/ttml/html/apply_font_size.ts
@@ -44,9 +44,8 @@ export default function applyFontSize(element: HTMLElement, fontSize: string): v
     const toNum = Number(firstFontSize[1]);
     if (isNaN(toNum)) {
       log.warn(
-        'TTML Parser: could not parse fontSize value "' +
-          firstFontSize[1] +
-          '" into a number',
+        "ttml",
+        'could not parse fontSize value "' + firstFontSize[1] + '" into a number',
       );
     } else {
       element.style.position = "relative";
@@ -54,6 +53,6 @@ export default function applyFontSize(element: HTMLElement, fontSize: string): v
       element.setAttribute("data-proportional-font-size", String(toNum / 100));
     }
   } else {
-    log.warn("TTML Parser: unhandled fontSize unit:", firstFontSize[2]);
+    log.warn("ttml", "unhandled fontSize unit", { unit: firstFontSize[2] });
   }
 }

--- a/src/parsers/texttracks/ttml/html/apply_line_height.ts
+++ b/src/parsers/texttracks/ttml/html/apply_line_height.ts
@@ -43,6 +43,6 @@ export default function applyLineHeight(element: HTMLElement, lineHeight: string
     addClassName(element, "proportional-style");
     element.setAttribute("data-proportional-line-height", firstLineHeight[1]);
   } else {
-    log.warn("TTML Parser: unhandled lineHeight unit:", firstLineHeight[2]);
+    log.warn("ttml", "unhandled lineHeight unit", { unit: firstLineHeight[2] });
   }
 }

--- a/src/parsers/texttracks/ttml/html/apply_origin.ts
+++ b/src/parsers/texttracks/ttml/html/apply_origin.ts
@@ -40,7 +40,7 @@ export default function applyOrigin(element: HTMLElement, origin: string): void 
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-left", firstOrigin[1]);
     } else {
-      log.warn("TTML Parser: unhandled origin unit:", firstOrigin[2]);
+      log.warn("ttml", "unhandled origin unit", { unit: firstOrigin[2] });
     }
 
     if (secondOrigin[2] === "px" || secondOrigin[2] === "%" || secondOrigin[2] === "em") {
@@ -49,7 +49,7 @@ export default function applyOrigin(element: HTMLElement, origin: string): void 
       addClassName(element, "proportional-style");
       element.setAttribute("data-proportional-top", secondOrigin[1]);
     } else {
-      log.warn("TTML Parser: unhandled origin unit:", secondOrigin[2]);
+      log.warn("ttml", "unhandled origin unit", { unit: secondOrigin[2] });
     }
   }
 }

--- a/src/parsers/texttracks/ttml/html/apply_padding.ts
+++ b/src/parsers/texttracks/ttml/html/apply_padding.ts
@@ -57,7 +57,7 @@ export default function applyPadding(element: HTMLElement, padding: string): voi
       element.setAttribute("data-proportional-padding-top", firstPadding[1]);
     }
   } else {
-    log.warn("TTML Parser: unhandled padding unit:", firstPadding[2]);
+    log.warn("ttml", "unhandled padding unit", { unit: firstPadding[2] });
   }
 
   if (splittedPadding.length === 1) {
@@ -89,7 +89,7 @@ export default function applyPadding(element: HTMLElement, padding: string): voi
       element.setAttribute("data-proportional-padding-right", secondPadding[1]);
     }
   } else {
-    log.warn("TTML Parser: unhandled padding unit:", secondPadding[2]);
+    log.warn("ttml", "unhandled padding unit", { unit: secondPadding[2] });
   }
 
   if (splittedPadding.length === 2) {
@@ -107,7 +107,7 @@ export default function applyPadding(element: HTMLElement, padding: string): voi
     addClassName(element, "proportional-style");
     element.setAttribute("data-proportional-padding-bottom", thirdPadding[1]);
   } else {
-    log.warn("TTML Parser: unhandled padding unit:", thirdPadding[2]);
+    log.warn("ttml", "unhandled padding unit", { unit: thirdPadding[2] });
   }
 
   if (splittedPadding.length === 3) {
@@ -129,6 +129,6 @@ export default function applyPadding(element: HTMLElement, padding: string): voi
     addClassName(element, "proportional-style");
     element.setAttribute("data-proportional-padding-left", fourthPadding[1]);
   } else {
-    log.warn("TTML Parser: unhandled padding unit:", fourthPadding[2]);
+    log.warn("ttml", "unhandled padding unit", { unit: fourthPadding[2] });
   }
 }

--- a/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
+++ b/src/parsers/texttracks/ttml/resolve_styles_inheritance.ts
@@ -60,11 +60,11 @@ export default function resolveStylesInheritance(styles: IStyleObject[]): void {
     for (const extendedStyleID of styleElt.extendsStyles) {
       const extendedStyleIndex = arrayFindIndex(styles, (x) => x.id === extendedStyleID);
       if (extendedStyleIndex < 0) {
-        log.warn("TTML Parser: unknown style inheritance: " + extendedStyleID);
+        log.warn("ttml", "unknown style inheritance", { id: extendedStyleID });
       } else {
         const extendedStyle = styles[extendedStyleIndex];
         if (arrayIncludes(recursivelyBrowsedIndexes, extendedStyleIndex)) {
-          log.warn("TTML Parser: infinite style inheritance loop avoided");
+          log.warn("ttml", "infinite style inheritance loop avoided");
         } else {
           resolveStyleInheritance(extendedStyle, extendedStyleIndex);
         }

--- a/src/parsers/texttracks/webvtt/html/create_styled_element.ts
+++ b/src/parsers/texttracks/webvtt/html/create_styled_element.ts
@@ -23,7 +23,6 @@ import type { IStyleElements } from "../parse_style_block";
  * the right styling on it.
  * @param {Node} baseNode
  * @param {Array.<Object>} styleElements
- * @param {Array.<string>} styleClasses
  * @returns {Node}
  */
 export default function createStyledElement(

--- a/src/parsers/texttracks/webvtt/parse_mp4_embedded_wvtt.ts
+++ b/src/parsers/texttracks/webvtt/parse_mp4_embedded_wvtt.ts
@@ -69,7 +69,9 @@ export default function parseMp4EmbeddedWebVtt<T>(
           mdatOffset += payloadSize - 8;
         }
       } else {
-        log.error("webvtt: encountered unknown fragmented vtt box: ", currentBoxName);
+        log.error("vtt", "encountered unknown fragmented vtt box", {
+          box: currentBoxName,
+        });
         mdatOffset += Math.min(payloadSize - 8, 1);
       }
 
@@ -86,13 +88,16 @@ export default function parseMp4EmbeddedWebVtt<T>(
           }
         }
       } else {
-        log.error("webvtt: cue duration missing");
+        log.error("vtt", "cue duration missing");
       }
     }
   }
 
   if (mdatOffset !== mdat.length) {
-    log.error("WEBVTT: end offset is not equal to mdat length", mdatOffset, mdat.length);
+    log.error("vtt", "end offset is not equal to mdat length", {
+      mdataOffset: mdatOffset,
+      mdatLength: mdat.length,
+    });
   }
 
   return cuesArray;

--- a/src/parsers/texttracks/webvtt/utils.ts
+++ b/src/parsers/texttracks/webvtt/utils.ts
@@ -35,7 +35,8 @@ function getFirstLineAfterHeader(linified: string[]): number {
 
 /**
  * Returns true if the given line looks like the beginning of a Style block.
- * @param {string} text
+ * @param {Array.<string>} lines
+ * @param {number} index
  * @returns {Boolean}
  */
 function isStartOfStyleBlock(lines: string[], index: number): boolean {

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -304,7 +304,7 @@ export default class PlaybackObserver {
   }
 
   private _actuallySetCurrentTime(time: number): void {
-    log.info("API: Seeking internally", time);
+    log.info("media", "Seeking internally.", { time });
     this._internalSeeksIncoming.push(time);
     this._mediaElement.currentTime = time;
   }
@@ -512,31 +512,19 @@ export default class PlaybackObserver {
       fullyLoaded,
     });
     if (log.hasLevel("DEBUG")) {
-      log.debug(
-        "API: current media element state tick",
-        "event",
-        timings.event,
-        "position",
-        timings.position.getPolled(),
-        "seeking",
-        timings.seeking,
-        "internalSeek",
-        isInternalSeeking,
-        "rebuffering",
-        timings.rebuffering !== null,
-        "freezing",
-        timings.freezing !== null,
-        "ended",
-        timings.ended,
-        "paused",
-        timings.paused,
-        "playbackRate",
-        timings.playbackRate,
-        "readyState",
-        timings.readyState,
-        "pendingPosition",
+      log.debug("media", "Current media element state tick.", {
+        evt: timings.event,
+        position: timings.position.getPolled(),
+        seeking: timings.seeking,
+        internalSeek: isInternalSeeking,
+        rebuffering: timings.rebuffering !== null,
+        freezing: timings.freezing !== null,
+        ended: timings.ended,
+        paused: timings.paused,
+        playbackRate: timings.playbackRate,
+        readyState: timings.readyState,
         pendingPosition,
-      );
+      });
     }
     return timings;
   }
@@ -545,7 +533,8 @@ export default class PlaybackObserver {
     const newObservation = this._getCurrentObservation(event);
     if (log.hasLevel("DEBUG")) {
       log.debug(
-        "API: current playback timeline:\n" +
+        "media",
+        "current playback timeline:\n" +
           prettyPrintBuffered(
             newObservation.buffered,
             newObservation.position.getPolled(),

--- a/src/transports/dash/manifest_parser.ts
+++ b/src/transports/dash/manifest_parser.ts
@@ -77,36 +77,36 @@ export default function generateManifestParser(
       parsers.wasm.status === "uninitialized" ||
       parsers.wasm.status === "failure"
     ) {
-      log.debug("DASH: WASM MPD Parser not initialized. Running JS one.");
+      log.debug("dash", "WASM MPD Parser not initialized. Running JS one.");
       return runDefaultJsParser();
     } else {
       const manifestAB = getManifestAsArrayBuffer(responseData);
       if (!doesXmlSeemsUtf8Encoded(manifestAB)) {
         log.info(
-          "DASH: MPD doesn't seem to be UTF-8-encoded. " +
-            "Running JS parser instead of the WASM one.",
+          "dash",
+          "MPD doesn't seem to be UTF-8-encoded. Running JS parser instead of the WASM one.",
         );
         return runDefaultJsParser();
       }
 
       if (parsers.wasm.status === "initialized") {
-        log.debug("DASH: Running WASM MPD Parser.");
+        log.debug("dash", "Running WASM MPD Parser.");
         const parsed = parsers.wasm.runWasmParser(manifestAB, dashParserOpts);
         return processMpdParserResponse(parsed);
       } else {
-        log.debug("DASH: Awaiting WASM initialization before parsing the MPD.");
+        log.debug("dash", "Awaiting WASM initialization before parsing the MPD.");
         const initProm = parsers.wasm.waitForInitialization().catch(() => {
           /* ignore errors, we will check the status later */
         });
         return initProm.then(() => {
           if (parsers.wasm === null || parsers.wasm.status !== "initialized") {
             log.warn(
-              "DASH: WASM MPD parser initialization failed. " +
-                "Running JS parser instead",
+              "dash",
+              "WASM MPD parser initialization failed. Running JS parser instead",
             );
             return runDefaultJsParser();
           }
-          log.debug("DASH: Running WASM MPD Parser.");
+          log.debug("dash", "Running WASM MPD Parser.");
           const parsed = parsers.wasm.runWasmParser(manifestAB, dashParserOpts);
           return processMpdParserResponse(parsed);
         });

--- a/src/transports/smooth/extract_timings_infos.ts
+++ b/src/transports/smooth/extract_timings_infos.ts
@@ -84,7 +84,7 @@ export default function extractTimingsInfos(
       tfrfSegments = parseTfrf(traf);
       tfxdSegment = parseTfxd(traf);
     } else {
-      log.warn("smooth: could not find traf atom");
+      log.warn("smooth", "could not find traf atom");
     }
   }
 

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -328,7 +328,7 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
         chunkInfos = timingInfos?.chunkInfos ?? null;
         if (chunkInfos === null) {
           if (isChunked) {
-            log.warn("Smooth: Unavailable time data for current text track.");
+            log.warn("smooth", "Unavailable time data for current text track.");
           } else {
             segmentStart = segment.time;
             segmentEnd = segment.end;

--- a/src/transports/utils/get_isobmff_timing_infos.ts
+++ b/src/transports/utils/get_isobmff_timing_infos.ts
@@ -59,7 +59,8 @@ export default function getISOBMFFTimingInfos(
   if (isChunked || !segment.complete) {
     if (trunDuration === undefined) {
       log.warn(
-        "DASH: Chunked segments should indicate a duration through their" + " trun boxes",
+        "dash",
+        "Chunked segments should indicate a duration through their trun boxes",
       );
     }
     return {

--- a/src/transports/utils/parse_text_track.ts
+++ b/src/transports/utils/parse_text_track.ts
@@ -103,7 +103,7 @@ export function getISOBMFFEmbeddedTextTrackData(
   let endTime: number | undefined;
   if (chunkInfos === null) {
     if (!isChunked) {
-      log.warn("Transport: Unavailable time data for current text track.");
+      log.warn("utils", "Unavailable time data for current text track.");
     } else {
       startTime = segment.time;
       endTime = segment.end;
@@ -167,7 +167,7 @@ export function getPlainTextTrackData(
   let start;
   let end;
   if (isChunked) {
-    log.warn("Transport: Unavailable time data for current text track.");
+    log.warn("utils", "Unavailable time data for current text track.");
   } else {
     start = segment.time;
     if (segment.complete) {

--- a/src/utils/__tests__/base64.test.ts
+++ b/src/utils/__tests__/base64.test.ts
@@ -140,15 +140,19 @@ describe("base64ToBytes", () => {
     expect(logWarn).toHaveBeenCalledTimes(1);
     expect(logWarn).toHaveBeenNthCalledWith(
       1,
+      "utils",
       "base64ToBytes: base64 given miss padding",
+      { padding: 2 },
     );
     expect(base64ToBytes("dG90b/CfjIM")).toEqual(
       new Uint8Array([116, 111, 116, 111, 240, 159, 140, 131]),
     );
     expect(logWarn).toHaveBeenCalledTimes(2);
     expect(logWarn).toHaveBeenNthCalledWith(
-      1,
+      2,
+      "utils",
       "base64ToBytes: base64 given miss padding",
+      { padding: 3 },
     );
   });
 

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -116,10 +116,10 @@ describe("utils - Logger", () => {
 
   it('should never call console.* functions if logger level is set to "NONE"', () => {
     const logger = new Logger();
-    logger.error("test");
-    logger.warn("test");
-    logger.info("test");
-    logger.debug("test");
+    logger.error("ABR", "test");
+    logger.warn("CMCD", "test");
+    logger.info("MF", "test");
+    logger.debug("SF", "test");
     expect(mockLog).not.toHaveBeenCalled();
     expect(mockError).not.toHaveBeenCalled();
     expect(mockWarn).not.toHaveBeenCalled();
@@ -135,10 +135,10 @@ describe("utils - Logger", () => {
   it('should only call console.error if logger level is set to "ERROR"', () => {
     const logger = new Logger();
     logger.setLevel("ERROR", "standard");
-    logger.error("test");
-    logger.warn("test");
-    logger.info("test");
-    logger.debug("test");
+    logger.error("ABR", "test");
+    logger.warn("CMCD", "test");
+    logger.info("MF", "test");
+    logger.debug("SF", "test");
     expect(mockLog).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalled();
     expect(mockWarn).not.toHaveBeenCalled();
@@ -154,10 +154,10 @@ describe("utils - Logger", () => {
   it('should call console.{error,warn} if logger level is set to "WARNING"', () => {
     const logger = new Logger();
     logger.setLevel("WARNING", "standard");
-    logger.error("test");
-    logger.warn("test");
-    logger.info("test");
-    logger.debug("test");
+    logger.error("ABR", "test");
+    logger.warn("CMCD", "test");
+    logger.info("MF", "test");
+    logger.debug("SF", "test");
     expect(mockLog).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalled();
@@ -173,10 +173,10 @@ describe("utils - Logger", () => {
   it('should call console.{error,warn,info} if logger level is set to "INFO"', () => {
     const logger = new Logger();
     logger.setLevel("INFO", "standard");
-    logger.error("test");
-    logger.warn("test");
-    logger.info("test");
-    logger.debug("test");
+    logger.error("ABR", "test");
+    logger.warn("CMCD", "test");
+    logger.info("MF", "test");
+    logger.debug("SF", "test");
     expect(mockLog).not.toHaveBeenCalled();
     expect(mockError).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalled();
@@ -192,10 +192,10 @@ describe("utils - Logger", () => {
   it('should call console.{error,warn,info, log} if logger level is set to "DEBUG"', () => {
     const logger = new Logger();
     logger.setLevel("DEBUG", "standard");
-    logger.error("test");
-    logger.warn("test");
-    logger.info("test");
-    logger.debug("test");
+    logger.error("ABR", "test");
+    logger.warn("CMCD", "test");
+    logger.info("MF", "test");
+    logger.debug("SF", "test");
     expect(mockLog).toHaveBeenCalled();
     expect(mockError).toHaveBeenCalled();
     expect(mockWarn).toHaveBeenCalled();
@@ -291,43 +291,47 @@ describe("utils - Logger", () => {
     expect(mockInfo).not.toHaveBeenCalled();
     expect(mockDebug).not.toHaveBeenCalled();
 
-    logger.error("teste", "e r");
-    logger.warn("testw", "w a");
-    logger.info("testi", "i n");
-    logger.debug("testd", "d e");
+    logger.error("ABR", "teste");
+    logger.warn("CMCD", "testw");
+    logger.info("MF", "testi");
+    logger.debug("SF", "testd");
 
     expect(mockError).toHaveBeenCalledTimes(1);
     expect(errorMsgs).toHaveLength(1);
     expect(errorMsgs[0]).toHaveLength(4);
     expect(errorMsgs[0][0]).toMatch(/\d+\.\d\d/);
-    expect(errorMsgs[0][1]).toMatch("[error]");
-    expect(errorMsgs[0][2]).toMatch("teste");
-    expect(errorMsgs[0][3]).toMatch("e r");
+    expect(errorMsgs[0][1]).toMatch(/^\[error\]$/);
+    expect(errorMsgs[0][2]).toMatch(/^ABR:$/);
+    expect(errorMsgs[0][3]).toMatch(/^teste$/);
 
     expect(mockWarn).toHaveBeenCalledTimes(1);
     expect(warningMsgs).toHaveLength(1);
     expect(warningMsgs[0]).toHaveLength(4);
     expect(warningMsgs[0][0]).toMatch(/\d+\.\d\d/);
-    expect(warningMsgs[0][1]).toMatch("[warn]");
-    expect(warningMsgs[0][2]).toMatch("testw");
-    expect(warningMsgs[0][3]).toMatch("w a");
+    expect(warningMsgs[0][1]).toMatch(/^\[warn\]$/);
+    expect(warningMsgs[0][2]).toMatch(/^CMCD:$/);
+    expect(warningMsgs[0][3]).toMatch(/^testw$/);
 
     expect(mockInfo).toHaveBeenCalledTimes(1);
     expect(infoMsgs).toHaveLength(1);
     expect(infoMsgs[0]).toHaveLength(4);
     expect(infoMsgs[0][0]).toMatch(/\d+\.\d\d/);
-    expect(infoMsgs[0][1]).toMatch("[info]");
-    expect(infoMsgs[0][2]).toMatch("testi");
-    expect(infoMsgs[0][3]).toMatch("i n");
+    expect(infoMsgs[0][1]).toMatch(/^\[info\]$/);
+    expect(infoMsgs[0][2]).toMatch(/^MF:$/);
+    expect(infoMsgs[0][3]).toMatch(/^testi$/);
 
     expect(mockDebug).not.toHaveBeenCalled();
 
     expect(mockLog).toHaveBeenCalledTimes(2);
+    expect(logMsgs[0]).toHaveLength(3);
+    expect(logMsgs[0][0]).toMatch(/\d+\.\d\d/);
+    expect(logMsgs[0][1]).toMatch(/^\[Init\]$/);
+    expect(logMsgs[0][2]).toMatch(/^Local-Date: \d+$/);
     expect(logMsgs[1]).toHaveLength(4);
     expect(logMsgs[1][0]).toMatch(/\d+\.\d\d/);
-    expect(logMsgs[1][1]).toMatch("[log]");
-    expect(logMsgs[1][2]).toMatch("testd");
-    expect(logMsgs[1][3]).toMatch("d e");
+    expect(logMsgs[1][1]).toMatch(/^\[log\]$/);
+    expect(logMsgs[1][2]).toMatch(/^SF:$/);
+    expect(logMsgs[1][3]).toMatch(/^testd$/);
 
     mockLog.mockRestore();
     mockError.mockRestore();

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -185,7 +185,9 @@ export function base64ToBytes(str: string): Uint8Array {
   const paddingNeeded = str.length % 4;
   let paddedStr = str;
   if (paddingNeeded !== 0) {
-    log.warn("base64ToBytes: base64 given miss padding");
+    log.warn("utils", "base64ToBytes: base64 given miss padding", {
+      padding: paddingNeeded,
+    });
     // eslint-disable-next-line no-nested-ternary
     paddedStr += paddingNeeded === 3 ? "=" : paddingNeeded === 2 ? "==" : "==="; // invalid, but we will catch it
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -22,9 +22,96 @@ export type ILoggerLevel = "NONE" | "ERROR" | "WARNING" | "INFO" | "DEBUG";
 
 export type ILogFormat = "standard" | "full";
 
-type IAcceptedLogValue = boolean | string | number | Error | null | undefined;
+type IAcceptedLogValueBase = boolean | string | number | null | undefined;
+type IAcceptedLogValue =
+  | IAcceptedLogValueBase
+  | Error
+  | Partial<Record<string, IAcceptedLogValueBase>>;
 
-type IConsoleFn = (...args: IAcceptedLogValue[]) => void;
+/**
+ * Area of the code the log is linked to.
+ *
+ * Do not forget to update the corresponding API documentation page. When adding
+ * or removing namespaces.
+ */
+export type ILogNamespace =
+  /** Linked to adaptive bitrate quality selection */
+  | "ABR"
+  /** Linked to the RxPlayer public API. */
+  | "API"
+  /** Linked to the part of the RxPlayer handling audio/video/text track selection. */
+  | "Track"
+  /**
+   * Linked to the "Init" logic of the RxPlayer, which between other things set up a
+   * new content.
+   */
+  | "Init"
+  /**
+   * Global handling logic in the "Core" part of the player.
+   * The main orchestrator in the RxPlayer's worker-side.
+   */
+  | "Core"
+  /** Linked to logic implementing Manifest Fetching. */
+  | "MF"
+  /** Linked to logic implementing Segment Fetching. */
+  | "SF"
+  /** Linked to a generic utils function. */
+  | "utils"
+  /** Linked to CMCD logic. */
+  | "CMCD"
+  /** Heuristics involved in freeze-detection (when the media is stalled unexpectedly). */
+  | "Freeze"
+  /** Linked to the DASH protocol implementation and manifest parsing. */
+  | "dash"
+  /** Linked to the Smooth protocol implementation and manifest parsing. */
+  | "smooth"
+  /** Linked to the MetaPlaylist protocol implementation and manifest parsing. */
+  | "metaplaylist"
+  /** Linked to the exploitation of the `HTMLMediaElement` linked to the RxPlayer. */
+  | "media"
+  /** Linked to the code directly interacting with MSE API, e.g. to append media data. */
+  | "mse"
+  /** Linked to the code handling content decryption, including handling the EME API. */
+  | "DRM"
+  /** "Segment Inventory". Estimates the list of segment currently present in buffers, */
+  | "SI"
+  /** Core RxPlayer logic orchestrating segment fetching and pushing. */
+  | "Stream"
+  /** Linked to the code handling the "Manifest" structure, which describes a content. */
+  | "manifest"
+  /** Linked to the logic parsing ISOBMFF-compatible container files. */
+  | "isobmff"
+  /** Linked to the logic parsing MKV-compatible container files. */
+  | "webm"
+  /** Linked to the logic parsing TTML data, for text tracks. */
+  | "ttml"
+  /** Linked to the logic parsing VTT data, for text tracks. */
+  | "vtt"
+  /** Linked to the logic parsing SRT data, for text tracks. */
+  | "srt"
+  /** Linked to the logic parsing SAMI data, for text tracks. */
+  | "sami"
+  /** Linked to in-stream image thumbnails. */
+  | "Thumbnails"
+  /** Linked to subtitles / text management */
+  | "text"
+  /**
+   * Message sent from the RxPlayer's "main" part logic (e.g. the API) to the "Core"
+   * internal logic.
+   * Both may run in parallel (in "multithreading" mode).
+   */
+  | "M-->C"
+  /**
+   * Message sent from the RxPlayer's "Core" logic to the "main" logic.
+   * Both may run in parallel (in "multithreading" mode).
+   */
+  | "M<--C"
+  /** Log from the `MediaCapabilitiesProber` tool. */
+  | "MediaCapabilitiesProber"
+  /** Log from the `VideoThumbnailLoader` tool. */
+  | "VideoThumbnailLoader";
+
+type IConsoleFn = (namespace: ILogNamespace, ...args: IAcceptedLogValue[]) => void;
 
 const DEFAULT_LOG_LEVEL: ILoggerLevel = "NONE";
 
@@ -78,7 +165,8 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
     format: string,
     logFn?: (
       levelStr: ILoggerLevel,
-      logs: Array<boolean | string | number | Error | null | undefined>,
+      namespace: string,
+      logs: IAcceptedLogValue[],
     ) => void,
   ): void {
     let level: number;
@@ -108,13 +196,43 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
 
     const generateLogFn =
       this._currentFormat === "full"
-        ? (namespace: string, consoleFn: IConsoleFn): IConsoleFn => {
-            return (...args: IAcceptedLogValue[]) => {
+        ? (logMethod: string, consoleFn: (...vals: unknown[]) => void): IConsoleFn => {
+            return (
+              namespace: ILogNamespace,
+              ...args: Array<
+                IAcceptedLogValue | Partial<Record<string, IAcceptedLogValue>>
+              >
+            ) => {
               const now = getMonotonicTimeStamp();
-              return consoleFn(String(now.toFixed(2)), `[${namespace}]`, ...args);
+              return consoleFn(
+                String(now.toFixed(2)),
+                `[${logMethod}]`,
+                namespace + ":",
+                ...args.map((a) =>
+                  typeof a === "object" && a !== null && !(a instanceof Error)
+                    ? formatContextObject(a)
+                    : a,
+                ),
+              );
             };
           }
-        : (_namespace: string, consoleFn: IConsoleFn): IConsoleFn => consoleFn;
+        : (_logMethod: string, consoleFn: (...vals: unknown[]) => void): IConsoleFn => {
+            return (
+              namespace: ILogNamespace,
+              ...args: Array<
+                IAcceptedLogValue | Partial<Record<string, IAcceptedLogValue>>
+              >
+            ) => {
+              return consoleFn(
+                namespace + ":",
+                ...args.map((a) =>
+                  typeof a === "object" && a !== null && !(a instanceof Error)
+                    ? formatContextObject(a)
+                    : a,
+                ),
+              );
+            };
+          };
 
     if (logFn === undefined) {
       /* eslint-disable no-console */
@@ -136,10 +254,10 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
           : noop;
       /* eslint-enable no-console */
     } else {
-      const produceLogFn = (logLevel: ILoggerLevel) => {
+      const produceLogFn = (logLevel: ILoggerLevel): IConsoleFn => {
         return level >= this._levels[logLevel]
-          ? (...args: IAcceptedLogValue[]) => {
-              return logFn(logLevel, args);
+          ? (namespace: ILogNamespace, ...args: IAcceptedLogValue[]) => {
+              return logFn(logLevel, namespace, args);
             }
           : noop;
       };
@@ -180,4 +298,22 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
   public hasLevel(logLevel: ILoggerLevel): boolean {
     return this._levels[logLevel] >= this._levels[this._currentLevel];
   }
+}
+
+function formatContextObject(obj: Partial<Record<string, IAcceptedLogValue>>) {
+  let ret = "";
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      if (ret.length > 0) {
+        ret += " ";
+      }
+      const val = obj[key];
+      if (val instanceof Error) {
+        ret += `${key}="${JSON.stringify(val?.toString())}"`;
+      } else {
+        ret += `${key}=${typeof val === "string" ? `${JSON.stringify(val)}` : String(val)}`;
+      }
+    }
+  }
+  return ret;
 }

--- a/src/utils/request/fetch.ts
+++ b/src/utils/request/fetch.ts
@@ -122,7 +122,7 @@ export default function fetchRequest(
     }
   }
 
-  log.debug("Fetch: Called with URL", options.url);
+  log.debug("utils", "Fetch", { url: options.url });
   let cancellation: CancellationError | null = null;
   let isTimedOut = false;
   let isConnectionTimedOut = false;
@@ -137,7 +137,7 @@ export default function fetchRequest(
    */
   function abortFetch(): void {
     if (isNullOrUndefined(abortController)) {
-      log.warn("Fetch: AbortController API not available.");
+      log.warn("utils", "Fetch: AbortController API not available.");
       return;
     }
     abortController.abort();
@@ -179,7 +179,7 @@ export default function fetchRequest(
   fetchOpts.signal = !isNullOrUndefined(abortController) ? abortController.signal : null;
 
   if (log.hasLevel("DEBUG")) {
-    let logLine = "FETCH: Sending GET " + options.url;
+    let logLine = "fetch GET " + options.url;
     if (options.timeout !== undefined) {
       logLine += " to=" + String(options.timeout / 1000);
     }
@@ -189,7 +189,7 @@ export default function fetchRequest(
     if (options.headers?.Range !== undefined) {
       logLine += " Range=" + options.headers?.Range;
     }
-    log.debug(logLine);
+    log.debug("utils", logLine);
   }
   return fetch(options.url, fetchOpts)
     .then((response: Response): Promise<IFetchedStreamComplete> => {
@@ -197,7 +197,10 @@ export default function fetchRequest(
         clearTimeout(connectionTimeoutId);
       }
       if (response.status >= 300) {
-        log.warn("Fetch: Request HTTP Error", response.status, response.url);
+        log.warn("utils", "Fetch: Request HTTP Error", {
+          status: response.status,
+          responseUrl: response.url,
+        });
         throw new RequestError(
           response.url,
           response.status,
@@ -266,15 +269,23 @@ export default function fetchRequest(
       }
       deregisterCancelLstnr();
       if (isTimedOut) {
-        log.warn("Fetch: Request timed out.");
+        log.warn("utils", "Fetch: Request timed out.", {
+          url: options.url,
+          timeout: options.timeout,
+        });
         throw new RequestError(options.url, 0, RequestErrorTypes.TIMEOUT);
       } else if (isConnectionTimedOut) {
-        log.warn("Fetch: Request connection timed out.");
+        log.warn("utils", "Fetch: Request connection timed out.", {
+          url: options.url,
+          connectionTimeout: options.connectionTimeout,
+        });
         throw new RequestError(options.url, 0, RequestErrorTypes.TIMEOUT);
       } else if (err instanceof RequestError) {
         throw err;
       }
-      log.warn("Fetch: Request Error", err instanceof Error ? err.toString() : "");
+      log.warn("utils", "Fetch: Request Error", {
+        error: err instanceof Error ? err.toString() : "Unkwown Error",
+      });
       throw new RequestError(options.url, 0, RequestErrorTypes.ERROR_EVENT);
     });
 }

--- a/src/utils/request/xhr.ts
+++ b/src/utils/request/xhr.ts
@@ -212,7 +212,7 @@ export default function request<T>(
     };
 
     if (log.hasLevel("DEBUG")) {
-      let logLine = "XHR: Sending GET " + url;
+      let logLine = "XHR GET " + url;
       if (options.responseType !== undefined) {
         logLine += " type=" + options.responseType;
       }
@@ -225,7 +225,7 @@ export default function request<T>(
       if (headers?.Range !== undefined) {
         logLine += " Range=" + headers?.Range;
       }
-      log.debug(logLine);
+      log.debug("utils", logLine);
     }
     xhr.send();
 

--- a/src/utils/string_parsing.ts
+++ b/src/utils/string_parsing.ts
@@ -70,9 +70,10 @@ function utf16LEToStr(bytes: Uint8Array): string {
       const decoder = new TextDecoder("utf-16le");
       return decoder.decode(bytes);
     } catch (e) {
-      const err = e instanceof Error ? e : "";
+      const err = e instanceof Error ? e : "Unknown Error";
       log.warn(
-        "Utils: could not use TextDecoder to parse UTF-16LE, " +
+        "utils",
+        "could not use TextDecoder to parse UTF-16LE, " +
           "fallbacking to another implementation",
         err,
       );
@@ -98,9 +99,10 @@ function beUtf16ToStr(bytes: Uint8Array): string {
       const decoder = new TextDecoder("utf-16be");
       return decoder.decode(bytes);
     } catch (e) {
-      const err = e instanceof Error ? e : "";
+      const err = e instanceof Error ? e : "Unknown Error";
       log.warn(
-        "Utils: could not use TextDecoder to parse UTF-16BE, " +
+        "utils",
+        "Could not use TextDecoder to parse UTF-16BE, " +
           "fallbacking to another implementation",
         err,
       );
@@ -126,9 +128,10 @@ function strToUtf8(str: string): Uint8Array {
       const encoder = new TextEncoder();
       return encoder.encode(str);
     } catch (e) {
-      const err = e instanceof Error ? e : "";
+      const err = e instanceof Error ? e : "Unknown Error";
       log.warn(
-        "Utils: could not use TextEncoder to encode string into UTF-8, " +
+        "utils",
+        "Could not use TextEncoder to encode string into UTF-8, " +
           "fallbacking to another implementation",
         err,
       );
@@ -260,7 +263,7 @@ function intToHex(num: number, size: number): string {
 
 /**
  * Creates a string from the given Uint8Array containing utf-8 code units.
- * @param {Uint8Array} bytes
+ * @param {Uint8Array} data
  * @returns {string}
  */
 function utf8ToStr(data: Uint8Array): string {
@@ -270,9 +273,10 @@ function utf8ToStr(data: Uint8Array): string {
       const decoder = new TextDecoder();
       return decoder.decode(data);
     } catch (e) {
-      const err = e instanceof Error ? e : "";
+      const err = e instanceof Error ? e : "Unknown Error";
       log.warn(
-        "Utils: could not use TextDecoder to parse UTF-8, " +
+        "utils",
+        "could not use TextDecoder to parse UTF-8, " +
           "fallbacking to another implementation",
         err,
       );

--- a/src/utils/task_canceller.ts
+++ b/src/utils/task_canceller.ts
@@ -257,8 +257,9 @@ export class CancellationSignal {
           listener?.(cancellationError);
         } catch (err) {
           log.error(
+            "utils",
             "Error while calling clean up listener",
-            err instanceof Error ? err.toString() : "Unknown error",
+            err instanceof Error ? err : "Unknown Error",
           );
         }
       }


### PR DESCRIPTION
This is a proposal to add a little "formalization" for our logs, as those became our central focus for debugging complex issues.

BEFORE:
<img width="321" height="23" alt="image" src="https://github.com/user-attachments/assets/fda73aa8-185c-4821-a75d-5f31abb34f22" />
<img width="608" height="27" alt="image" src="https://github.com/user-attachments/assets/669a4168-0209-43f2-a28f-77f0f20e2b91" />
<img width="601" height="16" alt="image" src="https://github.com/user-attachments/assets/1aaedcc3-5911-4d4c-9f0a-4614ebed77de" />
<img width="689" height="21" alt="image" src="https://github.com/user-attachments/assets/bfd9571c-8137-4d62-85b5-61b9de5aba9f" />


AFTER:
<img width="608" height="27" alt="image" src="https://github.com/user-attachments/assets/78cb78ec-fd31-4cab-8328-4a7fb04ab5da" />
_(namespace is now `mse` to make it clear [this is about the MSE API](https://www.w3.org/TR/media-source-2/#dom-sourcebuffer-appendwindowend), values appended are clearly identified)_
<img width="756" height="26" alt="image" src="https://github.com/user-attachments/assets/0b98034f-700b-4b8c-8250-6a211c47fa2a" />
_(namespace is now `SF` for "segment fetching" as this is what it is about, here also values are clear)_
<img width="590" height="16" alt="image" src="https://github.com/user-attachments/assets/8abe3c04-f87f-4c9f-9ef3-569d48ab2de2" />
_(values are clearly identified here)_
<img width="743" height="19" alt="image" src="https://github.com/user-attachments/assets/806336d5-2404-46a4-8eb6-a40c81f1f3b4" />
_(values are more formalized than before, with the key=value format of the others, though here keys are very briefs to reduce verbosity, me may document those key names somewhere)_

There's already an implicit log API we have to maintain as we rely on a given format in our [RxPaired](https://github.com/canalplus/RxPaired) live debugger but this was just enforced by not changing too much the lready-present logs.

We also noticed that multiple partners outside of canal+ were using RxPaired and looking at our logs for debugging on their side first.

---

Consequently I tried a strategy which attempts to:

- Facilitate the readability of our logs by people relying on the RxPlayer. This is here done in two ways:

  1. The "namespace" (first part of the log, before `:`) has to be taken from a smallish list of authorized namespaces, enforced by TypeScript. E.g. `ABR` for adaptive, `DRM` for decryption, `mse` for MSE-linked code, `SF` for segment fetching code etc.

     The end idea would even to add clear documentation for those namespaces so that people using the RxPlayer have a vague idea of what the various messages we log are about.

     It also helps by enforcing more stability (NOTE: I do not consider the namespace as part of our API, but we should always have a very good reason to break it) for external tools exploiting those.

  2. When there's data associated with the log, it was previously just appended to the message without description (e.g. some numbers after a vague message about ABR).

     Now the preferred syntax is under a JS Object which is then written as `key1=value1 key2=value2` In our log messages. This helps people (including us here :p) quicly understand what those values are about.

- Try to put some more stability in our log for our external tools like RxPaired, through the same aforementioned strategies

---

The main downside I see is that adding logs needs a little more looking around to get the namespace and format right.

Thoughts?