### PR TITLE
[Proposal] rely on "provenance statements" when publishing our builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      - run: npm run check
 
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,7 +47,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      - run: npm run check
 
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests_base.yml
+++ b/.github/workflows/integration_tests_base.yml
@@ -1,0 +1,38 @@
+name: Reusable integration tests job
+on:
+  workflow_call:
+    inputs:
+      # e.g. "windows-latest", "ubuntu-latest" etc.
+      os: { required: true, type: string }
+
+      # "chrome", "firefox" or "edge"
+      browser: { required: true, type: string }
+
+jobs:
+  integration_tests:
+    runs-on: ${{ inputs.os }}
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - name: Linux prep
+        if: contains(inputs.os, 'ubuntu')
+        run: |
+          sudo add-apt-repository multiverse -y
+          sudo apt update && sudo apt install -y ubuntu-restricted-extras
+
+      - name: Run integration tests for ${{ inputs.browser }} on ${{ inputs.os }}
+        shell: bash
+        run: |
+          npm ci
+          npm run build
+          npm run "test:integration:${{ inputs.browser }}"

--- a/.github/workflows/perfs.yml
+++ b/.github/workflows/perfs.yml
@@ -13,11 +13,11 @@ jobs:
   perf-tests:
     if:
       ${{ !contains(github.event.pull_request.labels.*.name, 'skip-performance-checks') }}
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -6,8 +6,202 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
 
 jobs:
+  general_release_checks:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - run: npm ci
+      - run: rustup target add wasm32-unknown-unknown # Needed for fmt:rust:check
+      - run: npm run fmt:prettier:check # js formatting
+      - run: npm run fmt:rust:check # rs formatting
+      - run: npm run check # basic checks
+      - run: npm run test:unit
+
+  integration_linux_chrome:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration:chrome
+
+  integration_linux_firefox:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration:firefox
+
+  integration_linux_edge:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration:edge
+
+  integration_windows_chrome:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/checkout@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - shell: bash
+        run: npm ci
+      - shell: bash
+        run: npm run build
+      - shell: bash
+        run: npm run test:integration:chrome
+
+  integration_windows_firefox:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/checkout@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - shell: bash
+        run: npm ci
+      - shell: bash
+        run: npm run build
+      - shell: bash
+        run: npm run test:integration:firefox
+
+  integration_windows_edge:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/checkout@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - shell: bash
+        run: npm ci
+      - shell: bash
+        run: npm run build
+      - shell: bash
+        run: npm run test:integration:edge
+
+  memory_linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run test:memory
+
   publish_dev:
     runs-on: ubuntu-latest
+    needs:
+      [
+        "general_release_checks",
+        "integration_linux_chrome",
+        "integration_linux_firefox",
+        "integration_linux_edge",
+        "integration_windows_chrome",
+        "integration_windows_firefox",
+        "integration_windows_edge",
+        "memory_linux",
+      ]
 
     permissions:
       id-token: write # required for npm provenance
@@ -53,7 +247,7 @@ jobs:
         run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
       - name: Build and publish dev version
-        run: npm publish --tag dev --provenance
+        run: # npm publish --tag dev --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
@@ -65,6 +259,6 @@ jobs:
 
       - name: Build and publish Canal version
 
-        run: npm publish --tag canal --provenance
+        run: # npm publish --tag canal --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -1,18 +1,12 @@
 name: RxPlayer dev publishing
 
 on:
-  workflow_run:
-    workflows: ["RxPlayer Tests", "Performance tests"]
-    types: [completed]
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
 
 jobs:
   publish_dev:
-    if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      startsWith(github.event.workflow_run.head_branch, 'v') &&
-      contains(github.event.workflow_run.head_branch, '-dev.')
-
     runs-on: ubuntu-latest
 
     permissions:
@@ -23,47 +17,26 @@ jobs:
         node-version: [22.x]
 
     steps:
