### PR TITLE
[WIP] Do not rely on vitest for memory tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /tests/performance/control-current.js
 /tests/performance/package.json
 /tests/performance/package-lock.json
+/tests/simple-test-bundle.js
 
 /dist/
 

--- a/package.json
+++ b/package.json
@@ -200,8 +200,7 @@
     "test:integration:firefox": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=firefox vitest run tests/integration/scenarios",
     "test:integration:firefox:watch": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=firefox vitest watch tests/integration/scenarios",
     "test:integration:notice": "echo \"~~~ ⚠️ NOTICE ⚠️\n~~~ Tests have two dependencies: a local RxPlayer build and ffmpeg.\n~~~ Make sure you:\n~~~ 1.  Have an ffmpeg executable in your path and,\n~~~ 2.  You built an up-to-date RxPlayer through the \\`build\\` npm script.\n\"",
-    "test:memory": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest run tests/memory",
-    "test:memory:chrome:watch": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest watch tests/memory",
+    "test:memory": "npm run --silent test:integration:notice && node ./tests/simple-test-runner.mjs ./tests/memory/index.test.js",
     "test:performance": "node ./tests/performance/run.mjs",
     "test:unit": "vitest --config vitest.config.unit.mjs",
     "types": "tsc --noEmit --project .",
@@ -287,8 +286,7 @@
         "test:unit -- --watch": "Launch unit tests and restart them each one of its file changes"
       },
       "Memory tests (test memory usage to avoid memory leaks, call the `build` script BEFORE running them)": {
-        "test:memory": "Launch memory tests",
-        "test:memory:chrome:watch": "Launch memory tests in Chrome each times the files update"
+        "test:memory": "Launch memory tests"
       },
       "Performance tests (test against performance regressions on some key scenarios)": {
         "test:performance": "Launch performance tests on a Chrome browser",

--- a/tests/memory/index.test.js
+++ b/tests/memory/index.test.js
@@ -1,4 +1,4 @@
-import { expect, describe, afterEach, test } from "vitest";
+import { expect, describe, afterEach, test } from "../simple-test-lib";
 // TODO: rely on `dist` instead
 import RxPlayer from "../../src";
 import VideoThumbnailLoader, {

--- a/tests/simple-test-lib.js
+++ b/tests/simple-test-lib.js
@@ -1,0 +1,659 @@
+/**
+ * # simple-test-lib.js
+ *
+ * ## What's this?
+ *
+ * @see ./simple-test-runner.mjs for the explanation of why this file exists.
+ *
+ * ## How does it work?
+ *
+ * **TL;DR:** Just replace `vitest` imports with the path to that file in tests.
+ * If those tests do not rely on advanced mocking function, it should work directly.
+ * Then run `./simple-test-runner.mjs` with the right options (`-h` flag for help).
+ *
+ * This present file implements the usual test running functions (`describe` /
+ * `it` / `test` / `beforeEach` etc.) with the same semantics (or close enough
+ * to it) than your usual `vitest` / `jest` etc. testing framework.
+ *
+ * It still relies for now on `vitest` to re-export its `expect` assertion part
+ * as this is completely independent from the test running logic which I wanted
+ * to control here.
+ *
+ * It needs to be used together with `./simple-test-runner.mjs`, our test
+ * server, which will be the Node.js part, bundling a page for your tests,
+ * running a browser instance on it and processing the tests' result.
+ *
+ * ## Note about JSDoc syntax
+ *
+ * JSDoc with TypeScript types is used instead of plain TypeScript to make it
+ * easier to have it just plug and play: I just replace `vitest` imports with
+ * that file even on JS-only code and it just works.
+ */
+
+// TODO `describe.skip`?
+
+const DEFAULT_TIMEOUT = 30 * 60 * 1000;
+
+/**
+ * This test framework has an HTTP-based communication protocol between the
+ * test file (which include this file) and the test server (which ran the
+ * browser and process/display test results).
+ *
+ * To ensure ordered responses, we could have multiple strategies (ordered
+ * protocol like websockets, requests-responses. sequence id).
+ * I went with incrementing sequence-number as a very simple mechanism, just
+ * for simplicity reasons.
+ *
+ * This number is incremented with each request.
+ * TODO: WebSocket would probably be more robust. Here if a request misses,
+ * we'll just hang.
+ */
+let requestSequenceNb = 0;
+
+/**
+ * @typedef {() => void | Promise<void>} TestFn - Testing function. Can either
+ * be a synchronous function which just has to not throw to pass, or a
+ * Promise-returning function which has to resolve to pass.
+ */
+
+/**
+ * @typedef {Object} TestCase - A singular test, generally created through a
+ * `it` or `test` function call.
+ * @property {string} name - The test description
+ * @property {TestFn} fn - Test implementation
+ * @property {number} timeout - Maximum amount of milliseconds the tests should
+ * run in. If that limit is reached, the test will be marked as failed.
+ * @property {number} retry - If the test fails, it will be retried `retry`
+ * times until it succeeds. If it still fails after that number of retries, the
+ * test will be marked as a failure.
+ * @property {boolean} skip - If `true`, this test should be skipped in the
+ * current run.
+ * @property {TestSuite[]} suiteStack - The stack of suites the test is in.
+ */
+
+/**
+ * @typedef {Object} TestSuite - A collection of tests, generally created
+ * through a `describe` call.
+ * @property {string} name - The description of that suite.
+ * @property {TestCase[]} tests - Tests contained in that suite.
+ * @property {TestSuite[]} suites - Potential sub-suites
+ * @property {TestFn[]} beforeEachHooks - Functions that have to be invokated
+ * before each test run in that suite.
+ * @property {TestFn[]} afterEachHooks - Functions that have to be invokated
+ * after each test run in that suite.
+ * @property {TestFn[]} beforeAllHooks - Functions that have to be invokated
+ * before all tests run in that suite.
+ * @property {TestFn[]} afterAllHooks - Functions that have to be invokated
+ * after all test run in that suite.
+ */
+
+/**
+ * @typedef {Object} TestResults - Current test results for all tests that
+ * run here.
+ * @property {number} passed - Amount of tests that have succeeded.
+ * @property {number} failed - Amount of tests that have failed.
+ * @property {number} skipped - Amount of tests that were skipped.
+ * @property {TestErrorInfo[]} errors - Information on failed
+ * tests: the name and the corresponding error.
+ */
+
+/**
+ * @typedef {Object} TestErrorInfo - Information associated to a failing test.
+ * @property {TestCase} testCase - Test test that failed.
+ * @property {number|undefined} timer - Amount of time to run that test.
+ * `undefined` if we couldn't run it (e.g. its `beforeEach` hook failed).
+ * @property {any} error - The error thrown / rejected by that test
+ */
+
+/**
+ * @typedef {Object} SkippedTestInfo - Information associated to a skipped test.
+ * @property {TestCase} testCase - Test case that is being skipped
+ */
+
+/**
+ * @typedef {Object} ParentHooks - Callback associated to the lifecycle of a
+ * single `TestCase`.
+ * @property {TestFn[]} beforeEach - Callback to call just before a test.
+ * @property {TestFn[]} afterEach - Callback to call just after a test.
+ */
+
+// The HTTP port used for exchange with our "test server" is part of the URL's
+// "fragment" (after the first `#`). We here parse it to know how to communicate
+// result back to the main test process.
+
+const hashComponents = parseUrlHash();
+const resultServerPort = parseInt(hashComponents.p);
+
+/**
+ * Root object containing all test suites.
+ * @type {TestSuite}
+ */
+const rootSuite = {
+  name: "root",
+  tests: [],
+  suites: [],
+  beforeEachHooks: [],
+  afterEachHooks: [],
+  beforeAllHooks: [],
+  afterAllHooks: [],
+};
+
+/**
+ * The test suite that we're currently parsing (we're at evaluation-time here,
+ * before running).
+ * Set to `rootSuite` initially.
+ * @type {TestSuite}
+ */
+let currentSuite = rootSuite;
+
+/**
+ * Stack of suites we're currently in the process of parsing. Allows to handle
+ * nested suites easily.
+ * @type {TestSuite[]}
+ */
+const suiteStack = [rootSuite];
+
+/** @type {Array<{name: string, suite: string}>} */
+const skippedTests = [];
+
+/**
+ * Native, non-monkey-patched versions of console functions.
+ */
+const oldConsoleFns = {};
+["log", "warn", "debug", "info", "error"].forEach((meth) => {
+  /* eslint-disable no-console */
+  oldConsoleFns[meth] = console[meth];
+  console[meth] = function () {
+    sendLog(meth, ...arguments);
+    oldConsoleFns[meth].apply(this, arguments);
+  };
+  /* eslint-enable no-console */
+});
+
+setTimeout(() => {
+  run().then(sendDone, sendError);
+});
+
+/**
+ * @param {string} name
+ * @param {() => void} fn
+ * @returns {void}
+ */
+export function describe(name, fn) {
+  /** @type {TestSuite} */
+  const suite = {
+    name,
+    tests: [],
+    suites: [],
+    beforeEachHooks: [],
+    afterEachHooks: [],
+    beforeAllHooks: [],
+    afterAllHooks: [],
+  };
+
+  currentSuite.suites.push(suite);
+  suiteStack.push(suite);
+  currentSuite = suite;
+
+  fn();
+
+  suiteStack.pop();
+  currentSuite = suiteStack[suiteStack.length - 1];
+}
+
+/**
+ * @param {string} name
+ * @param {...*} args
+ * @returns {void}
+ */
+export function it(name, ...args) {
+  const testCase = parseTestCase(name, ...args);
+  if (testCase != null) {
+    currentSuite.tests.push(testCase);
+  }
+}
+
+/**
+ * TODO: Remove? `it` should be sufficient (or we remove `it`, no opinion).
+ * @param {...*} args
+ * @returns {void}
+ */
+export function test(...args) {
+  it(...args);
+}
+
+/**
+ * @param {string} name
+ * @param {...*} args
+ * @returns {TestCase|undefined}
+ */
+function parseTestCase(name, ...args) {
+  let fn;
+  let timeout = DEFAULT_TIMEOUT;
+  let retry = 0;
+
+  if (typeof args[0] === "function") {
+    fn = args[0];
+  } else if (typeof args[0] === "object") {
+    if (args[0]?.timeout != null) {
+      timeout = args[0].timeout;
+    }
+    if (args[0]?.retry != null) {
+      retry = args[0].retry;
+    }
+  } else if (args[0] !== undefined) {
+    oldConsoleFns.error("Invalid second argument for test: " + name);
+    return;
+  }
+
+  if (typeof args[1] === "number") {
+    timeout = args[1];
+  } else if (typeof args[1] === "function") {
+    fn = args[1];
+  } else if (args[1] !== undefined) {
+    oldConsoleFns.error("Invalid third argument for test: " + name);
+    return;
+  }
+
+  if (fn === undefined) {
+    oldConsoleFns.error("Missing test function for test: " + name);
+    return;
+  }
+  if (typeof fn !== "function") {
+    oldConsoleFns.error("Test function must be a function for test: " + name);
+    return;
+  }
+  if (typeof timeout !== "number") {
+    oldConsoleFns.error("Invalid timeout value for test: " + name);
+    return;
+  }
+  if (typeof retry !== "number") {
+    oldConsoleFns.error("Invalid retry value for test: " + name);
+    return;
+  }
+
+  return {
+    name,
+    fn,
+    timeout,
+    retry,
+    skip: false,
+    suiteStack: suiteStack.slice(1),
+  };
+}
+
+/**
+ * @param {string} name
+ * @param {...*} args
+ * @returns {void}
+ */
+it.skip = function (name, ...args) {
+  const testCase = parseTestCase(name, ...args);
+  if (testCase != null) {
+    testCase.skip = true;
+    skippedTests.push(testCase);
+    currentSuite.tests.push(testCase);
+  }
+};
+
+/**
+ * @param {...*} args
+ * @returns {void}
+ */
+test.skip = function (...args) {
+  it.skip(...args);
+};
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function beforeEach(fn) {
+  currentSuite.beforeEachHooks.push(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function afterEach(fn) {
+  currentSuite.afterEachHooks.push(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function beforeAll(fn) {
+  currentSuite.beforeAllHooks.push(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function before(fn) {
+  beforeAll(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function afterAll(fn) {
+  currentSuite.afterAllHooks.push(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @returns {void}
+ */
+export function after(fn) {
+  afterAll(fn);
+}
+
+/**
+ * @param {TestFn} fn
+ * @param {number} timeout
+ * @returns {Promise<void>}
+ */
+async function runWithTimeout(fn, timeout) {
+  return Promise.race([
+    fn(),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`Test timeout after ${timeout}ms`)), timeout),
+    ),
+  ]);
+}
+
+/**
+ * @param {TestSuite} suite
+ * @param {TestResults} results
+ * @param {ParentHooks} parentHooks
+ * @returns {Promise<void>}
+ */
+async function runSuite(suite, results, parentHooks) {
+  const beforeEachHooks = [...parentHooks.beforeEach, ...suite.beforeEachHooks];
+  const afterEachHooks = [...parentHooks.afterEach, ...suite.afterEachHooks];
+
+  for (const hook of suite.beforeAllHooks) {
+    try {
+      await hook();
+    } catch (err) {
+      oldConsoleFns.error(`Error in beforeAll hook for suite "${suite.name}":`, err);
+      throw err;
+    }
+  }
+
+  for (const test of suite.tests) {
+    if (test.skip) {
+      results.skipped++;
+      sendTestSkipped(test);
+      oldConsoleFns.log(`⊘ ${test.name} (skipped)`);
+      continue;
+    }
+
+    let lastError = null;
+    let passed = false;
+    let timeStart = undefined;
+    let timer = undefined;
+    const maxAttempts = test.retry + 1;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        for (const hook of beforeEachHooks) {
+          try {
+            await hook();
+          } catch (err) {
+            oldConsoleFns.error(`Error in beforeEach hook:`, err);
+            throw err;
+          }
+        }
+
+        timeStart = performance.now();
+        await runWithTimeout(test.fn, test.timeout);
+        timer = performance.now() - timeStart;
+        passed = true;
+        results.passed++;
+        sendTestPassed(test, timer, attempt);
+        if (attempt > 0) {
+          oldConsoleFns.log(`✓ ${test.name} (passed on retry ${attempt})`);
+        } else {
+          oldConsoleFns.log(`✓ ${test.name}`);
+        }
+        break;
+      } catch (err) {
+        timer = performance.now() - timeStart;
+        lastError = err;
+        if (attempt < maxAttempts - 1) {
+          oldConsoleFns.log(`  ↻ ${test.name} (retry ${attempt + 1}/${test.retry})`);
+        }
+      } finally {
+        for (const hook of afterEachHooks) {
+          try {
+            await hook();
+          } catch (err) {
+            oldConsoleFns.error(`Error in afterEach hook:`, err);
+          }
+        }
+      }
+    }
+
+    if (!passed) {
+      results.failed++;
+      results.errors.push({
+        testCase: test,
+        error: lastError,
+        timer,
+      });
+      let errorStr = "Unknown Error";
+      try {
+        errorStr = lastError.toString();
+      } catch {}
+      sendTestFailed(test, timer, errorStr);
+      if (test.retry > 0) {
+        oldConsoleFns.warn(
+          `✗ ${test.name} (failed after ${test.retry} retries)`,
+          lastError,
+        );
+      } else {
+        oldConsoleFns.warn(`✗ ${test.name}`, lastError);
+      }
+    }
+  }
+
+  // Run nested suites
+  for (const childSuite of suite.suites) {
+    sendSuite(`${childSuite.name}`);
+    await runSuite(childSuite, results, {
+      beforeEach: beforeEachHooks,
+      afterEach: afterEachHooks,
+    });
+  }
+
+  for (const hook of suite.afterAllHooks) {
+    try {
+      await hook();
+    } catch (err) {
+      oldConsoleFns.error(`Error in afterAll hook for suite "${suite.name}":`, err);
+      throw err;
+    }
+  }
+}
+
+/**
+ * @returns {Promise<TestResults>}
+ */
+async function run() {
+  /** @type {TestResults} */
+  const results = { passed: 0, failed: 0, skipped: 0, errors: [] };
+  await runSuite(rootSuite, results, { beforeEach: [], afterEach: [] });
+
+  if (skippedTests.length > 0) {
+    oldConsoleFns.log(`\n${skippedTests.length} test(s) skipped`);
+  }
+
+  return results;
+}
+
+/**
+ * Parse the current URL fragment (format: "#prop1=value1;prop2=value2") and
+ * return it into a JS object (e.g. `{ prop1: "value1", prop2: "value2" }`)
+ * etc.
+ * @returns {Object}
+ */
+function parseUrlHash() {
+  const hash = location.hash[0] === "#" ? location.hash.substring(1) : location.hash;
+  const hashParts = hash.split(";");
+  if (hashParts.length === 0) {
+    throw new Error("The current page should have a fragment present in its URL");
+  }
+  const ret = {};
+  for (const hashPart of hashParts) {
+    const eqlIdx = hashPart.indexOf("=");
+    if (eqlIdx > 0) {
+      const propName = hashPart.substring(0, eqlIdx);
+      ret[propName] = hashPart.substring(eqlIdx + 1);
+    }
+  }
+  return ret;
+}
+
+/**
+ * Send internally once tests on that page have been performed enough time.
+ * Allows the server to close the current browser instance and compile results.
+ */
+function sendDone() {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({ type: "done", sequenceNb: requestSequenceNb++ }),
+  });
+}
+
+function sendError(error) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({ type: "error", sequenceNb: requestSequenceNb++, data: error }),
+  });
+}
+
+/**
+ * Send log so it's displayed on the Node.js process running those tests.
+ * @param {string} level
+ * @param {Array.<string>} ...logs
+ */
+export function sendLog(level, ...logs) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({
+      type: "log",
+      sequenceNb: requestSequenceNb++,
+      data: { level, msg: logs.join(" ") },
+    }),
+  }).catch((err) => {
+    oldConsoleFns.error("Error: Cannot send log due to a request error.", err);
+  });
+}
+
+/**
+ * @param {string} suiteName
+ */
+export function sendSuite(suiteName) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({
+      type: "suite",
+      sequenceNb: requestSequenceNb++,
+      data: suiteName,
+    }),
+  }).catch((err) => {
+    oldConsoleFns.error("Error: Cannot send log due to a request error.", err);
+  });
+}
+
+/**
+ * @param {TestCase} test
+ * @param {number|undefined} timer
+ * @param {number} attempt
+ */
+export function sendTestPassed(test, timer, attempt) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({
+      type: "passed",
+      sequenceNb: requestSequenceNb++,
+      data: {
+        testCase: {
+          testName: test.name,
+          timeout: test.timeout,
+          retry: test.retry,
+          suiteStack: test.suiteStack.map((s) => s.name),
+        },
+        timer,
+        attempt,
+      },
+    }),
+  }).catch((err) => {
+    oldConsoleFns.error("Error: Cannot send log due to a request error.", err);
+  });
+}
+
+/**
+ * @param {TestCase} test
+ * @param {string} testName
+ */
+export function sendTestSkipped(test) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({
+      type: "skipped",
+      sequenceNb: requestSequenceNb++,
+      data: {
+        testCase: {
+          testName: test.name,
+          timeout: test.timeout,
+          retry: test.retry,
+          suiteStack: test.suiteStack.map((s) => s.name),
+        },
+      },
+    }),
+  }).catch((err) => {
+    oldConsoleFns.error("Error: Cannot send log due to a request error.", err);
+  });
+}
+
+/**
+ * @param {TestCase} test
+ * @param {number|undefined} timer
+ * @param {string} errorStr
+ */
+export function sendTestFailed(test, timer, errorStr) {
+  fetch(`http://127.0.0.1:${resultServerPort}`, {
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    body: JSON.stringify({
+      type: "failed",
+      sequenceNb: requestSequenceNb++,
+      data: {
+        testCase: {
+          testName: test.name,
+          timeout: test.timeout,
+          retry: test.retry,
+          suiteStack: test.suiteStack.map((s) => s.name),
+        },
+        timer,
+        errorStr,
+      },
+    }),
+  }).catch((err) => {
+    oldConsoleFns.error("Error: Cannot send log due to a request error.", err);
+  });
+}
+
+export { expect } from "vitest";

