### PR TITLE
tests: Quality-switch memory-leak tests now check both "lazy" and "reload"

### DIFF
--- a/tests/memory/index.test.js
+++ b/tests/memory/index.test.js
@@ -9,7 +9,6 @@ import sleep from "../utils/sleep.js";
 import waitForPlayerState, {
   waitForLoadedStateAfterLoadVideo,
 } from "../utils/waitForPlayerState";
-import waitForState from "../utils/waitForPlayerState";
 
 let player;
 
@@ -119,7 +118,7 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-      expect(heapDifference).to.be.below(7e6);
+      expect(heapDifference).to.be.below(3e6);
     },
   );
 
@@ -163,7 +162,7 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-      expect(heapDifference).to.be.below(7e6);
+      expect(heapDifference).to.be.below(2e6);
     },
   );
 
@@ -239,7 +238,7 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-      expect(heapDifference).to.be.below(9e6);
+      expect(heapDifference).to.be.below(2.5e6);
     },
   );
 
@@ -325,7 +324,7 @@ describe("Memory tests", () => {
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-      expect(heapDifference).to.be.below(9e6);
+      expect(heapDifference).to.be.below(2e6);
     },
   );
 

--- a/tests/memory/index.test.js
+++ b/tests/memory/index.test.js
@@ -9,6 +9,7 @@ import sleep from "../utils/sleep.js";
 import waitForPlayerState, {
   waitForLoadedStateAfterLoadVideo,
 } from "../utils/waitForPlayerState";
+import waitForState from "../utils/waitForPlayerState";
 
 let player;
 
