### PR TITLE
Use native base64-bytes conversion utils when they exist

### DIFF
--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -126,6 +126,29 @@ const base64codes = [
   47, 48, 49, 50, 51,
 ];
 
+// Not yet in ECMAScript, but present in most browsers
+// (2024 for SpiderMonkey, 2025 for V8)
+declare global {
+  interface Uint8Array {
+    // https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tobase64
+    toBase64(options?: {
+      alphabet?: "base64" | "base64url";
+      omitPadding?: boolean;
+    }): string;
+  }
+
+  interface Uint8ArrayConstructor {
+    // https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.frombase64
+    fromBase64(
+      base64: string,
+      options?: {
+        alphabet?: "base64" | "base64url";
+        lastChunkHandling?: "loose" | "strict" | "stop-before-partial";
+      },
+    ): Uint8Array<ArrayBuffer>;
+  }
+}
+
 /**
  * Obtain the value corresponding to a base64 char code.
  * /!\ Can throw if the char code given is invalid.
@@ -148,7 +171,10 @@ function getBase64Code(charCode: number): number {
  * @param {Array.<number>|Uint8Array} bytes
  * @returns {string}
  */
-export function bytesToBase64(bytes: number[] | Uint8Array): string {
+export function bytesToBase64(bytes: Uint8Array): string {
+  if (typeof bytes.toBase64 === "function") {
+    return bytes.toBase64();
+  }
   let result = "";
   let i;
   const length = bytes.length;
@@ -182,6 +208,9 @@ export function bytesToBase64(bytes: number[] | Uint8Array): string {
  * @returns {string}
  */
 export function base64ToBytes(str: string): Uint8Array<ArrayBuffer> {
+  if (typeof Uint8Array.fromBase64 === "function") {
+    return Uint8Array.fromBase64(str);
+  }
   const paddingNeeded = str.length % 4;
   let paddedStr = str;
   if (paddingNeeded !== 0) {


### PR DESCRIPTION
To convert between bytes and base64, we previously had a handmade (forked) util because there was no native way of doing it (conversion from and into base64 in the web is done through the HTML API `btoa` and `atob` which relies on a JS string for the raw bytes instead of an `Uint8Array` - probably because those former API predate the latter).

But there's now [native API planned (stage 4) in the future ECMAScript 2026](https://github.com/tc39/proposal-arraybuffer-base64) version which does just that, already implemented in most browsers.

Those are operations we may do often:

-  Manifests are text files which most often rely on base64 to include binary data - such as embedded PSSH

-  When persisting persistent license data, if the used storage is text-based (e.g. [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)), we may also serialize/deserialize a [lot of binary data through that util](https://github.com/canalplus/rx-player/blob/63be19736deafb7c59c8ca671e35c698e77b7c11/src/main_thread/decrypt/utils/serializable_bytes.ts#L36-L45)

As such we could profit in terms of performance from relying on native API instead of our JS ones, though the actual impact is difficult to know.

---

PS: Because this is interesting, I looked at how browsers implemented it:

- Chrome/v8's implem is here: https://source.chromium.org/chromium/chromium/src/+/bbb19280f88d291ded7b1536f5c8ae5fa59b4e45:v8/src/builtins/builtins-typed-array.cc;l=748

   [It calls into a lib called `simdutf` here](https://source.chromium.org/chromium/chromium/src/+/bbb19280f88d291ded7b1536f5c8ae5fa59b4e45:v8/src/builtins/builtins-typed-array.cc;l=865). Interestingly this is the lib proposed [in the ECMAScript proposal](https://github.com/tc39/proposal-arraybuffer-base64?tab=readme-ov-file#uint8array-tofrom-base64-and-hex)

  To transform into base64, they make heavy usage of [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) extensions. Their code is per-arch/generation and seems to me completely unreadable to mere mortals :D: e.g. [arm](https://github.com/simdutf/simdutf/blob/bcfbae9fad23aa5c0f893a72ed013416a8567608/src/arm64/arm_base64.cpp#L117)'s, [icelake](https://github.com/simdutf/simdutf/blob/bcfbae9fad23aa5c0f893a72ed013416a8567608/src/icelake/icelake_base64.inl.cpp#L181)'s

- Firefox/Spidermonkey's here: https://searchfox.org/firefox-main/rev/93aad2a6615f670b1279c229dd37f7397236131a/js/src/vm/TypedArrayObject.cpp#5517

  They have their own implem in there. Much more readable, still much more optimized than our previous simple implem

- Safari/JavaScriptCore: 

  They call a fantastic function named `base64EncodeToStringReturnNullIfOverflow` but they then make heavy use of C++ templates (generics) to then rely on the same base64 util than everything else.
  
  Then that util either call simdutf or does its own thing based on the size of each char in the output (e.g. UTF-16, ASCII...): https://github.com/WebKit/WebKit/blob/4eaf8042011babf1855953554288c14813aa91e4/Source/WTF/wtf/text/Base64.cpp#L117
  
  [Diving deep](https://github.com/WebKit/WebKit/blob/4eaf8042011babf1855953554288c14813aa91e4/Source/WTF/wtf/text/Base64.h#L194) our specific case here seems to be 8-bit and as such it also goes through simdutf