### PR TITLE
update vitest to vitest4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react-dom": "19.1.7",
         "@typescript-eslint/eslint-plugin": "^8.40.0",
         "@typescript-eslint/parser": "^8.40.0",
-        "@vitest/browser": "^3.2.4",
+        "@vitest/browser-webdriverio": "^4.0.16",
         "core-js": "3.45.0",
         "cross-env": "^10.0.0",
         "esbuild": "0.25.9",
@@ -35,8 +35,7 @@
         "semver": "7.7.2",
         "typescript": "5.9.2",
         "typescript-eslint": "^8.40.0",
-        "vitest": "3.2.4",
-        "webdriverio": "^9.20.0"
+        "vitest": "^4.0.16"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -51,41 +50,6 @@
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@canalplus/readme.doc": {
@@ -210,6 +174,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -233,6 +198,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -974,9 +940,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.2.tgz",
-      "integrity": "sha512-gKYheCylLIedI+CSZoDtGkFV9YEBxRRVcfCH7OfAqh4TyUyRjEE6WVE/aXDXX0p8BIe/QgLcaAoI0220KRRFgg==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1057,9 +1023,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.12.tgz",
-      "integrity": "sha512-mP9iLFZwH+FapKJLeA7/fLqOlSUwYpMwjR1P5J23qd4e7qGJwecJccJqHYrjw33jmIZYV4dtiTHPD/J+1e7cEw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
+      "integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1378,39 +1344,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
-      }
+      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -1419,21 +1358,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1480,6 +1413,7 @@
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1565,6 +1499,7 @@
       "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.40.0",
         "@typescript-eslint/types": "8.40.0",
@@ -1765,75 +1700,86 @@
       }
     },
     "node_modules/@vitest/browser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.4.tgz",
-      "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.0.16.tgz",
+      "integrity": "sha512-t4toy8X/YTnjYEPoY0pbDBg3EvDPg1elCDrfc+VupPHwoN/5/FNQ8Z+xBYIaEnOE2vVEyKwqYBzZ9h9rJtZVcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@testing-library/dom": "^10.4.0",
-        "@testing-library/user-event": "^14.6.1",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "magic-string": "^0.30.17",
-        "sirv": "^3.0.1",
-        "tinyrainbow": "^2.0.0",
-        "ws": "^8.18.2"
+        "@vitest/mocker": "4.0.16",
+        "@vitest/utils": "4.0.16",
+        "magic-string": "^0.30.21",
+        "pixelmatch": "7.1.0",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.0.3",
+        "ws": "^8.18.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "playwright": "*",
-        "vitest": "3.2.4",
-        "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
+        "vitest": "4.0.16"
+      }
+    },
+    "node_modules/@vitest/browser-webdriverio": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-webdriverio/-/browser-webdriverio-4.0.16.tgz",
+      "integrity": "sha512-DE0dCXQMtqMJJ0NruA0LTawHa4kPnNGfWYQh1r20QeD5oIDNbggpL4/jy58Wn8OcruaEGEHTKEWdaNOhdHefsg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/browser": "4.0.16"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.16",
+        "webdriverio": "*"
       },
       "peerDependenciesMeta": {
-        "playwright": {
-          "optional": true
-        },
-        "safaridriver": {
-          "optional": true
-        },
         "webdriverio": {
-          "optional": true
+          "optional": false
         }
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
+      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
+      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.0.16",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0-0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1845,42 +1791,41 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
+      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
+      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.0.16",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
+      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.0.16",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1888,47 +1833,42 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
+      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
+      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.0.16",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@wdio/config": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.20.0.tgz",
-      "integrity": "sha512-ggwd3EMsVj/LTcbYw2h+hma+/7fQ1cTXMuy9B5WTkLjDlOtbLjsqs9QLt4BLIo1cdsxvAw/UVpRVUuYy7rTmtQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-9.21.0.tgz",
+      "integrity": "sha512-8TP5/q+Agjc43LET1f0LhLmuEI803O3QtZEbSxOkkvJ7/e1jDWPm4qsL7SjQJlx8xGrW0kwRlPl7+U9Sr0dhCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@wdio/logger": "9.18.0",
         "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "deepmerge-ts": "^7.0.3",
         "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0",
-        "jiti": "^2.5.1"
+        "import-meta-resolve": "^4.0.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -1998,9 +1938,9 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.20.0.tgz",
-      "integrity": "sha512-T1ze005kncUTocYImSBQc/FAVcOwP/vOU4MDJFgzz/RTcps600qcKX98sVdWM5/ukXCVkjOufWteDHIbX5/tEA==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.21.0.tgz",
+      "integrity": "sha512-aj8ao2V/e6Sv9gZby2ZIj4dMLjwYVba47Nlr+pOfK8N4VKKU0VRLPzvTlfK1HWaoS6u/GBbVx2pefYRrvd72BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2010,7 +1950,7 @@
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
         "edgedriver": "^6.1.2",
-        "geckodriver": "^5.0.0",
+        "geckodriver": "^6.1.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
@@ -2024,9 +1964,9 @@
       }
     },
     "node_modules/@zip.js/zip.js": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.8.tgz",
