### PR TITLE
Fix Rust lifetime elision compilation warning

### DIFF
--- a/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
+++ b/src/parsers/manifest/dash/wasm-parser/rs/processor/mod.rs
@@ -162,7 +162,7 @@ impl MPDProcessor {
     /// This method is always inlined for optimization reasons as it is both
     /// short and generally used in loops.
     #[inline(always)]
-    fn read_next_event(&mut self) -> quick_xml::Result<quick_xml::events::Event> {
+    fn read_next_event<'a>(&'a mut self) -> quick_xml::Result<quick_xml::events::Event<'a>> {
         if !self.reader_buf.is_empty() {
             self.reader_buf.clear();
         }


### PR DESCRIPTION
Rust chose recently ([August 2025](https://releases.rs/docs/1.89.0/)) to output a new warning when compiling our WASM MPD parser because of an implicit lifetime.

It was just a warning, but it's very simple to make it explicit so I just did that.

To explain briefly this specific case: the lifetime (here declared as `'a`) allows to explicitly state how "long" the returned reference is going to be available, in relative terms.

In this example, the returned data is going to be available only as long as the mutable reference to `self` (here a `MPDProcessor` struct) is available. This type of complex annotation allows Rust to check whether some reference is still accessible at compile-time. When it was obvious, like here, it was previously perfectly fine to omit it, but apparently it's now better form to always indicate it.