### PR TITLE
Demo: fix video element weird apect ratio on chrome

### DIFF
--- a/demo/styles/style.css
+++ b/demo/styles/style.css
@@ -241,6 +241,9 @@ header .right {
 
 .video-screen-parent {
   position: relative;
+  display: flex;
+  aspect-ratio: 16 / 9;
+  min-height: 0; /* Ensures aspect-ratio takes effect */
 }
 
 .fullscreen .video-screen-parent {


### PR DESCRIPTION
It seems that for some time, and only seen on Chrome, our demo page now display a video element with a very small height by default :
<img width="1193" height="238" alt="image" src="https://github.com/user-attachments/assets/41400c5f-3d68-4451-91ca-cd628760cd13" />

This is very minor, yet as our demo page is supposed to present a credible experience, I decided to ""fix"" that weird initial aspect by forcing a 16/9 aspect ratio (and centering vertically the video in it if necessary through `flex`):

<img width="1151" height="699" alt="image" src="https://github.com/user-attachments/assets/5e7056b7-2a2f-4e07-9596-e84d871d966f" />

There may be much better way to do this, I did not spend much effort/time for this. I just have been weirded out by that sudden new aspect.