### PR TITLE
Proposal: `ContentInitializer`: remove explicit two-steps of prepare and start

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1465,7 +1465,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     });
 
     // Now, that most events are linked, prepare the next content.
-    initializer.prepare();
+    initializer.start(playbackObserver);
 
     // Now that the content is prepared, stop previous content and reset state
     // This is done after content preparation as `stop` could technically have
@@ -1477,8 +1477,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     //   - we can avoid involontarily catching events linked to the previous
     //     content.
     this.stop();
-
-    playbackObserver.attachMediaElement(videoElement);
 
     // Update the RxPlayer's state at the right events
     const playerStateRef = constructPlayerStateReference(
@@ -1634,7 +1632,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           stopListeningToLock();
 
           // start playback!
-          initializer.start(videoElement, playbackObserver);
+          playbackObserver.attachMediaElement(videoElement);
         }
       },
       { emitCurrentValue: true, clearSignal: currentContentCanceller.signal },

--- a/src/main_thread/init/directfile_content_initializer.ts
+++ b/src/main_thread/init/directfile_content_initializer.ts
@@ -72,10 +72,35 @@ export default class DirectFileContentInitializer extends ContentInitializer {
   }
 
   /**
-   * "Prepare" content so it can later be played by calling `start`.
+   * @param {Object} playbackObserver - Interface to the `HTMLMediaElement`,
+   * also allowing to poll playback information from it at regular intervals.
+   * Actual playback will start once an `HTMLMediaElement` is attached to it.
    */
-  public prepare(): void {
-    return; // Directfile contents do not have any preparation
+  public start(playbackObserver: IMediaElementPlaybackObserver): void {
+    playbackObserver.onMediaElementAttachment(
+      (mediaElement: IMediaElement) =>
+        this._startPlayback(mediaElement, playbackObserver),
+      this._initCanceller.signal,
+    );
+  }
+
+  /**
+   * Update URL this `ContentIntializer` depends on.
+   * @param {Array.<string>|undefined} _urls
+   * @param {boolean} _refreshNow
+   */
+  public updateContentUrls(_urls: string[] | undefined, _refreshNow: boolean): void {
+    throw new Error("Cannot update content URL of directfile contents");
+  }
+
+  /**
+   * Stop content and free all resources linked to this `ContentIntializer`.
+   * @param {string | undefined} reason - Human-inspectable reason behind the
+   * dispose. Used for debugging matters, especially for debug log
+   * inspection.
+   */
+  public dispose(reason: string | undefined): void {
+    this._initCanceller.cancel(reason ?? "Directfile Init dispose");
   }
 
   /**
@@ -86,7 +111,7 @@ export default class DirectFileContentInitializer extends ContentInitializer {
    * @param {Object} playbackObserver - Object regularly emitting playback
    * information.
    */
-  public start(
+  private _startPlayback(
     mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
@@ -177,25 +202,6 @@ export default class DirectFileContentInitializer extends ContentInitializer {
       },
       { emitCurrentValue: true, clearSignal: cancelSignal },
     );
-  }
-
-  /**
-   * Update URL this `ContentIntializer` depends on.
-   * @param {Array.<string>|undefined} _urls
-   * @param {boolean} _refreshNow
-   */
-  public updateContentUrls(_urls: string[] | undefined, _refreshNow: boolean): void {
-    throw new Error("Cannot update content URL of directfile contents");
-  }
-
-  /**
-   * Stop content and free all resources linked to this `ContentIntializer`.
-   * @param {string | undefined} reason - Human-inspectable reason behind the
-   * dispose. Used for debugging matters, especially for debug log
-   * inspection.
-   */
-  public dispose(reason: string | undefined): void {
-    this._initCanceller.cancel(reason ?? "Directfile Init dispose");
   }
 
   /**

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -171,9 +171,16 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
   }
 
   /**
-   * Perform non-destructive preparation steps, to prepare a future content.
+   * Starts loading the content linked to this `ContentInitializer`.
+   *
+   * Will perform non-destructive preparation steps, to prepare a future content
+   * until an `HTMLMediaElement` is attached to it, at which point playback will
+   * begin.
+   * @param {Object} playbackObserver - Interface to the `HTMLMediaElement`,
+   * also allowing to poll playback information from it at regular intervals.
+   * Actual playback will start once an `HTMLMediaElement` is attached to it.
    */
-  public prepare(): void {
+  public start(playbackObserver: IMediaElementPlaybackObserver): void {
     if (this._currentContentInfo !== null || this._initCanceller.isUsed()) {
       return;
     }
@@ -322,6 +329,12 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       },
       { clearSignal: this._initCanceller.signal, emitCurrentValue: true },
     );
+
+    playbackObserver.onMediaElementAttachment(
+      (mediaElement: IMediaElement) =>
+        this._startPlayback(mediaElement, playbackObserver),
+      this._initCanceller.signal,
+    );
   }
 
   /**
@@ -342,15 +355,24 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     });
   }
 
+  public dispose(reason: string | undefined): void {
+    this._initCanceller.cancel("Init dispose");
+    if (this._currentContentInfo !== null) {
+      if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
+        this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(reason);
+      }
+      this._currentContentInfo = null;
+    }
+  }
+
   /**
    * @param {HTMLMediaElement} mediaElement
    * @param {Object} playbackObserver
    */
