### PR TITLE
fix: add resilience to DRM fallback when position is not right

### DIFF
--- a/src/core/stream/orchestrator/stream_orchestrator.ts
+++ b/src/core/stream/orchestrator/stream_orchestrator.ts
@@ -399,7 +399,32 @@ export default function StreamOrchestrator(
         }
 
         const lastPosition = observation.position.getWanted();
-        const newInitialPeriod = manifest.getPeriodForTime(lastPosition);
+        let newInitialPeriod = manifest.getPeriodForTime(lastPosition);
+        if (newInitialPeriod === undefined) {
+          // If there's no Period for the current position exactly, select the next one
+          newInitialPeriod = manifest.getNextPeriod(lastPosition);
+          log.warn(
+            "Stream",
+            "No Period found for the reloading position, selecting next one instead",
+            {
+              reloadPosition: lastPosition,
+              nextPeriodStart: newInitialPeriod?.start,
+            },
+          );
+        }
+        if (newInitialPeriod === undefined) {
+          // If there's no Period after the current position, select the last one
+          newInitialPeriod = manifest.periods[manifest.periods.length - 1];
+          log.warn(
+            "Stream",
+            "No Period found for of after the reloading position, selecting the last one",
+            {
+              reloadPosition: lastPosition,
+              nextPeriodStart: newInitialPeriod?.start,
+              nextPeriodEnd: newInitialPeriod?.end,
+            },
+          );
+        }
         if (newInitialPeriod === undefined) {
           callbacks.error(
             new MediaError(


### PR DESCRIPTION
We've seen some error spike in production with Chrome 140 (which among other things added some DRM-linked capabilities) and one of the application using the RxPlayer.

The error received was `MEDIA_TIME_NOT_FOUND`, an error we should normally NEVER emit to the application (even though it's part of our errors API) as it is linked to some RxPlayer assertion.

The corresponding assertion checks that the position we reload to (usually the same position we were previously playing) is linked to a Period from the Manifest.

Now it is unsure why many users see this with Chrome 140 specifically: I cannot imagine an actual practical scenario in which this assertion would break. Yet it's very easy to add some resilience into that code to make the assertion almost unnecessary:

If the reloaded position is not linked to any Period: just start with the next one. At worse our gap-jumping code will just seek at the start of that next Period once playback can start again.

If there's no next Period, just take the last one instead. Here the worst that can happen is very long (or infinite) rebuffering as no data exists for the new position, but the application will receive the corresponding `MEDIA_TIME_AFTER_MANIFEST` errors through our `warning` event anyway and be able to seek back where it wants.

---

The fact that we don't know when it happens also mean that we may have another thing that either the RxPlayer or the application does wrong, or that there is a scenario happening here that we never considered before (or even a small browser issue).

But even with that in mind I think this resilience code is a good idea, from experience media playback is full of those previously-thought-to-be-impossible scenarios that actually do happen in random situations and some safety to still allow playback continuation (even at a potentially wrong position) seems sensible to me here.