### PR TITLE
fix(demo): don't set DRM if not selected in the UI

### DIFF
--- a/demo/scripts/controllers/ContentList.tsx
+++ b/demo/scripts/controllers/ContentList.tsx
@@ -516,14 +516,16 @@ function ContentList({
 
   const onClickLoad = () => {
     if (contentChoiceIndex === 0) {
-      const drmInfos = [
-        {
-          licenseServerUrl,
-          serverCertificateUrl,
-          drm: chosenDRMType,
-          customKeySystem,
-        },
-      ];
+      const drmInfos = shouldDisplayDRMSettings
+        ? [
+            {
+              licenseServerUrl,
+              serverCertificateUrl,
+              drm: chosenDRMType,
+              customKeySystem,
+            },
+          ]
+        : [];
       loadUrl(currentManifestURL, drmInfos);
     } else {
       loadContent(contentsToSelect[contentChoiceIndex]);


### PR DESCRIPTION
Fix bug in demo: when playing custom content without DRM, the player always tried to use the Widevine key system, even if no encryption options were set.