@@ -167,9 +168,85 @@ describe("Memory tests", () => {
   );
 
   test(
-    "should not have a sensible memory leak after many video quality switches",
+    "should not have a sensible memory leak after many video quality switches in lazy mode",
     {
-      timeout: 15 * 60 * 1000,
+      timeout: 30 * 60 * 1000,
+      retry: 2,
+    },
+    async function () {
+      if (
+        window.performance == null ||
+        window.performance.memory == null ||
+        window.gc == null
+      ) {
+        // eslint-disable-next-line no-console
+        console.warn("API not available. Skipping test.");
+        return;
+      }
+      player = new RxPlayer({
+        initialVideoBitrate: Infinity,
+        initialAudiobitrate: Infinity,
+        preferredtexttracks: [{ language: "fra", closedcaption: true }],
+      });
+      await sleep(1000);
+      player.setWantedBufferAhead(5);
+      player.setMaxBufferBehind(5);
+      player.setMaxBufferAhead(15);
+      player.loadVideo({
+        url: manifestInfos.url,
+        transport: manifestInfos.transport,
+        autoPlay: false,
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      const videoTrack = player.getVideoTrack();
+      if (videoTrack.representations.length <= 1) {
+        throw new Error(
+          "Not enough video Representations to perform sufficiently pertinent tests",
+        );
+      }
+      await sleep(5000);
+
+      window.gc();
+      await sleep(5000);
+      const initialMemory = window.performance.memory;
+
+      // Allows to alternate between two positions
+      let seekToBeginning = false;
+      for (let iterationIdx = 0; iterationIdx < 1000; iterationIdx++) {
+        if (seekToBeginning) {
+          player.seekTo(0);
+        } else {
+          player.seekTo(20);
+          seekToBeginning = true;
+        }
+        const repIdx = iterationIdx % videoTrack.representations.length;
+        player.lockVideoRepresentations({
+          representations: [videoTrack.representations[repIdx].id],
+          switchingMode: "lazy",
+        });
+        await sleep(1000);
+      }
+      await sleep(5000);
+      window.gc();
+      await sleep(10000);
+      const newMemory = window.performance.memory;
+      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
+
+      // eslint-disable-next-line no-console
+      console.log(`
+      ===========================================================
+      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
+      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
+      | Difference (B)         | ${heapDifference}
+    `);
+      expect(heapDifference).to.be.below(9e6);
+    },
+  );
+
+  test(
+    "should not have a sensible memory leak after many video quality switches in reload mode",
+    {
+      timeout: 30 * 60 * 1000,
       retry: 2,
     },
     async function () {
@@ -219,8 +296,21 @@ describe("Memory tests", () => {
           seekToBeginning = true;
         }
         const repIdx = iterationIdx % videoTrack.representations.length;
-        player.lockVideoRepresentations([videoTrack.representations[repIdx].id]);
-        await sleep(1000);
+        const repId = videoTrack.representations[repIdx].id;
+        const nextResolve = new Promise((resolve) => {
+          const onChange = (rep) => {
+            if (rep?.id === repId) {
+              player.removeEventListener("videoRepresentationChange", onChange);
+              resolve();
+            }
+          };
+          player.addEventListener("videoRepresentationChange", onChange);
+        });
+        player.lockVideoRepresentations({
+          representations: [repId],
+          switchingMode: "reload",
+        });
+        await nextResolve;
       }
       await sleep(5000);
       window.gc();

--- a/tests/memory/index.test.js
+++ b/tests/memory/index.test.js
@@ -27,15 +27,7 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
+      assertMemoryApiAvailable();
       player = new RxPlayer({
         initialVideoBitrate: Infinity,
         initialAudioBitrate: Infinity,
@@ -57,16 +49,7 @@ describe("Memory tests", () => {
       window.gc();
       await sleep(10000);
       const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
-
-      // eslint-disable-next-line no-console
-      console.log(`
-      ===========================================================
-      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
-      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
-      | Difference (B)         | ${heapDifference}
-    `);
-      expect(heapDifference).to.be.below(2e6);
+      displayResultAndCheckLimit({ maxMemoryUsage: 2e6, initialMemory, newMemory });
     },
   );
 
@@ -77,15 +60,7 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
+      assertMemoryApiAvailable();
       player = new RxPlayer({
         initialVideoBitrate: Infinity,
         initialAudiobitrate: Infinity,
@@ -109,16 +84,7 @@ describe("Memory tests", () => {
       window.gc();
       await sleep(15000);
       const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
-
-      // eslint-disable-next-line no-console
-      console.log(`
-      ===========================================================
-      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
-      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
-      | Difference (B)         | ${heapDifference}
-    `);
-      expect(heapDifference).to.be.below(3e6);
+      displayResultAndCheckLimit({ maxMemoryUsage: 3e6, initialMemory, newMemory });
     },
   );
 
@@ -129,15 +95,7 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
+      assertMemoryApiAvailable();
       window.gc();
       await sleep(5000);
       const initialMemory = window.performance.memory;
@@ -153,16 +111,7 @@ describe("Memory tests", () => {
       window.gc();
       await sleep(70000);
       const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
-
-      // eslint-disable-next-line no-console
-      console.log(`
-      ===========================================================
-      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
-      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
-      | Difference (B)         | ${heapDifference}
-    `);
-      expect(heapDifference).to.be.below(2e6);
+      displayResultAndCheckLimit({ maxMemoryUsage: 2e6, initialMemory, newMemory });
     },
   );
 
@@ -173,72 +122,9 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
-      player = new RxPlayer({
-        initialVideoBitrate: Infinity,
-        initialAudiobitrate: Infinity,
-        preferredtexttracks: [{ language: "fra", closedcaption: true }],
-      });
-      await sleep(1000);
-      player.setWantedBufferAhead(5);
-      player.setMaxBufferBehind(5);
-      player.setMaxBufferAhead(15);
-      player.loadVideo({
-        url: manifestInfos.url,
-        transport: manifestInfos.transport,
-        autoPlay: false,
-      });
-      await waitForLoadedStateAfterLoadVideo(player);
-      const videoTrack = player.getVideoTrack();
-      if (videoTrack.representations.length <= 1) {
-        throw new Error(
-          "Not enough video Representations to perform sufficiently pertinent tests",
-        );
-      }
-      await sleep(5000);
-
-      window.gc();
-      await sleep(5000);
-      const initialMemory = window.performance.memory;
-
-      // Allows to alternate between two positions
-      let seekToBeginning = false;
-      for (let iterationIdx = 0; iterationIdx < 1000; iterationIdx++) {
-        if (seekToBeginning) {
-          player.seekTo(0);
-        } else {
-          player.seekTo(20);
-          seekToBeginning = true;
-        }
-        const repIdx = iterationIdx % videoTrack.representations.length;
-        player.lockVideoRepresentations({
-          representations: [videoTrack.representations[repIdx].id],
-          switchingMode: "lazy",
-        });
-        await sleep(1000);
-      }
-      await sleep(5000);
-      window.gc();
-      await sleep(10000);
-      const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
-
-      // eslint-disable-next-line no-console
-      console.log(`
-      ===========================================================
-      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
-      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
-      | Difference (B)         | ${heapDifference}
-    `);
-      expect(heapDifference).to.be.below(2.5e6);
+      assertMemoryApiAvailable();
+      const { initialMemory, newMemory } = await runQualitySwitchTest("lazy");
+      displayResultAndCheckLimit({ maxMemoryUsage: 2.5e6, initialMemory, newMemory });
     },
   );
 
@@ -249,82 +135,9 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
-      player = new RxPlayer({
-        initialVideoBitrate: Infinity,
-        initialAudiobitrate: Infinity,
-        preferredtexttracks: [{ language: "fra", closedcaption: true }],
-      });
-      await sleep(1000);
-      player.setWantedBufferAhead(5);
-      player.setMaxBufferBehind(5);
-      player.setMaxBufferAhead(15);
-      player.loadVideo({
-        url: manifestInfos.url,
-        transport: manifestInfos.transport,
-        autoPlay: false,
-      });
-      await waitForLoadedStateAfterLoadVideo(player);
-      const videoTrack = player.getVideoTrack();
-      if (videoTrack.representations.length <= 1) {
-        throw new Error(
-          "Not enough video Representations to perform sufficiently pertinent tests",
-        );
-      }
-      await sleep(5000);
-
-      window.gc();
-      await sleep(5000);
-      const initialMemory = window.performance.memory;
-
-      // Allows to alternate between two positions
-      let seekToBeginning = false;
-      for (let iterationIdx = 0; iterationIdx < 500; iterationIdx++) {
-        if (seekToBeginning) {
-          player.seekTo(0);
-        } else {
-          player.seekTo(20);
-          seekToBeginning = true;
-        }
-        const repIdx = iterationIdx % videoTrack.representations.length;
-        const repId = videoTrack.representations[repIdx].id;
-        const nextResolve = new Promise((resolve) => {
-          const onChange = (rep) => {
-            if (rep?.id === repId) {
-              player.removeEventListener("videoRepresentationChange", onChange);
-              resolve();
-            }
-          };
-          player.addEventListener("videoRepresentationChange", onChange);
-        });
-        player.lockVideoRepresentations({
-          representations: [repId],
-          switchingMode: "reload",
-        });
-        await nextResolve;
-      }
-      await sleep(5000);
-      window.gc();
-      await sleep(10000);
-      const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
-
-      // eslint-disable-next-line no-console
-      console.log(`
-      ===========================================================
-      | Current heap usage (B) | ${newMemory.usedJSHeapSize}
-      | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
-      | Difference (B)         | ${heapDifference}
-    `);
-      expect(heapDifference).to.be.below(2e6);
+      assertMemoryApiAvailable();
+      const { initialMemory, newMemory } = await runQualitySwitchTest("reload");
+      displayResultAndCheckLimit({ maxMemoryUsage: 2e6, initialMemory, newMemory });
     },
   );
 
@@ -336,15 +149,7 @@ describe("Memory tests", () => {
       retry: 2,
     },
     async function () {
-      if (
-        window.performance == null ||
-        window.performance.memory == null ||
-        window.gc == null
-      ) {
-        // eslint-disable-next-line no-console
-        console.warn("API not available. Skipping test.");
-        return;
-      }
+      assertMemoryApiAvailable();
       player = new RxPlayer({
         initialVideoBitrate: Infinity,
         initialAudiobitrate: Infinity,
@@ -374,16 +179,124 @@ describe("Memory tests", () => {
       window.gc();
       await sleep(10000);
       const newMemory = window.performance.memory;
-      const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
+      displayResultAndCheckLimit({ maxMemoryUsage: 1e6, initialMemory, newMemory });
+    },
+  );
+});
 
-      // eslint-disable-next-line no-console
-      console.log(`
+/**
+ * Check that the required memory API for memory tests are available.
+ * Throw if that's not the case.
+ */
+function assertMemoryApiAvailable() {
+  if (
+    window.performance == null ||
+    window.performance.memory == null ||
+    window.gc == null
+  ) {
+    throw new Error("Required Memory API not available. Skipping test.");
+  }
+}
+
+/**
+ * Display memory usage information in stdout and check that the difference
+ * between the new usage and the initial one is below the given `maxMemoryUsage`
+ * in bytes.
+ *
+ * Throw if that's not the case.
+ * @param {Object} param0
+ * @param {number} param0.maxMemoryUsage - Memory difference from which this
+ * function will throw.
+ * @param {*} param0.initialMemory - Memory measure before the test.
+ * @param {*} param0.newMemory - Memory measure at the end of the test.
+ */
+function displayResultAndCheckLimit({ maxMemoryUsage, initialMemory, newMemory }) {
+  const heapDifference = newMemory.usedJSHeapSize - initialMemory.usedJSHeapSize;
+
+  // eslint-disable-next-line no-console
+  console.log(`
       ===========================================================
       | Current heap usage (B) | ${newMemory.usedJSHeapSize}
       | Initial heap usage (B) | ${initialMemory.usedJSHeapSize}
       | Difference (B)         | ${heapDifference}
     `);
-      expect(heapDifference).to.be.below(1e6);
-    },
+  expect(heapDifference).to.be.below(maxMemoryUsage);
+}
+
+/**
+ * Get JS heap usage before and after doing a lot of video quality switches with
+ * the given switchingMode.
+ * @param {string} [switchingMode="lazy"]
+ * @returns {Object}
+ */
+async function runQualitySwitchTest(switchingMode = "lazy") {
+  const maxIterations = 1000;
+  player = new RxPlayer({
+    preferredtexttracks: [{ language: "fra", closedcaption: true }],
+  });
+  await sleep(1000);
+  player.setWantedBufferAhead(5);
+  player.loadVideo({
+    url: manifestInfos.url,
+    transport: manifestInfos.transport,
+    autoPlay: false,
+  });
+  await waitForLoadedStateAfterLoadVideo(player);
+  const videoTrack = player.getVideoTrack();
+
+  // Sadly, that quality seems to have some issues
+  // TODO: Other content / fix that one / recheck that one
+  const representations = videoTrack.representations.filter(
+    (r) => r.id !== "video=1193000",
   );
-});
+  if (representations.length <= 1) {
+    throw new Error(
+      "Not enough video Representations to perform sufficiently pertinent tests",
+    );
+  }
+  await sleep(1000);
+  window.gc();
+  await sleep(5000);
+  const initialMemory = window.performance.memory;
+
+  for (let iterationIdx = 0; iterationIdx < maxIterations; iterationIdx++) {
+    // Do a flush, though unknown if it has an impact
+    player.seekTo(0);
+
+    const repIdx = iterationIdx % representations.length;
+    const repId = representations[repIdx].id;
+    player.lockVideoRepresentations({
+      representations: [repId],
+      switchingMode,
+    });
+    await sleep(500);
+    await waitForQuality(player, repId);
+  }
+  await sleep(5000);
+  window.gc();
+  await sleep(10000);
+  const newMemory = window.performance.memory;
+  return { newMemory, initialMemory };
+}
+
+function waitForQuality(player, repId) {
+  return new Promise((resolve, reject) => {
+    const reCheck = () => {
+      if (player.getVideoRepresentation()?.id === repId && player.isContentLoaded()) {
+        player.removeEventListener("videoRepresentationChange", reCheck);
+        player.removeEventListener("playerStateChange", reCheck);
+        resolve();
+      } else {
+        const err = player.getError();
+        if (err !== null) {
+          reject(
+            `RxPlayer failed on iteration ${iterationIdx} with an error: ${err.toString()}`,
+          );
+        }
+      }
+    };
+    reCheck();
+    player.addEventListener("videoRepresentationChange", reCheck);
+    player.addEventListener("playerStateChange", reCheck);
+  });
+}


### PR DESCRIPTION
I'm wondering the exact extent of the leak seen at #1778 and why we've never noticed it - even a somewhat small one in most cases - when quality switches was actually something we test for on each Pull Request in our memory leak tests.

Looking at its output [before](https://github.com/canalplus/rx-player/actions/runs/21177378879/job/60909834523#step:7:62) and [after](https://github.com/canalplus/rx-player/actions/runs/21140070611/job/60791526922#step:7:62) the fix I don't see any sensible difference (note that those numbers are very approximative, we don't have access into low-level memory metrics in browser JS).

I was wondering if maybe it was because the switches in that test led to a reload, but looking at it, it seems to go through the default switching mode [which appears to be `"seamless"`](https://github.com/canalplus/rx-player/blob/63be19736deafb7c59c8ca671e35c698e77b7c11/src/default_config.ts#L1212) - and thus doesn't reload.

So it should be the right scenario for our leak here...

But [the actual switching logic is a little complex](https://github.com/canalplus/rx-player/blob/63be19736deafb7c59c8ca671e35c698e77b7c11/src/core/stream/adaptation/get_representations_switch_strategy.ts#L34), so it could also just be a sort of timing issue, where the 1s delay we leave in our tests for the browser to clean the old buffer + switch to the new quality is not enough time for doing the full logic.  It could also just be that the ~4MB difference seen in test outputs after 500 switches is a/the leak but that my fix doesn't have the expected result.

To see more clearly, I here try to simplify and explicit what I'm testing by trying two opposite strategies:

-  the `"lazy"` switching mode, which directly switches quality without any cleaning step first - kind of like an ABR switch

- the `"reload"` switching mode, it switches to a new MediaSource and re-run the whole logic from scratch. Interesting that we did not test that scenario until now.