--- a/tests/simple-test-page.html
+++ b/tests/simple-test-page.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<!-- NOTE: This page is intended to be used when relying on the
+`./simple-test-runner.mjs` script, which implement a simple and hackable test
+ framework -->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>RxPlayer - Memory tests</title>
+  </head>
+  <body>
+    <video />
+  </body>
+  <script type="text/javascript" src="./simple-test-bundle.js" charset="utf-8"></script>
+</html>

--- a/tests/simple-test-runner.mjs
+++ b/tests/simple-test-runner.mjs
@@ -1,0 +1,746 @@
+#!/usr/bin/env node
+
+/**
+ * # simple-test-runner.mjs
+ *
+ * This script is intended to be a drop-in solution to replace `vitest` on tests
+ * that do not need its complex features, yet which can profit from more
+ * control of the lower-level aspects of a testing framework such as:
+ *
+ * - running the browser (finding it on the host, giving it the right flags,
+ *   controlling how it access the testing page, controlling how the testing
+ *   page responds back)
+ *
+ * - orchestrating tests (how/when tests run)
+ *
+ * It was born out of frustration of `vitest` and its dependencies breaking
+ * at every new version on my machine, when what we want to do is relatively
+ * simple and understood by us.
+ *
+ * So even if `vitest`-compatibility for those tests is still maintained, this
+ * library acts as a simpler alternative that's much easier to hack around, and
+ * allow me to just run my tests locally without too much maintainance. It is
+ * basically a backup runner in the (frequent) occurence where vitest fails.
+ *
+ * One of the other focus of this lib is simplicity: no JS magic, no mocking
+ * utils, we just implement what we need (`describe` / `it` / `beforeEach` etc.)
+ * in the expected manner.
+ *
+ * ## How to use it
+ *
+ * First, the tests that are run needs to rely on `./simple-test-lib.mjs`
+ * instead of `vitest`.
+ * This has been written to be a drop-in so you should theoretically just be
+ * able to rewrite:
+ * ```js
+ * import { describe, afterEach, it, expect } from "vitest";
+ * ````
+ * into:
+ * ```js
+ * import { describe, afterEach, it, expect } from "../simple-test-lib.js";
+ * ````
+ * (so just replacing the path) in most cases.
+ *
+ * Then you can run this script to run those tests on a local browser.
+ * See --help flag to see usage.
+ */
+
+/* eslint-env node */
+
+import { createServer } from "http";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+import runChrome from "../scripts/run_chrome.mjs";
+import runFirefox from "../scripts/run_firefox.mjs";
+import launchStaticServer from "../scripts/launch_static_server.mjs";
+import runBundler from "../scripts/run_bundler.mjs";
+import createContentServer from "./contents/server.mjs";
+
+/**
+ * Path to the directory this script is currently in.
+ * The same path should contain the `simple-test-page.html` page and will
+ * contain our `simple-test-bundle.js` test page bundle.
+ */
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+
+/** Default port of the HTTP server which will serve local contents. */
+const DEFAULT_CONTENT_SERVER_PORT = 3000;
+
+/** Default port of the HTTP server which will serve the test files */
+const DEFAULT_TEST_PAGE_PORT = 8080;
+
+/** Default port of the HTTP server which will be used to exchange about test results. */
+const DEFAULT_RESULT_SERVER_PORT = 6789;
+
+/**
+ * `ChildProcess` instance of the current browser being run.
+ * `undefined` if no browser is currently being run.
+ * @type {import("child_process").ChildProcess|undefined}
+ */
+let currentBrowser;
+
+/**
+ * Initialize and start all tests on the given browser.
+ * @param {Object} params
+ * @param {string} params.inputFile - The test input file.
+ * @param {string} params.browser - The browser to run the tests on.
+ * "chrome" by default. Can be either "chrome" or "firefox".
+ * @param {number} params.contentServerPort - The port through which test
+ * contents are served.
+ * @param {number} params.resultServerPort - The port through which test
+ * results should be sent.
+ * @param {number} params.testPagePort - The port through which the test page
+ * is acceeded.
+ * @returns {Promise.<Object>}
+ */
+export default function runTests({
+  inputFile,
+  browser = "chrome",
+  contentServerPort = DEFAULT_CONTENT_SERVER_PORT,
+  resultServerPort = DEFAULT_RESULT_SERVER_PORT,
+  testPagePort = DEFAULT_TEST_PAGE_PORT,
+}) {
+  if (inputFile === undefined) {
+    return Promise.reject(new Error("No input file provided."));
+  }
+  return new Promise((resolve, reject) => {
+    let isFinished = false;
+    let contentServer;
+    let resultServer;
+    let staticServer;
+    const results = {
+      success: [],
+      skipped: [],
+      failures: [],
+    };
+
+    const onFinished = (results) => {
+      isFinished = true;
+      closeServers();
+      closeBrowser().catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to close the browser:", err);
+      });
+      resolve(results);
+    };
+    const onError = (error) => {
+      isFinished = true;
+      closeServers();
+      closeBrowser().catch((err) => {
+        // eslint-disable-next-line no-console
+        console.error("Failed to close the browser:", err);
+      });
+      reject(error);
+    };
+
+    const closeServers = () => {
+      contentServer?.close();
+      contentServer = undefined;
+      resultServer?.close();
+      resultServer = undefined;
+      staticServer?.close();
+      staticServer = undefined;
+    };
+
+    Promise.all([
+      initializeServers({
+        contentServerPort,
+        resultServerPort,
+        testPagePort,
+        results,
+        onFinished,
+        onError,
+      }),
+      createTestBundle(inputFile, contentServerPort, {
+        output: "simple-test-bundle.js",
+        minify: false,
+        production: true,
+      }),
+    ])
+      .then(async ([servers]) => {
+        if (currentBrowser !== undefined) {
+          currentBrowser.kill("SIGKILL");
+        }
+        const testsUrl = `http://127.0.0.1:${testPagePort}/simple-test-page.html#p=${resultServerPort}`;
+        if (browser === "firefox") {
+          // eslint-disable-next-line no-console
+          console.log("Running tests on Firefox");
+          currentBrowser = await runFirefox(testsUrl, {
+            headless: true,
+            enableAutoPlay: true,
+          });
+        } else {
+          // eslint-disable-next-line no-console
+          console.log("Running tests on Chrome");
+          currentBrowser = await runChrome(testsUrl, {
+            headless: true,
+            enableAutoPlay: true,
+            memoryTools: true,
+          });
+        }
+        contentServer = servers.contentServer;
+        resultServer = servers.resultServer;
+        staticServer = servers.staticServer;
+        if (isFinished) {
+          closeServers();
+        }
+      })
+      .catch(onError);
+  });
+}
+
+/**
+ * @param {Object} params
+ * @param {number} params.contentServerPort
+ * @param {Object} params.results
+ * @param {Array<Object>} params.results.success
+ * @param {Array<Object>} params.results.skipped
+ * @param {Array<Object>} params.results.failures
+ * @param {Function} params.onFinished
+ * @param {function} params.onError
+ * @returns {Promise} - Resolves when all servers are listening.
+ */
+async function initializeServers({
+  contentServerPort,
+  resultServerPort,
+  testPagePort,
+  results,
+  onFinished,
+  onError,
+}) {
+  let contentServer;
+  let staticServer;
+  let resultServer;
+  try {
+    contentServer = createContentServer({ port: contentServerPort });
+    staticServer = launchStaticServer(currentDirectory, {
+      httpPort: testPagePort,
+    });
+    resultServer = createResultServer({ resultServerPort, results, onFinished, onError });
+    await Promise.all([
+      contentServer.listeningPromise,
+      staticServer.listeningPromise,
+      resultServer.listeningPromise,
+    ]);
+    return { contentServer, resultServer, staticServer };
+  } catch (error) {
+    contentServer?.close();
+    staticServer?.close();
+    resultServer?.close();
+    throw error;
+  }
+}
+
+/**
+ * Free all resources and terminate script.
+ */
+async function closeBrowser() {
+  if (currentBrowser !== undefined) {
+    currentBrowser.kill("SIGKILL");
+    currentBrowser = undefined;
+  }
+}
+
+/**
+ * Create HTTP server which will receive test results and react appropriately.
+ * @param {Object} params
+ * @param {Object} params.results
+ * @param {Array} params.results.success
+ * @param {Array} params.results.skipped
+ * @param {Array} params.results.failures
+ * @param {Function} params.onFinished
+ * @param {function} params.onError
+ * @returns {Object}
+ */
+function createResultServer({ resultServerPort, results, onFinished, onError }) {
+  // Results sent by HTTP can be received out-of-order. We use an incrementing id,
+  // `currentRequestNb`, to ensure that this is the next awaited message and if
+  // not, buffer that message until it is.
+  // TODO: use long-lived WebSocket instead of buffered HTTP requests with an
+  // index, for robustness when/if HTTP errors arise. Not done for now because
+  // more complex (needs to either write a WebSocket server or import one as a
+  // dependency.)
+  let currentRequestNb = 0;
+  const bufferedRequests = [];
+  const server = createServer(onRequest);
+  return {
+    listeningPromise: new Promise((res) => {
+      server.listen(resultServerPort, function () {
+        res();
+      });
+    }),
+    close() {
+      server.close();
+    },
+  };
+
+  function onRequest(request, response) {
+    if (request.method === "OPTIONS") {
+      answerWithCORS(response, 200);
+      response.end();
+    } else if (request.method == "POST") {
+      let body = "";
+      request.on("data", function (data) {
+        body += data;
+      });
+      request.on("end", function () {
+        let json;
+        try {
+          json = JSON.parse(body);
+          answerWithCORS(response, 200, "");
+        } catch {
+          answerWithCORS(response, 500, "Invalid JSON.");
+          return;
+        }
+        if (typeof json.sequenceNb !== "number") {
+          /* eslint-disable-next-line no-console */
+          console.error("Invalid/Missing sequence number");
+        } else if (json.sequenceNb < currentRequestNb) {
+          /* eslint-disable-next-line no-console */
+          console.error("Sequence number too low, is it another page running?");
+        } else {
+          // Buffer and find out next request nb
+          bufferedRequests.push(json);
+          while (true) {
+            const index = bufferedRequests.findIndex(
+              (req) => req.sequenceNb === currentRequestNb,
+            );
+            if (index === -1) {
+              break;
+            }
+            const requestInfo = bufferedRequests.splice(index, 1)[0];
+            try {
+              processRequest(requestInfo);
+            } catch (err) {
+              /* eslint-disable-next-line no-console */
+              console.error(err);
+            }
+            currentRequestNb++;
+          }
+        }
+      });
+    }
+  }
+
+  function processRequest(body) {
+    switch (body.type) {
+      case "log":
+        {
+          if (
+            body.data == null ||
+            typeof body.data.level !== "string" ||
+            typeof body.data.msg !== "string"
+          ) {
+            throw new Error("Invalid log message");
+          }
+          const { level, msg } = body.data;
+          switch (level) {
+            case "log":
+            case "warn":
+            case "debug":
+            case "info":
+              // eslint-disable-next-line no-console
+              console[level](level + ":", msg);
+              break;
+          }
+        }
+        break;
+
+      case "error": {
+        if (typeof body.data !== "string") {
+          throw new Error("Invalid error message");
+        }
+        onError(new Error("ERROR: A fatal error happened: " + body.data));
+        break;
+      }
+
+      case "done": {
+        if (currentBrowser !== undefined) {
+          currentBrowser.kill("SIGKILL");
+          currentBrowser = undefined;
+        }
+        onFinished(results);
+        break;
+      }
+
+      case "suite": {
+        if (typeof body.data !== "string") {
+          throw new Error("Invalid suite message");
+        }
+        /* eslint-disable-next-line no-console */
+        console.log("\n> test suite:", body.data);
+        break;
+      }
+
+      case "passed": {
+        if (
+          body.data == null ||
+          body.data.testCase == null ||
+          (typeof body.data.timer !== "number" && body.data.timer !== undefined) ||
+          typeof body.data.attempt !== "number"
+        ) {
+          throw new Error("Invalid passed message");
+        }
+        const parsedCase = assertAndParseTestCase(body.data.testCase);
+        onSuccess(parsedCase, body.data.timer, body.data.attempt);
+        break;
+      }
+
+      case "failed": {
+        if (
+          body.data == null ||
+          body.data.testCase == null ||
+          (typeof body.data.timer !== "number" && body.data.timer !== undefined) ||
+          typeof body.data.errorStr !== "string"
+        ) {
+          throw new Error("Invalid failed message");
+        }
+        const parsedCase = assertAndParseTestCase(body.data.testCase);
+        onFailure(parsedCase, body.data.timer, body.data.errorStr);
+        break;
+      }
+
+      case "skipped": {
+        if (body.data == null || body.data.testCase == null) {
+          throw new Error("Invalid skipped message");
+        }
+        const parsedCase = assertAndParseTestCase(body.data.testCase);
+        onSkipped(parsedCase);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Logic called when we are notified that a test failed.
+   * @param {Object} testCase
+   * @param {number|undefined} timer
+   * @param {string} errorStr
+   */
+  function onFailure(testCase, timer, errorStr) {
+    const logStr = `✗ ${testCase.testName} (failed after ${testCase.retry} retries)`;
+    /* eslint-disable-next-line no-console */
+    console.log(logStr);
+    /* eslint-disable-next-line no-console */
+    console.log("Error:", errorStr);
+    results.failures.push({
+      testCase,
+      timer,
+      errorStr,
+    });
+  }
+
+  /**
+   * Logic called when we are notified that a test succeeded.
+   * @param {Object} testCase
+   * @param {number|undefined} timer
+   * @param {number} attempt
+   */
+  function onSuccess(testCase, timer, attempt) {
+    let logStr = `✓ ${testCase.testName}`;
+    if (attempt > 0) {
+      logStr += ` (passed on retry ${attempt})`;
+    }
+    if (timer != null) {
+      logStr += ` - in ${timer.toFixed(1)}ms`;
+    }
+    /* eslint-disable-next-line no-console */
+    console.log(logStr);
+    results.success.push({ testCase, timer, attempt });
+  }
+
+  /**
+   * Logic called when we are notified that a test was skipped.
+   * @param {Object} testCase
+   */
+  function onSkipped(testCase) {
+    /* eslint-disable-next-line no-console */
+    console.log(`⊘ ${testCase.testName} (skipped)`);
+    results.skipped.push({ testCase });
+  }
+
+  /**
+   * Add CORS headers, Content-Length, body, HTTP status and answer with the
+   * Response Object given.
+   * @param {Response} response
+   * @param {number} status
+   * @param {*} body
+   */
+  function answerWithCORS(response, status, body) {
+    if (Buffer.isBuffer(body)) {
+      response.setHeader("Content-Length", body.byteLength);
+    }
+    response.writeHead(status, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "*",
+      "Access-Control-Allow-Credentials": true,
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+    });
+    if (body !== undefined) {
+      response.end(body);
+    } else {
+      response.end();
+    }
+  }
+}
+
+/**
+ * Build the bundle where tests will run.
+ * @param {string} inputFile - The test input file to bundle.
+ * @param {number} contentServerPort - The port used by the content server.
+ * @param {Object} options
+ * @param {Object} options.output - The output file
+ * @param {boolean} [options.minify] - If `true`, the output will be minified.
+ * @param {boolean} [options.production=true] - If `false`, the code will be compiled
+ * in "development" mode, which has supplementary assertions.
+ * @returns {Promise}
+ */
+async function createTestBundle(inputFile, contentServerPort, options) {
+  const minify = !!options.minify;
+  try {
+    await runBundler(inputFile, {
+      minify,
+      silent: true,
+      globalScope: false,
+      production: options.production ?? true,
+      watch: false,
+      outfile: path.join(currentDirectory, options.output),
+      globals: {
+        __TEST_CONTENT_SERVER__: JSON.stringify({
+          URL: "127.0.0.1",
+          PORT: String(contentServerPort),
+        }),
+      },
+    });
+  } catch (err) {
+    throw new Error(`Build failed: ${err}`);
+  }
+}
+
+/**
+ * @param {*} data
+ * @returns {Object}
+ */
+function assertAndParseTestCase(data) {
+  if (
+    data == null ||
+    typeof data.testName !== "string" ||
+    (typeof data.timeout !== "number" && data.timeout !== undefined) ||
+    typeof data.retry !== "number" ||
+    !Array.isArray(data.suiteStack) ||
+    data.suiteStack.some((s) => typeof s !== "string")
+  ) {
+    throw new Error("Invalid test case");
+  }
+  return {
+    testName: data.testName,
+    timeout: data.timeout,
+    retry: data.retry,
+    suiteStack: data.suiteStack,
+  };
+}
+
+/**
+ * Display information to stdout/stderr on the test results in its globality.
+ * To call once tests have all run.
+ * @param {Object} results
+ */
+function diplayResults(results) {
+  /* eslint-disable no-console */
+  if (results.success.length === 0) {
+    console.log();
+    if (results.skipped.length > 0) {
+      if (results.skipped.length === 1) {
+        console.log(`The only test was skipped.`);
+      } else {
+        console.log(`No test ran, ${results.skipped.length} tests were skipped`);
+      }
+    } else {
+      console.log("The given input file has no test!");
+    }
+  } else if (results.failures.length === 0) {
+    console.log();
+    if (results.success.length === 1) {
+      console.log("1 test passed!");
+    } else {
+      console.log(`All ${results.success.length} tests passed!`);
+    }
+    if (results.skipped.length > 0) {
+      if (results.skipped.length === 1) {
+        console.log(`(1 test was skipped)`);
+      } else {
+        console.log(`(${results.skipped.length} tests were skipped)`);
+      }
+    }
+  } else {
+    console.log();
+    if (results.failures.length === 1) {
+      console.log(`>> There is 1 test failure:`);
+    } else {
+      console.log(`>> There are ${results.failures.length} test failures:`);
+    }
+    console.log();
+    for (let i = 0; i < results.failures.length; i++) {
+      const failure = results.failures[i];
+      console.log(`${i + 1} / ${results.failures.length}`);
+      if (failure.testCase.suiteStack.length > 0) {
+        console.log("From suite: " + "> " + failure.testCase.suiteStack.join(" > "));
+      }
+      console.log(`✗ ${failure.testCase.testName}\n`);
+      console.log("Error Message:");
+      console.log(failure.errorStr);
+      console.log();
+      console.log("---");
+      console.log();
+    }
+    throw new Error("The test suite failed");
+  }
+  /* eslint-enable no-console */
+}
+
+// If true, this script is called directly
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+
+  let resultServerPort = DEFAULT_RESULT_SERVER_PORT;
+  let contentServerPort = DEFAULT_CONTENT_SERVER_PORT;
+  let testPagePort = DEFAULT_TEST_PAGE_PORT;
+
+  /**
+   * @param {string|undefined} input
+   * @param {string} flagName
+   * @returns {number}
+   */
+  const parsePort = (input, flagName) => {
+    if (input === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(`ERROR: no port provided to ${flagName} flag\n`);
+      displayHelp();
+      process.exit(1);
+    }
+    const port = +input;
+    if (isNaN(port)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `ERROR: Invalid port configured for flag ${flagName}. Should be a number, received "` +
+          input +
+          '"\n',
+      );
+      displayHelp();
+      process.exit(1);
+    }
+    return port;
+  };
+
+  /** @type {Array.<string>} */
+  const inputFiles = [];
+
+  let browser = "chrome";
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        displayHelp();
+        process.exit(0);
+        break;
+
+      case "--result-port":
+        argOffset++;
+        resultServerPort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "--page-port":
+        argOffset++;
+        testPagePort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "--content-port":
+        argOffset++;
+        contentServerPort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "--browser":
+        argOffset++;
+        if (!["chrome", "firefox"].includes(args[argOffset])) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `ERROR: Invalid browser configured: should be either "chrome" or "firefox", received: ` +
+              args[argOffset] +
+              '"\n',
+          );
+          displayHelp();
+          process.exit(1);
+        }
+        browser = args[argOffset];
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+
+      default:
+        inputFiles.push(args[argOffset]);
+        break;
+    }
+  }
+
+  if (inputFiles.length === 0) {
+    // eslint-disable-next-line no-console
+    console.error("Error: No input file provided");
+    displayHelp();
+    process.exit(1);
+  } else if (inputFiles.length > 1) {
+    // eslint-disable-next-line no-console
+    console.error("Error: Too many input files provided:\n" + inputFiles.join("\n"));
+    displayHelp();
+    process.exit(1);
+  }
+
+  runTests({
+    inputFile: inputFiles[0],
+    browser,
+    resultServerPort,
+    contentServerPort,
+    testPagePort,
+  })
+    .then(diplayResults)
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error("Error:", err);
+      return process.exit(1);
+    });
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  // eslint-disable-next-line no-console
+  console.log(
+    `Usage: node run-tests.mjs [options] <TEST_FILE_PATH>
+
+Available options:
+  -h, --help                 Display this help message
+  --browser <BROWSER>        The browser to run the tests on.
+                             Can be "chrome" or "firefox".
+                             "chrome" by default.
+  --result-port <NUMBER>     Configure the port used to send/receive test results.
+                             ${DEFAULT_RESULT_SERVER_PORT} by default.
+  --page-port <NUMBER>       Configure the port used to serve the test page.
+                             ${DEFAULT_TEST_PAGE_PORT} by default.
+  --content-port <NUMBER>    Configure the port used to serve test contents.
+                             ${DEFAULT_CONTENT_SERVER_PORT} by default.
+
+Examples:
+  # Running a test file
+  node run-tests.mjs ./index.test.js
+
+  # Running a test file on firefox
+  node run-tests.mjs --browser firefox ./index.test.js
+
+  # Running a test file with another test page port
+  node run-tests.mjs --page-port 12345 ./test1.js ./test2.js`,
+  );
+}


