### PR TITLE
tests: externalize generic code from our performance test runner + allow to run those tests on Firefox

### DIFF
--- a/.github/workflows/perfs.yml
+++ b/.github/workflows/perfs.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           export DISPLAY=:99
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
-          node tests/performance/run.mjs --branch $GITHUB_BASE_REF \
+          npm run test:performance -- --branch $GITHUB_BASE_REF \
             --remote-git-url https://github.com/canalplus/rx-player.git \
             --report perf-report.md
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -141,7 +141,7 @@ jobs:
       - run: export DISPLAY=:99
       - run: sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
       - run:
-          node tests/performance/run.mjs --branch stable --remote-git-url
+          npm run test:performance -- --branch stable --remote-git-url
           https://github.com/canalplus/rx-player.git
 
   publish_dev:

--- a/package.json
+++ b/package.json
@@ -204,6 +204,8 @@
     "test:integration:notice": "echo \"~~~ ⚠️ NOTICE ⚠️\n~~~ Tests have two dependencies: a local RxPlayer build and ffmpeg.\n~~~ Make sure you:\n~~~ 1.  Have an ffmpeg executable in your path and,\n~~~ 2.  You built an up-to-date RxPlayer through the \\`build\\` npm script.\n\"",
     "test:memory": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest run tests/memory",
     "test:memory:chrome:watch": "npm run --silent test:integration:notice && cross-env BROWSER_CONFIG=chrome vitest watch tests/memory",
+    "test:performance": "node ./tests/performance/run.mjs",
+    "test:performance:firefox": "node ./tests/performance/run.mjs --browser firefox",
     "test:unit": "vitest --config vitest.config.unit.mjs",
     "test:unit:watch": "vitest --config vitest.config.unit.mjs --watch",
     "update-version": "bash ./scripts/update-version-number.sh"
@@ -284,6 +286,10 @@
       "Memory tests (test memory usage to avoid memory leaks, call the `build` script BEFORE running them)": {
         "test:memory": "Launch memory tests",
         "test:memory:chrome:watch": "Launch memory tests in Chrome each times the files update"
+      },
+      "Performance tests (test against performance regressions on some key scenarios)": {
+        "test:performance": "Launch performance tests on a Chrome browser",
+        "test:performance:firefox": "Launch performance tests on a Firefox browser"
       }
     },
     "Build the player or one of its sub-parts": {

--- a/scripts/get_chrome_cmd.mjs
+++ b/scripts/get_chrome_cmd.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+
+/**
+ * # get_chrome_cmd.mjs
+ *
+ * This utils allows to get the string to the Chrome browser's executable on
+ * your computer.
+ * It can be imported or called directly.
+ */
+
+import { execFile } from "child_process";
+import * as fsProm from "fs/promises";
+import * as path from "path";
+import { pathToFileURL } from "url";
+
+/**
+ * Returns string corresponding to the Chrome binary.
+ * @returns {Promise.<string|null>}
+ */
+export default async function getChromeCmd() {
+  switch (process.platform) {
+    case "win32": {
+      const suffix = ["Google", "Chrome", "Application", "chrome.exe"];
+      const prefixes = [
+        process.env.LOCALAPPDATA,
+        process.env.PROGRAMFILES,
+        process.env["PROGRAMFILES(X86)"],
+      ];
+      for (const prefix of prefixes) {
+        if (!prefix) {
+          continue;
+        }
+        try {
+          const windowsChromeDirectory = path.join(prefix, ...suffix);
+          await fsProm.access(windowsChromeDirectory);
+          return windowsChromeDirectory;
+        } catch (e) {}
+      }
+
+      return null;
+    }
+
+    case "darwin": {
+      const defaultPath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+      try {
+        await fsProm.access(defaultPath);
+        return defaultPath;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    case "linux": {
+      const chromeBins = [
+        "google-chrome",
+        "google-chrome-stable",
+        "chromium",
+        "chromium-browser",
+      ];
+      for (const chromeBin of chromeBins) {
+        try {
+          return await which(chromeBin);
+        } catch {}
+      }
+      return null;
+    }
+    default:
+      throw new Error(`Error: unsupported platform: ${process.platform}`);
+  }
+}
+
+/**
+ * Execute `which` on the given command and output the path given by its output.
+ * @param {string} cmd
+ * @returns {Promise.<string>}
+ */
+function which(cmd) {
+  return new Promise((resolve, reject) => {
+    execFile("which", [cmd], (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout.split("\n")[0].trim());
+      }
+    });
+  });
+}
+
+// If true, this script is called directly
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  if (args.includes("-h") || args.includes("--help")) {
+    displayHelp();
+    process.exit(0);
+  }
+  getChromeCmd()
+    .then((chromeCmd) => {
+      if (chromeCmd) {
+        /* eslint-disable-next-line no-console */
+        console.log(chromeCmd);
+      } else {
+        /* eslint-disable-next-line no-console */
+        console.error("No chrome executable found on your machine");
+        process.exit(1);
+      }
+    })
+    .catch((err) => {
+      /* eslint-disable-next-line no-console */
+      console.error("Could not check the chrome executable on your machine:", err);
+      process.exit(1);
+    });
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  /* eslint-disable-next-line no-console */
+  console.log(
+    `Returns path to the Chrome browser on your machine.
+Empty with a \`1\` exit code if not found.
+
+Usage: node get_chrome_cmd.mjs
+
+Available options:
+  -h, --help                 Display this help message`,
+  );
+}

