### PR TITLE
Remove a reason to throw in the reload API

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -765,8 +765,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       startAt = { position: reloadOpts.reloadAt.position };
     } else if (reloadOpts?.reloadAt?.relative !== undefined) {
       if (reloadPosition === undefined) {
-        throw new Error(
-          "Can't reload to a relative position when previous content was not loaded.",
+        log.warn(
+          "API",
+          "reload API > reloadAt.relative option given but we don't know the previous content's position",
         );
       } else {
         startAt = { position: reloadOpts.reloadAt.relative + reloadPosition };


### PR DESCRIPTION
I noticed that one of the application relying on the RxPlayer had this type of code:

```js
try {
  rxPlayer.reload({ reloadAt: { relative: 5 }});
} catch {
  // Reload may throw if the previous content did not load, call
  // loadVideo instead
  rxPlayer.loadVideo(lastOptions);
}
```

I thought that relying on try-catch here based on a condition as unnatural that "the last content reached a LOADED state", was an unnecessary complexity.

Turns out the RxPlayer only throws in its `reload` API for one those two reasons:

1. `loadVideo` was never called (in which case calling the `reload` API does make no sense - if no content was ever loaded, I don't see why they would want to call `reload`).

2. They set a `reloadAt.relative` initial position (which means that we need to reload at a different position than the last we loaded it).

   Here if the position was never polled by the RxPlayer for the previous content, it is very difficult to us to understand where we would need to load now. So we throw based on that obscure rule of "we have to know the previous position we stopped at".

I propose here to just ignore `reloadAt.relative` if no position was ever known for the last loaded content:

- It's better IMO in any case than just throwing on call for such a specific issue.

- Finding out what the actual position would have been previously and doing the actual relative operation would be very difficult to implement, so I do not go there.