### PR TITLE
fix: don't replicate updates on main/ when monothreaded

### DIFF
--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -26,6 +26,7 @@ import features from "../../features";
 import log from "../../log";
 import type { IManifestMetadata } from "../../manifest";
 import {
+  ManifestMetadataFormat,
   replicateUpdatesOnManifestMetadata,
   updateDecipherabilityFromKeyIds,
   updateDecipherabilityFromProtectionData,
@@ -934,11 +935,17 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             return;
           }
 
-          replicateUpdatesOnManifestMetadata(
-            manifest,
-            msgData.value.manifest,
-            msgData.value.updates,
-          );
+          if (manifest.manifestFormat === ManifestMetadataFormat.MetadataObject) {
+            // If we're currently in possession of an `IManifestMetadata`, we need
+            // to replicate the updates sent by the Core on it.
+            // If we rely on **the** `Manifest` instance directly however, we already
+            // share it with Core and as such don't need to replicate the updates.
+            replicateUpdatesOnManifestMetadata(
+              manifest,
+              msgData.value.manifest,
+              msgData.value.updates,
+            );
+          }
           this._currentContentInfo?.streamEventsEmitter?.onManifestUpdate(manifest);
 
           this._updateCodecSupport(manifest, mediaElement);

--- a/src/manifest/utils.ts
+++ b/src/manifest/utils.ts
@@ -1,3 +1,4 @@
+import log from "../log";
 import type { IProcessedProtectionData } from "../main_thread/types";
 import type { IManifest, IPeriod, IAdaptation, IPeriodsUpdateResult } from "../manifest";
 import type {
@@ -593,6 +594,16 @@ export function replicateUpdatesOnManifestMetadata(
   newManifest: Omit<IManifestMetadata, "periods">,
   updates: IPeriodsUpdateResult,
 ) {
+  if (baseManifest.manifestFormat === ManifestMetadataFormat.Class) {
+    // This function is not intended for and could break a `Manifest` instance, as
+    // it might mutate it by adding metadata objects to it, whereas the `Manifest`
+    // instance generally expect the "instance versions" of those objects instead.
+    log.error(
+      "manifest",
+      "`replicateUpdatesOnManifestMetadata` called on a Manifest instance",
+    );
+    return;
+  }
   for (const prop of Object.keys(newManifest)) {
     if (prop !== "periods") {
       // trust me bro


### PR DESCRIPTION
This fixes the issue first seen in #1773

Until very recently, loading a content in a multitheaded or monothreaded mode went through very different logic (declared in different files, with distinct concepts).

To simplify the project maintainance, we decided to merge those two into one common path.
This gave a unique logic roughly of the same complexity than the more complex of the two (the multithreaded one), to which we added a sort of adapter to also support the less complex (the monothreaded) one.

When doing that, we forgot about a key difference about the Manifest:

- Monothreaded mode just keeps the same shared `Manifest` instance everywhere.

- Multi-threaded mode uses a simple `IManifestMetadata` object on main thread and the more powerful `Manifest` instance only for the "core" part of the code, that is here running in a WebWorker.

Because our new logic is mostly the multithreaded one that we lightly updated to support monothreaded cases, we still had some synchronization work on that structure, for when e.g. the Manifest is updated, that is only needed in the multithreaded scenario (no need to synchronize in the monothreaded case as the `Manifest` instance is the same one everywhere and thus already contain all updates immediately) even when running monothreaded.

Worse, due to some differences between the two structures, it could then lead to a runtime error (for now seen on Period updates in a monothreaded case, this is issue #1773).

To fix this I did both:

- only "synchronize" updates on main thread if what we have is an `IManifestMetadata` object, as this is the only case where synchronization needs to be done.

- In the function doing the synchronization (`replicateUpdatesOnManifestMetadata`), I exit directly if what we have in argument is a `Manifest` instance, also logging an error, as mutations done in that function could risk breaking the assumptions of that type.

  This should be unnecessary due to the first fix, but this is to protect our future developments from doing the same mistake.