### PR TITLE
[v3] fix(DRM): renew the mediaKeySystemAccess on Edge and Firefox when using a Playready keySystem

### DIFF
--- a/src/compat/__tests__/should_renew_media_key_system_access.test.ts
+++ b/src/compat/__tests__/should_renew_media_key_system_access.test.ts
@@ -31,12 +31,16 @@ describe("compat - shouldRenewMediaKeySystemAccess", () => {
       return {
         __esModule: true as const,
         isIE11: false,
+        isEdgeChromium: false,
+        isFirefox: false,
       };
     });
     const shouldRenewMediaKeySystemAccess = jest.requireActual(
       "../should_renew_media_key_system_access",
     );
-    expect(shouldRenewMediaKeySystemAccess.default()).toBe(false);
+    expect(shouldRenewMediaKeySystemAccess.default("com.microsoft.playready")).toBe(
+      false,
+    );
   });
 
   it("should return true if we are on IE11", () => {
@@ -44,14 +48,13 @@ describe("compat - shouldRenewMediaKeySystemAccess", () => {
       return {
         __esModule: true as const,
         isIE11: true,
+        isEdgeChromium: false,
+        isFirefox: false,
       };
     });
     const shouldRenewMediaKeySystemAccess = jest.requireActual(
       "../should_renew_media_key_system_access",
     );
-    expect(shouldRenewMediaKeySystemAccess.default()).toBe(true);
-  });
-  beforeEach(() => {
-    jest.resetModules();
+    expect(shouldRenewMediaKeySystemAccess.default("com.microsoft.playready")).toBe(true);
   });
 });

--- a/src/compat/should_renew_media_key_system_access.ts
+++ b/src/compat/should_renew_media_key_system_access.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { isIE11 } from "./browser_detection";
+import { isIE11, isEdgeChromium, isFirefox } from "./browser_detection";
 
 /**
  * Returns true if the current target require the MediaKeySystemAccess to be
  * renewed on each content.
  * @returns {Boolean}
  */
-export default function shouldRenewMediaKeySystemAccess(): boolean {
-  return isIE11;
+export default function shouldRenewMediaKeySystemAccess(keySystem: string): boolean {
+  return keySystem.indexOf("playready") !== -1 && (isIE11 || isEdgeChromium || isFirefox);
 }

--- a/src/core/decrypt/find_key_system.ts
+++ b/src/core/decrypt/find_key_system.ts
@@ -394,7 +394,7 @@ export default function getMediaKeySystemAccess(
       // Check if the current `MediaKeySystemAccess` created cannot be reused here
       if (
         currentState !== null &&
-        !shouldRenewMediaKeySystemAccess() &&
+        !shouldRenewMediaKeySystemAccess(currentState.mediaKeySystemAccess.keySystem) &&
         // TODO: Do it with MediaKeySystemAccess.prototype.keySystem instead?
         keyType === currentState.mediaKeySystemAccess.keySystem &&
         eme.implementation === currentState.emeImplementation.implementation &&


### PR DESCRIPTION
This is a backport of #1694 for the upcoming v3.33.6