### PR TITLE
Fix unnecessary duration warning

### DIFF
--- a/src/mse/utils/media_source_duration_updater.ts
+++ b/src/mse/utils/media_source_duration_updater.ts
@@ -171,7 +171,10 @@ function setMediaSourceDuration(
     const sourceBuffer = mediaSource.sourceBuffers[i];
     const sbBufferedLen = sourceBuffer.buffered.length;
     if (sbBufferedLen > 0) {
-      maxBufferedEnd = Math.max(sourceBuffer.buffered.end(sbBufferedLen - 1));
+      maxBufferedEnd = Math.max(
+        maxBufferedEnd,
+        sourceBuffer.buffered.end(sbBufferedLen - 1),
+      );
     }
   }
 


### PR DESCRIPTION
@Florent-Bouisset found that warning logs could be frequently (like 1 per second) sent by our demo page, even in our last published version on some contents as their last segment was fetched.

Those logs indicated that a duration set to the MediaSource was "invalid" once the content's end was reached.

By reading the corresponding code, it seems to just be a dumb typo, where we try to check the furthest presentation timestamp from all SourceBuffers (audio, video), but we end-up with just using the last one instead.

I don't think this issue led to actual real problems besides those logs.