-      - name: Check if this is a dev tag
-        id: check-tag
-        run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          echo "Checking branch: $BRANCH"
-
-          if [[ "$BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$ ]]; then
-            echo "✓ Valid dev tag format detected"
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "✗ Not a dev tag, skipping publication"
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v4
-        if: steps.check-tag.outputs.should_publish == 'true'
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Use Node.js ${{ matrix.node-version }}
-        if: steps.check-tag.outputs.should_publish == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
 
       - name: Extract version from tag
-        if: steps.check-tag.outputs.should_publish == 'true'
         id: get_version
         run: |
           # Extract version from tag (remove 'v' prefix)
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          VERSION=${BRANCH#v}
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=\"$VERSION\"" >> "$GITHUB_OUTPUT"
 
           # Create canal version (replace -dev. with -canal.)
           CANAL_VERSION="${VERSION/-dev./-canal.}"
           echo "canal_version=$CANAL_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if canal patch can be applied
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: |
           echo "Checking if canal patch can be applied..."
           if ! git apply --check ./scripts/canal-release.patch; then
@@ -74,29 +47,24 @@ jobs:
           echo "Canal patch check passed ✓"
 
       - name: Install RxPlayer dependencies
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm ci
 
       - name: Update version for dev release
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
       - name: Build and publish dev version
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm publish --tag dev --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Apply Canal+ patch
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: git apply ./scripts/canal-release.patch
 
       - name: Update version for canal release
-        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm run update-version "${{ steps.get_version.outputs.canal_version }}"
 
       - name: Build and publish Canal version
-        if: steps.check-tag.outputs.should_publish == 'true'
+
         run: npm publish --tag canal --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -27,11 +27,11 @@ jobs:
         run: |
           # Extract version from tag (remove 'v' prefix)
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=\"$VERSION\"" >> "$GITHUB_OUTPUT"
 
           # Create canal version (replace -dev. with -canal.)
-          CANAL_VERSION=${VERSION/-dev./-canal.}
-          echo "canal_version=$CANAL_VERSION" >> $GITHUB_OUTPUT
+          CANAL_VERSION="${VERSION/-dev./-canal.}"
+          echo "canal_version=$CANAL_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if canal patch can be applied
         run: |
@@ -46,14 +46,8 @@ jobs:
       - name: Install RxPlayer dependencies
         run: npm ci
 
-      - name: Type files generation (for legacy bundles)
-        run: |
-          echo "creating types for legacy code bases..."
-          mkdir -p dist
-          echo "import RxPlayer from \"./es2017/index\"; export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
-
       - name: Update version for dev release
-        run: npm run update-version ${{ steps.get_version.outputs.version }}
+        run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
       - name: Build and publish dev version
         run: npm publish --tag dev --provenance
@@ -64,7 +58,7 @@ jobs:
         run: git apply ./scripts/canal-release.patch
 
       - name: Update version for canal release
-        run: npm run update-version ${{ steps.get_version.outputs.canal_version }}
+        run: npm run update-version "${{ steps.get_version.outputs.canal_version }}"
 
       - name: Build and publish Canal version
         run: npm publish --tag canal --provenance

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -6,8 +6,66 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
 
 jobs:
+  # -------------------------------------------------------------
+  # 1. Guard job – keeps polling until the other workflows pass
+  # -------------------------------------------------------------
+  #
+  # This over-complicated job is here because github actions seems to not
+  # have good ways to depend both on tags and on other workflows to pass.
+  poll-other_workflows_before_dev_release:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - uses: actions/github-script@v7
+        id: wait
+        env:
+          NEEDED_WORKFLOWS: '["RxPlayer Tests", "Performance tests"]'
+        with:
+          retries: 120            # Maximum attempts, polled every minute
+          retry-exempt-status-codes: 400,401,403,404
+          script: |
+            await new Promise(r => setTimeout(r, 60000));
+
+            const needed = JSON.parse(process.env.NEEDED_WORKFLOWS);
+            const owner  = context.repo.owner;
+            const repo   = context.repo.repo;
+
+            let allGreen = true; // Here I am, take me by the hand, yeah ♫ ♫ ♫
+
+            // Find workflow_id by name
+            const { data: workflows } = await github.rest.actions.listRepoWorkflows({
+              owner,
+              repo,
+            });
+            for (const workflowName of needed) {
+              const wf = workflows.find(w => w.name === workflowName);
+              if (!wf) {
+                core.setFailed(`No workflow named "${workflowName}" found`);
+                return;
+              }
+              // Get last run status
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: wf.id, per_page: 1
+              });
+              const { conclusion } = runs.workflow_runs[0] || {};
+              if (conclusion !== "success") {
+                allGreen = false;
+                break;
+              }
+            }
+
+            if (allGreen) {
+              core.info(`All required workflows succeeded.`);
+              return;
+            }
+
+  # -------------------------------------------------------------
+  # 2. Real release job – runs only when guard succeeds
+  # -------------------------------------------------------------
   publish_dev:
     runs-on: ubuntu-latest
+    needs: poll-other_workflows_before_dev_release
 
     permissions:
       id-token: write # required for npm provenance
@@ -17,6 +75,7 @@ jobs:
         node-version: [22.x]
 
     steps:
+
       - uses: actions/checkout@v4
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -9,6 +9,9 @@ jobs:
   publish_dev:
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write # required for npm provenance
+
     strategy:
       matrix:
         node-version: [22.x]
@@ -61,6 +64,7 @@ jobs:
         run: npm run update-version "${{ steps.get_version.outputs.canal_version }}"
 
       - name: Build and publish Canal version
+
         run: npm publish --tag canal --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build and publish dev version
         run: npm publish --tag dev --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Apply Canal+ patch
         run: git apply ./scripts/canal-release.patch
@@ -63,4 +63,4 @@ jobs:
       - name: Build and publish Canal version
         run: npm publish --tag canal --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -1,71 +1,19 @@
 name: RxPlayer dev publishing
 
 on:
-  push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+  workflow_run:
+    workflows: ["RxPlayer Tests", "Performance tests"]
+    types: [completed]
 
 jobs:
-  # -------------------------------------------------------------
-  # 1. Guard job – keeps polling until the other workflows pass
-  # -------------------------------------------------------------
-  #
-  # This over-complicated job is here because github actions seems to not
-  # have good ways to depend both on tags and on other workflows to pass.
-  poll-other_workflows_before_dev_release:
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    steps:
-      - uses: actions/github-script@v7
-        id: wait
-        env:
-          NEEDED_WORKFLOWS: '["RxPlayer Tests", "Performance tests"]'
-        with:
-          retries: 120            # Maximum attempts, polled every minute
-          retry-exempt-status-codes: 400,401,403,404
-          script: |
-            await new Promise(r => setTimeout(r, 60000));
-
-            const needed = JSON.parse(process.env.NEEDED_WORKFLOWS);
-            const owner  = context.repo.owner;
-            const repo   = context.repo.repo;
-
-            let allGreen = true; // Here I am, take me by the hand, yeah ♫ ♫ ♫
-
-            // Find workflow_id by name
-            const { data: workflows } = await github.rest.actions.listRepoWorkflows({
-              owner,
-              repo,
-            });
-            for (const workflowName of needed) {
-              const wf = workflows.find(w => w.name === workflowName);
-              if (!wf) {
-                core.setFailed(`No workflow named "${workflowName}" found`);
-                return;
-              }
-              // Get last run status
-              const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                owner, repo, workflow_id: wf.id, per_page: 1
-              });
-              const { conclusion } = runs.workflow_runs[0] || {};
-              if (conclusion !== "success") {
-                allGreen = false;
-                break;
-              }
-            }
-
-            if (allGreen) {
-              core.info(`All required workflows succeeded.`);
-              return;
-            }
-
-  # -------------------------------------------------------------
-  # 2. Real release job – runs only when guard succeeds
-  # -------------------------------------------------------------
   publish_dev:
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      contains(github.event.workflow_run.head_branch, '-dev.')
+
     runs-on: ubuntu-latest
-    needs: poll-other_workflows_before_dev_release
 
     permissions:
       id-token: write # required for npm provenance
@@ -75,27 +23,47 @@ jobs:
         node-version: [22.x]
 
     steps:
+      - name: Check if this is a dev tag
+        id: check-tag
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          echo "Checking branch: $BRANCH"
+
+          if [[ "$BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$ ]]; then
+            echo "✓ Valid dev tag format detected"
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✗ Not a dev tag, skipping publication"
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: actions/checkout@v4
+        if: steps.check-tag.outputs.should_publish == 'true'
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Use Node.js ${{ matrix.node-version }}
+        if: steps.check-tag.outputs.should_publish == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
 
       - name: Extract version from tag
+        if: steps.check-tag.outputs.should_publish == 'true'
         id: get_version
         run: |
           # Extract version from tag (remove 'v' prefix)
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=\"$VERSION\"" >> "$GITHUB_OUTPUT"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          VERSION=${BRANCH#v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
           # Create canal version (replace -dev. with -canal.)
           CANAL_VERSION="${VERSION/-dev./-canal.}"
           echo "canal_version=$CANAL_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if canal patch can be applied
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: |
           echo "Checking if canal patch can be applied..."
           if ! git apply --check ./scripts/canal-release.patch; then
@@ -106,24 +74,29 @@ jobs:
           echo "Canal patch check passed ✓"
 
       - name: Install RxPlayer dependencies
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm ci
 
       - name: Update version for dev release
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
       - name: Build and publish dev version
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm publish --tag dev --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Apply Canal+ patch
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: git apply ./scripts/canal-release.patch
 
       - name: Update version for canal release
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm run update-version "${{ steps.get_version.outputs.canal_version }}"
 
       - name: Build and publish Canal version
-
+        if: steps.check-tag.outputs.should_publish == 'true'
         run: npm publish --tag canal --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Build and publish dev version
         run: npm publish --tag dev --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Apply Canal+ patch
         run: git apply ./scripts/canal-release.patch
@@ -151,4 +151,4 @@ jobs:
 
         run: npm publish --tag canal --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -1,0 +1,72 @@
+name: RxPlayer dev publishing
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+
+jobs:
+  publish_dev:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          # Create canal version (replace -dev. with -canal.)
+          CANAL_VERSION=${VERSION/-dev./-canal.}
+          echo "canal_version=$CANAL_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if canal patch can be applied
+        run: |
+          echo "Checking if canal patch can be applied..."
+          if ! git apply --check ./scripts/canal-release.patch; then
+            echo "Error: Canal patch cannot be applied cleanly!"
+            echo "Please resolve conflicts in the patch file before proceeding."
+            exit 1
+          fi
+          echo "Canal patch check passed ✓"
+
+      - name: Install RxPlayer dependencies
+        run: npm ci
+
+      - name: Type files generation (for legacy bundles)
+        run: |
+          echo "creating types for legacy code bases..."
+          mkdir -p dist
+          echo "import RxPlayer from \"./es2017/index\"; export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
+
+      - name: Update version for dev release
+        run: npm run update-version ${{ steps.get_version.outputs.version }}
+
+      - name: Build and publish dev version
+        run: npm publish --tag dev --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Apply Canal+ patch
+        run: git apply ./scripts/canal-release.patch
+
+      - name: Update version for canal release
+        run: npm run update-version ${{ steps.get_version.outputs.canal_version }}
+
+      - name: Build and publish Canal version
+        run: npm publish --tag canal --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_dev_releases.yml
+++ b/.github/workflows/publish_dev_releases.yml
@@ -31,141 +31,33 @@ jobs:
       - run: npm run fmt:rust:check # rs formatting
       - run: npm run check # basic checks
       - run: npm run test:unit
+      - run: npm run lint:demo
+      - run: npm run lint:tests
+      - run: npm run lint:scripts
 
   integration_linux_chrome:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      # needed for integration & memory tests codecs support
-      - run:
-          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
-          ubuntu-restricted-extras
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test:integration:chrome
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "chrome" }
 
   integration_linux_firefox:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      # needed for integration & memory tests codecs support
-      - run:
-          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
-          ubuntu-restricted-extras
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test:integration:firefox
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "firefox" }
 
   integration_linux_edge:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      # needed for integration & memory tests codecs support
-      - run:
-          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
-          ubuntu-restricted-extras
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test:integration:edge
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "edge" }
 
   integration_windows_chrome:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - shell: bash