-  public start(
+  private _startPlayback(
     mediaElement: IMediaElement,
     playbackObserver: IMediaElementPlaybackObserver,
   ): void {
-    this.prepare(); // Load Manifest if not already done
     if (this._initCanceller.isUsed()) {
       return;
     }
@@ -1345,16 +1367,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       log.debug("Init", "removeEventListener for core message");
       this._settings.coreInterface.removeMessageListener(onmessage);
     });
-  }
-
-  public dispose(reason: string | undefined): void {
-    this._initCanceller.cancel("Init dispose");
-    if (this._currentContentInfo !== null) {
-      if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
-        this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(reason);
-      }
-      this._currentContentInfo = null;
-    }
   }
 
   private _onFatalError(err: unknown) {

--- a/src/main_thread/init/types.ts
+++ b/src/main_thread/init/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { IMediaElement } from "../../compat/browser_compatibility_types.ts";
 import type { ISegmentSinkMetrics } from "../../core/segment_sinks/segment_sinks_store.ts";
 import type { IBufferType, IAdaptationChoice, IInbandEvent } from "../../core/types.ts";
 import type {
@@ -48,42 +47,24 @@ import type {
  */
 export abstract class ContentInitializer extends EventEmitter<IContentInitializerEvents> {
   /**
-   * Prepare the content linked to this `ContentInitializer` in the background,
-   * without actually trying to play it.
-   *
-   * This method may be used for optimization reasons, for example to prepare a
-   * future content without interrupting the previous one playing on a given
-   * `HTMLMediaElement`.
-   */
-  public abstract prepare(): void;
-
-  /**
-   * Actually starts playing the content linked to this `ContentInitializer` on
-   * the given `mediaElement`.
+   * Starts loading the content linked to this `ContentInitializer`.
    *
    * Only a single call to `start` is expected to be performed on each
    * `ContentInitializer`.
    *
-   * A call to `prepare` may or may not have been performed before calling
-   * `start`. If it was, it may or may not have yet finished the preparation
-   * phase before `start` is called (the `ContentInitializer` should stay
-   * resilient in both scenarios).
+   * Note: the `ContentInitializer` will rely on the `HTMLMediaElement`
+   * "attached" to the given `PlaybackObserver`. If a content was already
+   * playing on that `HTMLMediaElement`, it will be stopped.
+   * It's possible to "prepare" some of the content-loading logic (e.g. Manifest
+   * fetching) while a previous content is still playing by just attaching the
+   * corresponding `HTMLMediaElement` to the `PlaybackObserver` *after* calling
+   * this `start` method.
    *
-   * @param {HTMLMediaElement} mediaElement - `HTMLMediaElement` on which the
-   * content will play. This is given to `start` (and not sooner) to ensure
-   * that no prior step influence the `HTMLMediaElement`, on which a previous
-   * content could have been playing until then.
-   *
-   * If a content was already playing on that `HTMLMediaElement`, it will be
-   * stopped.
-   * @param {Object} playbackObserver - Interface allowing to poll playback
-   * information on what's playing on the `HTMLMediaElement` at regular
-   * intervals.
+   * @param {Object} playbackObserver - Interface to the `HTMLMediaElement`,
+   * also allowing to poll playback information from it at regular intervals.
+   * Actual playback will start once an `HTMLMediaElement` is attached to it.
    */
-  public abstract start(
-    mediaElement: IMediaElement,
-    playbackObserver: IMediaElementPlaybackObserver,
-  ): void;
+  public abstract start(playbackObserver: IMediaElementPlaybackObserver): void;
 
   /**
    * Update URL of the content currently being played (e.g. DASH's MPD).

--- a/src/playback_observer/media_element_playback_observer.ts
+++ b/src/playback_observer/media_element_playback_observer.ts
@@ -179,8 +179,11 @@ export default class PlaybackObserver {
    * element is ready to play your content (e.g. when pre-loading the next
    * content).
    *
-   * @param {HTMLMediaElement} mediaElement - The `HTMLMediaElement` on which
-   * the content plays.
+   * If callbacks are registered on `HTMLMediaElement` attachment through the
+   * `onMediaElementAttachment` method, they will be called synchronously.
+   *
+   * @param {HTMLMediaElement} mediaElement - The `HTMLMediaElement` to attach
+   * to this `PlaybackObserver.`
    */
   public attachMediaElement(mediaElement: IMediaElement): void {
     const prevMediaElement = this._mediaElementRef.getValue();
@@ -201,6 +204,61 @@ export default class PlaybackObserver {
     }
     if (mediaElement.readyState >= 1) {
       this._onLoadedMetadataEvent();
+    }
+  }
+
+  /**
+   * A `PlaybackObserver` can have an `HTMLMediaElement` attached or still await
+   * one. This method calls your given callback as soon as it is attached.
+   * Calls your callback synchronously if it is already attached.
+   *
+   * @param {Function} cb - The callback to call once the `HTMLMediaElement` is
+   * attached, with the `HTMLMediaElement` in argument.
+   * Note that `cb` will be called at most once.
+   * @param {CancellationSignal} cancelSignal - When/if this
+   * `CancellationSignal` emits before the given `cb` is called, we will stop
+   * registering that callback to be called.
+   */
+  public onMediaElementAttachment(
+    cb: (mediaElement: IMediaElement) => void,
+    cancelSignal: CancellationSignal,
+  ) {
+    if (cancelSignal.isCancelled()) {
+      return;
+    }
+    const mediaElement = this._mediaElementRef.getValue();
+    if (mediaElement !== null) {
+      try {
+        cb(mediaElement);
+      } catch (err) {
+        log.error(
+          "API",
+          "onMediaElementAttachment error",
+          err instanceof Error ? err : "Unknown Error",
+        );
+      }
+    } else {
+      this._mediaElementRef.onUpdate(
+        (lastMediaElement, stopListening) => {
+          if (lastMediaElement === null) {
+            return;
+          }
+          stopListening();
+          try {
+            cb(lastMediaElement);
+          } catch (err) {
+            log.error(
+              "API",
+              "onMediaElementAttachment error",
+              err instanceof Error ? err : "Unknown Error",
+            );
+          }
+        },
+        {
+          clearSignal: cancelSignal,
+          emitCurrentValue: false,
+        },
+      );
     }
   }
 

--- a/tests/unit/mocks/playback_observer.ts
+++ b/tests/unit/mocks/playback_observer.ts
@@ -28,6 +28,7 @@ export const DummyMediaElementPlaybackObserver =
       setPlaybackRate: notImplemented("setPlaybackRate"),
       listen: notImplemented("listen"),
       deriveReadOnlyObserver: notImplemented("deriveReadOnlyObserver"),
+      onMediaElementAttachment: notImplemented("onMediaElementAttachment"),
     },
     {},
   );


### PR DESCRIPTION
Since we brought the idea of allowing a `PlaybackObserver` to be without a media element attached (e.g. when a previous content is still not stopped), we have an occasion to simplify the `ContentInitializer` API a little:

Instead of having two methods `prepare` (non-destructive content preparation, e.g. manifest fetching) and `start` ("destructive" playback, in that the previous content will be stopped), we can now just have one exposed API and make it itself await for media element attachment to know when it's able to actually play.

i.e. instead of:
```js
const init = new ContentInitializer({ /* ... */ });

const playbackObserver = new PlaybackObserver({ /* ... */})
// ... Link callbacks to `init` events.

init.prepare();

// ... Stop previous content

playbackObserver.attachMediaElement(mediaElement);

// ... Ensure media element is ready to play a new content -
// (specifically clean some DRM state if needed)

init.start(mediaElement, playbackObserver);
```

We can now just do:
```js
const init = new ContentInitializer({ /* ... */ });

const playbackObserver = new PlaybackObserver({ /* ... */})
// ... Link callbacks to `init` events.

init.start(playbackObserver);

// ... Stop previous content

// ... Ensure media element is ready to play a new content -
// (specifically clean some DRM state if needed)

playbackObserver.attachMediaElement(mediaElement);
```

(`preprare` is renamed `start`, old `start` is removed, `attachMediaElement` is just done later).

Though this does mean a supplementary `PlaybackObserver` method - here called `onMediaElementAttachment(callback, cancelSignal)` that the `ContentInitializer` has to know about and call. This also means that it now understands the idea that a `PlaybackObserver` might not have a media element attached at first.

Also `playbackObserver.attachMediaElement()` now needs to be called only once the media element can actually play a content, not just when its properties seem clean enough. But IMO for that part, it's cleaner and more understandable that way than before.

---

Note that even if it can look like it, this is not at all linked to our potential "preload" feature.

This is just a possible alternative `ContentInitializer` API that I wanted to illustrate since we did the
"PlaybackObserver-without-media-element" thing.