### PR TITLE
Fix occurences of `MEDIA_TIME_NOT_FOUND` on initial fallback

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1164,7 +1164,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     /** Global "playback observer" which will emit playback conditions */
-    const playbackObserver = new MediaElementPlaybackObserver(videoElement, {
+    const playbackObserver = new MediaElementPlaybackObserver({
       withMediaSource: !isDirectFile,
       lowLatencyMode,
     });
@@ -1286,6 +1286,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     //   - we can avoid involontarily catching events linked to the previous
     //     content.
     this.stop();
+
+    playbackObserver.attachMediaElement(videoElement);
 
     // Update the RxPlayer's state at the right events
     const playerStateRef = constructPlayerStateReference(

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -17,6 +17,7 @@
 import type { IMediaElement } from "../compat/browser_compatibility_types";
 import isSeekingApproximate from "../compat/is_seeking_approximate";
 import config from "../config";
+import ManualTimeRanges from "../core/segment_sinks/implementations/utils/manual_time_ranges";
 import log from "../log";
 import getMonotonicTimeStamp from "../utils/monotonic_timestamp";
 import noop from "../utils/noop";
@@ -68,9 +69,9 @@ const SCANNED_MEDIA_ELEMENTS_EVENTS = [
  */
 export default class PlaybackObserver {
   /** HTMLMediaElement which we want to observe. */
-  private _mediaElement: IMediaElement;
+  private _mediaElementRef: SharedReference<IMediaElement | null>;
 
-  /** If `true`, a `MediaSource` object is linked to `_mediaElement`. */
+  /** If `true`, a `MediaSource` object is linked to the `HTMLMediaElement`. */
   private _withMediaSource: boolean;
 
   /**
@@ -132,6 +133,8 @@ export default class PlaybackObserver {
    */
   private _expectedSeekingPosition: number | null;
 
+  private _observationIntervalId: ReturnType<typeof setInterval> | null;
+
   /**
    * If `true` seek operations asked through the
    * `MediaElementPlaybackObserver` will not be performed now but after the
@@ -143,34 +146,62 @@ export default class PlaybackObserver {
    * Create a new `PlaybackObserver`, which allows to produce new "playback
    * observations" on various media events and intervals.
    *
+   * Once a `PlaybackObserver` is created, you will want to "attach" the
+   * media element to it through the `attachMediaElement` method once that
+   * element is ready to play your content.
+   *
    * Note that creating a `PlaybackObserver` lead to the usage of resources,
    * such as event listeners which will only be freed once the `stop` method is
    * called.
-   * @param {HTMLMediaElement} mediaElement
    * @param {Object} options
    */
-  constructor(mediaElement: IMediaElement, options: IPlaybackObserverOptions) {
+  constructor(options: IPlaybackObserverOptions) {
     this._internalSeeksIncoming = [];
-    this._mediaElement = mediaElement;
+    this._mediaElementRef = new SharedReference<IMediaElement | null>(null);
     this._withMediaSource = options.withMediaSource;
     this._lowLatencyMode = options.lowLatencyMode;
     this._canceller = new TaskCanceller();
-    this._observationRef = this._createSharedReference();
     this._expectedSeekingPosition = null;
     this._pendingSeek = null;
     this._isSeekBlocked = false;
-
-    const onLoadedMetadata = () => {
-      if (this._pendingSeek !== null && !this._isSeekBlocked) {
-        const { position: positionToSeekTo, isInternal } = this._pendingSeek;
-        this._pendingSeek = null;
-        this._actuallySetCurrentTime(positionToSeekTo, isInternal);
-      }
-    };
-    mediaElement.addEventListener("loadedmetadata", onLoadedMetadata);
+    this._observationIntervalId = null;
+    this._observationRef = this._createSharedReference();
     this._canceller.signal.register(() => {
-      mediaElement.removeEventListener("loadedmetadata", onLoadedMetadata);
+      this._mediaElementRef.finish();
     });
+  }
+
+  /**
+   * "Link" the actual `HTMLMediaElement` to this `PlaybackObserver`.
+   *
+   * This is done in a step separate from the constructor to allow complex
+   * situations where you want to inialize the polling logic before the media
+   * element is ready to play your content (e.g. when pre-loading the next
+   * content).
+   *
+   * @param {HTMLMediaElement} mediaElement - The `HTMLMediaElement` on which
+   * the content plays.
+   */
+  public attachMediaElement(mediaElement: IMediaElement): void {
+    const prevMediaElement = this._mediaElementRef.getValue();
+    if (prevMediaElement !== null) {
+      throw new Error("A media element was already attached to this PlaybackObserver");
+    }
+    this._mediaElementRef.setValue(mediaElement);
+    if (this._canceller.isUsed()) {
+      return;
+    }
+
+    this._registerLoadedMetadataEvent(mediaElement);
+    this._restartInterval();
+    this._registerMediaElementEvents(mediaElement);
+    this._generateObservationForEvent("init");
+    if (this._canceller.isUsed()) {
+      return;
+    }
+    if (mediaElement.readyState >= 1) {
+      this._onLoadedMetadataEvent();
+    }
   }
 
   /**
@@ -192,15 +223,21 @@ export default class PlaybackObserver {
    * @returns {number}
    */
   public getCurrentTime(): number {
-    return this._mediaElement.currentTime;
+    return (
+      this._mediaElementRef.getValue()?.currentTime ??
+      this._observationRef.getValue().position.getPolled()
+    );
   }
 
   /**
    * Returns the current playback rate advertised by the `HTMLMediaElement`.
-   * @returns {number}
+   * @returns {number|undefined}
    */
   public getPlaybackRate(): number {
-    return this._mediaElement.playbackRate;
+    return (
+      this._mediaElementRef.getValue()?.playbackRate ??
+      this._observationRef.getValue().playbackRate
+    );
   }
 
   /**
@@ -208,10 +245,12 @@ export default class PlaybackObserver {
    *
    * Use this instead of the same status emitted on an observation when you want
    * to be sure you're using the current value.
-   * @returns {boolean}
+   * @returns {boolean|undefined}
    */
   public getIsPaused(): boolean {
-    return this._mediaElement.paused;
+    return (
+      this._mediaElementRef.getValue()?.paused ?? this._observationRef.getValue().paused
+    );
   }
 
   /**
@@ -237,10 +276,15 @@ export default class PlaybackObserver {
   public unblockSeeking(): void {
     if (this._isSeekBlocked) {
       this._isSeekBlocked = false;
-      if (this._pendingSeek !== null && this._mediaElement.readyState >= 1) {
+      const mediaElement = this._mediaElementRef.getValue();
+      if (
+        mediaElement !== null &&
+        mediaElement.readyState >= 1 &&
+        this._pendingSeek !== null
+      ) {
         const { position: positionToSeekTo, isInternal } = this._pendingSeek;
         this._pendingSeek = null;
-        this._actuallySetCurrentTime(positionToSeekTo, isInternal);
+        this._actuallySetCurrentTime(mediaElement, positionToSeekTo, isInternal);
       }
     }
   }
@@ -290,31 +334,37 @@ export default class PlaybackObserver {
    * the user.
    */
   public setCurrentTime(time: number, isInternal: boolean = true): void {
-    if (!this._isSeekBlocked && this._mediaElement.readyState >= 1) {
-      this._actuallySetCurrentTime(time, isInternal);
+    const mediaElement = this._mediaElementRef.getValue();
+    if (mediaElement !== null && !this._isSeekBlocked && mediaElement.readyState >= 1) {
+      this._actuallySetCurrentTime(mediaElement, time, isInternal);
     } else {
       this._pendingSeek = { position: time, isInternal };
       this._internalSeeksIncoming = [];
-      if (!this._isSeekBlocked) {
-        this._generateObservationForEvent("manual");
-      }
+      this._generateObservationForEvent("manual");
     }
   }
 
   /**
-   * Update the playback rate of the `HTMLMediaElement`.
+   * Update the playback rate of the `HTMLmediaElement`.
    * @param {number} playbackRate
    */
   public setPlaybackRate(playbackRate: number): void {
-    this._mediaElement.playbackRate = playbackRate;
+    const mediaElement = this._mediaElementRef.getValue();
+    if (mediaElement === null) {
+      return;
+    }
+    mediaElement.playbackRate = playbackRate;
   }
 
   /**
-   * Returns the current `readyState` advertised by the `HTMLMediaElement`.
+   * Returns the current `readyState` advertised by the `HTMLmediaElement`.
    * @returns {number}
    */
   public getReadyState(): number {
-    return this._mediaElement.readyState;
+    return (
+      this._mediaElementRef.getValue()?.readyState ??
+      this._observationRef.getValue().readyState
+    );
   }
 
   /**
@@ -379,12 +429,16 @@ export default class PlaybackObserver {
     return generateReadOnlyObserver(this, transform, this._canceller.signal);
   }
 
-  private _actuallySetCurrentTime(time: number, isInternal: boolean): void {
+  private _actuallySetCurrentTime(
+    mediaElement: IMediaElement,
+    time: number,
+    isInternal: boolean,
+  ): void {
     log.info("media", "Actually seeking.", { time, isInternal });
     if (isInternal) {
       this._internalSeeksIncoming.push(time);
     }
-    this._mediaElement.currentTime = time;
+    mediaElement.currentTime = time;
   }
 
   /**
@@ -396,51 +450,25 @@ export default class PlaybackObserver {
     if (this._observationRef !== undefined) {
       return this._observationRef;
     }
-
-    const {
-      SAMPLING_INTERVAL_MEDIASOURCE,
-      SAMPLING_INTERVAL_LOW_LATENCY,
-      SAMPLING_INTERVAL_NO_MEDIASOURCE,
-    } = config.getCurrent();
     const returnedSharedReference = new SharedReference(
       this._getCurrentObservation("init"),
       this._canceller.signal,
     );
 
-    let interval: number;
-    if (this._lowLatencyMode) {
-      interval = SAMPLING_INTERVAL_LOW_LATENCY;
-    } else if (this._withMediaSource) {
-      interval = SAMPLING_INTERVAL_MEDIASOURCE;
-    } else {
-      interval = SAMPLING_INTERVAL_NO_MEDIASOURCE;
+    this._restartInterval();
+
+    const mediaElement = this._mediaElementRef.getValue();
+    if (mediaElement !== null) {
+      this._registerMediaElementEvents(mediaElement);
     }
 
-    const onInterval = () => {
-      this._generateObservationForEvent("timeupdate");
-    };
-    let intervalId = setInterval(onInterval, interval);
-    SCANNED_MEDIA_ELEMENTS_EVENTS.map((eventName) => {
-      const onMediaEvent = () => {
-        restartInterval();
-        this._generateObservationForEvent(eventName);
-      };
-
-      this._mediaElement.addEventListener(eventName, onMediaEvent);
-      this._canceller.signal.register(() => {
-        this._mediaElement.removeEventListener(eventName, onMediaEvent);
-      });
-    });
     this._canceller.signal.register(() => {
-      clearInterval(intervalId);
+      if (this._observationIntervalId !== null) {
+        clearInterval(this._observationIntervalId);
+      }
       returnedSharedReference.finish();
     });
     return returnedSharedReference;
-
-    function restartInterval() {
-      clearInterval(intervalId);
-      intervalId = setInterval(onInterval, interval);
-    }
   }
 
   private _getCurrentObservation(
@@ -448,12 +476,13 @@ export default class PlaybackObserver {
   ): IPlaybackObservation {
     /** Actual event emitted through an observation. */
     let tmpEvt: IPlaybackObserverEventType = event;
+    const mediaElement = this._mediaElementRef.getValue();
 
     // NOTE: `this._observationRef` may be `undefined` because we might here be
     // called in the constructor when that property is not yet set.
     const previousObservation =
       this._observationRef === undefined
-        ? getInitialObservation(this._mediaElement)
+        ? getInitialObservation(mediaElement)
         : this._observationRef.getValue();
 
     /**
@@ -466,7 +495,8 @@ export default class PlaybackObserver {
     let pendingPosition: number | null = this._pendingSeek?.position ?? null;
 
     /** Initially-polled playback observation, before adjustments. */
-    const mediaTimings = getMediaInfos(this._mediaElement);
+    const mediaTimings =
+      mediaElement === null ? getEmptyMediaInfo() : getMediaInfos(mediaElement);
     const { buffered, readyState, position, seeking } = mediaTimings;
     if (tmpEvt === "seeking") {
       // We just began seeking.
@@ -622,6 +652,59 @@ export default class PlaybackObserver {
     }
     this._observationRef.setValue(newObservation);
   }
+
+  private _restartInterval() {
+    const {
+      SAMPLING_INTERVAL_MEDIASOURCE,
+      SAMPLING_INTERVAL_LOW_LATENCY,
+      SAMPLING_INTERVAL_NO_MEDIASOURCE,
+    } = config.getCurrent();
+    let interval: number;
+    if (this._lowLatencyMode) {
+      interval = SAMPLING_INTERVAL_LOW_LATENCY;
+    } else if (this._withMediaSource) {
+      interval = SAMPLING_INTERVAL_MEDIASOURCE;
+    } else {
+      interval = SAMPLING_INTERVAL_NO_MEDIASOURCE;
+    }
+    if (this._observationIntervalId !== null) {
+      clearInterval(this._observationIntervalId);
+    }
+    this._observationIntervalId = setInterval(
+      () => this._generateObservationForEvent("timeupdate"),
+      interval,
+    );
+  }
+
+  private _registerMediaElementEvents(mediaElement: IMediaElement): void {
+    SCANNED_MEDIA_ELEMENTS_EVENTS.map((eventName) => {
+      const onMediaEvent = () => {
+        this._restartInterval();
+        this._generateObservationForEvent(eventName);
+      };
+      mediaElement.addEventListener(eventName, onMediaEvent);
+      this._canceller.signal.register(() => {
+        mediaElement.removeEventListener(eventName, onMediaEvent);
+      });
+    });
+  }
+
+  private _registerLoadedMetadataEvent(mediaElement: IMediaElement): void {
+    const loadedmetadataCb = this._onLoadedMetadataEvent.bind(this);
+    mediaElement.addEventListener("loadedmetadata", loadedmetadataCb);
+    this._canceller.signal.register(() => {
+      mediaElement.removeEventListener("loadedmetadata", loadedmetadataCb);
+    });
+  }
+
+  private _onLoadedMetadataEvent(): void {
+    const mediaElement = this._mediaElementRef.getValue();
+    if (mediaElement !== null && this._pendingSeek !== null && !this._isSeekBlocked) {
+      const { position: positionToSeekTo, isInternal } = this._pendingSeek;
+      this._pendingSeek = null;
+      this._actuallySetCurrentTime(mediaElement, positionToSeekTo, isInternal);
+    }
+  }
 }
 
 /**
@@ -681,8 +764,28 @@ function hasLoadedUntilTheEnd(
 }
 
 /**
+ * Get polled media metrics for when the `HTMLMediaElement` is not yet "attached"
+ * to the `PlaybackObserver`.
+ *
+ * Those metrics actually corresponds to an idle media element.
+ * @returns {Object}
+ */
+function getEmptyMediaInfo(): IMediaInfos {
+  return {
+    buffered: new ManualTimeRanges(),
+    position: 0,
+    duration: NaN,
+    ended: false,
+    paused: true,
+    playbackRate: 1,
+    readyState: 0,
+    seeking: false,
+  };
+}
+
+/**
  * Get basic playback information.
- * @param {HTMLMediaElement} mediaElement
+ * @param {HTMLmediaElement} mediaElement
  * @returns {Object}
  */
 function getMediaInfos(mediaElement: IMediaElement): IMediaInfos {
@@ -985,8 +1088,9 @@ function prettyPrintBuffered(buffered: TimeRanges, currentTime: number): string 
  * @param {HTMLMediaElement} mediaElement
  * @returns {Object}
  */
-function getInitialObservation(mediaElement: IMediaElement): IPlaybackObservation {
-  const mediaTimings = getMediaInfos(mediaElement);
+function getInitialObservation(mediaElement: IMediaElement | null): IPlaybackObservation {
+  const mediaTimings =
+    mediaElement === null ? getEmptyMediaInfo() : getMediaInfos(mediaElement);
   return objectAssign(mediaTimings, {
     rebuffering: null,
     event: "init" as const,


### PR DESCRIPTION
We've recently seen `MEDIA_TIME_NOT_FOUND` errors in a Canal+ application.

It's one of the errors that are part of our API that should actually be never sent to an application - unless there's an RxPlayer bug somewhere (it is documented as such in our API documentation).

The issue
---------

Turns out they were encountering a very specific race condition after a chain of events:

1. The application relied on a multi-threaded RxPlayer and played an encrypted content with some non-decipherable qualities.

   They also have all conditions met to allow our cache of `MediaKeySession` (which allows to reuse already-loaded decryption keys).

2. They then loaded another content, with a completely different media position that does not map to anything in the previous content (it shouldn't matter, but it will be important later)

3. The application switches again to the first content, without calling `stop` in between (which is OK and even more performant).

   In that situation, the following happen just after the third step:

4. We start to initialize everything for that last content.

   Since recently (https://github.com/canalplus/rx-player/pull/1607), that initialization step includes the initial polling of media metrics such as the position, the playbackRate etc.

   Before that work, this polling was done in a later step.

5. We stop the previous content. We do this after initializing the next content on purpose.

   "Stopping" a content (setting `mediaElement.src = ""`, typically) is a synchronous/blocking operations in JS that can actually take a lot of time - like hundred of ms on lower-end devices.

   To improve performance, we thus "initialize" the next content before stopping the previous one, as the former includes some parallelizable operations (network requests, `postMessage` to our Worker etc.) that can still take place while the "stop operation" is blocking the JS main thread.

6. The RxPlayer core (running in a WebWorker here) initialize everything, fetches the Manifest etc.

   Here the content is already known and its decryption keys are still "cached" locally, so we directly know that some qualities in the Manifest are not decipherable and decide to "fallback" from the higher qualities.

7. The fallback mechanism reads the last polled media metrics. If we reached that logic too fast, we will actually read the initially-polled metrics (3 steps earlier).

   This should be OK, but because we last polled the media metrics _BEFORE_ stopping the previous content **AND** no metrics has been emitted since then, the playback position in those metrics is actually the last position reached in the previous content.

8. The RxPlayer checks that wanted position, see that it doesn't make sense in the current content, and triggers the `MEDIA_TIME_NOT_FOUND` error.

The fixes
------------

The crux of this issue is that:
1. we poll media metrics before stopping the previous content and,
2. we do not emit new metrics immediately when the initial position to seek to is known (as this would also have saved us from this issue)
3. if we don't know the playing position when the DRM fallback logic is triggered, we throw a `MEDIA_TIME_NOT_FOUND` error

The fix I ended up choosing is very far from being the most straightforward one though :D. It's a solution I already PoCed with my [preload work](https://github.com/canalplus/rx-player/pull/1646) which I found elegant in terms of code architecture.

Basically the `PlaybackObserver` (the class doing the polling) can now be "headless" initially: without a media element. In that case, default media metrics are considered (position `0`, paused etc.)

When the media element is considered "ready", it can be attached to it, in which case "real" polling will be performed. This ensure that no polling of media metrics linked to a previous content is going on.

It wasn't done with this issue in mind, but I found that it also made sense there: before stopping the previous content, we want to start our metrics-polling module (the `PlaybackObserver`) but are not yet ready to attach the media element as it is still technically playing the previous content.
Once the previous content is stopped, we can now begin to actually link the media element to it to enable actual polling.

Moreover, I now also decide to emit those metrics right when we know what the initial position to seek to will be (as those metrics include this data point as a "wanted position"). This makes sure that the RxPlayer core always has the more up-to-date information.

Lastly, the already-merged #1755 fix should also have fixed that issue - as the initial position would have been known at some point by the RxPlayer Core anyway.

This makes it far from a hotfix (there's a lot of lines) but I like this solution.