-        run: npm ci
-      - shell: bash
-        run: npm run build
-      - shell: bash
-        run: npm run test:integration:chrome
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "chrome" }
 
   integration_windows_firefox:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - shell: bash
-        run: npm ci
-      - shell: bash
-        run: npm run build
-      - shell: bash
-        run: npm run test:integration:firefox
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "firefox" }
 
   integration_windows_edge:
-    runs-on: windows-latest
-
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - shell: bash
-        run: npm ci
-      - shell: bash
-        run: npm run build
-      - shell: bash
-        run: npm run test:integration:edge
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "edge" }
 
   memory_linux:
     runs-on: ubuntu-latest
@@ -192,16 +84,14 @@ jobs:
   publish_dev:
     runs-on: ubuntu-latest
     needs:
-      [
-        "general_release_checks",
-        "integration_linux_chrome",
-        "integration_linux_firefox",
-        "integration_linux_edge",
-        "integration_windows_chrome",
-        "integration_windows_firefox",
-        "integration_windows_edge",
-        "memory_linux",
-      ]
+      - general_release_checks
+      - integration_linux_chrome
+      - integration_linux_firefox
+      - integration_linux_edge
+      - integration_windows_chrome
+      - integration_windows_firefox
+      - integration_windows_edge
+      - memory_linux
 
     permissions:
       id-token: write # required for npm provenance
@@ -247,7 +137,7 @@ jobs:
         run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
       - name: Build and publish dev version
-        run: # npm publish --tag dev --provenance
+        run: npm publish --tag dev --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
@@ -259,6 +149,6 @@ jobs:
 
       - name: Build and publish Canal version
 
-        run: # npm publish --tag canal --provenance
+        run: npm publish --tag canal --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -31,51 +31,33 @@ jobs:
       - run: npm run fmt:rust:check # rs formatting
       - run: npm run check # basic checks
       - run: npm run test:unit
+      - run: npm run lint:demo
+      - run: npm run lint:tests
+      - run: npm run lint:scripts
 
-  integration_linux:
-    runs-on: ubuntu-latest
+  integration_linux_chrome:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "chrome" }
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+  integration_linux_firefox:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "firefox" }
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      # needed for integration & memory tests codecs support
-      - run:
-          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
-          ubuntu-restricted-extras
-      - run: npm ci
-      - run: npm run build
-      - run: npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
+  integration_linux_edge:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "edge" }
 
-  integration_windows:
-    runs-on: windows-latest
+  integration_windows_chrome:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "chrome" }
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+  integration_windows_firefox:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "firefox" }
 
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - shell: bash
-        run: npm ci
-      - shell: bash
-        run: npm run build
-      - shell: bash
-        run: npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
+  integration_windows_edge:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "edge" }
 
   memory_linux:
     runs-on: ubuntu-latest
@@ -99,7 +81,7 @@ jobs:
       - run: npm ci
       - run: npm run test:memory
 
-  performance-tests:
+  performance_tests:
     runs-on: [ubuntu-latest]
     permissions:
       pull-requests: write
@@ -124,13 +106,15 @@ jobs:
   publish_official:
     runs-on: ubuntu-latest
     needs:
-      [
-        "general_release_checks",
-        "integration_linux",
-        "integration_windows",
-        "memory_linux",
-        "performance-tests",
-      ]
+      - general_release_checks
+      - integration_linux_chrome
+      - integration_linux_firefox
+      - integration_linux_edge
+      - integration_windows_chrome
+      - integration_windows_firefox
+      - integration_windows_edge
+      - memory_linux
+      - performance_tests
 
     permissions:
       contents: read

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -1,0 +1,30 @@
+name: RxPlayer npm publishing
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # v1.0.0, v2.3.4 … nothing else
+
+jobs:
+  publish_official:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - run: |
+          npm ci
+          npm run build:all
+          echo "creating types for legacy code bases..."
+          echo "import RxPlayer from \"./es2017/index\"; export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
+      - run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -22,9 +22,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: |
           npm ci
-          npm run build:all
-          echo "creating types for legacy code bases..."
-          echo "import RxPlayer from \"./es2017/index\"; export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null
       - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -24,4 +24,4 @@ jobs:
           npm ci
       - run: npm publish --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -4,8 +4,8 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # v1.0.0, v2.3.4 … nothing else
-    workflow_dispatch:  # This allows manual triggering, for when the original
-                        # tag commit already failed
+    workflow_dispatch: # This allows manual triggering, for when the original
+      # tag commit already failed
 
 jobs:
   check_official_version:
@@ -152,7 +152,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0  # fetch all branches and history
+          fetch-depth: 0 # fetch all branches and history
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -172,6 +172,20 @@ jobs:
             echo "Error: Cannot fast-forward merge. The stable branch may be ahead of the release branch."
             exit 1
           fi
+
+      - name: Now align the dev branch on stable
+        run: |
+          git fetch origin dev:dev
+          git checkout dev
+          if ! git rebase stable; then
+            echo "Could not rebase dev on stable. Please check for any conflict first"
+            exit 1
+          fi
+          git push origin dev --force-with-lease
+
+      - name: Push stable branch
+        run: |
+          git checkout stable # go back to stable for publish
           git push origin stable
 
       - name: Build and publish official release

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -9,6 +9,10 @@ jobs:
   publish_official:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      id-token: write # required for npm provenance
+
     strategy:
       matrix:
         node-version: [22.x]

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -4,8 +4,26 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # v1.0.0, v2.3.4 … nothing else
+    workflow_dispatch:  # This allows manual triggering, for when the original
+                        # tag commit already failed
 
 jobs:
+  check_official_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.getversion.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check last commit contains right version tag
+        id: getversion
+        run: |
+          TAG=$(git describe --tags --exact-match HEAD)   # tag on current commit
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "No compatible semver tag on HEAD; exiting."
+            exit 1
+          fi
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"   # strip leading 'v'
+
   general_release_checks:
     runs-on: ubuntu-latest
 
@@ -82,11 +100,16 @@ jobs:
       - run: npm run test:memory
 
   performance_tests:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -106,6 +129,7 @@ jobs:
   publish_official:
     runs-on: ubuntu-latest
     needs:
+      - check_official_version
       - general_release_checks
       - integration_linux_chrome
       - integration_linux_firefox
@@ -117,7 +141,7 @@ jobs:
       - performance_tests
 
     permissions:
