### PR TITLE
Fix: representation returned by public API has incorrect shape

### DIFF
--- a/src/main_thread/api/__tests__/public_api.test.ts
+++ b/src/main_thread/api/__tests__/public_api.test.ts
@@ -1,5 +1,10 @@
 import { describe, beforeEach, it, expect, vi } from "vitest";
+import type { IBufferType } from "../../../core/types";
+import type { IRepresentationMetadata } from "../../../manifest";
+import type { IAudioRepresentation, IVideoRepresentation } from "../../../public_types";
+import TaskCanceller from "../../../utils/task_canceller";
 import type IPublicAPI from "../public_api";
+import type { IPublicApiContentInfos } from "../public_api";
 
 describe("API - Public API", () => {
   beforeEach(() => {
@@ -122,20 +127,74 @@ describe("API - Public API", () => {
     });
 
     describe("getVideoRepresentation", () => {
-      it("should return undefined in getVideoRepresentation by default", async () => {
+      let player: IPublicAPI;
+      beforeEach(async () => {
         const PublicAPI = (await vi.importActual("../public_api"))
           .default as typeof IPublicAPI;
-        const player = new PublicAPI();
+        player = new PublicAPI();
+      });
+
+      it("should return undefined in getVideoRepresentation by default", async () => {
         expect(player.getVideoRepresentation()).toBe(undefined);
+      });
+
+      it("should return the video representation if available", () => {
+        const mockGetCurrentRepresentation: Partial<
+          Record<IBufferType, IRepresentationMetadata | null>
+        > = {
+          video: {
+            id: "1",
+            bitrate: 1000,
+            codecs: ["avc1"],
+            uniqueId: "unique1",
+            isSupported: true,
+          },
+        };
+        vi.spyOn(player, "__priv_getCurrentRepresentations").mockReturnValue(
+          mockGetCurrentRepresentation,
+        );
+        expect(player.getVideoRepresentation()).toEqual({
+          id: "1",
+          bitrate: 1000,
+          codec: "avc1",
+          isCodecSupported: true,
+        } satisfies IVideoRepresentation);
       });
     });
 
     describe("getAudioRepresentation", () => {
-      it("should return undefined in getAudioRepresentation by default", async () => {
+      let player: IPublicAPI;
+
+      beforeEach(async () => {
         const PublicAPI = (await vi.importActual("../public_api"))
           .default as typeof IPublicAPI;
-        const player = new PublicAPI();
+        player = new PublicAPI();
+      });
+
+      it("should return undefined in getAudioRepresentation by default", async () => {
         expect(player.getAudioRepresentation()).toBe(undefined);
+      });
+      it("should return the audio representation if available", () => {
+        const mockGetCurrentRepresentation: Partial<
+          Record<IBufferType, IRepresentationMetadata | null>
+        > = {
+          audio: {
+            id: "2",
+            bitrate: 1000,
+            codecs: ["mp4a"],
+            uniqueId: "unique2",
+            isSupported: true,
+          },
+        };
+        vi.spyOn(player, "__priv_getCurrentRepresentations").mockReturnValue(
+          mockGetCurrentRepresentation,
+        );
+        expect(player.getAudioRepresentation()).toEqual({
+          id: "2",
+          bitrate: 1000,
+          codec: "mp4a",
+          isCodecSupported: true,
+        } satisfies IAudioRepresentation);
       });
     });
 
@@ -510,6 +569,116 @@ describe("API - Public API", () => {
          *
          */
         warn.mockClear();
+      });
+    });
+  });
+
+  describe("event emitters", () => {
+    describe("videoRepresentationChange", () => {
+      let player: IPublicAPI;
+      beforeEach(async () => {
+        const PublicAPI = (await vi.importActual("../public_api"))
+          .default as typeof IPublicAPI;
+        player = new PublicAPI();
+      });
+
+      it("should trigger videoRepresentationChange on representation change", async () => {
+        const taskCanceller = new TaskCanceller();
+        const contentInfos: Partial<IPublicApiContentInfos> = {
+          contentId: "123",
+          originalUrl: undefined,
+          isDirectFile: false,
+          defaultAudioTrackSwitchingMode: "direct",
+          currentPeriod: {
+            id: "p1",
+            start: 0,
+            adaptations: { video: [] },
+            streamEvents: [],
+            thumbnailTracks: [],
+          },
+          currentContentCanceller: taskCanceller,
+          activeRepresentations: null,
+        };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (player as any)._priv_contentInfos = contentInfos;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const spy = vi.spyOn(player as any, "_priv_triggerEventIfNotStopped");
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (player as any)._priv_onRepresentationChange(contentInfos, {
+          type: "video",
+          period: { id: "p1" },
+          representation: {
+            id: "1",
+            bitrate: 1000,
+            codecs: ["avc1"],
+            uniqueId: "unique1",
+            isSupported: true,
+          } satisfies IRepresentationMetadata,
+        });
+        expect(spy).toHaveBeenCalledWith(
+          "videoRepresentationChange",
+          {
+            id: "1",
+            bitrate: 1000,
+            codec: "avc1",
+            isCodecSupported: true,
+          } satisfies IVideoRepresentation,
+          taskCanceller.signal,
+        );
+      });
+    });
+
+    describe("audioRepresentationChange", () => {
+      let player: IPublicAPI;
+      beforeEach(async () => {
+        const PublicAPI = (await vi.importActual("../public_api"))
+          .default as typeof IPublicAPI;
+        player = new PublicAPI();
+      });
+
+      it("should trigger audioRepresentationChange on representation change", async () => {
+        const taskCanceller = new TaskCanceller();
+        const contentInfos: Partial<IPublicApiContentInfos> = {
+          contentId: "123",
+          originalUrl: undefined,
+          isDirectFile: false,
+          defaultAudioTrackSwitchingMode: "direct",
+          currentPeriod: {
+            id: "p1",
+            start: 0,
+            adaptations: { audio: [] },
+            streamEvents: [],
+            thumbnailTracks: [],
+          },
+          currentContentCanceller: taskCanceller,
+          activeRepresentations: null,
+        };
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (player as any)._priv_contentInfos = contentInfos;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const spy = vi.spyOn(player as any, "_priv_triggerEventIfNotStopped");
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        (player as any)._priv_onRepresentationChange(contentInfos, {
+          type: "audio",
+          period: { id: "p1" },
+          representation: {
+            id: "2",
+            bitrate: 1000,
+            codecs: ["mp4a"],
+            uniqueId: "unique2",
+            isSupported: true,
+          } satisfies IRepresentationMetadata,
+        });
+        expect(spy).toHaveBeenCalledWith(
+          "audioRepresentationChange",
+          {
+            id: "2",
+            bitrate: 1000,
+            codec: "mp4a",
+            isCodecSupported: true,
+          } satisfies IAudioRepresentation,
+          taskCanceller.signal,
+        );
       });
     });
   });

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -63,6 +63,8 @@ import {
   ManifestMetadataFormat,
   createRepresentationFilterFromFnString,
   getPeriodForTime,
+  toVideoRepresentation,
+  toAudioRepresentation,
 } from "../../manifest";
 import type { IWorkerMessage } from "../../multithread_types";
 import { MainThreadMessageType, WorkerMessageType } from "../../multithread_types";
@@ -1721,7 +1723,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (representations === null) {
       return undefined;
     }
-    return representations.video;
+    return isNullOrUndefined(representations.video)
+      ? representations.video
+      : toVideoRepresentation(representations.video);
   }
 
   /**
@@ -1738,7 +1742,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     if (representations === null) {
       return undefined;
     }
-    return representations.audio;
+    return isNullOrUndefined(representations.audio)
+      ? representations.video
+      : toAudioRepresentation(representations.audio);
   }
 
   /**
@@ -2932,13 +2938,17 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const audioRepresentation = this.__priv_getCurrentRepresentations()?.audio ?? null;
     this._priv_triggerEventIfNotStopped(
       "audioRepresentationChange",
-      audioRepresentation,
+      isNullOrUndefined(audioRepresentation)
+        ? audioRepresentation
+        : toVideoRepresentation(audioRepresentation),
       cancelSignal,
     );
     const videoRepresentation = this.__priv_getCurrentRepresentations()?.video ?? null;
     this._priv_triggerEventIfNotStopped(
       "videoRepresentationChange",
-      videoRepresentation,
+      isNullOrUndefined(videoRepresentation)
+        ? videoRepresentation
+        : toVideoRepresentation(videoRepresentation),
       cancelSignal,
     );
   }
@@ -3153,13 +3163,17 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (type === "video") {
         this._priv_triggerEventIfNotStopped(
           "videoRepresentationChange",
-          representation,
+          isNullOrUndefined(representation)
+            ? representation
+            : toVideoRepresentation(representation),
           cancelSignal,
         );
       } else if (type === "audio") {
         this._priv_triggerEventIfNotStopped(
           "audioRepresentationChange",
-          representation,
+          isNullOrUndefined(representation)
+            ? representation
+            : toAudioRepresentation(representation),
           cancelSignal,
         );
       }

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -322,7 +322,7 @@ export function toVideoTrack(
  * Format Representation as an `IAudioRepresentation`.
  * @returns {Object}
  */
-function toAudioRepresentation(
+export function toAudioRepresentation(
   representation: IRepresentationMetadata,
 ): IAudioRepresentation {
   const { id, bitrate, codecs, isSpatialAudio, isSupported, decipherable } =
@@ -341,7 +341,7 @@ function toAudioRepresentation(
  * Format Representation as an `IVideoRepresentation`.
  * @returns {Object}
  */
-function toVideoRepresentation(
+export function toVideoRepresentation(
   representation: IRepresentationMetadata,
 ): IVideoRepresentation {
   const {


### PR DESCRIPTION
The methods `getVideoRepresentation` and `getAudioRepresentation` returns object that are not matching the shape described in the documentation.
The issue is also present on events payload for events `videoRepresentationChange` and `audioRepresentationChange`.