### PR TITLE
Fix `getPeriodForTime` util

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -174,8 +174,11 @@ export default function StreamOrchestrator(
         if (!enableOutOfBoundsCheck || !isOutOfPeriodList(time)) {
           return;
         }
-        const nextPeriod =
+
+        const getNewBasePeriod = (): IPeriod | undefined =>
           manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
+
+        let nextPeriod = getNewBasePeriod();
         if (!isNullOrUndefined(nextPeriod) && periodList.has(nextPeriod)) {
           // Last check just for resilience reasons that the wanted Period is
           // not one of the already-handled ones
@@ -197,6 +200,9 @@ export default function StreamOrchestrator(
         currentCanceller = new TaskCanceller();
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
+        // As previous callbacks may have performed unknown side-effects, just
+        // re-compute the next Period now.
+        nextPeriod = getNewBasePeriod();
         if (nextPeriod === undefined) {
           log.warn("Stream", "The wanted position is not found in the Manifest.");
           enableOutOfBoundsCheck = true;

--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -174,6 +174,13 @@ export default function StreamOrchestrator(
         if (!enableOutOfBoundsCheck || !isOutOfPeriodList(time)) {
           return;
         }
+        const nextPeriod =
+          manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
+        if (!isNullOrUndefined(nextPeriod) && periodList.has(nextPeriod)) {
+          // Last check just for resilience reasons that the wanted Period is
+          // not one of the already-handled ones
+          return;
+        }
 
         log.info(
           "Stream",
@@ -190,8 +197,6 @@ export default function StreamOrchestrator(
         currentCanceller = new TaskCanceller();
         currentCanceller.linkToSignal(orchestratorCancelSignal);
 
-        const nextPeriod =
-          manifest.getPeriodForTime(time) ?? manifest.getNextPeriod(time);
         if (nextPeriod === undefined) {
           log.warn("Stream", "The wanted position is not found in the Manifest.");
           enableOutOfBoundsCheck = true;

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -139,7 +139,8 @@ export function getPeriodForTime(
   time: number,
 ): IPeriod | IPeriodMetadata | undefined {
   let nextPeriod = null;
-  for (const period of manifest.periods) {
+  for (let i = manifest.periods.length - 1; i >= 0; i--) {
+    const period = manifest.periods[i];
     if (periodContainsTime(period, time, nextPeriod)) {
       return period;
     }


### PR DESCRIPTION
An issue, https://github.com/canalplus/rx-player/issues/1736, noticed that we have a problem with the `getPeriodForTime` util which links the current playback timestamp and the Period to which it is associated to.

The way the util was written means it had to be looped over from the last to the first, but I don't know why I decided to replace it with a fancier `for...of` (which goes from first to last) in a totally unrelated refacto (https://github.com/canalplus/rx-player/pull/1507).

This broke the logic and lead, with conditions that are hard to predict, to some infinite rebuffering issues.

I also made some other code more resilient here, because I thought that I saw another issue first. I don't really know if that other case is possible but I thought that it didn't cost anything to be resilient there.