-      contents: read
+      contents: write
       id-token: write # required for npm provenance
 
     strategy:
@@ -126,13 +150,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0  # fetch all branches and history
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: "https://registry.npmjs.org"
-      - run: |
-          npm ci
-      - run: npm publish --provenance
+
+      - name: Install RxPlayer dependencies
+        run: npm ci
+
+      - name: Merge on stable branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin stable:stable
+          git checkout stable
+          if ! git merge --ff-only ${{ github.ref_name }}; then
+            echo "Error: Cannot fast-forward merge. The stable branch may be ahead of the release branch."
+            exit 1
+          fi
+          git push origin stable
+
+      - name: Build and publish official release
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -6,8 +6,131 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+" # v1.0.0, v2.3.4 … nothing else
 
 jobs:
+  general_release_checks:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - run: npm ci
+      - run: rustup target add wasm32-unknown-unknown # Needed for fmt:rust:check
+      - run: npm run fmt:prettier:check # js formatting
+      - run: npm run fmt:rust:check # rs formatting
+      - run: npm run check # basic checks
+      - run: npm run test:unit
+
+  integration_linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
+
+  integration_windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/checkout@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+
+      - shell: bash
+        run: npm ci
+      - shell: bash
+        run: npm run build
+      - shell: bash
+        run: npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
+
+  memory_linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for integration & memory tests codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: npm run test:memory
+
+  performance-tests:
+    runs-on: [ubuntu-latest]
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "npm"
+      # needed for codecs support
+      - run:
+          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
+          ubuntu-restricted-extras
+      - run: npm ci
+      - run: export DISPLAY=:99
+      - run: sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+      - run:
+          node tests/performance/run.mjs --branch $GITHUB_BASE_REF --remote-git-url
+          https://github.com/canalplus/rx-player.git
+
   publish_official:
     runs-on: ubuntu-latest
+    needs:
+      [
+        "general_release_checks",
+        "integration_linux",
+        "integration_windows",
+        "memory_linux",
+        "performance-tests",
+      ]
 
     permissions:
       contents: read

--- a/.github/workflows/publish_official_release.yml
+++ b/.github/workflows/publish_official_release.yml
@@ -135,4 +135,4 @@ jobs:
           npm ci
       - run: npm publish --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_test_package.yml
+++ b/.github/workflows/publish_test_package.yml
@@ -51,7 +51,7 @@ jobs:
         run: npm ci
 
       - name: Build Library
-        run: npm run build -- --no-check
+        run: npm run build:all -- --no-typecheck
 
       - name: Create archive
         run: echo "npm-pack=$(npm pack)" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Current dev build: v4.4.0-dev.2025090801
+## Current dev build: v4.4.0-dev.2025091701
 
 ### Features
 
