### PR TITLE
[v3] fix(firefox): check extensibly Playready DRMs support before using them

### DIFF
--- a/src/compat/can_rely_on_request_media_key_system_access.ts
+++ b/src/compat/can_rely_on_request_media_key_system_access.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isEdgeChromium } from "./browser_detection";
+import { isEdgeChromium, isFirefox } from "./browser_detection";
 
 /**
  * This functions tells if the RxPlayer can trust the browser when it has
@@ -29,13 +29,19 @@ import { isEdgeChromium } from "./browser_detection";
  *   "com.microsoft.playready.recommendation.3000", generating a request with
  *   `generateRequest` throws an error: "NotSupportedError: Failed to execute
  *   'generateRequest' on 'MediaKeySession': Failed to create MF PR CdmSession".
- *   In this particular case, the work-around was to consider
- *   recommendation.3000 as not supported and try another keySystem.
+ *   In this particular case, the work-around was to consider recommendation.3000 as not supported
+ *   and try another keySystem.
+ *
+ * - On Firefox v.137:
+ *   Similar issue with requestMediaKeySystemAccess that resolves correctly with
+ *   'com.microsoft.playready.recommendation.3000' but fail at the `createMediaKeys``
+ *   step with error `WMFCDMProxy: Init: WMFCDM init error`
+ *
  * @param keySystem - The key system in use.
  * @returns {boolean}
  */
 export function canRelyOnRequestMediaKeySystemAccess(keySystem: string): boolean {
-  if (isEdgeChromium && keySystem.indexOf("playready") !== -1) {
+  if ((isEdgeChromium || isFirefox) && keySystem.indexOf("playready") !== -1) {
     return false;
   }
   return true;


### PR DESCRIPTION
This is a backport of #1691 for the upcoming v3.33.6