### PR TITLE
Add remaining transports to multithread

### DIFF
--- a/doc/Getting_Started/ImportableWorker.md
+++ b/doc/Getting_Started/ImportableWorker.md
@@ -260,6 +260,7 @@ For now only the following features exist:
 | `DASH_WASM` [1] [2] | Enable DASH playback using a WebAssembly-based MPD parser |
 | `SMOOTH`            | Enable playback of Smooth Streaming contents              |
 | `LOCAL_MANIFEST`    | Enable playback of "local" contents                       |
+| `METAPLAYLIST`      | Enable playback of "metaplaylist" contents                |
 
 ---
 

--- a/doc/Getting_Started/ImportableWorker.md
+++ b/doc/Getting_Started/ImportableWorker.md
@@ -258,6 +258,7 @@ For now only the following features exist:
 | ------------------- | --------------------------------------------------------- |
 | `DASH` [1]          | Enable DASH playback using a JavaScript-based MPD parser  |
 | `DASH_WASM` [1] [2] | Enable DASH playback using a WebAssembly-based MPD parser |
+| `SMOOTH`            | Enable playback of Smooth Streaming contents              |
 | `LOCAL_MANIFEST`    | Enable playback of "local" contents                       |
 
 ---

--- a/doc/Getting_Started/MultiThreading.md
+++ b/doc/Getting_Started/MultiThreading.md
@@ -176,6 +176,13 @@ following conditions are respected:
   `loadVideo` call on that same RxPlayer instance, and the returned Promise is either
   still pending or resolved (i.e. it hasn't rejected).
 
+- You're not playing a directfile content (through the `"directfile"` `transport` option
+  of the `loadVideo` call).
+
+  Note that if you're playing a "smooth", a "metaplaylist" or a "local-manifest" content,
+  you'll have to add the corresponding feature
+  [to your own worker bundle](./ImportableWorker.md) to make it work.
+
 - You did not force the `"main"` mode through the
   [`mode` `loadVideo` option](../api/Loading_a_Content.md#mode).
 

--- a/doc/Getting_Started/MultiThreading.md
+++ b/doc/Getting_Started/MultiThreading.md
@@ -176,13 +176,6 @@ following conditions are respected:
   `loadVideo` call on that same RxPlayer instance, and the returned Promise is either
   still pending or resolved (i.e. it hasn't rejected).
 
-- You're playing either a DASH content (through the `"dash"` `transport` option of the
-  `loadVideo` call), or a "local-manifest" content (through the `"local"` `transport`).
-
-  Note that if you're playing a "local-manifest" content, you'll have to add the
-  `LOCAL_MANIFEST` feature [to your own worker bundle](./ImportableWorker.md) to make it
-  work.
-
 - You did not force the `"main"` mode through the
   [`mode` `loadVideo` option](../api/Loading_a_Content.md#mode).
 

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -64,7 +64,9 @@ Can be either:
 
   - For RxPlayer's ["multithread" mode](../Getting_Started/MultiThreading.md):
 
-    Smooth transport is not yet available in that mode.
+    You will need to rely on an
+    [importable worker](../Getting_Started/ImportableWorker.md), and add the `SMOOTH`
+    feature to it.
 
 - **`"directfile"` - for loading a video in _DirectFile_ mode, which allows to directly
   play media files** (example: `.mp4` or `.webm` files) without using a transport

--- a/doc/api/Loading_a_Content.md
+++ b/doc/api/Loading_a_Content.md
@@ -94,7 +94,9 @@ Can be either:
 
   - For RxPlayer's ["multithread" mode](../Getting_Started/MultiThreading.md):
 
-    MetaPlaylist transport is not yet available in that mode.
+    You will need to rely on an
+    [importable worker](../Getting_Started/ImportableWorker.md), and add the
+    `METAPLAYLIST` feature to it.
 
 - `"local"` for [local manifests](./Miscellaneous/Local_Contents.md), which allows to play
   downloaded DASH, Smooth or MetaPlaylist contents (when offline for example).

--- a/doc/api/Miscellaneous/MetaPlaylist.md
+++ b/doc/api/Miscellaneous/MetaPlaylist.md
@@ -213,7 +213,7 @@ same value than the `startTime` of the following one).
 
 The `"METAPLAYLIST"` feature is not included in the default RxPlayer build.
 
-You will need to import the `LOCAL_MANIFEST` experimental feature:
+You will need to import the `METAPLAYLIST` experimental feature:
 
 ```js
 // Import the RxPlayer

--- a/src/experimental/features/worker/index.ts
+++ b/src/experimental/features/worker/index.ts
@@ -1,4 +1,3 @@
 export { DASH, DASH_WASM, SMOOTH } from "../../../features/list";
 export { LOCAL_MANIFEST } from "../local";
-
-// TODO: `METAPLAYLIST` (once every transport is ported)
+export { METAPLAYLIST } from "../metaplaylist";

--- a/src/experimental/features/worker/index.ts
+++ b/src/experimental/features/worker/index.ts
@@ -1,5 +1,4 @@
-export { DASH, DASH_WASM } from "../../../features/list";
+export { DASH, DASH_WASM, SMOOTH } from "../../../features/list";
 export { LOCAL_MANIFEST } from "../local";
 
-// TODO: `SMOOTH` (has to be made worker-compatible)
 // TODO: `METAPLAYLIST` (once every transport is ported)

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -3795,7 +3795,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       // TODO: Make it work with multithread?
       return false;
     }
-    if (options.transport !== "dash" && options.transport !== "local") {
+    if (options.transport === "directfile") {
       return false;
     }
     if (


### PR DESCRIPTION
This adds the possibility to rely on Smooth streaming and MetaPlaylist in-worker, which is possible since:
- [x] https://github.com/canalplus/rx-player/pull/1719 (allow to import a custom worker)
- [x] https://github.com/canalplus/rx-player/pull/1731 (allows to rely on Smooth streaming in-worker)
- [x] https://github.com/canalplus/rx-player/pull/1723 (ports `LOCAL_MANIFEST` in-worker, this was needed because `METAPLAYLIST` is only supported once all other non-directfile transports are)