--- a/scripts/get_firefox_cmd.mjs
+++ b/scripts/get_firefox_cmd.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+ * # get_firefox_cmd.mjs
+ *
+ * Utility to get the string to the Firefox browser's executable
+ * on your computer.
+ * It can be imported or called directly.
+ */
+
+import { execFile } from "child_process";
+import * as fsProm from "fs/promises";
+import * as path from "path";
+import { pathToFileURL } from "url";
+
+/**
+ * Returns string corresponding to the Firefox binary.
+ * @returns {Promise.<string|null>}
+ */
+export default async function getFirefoxCmd() {
+  switch (process.platform) {
+    case "win32": {
+      const suffix = ["Mozilla Firefox", "firefox.exe"];
+      const prefixes = [
+        process.env.PROGRAMFILES,
+        process.env["PROGRAMFILES(X86)"],
+        process.env.LOCALAPPDATA,
+      ];
+
+      for (const prefix of prefixes) {
+        if (!prefix) {
+          continue;
+        }
+        try {
+          const firefoxPath = path.join(prefix, ...suffix);
+          await fsProm.access(firefoxPath);
+          return firefoxPath;
+        } catch {}
+      }
+
+      return null;
+    }
+
+    case "darwin": {
+      const firefoxPath = "/Applications/Firefox.app/Contents/MacOS/firefox";
+      try {
+        await fsProm.access(firefoxPath);
+        return firefoxPath;
+      } catch {
+        return null;
+      }
+    }
+
+    case "linux": {
+      const absoluteCandidates = ["/usr/bin/firefox", "/snap/bin/firefox"];
+
+      for (const candidate of absoluteCandidates) {
+        try {
+          await fsProm.access(candidate);
+          return candidate;
+        } catch {}
+      }
+
+      try {
+        return await which("firefox");
+      } catch {
+        return null;
+      }
+    }
+
+    default:
+      throw new Error(`Error: unsupported platform: ${process.platform}`);
+  }
+}
+
+/**
+ * Execute `which` on the given command and output its output.
+ * @param {string} cmd
+ * @returns {Promise.<string>}
+ */
+function which(cmd) {
+  return new Promise((resolve, reject) => {
+    execFile("which", [cmd], (err, stdout) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stdout.split("\n")[0].trim());
+      }
+    });
+  });
+}
+
+// If true, this script is called directly
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  if (args.includes("-h") || args.includes("--help")) {
+    displayHelp();
+    process.exit(0);
+  }
+
+  getFirefoxCmd()
+    .then((firefoxCmd) => {
+      if (firefoxCmd) {
+        /* eslint-disable-next-line no-console */
+        console.log(firefoxCmd);
+      } else {
+        /* eslint-disable-next-line no-console */
+        console.error("No Firefox executable found on your machine");
+        process.exit(1);
+      }
+    })
+    .catch((err) => {
+      /* eslint-disable-next-line no-console */
+      console.error("Could not check the Firefox executable on your machine:", err);
+      process.exit(1);
+    });
+}
+
+/**
+ * Display through `console.log` a helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  /* eslint-disable-next-line no-console */
+  console.log(
+    `Returns path to the Firefox browser on your machine.
+Empty with a \`1\` exit code if not found.
+
+Usage: node get_firefox_cmd.mjs
+
+Available options:
+  -h, --help                 Display this help message`,
+  );
+}

