### PR TITLE
MULTI_THREAD/DEBUG_MODE: Fix display of logs' payload

### DIFF
--- a/src/errors/encrypted_media_error.ts
+++ b/src/errors/encrypted_media_error.ts
@@ -105,6 +105,7 @@ export default class EncryptedMediaError extends Error {
    */
   public serialize(): ISerializedEncryptedMediaError {
     return {
+      isSerializedError: true,
       name: this.name,
       code: this.code,
       reason: this._originalMessage,
@@ -116,6 +117,7 @@ export default class EncryptedMediaError extends Error {
 }
 
 export interface ISerializedEncryptedMediaError {
+  isSerializedError: true;
   name: "EncryptedMediaError";
   code: IEncryptedMediaErrorCode;
   reason: string;

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -92,6 +92,7 @@ export default class MediaError extends Error {
    */
   public serialize(): ISerializedMediaError {
     return {
+      isSerializedError: true,
       name: this.name,
       code: this.code,
       reason: this._originalMessage,
@@ -102,6 +103,7 @@ export default class MediaError extends Error {
 
 /** Serializable object which allows to create a `MediaError` later. */
 export interface ISerializedMediaError {
+  isSerializedError: true;
   name: "MediaError";
   code: IMediaErrorCode;
   reason: string;

--- a/src/errors/network_error.ts
+++ b/src/errors/network_error.ts
@@ -76,6 +76,7 @@ export default class NetworkError extends Error {
    */
   public serialize(): ISerializedNetworkError {
     return {
+      isSerializedError: true,
       name: this.name,
       code: this.code,
       baseError: this._baseError.serialize(),
@@ -85,6 +86,7 @@ export default class NetworkError extends Error {
 
 /** Serializable object which allows to create a `NetworkError` later. */
 export interface ISerializedNetworkError {
+  isSerializedError: true;
   name: "NetworkError";
   code: INetworkErrorCode;
   baseError: ISerializedRequestError;

--- a/src/errors/other_error.ts
+++ b/src/errors/other_error.ts
@@ -53,12 +53,18 @@ export default class OtherError extends Error {
    * @returns {Object}
    */
   public serialize(): ISerializedOtherError {
-    return { name: this.name, code: this.code, reason: this._originalMessage };
+    return {
+      isSerializedError: true,
+      name: this.name,
+      code: this.code,
+      reason: this._originalMessage,
+    };
   }
 }
 
 /** Serializable object which allows to create an `OtherError` later. */
 export interface ISerializedOtherError {
+  isSerializedError: true;
   name: "OtherError";
   code: IOtherErrorCode;
   reason: string;

--- a/src/main_thread/init/multi_thread_content_initializer.ts
+++ b/src/main_thread/init/multi_thread_content_initializer.ts
@@ -27,6 +27,7 @@ import MainMediaSourceInterface from "../../mse/main_media_source_interface";
 import type {
   ICreateMediaSourceWorkerMessage,
   ISentError,
+  ISentLogValue,
   IWorkerMessage,
 } from "../../multithread_types";
 import { MainThreadMessageType, WorkerMessageType } from "../../multithread_types";
@@ -46,6 +47,7 @@ import arrayFind from "../../utils/array_find";
 import assert, { assertUnreachable } from "../../utils/assert";
 import idGenerator from "../../utils/id_generator";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
+import type { IAcceptedLogValue } from "../../utils/logger";
 import objectAssign from "../../utils/object_assign";
 import type { IReadOnlySharedReference } from "../../utils/reference";
 import SharedReference from "../../utils/reference";
@@ -223,7 +225,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
       const type = msgData.type;
       switch (type) {
         case WorkerMessageType.LogMessage: {
-          const formatted = msgData.value.logs.map((l) => {
+          const formatted: IAcceptedLogValue[] = msgData.value.logs.map((l) => {
             switch (typeof l) {
               case "string":
               case "number":
@@ -234,7 +236,7 @@ export default class MultiThreadContentInitializer extends ContentInitializer {
                 if (l === null) {
                   return null;
                 }
-                return formatWorkerError(l);
+                return formatSentLogObject(l);
               default:
                 assertUnreachable(l);
             }
@@ -2303,4 +2305,25 @@ function formatSourceBufferError(error: unknown): SourceBufferError {
   } else {
     return new SourceBufferError("Error", "Unknown SourceBufferError Error", false);
   }
+}
+
+/**
+ * The Core might send back logs. In that situation, the message might be
+ * formatted slightly differently to be able to cross threads (so a
+ * serializable format has to be sent).
+ *
+ * This function translates that Core format to what's expected by the
+ * logger.
+ *
+ * @param {*} arg
+ * @returns {*}
+ */
+function formatSentLogObject(arg: ISentLogValue): IAcceptedLogValue {
+  if (typeof arg !== "object") {
+    return arg;
+  }
+  if (arg?.isSerializedError === true) {
+    return formatWorkerError(arg as ISentError);
+  }
+  return arg as Exclude<ISentLogValue, ISentError>;
 }

--- a/src/multithread_types.ts
+++ b/src/multithread_types.ts
@@ -944,12 +944,18 @@ export interface IResetTextDisplayerWorkerMessage {
   value: null;
 }
 
+type ISentLogValueBase = boolean | string | number | null | undefined;
+export type ISentLogValue =
+  | ISentLogValueBase
+  | ISentError
+  | Partial<Record<string, ISentLogValueBase>>;
+
 export interface ILogMessageWorkerMessage {
   type: WorkerMessageType.LogMessage;
   value: {
     namespace: ILogNamespace;
     logLevel: ILoggerLevel;
-    logs: Array<boolean | string | number | ISentError | null | undefined>;
+    logs: ISentLogValue[];
   };
 }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -23,7 +23,7 @@ export type ILoggerLevel = "NONE" | "ERROR" | "WARNING" | "INFO" | "DEBUG";
 export type ILogFormat = "standard" | "full";
 
 type IAcceptedLogValueBase = boolean | string | number | null | undefined;
-type IAcceptedLogValue =
+export type IAcceptedLogValue =
   | IAcceptedLogValueBase
   | Error
   | Partial<Record<string, IAcceptedLogValueBase>>;
@@ -197,12 +197,7 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
     const generateLogFn =
       this._currentFormat === "full"
         ? (logMethod: string, consoleFn: (...vals: unknown[]) => void): IConsoleFn => {
-            return (
-              namespace: ILogNamespace,
-              ...args: Array<
-                IAcceptedLogValue | Partial<Record<string, IAcceptedLogValue>>
-              >
-            ) => {
+            return (namespace: ILogNamespace, ...args: IAcceptedLogValue[]) => {
               const now = getMonotonicTimeStamp();
               return consoleFn(
                 String(now.toFixed(2)),
@@ -217,12 +212,7 @@ export default class Logger extends EventEmitter<ILoggerEvents> {
             };
           }
         : (_logMethod: string, consoleFn: (...vals: unknown[]) => void): IConsoleFn => {
-            return (
-              namespace: ILogNamespace,
-              ...args: Array<
-                IAcceptedLogValue | Partial<Record<string, IAcceptedLogValue>>
-              >
-            ) => {
+            return (namespace: ILogNamespace, ...args: IAcceptedLogValue[]) => {
               return consoleFn(
                 namespace + ":",
                 ...args.map((a) =>


### PR DESCRIPTION
I noticed an issue on our not-yet-released future RxPlayer version where it would not show payload of logs from our worker, when the global `__RX_PLAYER_DEBUG_MODE__` bool was set to `true` (which unlocks our "debug mode", a mechanism mainly used by [RxPaired](https://github.com/canalplus/RxPaired)).

In that mode only, all worker logs are sent back to the main thread (to group all RxPlayer logs in a common JS realm, as it makes it much easier to debug).

Since \#1717, the format of those logs changed but were not properly handled by the main thread.

I fixed that here. There was a remaining issue for `Error` instances, the only "complex" type that may be set as a log payload, because we have to do serializing and deserializing steps after detecting that a payload seems to be a serialized error (this is done with duck typing for now). Most of the code here is linked to this situation.

I also greatly simplified what could be set as a log payload by removing a special `Record<Record<LogValue>>` case. It isn't needed and it just complexify things.