### PR TITLE
`MULTI_THREAD`: Add `LOCAL_MANIFEST` optional feature to importable worker

### DIFF
--- a/doc/Getting_Started/ImportableWorker.md
+++ b/doc/Getting_Started/ImportableWorker.md
@@ -258,6 +258,7 @@ For now only the following features exist:
 | ------------------- | --------------------------------------------------------- |
 | `DASH` [1]          | Enable DASH playback using a JavaScript-based MPD parser  |
 | `DASH_WASM` [1] [2] | Enable DASH playback using a WebAssembly-based MPD parser |
+| `LOCAL_MANIFEST`    | Enable playback of "local" contents                       |
 
 ---
 

--- a/doc/Getting_Started/MultiThreading.md
+++ b/doc/Getting_Started/MultiThreading.md
@@ -176,8 +176,12 @@ following conditions are respected:
   `loadVideo` call on that same RxPlayer instance, and the returned Promise is either
   still pending or resolved (i.e. it hasn't rejected).
 
-- You're playing a DASH content (through the `"dash"` `transport` option of the
-  `loadVideo` call).
+- You're playing either a DASH content (through the `"dash"` `transport` option of the
+  `loadVideo` call), or a "local-manifest" content (through the `"local"` `transport`).
+
+  Note that if you're playing a "local-manifest" content, you'll have to add the
+  `LOCAL_MANIFEST` feature [to your own worker bundle](./ImportableWorker.md) to make it
+  work.
 
 - You did not force the `"main"` mode through the
   [`mode` `loadVideo` option](../api/Loading_a_Content.md#mode).

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -105,7 +105,9 @@ Can be either:
 
   - For RxPlayer's ["multithread" mode](../Getting_Started/MultiThreading.md):
 
-    "local" transport is not yet available in that mode.
+    You will need to rely on an
+    [importable worker](../Getting_Started/ImportableWorker.md), and add the
+    `LOCAL_MANIFEST` feature to it.
 
 Example:
 

--- a/src/experimental/features/worker/index.ts
+++ b/src/experimental/features/worker/index.ts
@@ -1,5 +1,5 @@
 export { DASH, DASH_WASM } from "../../../features/list";
+export { LOCAL_MANIFEST } from "../local";
 
-// TODO: `LOCAL_MANIFEST` (should already be compatible? To test)
 // TODO: `SMOOTH` (has to be made worker-compatible)
 // TODO: `METAPLAYLIST` (once every transport is ported)

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -3766,7 +3766,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       // TODO: Make it work with multithread?
       return false;
     }
-    if (options.transport !== "dash") {
+    if (options.transport !== "dash" && options.transport !== "local") {
       return false;
     }
     if (


### PR DESCRIPTION
Based on #1719 

This feature build on the "importable worker" concept of #1719 and adds the possibility to import another transport than DASH to it.

There was currently only DASH available in a webworker, meaning it misses the following transport:
  - `SMOOTH`: This one is not done yet because its Manifest parser still heavily relies on the DOMParser API. Once this code is translated to use our JS XML parser instead, it should be portable.
  
  - `LOCAL_MANIFEST`: This one was not done before because it relies on a complex `manifestLoader` callback, which required a solution like #1719 to be implemented.
  
     Now that #1719 is developed, we can add it in this PR without much efforts.
  
  - `METAPLAYLIST`: I will probably allow this one once `SMOOTH` is done. There's no reason it should be complex to port
  
  - `DIRECTFILE`: I don't think it would be useful to run that one's very minimal logic in a worker. It probably is more efficient in main thread only

The `LOCAL_MANIFEST` transport in-worker has been tested successfully tested on one of Canal+'s application.