### PR TITLE
Text track id can only be string

### DIFF
--- a/doc/api/Track_Selection/getTextTrack.md
+++ b/doc/api/Track_Selection/getTextTrack.md
@@ -8,8 +8,8 @@ right now.
 If a text track is set and information about it is known, this method will return an
 object with the following properties:
 
-- `id` (`Number|string`): The id used to identify this track. No other text track for the
-  same [Period](../../Getting_Started/Glossary.md#period) will have the same `id`.
+- `id` (`string`): The id used to identify this track. No other text track for the same
+  [Period](../../Getting_Started/Glossary.md#period) will have the same `id`.
 
   This can be useful when setting the track through the `setTextTrack` method.
 

--- a/src/public_types.ts
+++ b/src/public_types.ts
@@ -1030,7 +1030,7 @@ export interface ITextTrack {
   forced: boolean | undefined;
   closedCaption: boolean;
   label?: string | undefined;
-  id: number | string;
+  id: string;
 }
 
 /**


### PR DESCRIPTION
Text track `id`s were previously typed as `number | string`, despite always being `string` in reality (like audio and video tracks).

I think that it was done at a time when we were unsure if we should be having a simpler incrementing unique id integer or some id derived from the original Manifest.

I propose to simplify the API by just making it always a string here, it doesn't prevent it from being unique anyway and it will simplify typings for applications.