@@ -35,6 +35,7 @@
   [#1720]
 - Directfile: set autoplay attribute on directfile contents, to work-around
   safari-specific issues [#1711]
+- Remove unnecessary duration logs when reaching the end of some VoD contents [#1744]
 
 ### Other improvements
 

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "node ./scripts/generate_build.mjs",
-    "build:all": "npm run clean:build && npm run build:wasm:release && npm run bundle && npm run bundle:min && npm run build",
+    "build:all": "bash ./scripts/make_all_builds.sh",
     "build:wasm:debug": "mkdir -p dist && cd ./src/parsers/manifest/dash/wasm-parser && cargo build --target wasm32-unknown-unknown && cp target/wasm32-unknown-unknown/debug/mpd_node_parser.wasm ../../../../../dist/mpd-parser.wasm",
     "build:wasm:release": "bash ./scripts/build_wasm_release.sh",
     "bundle": "node ./scripts/run_bundler.mjs src/index.ts --production-mode --globals --name \"RxPlayer default bundle\" -o dist/rx-player.js",
@@ -172,7 +172,7 @@
     "lint:scripts": "eslint -c scripts/eslint.config.mjs --ext .js --ext .mjs --ext .cjs scripts",
     "lint:tests": "eslint -c tests/eslint.config.mjs tests",
     "list": "node scripts/list-npm-scripts.mjs",
-    "prepublishOnly": "npm run build:all",
+    "prepublishOnly": "bash ./scripts/make_all_builds.sh",
     "releases:changelog": "node ./scripts/update_changelog.mjs",
     "releases:demo": "bash ./scripts/update_gh-pages_demo.sh",
     "releases:dev": "bash ./scripts/make-dev-releases.sh",

--- a/package.json
+++ b/package.json
@@ -294,9 +294,8 @@
       "releases:doc": "Publish current documentation as the GitHub's pages new documentation pages (\"stable\" branch only)"
     },
     "Make a release": {
-      "releases:dev": "Produce dev npm releases (which are tagged pre-releases on npm) from the current branch.",
-      "releases:official": "Produce a new official release of the RxPlayer from the current branch.",
-      "update-version": "Update the version of the RxPlayer. Will update the codebase and perform every builds."
+      "releases:dev": "Trigger our CI to produce dev npm releases (which are tagged pre-releases on npm) from the current branch.",
+      "releases:official": "Trigger our CI to produce a new official release of the RxPlayer from the current branch."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "bundle:min": "node ./scripts/run_bundler.mjs src/index.ts --production-mode --globals --name \"RxPlayer minified bundle\" -o dist/rx-player.min.js --minify",
     "certificate": "bash ./scripts/generate_certificate.sh",
     "check": "npm run check:types && npm run lint && npm run check:types:unit_tests",
-    "check:all": "npm run check:types && npm run lint && npm run lint:demo && npm run lint:tests && npm run lint:scripts && npm run test:unit && npm run test:integration && npm run test:memory",
+    "check:all": "npm run check:types && npm run lint && npm run lint:demo && npm run lint:tests && npm run lint:scripts",
     "check:demo": "npm run check:demo:types && npm run lint:demo",
     "check:demo:types": "tsc --noEmit --project demo/",
     "clean:build": "node ./scripts/utils/remove_dir.mjs dist",
@@ -240,18 +240,18 @@
     },
     "Type-check, format, or lint the current code": {
       "check": "Check the validity of the src directory by running the type checker and linter on it",
-      "check:all": "Check the validity of the whole project by running linters, type checkers and every tests",
+      "check:all": "Check the validity of the whole project by running linters and type checkers on all project directories",
+      "fmt:prettier": "Automatically format JavaScript, TypeScript, JSON, XML, HTML, YML and Markdown files",
+      "fmt:prettier:check": "Check that JavaScript, TypeScript, JSON, XML, HTML, YML and Markdown files are well-formatted",
+      "fmt:rust": "Automatically format Rust files",
+      "fmt:rust:check": "Check that Rust files are well-formatted",
       "check:types": "Check TypeScript typings in src",
       "check:types:watch": "Check TypeScript typings in src each time files change",
       "lint": "Lint rx-player source files",
       "lint:all": "Lint all RxPlayer JS files, including scripts, demo, integration tests etc.",
       "lint:demo": "Lint demo source files",
       "lint:scripts": "Lint our JS scripts in the scripts/ directory",
-      "lint:tests": "Lint integration tests source files",
-      "fmt:prettier": "Automatically format JavaScript, TypeScript, JSON, XML, HTML, YML and Markdown files",
-      "fmt:prettier:check": "Check that JavaScript, TypeScript, JSON, XML, HTML, YML and Markdown files are well-formatted",
-      "fmt:rust": "Automatically format Rust files",
-      "fmt:rust:check": "Check that Rust files are well-formatted"
+      "lint:tests": "Lint integration tests source files"
     },
     "Run tests": {
       "Integration tests (test the whole API, call the `build` script BEFORE running them)": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "test:unit": "vitest --config vitest.config.unit.mjs",
     "test:unit:watch": "vitest --config vitest.config.unit.mjs --watch",
     "update-version": "npm run version --git-tag-version=false",
-    "version": "bash ./scripts/update-version.sh"
+    "version": "bash ./scripts/update-version-number.sh"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -191,8 +191,7 @@
     "test:memory:chrome:watch": "cross-env BROWSER_CONFIG=chrome vitest watch tests/memory",
     "test:unit": "vitest --config vitest.config.unit.mjs",
     "test:unit:watch": "vitest --config vitest.config.unit.mjs --watch",
-    "update-version": "npm run version --git-tag-version=false",
-    "version": "bash ./scripts/update-version-number.sh"
+    "update-version": "bash ./scripts/update-version-number.sh"
   },
   "repository": {
     "type": "git",

--- a/scripts/deploy_new_demo.sh
+++ b/scripts/deploy_new_demo.sh
@@ -107,7 +107,7 @@ if [ -n "$(git status --porcelain "$deployed_branch")" ]; then
       git status "$deployed_branch"
     elif [[ $REPLY =~ ^[Aa](bort)?$ ]]; then
       echo "exiting"
-      exit 0
+      exit 1
     elif [[ $REPLY =~ ^[Cc](heckout)?$ ]]; then
       git checkout "$deployed_branch"
     elif [[ $REPLY =~ ^([Tt]|([Ss]tash))?$ ]]; then

--- a/scripts/make-dev-releases.sh
+++ b/scripts/make-dev-releases.sh
@@ -43,6 +43,21 @@ err() {
   exit 1
 }
 
+# Check that the given command is installed and quit on error if that's not the case
+check_dependency() {
+  if [ -z "$(command -v "$1")" ]; then
+    err "This script needs \"$1\" to be installed and be executable"
+  fi
+}
+
+check_dependency git
+check_dependency echo
+check_dependency npm
+check_dependency sed
+if [ -z "$EDITOR" ]; then
+  err "Environment variable EDITOR is not set. Please set it to your preferred text editor."
+fi
+
 if [ $# -eq 0 ]; then
   read -r -p "Please enter the wanted version number (example: 4.12.1): " version
   echo ""

--- a/scripts/make-dev-releases.sh
+++ b/scripts/make-dev-releases.sh
@@ -64,28 +64,19 @@ current_branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 date=$(date "+%Y%m%d")
 dev_version="${version}-dev.${date}${incr}"
 canal_version="${version}-canal.${date}${incr}"
-dev_branch="release/v${dev_version}"
-canal_branch="release/v${canal_version}"
 
 if [ -n "$(git status --porcelain)" ]; then
   err "There is unstaged changes in your worktree. Please commit your changes or stash them before creating the release."
 fi
 
-echo "This script will create the dev versions: $dev_version and $canal_version"
+echo "This script will prepare dev RxPlayer versions: $dev_version and $canal_version"
 
-echo "checking that the branches do not already exist locally or remotely..."
-if ! [ -z "$(git branch --list "$dev_branch")" ]; then
-  err "Branch name \"$dev_branch\" already exists locally. Please delete it first."
+if ! git apply --check "./scripts/canal-release.patch"; then
+  echo "Error: Canal patch cannot be applied cleanly!"
+  echo "Please resolve conflicts in the patch file before proceeding."
+  exit 1
 fi
-if ! [ -z "$(git branch --list "$canal_branch")" ]; then
-  err "Branch name \"$canal_branch\" already exists locally. Please delete it first."
-fi
-if ! [ -z "$(git ls-remote --heads git@github.com:canalplus/rx-player.git "refs/heads/$dev_branch")" ]; then
-  err "Branch name \"$dev_branch\" already exists remotely. Please delete it first."
-fi
-if ! [ -z "$(git ls-remote --heads git@github.com:canalplus/rx-player.git "refs/heads/$canal_branch")" ]; then
-  err "Branch name \"$canal_branch\" already exists remotely. Please delete it first."
-fi
+echo "Canal patch check passed ✓"
 
 echo "checking that the versions are not already published on npm..."
 if npm view "rx-player@$dev_version" >/dev/null 2>&1; then
@@ -129,7 +120,6 @@ if [ -n "$(git status --porcelain CHANGELOG.md)" ]; then
     elif [[ $REPLY =~ ^[Yy](es)?$ ]]; then
       git add CHANGELOG.md
       git commit -m "Update CHANGELOG.md for v$dev_version"
-      git push git@github.com:canalplus/rx-player.git "$current_branch"
       break
     elif [[ $REPLY =~ ^[Dd](iff)?$ ]]; then
       git diff CHANGELOG.md || true # ignore when return 1
@@ -150,12 +140,8 @@ if [ -n "$(git status --porcelain)" ]; then
   err "Unexpected diff in \"${current_branch}\""
 fi
 
-git checkout -b "${dev_branch}"
-./scripts/update-version.sh "$version-dev.${date}${incr}"
-git add --all
-git commit -m "update version"
 while true; do
-  read -r -n1 -p "Do you wish to push and publish the dev build? [y/n] " yn
+  read -r -n1 -p "Do you wish to publish the dev and canal builds? [y/n] " yn
   echo ""
   case $yn in
   [Yy]*) break ;;
@@ -163,24 +149,7 @@ while true; do
   *) echo "Please answer y or n." ;;
   esac
 done
-git push origin "${dev_branch}"
-npm publish --tag dev-v4
 
-git checkout "$current_branch"
-
-git checkout -b "${canal_branch}"
-git apply ./scripts/canal-release.patch
-./scripts/update-version.sh "$version-canal.${date}${incr}"
-git add --all
-git commit -m "update version"
-git push origin "${canal_branch}"
-while true; do
-  read -r -n1 -p "Do you wish to push and publish the canal build? [y/n] " yn
-  echo ""
-  case $yn in
-  [Yy]*) break ;;
-  [Nn]*) exit ;;
-  *) echo "Please answer y or n." ;;
-  esac
-done
-npm publish --tag canal-v4
+# TODO: Include release note as a tag description?
+git tag -a "v${dev_version}" -m "RxPlayer dev release: v${dev_version}"
+git push origin "${current_branch}"

--- a/scripts/make-dev-releases.sh
+++ b/scripts/make-dev-releases.sh
@@ -31,6 +31,9 @@
 #      did not output any issue and if it didn't you can confirm.
 #
 #   4. That's it!
+#
+#      If everything goes right, dev releases will be generated server-side
+#      once the right tag is created an pushed.
 
 set -e
 
@@ -151,5 +154,5 @@ while true; do
 done
 
 # TODO: Include release note as a tag description?
-git tag -a "v${dev_version}" -m "RxPlayer dev release: v${dev_version}"
+git tag -s -a "v${dev_version}" -m "RxPlayer dev release: v${dev_version}"
 git push origin "${current_branch}"

--- a/scripts/make-official-release.sh
+++ b/scripts/make-official-release.sh
@@ -21,6 +21,12 @@
 
 set -e
 