### PR DESCRIPTION
This is a low priority proposal.
Even if not merged, I plan to use it at least on my side to be able to run memory tests on my computer.

---

Until now, we relied on `vitest` + `webdriverio` to run our "memory tests", which check for memory leaks.

Those two are huge and complex libraries, a complexity that we don't need for those tests (or even for integration tests): `vitest` can readily patch native browser APIs, mock files, hoist logic blocks before tests - none of that is needed here.

More importantly: I always struggled to run them on my computer.
After some headaches, I had a container-based setup that worked (without a container it ended up picking the wrong network interface, or not finding the browser, or timeouting ...) but now it is broken again since very recently (the browser does not run, not sure what changed, but looking up why it broke each time is too time consuming).

---

Yet what we want to do in our memory tests is extremely simple by comparison to what those libs allow: we want to run a test page on a specific browser (with specific flags), then we want to log the results and finally exit either with success or failure depending on that result.

On that point we already have our own testing library for our "performance tests", because the paradigm of those tests is very different from the ones offered by the testing libs we know of (those tests compare the timings of some operations of two builds of the RxPlayer, by running them hundreds of time on each, and then check if there's a sensible diff with a null hypothesis test + some heuristics).

So `vitest` doesn't work for me, is very complex for reasons we don't need, and we already have a simpler setup which works for our need.

Adapting that setup for our memory tests was very straightforward. For now I copy-pasted the performance tests's `run.js` file (the test server + browser runner) and adapted it to memory tests just because I did not spend any time factorizing yet.

I also wrote here a small `vitest`/`jest`-compatible mininal testing library (providing `describe` / `it` / `beforeEach` etc. - and re-exporting `vitest`'s assertions).
I use `esbuild` to bundle the test file and then run a browser on the output, exactly like for our performance tests.