--- a/scripts/run_chrome.mjs
+++ b/scripts/run_chrome.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/**
+ * # run_chrome.mjs
+ *
+ * This utils allows to run the Chrome browser on a specific URL, in a headless
+ * mode or not.
+ * It can be imported or called directly, use `--help` flag for more info for
+ * the latter.
+ */
+
+import { spawn } from "child_process";
+import { pathToFileURL } from "url";
+import getChromeCmd from "../scripts/get_chrome_cmd.mjs";
+
+/** Flags used when starting the Chrome browser. */
+const CHROME_OPTIONS = [
+  "--no-default-browser-check",
+  "--no-first-run",
+  "--disable-default-apps",
+  "--disable-extensions",
+  "--disable-popup-blocking",
+  "--disable-translate",
+  "--disable-device-discovery-notifications",
+  "--disk-cache-dir=/dev/null",
+
+  // "--disable-renderer-backgrounding",
+  // "--disable-background-timer-throttling",
+  // "--disable-gpu",
+  // "--disable-dev-shm-usage",
+];
+
+/**
+ * Flags specific to run Chrome in "headless mode" (without a UI).
+ * Useful for just running test or automation for example.
+ */
+const HEADLESS_OPTIONS = ["--headless"];
+
+/**
+ * Flags specific to disable the default Chrome's behavior of forbidding
+ * autoplay if the user did not interact with the page first.
+ */
+const AUTO_PLAY_OPTIONS = ["--autoplay-policy=no-user-gesture-required"];
+
+/**
+ * Flags allowing to expose more memory control and information.
+ * Useful for tests whose job is to detect memory leaks.
+ */
+const MEMORY_OPTIONS = ["--enable-precise-memory-info", "--js-flags=--expose-gc"];
+
+/**
+ * Run the Chrome browser on the given URL and return its process.
+ * @param {string} url - The URL to run on Chrome
+ * @param {Object} [params={}] - Launched Chrome's configuration
+ * @param {boolean|undefined} params.headless - If `true`, the browser will
+ * be launched in headless mode.
+ * @param {boolean|undefined} params.enableAutoPlay - If `true`, the browser
+ * will be launched with specific flags to disable auto-play blocking.
+ * Useful for tests.
+ * @param {boolean|undefined} params.memoryTools - If `true`, the browser
+ * will be launched with specific flags to enable precise memory info and the
+ * possibility to trigger JS heap GC by calling `window.gc`
+ * @param {boolean|undefined} params.verbose - If `true`, the browser will
+ * output to stdout. If not set or set to `false`, it will stay silent.
+ * Can be used to debug issues.
+ * @returns {Promise.<ChildProcess>}
+ */
+export default async function runChrome(
+  url,
+  { headless, enableAutoPlay, memoryTools, verbose } = {},
+) {
+  const chromeCmd = await getChromeCmd();
+  const flags = CHROME_OPTIONS;
+  if (headless) {
+    flags.push(...HEADLESS_OPTIONS);
+  }
+  if (enableAutoPlay) {
+    flags.push(...AUTO_PLAY_OPTIONS);
+  }
+  if (memoryTools) {
+    flags.push(...MEMORY_OPTIONS);
+  }
+  try {
+    const spawned = spawnProc(chromeCmd, [...flags, url], {
+      verbose,
+      parseError: (code) => "Failed to run Chrome. Code = " + code,
+    });
+    return spawned.child;
+  } catch (err) {
+    throw new Error("Could not launch page on Chrome: " + err.toString());
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {Array.<string>} args
+ * @param {Object} [params]
+ * @param {Function|undefined} [params.parseError]
+ * @returns {Object}
+ */
+function spawnProc(command, args, { parseError, verbose } = {}) {
+  let child;
+  const prom = new Promise((res, rej) => {
+    child = spawn(command, args, { stdio: verbose ? "inherit" : undefined });
+    child.on("close", (code) => {
+      if (code) {
+        if (typeof parseError === "function") {
+          rej(parseError(code));
+        } else {
+          rej(code);
+        }
+        return;
+      }
+      res();
+    });
+  });
+  return {
+    promise: prom,
+    child,
+  };
+}
+
+// If true, this script is called directly
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const urls = [];
+  let headless;
+  let enableAutoPlay;
+  let memoryTools;
+  let verbose;
+  const args = process.argv.slice(2);
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        /* eslint-disable no-fallthrough */
+        displayHelp();
+        process.exit(0);
+
+      case "--headless":
+        /* eslint-enable no-fallthrough */
+        headless = true;
+        break;
+
+      case "--enable-autoplay":
+        enableAutoPlay = true;
+        break;
+
+      case "--memory-tools":
+        memoryTools = true;
+        break;
+
+      case "--verbose":
+        verbose = true;
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+
+      default:
+        if (args[argOffset]) {
+          urls.push(args[argOffset]);
+        }
+        break;
+    }
+  }
+
+  if (urls.length === 0) {
+    console.error("Error: No URL provided");
+    displayHelp();
+    process.exit(1);
+  } else if (urls.length > 1) {
+    console.error("Error: Too many URLs provided:\n" + urls.join("\n"));
+    displayHelp();
+    process.exit(1);
+  }
+  runChrome(urls[0], {
+    headless,
+    enableAutoPlay,
+    memoryTools,
+    verbose,
+  }).catch((err) => {
+    /* eslint-disable-next-line no-console */
+    console.error("Could not run Chrome on the given URL:", err);
+    process.exit(1);
+  });
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  /* eslint-disable-next-line no-console */
+  console.log(
+    `Run the Chrome browser to the given URL.
+
+Usage: node run_chrome.mjs [options] <URL>
+
+Available options:
+  -h, --help           Display this help message
+  --headless           Start the browser in headless mode (without a UI)
+  --enable-autoplay    Allow autoplaying media even without user interaction
+  --memory-tools       Enable precize memory control in that browser
+  --verbose            Enable browser output to stdio`,
+  );
+}