-      "integrity": "sha512-v0KutehhSAuaoFAFGLp+V4+UiZ1mIxQ8vNOYMD7k9ZJaBbtQV49MYlg568oRLiuwWDg2Di58Iw3Q0ESNWR+5JA==",
+      "version": "2.8.11",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.11.tgz",
+      "integrity": "sha512-0fztsk/0ryJ+2PPr9EyXS5/Co7OK8q3zY/xOoozEWaUsL5x+C0cyZ4YyMuUffOO2Dx/rAdq4JMPqW0VUtm+vzA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -2054,6 +1994,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2428,9 +2369,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.0.tgz",
-      "integrity": "sha512-GljgCjeupKZJNetTqxKaQArLK10vpmK28or0+RwWjEl5Rk+/xG3wkpmkv+WrcBm3q1BwHKlnhXzR8O37kcvkXQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
+      "integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2499,9 +2440,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
-      "integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -2605,16 +2546,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2676,20 +2607,13 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
-      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2707,16 +2631,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/cheerio": {
@@ -3035,13 +2949,13 @@
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14"
       }
     },
     "node_modules/data-urls": {
@@ -3150,16 +3064,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3250,13 +3154,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3357,28 +3254,27 @@
       }
     },
     "node_modules/edgedriver": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.1.2.tgz",
-      "integrity": "sha512-UvFqd/IR81iPyWMcxXbUNi+xKWR7JjfoHjfuwjqsj9UHQKn80RpQmS0jf+U25IPi+gKVPcpOSKm0XkqgGMq4zQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-6.2.0.tgz",
+      "integrity": "sha512-49G6010o0VYXUMNi5OvxqE9O/kazs0qmJVqHcSHNvp1VfojO21Kb/NaJN40uy11yrlGHRp7y6a372xoCnShzlA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.1.3",
-        "@zip.js/zip.js": "^2.7.53",
-        "decamelize": "^6.0.0",
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
         "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^5.0.8",
+        "fast-xml-parser": "^5.3.2",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^3.3.2",
-        "which": "^5.0.0"
+        "https-proxy-agent": "^7.0.6",
+        "which": "^6.0.0"
       },
       "bin": {
         "edgedriver": "bin/edgedriver.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/edgedriver/node_modules/isexe": {
@@ -3392,9 +3288,9 @@
       }
     },
     "node_modules/edgedriver/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+      "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3404,7 +3300,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -3714,6 +3610,7 @@
       "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4235,9 +4132,9 @@
       }
     },
     "node_modules/expect-type": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
-      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4324,9 +4221,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
-      "integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.3.tgz",
+      "integrity": "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==",
       "dev": true,
       "funding": [
         {
@@ -4360,30 +4257,6 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4483,19 +4356,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4553,53 +4413,25 @@
       }
     },
     "node_modules/geckodriver": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-5.0.0.tgz",