+GIT_REPO="git@github.com:canalplus/rx-player.git"
+
+# Both declared first as they will be needed for cleanup
+base_branch=""
+release_branch=""
+
 # Log a line prefixed with our script's name
 log() {
   echo "---- RxPlayer Release Script ----   $1"
@@ -35,7 +41,13 @@ emphasized_log() {
 
 # Log a line to stderr and exit with error code 1
 err() {
-  echo "ERROR: $1" >&2
+  echo "---- RxPlayer Release Script ----   ERROR: $1" >&2
+  if [[ -n "$base_branch" ]]; then
+		git checkout "$base_branch"
+		if [[ -n "$release_branch" ]]; then
+			git branch -D "$release_branch"
+		fi
+	fi
   exit 1
 }
 
@@ -53,7 +65,7 @@ current_branch() {
 
 # Get the local name for canalplus's remote repository
 git_remote_name() {
-  git remote -v | grep "git@github.com:canalplus/rx-player.git" | grep "(push)" | cut -f1
+  git remote -v | grep "$GIT_REPO" | grep "(push)" | cut -f1
 }
 
 # Check that the current branch is up-to-date with remote, errors if that's not
@@ -73,6 +85,9 @@ check_dependency cut
 check_dependency grep
 check_dependency sed
 check_dependency sleep
+if [ -z "$EDITOR" ]; then
+  err "Environment variable EDITOR is not set. Please set it to your preferred text editor."
+fi
 
 base_branch=$(current_branch)
 
@@ -84,7 +99,7 @@ if [ -n "$(git status --porcelain)" ]; then
   err "Please commit your modifications first"
 fi
 
-echo "Checking current branch is synchronized with remote..."
+log "Checking current branch is synchronized with remote..."
 check_branch_synchronized_with_remote
 
 if [ $# -eq 0 ]; then
@@ -100,16 +115,16 @@ fi
 
 emphasized_log "This script will create the official version: $version"
 
-echo "checking that the branche does not already exist locally or remotely..."
+log "checking that the branche does not already exist locally or remotely..."
 if ! [ -z "$(git branch --list "release/v$version")" ]; then
   err "Branch name \"release/v""$version""\" already exists locally. Please delete it first."
 fi
 
-if ! [ -z "$(git ls-remote --heads git@github.com:canalplus/rx-player.git "refs/heads/release/v$version")" ]; then
+if ! [ -z "$(git ls-remote --heads "$GIT_REPO" "refs/heads/release/v$version")" ]; then
   err "Branch name \"release/v""$version""\" already exists remotely. Please delete it first."
 fi
 
-echo "checking that the version are not already published on npm..."
+log "checking that the version are not already published on npm..."
 if npm view "rx-player@$version" >/dev/null 2>&1; then
   err "Version already published to npm: $version"
 fi
@@ -117,7 +132,7 @@ fi
 if [ "$base_branch" == "dev" ]; then
   emphasized_log "Checkout the stable branch and pull it..."
   git checkout stable
-  git pull git@github.com:canalplus/rx-player.git stable
+  git pull "$GIT_REPO" stable
 
   if [ -n "$(git status --porcelain)" ]; then
     err "Please commit your modifications first"
@@ -127,6 +142,7 @@ if [ "$base_branch" == "dev" ]; then
 
   emphasized_log "Rebase the dev branch on stable..."
   git checkout dev
+  git pull "$GIT_REPO" dev
   git rebase stable --rebase-merges
 fi
 
@@ -135,16 +151,17 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 emphasized_log "Creating \"release/v$version\" branch..."
-git checkout -b "release/v$version"
+release_branch="release/v$version"
+git checkout -b "$release_branch"
 
 emphasized_log "Calling update-version script to update files with the last version..."
-npm run update-version "$version"
+npm run update-version -- "$version"
 
 # Make Changelog
 npm run releases:changelog -- "$version"
 
 $EDITOR CHANGELOG.md
-echo "Running prettier on CHANGELOG.md..."
+log "Running prettier on CHANGELOG.md..."
 npx prettier --write CHANGELOG.md --log-level silent
 echo ""
 
@@ -155,7 +172,7 @@ if [ -n "$(git status --porcelain)" ]; then
 
   while :; do
     echo ""
-    log "We will push the following modification to a new release/v$version branch."
+    log "We will push the following modification to a new $release_branch branch."
     REPLY=""
     read -p "do you want to continue [y/d/s/a/c/t/h] (h for help) ? " -n 1 -r
     echo ""
@@ -169,8 +186,8 @@ if [ -n "$(git status --porcelain)" ]; then
       log "| h: see this help                                       |"
       log "+--------------------------------------------------------+"
     elif [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-      if ! [ "$(current_branch)" == "release/v$version" ]; then
-        err "The current branch is not \"release/v$version\""
+      if ! [ "$(current_branch)" == "$release_branch" ]; then
+        err "The current branch is not \"$release_branch\""
       fi
       emphasized_log "Commiting those updates..."
       git add --all
@@ -189,23 +206,35 @@ else
   log "nothing to do on the release branch"
 fi
 
+# Two following script ensure we are on the base branch with the right rights
+git checkout "$base_branch"
+
 emphasized_log "Running \"releases:demo\" script to update the gh-pages' demo..."
-npm run releases:demo
+if ! npm run releases:demo; then
+  git checkout "$base_branch"
+  git branch -D "$release_branch"
+  err "Failed to update demo page: \`releases:demo\` script failed"
+fi
 
 emphasized_log "Running \"releases:doc\" script to update the gh-pages' documentation..."
-npm run releases:doc
+if ! npm run releases:doc; then
+  git checkout "$base_branch"
+  git branch -D "$release_branch"
+  err "Failed to update doc page: \`releases:doc\` script failed"
+fi
 
-git checkout "release/v$version"
+# Go back to our new branch to be able to push it now that everything seems to pass
+git checkout "$release_branch"
 
-emphasized_log "Pushing \"release/v$version\" branch to GitHub..."
+emphasized_log "Pushing \"$release_branch\" branch to remote..."
 # TODO: Include release note as a tag description?
 git tag -s -a "v${version}" -m "RxPlayer release: v${version}"
-git push git@github.com:canalplus/rx-player.git "release/v$version"
+git push "$GIT_REPO" "$release_branch"
 
 echo ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
 log ""
-log "Your release branch has been pushed to a new \"release/v$version\" branch"
+log "Your release branch has been pushed to a new \"$release_branch\" branch"
 log "Please open a Pull Request on GitHub's interface for it and ensure the CI"
 log "passes. If the corresponding CI jobs do not trigger - it might be because"
 log "this is a retry attempt, in which case you may need to trigger it manually."
@@ -214,13 +243,15 @@ log "If the CI passes, it should automatically publish a version and merge that"
 log "work into the \"stable\" branch of the rx-player"
 log ""
 log "If the CI fails:"
-log "  1. Remove the \"release/v$version\" branch locally and remotely:"
-log "     - local remove: \`git branch -d \"release/v$version\"\`"
-log "     - remote remove: \`git push origin --delete \"release/v$version\"\`"
+log "  1. Remove the \"$release_branch\" branch locally and remotely:"
+log "     - local remove: \`git branch -d \"$release_branch\"\`"
+log "     - remote remove: \`git push origin --delete \"$release_branch\"\`"
 log "  2. Remove the version tag from the RxPlayer repository locally and remotely:"
 log "     - local remove: \`git tag -d \"$version\"\`"
 log "     - remote remove: \`git push origin --delete tag \"$version\"\`"
-log "  3. Re-launch this script again."
+log "  3. Launch this script again."
 log ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+# Go back to original branch
 git checkout "$base_branch"

--- a/scripts/make-official-release.sh
+++ b/scripts/make-official-release.sh
@@ -192,8 +192,8 @@ fi
 emphasized_log "Creating \"release/v$version\" branch..."
 git checkout -b "release/v$version"
 
-emphasized_log "Calling update-version.sh script to update files and produce builds..."
-npm run update-version.sh "$version"
+emphasized_log "Calling update-version script to update files and produce builds..."
+npm run update-version "$version"
 
 if [ -n "$(git status --porcelain)" ]; then
   echo ""
@@ -309,7 +309,9 @@ while :; do
   echo ""
 
   if [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-    emphasized_log "Pushing \"stable\" branch to GitHub..."
+    emphasized_log "Making tag and pushing \"stable\" branch to GitHub..."
+    # TODO: Include release note as a tag description?
+    it tag -a "v${version}" -m "RxPlayer official release: v${version}"
     git push git@github.com:canalplus/rx-player.git stable
     break
   elif [[ $REPLY =~ ^[Rr](ewind)?$ ]]; then
@@ -354,7 +356,8 @@ log ""
 log "The stable branch has been updated to now point to the v$version release and"
 log "has been pushed to remote."
 log ""
-log 'You may now run "npm publish", check the published package, and then create'
-log "the release on GitHub's interface (don't forget to include builds in it)."
+log 'Server-side, a build and publish of the package on npm is now scheduled.'
+log "Check the result, and then create the release on GitHub's interface (don't"
+log "forget to include builds in it)."
 log ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"

--- a/scripts/make-official-release.sh
+++ b/scripts/make-official-release.sh
@@ -134,6 +134,12 @@ if [ -n "$(git status --porcelain)" ]; then
   err "Error after doing rebases: updated files"
 fi
 
+emphasized_log "Creating \"release/v$version\" branch..."
+git checkout -b "release/v$version"
+
+emphasized_log "Calling update-version script to update files with the last version..."
+npm run update-version "$version"
+
 # Make Changelog
 npm run releases:changelog -- "$version"
 
@@ -141,59 +147,6 @@ $EDITOR CHANGELOG.md
 echo "Running prettier on CHANGELOG.md..."
 npx prettier --write CHANGELOG.md --log-level silent
 echo ""
-
-if [ -n "$(git status --porcelain CHANGELOG.md)" ]; then
-  echo "-- Current CHANGELOG.md Status: --"
-  echo ""
-  git status CHANGELOG.md
-
-  while :; do
-    echo ""
-    echo "We will push this CHANGELOG.md update to $base_branch."
-    read -r -p "do you want to continue [y/d/s/a/c/t/h] (h for help) ? " -n1 REPLY
-    echo ""
-
-    if [[ $REPLY =~ ^[Hh](elp)?$ ]]; then
-      echo ""
-      echo ""
-      echo "+- help -------------------------------------------------+"
-      echo "| y: commit and continue                                 |"
-      echo "| d: see diff                                            |"
-      echo "| s: see status                                          |"
-      echo "| a: abort script from here                              |"
-      echo "| c: skip CHANGELOG.md update and go to the next step    |"
-      echo "| h: see this help                                       |"
-      echo "+--------------------------------------------------------+"
-    elif [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-      git add CHANGELOG.md
-      git commit -m "Update CHANGELOG.md for v$version"
-      git push "git@github.com:canalplus/rx-player.git" "$base_branch"
-      break
-    elif [[ $REPLY =~ ^[Dd](iff)?$ ]]; then
-      git diff CHANGELOG.md || true # ignore when return 1
-    elif [[ $REPLY =~ ^[Ss](tatus)?$ ]]; then
-      git status CHANGELOG.md
-    elif [[ $REPLY =~ ^[Aa](bort)?$ ]]; then
-      echo "exiting"
-      exit 0
-    elif [[ $REPLY =~ ^[Cc](heckout)?$ ]]; then
-      git checkout CHANGELOG.md
-    else
-      echo "invalid input"
-    fi
-  done
-fi
-
-if [ -n "$(git status --porcelain doc)" ]; then
-  echo "ERROR: Unexpected diff in \"$base_branch\""
-  exit 1
-fi
-
-emphasized_log "Creating \"release/v$version\" branch..."
-git checkout -b "release/v$version"
-
-emphasized_log "Calling update-version script to update files and produce builds..."
-npm run update-version "$version"
 
 if [ -n "$(git status --porcelain)" ]; then
   echo ""
@@ -236,128 +189,38 @@ else
   log "nothing to do on the release branch"
 fi
 
-$EDITOR CHANGELOG.md
-echo "Running prettier on CHANGELOG.md..."
-npx prettier --write CHANGELOG.md --log-level silent
-echo ""
-if [ -n "$(git status --porcelain)" ]; then
-  emphasized_log "Commiting CHANGELOG.md update..."
-  git add CHANGELOG.md
-  git commit -m "Update CHANGELOG.md for v$version"
-fi
+emphasized_log "Running \"releases:demo\" script to update the gh-pages' demo..."
+npm run releases:demo
+
+emphasized_log "Running \"releases:doc\" script to update the gh-pages' documentation..."
+npm run releases:doc
+
+git checkout "release/v$version"
 
 emphasized_log "Pushing \"release/v$version\" branch to GitHub..."
+# TODO: Include release note as a tag description?
+git tag -s -a "v${version}" -m "RxPlayer release: v${version}"
 git push git@github.com:canalplus/rx-player.git "release/v$version"
-
-while :; do
-  echo ""
-  log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
-  log ""
-  log "Your release branch has been pushed to release/v$version"
-  log "Please open a Pull Request on GitHub's interface for it and ensure the CI"
-  log "passes."
-  log ""
-  log "If the CI fails, you can fix it directly on that release branch, keeping that"
-  log "script pending."
-  log ""
-  log 'Once the CI passes, type "y"'
-  log ""
-  log "If this script has to be interrupted before the CI passes, please delete the"
-  log "remote and local release branch before calling this script again."
-  log ""
-  log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-  REPLY=""
-  read -p "" -n 1 -r
-  echo ""
-
-  if [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-    break
-  fi
-done
-
-while :; do
-  emphasized_log "Merging \"release/v$version\" branch to \"stable\" branch..."
-  git checkout stable
-  git merge -S --no-ff "release/v$version" stable
-
-  emphasized_log "Running \"releases:demo\" script to update the gh-pages' demo..."
-  npm run releases:demo
-
-  emphasized_log "Running \"releases:doc\" script to update the gh-pages' documentation..."
-  npm run releases:doc
-  echo ""
-  log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
-  log ""
-  log "The demo page:"
-  log "https://developers.canal-plus.com/rx-player/"
-  log ""
-  log "And the documentation pages:"
-  log "https://developers.canal-plus.com/rx-player/doc/api/Overview.html"
-  log ""
-  log "Have just been updated (actual deployment may take several minutes, please"
-  log "check the anounced version on both pages first)."
-  log ""
-  log "Check that everything is working as intended."
-  log ""
-  log 'If those pages are OK, type "y"'
-  log ""
-  log 'If one of those pages has an issue, type "r"'
-  log ""
-  log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-  REPLY=""
-  read -p "" -n 1 -r
-  echo ""
-
-  if [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-    emphasized_log "Making tag and pushing \"stable\" branch to GitHub..."
-    # TODO: Include release note as a tag description?
-    it tag -a "v${version}" -m "RxPlayer official release: v${version}"
-    git push git@github.com:canalplus/rx-player.git stable
-    break
-  elif [[ $REPLY =~ ^[Rr](ewind)?$ ]]; then
-    if ! [ "$(current_branch)" == "stable" ]; then
-      err "The current branch is not \"stable\""
-    fi
-    emphasized_log "Resetting \"stable\" branch and checkouting \"release/v$version\" branch again..."
-    check_branch_synchronized_with_remote
-    git reset --hard HEAD~1
-    git checkout "release/v$version"
-    while :; do
-      echo ""
-      log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
-      log ""
-      log "We switched back to the branch: release/v$version"
-      log ""
-      log "Please fix the seen issues there, then ensure the CI passes."
-      log ""
-      log "If the CI fails, you can fix it directly on that release branch, keeping that"
-      log "script pending."
-      log ""
-      log 'Once the CI passes, type "y"'
-      log ""
-      log "If this script has to be interrupted before the CI passes, please delete the"
-      log "remote and local release branch before calling this script again."
-      log ""
-      log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-      REPLY=""
-      read -p "" -n 1 -r
-      echo ""
-
-      if [[ $REPLY =~ ^[Yy](es)?$ ]]; then
-        break
-      fi
-    done
-  fi
-done
 
 echo ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~  RxPlayer Release Script  ~~~~~~~~~~~~~~~~~~~~~~~~~"
 log ""
-log "The stable branch has been updated to now point to the v$version release and"
-log "has been pushed to remote."
+log "Your release branch has been pushed to a new \"release/v$version\" branch"
+log "Please open a Pull Request on GitHub's interface for it and ensure the CI"
+log "passes. If the corresponding CI jobs do not trigger - it might be because"
+log "this is a retry attempt, in which case you may need to trigger it manually."
 log ""
-log 'Server-side, a build and publish of the package on npm is now scheduled.'
-log "Check the result, and then create the release on GitHub's interface (don't"
-log "forget to include builds in it)."
+log "If the CI passes, it should automatically publish a version and merge that"
+log "work into the \"stable\" branch of the rx-player"
+log ""
+log "If the CI fails:"
+log "  1. Remove the \"release/v$version\" branch locally and remotely:"
+log "     - local remove: \`git branch -d \"release/v$version\"\`"
+log "     - remote remove: \`git push origin --delete \"release/v$version\"\`"
+log "  2. Remove the version tag from the RxPlayer repository locally and remotely:"
+log "     - local remove: \`git tag -d \"$version\"\`"
+log "     - remote remove: \`git push origin --delete tag \"$version\"\`"
+log "  3. Re-launch this script again."
 log ""
 log "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+git checkout "$base_branch"

--- a/scripts/make_all_builds.sh
+++ b/scripts/make_all_builds.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --no-typecheck   Skip TypeScript type-checking
+  -h, --help       Show this help message and exit
+EOF
+  exit 0
+}
+
+# Parse flags
+NO_TYPECHECK=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-typecheck) NO_TYPECHECK=1; shift ;;
+    -h|--help)      usage ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+npm run clean:build
+npm run build:wasm:release
+npm run bundle
+npm run bundle:min
+
+if [[ -n "$NO_TYPECHECK" ]]; then
+  npm run build -- --no-check
+else
+  npm run build
+fi
+
+# And now the bundle types, that actually just read the ones from our regular builds
+echo 'import RxPlayer from "./es2017/index"; export default RxPlayer;' \
+  | tee dist/rx-player.d.ts dist/rx-player.min.d.ts >/dev/null

--- a/scripts/update-version-number.sh
+++ b/scripts/update-version-number.sh
@@ -39,11 +39,3 @@ sed -i.bak -E -e "s/\/\\* PLAYER_VERSION \\*\/[[:space:]]*\".*\";/\/* PLAYER_VER
 sed -i.bak -E -e "s/\"version\":[[:space:]]*\"[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+[^\"]*\"/\"version\": \"${version}\"/g" package.json && rm package.json.bak
 sed -i.bak -E -e "s/sonar\.projectVersion= *.*/sonar.projectVersion=${version}/g" sonar-project.properties && rm sonar-project.properties.bak
 echo "$version" > VERSION
-
-npm install
-npm run build:all
-
-echo "creating types for legacy code bases..."
-rm -f dist/rx-player.d.ts rx-player.min.d.ts
-echo "import RxPlayer from \"./es2017/index\";
-export default RxPlayer;" | tee dist/rx-player.d.ts dist/rx-player.min.d.ts > /dev/null

--- a/scripts/update-version-number.sh
+++ b/scripts/update-version-number.sh
@@ -3,11 +3,11 @@
 # Update version
 # ==============
 #
-# This script updates the version number in files where it is indicated and
-# builds the rx-player for this new version.
+# This script updates the version number in files where it is indicated.
 #
-# /!\ It does not create a new git tag, nor commit anything. It only update
-# files and produce builds.
+# /!\ It does not create a new git tag, nor commit anything, nor produce
+# builds.
+# It only update files.
 #
 # To use it:
 #

--- a/scripts/update_gh-pages_doc.sh
+++ b/scripts/update_gh-pages_doc.sh
@@ -94,7 +94,7 @@ if [ -n "$(git status --porcelain doc "versions/$current_version/doc" documentat
       git status doc "versions/$current_version/doc" documentation_pages_by_version.html
     elif [[ $REPLY =~ ^[Aa](bort)?$ ]]; then
       echo "exiting"
-      exit 0
+      exit 1
     elif [[ $REPLY =~ ^[Cc](heckout)?$ ]]; then
       git checkout doc "versions/$current_version/doc" documentation_pages_by_version.html
     elif [[ $REPLY =~ ^[Tt]$ ]]; then


### PR DESCRIPTION
In the light of recent [npm security news on very popular packages that have been compromised on the npm registry](https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised) (we're not affected it seems), I thought about how we can improve our publish pipeline so applications can trust it.

_(This issue began as a fishing email from an npm impersonator, the change wasn't made on the base repo, it was only published to the `npm` registry directly from the attacker. What it did was to redirect cryptocurrencies transactions when in a browser)._

How it works for now
--------------------

When we publish a package on the npm registry, we do so by running scripts (in the `scripts/` directory) locally, and then call `npm publish` locally (while being authentified on npm with the right token).

So applications have to trust that:
  1. what we published was indeed linked to the code present in the git repository at that point.
  2. that we ran the same pushed build scripts to publish it, without modifying files first (which could be done only locally).

How can we improve on it
------------------------

It seems that npm provides a mechanim called ["provenance statements"](https://docs.npmjs.com/generating-provenance-statements).

The idea is to rely on a CI as a third party (they support only GitHub and Gitlab for now) which will do both the build process and the publishing in its entirety server-side, on a CI script that would be easy to audit (and the auditable source files that have been pushed) by another application wanting to rely on us.

Also, the repo linked to that CI has to be the repository listed in the project's `package.json` (it is for us!).

What I did
----------

I updated our publish scripts so they don't do the build nor publishing anymore.

Now they only check that conditions are right locally (e.g. the release has not already been published etc.) and then create a version tag (both for official and dev releases) and push to the current branch.

On those tags, CI scripts are now scheduled:

- for official releases, it builds the rx-player then publish the result on npm

- for dev releases, it does both the `dev` and `canal` releases. It also on its side that the "canal patch" is applied. That apply is checked multiple times (both locally and by the CI) to be sure it can be applied before doing any publishing.

Our build script is still complex (to be easily auditable by an application), but I think it's a step in the right direction.

There's though still a small detail: the secret token hasn't been added to GitHub yet (this is needed for the npm token), I'll have to contact the right people for that and it might take some time! I also haven't tested this, so no idea if I forgot some key step for now.

But anyway I still commit this to be able to receive opinions on this.

Also, we did not create tags for dev releases until now, but this means that we'll do it. I have no problem with it though, I even think that's a good idea to be able to check more quickly what a particular dev release contained (we would just checkout the tag).