--- a/scripts/run_firefox.mjs
+++ b/scripts/run_firefox.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+
+/**
+ * # run_firefox.mjs
+ *
+ * This utils allows to run the Firefox browser on a specific URL, in a headless
+ * mode or not.
+ * It can be imported or called directly, use `--help` flag for more info for
+ * the latter.
+ */
+
+import { spawn } from "child_process";
+import { pathToFileURL } from "url";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { tmpdir } from "os";
+import getFirefoxCmd from "../scripts/get_firefox_cmd.mjs";
+
+/** Flags used when starting the Firefox browser. */
+const FIREFOX_OPTIONS = ["-no-remote"];
+
+/**
+ * Flags specific to run Firefox in "headless mode" (without a UI).
+ * Useful for just running test or automation for example.
+ */
+const HEADLESS_OPTIONS = ["-headless"];
+
+/**
+ * Run the Firefox browser on the given URL and return its process.
+ * @param {string} url - The URL to run on Firefox
+ * @param {Object} [params={}] - Launched Firefox's configuration
+ * @param {boolean|undefined} params.headless - If `true`, the browser will
+ * be launched in headless mode.
+ * @param {boolean|undefined} params.enableAutoPlay - If `true`, the browser
+ * will be launched with specific flags to disable auto-play blocking.
+ * Useful for tests.
+ * @param {boolean|undefined} params.verbose - If `true`, the browser will
+ * output to stdout. If not set or set to `false`, it will stay silent.
+ * Can be used to debug issues.
+ * @returns {Promise.<ChildProcess>}
+ */
+export default async function runFirefox(
+  url,
+  { headless, enableAutoPlay, verbose } = {},
+) {
+  const firefoxCmd = await getFirefoxCmd();
+  const flags = FIREFOX_OPTIONS;
+  if (headless) {
+    flags.push(...HEADLESS_OPTIONS);
+  }
+  try {
+    const profileDir = await createFirefoxProfile({ enableAutoPlay });
+    const spawned = spawnProc(
+      firefoxCmd,
+      [...FIREFOX_OPTIONS, "-profile", profileDir, url],
+      { verbose, parseError: (code) => "Failed to run Firefox. Code = " + code },
+    );
+    spawned.child.on("exit", async () => {
+      try {
+        await fs.rm(profileDir, { recursive: true, force: true });
+      } catch (err) {
+        /* eslint-disable-next-line no-console */
+        console.error(`Failed to clean up Firefox profile: ${err}`);
+      }
+    });
+    return spawned.child;
+  } catch (err) {
+    throw new Error("Could not launch page on Firefox: " + err.toString());
+  }
+}
+
+/**
+ * @param {string} command
+ * @param {Array.<string>} args
+ * @param {Object} [params]
+ * @param {boolean|undefined} [params.verbose] - If `true`, the browser will
+ * output to stdout. If not set or set to `false`, it will stay silent.
+ * Can be used to debug issues.
+ * @param {Function|undefined} [params.parseError]
+ * @returns {Object}
+ */
+function spawnProc(command, args, { parseError, verbose } = {}) {
+  let child;
+  const prom = new Promise((res, rej) => {
+    child = spawn(command, args, { stdio: verbose ? "inherit" : undefined });
+    child.on("close", (code) => {
+      if (code) {
+        if (typeof parseError === "function") {
+          rej(parseError(code));
+        } else {
+          rej(code);
+        }
+        return;
+      }
+      res();
+    });
+  });
+  return {
+    promise: prom,
+    child,
+  };
+}
+
+/**
+ * Firefox (sadly) also requires the creation of a profile to setup autoplay
+ * policies etc.
+ * This util function does just that and return the temporary path created.
+ * @param {Object} [params={}] - Launched Firefox's configuration
+ * @param {boolean|undefined} params.headless - If `true`, the browser will
+ * be launched in headless mode.
+ * @param {boolean|undefined} params.enableAutoPlay - If `true`, the browser
+ * will be launched with specific flags to disable auto-play blocking.
+ * Useful for tests.
+ * @returns {Promise.<string>}
+ */
+async function createFirefoxProfile({ enableAutoPlay } = {}) {
+  const profileDir = path.join(tmpdir(), `firefox-test-${Date.now()}`);
+  await fs.mkdir(profileDir, { recursive: true });
+  let prefs = `
+user_pref("app.update.enabled", false);
+user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);`;
+  if (enableAutoPlay) {
+    prefs += `
+
+// Autoplay
+user_pref("media.autoplay.default", 0);
+user_pref("media.autoplay.blocking_policy", 0);`;
+  }
+  await fs.writeFile(path.join(profileDir, "user.js"), prefs);
+  return profileDir;
+}
+
+// If true, this script is called directly
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const urls = [];
+  let headless;
+  let enableAutoPlay;
+  let verbose;
+  const args = process.argv.slice(2);
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        /* eslint-disable no-fallthrough */
+        displayHelp();
+        process.exit(0);
+
+      case "--headless":
+        /* eslint-enable no-fallthrough */
+        headless = true;
+        break;
+
+      case "--enable-autoplay":
+        enableAutoPlay = true;
+        break;
+
+      case "--verbose":
+        verbose = true;
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+
+      default:
+        if (args[argOffset]) {
+          urls.push(args[argOffset]);
+        }
+        break;
+    }
+  }
+
+  if (urls.length === 0) {
+    console.error("Error: No URL provided");
+    displayHelp();
+    process.exit(1);
+  } else if (urls.length > 1) {
+    console.error("Error: Too many URLs provided:\n" + urls.join("\n"));
+    displayHelp();
+    process.exit(1);
+  }
+  runFirefox(urls[0], {
+    headless,
+    enableAutoPlay,
+    verbose,
+  }).catch((err) => {
+    /* eslint-disable-next-line no-console */
+    console.error("Could not run Firefox on the given URL:", err);
+    process.exit(1);
+  });
+}
+
+/**
+ * Display through `console.log` an helping message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  /* eslint-disable-next-line no-console */
+  console.log(
+    `Run the Firefox browser to the given URL.
+
+Usage: node run_firefox.mjs [options] <URL>
+
+Available options:
+  -h, --help           Display this help message
+  --headless           Start the browser in headless mode (without a UI)
+  --enable-autoplay    Allow autoplaying media even without user interaction
+  --verbose            Enable browser output to stdio`,
+  );
+}

--- a/tests/performance/run.mjs
+++ b/tests/performance/run.mjs
@@ -7,21 +7,28 @@ import * as fsProm from "fs/promises";
 import { createServer } from "http";
 import * as path from "path";
 import { fileURLToPath, pathToFileURL } from "url";
+import runChrome from "../../scripts/run_chrome.mjs";
+import runFirefox from "../../scripts/run_firefox.mjs";
 import launchStaticServer from "../../scripts/launch_static_server.mjs";
 import removeDir from "../../scripts/utils/remove_dir.mjs";
 import runBundler from "../../scripts/run_bundler.mjs";
 import createContentServer from "../contents/server.mjs";
 
+/**
+ * Path to the directory this script is currently in.
+ * The same path should contain the `./current.html` and `./previous.js` pages
+ * and will contain our `./current.js` and `./previous.js` test page bundles.
+ */
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 
-/** Port of the HTTP server which will serve local contents. */
-const CONTENT_SERVER_PORT = 3000;
+/** Default port of the HTTP server which will serve local contents. */
+const DEFAULT_CONTENT_SERVER_PORT = 3000;
 
-/** Port of the HTTP server which will serve the performance test files */
-const PERF_TESTS_PORT = 8080;
+/** Default port of the HTTP server which will serve the test files */
+const DEFAULT_TEST_PAGE_PORT = 8080;
 
-/** Port of the HTTP server which will be used to exchange about test results. */
-const RESULT_SERVER_PORT = 6789;
+/** Default port of the HTTP server which will be used to exchange about test results. */
+const DEFAULT_RESULT_SERVER_PORT = 6789;
 
 /**
  * Number of times test are runs on each browser/RxPlayer configuration.
@@ -31,45 +38,6 @@ const RESULT_SERVER_PORT = 6789;
  * TODO: GitHub actions fails when running the 128th browser. Find out why.
  */
 const TEST_ITERATIONS = 30;