-      "integrity": "sha512-vn7TtQ3b9VMJtVXsyWtQQl1fyBVFhQy7UvJF96kPuuJ0or5THH496AD3eUyaDD11+EqCxH9t6V+EP9soZQk4YQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@wdio/logger": "^9.1.3",
-        "@zip.js/zip.js": "^2.7.53",
-        "decamelize": "^6.0.0",
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
         "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.5",
-        "node-fetch": "^3.3.2",
-        "tar-fs": "^3.0.6",
-        "which": "^5.0.0"
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
       },
       "bin": {
         "geckodriver": "bin/geckodriver.js"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/geckodriver/node_modules/isexe": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
-      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/geckodriver/node_modules/which": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -4709,16 +4541,6 @@
         "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4"
       },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -5129,9 +4951,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5620,16 +5442,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5666,6 +5478,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6000,13 +5813,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
-      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -6014,24 +5820,14 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -6136,6 +5932,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.3.tgz",
+      "integrity": "sha512-4W79zekKGyYU4JXVmB78DOscMFaJth2gGhgfTl2alWE4rNe3nf4N2pqenQ0rEtIewrnD79M687Ouba3YGTLOvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -6187,46 +5993,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/normalize-path": {
@@ -6381,6 +6147,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6629,16 +6406,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -6664,6 +6431,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixelmatch": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
+      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6729,34 +6519,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -6907,6 +6669,7 @@
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6923,13 +6686,6 @@
       "peerDependencies": {
         "react": "^19.1.1"
       }
-    },
-    "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/readable-stream": {
       "version": "4.7.0",
@@ -7556,9 +7312,9 @@
       }
     },
     "node_modules/sirv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
-      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7692,9 +7448,9 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
-      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -7954,30 +7710,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-literal": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "dev": true,
       "funding": [
         {
@@ -8065,11 +7801,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -8112,6 +7851,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8119,30 +7859,10 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8361,6 +8081,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8476,6 +8197,7 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8545,29 +8267,6 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -8592,6 +8291,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8600,51 +8300,51 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
+      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.0.16",
+        "@vitest/mocker": "4.0.16",
+        "@vitest/pretty-format": "4.0.16",
+        "@vitest/runner": "4.0.16",
+        "@vitest/snapshot": "4.0.16",
+        "@vitest/spy": "4.0.16",
+        "@vitest/utils": "4.0.16",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.16",
+        "@vitest/browser-preview": "4.0.16",
+        "@vitest/browser-webdriverio": "4.0.16",
+        "@vitest/ui": "4.0.16",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -8652,13 +8352,19 @@
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
           "optional": true
         },
         "@vitest/ui": {
@@ -8673,9 +8379,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8716,30 +8422,20 @@
         "node": ">=10"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webdriver": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.20.0.tgz",
-      "integrity": "sha512-Kk+AGV1xWLNHVpzUynQJDULMzbcO3IjXo3s0BzfC30OpGxhpaNmoazMQodhtv0Lp242Mb1VYXD89dCb4oAHc4w==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.21.0.tgz",
+      "integrity": "sha512-XLOhpU/EFPo4TMk+0fRli4g1WriUujxrfDxGT/QRq0MJsfhSYPF8FdefFdL5gHIrJfSKscaQHGWkbnsHftfqeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "^20.1.0",
         "@types/ws": "^8.5.3",
-        "@wdio/config": "9.20.0",
+        "@wdio/config": "9.21.0",
         "@wdio/logger": "9.18.0",
         "@wdio/protocols": "9.16.2",
         "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "deepmerge-ts": "^7.0.3",
         "https-proxy-agent": "^7.0.6",
         "undici": "^6.21.3",
@@ -8750,20 +8446,21 @@
       }
     },
     "node_modules/webdriverio": {
-      "version": "9.20.0",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.20.0.tgz",
-      "integrity": "sha512-cqaXfahTzCFaQLlk++feZaze6tAsW8OSdaVRgmOGJRII1z2A4uh4YGHtusTpqOiZAST7OBPqycOwfh01G/Ktbg==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-9.21.0.tgz",
+      "integrity": "sha512-7teaXajOuNdn2UyyKlqMLssJjf0vDEih+Lo+tE/gHOt/P+mB8CinZym4PGtsriZLcyt4xV+Cun3hDmXM+pL26A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
-        "@wdio/config": "9.20.0",
+        "@wdio/config": "9.21.0",
         "@wdio/logger": "9.18.0",
         "@wdio/protocols": "9.16.2",
         "@wdio/repl": "9.16.2",
         "@wdio/types": "9.20.0",
-        "@wdio/utils": "9.20.0",
+        "@wdio/utils": "9.21.0",
         "archiver": "^7.0.1",
         "aria-query": "^5.3.0",
         "cheerio": "^1.0.0-rc.12",
@@ -8780,7 +8477,7 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^12.0.0",
         "urlpattern-polyfill": "^10.0.0",
-        "webdriver": "9.20.0"
+        "webdriver": "9.21.0"
       },
       "engines": {
         "node": ">=18.20.0"

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "@types/react-dom": "19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.40.0",
     "@typescript-eslint/parser": "^8.40.0",
-    "@vitest/browser": "^3.2.4",
+    "@vitest/browser-webdriverio": "^4.0.16",
     "core-js": "3.45.0",
     "cross-env": "^10.0.0",
     "esbuild": "0.25.9",
@@ -223,8 +223,7 @@
     "semver": "7.7.2",
     "typescript": "5.9.2",
     "typescript-eslint": "^8.40.0",
-    "vitest": "3.2.4",
-    "webdriverio": "^9.20.0"
+    "vitest": "^4.0.16"
   },
   "scripts-list": {
     " INFO ": "---- This field is read by the `list` npm script and allows to guide you through the RxPlayer's npm scripts ----",

--- a/src/manifest/classes/__tests__/adaptation.test.ts
+++ b/src/manifest/classes/__tests__/adaptation.test.ts
@@ -61,7 +61,7 @@ const minimalRepresentationIndex: IRepresentationIndex = {
     /* noop */
   },
 };
