### PR TITLE
Smooth: migrate from DOMParser API to our txml fork

### DIFF
--- a/src/parsers/manifest/smooth/create_parser.ts
+++ b/src/parsers/manifest/smooth/create_parser.ts
@@ -25,6 +25,7 @@ import getMonotonicTimeStamp from "../../../utils/monotonic_timestamp";
 import objectAssign from "../../../utils/object_assign";
 import { hexToBytes } from "../../../utils/string_parsing";
 import { getFilenameIndexInUrl } from "../../../utils/url-utils";
+import { parseXml, type ITNode } from "../../../utils/xml-parser";
 import { createBox } from "../../containers/isobmff";
 import type {
   IParsedAdaptation,
@@ -44,7 +45,7 @@ import reduceChildren from "./utils/reduceChildren";
 import { replaceRepresentationSmoothTokens } from "./utils/tokens";
 
 interface IAdaptationParserArguments {
-  root: Element;
+  root: ITNode;
   baseUrl: string;
   timescale: number;
   protections: IContentProtectionSmooth[];
@@ -108,7 +109,7 @@ interface ISmoothParsedQualityLevel {
 function createSmoothStreamingParser(
   parserOptions: IHSSParserConfiguration = {},
 ): (
-  manifest: Document,
+  manifest: string,
   url?: string | undefined,
   manifestReceivedTime?: number | undefined,
 ) => IParsedManifest {
@@ -128,12 +129,12 @@ function createSmoothStreamingParser(
       : undefined;
 
   /**
-   * @param {Element} q
+   * @param {Object} q
    * @param {string} streamType
    * @return {Object}
    */
   function parseQualityLevel(
-    q: Element,
+    q: ITNode,
     streamType: string,
   ): ISmoothParsedQualityLevel | null {
     const customAttributes = reduceChildren<string[]>(
@@ -145,9 +146,9 @@ function createSmoothStreamingParser(
               qNode,
               (cAttrs, cName, cNode) => {
                 if (cName === "Attribute") {
-                  const name = cNode.getAttribute("Name");
-                  const value = cNode.getAttribute("Value");
-                  if (name !== null && value !== null) {
+                  const name = cNode.attributes.Name;
+                  const value = cNode.attributes.Value;
+                  if (!isNullOrUndefined(name) && !isNullOrUndefined(value)) {
                     cAttrs.push(name + "=" + value);
                   }
                 }
@@ -167,7 +168,7 @@ function createSmoothStreamingParser(
      * @returns {string|undefined}
      */
     function getAttribute(name: string): string | undefined {
-      const attr = q.getAttribute(name);
+      const attr = q.attributes[name];
       return attr === null ? undefined : attr;
     }
 
@@ -286,14 +287,14 @@ function createSmoothStreamingParser(
       manifestReceivedTime,
       isLive,
     } = args;
-    const timescaleAttr = root.getAttribute("Timescale");
-    let _timescale = timescaleAttr === null ? timescale : +timescaleAttr;
+    const timescaleAttr = root.attributes.Timescale;
+    let _timescale = !isNonEmptyString(timescaleAttr) ? timescale : +timescaleAttr;
     if (isNaN(_timescale)) {
       _timescale = timescale;
     }
 
-    const typeAttribute = root.getAttribute("Type");
-    if (typeAttribute === null) {
+    const typeAttribute = root.attributes.Type;
+    if (isNullOrUndefined(typeAttribute)) {
       throw new Error("StreamIndex without type.");
     }
     if (!arrayIncludes(SUPPORTED_ADAPTATIONS_TYPE, typeAttribute)) {
@@ -301,15 +302,15 @@ function createSmoothStreamingParser(
     }
     const adaptationType = typeAttribute as IAdaptationType;
 
-    const subType = root.getAttribute("Subtype");
-    const language = root.getAttribute("Language");
-    const UrlAttr = root.getAttribute("Url");
-    const UrlPathWithTokens = UrlAttr === null ? "" : UrlAttr;
+    const subType = root.attributes.Subtype;
+    const language = root.attributes.Language;
+    const UrlAttr = root.attributes.Url;
+    const UrlPathWithTokens = UrlAttr ?? "";
     assert(UrlPathWithTokens !== "");
 
     const { qualityLevels, cNodes } = reduceChildren<{
       qualityLevels: ISmoothParsedQualityLevel[];
-      cNodes: Element[];
+      cNodes: ITNode[];
     }>(
       root,
       (res, _name, node) => {
@@ -452,31 +453,36 @@ function createSmoothStreamingParser(
     return parsedAdaptation;
   }
 
-  function parseFromDocument(
-    doc: Document,
+  function parseFromNode(
+    xml: string,
     url?: string,
     manifestReceivedTime?: number,
   ): IParsedManifest {
+    const parsed = parseXml(xml);
+    const root = parsed[parsed.length - 1];
     let baseUrl: string = "";
     if (url !== undefined) {
       const filenameIdx = getFilenameIndexInUrl(url);
       baseUrl = url.substring(0, filenameIdx);
     }
-    const root = doc.documentElement;
-    if (isNullOrUndefined(root) || root.nodeName !== "SmoothStreamingMedia") {
+    if (
+      isNullOrUndefined(root) ||
+      typeof root === "string" ||
+      root.tagName !== "SmoothStreamingMedia"
+    ) {
       throw new Error("document root should be SmoothStreamingMedia");
     }
-    const majorVersionAttr = root.getAttribute("MajorVersion");
-    const minorVersionAttr = root.getAttribute("MinorVersion");
+    const majorVersionAttr = root.attributes.MajorVersion;
+    const minorVersionAttr = root.attributes.MinorVersion;
     if (
-      majorVersionAttr === null ||
-      minorVersionAttr === null ||
+      isNullOrUndefined(majorVersionAttr) ||
+      isNullOrUndefined(minorVersionAttr) ||
       !/^[2]-[0-2]$/.test(majorVersionAttr + "-" + minorVersionAttr)
     ) {
       throw new Error("Version should be 2.0, 2.1 or 2.2");
     }
 
-    const timescaleAttr = root.getAttribute("Timescale");
+    const timescaleAttr = root.attributes.Timescale;
     let timescale = !isNonEmptyString(timescaleAttr) ? 10000000 : +timescaleAttr;
     if (isNaN(timescale)) {
       timescale = 10000000;
@@ -484,7 +490,7 @@ function createSmoothStreamingParser(
 
     const { protections, adaptationNodes } = reduceChildren<{
       protections: IContentProtectionSmooth[];
-      adaptationNodes: Element[];
+      adaptationNodes: ITNode[];
     }>(
       root,
       (res, name, node) => {
@@ -507,13 +513,13 @@ function createSmoothStreamingParser(
 
     const initialAdaptations: IParsedAdaptations = {};
 
-    const isLive = parseBoolean(root.getAttribute("IsLive"));
+    const isLive = parseBoolean(root.attributes.IsLive);
 
     let timeShiftBufferDepth: number | undefined;
     if (isLive) {
-      const dvrWindowLength = root.getAttribute("DVRWindowLength");
+      const dvrWindowLength = root.attributes.DVRWindowLength;
       if (
-        dvrWindowLength !== null &&
+        !isNullOrUndefined(dvrWindowLength) &&
         !isNaN(+dvrWindowLength) &&
         +dvrWindowLength !== 0
       ) {
@@ -522,7 +528,7 @@ function createSmoothStreamingParser(
     }
 
     const adaptations: IParsedAdaptations = adaptationNodes.reduce(
-      (acc: IParsedAdaptations, node: Element) => {
+      (acc: IParsedAdaptations, node: ITNode) => {
         const adaptation = parseAdaptation({
           root: node,
           baseUrl,
@@ -622,9 +628,9 @@ function createSmoothStreamingParser(
       }
     }
 
-    const manifestDuration = root.getAttribute("Duration");
+    const manifestDuration = root.attributes.Duration;
     const duration =
-      manifestDuration !== null && +manifestDuration !== 0
+      !isNullOrUndefined(manifestDuration) && +manifestDuration !== 0
         ? +manifestDuration / timescale
         : undefined;
 
@@ -694,7 +700,7 @@ function createSmoothStreamingParser(
     return manifest;
   }
 
-  return parseFromDocument;
+  return parseFromNode;
 }
 
 /**

--- a/src/parsers/manifest/smooth/parse_C_nodes.ts
+++ b/src/parsers/manifest/smooth/parse_C_nodes.ts
@@ -15,6 +15,7 @@
  */
 
 import isNonEmptyString from "../../../utils/is_non_empty_string";
+import type { ITNode } from "../../../utils/xml-parser";
 
 interface IHSSManifestSegment {
   start: number;
@@ -24,13 +25,18 @@ interface IHSSManifestSegment {
 
 /**
  * Parse C nodes to build index timeline.
- * @param {Element} nodes
+ * @param {Object} nodes
  */
-export default function parseCNodes(nodes: Element[]): IHSSManifestSegment[] {
+export default function parseCNodes(
+  nodes: Array<ITNode | string>,
+): IHSSManifestSegment[] {
   return nodes.reduce<IHSSManifestSegment[]>((timeline, node, i) => {
-    const dAttr = node.getAttribute("d");
-    const tAttr = node.getAttribute("t");
-    const rAttr = node.getAttribute("r");
+    if (typeof node === "string") {
+      return timeline;
+    }
+    const dAttr = node.attributes.d ?? null;
+    const tAttr = node.attributes.t ?? null;
+    const rAttr = node.attributes.r ?? null;
 
     const repeatCount = rAttr !== null ? +rAttr - 1 : 0;
     let start = tAttr !== null ? +tAttr : undefined;
@@ -50,9 +56,14 @@ export default function parseCNodes(nodes: Element[]): IHSSManifestSegment[] {
       }
     }
     if (duration === undefined || isNaN(duration)) {
-      const nextNode = nodes[i + 1];
-      if (nextNode !== undefined) {
-        const nextTAttr = nextNode.getAttribute("t");
+      let nextNodeIdx = i;
+      let nextNodeElt;
+      do {
+        nextNodeIdx++;
+        nextNodeElt = node.children[nextNodeIdx];
+      } while (nextNodeElt !== undefined && typeof nextNodeElt === "string");
+      if (nextNodeElt !== undefined) {
+        const nextTAttr = nextNodeElt.attributes.t ?? null;
         const nextStart = isNonEmptyString(nextTAttr) ? +nextTAttr : null;
         if (nextStart === null) {
           throw new Error("Can't build index timeline from Smooth Manifest.");

--- a/src/parsers/manifest/smooth/parse_C_nodes.ts
+++ b/src/parsers/manifest/smooth/parse_C_nodes.ts
@@ -57,10 +57,10 @@ export default function parseCNodes(
     }
     if (duration === undefined || isNaN(duration)) {
       let nextNodeIdx = i;
-      let nextNodeElt;
+      let nextNodeElt: ITNode | undefined | string;
       do {
         nextNodeIdx++;
-        nextNodeElt = node.children[nextNodeIdx];
+        nextNodeElt = nodes[nextNodeIdx];
       } while (nextNodeElt !== undefined && typeof nextNodeElt === "string");
       if (nextNodeElt !== undefined) {
         const nextTAttr = nextNodeElt.attributes.t ?? null;

--- a/src/parsers/manifest/smooth/parse_protection_node.ts
+++ b/src/parsers/manifest/smooth/parse_protection_node.ts
@@ -17,6 +17,7 @@
 import { base64ToBytes } from "../../../utils/base64";
 import { concat } from "../../../utils/byte_parsing";
 import { hexToBytes } from "../../../utils/string_parsing";
+import type { ITNode } from "../../../utils/xml-parser";
 import { getPlayReadyKIDFromPrivateData } from "../../containers/isobmff";
 
 export interface IKeySystem {
@@ -44,28 +45,35 @@ function createWidevineKeySystem(keyIdBytes: Uint8Array): IKeySystem[] {
 
 /**
  * Parse "Protection" Node, which contains DRM information
- * @param {Element} protectionNode
+ * @param {Object} protectionNode
  * @returns {Object}
  */
 export default function parseProtectionNode(
-  protectionNode: Element,
+  protectionNode: ITNode,
   keySystemCreator: (keyId: Uint8Array) => IKeySystem[] = createWidevineKeySystem,
 ): IContentProtectionSmooth {
-  if (
-    protectionNode.firstElementChild === null ||
-    protectionNode.firstElementChild.nodeName !== "ProtectionHeader"
-  ) {
+  let header;
+  for (const subNode of protectionNode.children) {
+    if (typeof subNode === "string") {
+      continue;
+    }
+    if (subNode.tagName === "ProtectionHeader") {
+      header = subNode;
+      break;
+    }
+  }
+  if (header === undefined) {
     throw new Error("Protection should have ProtectionHeader child");
   }
-  const header = protectionNode.firstElementChild;
+
   const privateData = base64ToBytes(
-    header.textContent === null ? "" : header.textContent,
+    typeof header.children[0] === "string" ? header.children[0] : "",
   );
   const keyIdHex = getPlayReadyKIDFromPrivateData(privateData);
   const keyIdBytes = hexToBytes(keyIdHex);
 
   // remove possible braces
-  const systemIdAttr = header.getAttribute("SystemID");
+  const systemIdAttr = header.attributes.SystemID ?? null;
   const systemId = (systemIdAttr !== null ? systemIdAttr : "")
     .toLowerCase()
     .replace(/\{|\}/g, "");

--- a/src/parsers/manifest/smooth/utils/parseBoolean.ts
+++ b/src/parsers/manifest/smooth/utils/parseBoolean.ts
@@ -18,7 +18,7 @@
  * @param {*} val
  * @returns {Boolean}
  */
-export default function parseBoolean(val: string | null): boolean {
+export default function parseBoolean(val: string | null | undefined | boolean): boolean {
   if (typeof val === "boolean") {
     return val;
   } else if (typeof val === "string") {

--- a/src/parsers/manifest/smooth/utils/reduceChildren.ts
+++ b/src/parsers/manifest/smooth/utils/reduceChildren.ts
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
+import type { ITNode } from "../../../../utils/xml-parser";
+
 /**
  * Reduce implementation for the children of the given element.
- * @param {Element} root
+ * @param {Object} root
  * @param {Function} fn
  * @param {*} init
  * @returns {*}
  */
 export default function reduceChildren<T>(
-  root: Element,
-  fn: (accu: T, nodeName: string, nodeElt: Element) => T,
+  root: ITNode,
+  fn: (accu: T, nodeName: string, nodeElt: ITNode) => T,
   init: T,
 ): T {
-  let node = root.firstElementChild;
   let accumulator = init;
-  while (node !== null) {
-    accumulator = fn(accumulator, node.nodeName, node);
-    node = node.nextElementSibling;
+  for (const elt of root.children) {
+    if (typeof elt === "string") {
+      continue;
+    }
+    accumulator = fn(accumulator, elt.tagName, elt);
   }
   return accumulator;
 }

--- a/src/transports/smooth/pipelines.ts
+++ b/src/transports/smooth/pipelines.ts
@@ -19,6 +19,8 @@ import Manifest from "../../manifest/classes";
 import { getMDAT } from "../../parsers/containers/isobmff";
 import type { ICdnMetadata } from "../../parsers/manifest";
 import createSmoothManifestParser from "../../parsers/manifest/smooth";
+import globalScope from "../../utils/global_scope";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import request from "../../utils/request";
 import { strToUtf8, utf8ToStr } from "../../utils/string_parsing";
 import type { CancellationSignal } from "../../utils/task_canceller";
@@ -69,11 +71,7 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
       const url = manifestData.url ?? parserOptions.originalUrl;
       const { receivedTime: manifestReceivedTime, responseData } = manifestData;
 
-      const documentData =
-        typeof responseData === "string"
-          ? new DOMParser().parseFromString(responseData, "text/xml")
-          : (responseData as Document); // TODO find a way to check if Document?
-
+      const documentData = getManifestAsString(responseData);
       const parserResult = smoothManifestParser(documentData, url, manifestReceivedTime);
 
       const manifest = new Manifest(parserResult, {
@@ -433,4 +431,26 @@ export default function (transportOptions: ITransportOptions): ITransportPipelin
       },
     },
   };
+}
+
+/**
+ * Try to convert a Manifest from an unknown format to a JS string format.
+ *
+ * Throws if the format cannot be converted.
+ * @param {*} manifestSrc
+ * @returns {Array.<Object | string>}
+ */
+function getManifestAsString(manifestSrc: unknown): string {
+  if (manifestSrc instanceof ArrayBuffer) {
+    return utf8ToStr(new Uint8Array(manifestSrc));
+  } else if (typeof manifestSrc === "string") {
+    return manifestSrc;
+  } else if (
+    !isNullOrUndefined(globalScope.Document) &&
+    manifestSrc instanceof globalScope.Document
+  ) {
+    return manifestSrc.documentElement.outerHTML;
+  } else {
+    throw new Error("Smooth Manifest Parser: Unrecognized Manifest format");
+  }
 }


### PR DESCRIPTION
This PR removes the need to have DOM API present when parsing a Smooth Manifest, by relying on our full-JS tXml lib instead for XML parsing.

This is already what we do for DASH contents and it mainly will allow to play Smooth contents in a WebWorker context, such as in our multithreading mode.

Now that something like #1719 is under way, Smooth is the last transport which needed effort to be ported to run in multithread mode.

Porting it means there will be no feature difference between main and multithread modes.
This is a nice milestone and will also simplify the documentation of that complex feature, by removing a key limitation from it.

This PR does not add the Smooth feature to multithread mode yet, but doing that should be really easy to do once #1719 and #1723 are merged.