### PR TITLE
CI's Pull Requests integration tests rely on the same base than our releases

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -67,70 +67,29 @@ jobs:
       - run: npm ci
       - run: npm run test:unit
 
-  integration_linux:
-    runs-on: ubuntu-latest
+  integration_linux_chrome:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "chrome" }
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+  integration_linux_firefox:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "firefox" }
 
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      # needed for integration & memory tests codecs support
-      - run:
-          sudo add-apt-repository multiverse && sudo apt update && sudo apt install -y
-          ubuntu-restricted-extras
-      - run: npm ci
-      - run: npm run build
-      - run: |
-          npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge ||
-          # retry on failure
-          if [ $? -ne 0 ]; then
-            echo "First tests attempt failed. Retrying after 20 seconds..."
-            sleep 20
-            npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
-          fi
+  integration_linux_edge:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "ubuntu-latest", browser: "edge" }
 
-  integration_windows:
-    runs-on: windows-latest
+  integration_windows_chrome:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "chrome" }
 
-    strategy:
-      matrix:
-        node-version: [22.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+  integration_windows_firefox:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "firefox" }
 
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/checkout@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-
-      - shell: bash
-        run: npm ci
-      - shell: bash
-        run: npm run build
-      - shell: bash
-        run: |
-          npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge ||
-          # retry on failure
-          if [ $? -ne 0 ]; then
-            echo "First tests attempt failed. Retrying after 20 seconds..."
-            sleep 20
-            npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge ||
-            # Other OSes than linux are particularly bad on github actions, run it three times
-            if [ $? -ne 0 ]; then
-              echo "Second tests attempt failed. Retrying after 60 seconds..."
-              sleep 60
-              npm run test:integration:chrome && npm run test:integration:firefox && npm run test:integration:edge
-            fi
-          fi
+  integration_windows_edge:
+    uses: ./.github/workflows/integration_tests_base.yml
+    with: { os: "windows-latest", browser: "edge" }
 
   memory_linux:
     runs-on: ubuntu-latest

--- a/tests/integration/scenarios/dash_multi-track.test.js
+++ b/tests/integration/scenarios/dash_multi-track.test.js
@@ -315,7 +315,6 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     await sleep(0);
 
     expect(manifestLoaderCalledTimes).to.equal(1);
-    expect(requestedSegments).to.be.empty;
     expect(player.getPlayerState()).to.equal("LOADING");
     await waitForLoadedStateAfterLoadVideo(player);
     expect(requestedSegments.length).to.be.above(2);
@@ -384,14 +383,20 @@ describe("DASH multi-track content (SegmentTimeline)", function () {
     if (player.getPlayerState() !== "LOADED") {
       await waitForLoadedStateAfterLoadVideo(player);
     }
-    expect(eventCalled).to.equal(1);
+    expect(eventCalled).to.equal(
+      1,
+      `newAvailablePeriods event called ${eventCalled} times instead of 1`,
+    );
 
     checkAudioTrack("fr", "fra", false);
     checkTextTrack("de", "deu", false);
     checkVideoTrack({ all: true, test: /avc1\.42C014/ }, true);
 
     await goToSecondPeriod();
-    expect(eventCalled).to.equal(2);
+    expect(eventCalled).to.equal(
+      2,
+      `newAvailablePeriods event called ${eventCalled} times instead of 2`,
+    );
     checkAudioTrack("de", "deu", true);
     checkTextTrack("fr", "fra", true);
     checkVideoTrack({ all: false, test: /avc1\.640028/ }, undefined);

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1531,7 +1531,7 @@ export default function launchTestsForContent(manifestInfos, { multithread } = {
             /* do nothing */
           },
         });
-        await checkAfterSleepWithBackoff({ maxTimeMs: 50 }, () => {
+        await checkAfterSleepWithBackoff({ maxTimeMs: 200 }, () => {
           const audioTracks = player.getAvailableAudioTracks();
 
           const audioAdaptations = manifestInfos.periods[0].adaptations.audio;
@@ -1577,7 +1577,7 @@ export default function launchTestsForContent(manifestInfos, { multithread } = {
             /* do nothing */
           },
         });
-        await checkAfterSleepWithBackoff({ maxTimeMs: 50 }, () => {
+        await checkAfterSleepWithBackoff({ maxTimeMs: 200 }, () => {
           const textTracks = player.getAvailableTextTracks();
 
           const textAdaptations = manifestInfos.periods[0].adaptations.text;
@@ -1621,7 +1621,7 @@ export default function launchTestsForContent(manifestInfos, { multithread } = {
             /* do nothing */
           },
         });
-        await checkAfterSleepWithBackoff({ maxTimeMs: 50 }, () => {
+        await checkAfterSleepWithBackoff({ maxTimeMs: 200 }, () => {
           const videoTracks = player.getAvailableVideoTracks();
 
           const videoAdaptations = manifestInfos.periods[0].adaptations.video;


### PR DESCRIPTION
To improve the readability of our release publishing script, we've put recently a "base" file for our integration tests in a separate yml (.github/workflows/integration_tests_base.yml) that can be called and parametarized (for setting the right OS and browser).

We only used it for our releases workflow, not for the regular checks on each PR yet. This PR changes that so every workflow uses it, hopefully making those easier to maintain.

There are two important differences:

- The previous way grouped all OS under the same job. You had one for linux and one for windows (github-actions on macOS had too poor of a performance last time we checked, sadly), each browser being tested in each.

  Now you have 3 (browsers) * 2 (OS) different jobs instead. This should also make it easier to parallelize.

- We had previously a retrying logic after a backoff because some of our tests are time-sensitive (rightfully, e.g. to check that playback rate updates are not broken on an actual playback by waiting some time and checking the position) and thus can end up with many false negatives when the CI is not performant enough.

  I chose to remove that retrying logic for now. In any way, it should
  be doable to bring it back if it proves to be annoying.