-
-/**
- * After initialization is done, contains the path allowing to run the Chrome
- * browser.
- * @type {string|undefined|null}
- */
-let CHROME_CMD;
-
-// /**
-//  * After initialization is done, contains the path allowing to run the Firefox
-//  * browser.
-//  * @type {string|undefined|null}
-//  */
-// let FIREFOX_CMD;
-
-/** Options used when starting the Chrome browser. */
-const CHROME_OPTIONS = [
-  "--enable-automation",
-  "--no-default-browser-check",
-  "--no-first-run",
-  "--disable-default-apps",
-  "--disable-popup-blocking",
-  "--disable-translate",
-  "--disable-background-timer-throttling",
-  "--disable-renderer-backgrounding",
-  "--disable-device-discovery-notifications",
-  "--autoplay-policy=no-user-gesture-required",
-  "--headless",
-  "--disable-gpu",
-  "--disable-dev-shm-usage",
-  "--disk-cache-dir=/dev/null",
-];
-
-// /** Options used when starting the Firefox browser. */
-// const FIREFOX_OPTIONS = [
-//   "-no-remote",
-//   "-wait-for-browser",
-//   "-headless",
-// ];
 
 /**
  * `ChildProcess` instance of the current browser being run.
@@ -98,77 +66,136 @@ const allSamples = {
 // If true, this script is called directly
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const args = process.argv.slice(2);
-  if (args.includes("-h") || args.includes("--help")) {
-    displayHelp();
-    process.exit(0);
-  }
 
+  let resultServerPort = DEFAULT_RESULT_SERVER_PORT;
+  let contentServerPort = DEFAULT_CONTENT_SERVER_PORT;
+  let testPagePort = DEFAULT_TEST_PAGE_PORT;
+
+  let browser;
   let branchName;
-  {
-    let branchNameIndex = args.indexOf("-b");
-    if (branchNameIndex < 0) {
-      branchNameIndex = args.indexOf("--branch");
-    }
-    if (branchNameIndex >= 0) {
-      branchName = args[branchNameIndex + 1];
-      if (branchName === undefined) {
-        // eslint-disable-next-line no-console
-        console.error("ERROR: no branch name provided\n");
-        displayHelp();
-        process.exit(1);
-      }
-    }
-  }
-
   let remote;
-  {
-    let branchNameIndex = args.indexOf("-u");
-    if (branchNameIndex < 0) {
-      branchNameIndex = args.indexOf("--remote-git-url");
-    }
-    if (branchNameIndex >= 0) {
-      remote = args[branchNameIndex + 1];
-      if (remote === undefined) {
-        // eslint-disable-next-line no-console
-        console.error("ERROR: no remote URL provided\n");
-        displayHelp();
-        process.exit(1);
-      }
-    }
-  }
-
   let reportFile;
-  {
-    let reportFileIndex = args.indexOf("-r");
-    if (reportFileIndex < 0) {
-      reportFileIndex = args.indexOf("--report");
+  /**
+   * @param {string|undefined} input
+   * @param {string} flagName
+   * @returns {number}
+   */
+  const parsePort = (input, flagName) => {
+    if (input === undefined) {
+      /* eslint-disable-next-line no-console */
+      console.error(`ERROR: no port provided to ${flagName} flag\n`);
+      displayHelp();
+      process.exit(1);
     }
-    if (reportFileIndex >= 0) {
-      reportFile = args[reportFileIndex + 1];
-      if (reportFile === undefined) {
+    const port = +input;
+    if (isNaN(port)) {
+      /* eslint-disable-next-line no-console */
+      console.error(
+        `ERROR: Invalid port configured for flag ${flagName}. Should be a number, received "` +
+          input +
+          '"\n',
+      );
+      displayHelp();
+      process.exit(1);
+    }
+    return port;
+  };
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        displayHelp();
+        process.exit(0);
+
+      case "--result-port":
+        argOffset++;
+        resultServerPort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "--page-port":
+        argOffset++;
+        testPagePort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "--content-port":
+        argOffset++;
+        contentServerPort = parsePort(args[argOffset], currentArg);
+        break;
+
+      case "-b":
+      case "--branch":
+        argOffset++;
+        branchName = args[argOffset];
+        if (branchName === undefined) {
+          // eslint-disable-next-line no-console
+          console.error("ERROR: no branch name provided\n");
+          displayHelp();
+          process.exit(1);
+        }
+        break;
+
+      case "-u":
+      case "--remote-git-url":
+        argOffset++;
+        remote = args[argOffset];
+        if (remote === undefined) {
+          // eslint-disable-next-line no-console
+          console.error("ERROR: no remote URL provided\n");
+          displayHelp();
+          process.exit(1);
+        }
+        break;
+
+      case "-r":
+      case "--report":
+        {
+          argOffset++;
+          reportFile = args[argOffset];
+          if (reportFile === undefined) {
+            // eslint-disable-next-line no-console
+            console.error("ERROR: no file path provided\n");
+            displayHelp();
+            process.exit(1);
+          }
+        }
+        break;
+
+      case "--browser":
+        argOffset++;
+        if (!["chrome", "firefox"].includes(args[argOffset])) {
+          /* eslint-disable-next-line no-console */
+          console.error(
+            `ERROR: Invalid browser configured: should be either "chrome" or "firefox", received: ` +
+              args[argOffset] +
+              '"\n',
+          );
+          displayHelp();
+          process.exit(1);
+        }
+        browser = args[argOffset];
+        break;
+
+      case "--":
+        argOffset = args.length;
+        break;
+
+      default:
         // eslint-disable-next-line no-console
-        console.error("ERROR: no file path provided\n");
+        console.error("ERROR: Unrecognized flag:", currentArg);
         displayHelp();
         process.exit(1);
-      }
-    }
-  }
-
-  /* eslint-disable no-console */
-  if (reportFile !== undefined) {
-    try {
-      console.log(`Removing previous report file if it exists ("${reportFile}")`);
-      fs.rmSync(reportFile);
-    } catch (_) {
-      // We don't really care here
     }
   }
 
   initializePerformanceTestsPages({
     branchName: branchName ?? "dev",
     remoteGitUrl: remote,
+    contentServerPort,
   })
