### PR TITLE
Make "local-manifest" contents support forced subtitles

### DIFF
--- a/doc/api/Miscellaneous/Local_Contents.md
+++ b/doc/api/Miscellaneous/Local_Contents.md
@@ -276,6 +276,7 @@ We'll finish with a text track example:
   closedCaption: false, // if `true`, that text track contains supplementary
                         // cues about the audio content (generally used for the
                         // hard of hearing)
+  forcedSubtitles: false, // if `true`, that text track contains "forced subtitles".
   representations: [ /* ... */ ]
 }
 ```
@@ -313,12 +314,14 @@ Here how it looks when adaptations are integrated in a given period:
       type: "text",
       language: "fra",
       closedCaption: false,
+      forcedSubtitles: false,
       representations: [ /* ... */ ]
     },
     {
       type: "text",
       language: "fra",
       closedCaption: true,
+      forcedSubtitles: false,
       representations: [ /* ... */ ]
     }
   ]
@@ -350,6 +353,14 @@ The following properties are found in an adaptation object:
   is generally only relevant for text tracks helping to understand what's on the screen.
   Mostly useful for the visually impaired, this property is generally only relevant for
   audio tracks.
+
+- forcedSubtitles (`boolean|undefined`): If `true`, that text track is intended as a
+  "forced subtitles" text track, which is the text track to display when there's no other
+  text track selected.
+
+  This type of text track usually contains e.g. translation of foreign language inside a
+  film (think things like klingon in star trek for example) or important foreign writing
+  that needs translation on screen.
 
 - representations (`Array.<Object>`): The different available qualities for this track.
   Will be described below.

--- a/src/parsers/manifest/local/parse_local_manifest.ts
+++ b/src/parsers/manifest/local/parse_local_manifest.ts
@@ -127,6 +127,7 @@ function parseAdaptation(
     type: adaptation.type,
     audioDescription: adaptation.audioDescription,
     closedCaption: adaptation.closedCaption,
+    forcedSubtitles: adaptation.forcedSubtitles,
     language: adaptation.language,
     representations: adaptation.representations.map((representation) =>
       parseRepresentation(representation, { representationIdGenerator }),

--- a/src/parsers/manifest/local/types.ts
+++ b/src/parsers/manifest/local/types.ts
@@ -210,6 +210,8 @@ export interface ILocalAdaptation {
   audioDescription?: boolean;
   /** If `true`, this track contains closed captions. */
   closedCaption?: boolean;
+  /** If `true`, this track contains "forced subtitles". */
+  forcedSubtitles?: boolean;
   /** The ISO 639-3, ISO 639-2 or ISO 639-1 language code for that track. */
   language?: string;
   /** The different qualities this track is available in. */

--- a/src/parsers/manifest/types.ts
+++ b/src/parsers/manifest/types.ts
@@ -270,7 +270,7 @@ export interface IParsedAdaptation {
    * languages, texted graphics or location/person IDs that are not otherwise
    * covered in the dubbed/localized audio Adaptation.
    */
-  forcedSubtitles?: boolean;
+  forcedSubtitles?: boolean | undefined;
   /**
    * If true this Adaptation is in a dub: it was recorded in another language
    * than the original(s) one(s).


### PR DESCRIPTION
We never made our "local-manifest" manifest format, which is an RxPlayer-specific format for contents loaded locally, compatible with "forced subtitles".

Forced subtitles are subtitles that should be displayed when no other subtitles is displayed. There are here for cases where subtitling is needed in any case: foreign characters that needs on-screen translation foreign/invented languages (e.g. klingon in star trek) that should be translated through subtitles etc.

Here I chose to just add the `forcedSubtitles` boolean to a `local-manifest`'s `Adaptation` concept to indicate that that track defines forced subtitles.