### PR TITLE
Thumbnails: Cache pending thumbnail request

### DIFF
--- a/demo/scripts/components/ThumbnailPreview.tsx
+++ b/demo/scripts/components/ThumbnailPreview.tsx
@@ -73,24 +73,24 @@ export default function ThumbnailPreview({
 
     startSpinnerTimeoutIfNotAlreadyStarted();
 
-    // load thumbnail after a  timer to avoid doing too many requests when the
-    // user quickly moves its pointer or whatever is calling this
-    loadThumbnailTimeout = window.setTimeout(() => {
-      loadThumbnailTimeout = null;
+    // There's two available ways of displaying thumbnails
+    //
+    // 1.   Through what's called a "trickmode track", which is a video track
+    //      only containing intra-frames. Such thumbnails are shown through a
+    //      video tag thanks the the `VideoThumbnailLoader` tool
+    //
+    // 2.   Through an especially-purposed "thumbnail track" in a Manifest
+    //      which usually is based on tiles of jpg/png images. Those are loaded
+    //      through specific RxPlayer method.
+    if (showVideoThumbnail) {
+      if (videoThumbnailLoader === null) {
+        return;
+      }
+      // load thumbnail after a  timer to avoid doing too many requests when the
+      // user quickly moves the pointer or whatever is calling this
+      loadThumbnailTimeout = window.setTimeout(() => {
+        loadThumbnailTimeout = null;
 
-      // There's two available ways of displaying thumbnails
-      //
-      // 1.   Through what's called a "trickmode track", which is a video track
-      //      only containing intra-frames. Such thumbnails are shown through a
-      //      video tag thanks the the `VideoThumbnailLoader` tool
-      //
-      // 2.   Through an especially-purposed "thumbnail track" in a Manifest
-      //      which usually is based on tiles of jpg/png images. Those are loadd
-      //      through specific RxPlayer method.
-      if (showVideoThumbnail) {
-        if (videoThumbnailLoader === null) {
-          return;
-        }
         videoThumbnailLoader
           .setTime(ceiledTime)
           .then(hideSpinner)
@@ -108,43 +108,43 @@ export default function ThumbnailPreview({
               console.error("Error while loading thumbnails:", err);
             }
           });
-      } else {
-        const metadata = player.actions.getAvailableThumbnailTracks(ceiledTime);
-        const thumbnailTrack = metadata.reduce((acc: IThumbnailTrackInfo | null, t) => {
-          if (acc === null || acc.height === undefined) {
-            return t;
-          }
-          if (t.height === undefined) {
-            return acc;
-          }
-          if (acc.height > t.height) {
-            return t.height > 100 ? t : acc;
-          } else {
-            return acc.height > 100 ? acc : t;
-          }
-        }, null);
-        if (thumbnailTrack === null || imageThumbnailRef.current === null) {
-          hideSpinner();
-          return;
+      }, 30);
+    } else {
+      const metadata = player.actions.getAvailableThumbnailTracks(ceiledTime);
+      const thumbnailTrack = metadata.reduce((acc: IThumbnailTrackInfo | null, t) => {
+        if (acc === null || acc.height === undefined) {
+          return t;
         }
-        player.actions
-          .renderThumbnail(imageThumbnailRef.current, ceiledTime, thumbnailTrack.id)
-          .then(hideSpinner)
-          .catch((err) => {
-            if (
-              typeof err === "object" &&
-              err !== null &&
-              (err as Partial<Record<string, unknown>>).code === "ABORTED"
-            ) {
-              return;
-            } else {
-              hideSpinner();
-              // eslint-disable-next-line no-console
-              console.warn("Error while loading thumbnails:", err);
-            }
-          });
+        if (t.height === undefined) {
+          return acc;
+        }
+        if (acc.height > t.height) {
+          return t.height > 100 ? t : acc;
+        } else {
+          return acc.height > 100 ? acc : t;
+        }
+      }, null);
+      if (thumbnailTrack === null || imageThumbnailRef.current === null) {
+        hideSpinner();
+        return;
       }
-    }, 30);
+      player.actions
+        .renderThumbnail(imageThumbnailRef.current, ceiledTime, thumbnailTrack.id)
+        .then(hideSpinner)
+        .catch((err) => {
+          if (
+            typeof err === "object" &&
+            err !== null &&
+            (err as Partial<Record<string, unknown>>).code === "ABORTED"
+          ) {
+            return;
+          } else {
+            hideSpinner();
+            // eslint-disable-next-line no-console
+            console.warn("Error while loading thumbnails:", err);
+          }
+        });
+    }
 
     return () => {
       if (loadThumbnailTimeout !== null) {

--- a/src/core/fetchers/index.ts
+++ b/src/core/fetchers/index.ts
@@ -23,7 +23,7 @@ import type {
 import ManifestFetcher from "./manifest";
 import type { SegmentQueue, ISegmentQueueCreatorBackoffOptions } from "./segment";
 import SegmentQueueCreator from "./segment";
-import createThumbnailFetcher, { getThumbnailFetcherRequestOptions } from "./thumbnails";
+import createThumbnailFetcher from "./thumbnails";
 import type { IThumbnailFetcher } from "./thumbnails";
 
 export type {
@@ -34,10 +34,4 @@ export type {
   SegmentQueue,
   IThumbnailFetcher,
 };
-export {
-  CdnPrioritizer,
-  ManifestFetcher,
-  SegmentQueueCreator,
-  createThumbnailFetcher,
-  getThumbnailFetcherRequestOptions,
-};
+export { CdnPrioritizer, ManifestFetcher, SegmentQueueCreator, createThumbnailFetcher };

--- a/src/core/fetchers/thumbnails/index.ts
+++ b/src/core/fetchers/thumbnails/index.ts
@@ -1,8 +1,5 @@
-import createThumbnailFetcher, {
-  getThumbnailFetcherRequestOptions,
-} from "./thumbnail_fetcher";
+import createThumbnailFetcher from "./thumbnail_fetcher";
 import type { IThumbnailFetcher } from "./thumbnail_fetcher";
 
 export default createThumbnailFetcher;
-export { getThumbnailFetcherRequestOptions };
 export type { IThumbnailFetcher };

--- a/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
+++ b/src/core/fetchers/thumbnails/thumbnail_fetcher.ts
@@ -3,15 +3,17 @@ import { formatError } from "../../../errors";
 import log from "../../../log";
 import type { ISegment, IThumbnailTrack } from "../../../manifest";
 import type { ICdnMetadata } from "../../../parsers/manifest";
+import type { IPeriod } from "../../../public_types";
 import type {
   IThumbnailLoader,
   IThumbnailLoaderOptions,
   IThumbnailPipeline,
   IThumbnailResponse,
 } from "../../../transports";
+import arrayFind from "../../../utils/array_find";
 import objectAssign from "../../../utils/object_assign";
 import type { CancellationSignal } from "../../../utils/task_canceller";
-import { CancellationError } from "../../../utils/task_canceller";
+import TaskCanceller, { CancellationError } from "../../../utils/task_canceller";
 import type CdnPrioritizer from "../cdn_prioritizer";
 import errorSelector from "../utils/error_selector";
 import { scheduleRequestWithCdns } from "../utils/schedule_request";
@@ -42,22 +44,82 @@ export default function createThumbnailFetcher(
 ): IThumbnailFetcher {
   const { loadThumbnail } = pipeline;
 
-  // TODO short-lived cache?
+  interface IPendingThumbnailRequestInfo {
+    /** Promise behind the thumbnail request. */
+    promise: Promise<IThumbnailResponse>;
+    /**
+     * Multiple caller might share the same request promise.
+     * This reference counter keeps track of the number of caller that are
+     * currently waiting for that promise to be fulfilled.
+     * If reaching `0` before the promise resolves or rejects, we know we can
+     * cancel the request.
+     */
+    referenceCount: number;
+    /** Information linked to that thumbnail segment. */
+    thumbnailContext: {
+      segment: ISegment;
+      track: IThumbnailTrack;
+      period: IPeriod;
+    };
+  }
+
+  // We store information on pending requests, as often the same thumbnail is
+  // requested many times in a row (due to e.g. the mouse cursor rapidly moving
+  // on the seek bar).
+  // So `pendingRequestsInfo` contains metadata on the pending thumbnail request
+  // if one or else `null`.
+  const pendingRequestsInfo: IPendingThumbnailRequestInfo[] = [];
 
   /**
-   * Fetch a specific segment.
-   * @param {Object} thumbnail
-   * @param {Object} thumbnailTrack
-   * @param {Object} requestOptions
+   * Fetch a specific thumbnail.
+   * @param {Object} thumbnailContext
    * @param {Object} cancellationSignal
    * @returns {Promise}
    */
   return async function fetchThumbnail(
-    thumbnail: ISegment,
-    thumbnailTrack: IThumbnailTrack,
-    requestOptions: IThumbnailFetcherOptions,
+    thumbnailContext: {
+      segment: ISegment;
+      track: IThumbnailTrack;
+      period: IPeriod;
+    },
     cancellationSignal: CancellationSignal,
   ): Promise<IThumbnailResponse> {
+    cancellationSignal.register(onCancellation);
+
+    let currRequestInfo: IPendingThumbnailRequestInfo;
+
+    // First check if we're not requesting again the last thumbnail
+    const pendingInfo = arrayFind(pendingRequestsInfo, ({ thumbnailContext: pCtxt }) => {
+      return (
+        pCtxt.period.id === thumbnailContext.period.id &&
+        pCtxt.track.id === thumbnailContext.track.id &&
+        pCtxt.segment.id === thumbnailContext.segment.id
+      );
+    });
+
+    if (pendingInfo !== undefined) {
+      log.debug("TF: Requesting same thumbnail than the pending one");
+      currRequestInfo = pendingInfo;
+      currRequestInfo.referenceCount++;
+
+      // Same thumbnail than the pending one, return it.
+      let response;
+      try {
+        response = await currRequestInfo.promise;
+      } catch (err) {
+        cancellationSignal.deregister(onCancellation);
+        throw err;
+      }
+      cancellationSignal.deregister(onCancellation);
+      return response;
+    }
+
+    const { segment: thumbnail, track: thumbnailTrack } = thumbnailContext;
+
+    // NOTE: For now, as multiple `fetchThumbnail` calls might rely on the
+    // same request, it is difficult to let different request options
+    // per call. So this is not enabled yet.
+    const requestOptions = getThumbnailFetcherRequestOptions({});
     let connectionTimeout;
     if (
       requestOptions.connectionTimeout === undefined ||
@@ -74,48 +136,87 @@ export default function createThumbnailFetcher(
       cmcdPayload: undefined,
     };
 
-    log.debug("TF: Beginning thumbnail request", thumbnail.time);
-    cancellationSignal.register(onCancellation);
-    let res;
-    try {
-      res = await scheduleRequestWithCdns(
-        thumbnailTrack.cdnMetadata,
-        cdnPrioritizer,
-        callLoaderWithUrl,
-        objectAssign({ onRetry }, requestOptions),
-        cancellationSignal,
-      );
-
-      if (cancellationSignal.isCancelled()) {
-        return Promise.reject(cancellationSignal.cancellationError);
+    /**
+     * `TaskCanceller` linked to the thumbnail request.
+     * This is different than `cancellationSignal` which is linked to this call,
+     * as several calls might share the same request.
+     */
+    const requestCanceller = new TaskCanceller();
+    const fetchPromise = doFetch();
+    currRequestInfo = {
+      thumbnailContext,
+      promise: fetchPromise,
+      referenceCount: 1,
+    };
+    pendingRequestsInfo.push(currRequestInfo);
+    const clearRequestInfo = (): void => {
+      const currRequestIdx = pendingRequestsInfo.indexOf(currRequestInfo);
+      if (currRequestIdx >= 0) {
+        pendingRequestsInfo.splice(currRequestIdx, 1);
       }
-
-      log.debug("TF: Thumbnail request ended with success", thumbnail.time);
-      cancellationSignal.deregister(onCancellation);
+    };
+    try {
+      const fetchResult = await fetchPromise;
+      clearRequestInfo();
+      return fetchResult;
     } catch (err) {
-      cancellationSignal.deregister(onCancellation);
-      if (err instanceof CancellationError) {
-        log.debug("TF: Thumbnail request aborted", thumbnail.time);
-        throw err;
-      }
-      log.debug("TF: Thumbnail request failed", thumbnail.time);
-      throw errorSelector(err);
+      clearRequestInfo();
+      throw err;
     }
 
-    try {
-      const parsed = pipeline.parseThumbnail(res.responseData, {
-        thumbnail,
-        thumbnailTrack,
-      });
-      return parsed;
-    } catch (error) {
-      throw formatError(error, {
-        defaultCode: "PIPELINE_PARSE_ERROR",
-        defaultReason: "Unknown parsing error",
-      });
+    async function doFetch() {
+      log.debug("TF: Beginning thumbnail request", thumbnail.time);
+      let res;
+      try {
+        res = await scheduleRequestWithCdns(
+          thumbnailTrack.cdnMetadata,
+          cdnPrioritizer,
+          callLoaderWithUrl,
+          objectAssign({ onRetry }, requestOptions),
+          requestCanceller.signal,
+        );
+
+        if (cancellationSignal.isCancelled()) {
+          return Promise.reject(cancellationSignal.cancellationError);
+        }
+
+        log.debug("TF: Thumbnail request ended with success", thumbnail.time);
+        cancellationSignal.deregister(onCancellation);
+      } catch (err) {
+        cancellationSignal.deregister(onCancellation);
+        if (err instanceof CancellationError) {
+          log.debug("TF: Thumbnail request aborted", thumbnail.time);
+          throw err;
+        }
+        log.debug("TF: Thumbnail request failed", thumbnail.time);
+        throw errorSelector(err);
+      }
+
+      try {
+        const parsed = pipeline.parseThumbnail(res.responseData, {
+          thumbnail,
+          thumbnailTrack,
+        });
+        return parsed;
+      } catch (error) {
+        throw formatError(error, {
+          defaultCode: "PIPELINE_PARSE_ERROR",
+          defaultReason: "Unknown parsing error",
+        });
+      }
     }
+
     function onCancellation() {
       log.debug("TF: Thumbnail request cancelled", thumbnail.time);
+      const requestIdx = pendingRequestsInfo.indexOf(currRequestInfo);
+      if (requestIdx < 0) {
+        return;
+      }
+      pendingRequestsInfo[requestIdx].referenceCount--;
+      if (pendingRequestsInfo[requestIdx].referenceCount <= 0) {
+        requestCanceller.cancel();
+        pendingRequestsInfo.splice(requestIdx, 1);
+      }
     }
 
     /**
@@ -155,15 +256,15 @@ export default function createThumbnailFetcher(
  * success or on error.
  */
 export type IThumbnailFetcher = (
-  /** Actual thumbnail you want to load */
-  thumbnail: ISegment,
-  /** Metadata on the linked thumbnails track. */
-  thumbnailTrack: IThumbnailTrack,
-  /**
-   * Various tweaking requestOptions allowing to configure the behavior of the returned
-   * `IThumbnailFetcher` regarding segment requests.
-   */
-  requestOptions: IThumbnailFetcherOptions,
+  /** Context on the thumbnail you want to load */
+  thumbnailContext: {
+    /** Thumbnail "segment". */
+    segment: ISegment;
+    /** Metadata on the linked thumbnails track. */
+    track: IThumbnailTrack;
+    /** Metadata on the `Period` this thumbnail track is a part of. */
+    period: IPeriod;
+  },
   /** CancellationSignal allowing to cancel the request. */
   cancellationSignal: CancellationSignal,
 ) => Promise<IThumbnailResponse>;
@@ -203,7 +304,7 @@ export interface IThumbnailFetcherOptions {
  * @param {Object} baseOptions
  * @returns {Object}
  */
-export function getThumbnailFetcherRequestOptions({
+function getThumbnailFetcherRequestOptions({
   maxRetry,
   requestTimeout,
   connectionTimeout,

--- a/src/core/main/common/get_thumbnail_data.ts
+++ b/src/core/main/common/get_thumbnail_data.ts
@@ -2,7 +2,6 @@ import type { IManifest } from "../../../manifest";
 import type { IThumbnailResponse } from "../../../transports";
 import arrayFind from "../../../utils/array_find";
 import TaskCanceller from "../../../utils/task_canceller";
-import { getThumbnailFetcherRequestOptions } from "../../fetchers";
 import type { IThumbnailFetcher } from "../../fetchers";
 
 /**
@@ -35,9 +34,7 @@ export default async function getThumbnailData(
     throw new Error("No thumbnail for the given timestamp");
   }
   return fetchThumbnails(
-    wantedThumbnail,
-    thumbnailTrack,
-    getThumbnailFetcherRequestOptions({}),
+    { segment: wantedThumbnail, track: thumbnailTrack, period },
     new TaskCanceller().signal,
   );
 }

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -753,6 +753,10 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         getLoadedReference(playbackObserver, false, cancelSignal).onUpdate(
           (isLoaded, stopListening) => {
             if (isLoaded) {
+              const fetchThumbnails = createThumbnailFetcher(
+                transport.thumbnails,
+                cdnPrioritizer,
+              );
               stopListening();
               this.trigger("loaded", {
                 getSegmentSinkMetrics: async () => {
@@ -765,10 +769,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
                   thumbnailTrackId: string,
                   time: number,
                 ): Promise<IThumbnailResponse> => {
-                  const fetchThumbnails = createThumbnailFetcher(
-                    transport.thumbnails,
-                    cdnPrioritizer,
-                  );
                   return getThumbnailData(
                     fetchThumbnails,
                     manifest,

--- a/src/main_thread/render_thumbnail.ts
+++ b/src/main_thread/render_thumbnail.ts
@@ -51,7 +51,7 @@ export default async function renderThumbnail(
 
   const { thumbnailRequestsInfo, currentContentCanceller } = contentInfos;
   const canceller = new TaskCanceller();
-  canceller.linkToSignal(currentContentCanceller.signal);
+  const unlinkCanceller = canceller.linkToSignal(currentContentCanceller.signal);
 
   let imageUrl: string | undefined;
 
@@ -61,6 +61,7 @@ export default async function renderThumbnail(
   thumbnailRequestsInfo.pendingRequests.set(container, canceller);
 
   const onFinished = () => {
+    unlinkCanceller();
     canceller.cancel();
     thumbnailRequestsInfo.pendingRequests.delete(container);
 
@@ -153,6 +154,11 @@ export default async function renderThumbnail(
     canvas.width = res.thumbnails[foundIdx].width;
     return new Promise((resolve, reject) => {
       image.onload = () => {
+        if (canceller.signal.cancellationError !== null) {
+          reject(canceller.signal.cancellationError);
+          onFinished();
+          return;
+        }
         try {
           context.drawImage(
             image,
@@ -184,6 +190,11 @@ export default async function renderThumbnail(
       };
 
       image.onerror = () => {
+        if (canceller.signal.cancellationError !== null) {
+          reject(canceller.signal.cancellationError);
+          onFinished();
+          return;
+        }
         if (options.keepPreviousThumbnailOnError !== true) {
           clearPreviousThumbnails();
         }


### PR DESCRIPTION
When I demoed how DASH thumbnails worked in the RxPlayer demo, I was unhappy to realize that there was a noticeable delay when quickly moving the mouse over the seekbar.

https://github.com/user-attachments/assets/89a33940-ccbd-406d-9ef1-bd0ac95bbfe9

_Video: how thumbnails displayed before in our demo page. It's slow and, especially for `tile5`, we can see that it's requested multiple times._

This is both because we have a timer in our demo of a few milliseconds before doing the actual thumbnail request, and even much more importantly because the RxPlayer cancel the last thumbnail request when the application decides to fetch one from a new position instead.

Yet positions that are sufficiently close (which is frequent when moving the mouse over a seekbar) are often going to lead to the same thumbnail request. Here cancelling the last one is unfortunate: we should reuse the same request.

---

We already have a thumbnail cache but sadly enough it is only populated once the request is done. If the request is still pending and an application ask a thumbnail for a new position, we're going to run a new request even if it leads to the same thumbnail.

Our "last loaded" cache was in main thread, which does not even know the relation between the wanted time and the corresponding thumbnail, so this new logic cannot be added there.

Instead I added another level of "cache" in our `ThumbnailFetcher` (in `core/fetchers`) for the pending request only. The result is much more satisfying:


https://github.com/user-attachments/assets/21e381e8-5a7f-448b-8762-bcd709f6a568