-    .then(() => runPerformanceTests())
+    .then(() =>
+      runPerformanceTests({ browser, contentServerPort, resultServerPort, testPagePort }),
+    )
     .then(async (results) => {
       /** Contain results on the second run if it is done */
       let results2 = null;
@@ -198,7 +225,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
 
       console.warn("\nRetrying one time just to check if unlucky...");
 
-      results2 = await runPerformanceTests();
+      results2 = await runPerformanceTests(browser);
       console.error("\nFinal result after 2 attempts\n-----------------------------\n");
 
       if (results.better.length > 0) {
@@ -361,10 +388,24 @@ function formatResultAsMarkdownTable(results) {
 }
 
 /**
- * Initialize and start all tests on Chrome.
+ * Initialize and start all tests on a browser..
+ * @param {Object} params
+ * @param {string} [params.browser="chrome"] - The browser to run the tests on.
+ * "chrome" by default. Can be either "chrome" or "firefox".
+ * @param {number} params.contentServerPort - The port through which test
+ * contents are served.
+ * @param {number} params.resultServerPort - The port through which test
+ * results should be sent.
+ * @param {number} params.testPagePort - The port through which the test page
+ * is acceeded.
  * @returns {Promise.<Object>}
  */
-function runPerformanceTests() {
+function runPerformanceTests({
+  browser = "chrome",
+  contentServerPort = DEFAULT_CONTENT_SERVER_PORT,
+  resultServerPort = DEFAULT_RESULT_SERVER_PORT,
+  testPagePort = DEFAULT_TEST_PAGE_PORT,
+}) {
   return new Promise((resolve, reject) => {
     let isFinished = false;
     let contentServer;
@@ -400,7 +441,13 @@ function runPerformanceTests() {
       staticServer = undefined;
     };
 
-    initServers(onFinished, onError)
+    initServers({
+      contentServerPort,
+      testPagePort,
+      resultServerPort,
+      onFinished,
+      onError,
+    })
       .then((servers) => {
         contentServer = servers.contentServer;
         resultServer = servers.resultServer;
@@ -408,7 +455,7 @@ function runPerformanceTests() {
         if (isFinished) {
           closeServers();
         }
-        return startAllTestsOnChrome();
+        return startAllTests({ browser, testPagePort, resultServerPort });
       })
       .catch(onError);
   });
@@ -416,20 +463,33 @@ function runPerformanceTests() {
 
 /**
  * Initialize all servers used for the performance tests.
- * @param {Function} onFinished
- * @param {function} onError
+ * @param {Object} params
+ * @param {number} params.contentServerPort - The port through which test
+ * contents are served.
+ * @param {number} params.resultServerPort - The port through which test
+ * results should be sent.
+ * @param {number} params.testPagePort - The port through which the test page
+ * is acceeded.
+ * @param {Function} params.onFinished
+ * @param {function} params.onError
  * @returns {Promise} - Resolves when all servers are listening.
  */
-async function initServers(onFinished, onError) {
+async function initServers({
+  contentServerPort,
+  testPagePort,
+  resultServerPort,
+  onFinished,
+  onError,
+}) {
   let contentServer;
   let staticServer;
   let resultServer;
   try {
-    contentServer = createContentServer(CONTENT_SERVER_PORT);
+    contentServer = createContentServer({ port: contentServerPort });
     staticServer = launchStaticServer(currentDirectory, {
-      httpPort: PERF_TESTS_PORT,
+      httpPort: testPagePort,
     });
-    resultServer = createResultServer(onFinished, onError);
+    resultServer = createResultServer({ port: resultServerPort, onFinished, onError });
     await Promise.all([
       contentServer.listeningPromise,
       staticServer.listeningPromise,
@@ -447,6 +507,8 @@ async function initServers(onFinished, onError) {
 /**
  * Prepare all scripts needed for the performance tests.
  * @param {Object} opts - Various options for scripts initialization.
+ * @param {number} params.contentServerPort - Port on which media content is
+ * served.
  * @param {string} opts.branchName - The name of the branch results should be
  * compared to.
  * @param {string} [opts.remoteGitUrl] - The git URL where the current
@@ -454,18 +516,30 @@ async function initServers(onFinished, onError) {
  * The one for the current git repository by default.
  * @returns {Promise} - Resolves when the initialization is finished.
  */
-async function initializePerformanceTestsPages({ branchName, remoteGitUrl }) {
-  await prepareLastRxPlayerTests({ branchName, remoteGitUrl });
-  await prepareCurrentRxPlayerTests();
+async function initializePerformanceTestsPages({
+  branchName,
+  remoteGitUrl,
+  contentServerPort,
+}) {
+  await prepareLastRxPlayerTests({ branchName, remoteGitUrl, contentServerPort });
+  await prepareCurrentRxPlayerTests({ contentServerPort });
 }
 
 /**
  * Build test file for testing the current RxPlayer.
+ * @param {Object} params
+ * @param {number} params.contentServerPort - Port on which media content is
+ * served.
  * @returns {Promise}
  */
-async function prepareCurrentRxPlayerTests() {
+async function prepareCurrentRxPlayerTests({ contentServerPort }) {
   await linkCurrentRxPlayer();
-  await createBundle({ output: "current.js", minify: true, production: true });
+  await createBundle({
+    output: "current.js",
+    contentServerPort,
+    minify: true,
+    production: true,
+  });
 }
 
 /**
@@ -473,14 +547,21 @@ async function prepareCurrentRxPlayerTests() {
  * @param {Object} opts - Various options.
  * @param {string} opts.branchName - The name of the branch results should be
  * compared to.
+ * @param {number} params.contentServerPort - Port on which media content is
+ * served.
  * @param {string} [opts.remoteGitUrl] - The git URL where the current
  * repository can be cloned for comparisons.
  * The one for the current git repository by default.
  * @returns {Promise}
  */
-async function prepareLastRxPlayerTests({ branchName, remoteGitUrl }) {
+async function prepareLastRxPlayerTests({ branchName, contentServerPort, remoteGitUrl }) {
   await linkRxPlayerBranch({ branchName, remoteGitUrl });
-  await createBundle({ output: "previous.js", minify: true, production: true });
+  await createBundle({
+    contentServerPort,
+    output: "previous.js",
+    minify: true,
+    production: true,
+  });
 }
 
 /**
@@ -525,7 +606,7 @@ async function linkRxPlayerBranch({ branchName, remoteGitUrl }) {
     remoteGitUrl ??
     (await execCommandAndGetFirstOutput("git config --get remote.origin.url"));
   url = url.trim();
-  await spawnProc("git", ["clone", "-b", branchName, url, rxPlayerPath], {
+  await spawnProc("git", ["clone", "--depth", "1", "-b", branchName, url, rxPlayerPath], {
     parseError: (code) => new Error(`git clone exited with code ${code}`),
   }).promise;
   await spawnProc("npm", ["install"], {
@@ -546,17 +627,29 @@ async function linkRxPlayerBranch({ branchName, remoteGitUrl }) {
 }
 
 /**
- * Build the `tasks` array and start all tests on the Chrome browser.
+ * Build the `tasks` array and start all tests on the given browser.
+ * @param {Object} params
+ * @param {string} params.browser - The web browser to run those tests on. Can
+ * be either "chrome" or "firefox".
+ * @param {number} params.resultServerPort - The port through which test
+ * results should be sent.
+ * @param {number} params.testPagePort - The port through which the test page
+ * is acceeded.
  * @returns {Promise}
  */
-async function startAllTestsOnChrome() {
-  CHROME_CMD = await getChromeCmd();
+async function startAllTests({ browser, testPagePort, resultServerPort }) {
   tasks.length = 0;
   for (let i = 0; i < TEST_ITERATIONS; i++) {
-    tasks.push(() => startTestsOnChrome(i % 2 === 0, i + 1, TEST_ITERATIONS));
-  }
-  if (CHROME_CMD === null) {
-    throw new Error("Error: Chrome not found on the current platform");
+    tasks.push(() =>
+      startIteration({
+        browser,
+        startWithCurrent: i % 2 === 0,
+        iteration: i + 1,
+        total: TEST_ITERATIONS,
+        testPagePort,
+        resultServerPort,
+      }),
+    );
   }
   if (tasks.length === 0) {
     throw new Error("No task scheduled");
@@ -588,60 +681,69 @@ function startNextTaskOrFinish(onFinished) {
 }
 
 /**
- * Start Chrome browser running performance tests.
- * @param {boolean} startWithCurrent - If `true` we will begin with tests on the
- * current build. If `false` we will start with the previous build. We will
- * then alternate.
+ * Start browser running performance tests.
+ * @param {Object} params
+ * @param {boolean} params.startWithCurrent - If `true` we will begin with
+ * tests on the current build. If `false` we will start with the previous
+ * build. We will then alternate.
  * The global idea is to ensure we're testing both cases as to remove some
  * potential for lower performances due e.g. to browser internal logic.
- * @param {number} testNb - The current test iteration, starting from `1` to
- * `testTotal`. Used to indicate progress.
- * @param {number} testTotal - The maximum number of iterations. Used to
+ * @param {string} params.browser - The web browser to run those tests on.
+ * Can be either "chrome" or "firefox".
+ * @param {number} params.iteration - The current test iteration, starting
+ * from `1` to `total`. Used to indicate progress.
+ * @param {number} params.total - The maximum number of iterations. Used to
  * indicate progress.
  * @returns {Promise}
  */
-async function startTestsOnChrome(startWithCurrent, testNb, testTotal) {
-  // eslint-disable-next-line no-console
-  console.log(`Running tests on Chrome (${testNb}/${testTotal})`);
-  return startPerfhomepageOnChrome(
-    startWithCurrent
-      ? `current.html#p=${RESULT_SERVER_PORT};`
-      : `previous.html#p=${RESULT_SERVER_PORT};`,
-  ).catch((err) => {
-    throw new Error("Could not launch page on Chrome: " + err.toString());
-  });
-}
-
-/**
- * Start the performance tests on Chrome.
- * Set `currentBrowser` to chrome.
- * @param {string} homePage - Page on which to run the browser.
- */
-async function startPerfhomepageOnChrome(homePage) {
+async function startIteration({
+  browser,
+  startWithCurrent,
+  iteration,
+  total,
+  testPagePort,
+  resultServerPort,
+}) {
   if (currentBrowser !== undefined) {
     currentBrowser.kill("SIGKILL");
   }
-  if (CHROME_CMD === undefined || CHROME_CMD === null) {
-    throw new Error("Starting browser before initialization");
+  const url = startWithCurrent
+    ? `http://localhost:${testPagePort}/current.html#p=${resultServerPort};`
+    : `http://localhost:${testPagePort}/previous.html#p=${resultServerPort};`;
+  if (browser === "firefox") {
+    // eslint-disable-next-line no-console
+    console.log(`Running tests on Firefox (${iteration}/${total})`);
+    currentBrowser = await runFirefox(url, {
+      headless: true,
+      enableAutoPlay: true,
+    }).catch((err) => {
+      throw new Error("Could not launch page on Firefox: " + err.toString());
+    });
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(`Running tests on Chrome (${iteration}/${total})`);
+    currentBrowser = await runChrome(url, {
+      headless: true,
+      enableAutoPlay: true,
+    }).catch((err) => {
+      throw new Error("Could not launch page on Chrome: " + err.toString());
+    });
   }
-  const spawned = spawnProc(CHROME_CMD, [
-    ...CHROME_OPTIONS,
-    `http://localhost:${PERF_TESTS_PORT}/${homePage}`,
-  ]);
-  currentBrowser = spawned.child;
 }
 
 /**
  * Create HTTP server which will receive test results and react appropriately.
- * @param {Function} onFinished
- * @param {function} onError
+ * @param {Object} params
+ * @param {number} params.port
+ * @param {Function} params.onFinished
+ * @param {function} params.onError
  * @returns {Object}
  */
-function createResultServer(onFinished, onError) {
+function createResultServer({ port, onFinished, onError }) {
   const server = createServer(onRequest);
   return {
     listeningPromise: new Promise((res) => {
-      server.listen(RESULT_SERVER_PORT, function () {
+      server.listen(port, function () {
         res();
       });
     }),
@@ -970,6 +1072,8 @@ function getSamplePerScenarios(samplesObj) {
  * Build the performance tests.
  * @param {Object} options
  * @param {Object} options.output - The output file
+ * @param {number} options.contentServerPort - Port on which media content is
+ * served.
  * @param {boolean} [options.minify] - If `true`, the output will be minified.
  * @param {boolean} [options.production=true] - If `false`, the code will be compiled
  * in "development" mode, which has supplementary assertions.
@@ -988,7 +1092,7 @@ async function createBundle(options) {
       globals: {
         __TEST_CONTENT_SERVER__: JSON.stringify({
           URL: "127.0.0.1",
-          PORT: "3000",
+          PORT: String(options.contentServerPort),
         }),
       },
     });
@@ -1021,71 +1125,6 @@ function spawnProc(command, args, { cwd, parseError } = {}) {
     child,
   };
 }
-
-/**
- * Returns string corresponding to the Chrome binary.
- * @returns {Promise.<string>}
- */
-async function getChromeCmd() {
-  switch (process.platform) {
-    case "win32": {
-      const suffix = "\\Google\\Chrome\\Application\\chrome.exe";
-      const prefixes = [
-        process.env.LOCALAPPDATA,
-        process.env.PROGRAMFILES,
-        process.env["PROGRAMFILES(X86)"],
-      ];
-      for (const prefix of prefixes) {
-        try {
-          const windowsChromeDirectory = path.join(prefix, suffix);
-          fs.accessSync(windowsChromeDirectory);
-          return windowsChromeDirectory;
-        } catch (e) {}
-      }
-
-      return null;
-    }
-
-    case "darwin": {
-      const defaultPath = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
-      try {
-        const homePath = path.join(process.env.HOME, defaultPath);
-        fs.accessSync(homePath);
-        return homePath;
-      } catch (e) {
-        return defaultPath;
-      }
-    }
-
-    case "linux": {
-      const chromeBins = ["google-chrome", "google-chrome-stable"];
-      for (const chromeBin of chromeBins) {
-        try {
-          await execCommandAndGetFirstOutput(`which ${chromeBin}`);
-          return chromeBin;
-        } catch (e) {}
-      }
-      return null;
-    }
-    default:
-      throw new Error("Error: unsupported platform:", process.platform);
-  }
-}
-//
-// /**
-//  * Returns string corresponding to the Chrome binary.
-//  * @returns {Promise.<string>}
-//  */
-// async function getFirefoxCmd() {
-//   switch (process.platform) {
-//     case "linux": {
-//       return "firefox";
-//     }
-//     // TODO other platforms
-//     default:
-//       throw new Error("Error: unsupported platform:", process.platform);
-//   }
-// }
 
 function execCommandAndGetFirstOutput(command) {
   return new Promise((res, rej) => {
@@ -1219,6 +1258,14 @@ Available options:
                                     Defaults to the "dev" branch.,
   -u <URL>, --remote-git-url <URL>  Specify the remote git URL where the current repository can be cloned from.
                                     Defaults to the current remote URL.
+  --browser <BROWSER>               The browser to run the tests on. Can be \"chrome\" or \"firefox\".
+                                    \"chrome\" by default.
+  --result-port <NUMBER>            Configure the port used to send/receive test results.
+                                    ${DEFAULT_RESULT_SERVER_PORT} by default.
+  --page-port <NUMBER>              Configure the port used to serve the test page.
+                                    ${DEFAULT_TEST_PAGE_PORT} by default.
+  --content-port <NUMBER>           Configure the port used to serve test contents.
+                                    ${DEFAULT_CONTENT_SERVER_PORT} by default.
   -r <path>, --report <path>        Optional path to HTML file where a report will be written in once done.`,
   );
 }


### PR DESCRIPTION
Our performance tests, which tests for performance regressions on some key scenarios (loading a content, switching a track etc.) has its own testing library which:

- Build a testing page both with the RxPlayer to test and the one to compare it to.

- Find a path to a browser executable

- Run the browser on those pages

- Do performance measures, hundreds of time for each scenario

- Compare the two and output the result

Lately, I've also become very frustrated with `vitest`, the testing framework we use for other type of tests ("memory tests", integration tests and unit tests), and in that process made a generic very simple testing library on my side which only contains what we want to do: roughly the same steps than our performance tests without the performance part.

When doing that work, I identified a lot of logic in the performance "run.mjs" script that could be useful as a separate script, specifically the logic to identify and run a browser on the current device.

As that script is very large, I think this is a good idea to externalize that code even if the other test refactoring work is not merged.