-const mockDefaultRepresentationImpl = vi.fn((arg: IParsedRepresentation) => {
+const mockDefaultRepresentationImpl = vi.fn(function (arg: IParsedRepresentation) {
   return {
     bitrate: arg.bitrate,
     id: arg.id,
@@ -221,7 +221,7 @@ describe("Manifest - Adaptation", () => {
   });
 
   it("should execute the representationFilter if given", async () => {
-    const mockRepresentation = vi.fn((arg: IParsedRepresentation) => {
+    const mockRepresentation = vi.fn(function (arg: IParsedRepresentation) {
       return {
         bitrate: arg.bitrate,
         id: arg.id,

--- a/src/manifest/classes/__tests__/manifest.test.ts
+++ b/src/manifest/classes/__tests__/manifest.test.ts
@@ -123,7 +123,7 @@ describe("Manifest - Manifest", () => {
       periods: [period1, period2],
     };
 
-    const fakePeriod = vi.fn((period: IPeriod) => {
+    const fakePeriod = vi.fn(function (period: IPeriod) {
       return { id: `foo${period.id}`, adaptations: period.adaptations };
     });
     vi.doMock("../period", () => ({
@@ -183,7 +183,7 @@ describe("Manifest - Manifest", () => {
       return false;
     };
 
-    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+    const fakePeriod = vi.fn(function (period: IParsedPeriod): IPeriod {
       return { id: `foo${period.id}` } as IPeriod;
     });
     vi.doMock("../period", () => ({
@@ -238,7 +238,7 @@ describe("Manifest - Manifest", () => {
       periods: [period1, period2],
     };
 
-    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+    const fakePeriod = vi.fn(function (period: IParsedPeriod): IPeriod {
       return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
     });
     vi.doMock("../period", () => ({
@@ -299,7 +299,7 @@ describe("Manifest - Manifest", () => {
       uris: ["url1", "url2"],
     };
 
-    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+    const fakePeriod = vi.fn(function (period: IParsedPeriod): IPeriod {
       return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
     });
     vi.doMock("../period", () => ({
@@ -342,7 +342,7 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should return all URLs given with `getContentUrls`", async () => {
-    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+    const fakePeriod = vi.fn(function (period: IParsedPeriod): IPeriod {
       return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
     });
     vi.doMock("../period", () => ({
@@ -410,7 +410,7 @@ describe("Manifest - Manifest", () => {
   });
 
   it("should replace with a new Manifest when calling `replace`", async () => {
-    const fakePeriod = vi.fn((period: IParsedPeriod): IPeriod => {
+    const fakePeriod = vi.fn(function (period: IParsedPeriod): IPeriod {
       return { ...period, id: `foo${period.id}` } as unknown as IPeriod;
     });
     const fakeReplacePeriodsRes = {

--- a/src/manifest/classes/__tests__/period.test.ts
+++ b/src/manifest/classes/__tests__/period.test.ts
@@ -10,14 +10,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no adaptation is given", async () => {
-    const mockAdaptation = vi.fn((arg: IParsedAdaptation) => ({
-      ...arg,
-      supportStatus: {
-        hasSupportedCodec: undefined,
-        hasCodecWithUndefinedSupport: true,
-        isDecipherable: undefined,
-      },
-    }));
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation) {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      };
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -51,17 +53,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if no audio nor video adaptation is given", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
@@ -115,17 +116,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if only empty audio and video adaptations is given", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
@@ -166,17 +166,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should throw if there is no video nor audio representations in any adaptations.", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
@@ -258,17 +257,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should not throw if there is no video representation but it has an audio representation.", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -313,17 +311,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should report that all video adaptations are not supported", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: arg.type !== "video",
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: arg.type !== "video",
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
@@ -396,17 +393,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should not set a parsing error if an empty unsupported adaptation is given", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text", "foo"],
@@ -449,17 +445,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should give a representationFilter to the adaptation", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     const representationFilter = vi.fn();
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
@@ -501,17 +496,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should not report if an Adaptation has no Representation", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -554,17 +548,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should set the given start", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -597,17 +590,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should set a given duration", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -646,17 +638,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should infer the end from the start and the duration", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -695,17 +686,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should return every Adaptations combined with `getAdaptations`", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -756,17 +746,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should return every Adaptations from a given type with `getAdaptationsForType`", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -826,17 +815,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should return the first Adaptations with a given Id when calling `getAdaptation`", async () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],
@@ -894,17 +882,16 @@ describe("Manifest - Period", () => {
   });
 
   it("should return undefind if no adaptation has the given Id when calling `getAdaptation`", () => {
-    const mockAdaptation = vi.fn(
-      (arg: IParsedAdaptation): Adaptation =>
-        ({
-          ...arg,
-          supportStatus: {
-            hasSupportedCodec: undefined,
-            hasCodecWithUndefinedSupport: true,
-            isDecipherable: undefined,
-          },
-        }) as unknown as Adaptation,
-    );
+    const mockAdaptation = vi.fn(function (arg: IParsedAdaptation): Adaptation {
+      return {
+        ...arg,
+        supportStatus: {
+          hasSupportedCodec: undefined,
+          hasCodecWithUndefinedSupport: true,
+          isDecipherable: undefined,
+        },
+      } as unknown as Adaptation;
+    });
     vi.doMock("../adaptation", () => ({
       default: mockAdaptation,
       SUPPORTED_ADAPTATIONS_TYPE: ["audio", "video", "text"],

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,25 +1,28 @@
 import { defineConfig } from "vitest/config";
+import { webdriverio } from "@vitest/browser-webdriverio";
 
 function getBrowserConfig(browser) {
   switch (browser) {
     case "chrome":
       return {
         enabled: true,
-        provider: "webdriverio",
+        provider: webdriverio({
+          capabilities: {
+            browserName: "chrome",
+            "goog:chromeOptions": {
+              args: [
+                "--autoplay-policy=no-user-gesture-required",
+                "--enable-precise-memory-info",
+                "--js-flags=--expose-gc",
+              ],
+            },
+          },
+        }),
         headless: true,
         screenshotFailures: false,
         instances: [
           {
             browser: "chrome",
-            capabilities: {
-              "goog:chromeOptions": {
-                args: [
-                  "--autoplay-policy=no-user-gesture-required",
-                  "--enable-precise-memory-info",
-                  "--js-flags=--expose-gc",
-                ],
-              },
-            },
           },
         ],
       };
@@ -27,24 +30,26 @@ function getBrowserConfig(browser) {
     case "firefox":
       return {
         enabled: true,
-        provider: "webdriverio",
+        provider: webdriverio({
+          capabilities: {
+            browserName: "firefox",
+            "moz:firefoxOptions": {
+              prefs: {
+                "media.autoplay.default": 0,
+                "media.autoplay.enabled.user-gestures-needed": false,
+                "media.autoplay.block-webaudio": false,
+                "media.autoplay.ask-permission": false,
+                "media.autoplay.block-event.enabled": false,
+                "media.block-autoplay-until-in-foreground": false,
+              },
+            },
+          },
+        }),
         headless: true,
         screenshotFailures: false,
         instances: [
           {
             browser: "firefox",
-            capabilities: {
-              "moz:firefoxOptions": {
-                prefs: {
-                  "media.autoplay.default": 0,
-                  "media.autoplay.enabled.user-gestures-needed": false,
-                  "media.autoplay.block-webaudio": false,
-                  "media.autoplay.ask-permission": false,
-                  "media.autoplay.block-event.enabled": false,
-                  "media.block-autoplay-until-in-foreground": false,
-                },
-              },
-            },
           },
         ],
       };
@@ -52,17 +57,19 @@ function getBrowserConfig(browser) {
     case "edge":
       return {
         enabled: true,
-        provider: "webdriverio",
+        provider: webdriverio({
+          capabilities: {
+            browserName: "edge",
+            "ms:edgeOptions": {
+              args: ["--autoplay-policy=no-user-gesture-required"],
+            },
+          },
+        }),
         headless: true,
         screenshotFailures: false,
         instances: [
           {
             browser: "edge",
-            capabilities: {
-              "ms:edgeOptions": {
-                args: ["--autoplay-policy=no-user-gesture-required"],
-              },
-            },
           },
         ],
       };


### PR DESCRIPTION
I noticed that integration tests were failing more frequently on the CI.

gh-actions anounced some changes lately and I wondered if perhaps for open-source projects like us, which have a special free plan, we had now lower-performing machines.
Low perfs are for us known to lead to some false negatives on our performance-sensitive tests (e.g. to check that playback rate change works, check that the RxPlayer does buffer a lot of segments with a high `wantedBufferAhead` value etc.).

To check, I wanted to run those tests locally, but... `vitest` just refused to run on any browser with an `ECONNREFUSED` error indicating that it could not connect to the browser I ran through `webdriverio`.

After thinking it was a `webdriverio` issue, I found out that other were having the issue and a common denominator was Arch Linux (my current setup) and that the issue may also be `vitest`'s (like their issue 8327). Frustratingly, issues were since marked as "resolved" with no comment nor link to any newer development.

I ended up updating vitest to its version 4, which also changes their browser-running API (not the same dependencies, not the same configuration). After doing that... it still didn't work, but the issue was different.

For some reason, now `vitest` wants in its internal logic to bind to an IP address belonging to a network interface linked to a container I use for another project on my machine.
I don't know how it selects the address to bind to, I tried configurating one explicitly through the config but there I had another error later in the process (`make sure browser driver is running on that address`)...

I gave up and now decided to run integration tests on my side inside its own container so it can only see the interfaces I want it to and it now works...

So here's the vitest v4 update, which for me only work on my container - but hopefully that's just a me problem.

Now back to square 1 though: why are integration tests failing more often on CI :D?