### PR TITLE
tests: filter out outliers in performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /tests/performance/node_modules
 /tests/performance/previous.js
 /tests/performance/current.js
+/tests/performance/control-current.js
 /tests/performance/package.json
 /tests/performance/package-lock.json
 

--- a/tests/contents/static/DASH_static_Large_MultiPeriod/urls.mjs
+++ b/tests/contents/static/DASH_static_Large_MultiPeriod/urls.mjs
@@ -2,19 +2,62 @@
 
 const BASE_MEDIA_URL = "/DASH_static_SegmentTimeline/media/dash/";
 const PERIOD_COUNT = 100;
-const VIDEO_ADAPTATION_COUNT = 5;
-const REPRESENTATION_COUNT = 12;
+const VIDEO_ADAPTATION_COUNT = 4;
+const VIDEO_REPRESENTATION_COUNT = 10;
+const AUDIO_ADAPTATION_COUNT = 4;
+const AUDIO_REPRESENTATION_COUNT = 4;
+const TEXT_ADAPTATION_COUNT = 4;
+const TEXT_REPRESENTATION_COUNT = 2;
+const LANGUAGES = ["en", "fr", "de", "es"];
 
 let periods = "";
 for (let periodIndex = 0; periodIndex < PERIOD_COUNT; periodIndex++) {
-  let adaptations = `
-    <AdaptationSet id="audio-${periodIndex}" contentType="audio" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="44100">
+  let adaptations = "";
+  for (
+    let adaptationIndex = 0;
+    adaptationIndex < AUDIO_ADAPTATION_COUNT;
+    adaptationIndex++
+  ) {
+    let representations = "";
+    for (
+      let representationIndex = 0;
+      representationIndex < AUDIO_REPRESENTATION_COUNT;
+      representationIndex++
+    ) {
+      representations += `
+      <Representation id="audio-${periodIndex}-${adaptationIndex}-${representationIndex}" bandwidth="${96000 + representationIndex * 16000}" />`;
+    }
+    adaptations += `
+    <AdaptationSet id="audio-${periodIndex}-${adaptationIndex}" contentType="audio" lang="${LANGUAGES[adaptationIndex]}" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="44100">
       <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
       <SegmentTemplate timescale="44100" initialization="${BASE_MEDIA_URL}ateam-audio=128000.dash" media="${BASE_MEDIA_URL}ateam-audio=128000-$Time$.dash">
         <SegmentTimeline><S t="0" d="177341" /></SegmentTimeline>
-      </SegmentTemplate>
-      <Representation id="audio-${periodIndex}" bandwidth="128000" />
+      </SegmentTemplate>${representations}
     </AdaptationSet>`;
+  }
+
+  for (
+    let adaptationIndex = 0;
+    adaptationIndex < TEXT_ADAPTATION_COUNT;
+    adaptationIndex++
+  ) {
+    let representations = "";
+    for (
+      let representationIndex = 0;
+      representationIndex < TEXT_REPRESENTATION_COUNT;
+      representationIndex++
+    ) {
+      representations += `
+      <Representation id="text-${periodIndex}-${adaptationIndex}-${representationIndex}" bandwidth="256" mimeType="text/vtt" />`;
+    }
+    adaptations += `
+    <AdaptationSet id="text-${periodIndex}-${adaptationIndex}" contentType="text" lang="${LANGUAGES[adaptationIndex]}" subsegmentAlignment="true">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="${adaptationIndex % 2 === 0 ? "main" : "alternate"}" />
+      <SegmentTemplate timescale="1" media="${BASE_MEDIA_URL}ateam-text-$Time$.dash">
+        <SegmentTimeline><S t="0" d="10" /></SegmentTimeline>
+      </SegmentTemplate>${representations}
+    </AdaptationSet>`;
+  }
 
   for (
     let adaptationIndex = 0;
@@ -24,7 +67,7 @@ for (let periodIndex = 0; periodIndex < PERIOD_COUNT; periodIndex++) {
     let representations = "";
     for (
       let representationIndex = 0;
-      representationIndex < REPRESENTATION_COUNT;
+      representationIndex < VIDEO_REPRESENTATION_COUNT;
       representationIndex++
     ) {
       representations += `

--- a/tests/contents/static/DASH_static_Large_MultiPeriod/urls.mjs
+++ b/tests/contents/static/DASH_static_Large_MultiPeriod/urls.mjs
@@ -1,0 +1,56 @@
+/* eslint-env node */
+
+const BASE_MEDIA_URL = "/DASH_static_SegmentTimeline/media/dash/";
+const PERIOD_COUNT = 100;
+const VIDEO_ADAPTATION_COUNT = 5;
+const REPRESENTATION_COUNT = 12;
+
+let periods = "";
+for (let periodIndex = 0; periodIndex < PERIOD_COUNT; periodIndex++) {
+  let adaptations = `
+    <AdaptationSet id="audio-${periodIndex}" contentType="audio" mimeType="audio/mp4" codecs="mp4a.40.2" audioSamplingRate="44100">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+      <SegmentTemplate timescale="44100" initialization="${BASE_MEDIA_URL}ateam-audio=128000.dash" media="${BASE_MEDIA_URL}ateam-audio=128000-$Time$.dash">
+        <SegmentTimeline><S t="0" d="177341" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio-${periodIndex}" bandwidth="128000" />
+    </AdaptationSet>`;
+
+  for (
+    let adaptationIndex = 0;
+    adaptationIndex < VIDEO_ADAPTATION_COUNT;
+    adaptationIndex++
+  ) {
+    let representations = "";
+    for (
+      let representationIndex = 0;
+      representationIndex < REPRESENTATION_COUNT;
+      representationIndex++
+    ) {
+      representations += `
+        <Representation id="video-${periodIndex}-${adaptationIndex}-${representationIndex}" bandwidth="${400000 + representationIndex * 1000}" width="640" height="360" />`;
+    }
+    adaptations += `
+    <AdaptationSet id="video-${periodIndex}-${adaptationIndex}" contentType="video" mimeType="video/mp4" codecs="avc1.4D401E" segmentAlignment="true">
+      <SegmentTemplate timescale="90000" initialization="${BASE_MEDIA_URL}ateam-video=400000.dash" media="${BASE_MEDIA_URL}ateam-video=400000-$Time$.dash">
+        <SegmentTimeline><S t="0" d="360360" /></SegmentTimeline>
+      </SegmentTemplate>${representations}
+    </AdaptationSet>`;
+  }
+
+  periods += `
+  <Period id="period-${periodIndex}" start="PT${periodIndex * 4}S" duration="PT4S">${adaptations}
+  </Period>`;
+}
+
+const manifest = `<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" type="static" mediaPresentationDuration="PT${PERIOD_COUNT * 4}S" minBufferTime="PT1S" profiles="urn:mpeg:dash:profile:isoff-live:2011">${periods}
+</MPD>`;
+
+export default [
+  {
+    url: "/DASH_static_Large_MultiPeriod/manifest.mpd",
+    data: manifest,
+    contentType: "application/dash+xml",
+  },
+];

--- a/tests/contents/static/urls.mjs
+++ b/tests/contents/static/urls.mjs
@@ -17,6 +17,7 @@ import urls12 from "./DASH_DRM_static_SegmentTemplate/urls.mjs";
 import urls13 from "./DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs";
 import urls14 from "./imagetracks/urls.mjs";
 import urls15 from "./DASH_static_audio_tag/urls.mjs";
+import urls16 from "./DASH_static_Large_MultiPeriod/urls.mjs";
 
 export default [
   ...urls1,
@@ -34,4 +35,5 @@ export default [
   ...urls13,
   ...urls14,
   ...urls15,
+  ...urls16,
 ];

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,127 @@
+# Performance tests
+
+This directory regroups tests allowing to detect RxPlayer performance regressions on some
+key scenarios.
+
+Unlike unit or integration tests, they do not check that a precise behavior happened. They
+measure through `performance.now()` the time taken by some player operations and compare
+results obtained with the current code to results obtained with another git branch, `dev`
+by default.
+
+Those tests are intended to automatically run in CI. They may also be run locally through:
+
+```sh
+npm run test:performance
+```
+
+Use `npm run test:performance -- --help` to list the available options. For example, the
+following command compares the current code to the `stable` branch on Firefox:
+
+```sh
+npm run test:performance -- --branch stable --browser firefox
+```
+
+## Dependencies
+
+Performance tests rely on:
+
+- the project's JavaScript dependencies, which should first be installed through
+  `npm install` or `npm ci`;
+
+- Git and a reachable git repository. The branch to compare to is cloned in a temporary
+  local `node_modules` directory. By default, the URL of the current `origin` remote is
+  used, but another one can be given through the `--remote-git-url` option;
+
+- either a Chrome or Firefox executable. Chrome is used by default;
+
+- browser support for the codecs used by the static test contents;
+
+- the ports `3000`, `8080` and `6789` being available by default, respectively for the
+  content server, test pages server and results server. Each can be changed through a
+  command line option.
+
+Note that running those tests removes and recreates the root `dist` directory and the
+`tests/performance/node_modules` directory. It also creates generated JavaScript files in
+this directory. Those generated files are ignored by git.
+
+## How tests are performed
+
+Before running tests, `run.mjs` builds two production, minified test bundles:
+
+- `previous.js`, relying on the RxPlayer built from the branch we want to compare to;
+
+- `current.js`, relying on the RxPlayer built from the current working tree.
+
+A third `control-current.js` bundle is copied from `previous.js` to perform an A/A control
+where both compared slots actually use the previous RxPlayer. This allows to estimate and
+remove a potential bias caused by the order in which pages are run.
+
+Tests are then divided into an A/A control and an A/B treatment, each performed in
+multiple (40 as of 2026-08-31) fresh browser processes. Their order is randomized. Inside
+each browser process, the two slots alternate page loads, with half of the processes
+starting with the current slot and half with the previous one.
+
+For each scenario, `run.mjs` compares per-process mean and median differences from the A/B
+treatment to those from the A/A control through a Mann-Whitney U test. A change is only
+considered significant for an absolute z-score higher than `2.575829` and a corrected
+difference higher than 2 milliseconds:
+
+- a significant median regression makes the test run fail;
+
+- a regression only visible on the mean is displayed as a warning;
+
+- a significant median improvement is also displayed;
+
+- everything else is indicated as not significative.
+
+When a median regression is found, the whole run is performed a second time. The command
+only exits with an error if the same scenario has a median regression in both runs.
+
+An HTML report can optionally be written through the `--report` option.
+
+## Tested scenarios
+
+As of 2026-08-31, the tests measure:
+
+- loading a DASH content in monothread mode;
+
+- seeking in that content;
+
+- switching the audio track with the `"reload"` switching mode;
+
+- loading a content over an already active content;
+
+- parsing a large multi-Period Manifest;
+
+- cold loading in multithread mode, including Worker attachment;
+
+- seeking and reloading an audio track in multithread mode;
+
+- hot loading in multithread mode, once the Worker is already attached.
+
+The more expensive loading-over-active-content and large Manifest scenarios only run for
+the first four page loads of each browser process, to keep the global duration reasonable.
+
+## Files
+
+- `run.mjs` is the Node.js entry point. It parses command line options, clones and builds
+  the compared branch, builds the current code, starts all three HTTP servers, launches
+  fresh browser processes, collects samples, compares them and optionally generates a
+  report.
+
+- `src/main.js` declares the tested scenarios. New measurements should be delimited by
+  calls to `testStart` and `testEnd` with the same unique name.
+
+- `src/lib.js` contains browser-side test utilities. It registers and runs test groups,
+  measures their duration, alternates between pages and sends results or errors to the
+  Node.js results server.
+
+- `current.html` and `previous.html` are the A/B treatment pages. They respectively load
+  the generated `current.js` and `previous.js` bundles.
+
+- `control-current.html` and `control-previous.html` are the A/A control pages. They load
+  two copies of the generated bundle for the compared branch.
+
+When adding a scenario, keep in mind that the same `src/main.js` file is bundled against
+both revisions. It consequently has to stay compatible with the branch given to
+`--branch`, including for the RxPlayer API and imported test files it relies on.

--- a/tests/performance/control-current.html
+++ b/tests/performance/control-current.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <script type="text/javascript" src="./control-current.js" charset="utf-8"></script>
+    <title>RxPlayer - Performance tests control current slot</title>
+  </head>
+  <body>
+    <video />
+  </body>
+</html>

--- a/tests/performance/control-previous.html
+++ b/tests/performance/control-previous.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <script type="text/javascript" src="./previous.js" charset="utf-8"></script>
+    <title>RxPlayer - Performance tests control previous slot</title>
+  </head>
+  <body>
+    <video />
+  </body>
+</html>

--- a/tests/performance/run.mjs
+++ b/tests/performance/run.mjs
@@ -199,8 +199,14 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       let results2 = null;
       if (results.worse.length > 0) {
         console.warn(
-          "\nWorse performance for tests:\n\n" +
+          "\nMedian performance regressions (CI blocking):\n\n" +
             formatResultAsMarkdownTable(results.worse),
+        );
+      }
+      if (results.meanOnlyWorse.length > 0) {
+        console.warn(
+          "\nMean-only performance regressions (warning):\n\n" +
+            formatResultAsMarkdownTable(results.meanOnlyWorse),
         );
       }
       if (results.better.length > 0) {
@@ -230,6 +236,13 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
         testPagePort,
       });
       console.error("\nFinal result after 2 attempts\n-----------------------------\n");
+
+      if (results2.meanOnlyWorse.length > 0) {
+        console.warn(
+          "\nMean-only performance regressions on second attempt (warning):\n\n" +
+            formatResultAsMarkdownTable(results2.meanOnlyWorse),
+        );
+      }
 
       // Collect all regressions from both runs
       const allRegressions = new Map();
@@ -330,15 +343,24 @@ function formatResultAsMarkdownTable(results) {
   if (results.length === 0) {
     return "";
   }
-  const testNames = results.map((r) => r.testName);
+  const testNames = results.map((r) =>
+    r.regressionSignals === undefined
+      ? r.testName
+      : `${r.testName} (${r.regressionSignals})`,
+  );
   const meanResult = results.map(
     (r) =>
       `${r.previousMean.toFixed(2)}ms -> ${r.currentMean.toFixed(2)}ms ` +
       `(corrected: ${r.meanDifferenceMs.toFixed(3)}ms, ` +
-      `A/A bias: ${r.controlDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
+      `A/A bias: ${r.controlMeanDifferenceMs.toFixed(3)}ms, ` +
+      `z: ${r.meanZScore.toFixed(5)})`,
   );
   const medianResult = results.map(
-    (r) => `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms`,
+    (r) =>
+      `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms ` +
+      `(corrected: ${r.medianDifferenceMs.toFixed(3)}ms, ` +
+      `A/A bias: ${r.controlMedianDifferenceMs.toFixed(3)}ms, ` +
+      `z: ${r.medianZScore.toFixed(5)})`,
   );
 
   const nameColumnInnerLength = Math.max(
@@ -932,6 +954,7 @@ function compareSamples() {
 
   const results = {
     worse: [],
+    meanOnlyWorse: [],
     better: [],
     notSignificative: [],
   };
@@ -943,28 +966,60 @@ function compareSamples() {
       console.error("Error: second result misses a scenario:", testName);
       continue;
     }
-    const treatmentSample = treatmentDifferences[testName];
-    const controlSample = controlDifferences[testName];
-    if (treatmentSample === undefined || controlSample === undefined) {
+    const treatmentSamples = treatmentDifferences[testName];
+    const controlSamples = controlDifferences[testName];
+    if (treatmentSamples === undefined || controlSamples === undefined) {
       // eslint-disable-next-line no-console
       console.error("Error: control or treatment results miss a scenario:", testName);
       continue;
     }
     const resultCurrent = getResultsForSample(sampleCurrent);
     const resultPrevious = getResultsForSample(samplePrevious);
-    const resultTreatment = getResultsForSample(treatmentSample);
-    const resultControl = getResultsForSample(controlSample);
+    const resultTreatmentMean = getResultsForSample(treatmentSamples.mean);
+    const resultControlMean = getResultsForSample(controlSamples.mean);
+    const resultTreatmentMedian = getResultsForSample(treatmentSamples.median);
+    const resultControlMedian = getResultsForSample(controlSamples.median);
 
-    const medianDiffMs = resultTreatment.median - resultControl.median;
-    const meanDiffMs = resultTreatment.mean - resultControl.mean;
-    const uValue = getUValueFromSamples(treatmentSample, controlSample);
-    const zScore = Math.abs(
-      calculateZScore(uValue, treatmentSample.length, controlSample.length),
+    const meanDiffMs = resultTreatmentMean.mean - resultControlMean.mean;
+    const medianDiffMs = resultTreatmentMedian.median - resultControlMedian.median;
+    const meanUValue = getUValueFromSamples(treatmentSamples.mean, controlSamples.mean);
+    const meanZScore = Math.abs(
+      calculateZScore(
+        meanUValue,
+        treatmentSamples.mean.length,
+        controlSamples.mean.length,
+      ),
     );
-    // For p-value of 5%
-    // const isSignificant = zScore > 1.96;
-    // For p-value of 1%
-    const isSignificant = zScore > 2.575829;
+    const medianUValue = getUValueFromSamples(
+      treatmentSamples.median,
+      controlSamples.median,
+    );
+    const medianZScore = Math.abs(
+      calculateZScore(
+        medianUValue,
+        treatmentSamples.median.length,
+        controlSamples.median.length,
+      ),
+    );
+    const isMeanSignificant = meanZScore > 2.575829;
+    const isMedianSignificant = medianZScore > 2.575829;
+    const isMeanWorse = isMeanSignificant && meanDiffMs < -2;
+    const isMedianWorse = isMedianSignificant && medianDiffMs < -2;
+    const isMedianBetter = isMedianSignificant && medianDiffMs > 2;
+
+    const result = {
+      testName,
+      previousMean: resultPrevious.mean,
+      currentMean: resultCurrent.mean,
+      previousMedian: resultPrevious.median,
+      currentMedian: resultCurrent.median,
+      meanDifferenceMs: meanDiffMs,
+      medianDifferenceMs: medianDiffMs,
+      controlMeanDifferenceMs: resultControlMean.mean,
+      controlMedianDifferenceMs: resultControlMedian.median,
+      meanZScore,
+      medianZScore,
+    };
 
     /* eslint-disable no-console */
     console.log("");
@@ -987,59 +1042,29 @@ function compareSamples() {
     console.log(`      moe: ${resultPrevious.moe}`);
     console.log("");
     console.log("    Results");
-    console.log(`      A/A mean slot difference: ${resultControl.mean} ms`);
-    console.log(`      A/B mean difference: ${resultTreatment.mean} ms`);
+    console.log(`      A/A mean slot difference: ${resultControlMean.mean} ms`);
+    console.log(`      A/B mean difference: ${resultTreatmentMean.mean} ms`);
     console.log(
       `      bias-corrected mean difference (negative is slower): ${meanDiffMs} ms`,
     );
-    if (isSignificant) {
-      console.log(`      The difference is significant (z: ${zScore})`);
-      if (meanDiffMs < -2 && medianDiffMs < -2) {
-        results.worse.push({
-          testName,
-          previousMean: resultPrevious.mean,
-          currentMean: resultCurrent.mean,
-          previousMedian: resultPrevious.median,
-          currentMedian: resultCurrent.median,
-          meanDifferenceMs: meanDiffMs,
-          controlDifferenceMs: resultControl.mean,
-          zScore,
-        });
-      } else if (meanDiffMs > 2 && medianDiffMs > 2) {
-        results.better.push({
-          testName,
-          previousMean: resultPrevious.mean,
-          currentMean: resultCurrent.mean,
-          previousMedian: resultPrevious.median,
-          currentMedian: resultCurrent.median,
-          meanDifferenceMs: meanDiffMs,
-          controlDifferenceMs: resultControl.mean,
-          zScore,
-        });
-      } else {
-        results.notSignificative.push({
-          testName,
-          previousMean: resultPrevious.mean,
-          currentMean: resultCurrent.mean,
-          previousMedian: resultPrevious.median,
-          currentMedian: resultCurrent.median,
-          meanDifferenceMs: meanDiffMs,
-          controlDifferenceMs: resultControl.mean,
-          zScore,
-        });
-      }
+    console.log(`      Mean z-score: ${meanZScore}`);
+    console.log(`      A/A median slot difference: ${resultControlMedian.median} ms`);
+    console.log(`      A/B median difference: ${resultTreatmentMedian.median} ms`);
+    console.log(
+      `      bias-corrected median difference (negative is slower): ${medianDiffMs} ms`,
+    );
+    console.log(`      Median z-score: ${medianZScore}`);
+
+    if (isMedianWorse) {
+      result.regressionSignals = isMeanWorse ? "mean + median" : "median";
+      results.worse.push(result);
+    } else if (isMeanWorse) {
+      result.regressionSignals = "mean only";
+      results.meanOnlyWorse.push(result);
+    } else if (isMedianBetter) {
+      results.better.push(result);
     } else {
-      console.log(`      The difference is not significant (z: ${zScore})`);
-      results.notSignificative.push({
-        testName,
-        previousMean: resultPrevious.mean,
-        currentMean: resultCurrent.mean,
-        previousMedian: resultPrevious.median,
-        currentMedian: resultCurrent.median,
-        meanDifferenceMs: meanDiffMs,
-        controlDifferenceMs: resultControl.mean,
-        zScore,
-      });
+      results.notSignificative.push(result);
     }
     console.log("");
   }
@@ -1050,9 +1075,10 @@ function compareSamples() {
   }
 
   /**
-   * Return one previous-minus-current mean difference per browser process and scenario.
+   * Return one previous-minus-current mean and median difference per browser process
+   * and scenario.
    * @param {"control"|"treatment"} experiment
-   * @returns {Object.<string, Array.<number>>}
+   * @returns {Object.<string, {mean: Array.<number>, median: Array.<number>}>}
    */
   function getProcessDifferences(experiment) {
     const valuesPerProcess = new Map();
@@ -1079,9 +1105,12 @@ function compareSamples() {
       const currentMean = getResultsForSample(current).mean;
       const previousMean = getResultsForSample(previous).mean;
       if (differences[name] === undefined) {
-        differences[name] = [];
+        differences[name] = { mean: [], median: [] };
       }
-      differences[name].push(previousMean - currentMean);
+      const currentMedian = getResultsForSample(current).median;
+      const previousMedian = getResultsForSample(previous).median;
+      differences[name].mean.push(previousMean - currentMean);
+      differences[name].median.push(previousMedian - currentMedian);
     }
     return differences;
   }
@@ -1268,8 +1297,13 @@ function formatHtmlReport(reportObj) {
 
   const { firstRun, secondRun } = reportObj;
   if (firstRun.worse.length > 0) {
-    str += "\n<p>Worse performance for tests:</p>\n\n";
+    str += "\n<p>Median performance regressions (CI blocking):</p>\n\n";
     str += formatResultAsHtmlTable(firstRun.worse);
+  }
+
+  if (firstRun.meanOnlyWorse.length > 0) {
+    str += "\n<p>Mean-only performance regressions (warning):</p>\n\n";
+    str += formatResultAsHtmlTable(firstRun.meanOnlyWorse);
   }
 
   if (firstRun.better.length > 0) {
@@ -1287,8 +1321,13 @@ function formatHtmlReport(reportObj) {
     str += "\n";
     str += "<h2>Performance tests 2nd run output</h2>\n";
     if (secondRun.worse.length > 0) {
-      str += "\n<p>Worse performance for tests:</p>\n\n";
+      str += "\n<p>Median performance regressions (CI blocking):</p>\n\n";
       str += formatResultAsHtmlTable(secondRun.worse);
+    }
+
+    if (secondRun.meanOnlyWorse.length > 0) {
+      str += "\n<p>Mean-only performance regressions (warning):</p>\n\n";
+      str += formatResultAsHtmlTable(secondRun.meanOnlyWorse);
     }
 
     if (secondRun.better.length > 0) {
@@ -1317,15 +1356,24 @@ function formatResultAsHtmlTable(results) {
   if (results.length === 0) {
     return "";
   }
-  const testNames = results.map((r) => r.testName);
+  const testNames = results.map((r) =>
+    r.regressionSignals === undefined
+      ? r.testName
+      : `${r.testName} (${r.regressionSignals})`,
+  );
   const meanResult = results.map(
     (r) =>
       `${r.previousMean.toFixed(2)}ms -> ${r.currentMean.toFixed(2)}ms ` +
       `(corrected: ${r.meanDifferenceMs.toFixed(3)}ms, ` +
-      `A/A bias: ${r.controlDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
+      `A/A bias: ${r.controlMeanDifferenceMs.toFixed(3)}ms, ` +
+      `z: ${r.meanZScore.toFixed(5)})`,
   );
   const medianResult = results.map(
-    (r) => `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms`,
+    (r) =>
+      `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms ` +
+      `(corrected: ${r.medianDifferenceMs.toFixed(3)}ms, ` +
+      `A/A bias: ${r.controlMedianDifferenceMs.toFixed(3)}ms, ` +
+      `z: ${r.medianZScore.toFixed(5)})`,
   );
 
   let str;

--- a/tests/performance/run.mjs
+++ b/tests/performance/run.mjs
@@ -1268,7 +1268,7 @@ function formatHtmlReport(reportObj) {
 
   const { firstRun, secondRun } = reportObj;
   if (firstRun.worse.length > 0) {
-    str += "\n<p>No significative change in performance for tests:</p>\n\n";
+    str += "\n<p>Worse performance for tests:</p>\n\n";
     str += formatResultAsHtmlTable(firstRun.worse);
   }
 
@@ -1285,9 +1285,9 @@ function formatHtmlReport(reportObj) {
 
   if (secondRun) {
     str += "\n";
-    str += "<h2>Performance tests 2st run output</h2>\n";
+    str += "<h2>Performance tests 2nd run output</h2>\n";
     if (secondRun.worse.length > 0) {
-      str += "\n<p>No significative change in performance for tests:</p>\n\n";
+      str += "\n<p>Worse performance for tests:</p>\n\n";
       str += formatResultAsHtmlTable(secondRun.worse);
     }
 

--- a/tests/performance/run.mjs
+++ b/tests/performance/run.mjs
@@ -31,13 +31,12 @@ const DEFAULT_TEST_PAGE_PORT = 8080;
 const DEFAULT_RESULT_SERVER_PORT = 6789;
 
 /**
- * Number of times test are runs on each browser/RxPlayer configuration.
- * More iterations means (much) more time to perform tests, but also produce
- * better estimates.
+ * Number of fresh browser processes used by the A/A control and A/B treatment.
  *
  * TODO: GitHub actions fails when running the 128th browser. Find out why.
  */
-const TEST_ITERATIONS = 100;
+const CONTROL_ITERATIONS = 40;
+const TREATMENT_ITERATIONS = 40;
 
 /**
  * `ChildProcess` instance of the current browser being run.
@@ -46,10 +45,7 @@ const TEST_ITERATIONS = 100;
 let currentBrowser;
 
 /**
- * Contains "tasks" which are function each run inside a new browser process.
- * Task are added by groups of two:
- *   - the first one testing the current player build
- *   - the second one testing the last RxPlayer production version.
+ * Contains tasks which each run inside a fresh browser process.
  */
 const tasks = [];
 
@@ -338,7 +334,8 @@ function formatResultAsMarkdownTable(results) {
   const meanResult = results.map(
     (r) =>
       `${r.previousMean.toFixed(2)}ms -> ${r.currentMean.toFixed(2)}ms ` +
-      `(${r.meanDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
+      `(corrected: ${r.meanDifferenceMs.toFixed(3)}ms, ` +
+      `A/A bias: ${r.controlDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
   );
   const medianResult = results.map(
     (r) => `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms`,
@@ -412,6 +409,10 @@ function formatResultAsMarkdownTable(results) {
 /**
  * Initialize and start all tests on a browser..
  * @param {Object} params
+ * @param {"control"|"treatment"} params.experiment - Whether both slots load
+ * the previous build or the current slot loads the current build.
+ * @param {number} params.processIteration - Identifier attached to every sample
+ * produced by this browser process.
  * @param {string} [params.browser="chrome"] - The browser to run the tests on.
  * "chrome" by default. Can be either "chrome" or "firefox".
  * @param {number} params.contentServerPort - The port through which test
@@ -586,6 +587,10 @@ async function prepareLastRxPlayerTests({ branchName, contentServerPort, remoteG
     minify: true,
     production: true,
   });
+  await fsProm.copyFile(
+    path.join(currentDirectory, "previous.js"),
+    path.join(currentDirectory, "control-current.js"),
+  );
 }
 
 /**
@@ -663,13 +668,28 @@ async function linkRxPlayerBranch({ branchName, remoteGitUrl }) {
  */
 async function startAllTests({ browser, testPagePort, resultServerPort }) {
   tasks.length = 0;
-  for (let i = 0; i < TEST_ITERATIONS; i++) {
+  const iterations = [];
+  for (const [experiment, count] of [
+    ["control", CONTROL_ITERATIONS],
+    ["treatment", TREATMENT_ITERATIONS],
+  ]) {
+    for (let i = 0; i < count; i++) {
+      iterations.push({ experiment, startWithCurrent: i % 2 === 0 });
+    }
+  }
+  for (let i = iterations.length - 1; i > 0; i--) {
+    const randomIndex = Math.floor(Math.random() * (i + 1));
+    [iterations[i], iterations[randomIndex]] = [iterations[randomIndex], iterations[i]];
+  }
+  for (const [index, { experiment, startWithCurrent }] of iterations.entries()) {
     tasks.push(() =>
       startIteration({
         browser,
-        startWithCurrent: i % 2 === 0,
-        iteration: i + 1,
-        total: TEST_ITERATIONS,
+        experiment,
+        processIteration: index + 1,
+        startWithCurrent,
+        iteration: index + 1,
+        total: iterations.length,
         testPagePort,
         resultServerPort,
       }),
@@ -700,7 +720,7 @@ function startNextTaskOrFinish(onFinished) {
   const nextTask = tasks.shift();
   if (nextTask === undefined) {
     onFinished();
-    return;
+    return Promise.resolve();
   }
   return nextTask();
 }
@@ -723,6 +743,8 @@ function startNextTaskOrFinish(onFinished) {
  */
 async function startIteration({
   browser,
+  experiment,
+  processIteration,
   startWithCurrent,
   iteration,
   total,
@@ -732,9 +754,11 @@ async function startIteration({
   if (currentBrowser !== undefined) {
     currentBrowser.kill("SIGKILL");
   }
-  const url = startWithCurrent
-    ? `http://localhost:${testPagePort}/current.html#p=${resultServerPort};`
-    : `http://localhost:${testPagePort}/previous.html#p=${resultServerPort};`;
+  const pagePrefix = experiment === "control" ? "control-" : "";
+  const page = startWithCurrent ? "current" : "previous";
+  const url =
+    `http://localhost:${testPagePort}/${pagePrefix}${page}.html` +
+    `#p=${resultServerPort};e=${experiment};o=${processIteration};`;
   if (browser === "firefox") {
     // eslint-disable-next-line no-console
     console.log(`Running tests on Firefox (${iteration}/${total})`);
@@ -799,9 +823,6 @@ function createResultServer({ port, onFinished, onError }) {
             if (currentBrowser !== undefined) {
               currentBrowser.kill("SIGKILL");
               currentBrowser = undefined;
-            }
-            if (allSamples.previous.length > 0 && allSamples.current.length > 0) {
-              compareSamples();
             }
             startNextTaskOrFinish(onFinished).catch(onError);
           } else if (parsedBody.type === "value") {
@@ -899,9 +920,15 @@ function rankSamples(list) {
  */
 function compareSamples() {
   const samplesPerScenario = {
-    current: getSamplePerScenarios(allSamples.current),
-    previous: getSamplePerScenarios(allSamples.previous),
+    current: getSamplePerScenarios(
+      allSamples.current.filter((sample) => sample.experiment === "treatment"),
+    ),
+    previous: getSamplePerScenarios(
+      allSamples.previous.filter((sample) => sample.experiment === "treatment"),
+    ),
   };
+  const treatmentDifferences = getProcessDifferences("treatment");
+  const controlDifferences = getProcessDifferences("control");
 
   const results = {
     worse: [],
@@ -916,14 +943,23 @@ function compareSamples() {
       console.error("Error: second result misses a scenario:", testName);
       continue;
     }
+    const treatmentSample = treatmentDifferences[testName];
+    const controlSample = controlDifferences[testName];
+    if (treatmentSample === undefined || controlSample === undefined) {
+      // eslint-disable-next-line no-console
+      console.error("Error: control or treatment results miss a scenario:", testName);
+      continue;
+    }
     const resultCurrent = getResultsForSample(sampleCurrent);
     const resultPrevious = getResultsForSample(samplePrevious);
+    const resultTreatment = getResultsForSample(treatmentSample);
+    const resultControl = getResultsForSample(controlSample);
 
-    const medianDiffMs = resultPrevious.median - resultCurrent.median;
-    const meanDiffMs = resultPrevious.mean - resultCurrent.mean;
-    const uValue = getUValueFromSamples(sampleCurrent, samplePrevious);
+    const medianDiffMs = resultTreatment.median - resultControl.median;
+    const meanDiffMs = resultTreatment.mean - resultControl.mean;
+    const uValue = getUValueFromSamples(treatmentSample, controlSample);
     const zScore = Math.abs(
-      calculateZScore(uValue, sampleCurrent.length, samplePrevious.length),
+      calculateZScore(uValue, treatmentSample.length, controlSample.length),
     );
     // For p-value of 5%
     // const isSignificant = zScore > 1.96;
@@ -951,7 +987,11 @@ function compareSamples() {
     console.log(`      moe: ${resultPrevious.moe}`);
     console.log("");
     console.log("    Results");
-    console.log(`      mean difference time (negative is slower): ${meanDiffMs} ms`);
+    console.log(`      A/A mean slot difference: ${resultControl.mean} ms`);
+    console.log(`      A/B mean difference: ${resultTreatment.mean} ms`);
+    console.log(
+      `      bias-corrected mean difference (negative is slower): ${meanDiffMs} ms`,
+    );
     if (isSignificant) {
       console.log(`      The difference is significant (z: ${zScore})`);
       if (meanDiffMs < -2 && medianDiffMs < -2) {
@@ -962,6 +1002,7 @@ function compareSamples() {
           previousMedian: resultPrevious.median,
           currentMedian: resultCurrent.median,
           meanDifferenceMs: meanDiffMs,
+          controlDifferenceMs: resultControl.mean,
           zScore,
         });
       } else if (meanDiffMs > 2 && medianDiffMs > 2) {
@@ -972,6 +1013,7 @@ function compareSamples() {
           previousMedian: resultPrevious.median,
           currentMedian: resultCurrent.median,
           meanDifferenceMs: meanDiffMs,
+          controlDifferenceMs: resultControl.mean,
           zScore,
         });
       } else {
@@ -982,6 +1024,7 @@ function compareSamples() {
           previousMedian: resultPrevious.median,
           currentMedian: resultCurrent.median,
           meanDifferenceMs: meanDiffMs,
+          controlDifferenceMs: resultControl.mean,
           zScore,
         });
       }
@@ -994,6 +1037,7 @@ function compareSamples() {
         previousMedian: resultPrevious.median,
         currentMedian: resultCurrent.median,
         meanDifferenceMs: meanDiffMs,
+        controlDifferenceMs: resultControl.mean,
         zScore,
       });
     }
@@ -1003,6 +1047,43 @@ function compareSamples() {
   return results;
   function calculateZScore(u, len1, len2) {
     return (u - (len1 * len2) / 2) / Math.sqrt((len1 * len2 * (len1 + len2 + 1)) / 12);
+  }
+
+  /**
+   * Return one previous-minus-current mean difference per browser process and scenario.
+   * @param {"control"|"treatment"} experiment
+   * @returns {Object.<string, Array.<number>>}
+   */
+  function getProcessDifferences(experiment) {
+    const valuesPerProcess = new Map();
+    for (const page of ["current", "previous"]) {
+      for (const sample of allSamples[page]) {
+        if (sample.experiment !== experiment) {
+          continue;
+        }
+        const key = `${sample.processIteration}:${sample.name}`;
+        let values = valuesPerProcess.get(key);
+        if (values === undefined) {
+          values = { name: sample.name, current: [], previous: [] };
+          valuesPerProcess.set(key, values);
+        }
+        values[page].push(sample.value);
+      }
+    }
+
+    const differences = {};
+    for (const { name, current, previous } of valuesPerProcess.values()) {
+      if (current.length === 0 || previous.length === 0) {
+        continue;
+      }
+      const currentMean = getResultsForSample(current).mean;
+      const previousMean = getResultsForSample(previous).mean;
+      if (differences[name] === undefined) {
+        differences[name] = [];
+      }
+      differences[name].push(previousMean - currentMean);
+    }
+    return differences;
   }
 }
 
@@ -1240,7 +1321,8 @@ function formatResultAsHtmlTable(results) {
   const meanResult = results.map(
     (r) =>
       `${r.previousMean.toFixed(2)}ms -> ${r.currentMean.toFixed(2)}ms ` +
-      `(${r.meanDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
+      `(corrected: ${r.meanDifferenceMs.toFixed(3)}ms, ` +
+      `A/A bias: ${r.controlDifferenceMs.toFixed(3)}ms, z: ${r.zScore.toFixed(5)})`,
   );
   const medianResult = results.map(
     (r) => `${r.previousMedian.toFixed(2)}ms -> ${r.currentMedian.toFixed(2)}ms`,

--- a/tests/performance/run.mjs
+++ b/tests/performance/run.mjs
@@ -37,7 +37,7 @@ const DEFAULT_RESULT_SERVER_PORT = 6789;
  *
  * TODO: GitHub actions fails when running the 128th browser. Find out why.
  */
-const TEST_ITERATIONS = 30;
+const TEST_ITERATIONS = 100;
 
 /**
  * `ChildProcess` instance of the current browser being run.
@@ -227,32 +227,49 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 
       console.warn("\nRetrying one time just to check if unlucky...");
 
-      results2 = await runPerformanceTests(browser);
+      results2 = await runPerformanceTests({
+        browser,
+        contentServerPort,
+        resultServerPort,
+        testPagePort,
+      });
       console.error("\nFinal result after 2 attempts\n-----------------------------\n");
 
-      if (results.better.length > 0) {
-        console.error(
-          "\nBetter performance at first attempt for tests:\n\n" +
-            formatResultAsMarkdownTable(results.better),
-        );
+      // Collect all regressions from both runs
+      const allRegressions = new Map();
+      for (const failure of results.worse) {
+        allRegressions.set(failure.testName, { first: failure, second: null });
       }
-      if (results2.better.length > 0) {
-        console.error(
-          "\nBetter performance at second attempt for tests:\n\n" +
-            formatResultAsMarkdownTable(results2.better),
-        );
+      for (const failure of results2.worse) {
+        const existing = allRegressions.get(failure.testName);
+        if (existing) {
+          existing.second = failure;
+        } else {
+          allRegressions.set(failure.testName, { first: null, second: failure });
+        }
       }
 
-      if (results.worse.length > 0) {
+      const confirmedRegressions = [];
+      const inconsistentResults = [];
+
+      for (const [_testName, { first, second }] of allRegressions) {
+        if (first && second) {
+          confirmedRegressions.push(first);
+        } else {
+          inconsistentResults.push(first || second);
+        }
+      }
+
+      if (confirmedRegressions.length > 0) {
         console.error(
           "\nWorse performance at first attempt for tests:\n\n" +
-            formatResultAsMarkdownTable(results.worse),
+            formatResultAsMarkdownTable(confirmedRegressions),
         );
       }
-      if (results2.worse.length > 0) {
+      if (inconsistentResults.length > 0) {
         console.warn(
-          "\nWorse performance at second attempt for tests:\n\n" +
-            formatResultAsMarkdownTable(results.worse),
+          "\nInconsistent results for tests (failed only one run):\n\n" +
+            formatResultAsMarkdownTable(inconsistentResults),
         );
       }
 
@@ -281,10 +298,13 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
             }
             const htmlReport = formatHtmlReport({
               success:
-                results.worse.length === 0 &&
-                (results2 === undefined ||
-                  results2 === null ||
-                  results2.worse.length === 0),
+                results.worse.length === 0 ||
+                (results2 !== null &&
+                  !results.worse.some((firstResult) =>
+                    results2.worse.some(
+                      (secondResult) => secondResult.testName === firstResult.testName,
+                    ),
+                  )),
               baseBranch: branchName,
               commitSha,
               firstRun: results,
@@ -408,6 +428,8 @@ function runPerformanceTests({
   resultServerPort = DEFAULT_RESULT_SERVER_PORT,
   testPagePort = DEFAULT_TEST_PAGE_PORT,
 }) {
+  allSamples.current.length = 0;
+  allSamples.previous.length = 0;
   return new Promise((resolve, reject) => {
     let isFinished = false;
     let contentServer;
@@ -678,6 +700,7 @@ function startNextTaskOrFinish(onFinished) {
   const nextTask = tasks.shift();
   if (nextTask === undefined) {
     onFinished();
+    return;
   }
   return nextTask();
 }
@@ -1028,14 +1051,14 @@ function getUValueFromSamples(sampleCurrent, samplePrevious) {
  * @returns {Object}
  */
 function getResultsForSample(sample) {
-  sample.sort();
+  sample.sort((a, b) => a - b);
   let median;
   if (sample.length === 0) {
     median = 0;
   } else {
     median =
       sample.length % 2 === 0
-        ? sample[sample.length / 2 - 1] + sample[sample.length / 2] / 2
+        ? (sample[sample.length / 2 - 1] + sample[sample.length / 2]) / 2
         : sample[Math.floor(sample.length / 2)];
   }
   const mean = sample.reduce((acc, x) => acc + x, 0) / sample.length;

--- a/tests/performance/src/lib.js
+++ b/tests/performance/src/lib.js
@@ -32,7 +32,7 @@ const INNER_ITERATIONS = 20;
  * @returns {boolean}
  */
 export function shouldRunExtendedTests() {
-  return tryAttempt <= 2;
+  return tryAttempt <= 4;
 }
 
 if (isNaN(resultServerPort)) {

--- a/tests/performance/src/lib.js
+++ b/tests/performance/src/lib.js
@@ -22,6 +22,9 @@ let areTestsAlreadyRunning = false;
 const hashComponents = parseUrlHash();
 const resultServerPort = parseInt(hashComponents.p);
 const tryAttempt = hashComponents.t === undefined ? 1 : parseInt(hashComponents.t);
+const experiment = hashComponents.e;
+const processIteration = parseInt(hashComponents.o);
+const INNER_ITERATIONS = 20;
 
 if (isNaN(resultServerPort)) {
   throw new Error("The current page should have a valid result server port in its URL");
@@ -36,9 +39,15 @@ if (isNaN(resultServerPort)) {
  *     compare.
  */
 let page;
-if (location.pathname === "/previous.html") {
+if (
+  location.pathname === "/previous.html" ||
+  location.pathname === "/control-previous.html"
+) {
   page = "previous";
-} else if (location.pathname === "/current.html") {
+} else if (
+  location.pathname === "/current.html" ||
+  location.pathname === "/control-current.html"
+) {
   page = "current";
 } else {
   error("Unknown launched page: " + location.pathname);
@@ -175,7 +184,13 @@ function reportResult(testName, testResult) {
     body: JSON.stringify({
       type: "value",
       page,
-      data: { name: testName, value: testResult },
+      data: {
+        name: testName,
+        value: testResult,
+        experiment,
+        processIteration,
+        attempt: tryAttempt,
+      },
     }),
   }).catch((err) => {
     log("ERROR: Failed to send results for ", testName, err.toString());
@@ -187,13 +202,15 @@ function reportResult(testName, testResult) {
  * page or indicates to the server that it's finished if it is.
  */
 function done() {
-  if (tryAttempt < 100) {
+  if (tryAttempt < INNER_ITERATIONS) {
     hashComponents.t = tryAttempt + 1;
     updateUrlHash(hashComponents);
     if (page === "previous") {
-      location.pathname = "/current.html";
+      location.pathname =
+        experiment === "control" ? "/control-current.html" : "/current.html";
     } else {
-      location.pathname = "/previous.html";
+      location.pathname =
+        experiment === "control" ? "/control-previous.html" : "/previous.html";
     }
   } else {
     sendDone();

--- a/tests/performance/src/lib.js
+++ b/tests/performance/src/lib.js
@@ -26,6 +26,15 @@ const experiment = hashComponents.e;
 const processIteration = parseInt(hashComponents.o);
 const INNER_ITERATIONS = 20;
 
+/**
+ * Return `true` for the first current/previous pair of a browser process.
+ * Expensive scenarios can use this to keep the overall CI duration bounded.
+ * @returns {boolean}
+ */
+export function shouldRunExtendedTests() {
+  return tryAttempt <= 2;
+}
+
 if (isNaN(resultServerPort)) {
   throw new Error("The current page should have a valid result server port in its URL");
 }

--- a/tests/performance/src/main.js
+++ b/tests/performance/src/main.js
@@ -6,7 +6,7 @@ import sleep from "../../utils/sleep";
 import waitForPlayerState, {
   waitForLoadedStateAfterLoadVideo,
 } from "../../utils/waitForPlayerState";
-import { declareTestGroup, testEnd, testStart } from "./lib";
+import { declareTestGroup, shouldRunExtendedTests, testEnd, testStart } from "./lib";
 
 declareTestGroup(
   "content loading monothread",
@@ -56,6 +56,57 @@ declareTestGroup(
   },
   20000,
 );
+
+if (shouldRunExtendedTests()) {
+  declareTestGroup(
+    "extended loading scenarios",
+    async () => {
+      const player = new RxPlayer({
+        initialVideoBitrate: Infinity,
+        initialAudioBitrate: Infinity,
+        videoElement: document.getElementsByTagName("video")[0],
+      });
+
+      player.loadVideo({
+        url: multiAdaptationSetsInfos.url,
+        transport: multiAdaptationSetsInfos.transport,
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+
+      testStart("loading over active content");
+      player.loadVideo({
+        url: multiAdaptationSetsInfos.url,
+        transport: multiAdaptationSetsInfos.transport,
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      testEnd("loading over active content");
+      player.dispose();
+      await sleep(10);
+
+      const largeManifestPlayer = new RxPlayer({
+        videoElement: document.getElementsByTagName("video")[0],
+      });
+      const manifestParsed = new Promise((resolve) => {
+        largeManifestPlayer.addEventListener("newAvailablePeriods", resolve);
+      });
+      testStart("large multi-period manifest");
+      largeManifestPlayer.loadVideo({
+        url:
+          "http://" +
+          __TEST_CONTENT_SERVER__.URL +
+          ":" +
+          __TEST_CONTENT_SERVER__.PORT +
+          "/DASH_static_Large_MultiPeriod/manifest.mpd",
+        transport: "dash",
+      });
+      await manifestParsed;
+      testEnd("large multi-period manifest");
+      largeManifestPlayer.dispose();
+      await sleep(10);
+    },
+    20000,
+  );
+}
 
 declareTestGroup(
   "content loading multithread",

--- a/tests/performance/src/main.js
+++ b/tests/performance/src/main.js
@@ -30,8 +30,9 @@ declareTestGroup(
     // --- 2: seek ---
 
     testStart("seeking");
+    const seekFinished = waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
     player.seekTo(20);
-    await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    await seekFinished;
     testEnd("seeking");
     await sleep(10);
 
@@ -135,8 +136,9 @@ declareTestGroup(
     // --- 2: seek ---
 
     testStart("seeking multithread");
+    const seekFinished = waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
     player.seekTo(20);
-    await waitForPlayerState(player, "PAUSED", ["SEEKING", "BUFFERING"]);
+    await seekFinished;
     testEnd("seeking multithread");
     await sleep(10);
 


### PR DESCRIPTION
For multiple years now, we run performance tests on each PR - to detect performance regressions on some key scenarios (load, seek, track switching).

It should be able to catch true large regressions but it bothers me that sometimes it seems to detect with a high confidence a very minor regression in the "cold loading multithread" scenario.

This one could particularly be sensitive to ordering / optimizations made by the browsers' cache.

So I'm here trying to experiment with some strategies to limit the possibility of having some kind of bias in our performance tests.