### PR TITLE
Pass arround MediaSourceClass to replace DummyMediaElement's hotfix

### DIFF
--- a/src/compat/__tests__/is_codec_supported.test.ts
+++ b/src/compat/__tests__/is_codec_supported.test.ts
@@ -1,65 +1,57 @@
-import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
+import { describe, beforeEach, it, expect, vi } from "vitest";
+import type { IMediaSourceClass } from "../browser_compatibility_types.ts";
 import isCodecSupported from "../is_codec_supported.ts";
-
-type IMockedMediaSource =
-  | {
-      isTypeSupported?: ((codec: string) => boolean) | undefined;
-    }
-  | undefined;
-
-const mocks: { default: { MediaSource_: IMockedMediaSource } } = vi.hoisted(() => {
-  return {
-    default: {
-      MediaSource_: {},
-    },
-  };
-});
-
-vi.mock("../browser_compatibility_types", () => {
-  return mocks;
-});
 
 describe("Compat - isCodecSupported", () => {
   beforeEach(() => {
     vi.resetModules();
   });
-  afterEach(() => {
-    mocks.default.MediaSource_ = {};
+
+  it("should return false if MediaSource is not supported in the current device", async () => {
+    expect(isCodecSupported(null, "foo")).toEqual(false);
+    expect(isCodecSupported(null, "")).toEqual(false);
   });
 
-  it("should return false if MediaSource is not supported in the current device", () => {
-    mocks.default.MediaSource_ = undefined;
-    expect(isCodecSupported(document.createElement("video"), "foo")).toEqual(false);
-    expect(isCodecSupported(document.createElement("video"), "")).toEqual(false);
+  it("should return true in any case if the MediaSource does not have the right function", async () => {
+    expect(
+      isCodecSupported(
+        { isCodecSupported: undefined } as unknown as IMediaSourceClass,
+        "foo",
+      ),
+    ).toEqual(true);
+    expect(
+      isCodecSupported(
+        { isCodecSupported: undefined } as unknown as IMediaSourceClass,
+        "",
+      ),
+    ).toEqual(true);
   });
 
-  it("should return true in any case if the MediaSource does not have the right function", () => {
-    mocks.default.MediaSource_ = { isTypeSupported: undefined };
-    expect(isCodecSupported(document.createElement("video"), "foo")).toEqual(true);
-    expect(isCodecSupported(document.createElement("video"), "")).toEqual(true);
-  });
-
-  it("should return true if MediaSource.isTypeSupported returns true", () => {
-    mocks.default.MediaSource_ = {
+  it("should return true if MediaSource.isTypeSupported returns true", async () => {
+    const MediaSourceClass = {
       isTypeSupported(_codec: string) {
         return true;
       },
     };
-    expect(isCodecSupported(document.createElement("video"), "foo")).toEqual(true);
-    expect(isCodecSupported(document.createElement("video"), "")).toEqual(true);
+    expect(
+      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "foo"),
+    ).toEqual(true);
+    expect(
+      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, ""),
+    ).toEqual(true);
   });
 
-  it("should return false if MediaSource.isTypeSupported returns false", () => {
-    mocks.default.MediaSource_ = {
+  it("should return false if MediaSource.isTypeSupported returns false", async () => {
+    const MediaSourceClass = {
       isTypeSupported(_codec: string) {
         return false;
       },
     };
     expect(
-      isCodecSupported(document.createElement("video"), "oohjustlikeweneversaidgoodbye"),
+      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "foo-false"),
     ).toEqual(false);
     expect(
-      isCodecSupported(document.createElement("video"), "ontheinternetwaitingtosayhi"),
+      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "empty-false"),
     ).toEqual(false);
   });
 });

--- a/src/compat/__tests__/is_codec_supported.test.ts
+++ b/src/compat/__tests__/is_codec_supported.test.ts
@@ -1,6 +1,52 @@
 import { describe, beforeEach, it, expect, vi } from "vitest";
-import type { IMediaSourceClass } from "../browser_compatibility_types.ts";
+import type {
+  IMediaSource,
+  IMediaSourceClass,
+  ISourceBuffer,
+  ISourceBufferList,
+} from "../browser_compatibility_types.ts";
 import isCodecSupported from "../is_codec_supported.ts";
+
+class BaseMockMediaSource implements IMediaSource {
+  static isTypeSupported(_codec: string): boolean {
+    return true;
+  }
+
+  duration: number = 0;
+  readyState: "closed" | "open" | "ended" = "closed";
+  sourceBuffers: ISourceBufferList = {
+    length: 0,
+    onaddsourcebuffer: null,
+    onremovesourcebuffer: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+  onsourceopen = null;
+  onsourceended = null;
+  onsourceclose = null;
+
+  addSourceBuffer(_type: string): ISourceBuffer {
+    throw new Error("Not implemented");
+  }
+  clearLiveSeekableRange(): void {
+    // noop
+  }
+  endOfStream(): void {
+    // noop
+  }
+  removeSourceBuffer(_sb: ISourceBuffer): void {
+    // noop
+  }
+  setLiveSeekableRange(_start: number, _end: number): void {
+    // noop
+  }
+  addEventListener(): void {
+    // noop
+  }
+  removeEventListener(): void {
+    // noop
+  }
+}
 
 describe("Compat - isCodecSupported", () => {
   beforeEach(() => {
@@ -13,45 +59,32 @@ describe("Compat - isCodecSupported", () => {
   });
 
   it("should return true in any case if the MediaSource does not have the right function", async () => {
-    expect(
-      isCodecSupported(
-        { isCodecSupported: undefined } as unknown as IMediaSourceClass,
-        "foo",
-      ),
-    ).toEqual(true);
-    expect(
-      isCodecSupported(
-        { isCodecSupported: undefined } as unknown as IMediaSourceClass,
-        "",
-      ),
-    ).toEqual(true);
+    class MediaSourceClass extends BaseMockMediaSource {}
+    const checkedMediaSourceClass = MediaSourceClass satisfies IMediaSourceClass;
+    Reflect.deleteProperty(MediaSourceClass, "isTypeSupported");
+    expect(isCodecSupported(checkedMediaSourceClass, "foo")).toEqual(true);
+    expect(isCodecSupported(checkedMediaSourceClass, "")).toEqual(true);
   });
 
   it("should return true if MediaSource.isTypeSupported returns true", async () => {
-    const MediaSourceClass = {
-      isTypeSupported(_codec: string) {
+    class MediaSourceClass extends BaseMockMediaSource {
+      static isTypeSupported(_codec: string): boolean {
         return true;
-      },
-    };
-    expect(
-      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "foo"),
-    ).toEqual(true);
-    expect(
-      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, ""),
-    ).toEqual(true);
+      }
+    }
+    const checkedMediaSourceClass = MediaSourceClass satisfies IMediaSourceClass;
+    expect(isCodecSupported(checkedMediaSourceClass, "foo")).toEqual(true);
+    expect(isCodecSupported(checkedMediaSourceClass, "")).toEqual(true);
   });
 
   it("should return false if MediaSource.isTypeSupported returns false", async () => {
-    const MediaSourceClass = {
-      isTypeSupported(_codec: string) {
+    class MediaSourceClass extends BaseMockMediaSource {
+      static isTypeSupported(_codec: string): boolean {
         return false;
-      },
-    };
-    expect(
-      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "foo-false"),
-    ).toEqual(false);
-    expect(
-      isCodecSupported(MediaSourceClass as unknown as IMediaSourceClass, "empty-false"),
-    ).toEqual(false);
+      }
+    }
+    const checkedMediaSourceClass = MediaSourceClass satisfies IMediaSourceClass;
+    expect(isCodecSupported(checkedMediaSourceClass, "foo-false")).toEqual(false);
+    expect(isCodecSupported(checkedMediaSourceClass, "empty-false")).toEqual(false);
   });
 });

--- a/src/compat/browser_compatibility_types.ts
+++ b/src/compat/browser_compatibility_types.ts
@@ -234,7 +234,7 @@ export interface IMediaElement extends IEventTarget<IMediaElementEventMap> {
    * Optional property allowing to force a specific MSE Implementation when
    * relying on a given `IMediaElement`.
    */
-  FORCED_MEDIA_SOURCE?: new () => IMediaSource;
+  FORCED_MEDIA_SOURCE?: IMediaSourceClass;
 
   FORCED_EME_API?: IEmeApiImplementation;
 
@@ -437,9 +437,12 @@ const gs = globalScope as typeof window & {
   ManagedMediaSource?: typeof MediaSource | undefined | null;
 };
 
-const MediaSource_:
-  | { new (): IMediaSource; isTypeSupported(type: string): boolean }
-  | undefined =
+export interface IMediaSourceClass {
+  new (): IMediaSource;
+  isTypeSupported(type: string): boolean;
+}
+
+const MediaSource_: IMediaSourceClass | undefined =
   gs?.MediaSource ??
   gs?.MozMediaSource ??
   gs?.WebKitMediaSource ??

--- a/src/compat/is_codec_supported.ts
+++ b/src/compat/is_codec_supported.ts
@@ -33,7 +33,7 @@ const supportMap: Map<string, boolean> = new Map();
 /**
  * Returns true if the given codec is supported by the browser's MediaSource
  * implementation.
- * @param {Object|Function|null|undefined} MediaSourceClass - The `MediaSource`
+ * @param {Object|Function|null|undefined} mediaSourceClass - The `MediaSource`
  * class that is intended to be used to play the content.
  * @param {string} mimeType - The MIME media type that you want to test support
  * for in the current browser.
@@ -42,23 +42,22 @@ const supportMap: Map<string, boolean> = new Map();
  * @returns {Boolean}
  */
 export default function isCodecSupported(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  MediaSourceClass: IMediaSourceClass | null,
+  mediaSourceClass: IMediaSourceClass | null,
   mimeType: string,
 ): boolean {
-  if (isNullOrUndefined(MediaSourceClass)) {
+  if (isNullOrUndefined(mediaSourceClass)) {
     if (isWorker) {
       log.error("mse", "Cannot request codec support in a worker without MSE.");
     }
     return false;
   }
 
-  if (typeof MediaSourceClass.isTypeSupported === "function") {
+  if (typeof mediaSourceClass.isTypeSupported === "function") {
     const cachedSupport = supportMap.get(mimeType);
     if (cachedSupport !== undefined) {
       return cachedSupport;
     } else {
-      const isSupported = MediaSourceClass.isTypeSupported(mimeType);
+      const isSupported = mediaSourceClass.isTypeSupported(mimeType);
       if (supportMap.size >= MAX_SUPPORT_MAP_ENTRIES) {
         supportMap.clear();
       }

--- a/src/compat/is_codec_supported.ts
+++ b/src/compat/is_codec_supported.ts
@@ -14,12 +14,10 @@
  * limitations under the License.
  */
 
-import type DummyMediaElement from "../experimental/tools/DummyMediaElement/index.ts";
 import log from "../log.ts";
 import isNullOrUndefined from "../utils/is_null_or_undefined.ts";
 import isWorker from "../utils/is_worker.ts";
-import BROWSER_GLOBALS from "./browser_compatibility_types.ts";
-import type { IMediaElement } from "./browser_compatibility_types.ts";
+import type { IMediaSourceClass } from "./browser_compatibility_types.ts";
 
 /**
  * Setting this value limit the number of entries in the support map
@@ -35,7 +33,8 @@ const supportMap: Map<string, boolean> = new Map();
 /**
  * Returns true if the given codec is supported by the browser's MediaSource
  * implementation.
- * @param {HTMLMediaElement} mediaElement
+ * @param {Object|Function|null|undefined} MediaSourceClass - The `MediaSource`
+ * class that is intended to be used to play the content.
  * @param {string} mimeType - The MIME media type that you want to test support
  * for in the current browser.
  * This may include the codecs parameter to provide added details about the
@@ -43,30 +42,23 @@ const supportMap: Map<string, boolean> = new Map();
  * @returns {Boolean}
  */
 export default function isCodecSupported(
-  mediaElement: IMediaElement,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  MediaSourceClass: IMediaSourceClass | null,
   mimeType: string,
 ): boolean {
-  // TODO: We only added that as a hotfix for now, to allow support of the right codecs
-  // on a dummy media element
-  if ((mediaElement as DummyMediaElement).isDummy) {
-    return (mediaElement as DummyMediaElement).FORCED_MEDIA_SOURCE.isTypeSupported(
-      mimeType,
-    );
-  }
-  const { MediaSource_ } = BROWSER_GLOBALS;
-  if (isNullOrUndefined(MediaSource_)) {
+  if (isNullOrUndefined(MediaSourceClass)) {
     if (isWorker) {
       log.error("mse", "Cannot request codec support in a worker without MSE.");
     }
     return false;
   }
 
-  if (typeof MediaSource_.isTypeSupported === "function") {
+  if (typeof MediaSourceClass.isTypeSupported === "function") {
     const cachedSupport = supportMap.get(mimeType);
     if (cachedSupport !== undefined) {
       return cachedSupport;
     } else {
-      const isSupported = MediaSource_.isTypeSupported(mimeType);
+      const isSupported = MediaSourceClass.isTypeSupported(mimeType);
       if (supportMap.size >= MAX_SUPPORT_MAP_ENTRIES) {
         supportMap.clear();
       }

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -1,3 +1,4 @@
+import BROWSER_GLOBALS from "../../compat/browser_compatibility_types.ts";
 import features from "../../features/index.ts";
 import log from "../../log.ts";
 import type { IContentInitializationData } from "../../main_thread/types.ts";
@@ -481,7 +482,13 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
 ): [IMediaSourceInterface, SegmentSinksStore, CoreTextDisplayerInterface | null] {
   let mediaSourceInterface: IMediaSourceInterface;
   if (capabilities.useMseInWorker) {
-    const mainMediaSource = new MainMediaSourceInterface(generateMediaSourceId());
+    if (BROWSER_GLOBALS.MediaSource_ === undefined) {
+      throw new Error("ContentPreparer: Cannot use MSE-in-Worker: no MSE");
+    }
+    const mainMediaSource = new MainMediaSourceInterface(
+      generateMediaSourceId(),
+      BROWSER_GLOBALS.MediaSource_,
+    );
     mediaSourceInterface = mainMediaSource;
 
     let sentMediaSourceLink: IAttachMediaSourceCoreMessagePayload;

--- a/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
+++ b/src/experimental/tools/VideoThumbnailLoader/prepare_source_buffer.ts
@@ -53,7 +53,10 @@ export default function prepareSourceBuffer(
     resetMediaElement(videoElement, oldSrc);
 
     log.info("VideoThumbnailLoader", "Creating MediaSource");
-    const mediaSource = new MainMediaSourceInterface(generateMediaSourceId());
+    const mediaSource = new MainMediaSourceInterface(
+      generateMediaSourceId(),
+      MediaSource_,
+    );
     if (mediaSource.handle.type === "handle") {
       videoElement.srcObject = mediaSource.handle.value;
       cleanUpSignal.register(() => {

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -19,7 +19,9 @@
  * It also starts the different sub-parts of the player on various API calls.
  */
 
-import type { IMediaElement } from "../../compat/browser_compatibility_types.ts";
+import BROWSER_GLOBALS, {
+  type IMediaElement,
+} from "../../compat/browser_compatibility_types.ts";
 import canRelyOnVideoVisibilityAndSize from "../../compat/can_rely_on_video_visibility_and_size.ts";
 import type { IPictureInPictureEvent } from "../../compat/event_listeners.ts";
 import {
@@ -1042,6 +1044,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     let useWorker = false;
     let mediaElementTracksStore: IMediaElementTracksStore | null = null;
     if (!isDirectFile) {
+      const MediaSourceClass =
+        this.videoElement.FORCED_MEDIA_SOURCE ?? BROWSER_GLOBALS.MediaSource_;
+      if (MediaSourceClass === undefined) {
+        throw new Error("Cannot load video: No MediaSource instance available currently");
+      }
+
       /** Interface used to load and refresh the Manifest. */
       const manifestRequestSettings = {
         lowLatencyMode,
@@ -1223,6 +1231,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           textTrackOptions,
           url,
           useMseInWorker: false,
+          MediaSourceClass,
         });
       } else {
         if (features.multithread === null) {
@@ -1303,6 +1312,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           textTrackOptions,
           url,
           useMseInWorker: hasMseInWorker,
+          MediaSourceClass,
         });
       }
     } else {

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -1,4 +1,7 @@
-import type { IMediaElement } from "../../compat/browser_compatibility_types.ts";
+import type {
+  IMediaElement,
+  IMediaSourceClass,
+} from "../../compat/browser_compatibility_types.ts";
 import disableRemotePlaybackOnManagedMediaSource from "../../compat/disable_remote_playback_on_managed_media_source.ts";
 import getEmeApiImplementation from "../../compat/eme/index.ts";
 import mayMediaElementFailOnUndecipherableData from "../../compat/may_media_element_fail_on_undecipherable_data.ts";
@@ -954,7 +957,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           const manifest = msgData.value.manifest;
           streamEventsEmitter.start(manifest);
           this._currentContentInfo.manifest = manifest;
-          this._updateCodecSupport(manifest, mediaElement);
+          this._updateCodecSupport(manifest);
           this._startPlaybackIfReady(playbackStartParams);
           break;
         }
@@ -981,7 +984,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             );
           }
           streamEventsEmitter.onManifestUpdate(manifest);
-          this._updateCodecSupport(manifest, mediaElement);
+          this._updateCodecSupport(manifest);
           this.trigger("manifestUpdate", msgData.value.updates);
           break;
         }
@@ -1435,7 +1438,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         if (isNullOrUndefined(manifest)) {
           return;
         }
-        this._updateCodecSupport(manifest, mediaElement);
+        this._updateCodecSupport(manifest);
         contentDecryptor.removeEventListener(
           "stateChange",
           updateCodecSupportOnStateChange,
@@ -1554,12 +1557,12 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
    * status of these codecs, and forwards the list of supported codecs to core.
    * @param manifest
    */
-  private _updateCodecSupport(manifest: IManifestMetadata, mediaElement: IMediaElement) {
+  private _updateCodecSupport(manifest: IManifestMetadata) {
     try {
       const updatedCodecs = updateManifestCodecSupport(
+        this._settings.MediaSourceClass,
         manifest,
         this._currentContentInfo?.contentDecryptor ?? null,
-        mediaElement,
         this._currentContentInfo?.useMseInWorker ?? false,
       );
       if (updatedCodecs.length > 0) {
@@ -1967,9 +1970,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               stopListening();
               const mediaSource = new MainMediaSourceInterface(
                 mediaSourceId,
-                "FORCED_MEDIA_SOURCE" in mediaElement
-                  ? mediaElement.FORCED_MEDIA_SOURCE
-                  : undefined,
+                this._settings.MediaSourceClass,
               );
               if (this._currentContentInfo.mediaSourceInfo?.type === "main") {
                 this._currentContentInfo.mediaSourceInfo.mediaSource.dispose(
@@ -2240,6 +2241,8 @@ export interface IInitializeArguments {
   textTrackOptions: ITextDisplayerOptions;
   /** URL of the Manifest. `undefined` if unknown or not pertinent. */
   url: string | undefined;
+  /** `MediaSource` implementation that is wanted for that content. */
+  MediaSourceClass: IMediaSourceClass;
 }
 
 function bindNumberReferencesToCore(

--- a/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
+++ b/src/main_thread/init/utils/__tests__/update_manifest_codec_support.test.ts
@@ -1,5 +1,8 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import type { IMediaElement } from "../../../../compat/browser_compatibility_types.ts";
+import type {
+  IMediaElement,
+  IMediaSourceClass,
+} from "../../../../compat/browser_compatibility_types.ts";
 import type {
   IManifestMetadata,
   IPeriodMetadata,
@@ -13,6 +16,17 @@ import assert from "../../../../utils/assert.ts";
 import sleep from "../../../../utils/sleep.ts";
 import ContentDecryptor from "../../../decrypt/index.ts";
 import { updateManifestCodecSupport } from "../update_manifest_codec_support.ts";
+
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+const FakeMediaSourceClass = class {
+  constructor() {
+    throw new Error("Should not create a MediaSource instance");
+  }
+  static isTypeSupported(type: string): boolean {
+    // Mocked behavior: return true for all codecs and return false for vp9 codec
+    return type.indexOf("vp9") === -1;
+  }
+} as IMediaSourceClass;
 
 function generateFakeManifestWithRepresentations(
   videoRepresentations: IRepresentationMetadata[],
@@ -75,27 +89,6 @@ function generateFakeManifestWithRepresentations(
   return manifest;
 }
 beforeAll(() => {
-  // Mock MediaSource APIs
-  vi.mock("../../../../compat/browser_compatibility_types", () => ({
-    default: {
-      READY_STATES: {
-        HAVE_NOTHING: 0,
-        HAVE_METADATA: 1,
-        HAVE_CURRENT_DATA: 2,
-        HAVE_FUTURE_DATA: 3,
-        HAVE_ENOUGH_DATA: 4,
-      },
-      isManagedMediaSource: false,
-      // eslint-disable-next-line @typescript-eslint/no-extraneous-class
-      MediaSource_: class {
-        static isTypeSupported(type: string) {
-          // Mocked behavior: return true for all codecs and return false for vp9 codec
-          return type.indexOf("vp9") === -1;
-        }
-      },
-    },
-  }));
-
   // Mock EME APIs
   vi.mock("../../../../compat/eme/eme-api-implementation", () => ({
     default: () => ({
@@ -212,12 +205,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
     const emeImplem = getEmeApiImplementation("auto");
     assert(emeImplem !== null);
     const contentDecryptor = new ContentDecryptor(emeImplem, video, [keySystem1]);
-    updateManifestCodecSupport(
-      manifest,
-      contentDecryptor,
-      document.createElement("video"),
-      true,
-    );
+    updateManifestCodecSupport(FakeMediaSourceClass, manifest, contentDecryptor, true);
     expect(representationAVC.isSupported).toBe(true);
     expect(representationHEVC.isSupported).toBe(true);
     expect(representationVP9.isSupported).toBe(false); // Not Supported by MSE
@@ -307,12 +295,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
     const contentDecryptor = new ContentDecryptor(emeImplem, video, [keySystem1]);
     await sleep(100);
     contentDecryptor.attach();
-    updateManifestCodecSupport(
-      manifest,
-      contentDecryptor,
-      document.createElement("video"),
-      true,
-    );
+    updateManifestCodecSupport(FakeMediaSourceClass, manifest, contentDecryptor, true);
     expect(encryptedRepresentationAVC.isSupported).toBe(true);
     expect(encryptedRepresentationHEVC.isSupported).toBe(false); // Not supported by EME
     expect(encryptedRepresentationVP9.isSupported).toBe(false); // Not supported by MSE
@@ -363,12 +346,7 @@ describe("init - utils - updateManifestCodecSupport", () => {
     const emeImplem = getEmeApiImplementation("auto");
     assert(emeImplem !== null);
     const contentDecryptor = new ContentDecryptor(emeImplem, video, []);
-    updateManifestCodecSupport(
-      manifest,
-      contentDecryptor,
-      document.createElement("video"),
-      true,
-    );
+    updateManifestCodecSupport(FakeMediaSourceClass, manifest, contentDecryptor, true);
     expect(representationAVC.isSupported).toBe(true);
     expect(representationHEVC.isSupported).toBe(false); // not supported with MSE in worker
     expect(representationMP4A.isSupported).toBe(true);

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -57,7 +57,7 @@ export function getCodecsWithUnknownSupport(
  * Because probing for codec support is always synchronous in the main thread,
  * calling this function ensures that support is now known.
  *
- * @param {Object|Function|null|undefined} MediaSourceClass - The `MediaSource`
+ * @param {Object|Function|null|undefined} mediaSourceClass - The `MediaSource`
  * class that is intended to be used to play the content.
  * @param {Object} manifest - The manifest to update
  * @param {Object|null} contentDecryptor - The current content decryptor
@@ -65,8 +65,7 @@ export function getCodecsWithUnknownSupport(
  * @returns {Array.<Object>}
  */
 export function updateManifestCodecSupport(
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  MediaSourceClass: IMediaSourceClass,
+  mediaSourceClass: IMediaSourceClass,
   manifest: IManifestMetadata,
   contentDecryptor: ContentDecryptor | null,
   isPlayingWithMSEinWorker: boolean,
@@ -94,7 +93,7 @@ export function updateManifestCodecSupport(
     }
 
     let newData;
-    const isSupported = isCodecSupported(MediaSourceClass, inputCodec);
+    const isSupported = isCodecSupported(mediaSourceClass, inputCodec);
     if (!isSupported) {
       newData = {
         isSupportedClear: false,

--- a/src/main_thread/init/utils/update_manifest_codec_support.ts
+++ b/src/main_thread/init/utils/update_manifest_codec_support.ts
@@ -1,4 +1,4 @@
-import type { IMediaElement } from "../../../compat/browser_compatibility_types.ts";
+import type { IMediaSourceClass } from "../../../compat/browser_compatibility_types.ts";
 import isCodecSupported from "../../../compat/is_codec_supported.ts";
 import type Manifest from "../../../manifest/classes/index.ts";
 import type { IManifestMetadata } from "../../../manifest/index.ts";
@@ -57,15 +57,18 @@ export function getCodecsWithUnknownSupport(
  * Because probing for codec support is always synchronous in the main thread,
  * calling this function ensures that support is now known.
  *
+ * @param {Object|Function|null|undefined} MediaSourceClass - The `MediaSource`
+ * class that is intended to be used to play the content.
  * @param {Object} manifest - The manifest to update
  * @param {Object|null} contentDecryptor - The current content decryptor
  * @param {boolean} isPlayingWithMSEinWorker - True if WebWorker is used with MSE in worker
  * @returns {Array.<Object>}
  */
 export function updateManifestCodecSupport(
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  MediaSourceClass: IMediaSourceClass,
   manifest: IManifestMetadata,
   contentDecryptor: ContentDecryptor | null,
-  mediaElement: IMediaElement,
   isPlayingWithMSEinWorker: boolean,
 ): ICodecSupportInfo[] {
   const codecSupportMap: Map<
@@ -91,7 +94,7 @@ export function updateManifestCodecSupport(
     }
 
     let newData;
-    const isSupported = isCodecSupported(mediaElement, inputCodec);
+    const isSupported = isCodecSupported(MediaSourceClass, inputCodec);
     if (!isSupported) {
       newData = {
         isSupportedClear: false,

--- a/src/main_thread/tracks_store/__tests__/tracks_store.test.ts
+++ b/src/main_thread/tracks_store/__tests__/tracks_store.test.ts
@@ -7,7 +7,7 @@ import {
   DummyPeriod,
   DummyRepresentation,
 } from "../../../manifest/classes/__tests__/mocks.ts";
-import type { Adaptation, Period } from "../../../manifest/classes/index.js";
+import type { Adaptation, Period } from "../../../manifest/classes/index.ts";
 import SharedReference from "../../../utils/reference.ts";
 import TracksStore from "../tracks_store.ts";
 

--- a/src/mse/__tests__/main_media_source_interface.test.ts
+++ b/src/mse/__tests__/main_media_source_interface.test.ts
@@ -100,6 +100,10 @@ const {
 
   let lastCreatedMockMS: InnerMockMediaSource | null = null;
   class InnerMockMediaSource implements IMediaSource {
+    static isTypeSupported(): boolean {
+      return true;
+    }
+
     private _mediaSourceListeners: Record<string, Array<() => void>>;
     readyState: ReadyState = "open";
     duration: number = 0;
@@ -231,7 +235,7 @@ describe("MainMediaSourceInterface", () => {
   });
 
   it("constructs correctly and registers event listeners", () => {
-    const iface = new MainMediaSourceInterface("test-id");
+    const iface = new MainMediaSourceInterface("test-id", MockMediaSource);
     expect(iface.id).toBe("test-id");
     expect(iface.sourceBuffers).toEqual([]);
     expect(iface.readyState).toBe("open");
@@ -254,29 +258,29 @@ describe("MainMediaSourceInterface", () => {
 
   it("sets handle to media-source type when mediaSource.handle is nullish", () => {
     mediaSourceProps.handle = undefined;
-    const iface = new MainMediaSourceInterface("h-id");
+    const iface = new MainMediaSourceInterface("h-id", MockMediaSource);
     expect(iface.handle).toMatchObject({ type: "media-source" });
   });
 
   it("sets handle to 'handle' type when mediaSource.handle is defined", () => {
     const fakeHandle = new Blob();
     mediaSourceProps.handle = fakeHandle;
-    const iface = new MainMediaSourceInterface("h-id");
+    const iface = new MainMediaSourceInterface("h-id", MockMediaSource);
     expect(iface.handle).toMatchObject({ type: "handle", value: fakeHandle });
   });
 
   it("tracks streaming from the MediaSource when it is defined", () => {
     mediaSourceProps.streaming = true;
-    const iface1 = new MainMediaSourceInterface("stream-id");
+    const iface1 = new MainMediaSourceInterface("stream-id", MockMediaSource);
     expect(iface1.streaming).toBe(true);
     mediaSourceProps.streaming = false;
-    const iface2 = new MainMediaSourceInterface("stream-id");
+    const iface2 = new MainMediaSourceInterface("stream-id", MockMediaSource);
     expect(iface2.streaming).toBe(false);
   });
 
   it("updates streaming to true when 'startstreaming' fires", () => {
     mediaSourceProps.streaming = false;
-    const iface = new MainMediaSourceInterface("stream-id");
+    const iface = new MainMediaSourceInterface("stream-id", MockMediaSource);
     mockMS = getLastMediaSourceMock();
     mockMS._emit("startstreaming");
     expect(iface.streaming).toBe(true);
@@ -284,14 +288,14 @@ describe("MainMediaSourceInterface", () => {
 
   it("updates streaming to false when 'endstreaming' fires", () => {
     mediaSourceProps.streaming = true;
-    const iface = new MainMediaSourceInterface("stream-id");
+    const iface = new MainMediaSourceInterface("stream-id", MockMediaSource);
     mockMS = getLastMediaSourceMock();
     mockMS._emit("endstreaming");
     expect(iface.streaming).toBe(false);
   });
 
   it("triggers mediaSourceOpen when onSourceOpen callback fires", () => {
-    const iface = new MainMediaSourceInterface("open-id");
+    const iface = new MainMediaSourceInterface("open-id", MockMediaSource);
     const listener = vi.fn();
     iface.addEventListener("mediaSourceOpen", listener);
     const [[, cb]] = mockOnSourceOpen.mock.calls;
@@ -300,7 +304,7 @@ describe("MainMediaSourceInterface", () => {
   });
 
   it("triggers mediaSourceEnded when onSourceEnded callback fires", () => {
-    const iface = new MainMediaSourceInterface("ended-id");
+    const iface = new MainMediaSourceInterface("ended-id", MockMediaSource);
     const listener = vi.fn();
     iface.addEventListener("mediaSourceEnded", listener);
     const [[, cb]] = mockOnSourceEnded.mock.calls;
@@ -309,7 +313,7 @@ describe("MainMediaSourceInterface", () => {
   });
 
   it("triggers mediaSourceClose when onSourceClose callback fires", () => {
-    const iface = new MainMediaSourceInterface("close-id");
+    const iface = new MainMediaSourceInterface("close-id", MockMediaSource);
     const listener = vi.fn();
     iface.addEventListener("mediaSourceClose", listener);
     const [[, cb]] = mockOnSourceClose.mock.calls;
@@ -320,7 +324,7 @@ describe("MainMediaSourceInterface", () => {
   it("addSourceBuffer creates and stores a MainSourceBufferInterface", () => {
     const sb = new MockSourceBuffer();
     vi.spyOn(MockMediaSource.prototype, "addSourceBuffer").mockReturnValue(sb);
-    const iface = new MainMediaSourceInterface("sb-id");
+    const iface = new MainMediaSourceInterface("sb-id", MockMediaSource);
     const result = iface.addSourceBuffer(
       SourceBufferType.Video,
       "video/mp4; codecs=avc1",
@@ -331,26 +335,26 @@ describe("MainMediaSourceInterface", () => {
   });
 
   it("setDuration delegates to durationUpdater", () => {
-    const iface = new MainMediaSourceInterface("dur-id");
+    const iface = new MainMediaSourceInterface("dur-id", MockMediaSource);
     iface.setDuration(120, true);
     expect(mockUpdateDuration).toHaveBeenCalledWith(120, true);
   });
 
   it("interruptDurationSetting delegates to durationUpdater", () => {
-    const iface = new MainMediaSourceInterface("dur-id");
+    const iface = new MainMediaSourceInterface("dur-id", MockMediaSource);
     iface.interruptDurationSetting("test-reason");
     expect(mockStopUpdating).toHaveBeenCalledWith("test-reason");
   });
 
   it("maintainEndOfStream calls maintainEndOfStream util only once", () => {
-    const iface = new MainMediaSourceInterface("eos-id");
+    const iface = new MainMediaSourceInterface("eos-id", MockMediaSource);
     iface.maintainEndOfStream();
     iface.maintainEndOfStream(); // second call should not create another canceller
     expect(mockMaintainEndOfStream).toHaveBeenCalledOnce();
   });
 
   it("stopEndOfStream cancels active end-of-stream", () => {
-    const iface = new MainMediaSourceInterface("eos-id");
+    const iface = new MainMediaSourceInterface("eos-id", MockMediaSource);
     iface.maintainEndOfStream();
     expect(mockMaintainEndOfStream).toHaveBeenCalledOnce();
     iface.stopEndOfStream();
@@ -362,7 +366,7 @@ describe("MainMediaSourceInterface", () => {
     const sb = new MockSourceBuffer();
     const mockAbort = vi.spyOn(sb, "abort");
     vi.spyOn(MockMediaSource.prototype, "addSourceBuffer").mockReturnValue(sb);
-    const iface = new MainMediaSourceInterface("dispose-id");
+    const iface = new MainMediaSourceInterface("dispose-id", MockMediaSource);
     mockMS = getLastMediaSourceMock();
     mockMS.sourceBuffers = makeMockSourceBufferList([sb]);
     iface.addSourceBuffer(SourceBufferType.Audio, "audio/mp4; codecs=mp4a");

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -86,21 +86,17 @@ export default class MainMediaSourceInterface
    *
    * @param {string} id - The wanted `id` property for this new `MediaSource`
    * instance.
-   * @param {Object|function} MediaSourceClass - `MediaSource` implementation
+   * @param {Object|function} mediaSourceClass - `MediaSource` implementation
    * relied on.
    */
-  constructor(
-    id: string,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    MediaSourceClass: IMediaSourceClass,
-  ) {
+  constructor(id: string, mediaSourceClass: IMediaSourceClass) {
     super();
     this.id = id;
     this.sourceBuffers = [];
     this._canceller = new TaskCanceller("MainMediaSourceInterface");
 
     log.info("mse", "Creating MediaSource");
-    const mediaSource = new MediaSourceClass();
+    const mediaSource = new mediaSourceClass();
     const handle = (mediaSource as unknown as { handle: MediaProvider }).handle;
     this.handle = isNullOrUndefined(handle)
       ? // eslint-disable-next-line @typescript-eslint/no-restricted-types

--- a/src/mse/main_media_source_interface.ts
+++ b/src/mse/main_media_source_interface.ts
@@ -1,11 +1,11 @@
 import type {
   IMediaSource,
+  IMediaSourceClass,
   ISourceBuffer,
 } from "../compat/browser_compatibility_types.ts";
-import BROWSER_GLOBALS from "../compat/browser_compatibility_types.ts";
 import tryToChangeSourceBufferType from "../compat/change_source_buffer_type.ts";
 import { onSourceClose, onSourceEnded, onSourceOpen } from "../compat/event_listeners.ts";
-import { MediaError, SourceBufferError } from "../errors/index.ts";
+import { SourceBufferError } from "../errors/index.ts";
 import log from "../log.ts";
 import { concat } from "../utils/byte_parsing.ts";
 import EventEmitter from "../utils/event_emitter.ts";
@@ -83,24 +83,24 @@ export default class MainMediaSourceInterface
    *
    * You can then obtain a link to that `MediaSource`, for example to link it
    * to an `HTMLMediaElement`, through the `handle` property.
+   *
+   * @param {string} id - The wanted `id` property for this new `MediaSource`
+   * instance.
+   * @param {Object|function} MediaSourceClass - `MediaSource` implementation
+   * relied on.
    */
-  constructor(id: string, forcedMediaSource?: new () => IMediaSource) {
+  constructor(
+    id: string,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    MediaSourceClass: IMediaSourceClass,
+  ) {
     super();
     this.id = id;
     this.sourceBuffers = [];
     this._canceller = new TaskCanceller("MainMediaSourceInterface");
 
-    const { MediaSource_ } = BROWSER_GLOBALS;
-    if (isNullOrUndefined(MediaSource_)) {
-      throw new MediaError(
-        "MEDIA_SOURCE_NOT_SUPPORTED",
-        "No MediaSource Object was found in the current browser.",
-      );
-    }
-
     log.info("mse", "Creating MediaSource");
-    const mediaSource =
-      forcedMediaSource !== undefined ? new forcedMediaSource() : new MediaSource_();
+    const mediaSource = new MediaSourceClass();
     const handle = (mediaSource as unknown as { handle: MediaProvider }).handle;
     this.handle = isNullOrUndefined(handle)
       ? // eslint-disable-next-line @typescript-eslint/no-restricted-types


### PR DESCRIPTION
Back in our `v4.4.0` we brought the `DummyMediaElement` feature allowing to run the RxPlayer's logic even on environments where actual decoding and/or decryption is not possible (incompatible codecs, DRMs, unavailable media API etc.).
Our main use case for this are testing purposes.

While wrapping up the release, we noted that we still relied on the actual `MediaSource` API for checking codec support, removing a key use case of the feature: testing the RxPlayer on a content even if the current env does not support any of its codec.

So we quickly implemented an exception in the corresponding code branch. It works and should catch all cases, but it was nonetheless not satisfactory for long-term maintainance.

---

To make it more explicit, I propose here to pass from the `API` to the `Init` the `MediaSource` class that should be used to play the content. In a `DummyMediaElement`'s case, the `MediaSource` implementation linked to it will be provided instead of the favored `MediaSource` implementation found on the device.

A remaining issue is that as the class is not transmitted to `core` (as it is not serializable), `core` will still need to rely on the device's favored `MediaSource` implem. I thought that it wasn't an issue as a `DummyMediaElement` is not compatible for now with "MSE-in-worker" which is the only scenario where communicating its linked `MediaSource` would be needed.