### PR TITLE
[v3] [WIP] fix(safari): wait for canplay event to seek on safari

### DIFF
--- a/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
+++ b/src/compat/__tests__/should_wait_for_data_before_loaded.test.ts
@@ -31,6 +31,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
       return {
         __esModule: true as const,
         isSafariMobile: false,
+        isSafariDesktop: false,
       };
     });
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
@@ -44,6 +45,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
       return {
         __esModule: true as const,
         isSafariMobile: false,
+        isSafariDesktop: false,
       };
     });
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
@@ -59,6 +61,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
       return {
         __esModule: true as const,
         isSafariMobile: true,
+        isSafariDesktop: false,
       };
     });
     const shouldWaitForDataBeforeLoaded = jest.requireActual(
@@ -73,6 +76,7 @@ describe("compat - shouldWaitForDataBeforeLoaded", () => {
       return {
         __esModule: true as const,
         isSafariMobile: true,
+        isSafariDesktop: false,
       };
     });
     const shouldWaitForDataBeforeLoaded = jest.requireActual(

--- a/src/compat/can_preload_before_play.ts
+++ b/src/compat/can_preload_before_play.ts
@@ -1,0 +1,18 @@
+import { isSafariDesktop, isSafariMobile } from "./browser_detection";
+
+/**
+ * On Safari (both mobile and desktop), when using direct file playback,
+ * the `readyState` may remain at `1` (HAVE_METADATA) until `play()` is called,
+ * even though the media is effectively ready to play.
+ *
+ * In such cases, the media cannot be preloaded before `play()`.
+ * @param {boolean} isDirectfile - Whether playback is through directfile.
+ * @returns {boolean} - True if the media can be preloaded; false otherwise.
+ */
+export default function canPreloadBeforePlay(isDirectfile: boolean): boolean {
+  if (isDirectfile && (isSafariMobile || isSafariDesktop)) {
+    return false;
+  } else {
+    return true;
+  }
+}

--- a/src/compat/should_seek_only_after_canplay.ts
+++ b/src/compat/should_seek_only_after_canplay.ts
@@ -1,0 +1,10 @@
+import { isSafariDesktop, isSafariMobile } from "./browser_detection";
+
+/**
+ * On safari mobile (version 17.1.2) and desktop (version 18.4) seeking too early cause
+ * the video to never buffer media data. Particularly if the user agent has blocked autoplay.
+ * Using delaying mechanisms such as seeking after the "canplay" event defers the seek
+ * to a moment at which safari should be more able to handle a seek.
+ */
+const shouldWaitCanPlayEventForSeeking = isSafariMobile || isSafariDesktop;
+export default shouldWaitCanPlayEventForSeeking;

--- a/src/compat/should_wait_for_data_before_loaded.ts
+++ b/src/compat/should_wait_for_data_before_loaded.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isSafariMobile } from "./browser_detection";
+import { isSafariDesktop, isSafariMobile } from "./browser_detection";
 
 /**
  * On some browsers, the ready state might never go above `1` when autoplay is
@@ -25,7 +25,7 @@ import { isSafariMobile } from "./browser_detection";
  * @returns {Boolean}
  */
 export default function shouldWaitForDataBeforeLoaded(isDirectfile: boolean): boolean {
-  if (isDirectfile && isSafariMobile) {
+  if (isDirectfile && (isSafariMobile || isSafariDesktop)) {
     return false;
   } else {
     return true;

--- a/src/core/api/__tests__/utils.test.ts
+++ b/src/core/api/__tests__/utils.test.ts
@@ -28,18 +28,34 @@ describe("API - getLoadedContentState", () => {
     const mediaElement = fakeProps as HTMLMediaElement;
 
     // we can just do every possibility here
-    expect(getLoadedContentState(mediaElement, null)).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, null, false, "STOPPED")).toBe("ENDED");
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, null)).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, null, false, "STOPPED")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
     fakeProps.paused = false;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
   });
 
   it("should be PLAYING if not stalled nor ended and if not paused", () => {
@@ -50,7 +66,7 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, null)).toBe("PLAYING");
+    expect(getLoadedContentState(mediaElement, null, false, "STOPPED")).toBe("PLAYING");
   });
 
   it("should be PAUSED if not stalled nor ended and if paused", () => {
@@ -61,7 +77,7 @@ describe("API - getLoadedContentState", () => {
       paused: true,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, null)).toBe("PAUSED");
+    expect(getLoadedContentState(mediaElement, null, false, "STOPPED")).toBe("PAUSED");
   });
 
   it("should be BUFFERING if not ended and stalled because of buffering", () => {
@@ -72,9 +88,13 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
   });
 
   it("should be BUFFERING if not ended and stalled because of freezing", () => {
@@ -85,9 +105,13 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
   });
 
   it("should be BUFFERING if not ended and stalled because of `not-ready`", () => {
@@ -98,9 +122,13 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("BUFFERING");
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "BUFFERING",
+    );
   });
 
   it("should be SEEKING if not ended and stalled because of `seeking`", () => {
@@ -111,9 +139,13 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "SEEKING",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("SEEKING");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "SEEKING",
+    );
   });
 
   it("should be ENDED if stalled and currentTime is equal to duration", () => {
@@ -124,15 +156,31 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
   });
 
   it("should be ENDED if stalled and currentTime is very close to the duration", () => {
@@ -143,15 +191,31 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement = fakeProps as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
     fakeProps.paused = true;
-    expect(getLoadedContentState(mediaElement, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
   });
   it("should be ENDED if stalled and currentTime is very close to the duration", () => {
     const fakeProps1 = {
@@ -161,15 +225,31 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement1 = fakeProps1 as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement1, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
     fakeProps1.paused = true;
-    expect(getLoadedContentState(mediaElement1, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement1, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement1, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement1, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
 
     const fakeProps2 = {
       ended: false,
@@ -178,14 +258,30 @@ describe("API - getLoadedContentState", () => {
       paused: false,
     };
     const mediaElement2 = fakeProps2 as HTMLMediaElement;
-    expect(getLoadedContentState(mediaElement2, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
     fakeProps2.paused = true;
-    expect(getLoadedContentState(mediaElement2, "seeking")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "buffering")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "not-ready")).toBe("ENDED");
-    expect(getLoadedContentState(mediaElement2, "freezing")).toBe("ENDED");
+    expect(getLoadedContentState(mediaElement2, "seeking", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "buffering", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "not-ready", false, "STOPPED")).toBe(
+      "ENDED",
+    );
+    expect(getLoadedContentState(mediaElement2, "freezing", false, "STOPPED")).toBe(
+      "ENDED",
+    );
   });
 });

--- a/src/core/api/public_api.ts
+++ b/src/core/api/public_api.ts
@@ -1032,6 +1032,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       initializer,
       videoElement,
       playbackObserver,
+      isDirectFile,
       currentContentCanceller.signal,
     );
     currentContentCanceller.signal.register(() => {

--- a/src/core/api/utils.ts
+++ b/src/core/api/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import canPreloadBeforePlay from "../../compat/can_preload_before_play";
 import config from "../../config";
 import type { IPlayerState } from "../../public_types";
 import arrayIncludes from "../../utils/array_includes";
@@ -112,6 +113,7 @@ export function constructPlayerStateReference(
   initializer: ContentInitializer,
   mediaElement: HTMLMediaElement,
   playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
+  isDirectFile: boolean,
   cancelSignal: CancellationSignal,
 ): IReadOnlySharedReference<IPlayerState> {
   const playerStateRef = new SharedReference<IPlayerState>(
@@ -124,13 +126,25 @@ export function constructPlayerStateReference(
       if (playerStateRef.getValue() === PLAYER_STATES.LOADING) {
         playerStateRef.setValue(PLAYER_STATES.LOADED);
         if (!cancelSignal.isCancelled()) {
-          const newState = getLoadedContentState(mediaElement, null);
+          const newState = getLoadedContentState(
+            mediaElement,
+            null,
+            isDirectFile,
+            playerStateRef.getValue(),
+          );
           if (newState !== PLAYER_STATES.PAUSED) {
             playerStateRef.setValue(newState);
           }
         }
       } else {
-        playerStateRef.setValueIfChanged(getLoadedContentState(mediaElement, null));
+        playerStateRef.setValueIfChanged(
+          getLoadedContentState(
+            mediaElement,
+            null,
+            isDirectFile,
+            playerStateRef.getValue(),
+          ),
+        );
       }
     },
     cancelSignal,
@@ -156,7 +170,14 @@ export function constructPlayerStateReference(
     (s) => {
       if (s !== prevStallReason) {
         if (isLoadedState(playerStateRef.getValue())) {
-          playerStateRef.setValueIfChanged(getLoadedContentState(mediaElement, s));
+          playerStateRef.setValueIfChanged(
+            getLoadedContentState(
+              mediaElement,
+              s,
+              isDirectFile,
+              playerStateRef.getValue(),
+            ),
+          );
         }
         prevStallReason = s;
       }
@@ -168,7 +189,14 @@ export function constructPlayerStateReference(
     () => {
       if (prevStallReason !== null) {
         if (isLoadedState(playerStateRef.getValue())) {
-          playerStateRef.setValueIfChanged(getLoadedContentState(mediaElement, null));
+          playerStateRef.setValueIfChanged(
+            getLoadedContentState(
+              mediaElement,
+              null,
+              isDirectFile,
+              playerStateRef.getValue(),
+            ),
+          );
         }
         prevStallReason = null;
       }
@@ -183,7 +211,12 @@ export function constructPlayerStateReference(
         arrayIncludes(["seeking", "ended", "play", "pause"], observation.event)
       ) {
         playerStateRef.setValueIfChanged(
-          getLoadedContentState(mediaElement, prevStallReason),
+          getLoadedContentState(
+            mediaElement,
+            prevStallReason,
+            isDirectFile,
+            playerStateRef.getValue(),
+          ),
         );
       }
     },
@@ -198,11 +231,14 @@ export function constructPlayerStateReference(
  * @param {Object} stalledStatus - Current stalled state:
  *   - null when not stalled
  *   - a description of the situation if stalled.
+ * @param {boolean} isDirectFile
  * @returns {string}
  */
 export function getLoadedContentState(
   mediaElement: HTMLMediaElement,
   stalledStatus: IStallingSituation | null,
+  isDirectFile: boolean,
+  previousState: IPlayerState,
 ): IPlayerState {
   const { FORCED_ENDED_THRESHOLD } = config.getCurrent();
   if (mediaElement.ended) {
@@ -224,7 +260,21 @@ export function getLoadedContentState(
       return PLAYER_STATES.ENDED;
     }
 
-    return stalledStatus === "seeking" ? PLAYER_STATES.SEEKING : PLAYER_STATES.BUFFERING;
+    if (stalledStatus === "seeking") {
+      return PLAYER_STATES.SEEKING;
+    }
+
+    if (previousState === PLAYER_STATES.LOADED && !canPreloadBeforePlay(isDirectFile)) {
+      /**
+       * On devices that do not support preloading, a data buffer cannot be constructed.
+       * Normally, this situation would trigger the BUFFERING state. However, since these devices
+       * are unable to buffer data, having low or no data is expected while waiting for a play() call.
+       * Therefore, in this case, we remain in the LOADED state instead of transitioning to BUFFERING.
+       */
+      return PLAYER_STATES.LOADED;
+    }
+
+    return PLAYER_STATES.BUFFERING;
   }
   return mediaElement.paused ? PLAYER_STATES.PAUSED : PLAYER_STATES.PLAYING;
 }


### PR DESCRIPTION
This is a partial backport of #1707 for the v3.

Still missing the logic in `initial_seek_and_play.ts` from it because I'm not totally sure of how it would be ported nor if it needs to be.

To investigate that one.