### PR TITLE
Fix ordering of a PeriodChange/AdaptationChange couple

### DIFF
--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -767,17 +767,6 @@ function loadPreparedContent(
         },
 
         adaptationChange(value) {
-          contentTimeBoundariesObserver.onAdaptationChange(
-            value.type,
-            value.period,
-            value.adaptation,
-          );
-          if (
-            currentLoadCanceller === null ||
-            currentLoadCanceller.signal.isCancelled()
-          ) {
-            return;
-          }
           sendMessage({
             type: CoreMessageType.AdaptationChanged,
             contentId,
@@ -787,6 +776,11 @@ function loadPreparedContent(
               type: value.type,
             },
           });
+          contentTimeBoundariesObserver.onAdaptationChange(
+            value.type,
+            value.period,
+            value.adaptation,
+          );
         },
 
         representationChange(value) {


### PR DESCRIPTION
New integration tests I've added recently (#1763) led me to a curious RxPlayer behavior: for multithreaded contents, we had two initial `textTrackChange` (with the payload `null`) in a row instead of just one.

This exact behavior does not break the API (so it's not a bug), but it was nonetheless not normal, so I looked at it.

---

Turns out it is linked to a bad ordering in core between the first "PeriodChange" Core message (indicating a Period is currently playing, thus implies that we already chose the audio+video+text tracks) and the last "AdaptationChange" (for audio or video or text type) for that first period.

What happened:

1. The content begins to be loaded, the RxPlayer setup everything, and start choosing the initial Adaptations (tracks) and Representations.
2. Once all Adaptation are setup, Core send a `PeriodChange` message
3. Then Core sent an `AdaptationChange` message for the last Adaptation set-up (the text one here)
4. Main thread receives the `PeriodChange` message and bubble it to the public API module.
5. The public API on this event looks at the current audio / video / text tracks for that new Period and send the right `...TrackChange` events, then send a `periodChange` event, as expected
6. Main thread then receives the `AdaptationChange` message and also bubble it.
7. The Public API reacts on this event by sending again `textTrackChange` for the same text track, because it thinks from the `AdaptationChange` message that the track just changed, after the PeriodChange

---

Reversing the ordering (the last `AdaptationChange`, then `PeriodChange`) in Core makes more sense (messages are the Core's API, and advertising for a Period change should be done after advertising for all tracks initially choosen for that Period) fixes the issue.

It's very unclear to me if this led to actual bugs later in the RxPlayer. For now the only seen impact was a failing integration test which was voluntarily less "tolerant" than our advertised API.