### PR TITLE
Add unit tests for adaptive+stream

### DIFF
--- a/src/core/adaptive/__tests__/guess_based_chooser.test.ts
+++ b/src/core/adaptive/__tests__/guess_based_chooser.test.ts
@@ -1,0 +1,790 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IRepresentation } from "../../../manifest";
+import GuessBasedChooser from "../guess_based_chooser";
+import { ABRAlgorithmType } from "../utils/last_estimate_storage";
+import type { IRequestInfo } from "../utils/pending_requests_store";
+import type { IRepresentationMaintainabilityScore } from "../utils/representation_score_calculator";
+import { ScoreConfidenceLevel } from "../utils/representation_score_calculator";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+const mocks = vi.hoisted(() => ({
+  estimateRequestBandwidth: vi.fn(),
+  getMonotonicTimeStamp: vi.fn(),
+}));
+
+vi.mock("../../../log", () => ({
+  default: {
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../../../utils/array_find_index", () => ({
+  // eslint-disable-next-line no-restricted-properties
+  default: vi.fn((arr, predicate) => arr.findIndex(predicate)),
+}));
+
+vi.mock("../../../utils/monotonic_timestamp", () => ({
+  default: mocks.getMonotonicTimeStamp,
+}));
+
+vi.mock("../network_analyzer", () => ({
+  estimateRequestBandwidth: mocks.estimateRequestBandwidth,
+}));
+
+// Helper functions
+function createRepresentation(id: string, bitrate: number): IRepresentation {
+  return {
+    id,
+    bitrate,
+  } as IRepresentation;
+}
+
+function createScoreData(
+  score: number,
+  confidenceLevel: ScoreConfidenceLevel,
+): IRepresentationMaintainabilityScore {
+  return { score, confidenceLevel };
+}
+
+function createRequest(
+  representationId: string,
+  segmentDuration: number,
+  requestTimestamp: number,
+  isInit = false,
+): IRequestInfo {
+  return {
+    content: {
+      representation: { id: representationId } as IRepresentation,
+      segment: {
+        duration: segmentDuration,
+        isInit,
+      },
+    },
+    requestTimestamp,
+  } as IRequestInfo;
+}
+
+describe("GuessBasedChooser", () => {
+  let mockScoreCalculator: any;
+  let mockPrevEstimate: any;
+  let representations: IRepresentation[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getMonotonicTimeStamp.mockReturnValue(10000);
+
+    // Setup mock representations (sorted by bitrate ascending)
+    representations = [
+      createRepresentation("rep-1", 100000),
+      createRepresentation("rep-2", 500000),
+      createRepresentation("rep-3", 1000000),
+      createRepresentation("rep-4", 2000000),
+      createRepresentation("rep-5", 3000000),
+    ];
+
+    mockScoreCalculator = {
+      getEstimate: vi.fn(),
+    };
+
+    mockPrevEstimate = {
+      representation: null,
+      algorithmType: ABRAlgorithmType.GuessBased,
+    };
+  });
+
+  describe("constructor", () => {
+    it("should initialize with correct default values", () => {
+      const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+      expect(chooser).toBeDefined();
+    });
+  });
+
+  describe("getGuess", () => {
+    describe("when last chosen representation is null", () => {
+      it("should return null - nothing to base guess on", () => {
+        mockPrevEstimate.representation = null;
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 5, speed: 1 },
+          representations[2],
+          1500000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when incomingBestBitrate > lastChosenRep.bitrate", () => {
+      it("should return null - ABR estimates are already superior", () => {
+        mockPrevEstimate.representation = representations[1]; // 500000
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 5, speed: 1 },
+          representations[1],
+          1000000, // Higher than last chosen
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should reset consecutive wrong guesses when algorithm was GuessBased", () => {
+        mockPrevEstimate.representation = representations[1];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        // First call should reset counter
+        chooser.getGuess(
+          representations,
+          { bufferGap: 5, speed: 1 },
+          representations[1],
+          1000000,
+          [],
+        );
+
+        // Subsequent calls should still work (counter was reset)
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 5, speed: 1 },
+          representations[1],
+          1000000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when not in guessing mode yet", () => {
+      beforeEach(() => {
+        mockPrevEstimate.representation = representations[1];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+      });
+
+      it("should return null when score data is undefined", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(undefined);
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 5, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should return next representation when conditions allow guessing higher", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[2]);
+      });
+
+      it("should return null when buffer gap is too low to guess higher", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 1.5, speed: 1 }, // Below 2.5 threshold
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should return null when confidence level is not HIGH", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.LOW),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should return null when score/speed ratio is too low", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.005, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should account for playback speed when checking score", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(2.0, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 2.0 }, // Speed 2x requires higher score
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull(); // 2.0 / 2.0 = 1.0, not > 1.01
+      });
+
+      it("should return null when already at highest representation", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[4], // Highest representation
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("when already in guessing mode", () => {
+      beforeEach(() => {
+        mockPrevEstimate.representation = representations[2]; // 1000000
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+      });
+
+      it("should take higher guess when conditions are met", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(2.0, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          1000000,
+          [],
+        );
+        expect(result).toBe(representations[3]);
+      });
+
+      it("should take same guess when conditions are met with highest guess", () => {
+        mockPrevEstimate.representation = representations[4];
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(2.0, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          1000000,
+          [],
+        );
+        expect(result).toBe(representations[4]);
+      });
+
+      it("should return last chosen representation when current differs", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.2, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1], // Different from last chosen
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[2]);
+      });
+
+      it("should stop guess and downgrade when score is too low", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(0.9, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[1]); // Previous representation
+      });
+
+      it("should stop guess when buffer gap is low and score is marginal", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.1, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 0.5, speed: 1 }, // Below 0.6 threshold
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[1]);
+      });
+
+      it("should stop guess when score is undefined and buffer gap is low", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(undefined);
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 0.5, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[1]);
+      });
+
+      it("should block guesses for increasing duration after consecutive wrong guesses", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(0.9, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        // First wrong guess
+        chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        // Try to guess again immediately
+        mocks.getMonotonicTimeStamp.mockReturnValue(10000 + 5000); // 5 seconds later
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        // Should be blocked (15 seconds block)
+        expect(result).toBeNull();
+      });
+
+      it("should allow guessing after block period expires", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(0.9, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        // First wrong guess
+        chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        // Wait for block to expire
+        mocks.getMonotonicTimeStamp.mockReturnValue(10000 + 20000); // 20 seconds later
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        // Should be allowed now
+        expect(result).toBe(representations[2]);
+      });
+
+      it("should guess higher when conditions allow in guessing mode", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[3]); // Next higher representation
+      });
+
+      it("should return current representation when score data is undefined and not stopping", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(undefined);
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[2]);
+      });
+    });
+
+    describe("request-based guess stopping", () => {
+      beforeEach(() => {
+        mockPrevEstimate.representation = representations[2];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.2, ScoreConfidenceLevel.HIGH),
+        );
+      });
+
+      it("should stop guess when init segment takes too long (>1000ms)", () => {
+        const requests = [
+          createRequest("rep-3", 0, 8000, true), // 2000ms elapsed (10000 - 8000)
+        ];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[1]);
+      });
+
+      it("should not stop guess when init segment is fast enough", () => {
+        const requests = [
+          createRequest("rep-3", 0, 9500, true), // 500ms elapsed
+        ];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[3]);
+      });
+
+      it("should stop guess when regular segment takes too long", () => {
+        const requests = [
+          createRequest("rep-3", 2, 5000, false), // 5000ms elapsed, duration is 2s
+        ];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[1]); // Should downgrade
+      });
+
+      it("should not stop guess when regular segment is within acceptable time", () => {
+        const requests = [
+          createRequest("rep-3", 2, 8500, false), // 1500ms elapsed, duration is 2s (threshold: 2200ms)
+        ];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[3]);
+      });
+
+      it("should stop guess when estimated bandwidth is too low", () => {
+        vi.mocked(mocks.estimateRequestBandwidth).mockReturnValue(700000); // 70% of bitrate
+
+        const requests = [createRequest("rep-3", 2, 9000, false)];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[1]);
+      });
+
+      it("should not consider requests for other representations", () => {
+        const requests = [createRequest("rep-4", 2, 5000, false)];
+
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.1, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 2.0, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[2]);
+      });
+
+      it("should handle multiple requests and stop on any failing condition", () => {
+        const requests = [
+          createRequest("rep-3", 2, 9500, false), // OK
+          createRequest("rep-3", 2, 5000, false), // TOO SLOW - should trigger stop
+          createRequest("rep-3", 2, 9000, false), // OK
+        ];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          requests,
+        );
+
+        expect(result).toBe(representations[1]);
+      });
+    });
+
+    describe("guess validation", () => {
+      beforeEach(() => {
+        mockPrevEstimate.representation = representations[2];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+      });
+
+      it("should validate guess with high score and high confidence", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.6, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        // If validated, should allow guessing higher next time
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[3]);
+      });
+
+      it("should validate guess when incoming bitrate matches and it's an improvement", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.2, ScoreConfidenceLevel.LOW),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[2],
+          1000000, // Matches current bitrate
+          [],
+        );
+
+        // Should be validated and allow progression
+        expect(result).toBe(representations[2]);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle infinite buffer gap correctly", () => {
+        mockPrevEstimate.representation = representations[1];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: Infinity, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(null);
+      });
+
+      it("should handle NaN buffer gap by not guessing", () => {
+        mockPrevEstimate.representation = representations[1];
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: NaN, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBeNull();
+      });
+
+      it("should cap block duration at 120 seconds", () => {
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(0.9, ScoreConfidenceLevel.HIGH),
+        );
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.GuessBased;
+        mockPrevEstimate.representation = representations[2];
+
+        const chooser = new GuessBasedChooser(mockScoreCalculator, mockPrevEstimate);
+
+        // Trigger many consecutive wrong guesses
+        for (let i = 0; i < 20; i++) {
+          chooser.getGuess(
+            representations,
+            { bufferGap: 3, speed: 1 },
+            representations[2],
+            100000,
+            [],
+          );
+          mocks.getMonotonicTimeStamp.mockReturnValue(10000 + 1000 * (i + 1));
+        }
+
+        // The block should be capped at 120 seconds max
+        // After 120 seconds, should be able to guess again
+        mocks.getMonotonicTimeStamp.mockReturnValue(10000 + 20000 + 120100);
+        mockPrevEstimate.algorithmType = ABRAlgorithmType.BufferBased;
+        mockPrevEstimate.representation = representations[1]; // Update to reflect actual downgraded state
+        mockScoreCalculator.getEstimate.mockReturnValue(
+          createScoreData(1.5, ScoreConfidenceLevel.HIGH),
+        );
+
+        const result = chooser.getGuess(
+          representations,
+          { bufferGap: 3, speed: 1 },
+          representations[1],
+          100000,
+          [],
+        );
+
+        expect(result).toBe(representations[2]);
+      });
+    });
+  });
+});

--- a/src/core/adaptive/__tests__/network_analyzer.test.ts
+++ b/src/core/adaptive/__tests__/network_analyzer.test.ts
@@ -1,0 +1,514 @@
+import { describe, it, expect, vi } from "vitest";
+import NetworkAnalyzer, { estimateRequestBandwidth } from "../network_analyzer";
+import type { IRequestInfo } from "../utils/pending_requests_store";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+vi.mock("../../../config", () => ({
+  default: {
+    getCurrent: vi.fn(() => ({
+      ABR_STARVATION_GAP: {
+        DEFAULT: 2,
+        LOW_LATENCY: 1,
+      },
+      OUT_OF_STARVATION_GAP: {
+        DEFAULT: 3,
+        LOW_LATENCY: 1.5,
+      },
+      ABR_STARVATION_FACTOR: {
+        DEFAULT: 0.72,
+        LOW_LATENCY: 0.8,
+      },
+      ABR_REGULAR_FACTOR: {
+        DEFAULT: 0.8,
+        LOW_LATENCY: 0.85,
+      },
+      ABR_STARVATION_DURATION_DELTA: 5,
+    })),
+  },
+}));
+
+vi.mock("../../../log", () => ({
+  default: {
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("../../../utils/monotonic_timestamp", () => ({
+  // eslint-disable-next-line no-restricted-properties
+  default: vi.fn(() => performance.now()),
+}));
+
+function createMockRequest(
+  segmentTime: number,
+  segmentDuration: number,
+  requestTimestamp: number,
+  progress: Array<{ size: number; timestamp: number; totalSize: number }> = [],
+  complete = true,
+): IRequestInfo {
+  return {
+    content: {
+      segment: {
+        time: segmentTime,
+        duration: segmentDuration,
+        complete,
+      },
+    },
+    requestTimestamp,
+    progress,
+  } as IRequestInfo;
+}
+
+function createMockPlaybackInfo(
+  bufferGap: number,
+  position: number,
+  speed = 1,
+  duration = 100,
+): any {
+  return {
+    bufferGap,
+    position: { getWanted: () => position },
+    speed,
+    duration,
+  };
+}
+
+function createMockBandwidthEstimator(estimate?: number): any {
+  return {
+    getEstimate: vi.fn(() => estimate),
+    reset: vi.fn(),
+  };
+}
+
+describe("estimateRequestBandwidth", () => {
+  it("should return undefined if progress events are less than 5", () => {
+    // eslint-disable-next-line no-restricted-properties
+    const request = createMockRequest(0, 4, performance.now(), [
+      { size: 1000, timestamp: 1000, totalSize: 10000 },
+      { size: 2000, timestamp: 2000, totalSize: 10000 },
+    ]);
+    expect(estimateRequestBandwidth(request)).toBeUndefined();
+  });
+
+  it("should calculate bandwidth estimate from progress events", () => {
+    const baseTime = 1000;
+    const request = createMockRequest(0, 4, baseTime, [
+      { size: 0, timestamp: baseTime, totalSize: 10000 },
+      { size: 1000, timestamp: baseTime + 100, totalSize: 10000 },
+      { size: 2000, timestamp: baseTime + 200, totalSize: 10000 },
+      { size: 3000, timestamp: baseTime + 300, totalSize: 10000 },
+      { size: 4000, timestamp: baseTime + 400, totalSize: 10000 },
+      { size: 5000, timestamp: baseTime + 500, totalSize: 10000 },
+    ]);
+    const estimate = estimateRequestBandwidth(request);
+    expect(estimate).toBeDefined();
+    expect(typeof estimate).toBe("number");
+    expect(estimate).toBeGreaterThan(50000);
+  });
+
+  it("should handle varying download speeds", () => {
+    const baseTime = 1000;
+    const request = createMockRequest(0, 4, baseTime, [
+      { size: 0, timestamp: baseTime, totalSize: 20000 },
+      { size: 2000, timestamp: baseTime + 100, totalSize: 20000 },
+      { size: 4000, timestamp: baseTime + 200, totalSize: 20000 },
+      { size: 5000, timestamp: baseTime + 400, totalSize: 20000 }, // Slower
+      { size: 6000, timestamp: baseTime + 600, totalSize: 20000 }, // Slower
+      { size: 7000, timestamp: baseTime + 800, totalSize: 20000 },
+    ]);
+    const estimate = estimateRequestBandwidth(request);
+    expect(estimate).toBeDefined();
+    expect(estimate).toBeGreaterThan(50000);
+  });
+});
+
+describe("NetworkAnalyzer", () => {
+  describe("constructor", () => {
+    it("should initialize with default mode configuration", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      expect(analyzer).toBeDefined();
+    });
+
+    it("should initialize with low latency mode configuration", () => {
+      const analyzer = new NetworkAnalyzer(1000000, true);
+      expect(analyzer).toBeDefined();
+    });
+  });
+
+  describe("getBandwidthEstimate", () => {
+    it("should return initial bitrate when no bandwidth estimate is available", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+      const bandwidthEstimator = createMockBandwidthEstimator(undefined);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      expect(result.bitrateChosen).toBe(1000000);
+    });
+
+    it("should apply regular factor to bandwidth estimate in normal mode", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should apply ABR_REGULAR_FACTOR.DEFAULT (0.8)
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+      expect(result.bandwidthEstimate).toBe(2000000);
+    });
+
+    it("should enter starvation mode when buffer gap is low", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(1, 10); // Low buffer gap
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should apply ABR_STARVATION_FACTOR.DEFAULT (0.72)
+      expect(result.bitrateChosen).toBe(2000000 * 0.72);
+    });
+
+    it("should exit starvation mode when buffer gap increases", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      // Enter starvation mode
+      analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(1, 10),
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Exit starvation mode
+      const result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 10),
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should apply regular factor again (0.8)
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+    });
+
+    it("should adjust bitrate based on playback speed", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0, 2); // 2x speed
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should divide by speed: (2000000 * 0.8) / 2
+      expect(result.bitrateChosen).toBe((2000000 * 0.8) / 2);
+    });
+
+    it("should use last estimated bitrate when no new estimate available", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+      const bandwidthEstimator = createMockBandwidthEstimator(undefined);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        1500000, // Last estimated bitrate
+      );
+
+      expect(result.bitrateChosen).toBe(1500000 * 0.8);
+    });
+
+    it("should exit starvation mode near end of content", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      // Enter starvation mode
+      analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(1, 10, 1, 100),
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Near end of content (position + buffer gap close to duration)
+      const result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(1, 96, 1, 100), // 96 + 1 = 97, close to 100
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should exit starvation mode and use regular factor
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+    });
+
+    it("should handle infinite buffer gap", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(Infinity, 0);
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should treat infinite as 0 and apply starvation factor
+      expect(result.bitrateChosen).toBe(2000000 * 0.72);
+    });
+
+    it("should use different thresholds in low latency mode", () => {
+      const analyzer = new NetworkAnalyzer(1000000, true);
+      const playbackInfo = createMockPlaybackInfo(0.5, 10); // Would enter starvation in low latency
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      const result = analyzer.getBandwidthEstimate(
+        playbackInfo,
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+
+      // Should use low latency starvation factor (0.8)
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+    });
+  });
+
+  describe("isUrgent", () => {
+    it("should return true when no current representation", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+
+      const result = analyzer.isUrgent(500000, null, [], playbackInfo);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when bitrate is higher than current representation", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+      const currentRepresentation = { bitrate: 1000000 } as any;
+
+      const result = analyzer.isUrgent(2000000, currentRepresentation, [], playbackInfo);
+
+      expect(result).toBe(false);
+    });
+
+    it("should return true in low latency mode when switching to lower bitrate", () => {
+      const analyzer = new NetworkAnalyzer(1000000, true);
+      const playbackInfo = createMockPlaybackInfo(5, 0);
+      const currentRepresentation = { bitrate: 2000000 } as any;
+
+      const result = analyzer.isUrgent(1000000, currentRepresentation, [], playbackInfo);
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when no pending requests for lower bitrate", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 10);
+      const currentRepresentation = { bitrate: 2000000 } as any;
+
+      const result = analyzer.isUrgent(1000000, currentRepresentation, [], playbackInfo);
+
+      expect(result).toBe(true);
+    });
+
+    it("should evaluate urgency based on pending request progress", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      // eslint-disable-next-line no-restricted-properties
+      const now = performance.now();
+      const playbackInfo = createMockPlaybackInfo(2, 10);
+      const currentRepresentation = { bitrate: 2000000 } as any;
+
+      const request = createMockRequest(10, 4, now - 1000, [
+        { size: 0, timestamp: now - 1000, totalSize: 10000 },
+        { size: 2000, timestamp: now - 800, totalSize: 10000 },
+        { size: 4000, timestamp: now - 600, totalSize: 10000 },
+        { size: 6000, timestamp: now - 400, totalSize: 10000 },
+        { size: 8000, timestamp: now - 200, totalSize: 10000 },
+      ]);
+
+      const result = analyzer.isUrgent(
+        1000000,
+        currentRepresentation,
+        [request],
+        playbackInfo,
+      );
+
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("should handle requests with zero duration segments", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(5, 10);
+      const currentRepresentation = { bitrate: 2000000 } as any;
+
+      // eslint-disable-next-line no-restricted-properties
+      const request = createMockRequest(10, 0, performance.now()); // Zero duration
+
+      const result = analyzer.isUrgent(
+        1000000,
+        currentRepresentation,
+        [request],
+        playbackInfo,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("should handle infinite buffer gap in urgency check", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const playbackInfo = createMockPlaybackInfo(Infinity, 10);
+      const currentRepresentation = { bitrate: 2000000 } as any;
+
+      const result = analyzer.isUrgent(1000000, currentRepresentation, [], playbackInfo);
+
+      expect(typeof result).toBe("boolean");
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle typical playback progression", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const bandwidthEstimator = createMockBandwidthEstimator(2000000);
+
+      // Initial state - good buffer
+      let result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(10, 0),
+        bandwidthEstimator,
+        null,
+        [],
+        undefined,
+      );
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+
+      // Buffer depleting - entering starvation
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(1.5, 20),
+        bandwidthEstimator,
+        { bitrate: 1600000 } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(2000000 * 0.72);
+
+      // Buffer recovering - exiting starvation
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(4, 30),
+        bandwidthEstimator,
+        { bitrate: 1440000 } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(2000000 * 0.8);
+    });
+
+    it("should handle bandwidth fluctuations", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+
+      // Start with good bandwidth
+      let estimator = createMockBandwidthEstimator(3000000);
+      let result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 0),
+        estimator,
+        null,
+        [],
+        undefined,
+      );
+      expect(result.bitrateChosen).toBe(3000000 * 0.8);
+
+      // Bandwidth drops
+      estimator = createMockBandwidthEstimator(1000000);
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 10),
+        estimator,
+        { bitrate: 2400000 } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(1000000 * 0.8);
+
+      // Bandwidth recovers
+      estimator = createMockBandwidthEstimator(2500000);
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 20),
+        estimator,
+        { bitrate: 800000 } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(2500000 * 0.8);
+    });
+
+    it("should handle speed changes during playback", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const estimator = createMockBandwidthEstimator(2000000);
+
+      // Normal speed
+      let result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 0, 1),
+        estimator,
+        null,
+        [],
+        undefined,
+      );
+      const normalBitrate = result.bitrateChosen;
+
+      // 2x speed - should halve the bitrate
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 10, 2),
+        estimator,
+        { bitrate: normalBitrate } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(normalBitrate / 2);
+
+      // 0.5x speed - keep regular bitrate
+      result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(5, 20, 0.5),
+        estimator,
+        { bitrate: normalBitrate } as any,
+        [],
+        result.bitrateChosen,
+      );
+      expect(result.bitrateChosen).toBe(normalBitrate);
+    });
+  });
+});

--- a/src/core/adaptive/utils/__tests__/pending_requests_store.test.ts
+++ b/src/core/adaptive/utils/__tests__/pending_requests_store.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import PendingRequestsStore from "../pending_requests_store";
+import type {
+  IPendingRequestStoreBegin,
+  IPendingRequestStoreProgress,
+} from "../pending_requests_store";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+const mocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+// Mock dependencies
+vi.mock("../../../../log", () => ({
+  default: {
+    warn: mocks.warn,
+  },
+}));
+
+describe("PendingRequestsStore", () => {
+  let store: PendingRequestsStore;
+
+  const createMockContent = (segmentTime: number = 0) => ({
+    manifest: {} as any,
+    period: {} as any,
+    adaptation: {} as any,
+    representation: {} as any,
+    segment: { time: segmentTime } as any,
+  });
+
+  const createMockRequest = (
+    id: string = "req-1",
+    requestTimestamp: number = 1000,
+    segmentTime: number = 0,
+  ): IPendingRequestStoreBegin => ({
+    id,
+    requestTimestamp,
+    content: createMockContent(segmentTime),
+  });
+
+  const createMockProgress = (
+    id: string = "req-1",
+    duration: number = 0.5,
+    size: number = 1024,
+    totalSize: number = 2048,
+    timestamp: number = 1500,
+  ): IPendingRequestStoreProgress => ({
+    id,
+    duration,
+    size,
+    totalSize,
+    timestamp,
+  });
+
+  beforeEach(() => {
+    store = new PendingRequestsStore();
+    vi.clearAllMocks();
+  });
+
+  describe("add", () => {
+    it("should add a new pending request", () => {
+      const request = createMockRequest();
+
+      store.add(request);
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(1);
+      expect(requests[0]).toEqual({
+        requestTimestamp: request.requestTimestamp,
+        progress: [],
+        content: request.content,
+      });
+    });
+
+    it("should add multiple pending requests", () => {
+      const request1 = createMockRequest("req-1", 1000);
+      const request2 = createMockRequest("req-2", 2000);
+
+      store.add(request1);
+      store.add(request2);
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(2);
+    });
+
+    it("should initialize progress as empty array", () => {
+      const request = createMockRequest();
+
+      store.add(request);
+
+      const requests = store.getRequests();
+      expect(requests[0].progress).toEqual([]);
+    });
+  });
+
+  describe("addProgress", () => {
+    it("should add progress to an existing request", () => {
+      const request = createMockRequest("req-1");
+      const progress = createMockProgress("req-1");
+
+      store.add(request);
+      store.addProgress(progress);
+
+      const requests = store.getRequests();
+      expect(requests[0].progress).toHaveLength(1);
+      expect(requests[0].progress[0]).toEqual(progress);
+    });
+
+    it("should add multiple progress updates to the same request", () => {
+      const request = createMockRequest("req-1");
+      const progress1 = createMockProgress("req-1", 0.5, 1024);
+      const progress2 = createMockProgress("req-1", 1.0, 2048);
+
+      store.add(request);
+      store.addProgress(progress1);
+      store.addProgress(progress2);
+
+      const requests = store.getRequests();
+      expect(requests[0].progress).toHaveLength(2);
+      expect(requests[0].progress[0]).toEqual(progress1);
+      expect(requests[0].progress[1]).toEqual(progress2);
+    });
+
+    it("should throw error when adding progress for non-existent request", () => {
+      const progress = createMockProgress("unknown-id");
+
+      expect(() => store.addProgress(progress)).toThrow(
+        "ABR: progress for a request not added",
+      );
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove an existing request", () => {
+      const request = createMockRequest("req-1");
+
+      store.add(request);
+      expect(store.getRequests()).toHaveLength(1);
+
+      store.remove("req-1");
+      expect(store.getRequests()).toHaveLength(0);
+    });
+
+    it("should only remove the specified request", () => {
+      const request1 = createMockRequest("req-1");
+      const request2 = createMockRequest("req-2");
+
+      store.add(request1);
+      store.add(request2);
+
+      store.remove("req-1");
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].content).toBe(request2.content);
+    });
+
+    it("should throw error when removing non-existent request", () => {
+      expect(() => store.remove("unknown-id")).toThrow(
+        "ABR: can't remove unknown request",
+      );
+    });
+  });
+
+  describe("getRequests", () => {
+    it("should return empty array when no requests exist", () => {
+      const requests = store.getRequests();
+      expect(requests).toEqual([]);
+    });
+
+    it("should return all pending requests", () => {
+      const request1 = createMockRequest("req-1");
+      const request2 = createMockRequest("req-2");
+
+      store.add(request1);
+      store.add(request2);
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(2);
+    });
+
+    it("should sort requests by segment time in chronological order", () => {
+      const request1 = createMockRequest("req-1", 1000, 300);
+      const request2 = createMockRequest("req-2", 2000, 100);
+      const request3 = createMockRequest("req-3", 3000, 200);
+
+      store.add(request1);
+      store.add(request2);
+      store.add(request3);
+
+      const requests = store.getRequests();
+      expect(requests[0].content.segment.time).toBe(100);
+      expect(requests[1].content.segment.time).toBe(200);
+      expect(requests[2].content.segment.time).toBe(300);
+    });
+
+    it("should return requests with their progress updates", () => {
+      const request = createMockRequest("req-1");
+      const progress1 = createMockProgress("req-1", 0.5, 1024);
+      const progress2 = createMockProgress("req-1", 1.0, 2048);
+
+      store.add(request);
+      store.addProgress(progress1);
+      store.addProgress(progress2);
+
+      const requests = store.getRequests();
+      expect(requests[0].progress).toEqual([progress1, progress2]);
+    });
+
+    it("should not include removed requests", () => {
+      const request1 = createMockRequest("req-1");
+      const request2 = createMockRequest("req-2");
+
+      store.add(request1);
+      store.add(request2);
+      store.remove("req-1");
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].content).toBe(request2.content);
+    });
+
+    it("should filter out null/undefined values", () => {
+      const request = createMockRequest("req-1");
+
+      store.add(request);
+      // Manually corrupt the internal state to test filtering
+      (store as any)._currentRequests.corrupted = null;
+
+      const requests = store.getRequests();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].content).toBe(request.content);
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle complete request lifecycle", () => {
+      const request = createMockRequest("req-1", 1000);
+      const progress1 = createMockProgress("req-1", 0.5, 1024, 2048, 1500);
+      const progress2 = createMockProgress("req-1", 1.0, 2048, 2048, 2000);
+
+      // Add request
+      store.add(request);
+      expect(store.getRequests()).toHaveLength(1);
+
+      // Add progress updates
+      store.addProgress(progress1);
+      store.addProgress(progress2);
+      expect(store.getRequests()[0].progress).toHaveLength(2);
+
+      // Remove request
+      store.remove("req-1");
+      expect(store.getRequests()).toHaveLength(0);
+    });
+
+    it("should handle multiple concurrent requests with different segment times", () => {
+      const request1 = createMockRequest("req-1", 1000, 500);
+      const request2 = createMockRequest("req-2", 1100, 200);
+      const request3 = createMockRequest("req-3", 1200, 350);
+
+      store.add(request1);
+      store.add(request2);
+      store.add(request3);
+
+      store.addProgress(createMockProgress("req-1", 0.5, 512));
+      store.addProgress(createMockProgress("req-2", 0.3, 300));
+      store.addProgress(createMockProgress("req-3", 0.7, 700));
+
+      const requests = store.getRequests();
+
+      // Should be sorted by segment time: 200, 350, 500
+      expect(requests[0].content.segment.time).toBe(200);
+      expect(requests[1].content.segment.time).toBe(350);
+      expect(requests[2].content.segment.time).toBe(500);
+
+      // Each should have their progress
+      expect(requests[0].progress).toHaveLength(1);
+      expect(requests[1].progress).toHaveLength(1);
+      expect(requests[2].progress).toHaveLength(1);
+    });
+  });
+});

--- a/src/core/adaptive/utils/__tests__/representation_score_calculator.test.ts
+++ b/src/core/adaptive/utils/__tests__/representation_score_calculator.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IRepresentation } from "../../../../manifest";
+import RepresentationScoreCalculator, {
+  ScoreConfidenceLevel,
+} from "../representation_score_calculator";
+
+vi.mock("../../../../log", () => ({
+  default: {
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("../ewma", () => {
+  class EWMA {
+    private _estimate: number;
+    private _samples: Array<{ duration: number; value: number }>;
+    constructor() {
+      this._estimate = 0;
+      this._samples = [];
+    }
+    public addSample = vi.fn((duration: number, value: number) => {
+      this._samples.push({ duration, value });
+      // Simple average for testing purposes
+      this._estimate =
+        this._samples.reduce((sum, s) => sum + s.value, 0) / this._samples.length;
+    });
+    public getEstimate = vi.fn(() => this._estimate);
+  }
+
+  return {
+    default: EWMA,
+  };
+});
+
+describe("RepresentationScoreCalculator", () => {
+  let calculator: RepresentationScoreCalculator;
+  let mockRepresentation1: IRepresentation;
+  let mockRepresentation2: IRepresentation;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    calculator = new RepresentationScoreCalculator();
+
+    mockRepresentation1 = {
+      id: "rep1",
+      bitrate: 1000000,
+    } as IRepresentation;
+
+    mockRepresentation2 = {
+      id: "rep2",
+      bitrate: 2000000,
+    } as IRepresentation;
+  });
+
+  describe("addSample", () => {
+    it("should add a sample for a new representation", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeDefined();
+      expect(estimate?.score).toBe(2); // 4 / 2 = 2
+    });
+
+    it("should calculate the correct ratio (segmentDuration / requestDuration)", () => {
+      // If we can download 10 seconds of content in 5 seconds, ratio should be 2
+      calculator.addSample(mockRepresentation1, 5, 10);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.score).toBe(2);
+    });
+
+    it("should accumulate samples for the same representation", () => {
+      calculator.addSample(mockRepresentation1, 2, 4); // ratio: 2
+      calculator.addSample(mockRepresentation1, 4, 8); // ratio: 2
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeDefined();
+      expect(estimate?.score).toBe(2);
+    });
+
+    it("should reset data when switching to a different representation", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation2, 1, 2);
+
+      const estimate1 = calculator.getEstimate(mockRepresentation1);
+      const estimate2 = calculator.getEstimate(mockRepresentation2);
+
+      expect(estimate1).toBeUndefined();
+      expect(estimate2).toBeDefined();
+      expect(estimate2?.score).toBe(2);
+    });
+
+    it("should track loaded segments count", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation1, 2, 4);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeDefined();
+    });
+
+    it("should track total loaded duration", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation1, 2, 6);
+      calculator.addSample(mockRepresentation1, 2, 5);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeDefined();
+      // Total duration should be 4 + 6 + 5 = 15
+    });
+  });
+
+  describe("getEstimate", () => {
+    it("should return undefined for a representation with no samples", () => {
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeUndefined();
+    });
+
+    it("should return LOW confidence when less than 5 segments loaded", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation1, 2, 4);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.LOW);
+    });
+
+    it("should return LOW confidence when loaded duration is less than 10 seconds", () => {
+      // Add 5 segments but with short duration
+      for (let i = 0; i < 5; i++) {
+        calculator.addSample(mockRepresentation1, 1, 1);
+      }
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.LOW);
+    });
+
+    it("should return HIGH confidence when > 5 segments and >= 10 seconds loaded", () => {
+      // Add 5 segments with 2 seconds each (total 10 seconds)
+      for (let i = 0; i < 6; i++) {
+        calculator.addSample(mockRepresentation1, 1, 2);
+      }
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.HIGH);
+    });
+
+    it("should return HIGH confidence when > 5 segments and > 10 seconds loaded", () => {
+      // Add 5 segments with 3 seconds each (total 15 seconds)
+      for (let i = 0; i < 6; i++) {
+        calculator.addSample(mockRepresentation1, 1, 3);
+      }
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.HIGH);
+    });
+
+    it("should return undefined after switching representations", () => {
+      calculator.addSample(mockRepresentation1, 2, 4);
+      calculator.addSample(mockRepresentation2, 1, 2);
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate).toBeUndefined();
+    });
+  });
+
+  describe("getLastStableRepresentation", () => {
+    it("should return null initially", () => {
+      expect(calculator.getLastStableRepresentation()).toBeNull();
+    });
+
+    it("should return the representation when score exceeds 1", () => {
+      // Add sample with ratio > 1 (can download faster than playback)
+      calculator.addSample(mockRepresentation1, 2, 5); // ratio: 2.5
+
+      expect(calculator.getLastStableRepresentation()).toBe(mockRepresentation1);
+    });
+
+    it("should not update when score is <= 1", () => {
+      // Add sample with ratio <= 1
+      calculator.addSample(mockRepresentation1, 5, 4); // ratio: 0.8
+
+      expect(calculator.getLastStableRepresentation()).toBeNull();
+    });
+
+    it("should update to new representation with good score", () => {
+      calculator.addSample(mockRepresentation1, 2, 5); // ratio: 2.5
+      expect(calculator.getLastStableRepresentation()).toBe(mockRepresentation1);
+
+      calculator.addSample(mockRepresentation2, 1, 3); // ratio: 3
+      expect(calculator.getLastStableRepresentation()).toBe(mockRepresentation2);
+    });
+
+    it("should not update when adding more samples to same representation", () => {
+      calculator.addSample(mockRepresentation1, 2, 5); // ratio: 2.5
+      const firstStable = calculator.getLastStableRepresentation();
+
+      calculator.addSample(mockRepresentation1, 2, 6); // ratio: 3
+      const secondStable = calculator.getLastStableRepresentation();
+
+      expect(firstStable).toBe(secondStable);
+      expect(secondStable).toBe(mockRepresentation1);
+    });
+
+    it("should persist last stable representation even after switching to worse representation", () => {
+      calculator.addSample(mockRepresentation1, 2, 5); // ratio: 2.5
+      expect(calculator.getLastStableRepresentation()).toBe(mockRepresentation1);
+
+      calculator.addSample(mockRepresentation2, 5, 2); // ratio: 0.4
+      expect(calculator.getLastStableRepresentation()).toBe(mockRepresentation1);
+    });
+  });
+
+  describe("score calculation scenarios", () => {
+    it("should handle score exactly equal to 1", () => {
+      // Can download exactly at playback speed
+      calculator.addSample(mockRepresentation1, 4, 4); // ratio: 1
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.score).toBe(1);
+    });
+
+    it("should handle score less than 1 (slow download)", () => {
+      // Takes 10 seconds to download 5 seconds of content
+      calculator.addSample(mockRepresentation1, 10, 5); // ratio: 0.5
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.score).toBe(0.5);
+    });
+
+    it("should handle score greater than 1 (fast download)", () => {
+      // Takes 2 seconds to download 10 seconds of content
+      calculator.addSample(mockRepresentation1, 2, 10); // ratio: 5
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      expect(estimate?.score).toBe(5);
+    });
+
+    it("should average multiple samples correctly", () => {
+      calculator.addSample(mockRepresentation1, 2, 4); // ratio: 2
+      calculator.addSample(mockRepresentation1, 2, 6); // ratio: 3
+
+      const estimate = calculator.getEstimate(mockRepresentation1);
+      // Average of 2 and 3 is 2.5
+      expect(estimate?.score).toBe(2.5);
+    });
+  });
+});

--- a/src/core/stream/adaptation/__tests__/get_representations_switch_strategy.test.ts
+++ b/src/core/stream/adaptation/__tests__/get_representations_switch_strategy.test.ts
@@ -1,0 +1,592 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IAdaptation, IPeriod } from "../../../../manifest";
+import type { IReadOnlyPlaybackObserver } from "../../../../playback_observer";
+import type { SegmentSink } from "../../../segment_sinks";
+import { SegmentSinkOperation } from "../../../segment_sinks";
+import getRepresentationsSwitchingStrategy from "../get_representations_switch_strategy";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+// Mock dependencies
+vi.mock("../../../config", () => ({
+  default: {
+    getCurrent: vi.fn(() => ({
+      ADAP_REP_SWITCH_BUFFER_PADDINGS: {
+        video: { before: 0.5, after: 0.5 },
+        audio: { before: 0.5, after: 0.5 },
+        text: { before: 0, after: 0 },
+      },
+    })),
+  },
+}));
+
+describe("getRepresentationsSwitchingStrategy", () => {
+  let mockPeriod: IPeriod;
+  let mockAdaptation: IAdaptation;
+  let mockSegmentSink: any;
+  let mockPlaybackObserver: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPeriod = {
+      id: "period-1",
+      start: 0,
+      end: 100,
+    } as IPeriod;
+
+    mockAdaptation = {
+      id: "adaptation-1",
+      type: "video",
+    } as IAdaptation;
+
+    mockSegmentSink = {
+      getLastKnownInventory: vi.fn(() => []),
+      getPendingOperations: vi.fn(() => []),
+    } as unknown as SegmentSink;
+
+    mockPlaybackObserver = {
+      getReadyState: vi.fn(() => 4),
+      getCurrentTime: vi.fn(() => 10),
+      getReference: vi.fn(() => ({
+        getValue: () => ({
+          position: {
+            getPolled: () => 10,
+          },
+        }),
+      })),
+    } as unknown as IReadOnlyPlaybackObserver<any>;
+  });
+
+  describe("lazy switching mode", () => {
+    it("should return continue when switching mode is lazy", () => {
+      const settings = {
+        switchingMode: "lazy" as const,
+        representationIds: ["rep-1"],
+      };
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("no unwanted segments", () => {
+    it("should return continue when inventory is empty", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-1"],
+      };
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+
+    it("should return continue when all segments match current representation", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-1"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("unwanted segments in inventory", () => {
+    it("should identify unwanted segments from different representation", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" }, // Different representation
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+
+    it("should identify unwanted segments from different adaptation", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-1"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-2" }, // Different adaptation
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+
+    it("should ignore segments from different periods", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-2" }, // Different period
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("pending operations", () => {
+    it("should identify unwanted segments in pending push operations", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getPendingOperations = vi.fn(() => [
+        {
+          type: SegmentSinkOperation.Push,
+          value: {
+            inventoryInfos: {
+              period: { id: "period-1" },
+              adaptation: { id: "adaptation-1" },
+              representation: { id: "rep-1" }, // Different representation
+              segment: {
+                time: 5,
+                duration: 5,
+              },
+            },
+          },
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+
+    it("should ignore non-push pending operations", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getPendingOperations = vi.fn(() => [
+        {
+          type: "remove",
+          value: {},
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("reload switching mode", () => {
+    it("should return needs-reload when readyState > 1 and mode is reload", () => {
+      const settings = {
+        switchingMode: "reload" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockPlaybackObserver.getReadyState = vi.fn(() => 4);
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "needs-reload", value: undefined });
+    });
+
+    it("should reload when readyState is undefined", () => {
+      const settings = {
+        switchingMode: "reload" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockPlaybackObserver.getReadyState = vi.fn(() => undefined);
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("needs-reload");
+    });
+
+    it("should not reload when readyState <= 1", () => {
+      const settings = {
+        switchingMode: "reload" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockPlaybackObserver.getReadyState = vi.fn(() => 1);
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).not.toBe("needs-reload");
+    });
+  });
+
+  describe("direct vs clean-buffer mode", () => {
+    it("should return flush-buffer when mode is direct", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+
+    it("should return clean-buffer when mode is not direct or reload", () => {
+      const settings = {
+        switchingMode: "seamless" as any,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("clean-buffer");
+    });
+  });
+
+  describe("getCurrentTime fallback", () => {
+    it("should use getPolled when getCurrentTime returns undefined", () => {
+      const settings = {
+        switchingMode: "seamless" as any,
+        representationIds: ["rep-2"],
+      };
+
+      const getPolledMock = vi.fn(() => 15);
+      mockPlaybackObserver.getCurrentTime = vi.fn(() => undefined);
+      mockPlaybackObserver.getReference = vi.fn(() => ({
+        getValue: () => ({
+          position: {
+            getPolled: getPolledMock,
+          },
+        }),
+      }));
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(getPolledMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("segment buffered time handling", () => {
+    it("should use bufferedStart/bufferedEnd when available", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: 5,
+          bufferedEnd: 15,
+          start: 0,
+          end: 20,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+
+    it("should fallback to start/end when bufferedStart/bufferedEnd is undefined", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-2"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-1" },
+          },
+          bufferedStart: undefined,
+          bufferedEnd: undefined,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result.type).toBe("flush-buffer");
+    });
+  });
+
+  describe("multiple representation IDs", () => {
+    it("should not mark segments as unwanted if they match any of the representation IDs", () => {
+      const settings = {
+        switchingMode: "direct" as const,
+        representationIds: ["rep-1", "rep-2", "rep-3"],
+      };
+
+      mockSegmentSink.getLastKnownInventory = vi.fn(() => [
+        {
+          infos: {
+            period: { id: "period-1" },
+            adaptation: { id: "adaptation-1" },
+            representation: { id: "rep-2" },
+          },
+          bufferedStart: 0,
+          bufferedEnd: 10,
+          start: 0,
+          end: 10,
+        },
+      ]);
+
+      const result = getRepresentationsSwitchingStrategy(
+        mockPeriod,
+        mockAdaptation,
+        settings,
+        mockSegmentSink,
+        mockPlaybackObserver,
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+});

--- a/src/core/stream/period/utils/__tests__/get_adaptation_switch_strategy.test.ts
+++ b/src/core/stream/period/utils/__tests__/get_adaptation_switch_strategy.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SegmentSinkOperation } from "../../../../segment_sinks";
+import getAdaptationSwitchStrategy from "../get_adaptation_switch_strategy";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+// Mock only external dependencies that have side effects or complex behavior
+vi.mock("../../../../../config", () => ({
+  default: {
+    getCurrent: vi.fn(() => ({
+      ADAP_REP_SWITCH_BUFFER_PADDINGS: {
+        video: { before: 0.5, after: 0.5 },
+        audio: { before: 0.5, after: 0.5 },
+        text: { before: 0, after: 0 },
+      },
+    })),
+  },
+}));
+
+describe("getAdaptationSwitchStrategy", () => {
+  let mockSegmentSink: any;
+  let mockPeriod: any;
+  let mockAdaptation: any;
+  let mockPlaybackObserver: any;
+
+  beforeEach(() => {
+    // Create base mocks
+    mockSegmentSink = {
+      codec: undefined,
+      getLastKnownInventory: vi.fn(() => []),
+      getPendingOperations: vi.fn(() => []),
+    };
+
+    mockPeriod = {
+      id: "period-1",
+      start: 10,
+      end: 20,
+    };
+
+    mockAdaptation = {
+      id: "adaptation-1",
+      type: "video",
+      representations: [],
+    };
+
+    mockPlaybackObserver = {
+      getCurrentTime: vi.fn(() => 15),
+      getReadyState: vi.fn(() => 3),
+      getReference: vi.fn(() => ({
+        getValue: () => ({
+          position: {
+            getPolled: () => 15,
+          },
+        }),
+      })),
+    };
+  });
+
+  describe("codec compatibility", () => {
+    it("should return needs-reload when codec is incompatible and onCodecSwitch is reload", () => {
+      mockSegmentSink.codec = "avc1.64001f";
+      mockAdaptation.representations = [
+        {
+          isPlayable: () => true,
+          getMimeTypeString: () => "video/mp4; codecs=hev1.1.6.L93.B0",
+        },
+      ];
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "reload" },
+      );
+
+      expect(result).toEqual({ type: "needs-reload", value: undefined });
+    });
+
+    it("should continue when codec is compatible", () => {
+      mockSegmentSink.codec = "video/mp4;codecs=avc1.64001f";
+      mockAdaptation.representations = [
+        {
+          isPlayable: () => true,
+          getMimeTypeString: () => "video/mp4;codecs=avc1.65001f",
+        },
+      ];
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "reload" },
+      );
+
+      expect(result.type).not.toBe("needs-reload");
+    });
+
+    it("should continue when onCodecSwitch is continue regardless of codec", () => {
+      mockSegmentSink.codec = "avc1.64001f";
+      mockAdaptation.representations = [
+        {
+          isPlayable: () => true,
+          getMimeTypeString: () => "video/mp4; codecs=hev1.1.6.L93.B0",
+        },
+      ];
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("needs-reload");
+    });
+  });
+
+  describe("no unwanted segments", () => {
+    it("should return continue when no other adaptation is buffered", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 10,
+          end: 15,
+          bufferedStart: 10,
+          bufferedEnd: 15,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-1" }, // Same adaptation
+          },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+
+    it("should return continue when segments are from different period", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 5,
+          end: 10,
+          bufferedStart: 5,
+          bufferedEnd: 10,
+          infos: {
+            period: { id: "period-0", start: 0 }, // Different period
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("unwanted segments in inventory", () => {
+    it("should detect unwanted segments from different adaptation in same period", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 10,
+          end: 15,
+          bufferedStart: 10,
+          bufferedEnd: 15,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" }, // Different adaptation
+          },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("continue");
+    });
+
+    it("should use bufferedStart/bufferedEnd when available", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 10,
+          end: 15,
+          bufferedStart: 10.5,
+          bufferedEnd: 14.5,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("continue");
+    });
+  });
+
+  describe("pending operations", () => {
+    it("should include unwanted segments from pending push operations", () => {
+      mockSegmentSink.getPendingOperations.mockReturnValue([
+        {
+          type: SegmentSinkOperation.Push,
+          value: {
+            inventoryInfos: {
+              period: { id: "period-1", start: 0 },
+              adaptation: { id: "adaptation-2" },
+              segment: {
+                time: 12,
+                duration: 3,
+              },
+            },
+          },
+        },
+      ]);
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("continue");
+    });
+
+    it("should ignore non-push operations", () => {
+      mockSegmentSink.getPendingOperations.mockReturnValue([
+        {
+          type: SegmentSinkOperation.Remove,
+          value: { start: 10, end: 15 },
+        },
+        {
+          type: SegmentSinkOperation.SignalSegmentComplete,
+          value: { start: 10, end: 15 },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+
+  describe("switching modes", () => {
+    beforeEach(() => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 10,
+          end: 15,
+          bufferedStart: 10,
+          bufferedEnd: 15,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+    });
+
+    it("should return needs-reload when switchingMode is reload and readyState > 1", () => {
+      mockPlaybackObserver.getReadyState.mockReturnValue(3);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "reload",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result).toEqual({ type: "needs-reload", value: undefined });
+    });
+
+    it("should not reload when readyState is 1 or less", () => {
+      mockPlaybackObserver.getReadyState.mockReturnValue(1);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "reload",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("needs-reload");
+    });
+
+    it("should flush-buffer for direct mode with non-text adaptation", () => {
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "direct",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).toBe("flush-buffer");
+      expect(Array.isArray(result.value)).toBe(true);
+      expect(result.value?.length).toBeGreaterThan(0);
+    });
+
+    it("should clean-buffer for direct mode with text adaptation", () => {
+      mockAdaptation.type = "text";
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "direct",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).toBe("clean-buffer");
+      expect(Array.isArray(result.value)).toBe(true);
+      expect(result.value?.length).toBeGreaterThan(0);
+    });
+
+    it("should clean-buffer for seamless mode", () => {
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).toBe("clean-buffer");
+    });
+  });
+
+  describe("range exclusion logic", () => {
+    beforeEach(() => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 12,
+          end: 18,
+          bufferedStart: 12,
+          bufferedEnd: 18,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+    });
+
+    it("should return continue when all unwanted ranges are excluded around current position", () => {
+      // Set up inventory with segments only around current time (which will be excluded)
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 14.6,
+          end: 15.4,
+          bufferedStart: 14.6,
+          bufferedEnd: 15.4,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(15);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+
+    it("should clean ranges that are far from period boundaries", () => {
+      // Segment in the middle of the period, away from boundaries
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 13,
+          end: 17,
+          bufferedStart: 13,
+          bufferedEnd: 17,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(18); // Away from segment
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(result.type).not.toBe("continue");
+      expect(result.value?.length).toBeGreaterThan(0);
+    });
+
+    it("should exclude range near period start when previous period segment is close", () => {
+      // Set up inventory where segment from period-1 exists
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 8,
+          end: 9.5,
+          bufferedStart: 8,
+          bufferedEnd: 9.5, // Less than 1 second before period start (10)
+          infos: {
+            period: { id: "period-0", start: 0 },
+            adaptation: { id: "adaptation-1" },
+          },
+        },
+        {
+          start: 10,
+          end: 10.5,
+          bufferedStart: 10,
+          bufferedEnd: 10.5,
+          infos: {
+            period: { id: "period-1", start: 0 },
+            adaptation: { id: "adaptation-2" }, // Different adaptation
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(18); // Far away
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      // The segment at period start should be excluded from removal
+      expect(result.type).toBe("continue");
+    });
+
+    it("should exclude range near period end when next period segment is close", () => {
+      // Set up inventory where segment from next period exists
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 19.5,
+          end: 20,
+          bufferedStart: 19.5,
+          bufferedEnd: 20,
+          infos: {
+            period: { id: "period-1", start: 0, end: 20 },
+            adaptation: { id: "adaptation-2" }, // Different adaptation
+          },
+        },
+        {
+          start: 20,
+          end: 21,
+          bufferedStart: 20.5, // Less than 1 second after period end (20)
+          bufferedEnd: 21,
+          infos: {
+            period: { id: "period-2", start: 20 },
+            adaptation: { id: "adaptation-1" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(12); // Far away
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      // The segment at period end should be excluded from removal
+      expect(result.type).toBe("continue");
+    });
+
+    it("should not exclude period end range when period.end is undefined", () => {
+      mockPeriod.end = undefined;
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 12,
+          end: 15,
+          bufferedStart: 12,
+          bufferedEnd: 15,
+          infos: {
+            period: { id: "period-1", start: 10 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(18);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      // Should be able to clean buffer since no end boundary to worry about
+      expect(result.type).not.toBe("continue");
+    });
+
+    it("should exclude current position padding for seamless mode", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 14.6,
+          end: 15.4,
+          bufferedStart: 14.6,
+          bufferedEnd: 15.4,
+          infos: {
+            period: { id: "period-1", start: 10 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(15);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      // Segment is within padding (15 - 0.5 to 15 + 0.5), so should be excluded
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+
+    it("should not exclude current position padding for direct mode", () => {
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 14.6,
+          end: 15.4,
+          bufferedStart: 14.6,
+          bufferedEnd: 15.4,
+          infos: {
+            period: { id: "period-1", start: 10 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(15);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "direct",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      // In direct mode, current position is not excluded, so buffer should be flushed
+      expect(result.type).toBe("flush-buffer");
+      expect(result.value?.length).toBeGreaterThan(0);
+    });
+
+    it("should use polled position when getCurrentTime returns undefined", () => {
+      mockPlaybackObserver.getCurrentTime.mockReturnValue(undefined);
+      mockSegmentSink.getLastKnownInventory.mockReturnValue([
+        {
+          start: 14.6,
+          end: 15.4,
+          bufferedStart: 14.6,
+          bufferedEnd: 15.4,
+          infos: {
+            period: { id: "period-1", start: 10 },
+            adaptation: { id: "adaptation-2" },
+          },
+        },
+      ]);
+
+      const result = getAdaptationSwitchStrategy(
+        mockSegmentSink,
+        mockPeriod,
+        mockAdaptation,
+        "seamless",
+        mockPlaybackObserver,
+        { onCodecSwitch: "continue" },
+      );
+
+      expect(mockPlaybackObserver.getReference).toHaveBeenCalled();
+      // Should still exclude based on polled position (15)
+      expect(result).toEqual({ type: "continue", value: undefined });
+    });
+  });
+});

--- a/src/core/stream/representation/__tests__/encryption_data_notifier.test.ts
+++ b/src/core/stream/representation/__tests__/encryption_data_notifier.test.ts
@@ -1,0 +1,531 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { IRepresentationProtectionData } from "../../../../manifest/classes";
+import type { IProtectionDataInfo } from "../../../../transports";
+import EncryptionDataNotifier from "../encryption_data_notifier";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+vi.mock("../../../../manifest/classes", () => ({
+  Representation: vi.fn(),
+}));
+
+describe("EncryptionDataNotifier", () => {
+  let mockRepresentation: any;
+  let mockNotify: any;
+
+  beforeEach(() => {
+    mockNotify = vi.fn();
+    mockRepresentation = {
+      getEncryptionData: vi.fn(() => []),
+      addProtectionData: vi.fn(),
+      getAllEncryptionData: vi.fn(() => []),
+    };
+  });
+
+  describe("constructor - early notification", () => {
+    it("should send notification immediately when drmSystemId is provided and encryption data is complete", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: [new Uint8Array([5, 6, 7, 8]), new Uint8Array([8, 7, 6, 5])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockRepresentation.getEncryptionData).toHaveBeenCalledWith(
+        "edef8ba979d64acea3c827dcd51d21ed",
+      );
+      expect(mockNotify).toHaveBeenCalledWith(mockEncryptionData);
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT send notification when encryption data exists but keyIds are undefined", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: undefined,
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockRepresentation.getEncryptionData).toHaveBeenCalledWith(
+        "edef8ba979d64acea3c827dcd51d21ed",
+      );
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it("should NOT send notification when some items have keyIds and others don't", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+        {
+          keyIds: undefined,
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it("should NOT send notification when encryption data array is empty", () => {
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it("should NOT send notification when drmSystemId is undefined", () => {
+      new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockRepresentation.getEncryptionData).not.toHaveBeenCalled();
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it("should handle empty keyIds array as valid", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: [],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockNotify).toHaveBeenCalledWith(mockEncryptionData);
+    });
+  });
+
+  describe("onNewProtectionData - deferred notification", () => {
+    it("should add protection data to representation and send notification", () => {
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      const protectionData: IProtectionDataInfo[] = [
+        {
+          keyId: new Uint8Array([1, 2, 3]),
+          initDataType: "cenc",
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+
+      const allEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+      mockRepresentation.getAllEncryptionData.mockReturnValue(allEncryptionData);
+
+      notifier.onNewProtectionData(protectionData);
+
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalledWith(
+        "cenc",
+        new Uint8Array([1, 2, 3]),
+        [
+          {
+            systemId: "edef8ba979d64acea3c827dcd51d21ed",
+            data: new Uint8Array([4, 5, 6]),
+          },
+        ],
+      );
+      expect(mockRepresentation.getAllEncryptionData).toHaveBeenCalled();
+      expect(mockNotify).toHaveBeenCalledWith(allEncryptionData);
+    });
+
+    it("should add multiple protection data items to representation", () => {
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      const protectionData: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([1, 2, 3]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([7, 8, 9]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([10, 11, 12]),
+            },
+          ],
+        },
+      ];
+
+      const allEncryptionData: IRepresentationProtectionData[] = [
+        {
+          type: "cenc",
+          keyIds: [new Uint8Array([5, 6, 7, 8]), new Uint8Array([8, 7, 6, 5])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+
+      mockRepresentation.getAllEncryptionData.mockReturnValue(allEncryptionData);
+
+      notifier.onNewProtectionData(protectionData);
+
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalledTimes(2);
+      expect(mockRepresentation.addProtectionData).toHaveBeenNthCalledWith(
+        1,
+        "cenc",
+        new Uint8Array([1, 2, 3]),
+        [
+          {
+            systemId: "edef8ba979d64acea3c827dcd51d21ed",
+            data: new Uint8Array([4, 5, 6]),
+          },
+        ],
+      );
+      expect(mockRepresentation.addProtectionData).toHaveBeenNthCalledWith(
+        2,
+        "cenc",
+        new Uint8Array([7, 8, 9]),
+        [
+          {
+            systemId: "edef8ba979d64acea3c827dcd51d21ed",
+            data: new Uint8Array([10, 11, 12]),
+          },
+        ],
+      );
+      expect(mockNotify).toHaveBeenCalledWith(allEncryptionData);
+    });
+
+    it("should NOT send notification if no encryption data is available after adding", () => {
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      const protectionData: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([1, 2, 3]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+      notifier.onNewProtectionData(protectionData);
+
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalled();
+      expect(mockRepresentation.getAllEncryptionData).toHaveBeenCalled();
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+
+    it("should handle empty protection data array", () => {
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+      notifier.onNewProtectionData([]);
+      expect(mockRepresentation.addProtectionData).not.toHaveBeenCalled();
+      expect(mockRepresentation.getAllEncryptionData).toHaveBeenCalled();
+      expect(mockNotify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("notification sent only once", () => {
+    it("should NOT send notification again after early notification", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+          type: "cenc",
+        },
+      ];
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      // Early notification should have been sent
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+
+      // Now call onNewProtectionData
+      const protectionData: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([4, 5, 6]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([7, 8, 9]),
+            },
+          ],
+        },
+      ];
+
+      mockRepresentation.getAllEncryptionData.mockReturnValue([
+        ...mockEncryptionData,
+        {
+          keyIds: [new Uint8Array([8, 7, 6, 5])],
+          systemId: "edef8ba979d64acea3c827dcd51d21ed",
+          initData: new Uint8Array([7, 8, 9]),
+          initDataType: "cenc",
+        },
+      ]);
+
+      notifier.onNewProtectionData(protectionData);
+
+      // Should still be called only once
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalled();
+    });
+
+    it("should NOT send notification again on subsequent onNewProtectionData calls", () => {
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: undefined,
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      const protectionData1: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([1, 2, 3]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+      const allEncryptionData: IRepresentationProtectionData[] = [
+        {
+          type: "cenc",
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+      mockRepresentation.getAllEncryptionData.mockReturnValue(allEncryptionData);
+
+      // First call should trigger notification
+      notifier.onNewProtectionData(protectionData1);
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+
+      // Second call should NOT trigger notification
+      const protectionData2: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([7, 8, 9]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([10, 11, 12]),
+            },
+          ],
+        },
+      ];
+
+      notifier.onNewProtectionData(protectionData2);
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle multiple encryption data items with all keyIds defined", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          type: "cenc",
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+        },
+        {
+          type: "cenc",
+          keyIds: [new Uint8Array([8, 7, 6, 5]), new Uint8Array([8, 8, 8, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([4, 5, 6]),
+            },
+          ],
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockNotify).toHaveBeenCalledWith(mockEncryptionData);
+    });
+
+    it("should add protection data even when notification was already sent", () => {
+      const mockEncryptionData: IRepresentationProtectionData[] = [
+        {
+          type: "cenc",
+          keyIds: [new Uint8Array([5, 6, 7, 8])],
+          values: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([1, 2, 3]),
+            },
+          ],
+        },
+      ];
+
+      mockRepresentation.getEncryptionData.mockReturnValue(mockEncryptionData);
+
+      const notifier = new EncryptionDataNotifier({
+        drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+        representation: mockRepresentation,
+        notify: mockNotify,
+      });
+
+      expect(mockNotify).toHaveBeenCalledTimes(1);
+
+      const protectionData: IProtectionDataInfo[] = [
+        {
+          initDataType: "cenc",
+          keyId: new Uint8Array([7, 8, 9]),
+          initData: [
+            {
+              systemId: "edef8ba979d64acea3c827dcd51d21ed",
+              data: new Uint8Array([10, 11, 12]),
+            },
+          ],
+        },
+      ];
+
+      notifier.onNewProtectionData(protectionData);
+
+      // Data should still be added even though notification won't be sent again
+      expect(mockRepresentation.addProtectionData).toHaveBeenCalledWith(
+        "cenc",
+        new Uint8Array([7, 8, 9]),
+        [
+          {
+            systemId: "edef8ba979d64acea3c827dcd51d21ed",
+            data: new Uint8Array([10, 11, 12]),
+          },
+        ],
+      );
+    });
+  });
+});

--- a/src/core/stream/representation/encryption_data_notifier.ts
+++ b/src/core/stream/representation/encryption_data_notifier.ts
@@ -1,0 +1,122 @@
+import type {
+  Representation,
+  IRepresentationProtectionData,
+} from "../../../manifest/classes";
+import type { IProtectionDataInfo } from "../../../transports";
+
+/**
+ * Manages the one-time notification of encryption/DRM data for a Representation.
+ *
+ * This class collects encryption data from parsed segments and ensures that
+ * the encryption notification callback is triggered exactly once, as soon as
+ * sufficient data is available.
+ *
+ * The notification may occur in two ways:
+ * 1. **Early notification** (constructor): If the DRM system ID is known and
+ *    complete encryption data (with all key IDs) is already available, the
+ *    notification is sent immediately to enable faster license negotiation.
+ * 2. **Deferred notification** (onNewProtectionData): If early notification
+ *    doesn't occur, encryption data is collected from parsed segments and
+ *    the notification is sent once any encryption data becomes available.
+ *
+ * @example
+ * const notifier = new EncryptionDataNotifier({
+ *   drmSystemId: "edef8ba979d64acea3c827dcd51d21ed",
+ *   representation,
+ *   notify: (data) => callbacks.encryptionDataEncountered(data),
+ * });
+ *
+ * // Later, when a segment is parsed:
+ * notifier.onNewProtectionData(parsedSegmentEvent.protectionData);
+ */
+export default class EncryptionDataNotifier {
+  /**
+   * If `true` encryption data has already been sent through this
+   * `EncryptionDataNotifier`.
+   *
+   * For now we only send encryption data once per notifier at most as it was
+   * historically the only encountered case (encryption data in initialization
+   * segment).
+   * TODO: remove rule?
+   */
+  private _hasSentEncryptionData: boolean;
+  /**
+   * `Representation` linked to that `EncryptionDataNotifier`. Might be mutated
+   * to add encryption data information.
+   */
+  private _representation: Representation;
+  /** Callback to call when encryption information is first encountered. */
+  private _notify: (contentProtections: IRepresentationProtectionData[]) => void;
+
+  /**
+   * Create a new `EncryptionDataNotifier`.
+   * @param {Object} param0
+   * @param {string|undefined} param0.drmSystemId - If known the ID in hex
+   * format of the used DRM system (playready, widevine etc.).
+   * @param {Object} param0.representation - Object describing the
+   * Representation (including protection-related information). New encryption
+   * data might be added to it by this class.
+   * @param {Function} param0.notify - Function that will be called once new
+   * protection data has been detected.
+   */
+  constructor({
+    drmSystemId,
+    representation,
+    notify,
+  }: {
+    drmSystemId: string | undefined;
+    representation: Representation;
+    notify: (contentProtections: IRepresentationProtectionData[]) => void;
+  }) {
+    this._hasSentEncryptionData = false;
+    this._representation = representation;
+    this._notify = notify;
+
+    // If the DRM system id is already known, and if we already have encryption data
+    // for it, we may not need to wait until the initialization segment is loaded to
+    // signal required protection data, thus performing License negotiations sooner
+    if (drmSystemId !== undefined) {
+      const encryptionData = representation.getEncryptionData(drmSystemId);
+
+      // If some key ids are not known yet, it may be safer to wait for this initialization
+      // segment to be loaded first
+      if (
+        encryptionData.length > 0 &&
+        encryptionData.every((e) => e.keyIds !== undefined)
+      ) {
+        this._hasSentEncryptionData = true;
+        notify(encryptionData);
+      }
+    }
+  }
+
+  /**
+   * Signal that new protection data information is available.
+   * If necessary, that data will be added to the Representation and sent
+   * through the `notifiy` callback passed in constructor.
+   * @param {Array.<Object>} data - The new protection data encountered.
+   */
+  public onNewProtectionData(data: IProtectionDataInfo[]): void {
+    // Supplementary encryption information might have been parsed.
+    for (const protInfo of data) {
+      // TODO better handle use cases like key rotation by not always grouping
+      // every protection data together? To check.
+      this._representation.addProtectionData(
+        protInfo.initDataType,
+        protInfo.keyId,
+        protInfo.initData,
+      );
+    }
+
+    // Now that the initialization segment has been parsed - which may have
+    // included encryption information - take care of the encryption event
+    // if not already done.
+    if (!this._hasSentEncryptionData) {
+      const allEncryptionData = this._representation.getAllEncryptionData();
+      if (allEncryptionData.length > 0) {
+        this._notify(allEncryptionData);
+        this._hasSentEncryptionData = true;
+      }
+    }
+  }
+}

--- a/src/core/stream/representation/representation_stream.ts
+++ b/src/core/stream/representation/representation_stream.ts
@@ -33,6 +33,7 @@ import type {
   IParsedInitSegmentPayload,
   IParsedSegmentPayload,
 } from "../../fetchers/segment/segment_queue";
+import EncryptionDataNotifier from "./encryption_data_notifier";
 import type {
   IQueuedSegment,
   IRepresentationStreamArguments,
@@ -125,33 +126,16 @@ export default function RepresentationStream<TSegmentDataType>(
     initSegmentState.isLoaded = true;
   }
 
-  /**
-   * `true` if the event notifying about encryption data has already been
-   * constructed.
-   * Allows to avoid sending multiple times protection events.
-   */
-  let hasSentEncryptionData = false;
-
-  // If the DRM system id is already known, and if we already have encryption data
-  // for it, we may not need to wait until the initialization segment is loaded to
-  // signal required protection data, thus performing License negotiations sooner
-  if (drmSystemId !== undefined) {
-    const encryptionData = representation.getEncryptionData(drmSystemId);
-
-    // If some key ids are not known yet, it may be safer to wait for this initialization
-    // segment to be loaded first
-    if (
-      encryptionData.length > 0 &&
-      encryptionData.every((e) => e.keyIds !== undefined)
-    ) {
-      hasSentEncryptionData = true;
+  const drmNotifier = new EncryptionDataNotifier({
+    drmSystemId,
+    representation,
+    notify: (encryptionData) =>
       callbacks.encryptionDataEncountered(
         encryptionData.map((d) => objectAssign({ content }, d)),
-      );
-      if (canceller.isUsed()) {
-        return; // previous callback has stopped everything by side-effect
-      }
-    }
+      ),
+  });
+  if (canceller.isUsed()) {
+    return;
   }
 
   segmentQueue.addEventListener(
@@ -369,29 +353,7 @@ export default function RepresentationStream<TSegmentDataType>(
       | IParsedInitSegmentPayload<TSegmentDataType>
       | IParsedSegmentPayload<TSegmentDataType>,
   ): void {
-    // Supplementary encryption information might have been parsed.
-    for (const protInfo of evt.protectionData) {
-      // TODO better handle use cases like key rotation by not always grouping
-      // every protection data together? To check.
-      representation.addProtectionData(
-        protInfo.initDataType,
-        protInfo.keyId,
-        protInfo.initData,
-      );
-    }
-
-    // Now that the initialization segment has been parsed - which may have
-    // included encryption information - take care of the encryption event
-    // if not already done.
-    if (!hasSentEncryptionData) {
-      const allEncryptionData = representation.getAllEncryptionData();
-      if (allEncryptionData.length > 0) {
-        callbacks.encryptionDataEncountered(
-          allEncryptionData.map((p) => objectAssign({ content }, p)),
-        );
-        hasSentEncryptionData = true;
-      }
-    }
+    drmNotifier.onNewProtectionData(evt.protectionData);
 
     if (evt.segmentType === "init") {
       if (!representation.index.isInitialized() && evt.segmentList !== undefined) {

--- a/src/core/stream/representation/utils/__tests__/append_segment_to_buffer.test.ts
+++ b/src/core/stream/representation/utils/__tests__/append_segment_to_buffer.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MediaError, SourceBufferError } from "../../../../../errors";
+import SharedReference from "../../../../../utils/reference";
+import TaskCanceller, { CancellationError } from "../../../../../utils/task_canceller";
+import appendSegmentToBuffer from "../append_segment_to_buffer";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+vi.mock("../../../../../log", () => ({
+  default: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+vi.mock("../../../../../utils/sleep", () => ({
+  default: vi.fn(() => Promise.resolve()),
+}));
+
+describe("appendSegmentToBuffer", () => {
+  let mockPlaybackObserver: any;
+  let mockSegmentSink: any;
+  let mockDataInfos: any;
+  let mockBufferGoal: SharedReference<number>;
+  let mockTaskCanceller = new TaskCanceller("test canceller");
+
+  beforeEach(() => {
+    mockPlaybackObserver = {
+      getReference: vi.fn(
+        () =>
+          new SharedReference({
+            position: {
+              getWanted: () => 10,
+            },
+          }),
+      ),
+    };
+    mockSegmentSink = {
+      pushChunk: vi.fn(() => Promise.resolve([{ start: 0, end: 10 }])),
+      removeBuffer: vi.fn(() => Promise.resolve(undefined)),
+    };
+    mockDataInfos = {
+      inventoryInfos: {
+        adaptation: { id: "test-adaptation", type: "video", representations: [] },
+      },
+    };
+    mockBufferGoal = new SharedReference(30);
+    mockTaskCanceller.cancel("test end");
+    mockTaskCanceller = new TaskCanceller("test canceller");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("successful append", () => {
+    it("should push chunk successfully on first try", async () => {
+      const result = await appendSegmentToBuffer(
+        mockPlaybackObserver,
+        mockSegmentSink,
+        mockDataInfos,
+        mockBufferGoal,
+        mockTaskCanceller.signal,
+      );
+
+      expect(mockSegmentSink.pushChunk).toHaveBeenCalledTimes(1);
+      expect(mockSegmentSink.pushChunk).toHaveBeenCalledWith(mockDataInfos);
+      expect(result).toEqual([{ start: 0, end: 10 }]);
+    });
+  });
+
+  describe("buffer full error handling", () => {
+    it("should run garbage collector and retry on buffer full error", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockResolvedValueOnce([{ start: 0, end: 10 }]);
+
+      const result = await appendSegmentToBuffer(
+        mockPlaybackObserver,
+        mockSegmentSink,
+        mockDataInfos,
+        mockBufferGoal,
+        mockTaskCanceller.signal,
+      );
+
+      expect(mockSegmentSink.pushChunk).toHaveBeenCalledTimes(2);
+      expect(mockSegmentSink.removeBuffer).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([{ start: 0, end: 10 }]);
+    });
+
+    it("should remove buffer before current position (start)", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockResolvedValueOnce([{ start: 0, end: 10 }]);
+
+      await appendSegmentToBuffer(
+        mockPlaybackObserver,
+        mockSegmentSink,
+        mockDataInfos,
+        mockBufferGoal,
+        mockTaskCanceller.signal,
+      );
+
+      // Should remove from 0 to (currentPos - 5) = 5
+      expect(mockSegmentSink.removeBuffer).toHaveBeenCalledWith(0, 5);
+    });
+
+    it("should remove buffer after buffer goal (end)", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockResolvedValueOnce([{ start: 0, end: 10 }]);
+
+      mockBufferGoal.setValue(30);
+
+      await appendSegmentToBuffer(
+        mockPlaybackObserver,
+        mockSegmentSink,
+        mockDataInfos,
+        mockBufferGoal,
+        mockTaskCanceller.signal,
+      );
+
+      // Should remove from (currentPos + bufferGoal + 12) = 52 to MAX_VALUE
+      expect(mockSegmentSink.removeBuffer).toHaveBeenCalledWith(52, Number.MAX_VALUE);
+    });
+
+    it("should not remove start buffer when position is < 5", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockResolvedValueOnce([{ start: 0, end: 10 }]);
+
+      mockPlaybackObserver.getReference.mockReturnValue(
+        new SharedReference({
+          position: {
+            getWanted: vi.fn(() => 3),
+          },
+        }),
+      );
+      await appendSegmentToBuffer(
+        mockPlaybackObserver,
+        mockSegmentSink,
+        mockDataInfos,
+        mockBufferGoal,
+        mockTaskCanceller.signal,
+      );
+      expect(mockSegmentSink.removeBuffer).toHaveBeenCalledWith(45, Number.MAX_VALUE);
+
+      // Should only be called once for the end buffer
+      expect(mockSegmentSink.removeBuffer).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw BUFFER_FULL_ERROR if retry fails", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      const retryError = new Error("Retry failed");
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockRejectedValueOnce(retryError);
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow("BUFFER_FULL_ERROR");
+    });
+  });
+
+  describe("non-buffer-full errors", () => {
+    it("should throw BUFFER_APPEND_ERROR for non-buffer-full SourceBufferError", async () => {
+      const error = new SourceBufferError("SOME_ERROR", "Some error", false);
+      mockSegmentSink.pushChunk.mockRejectedValueOnce(error);
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(
+        new MediaError("BUFFER_APPEND_ERROR", "SOME_ERROR: Some error", {
+          tracks: [
+            {
+              type: "video",
+              track: {
+                id: "test-adaptation",
+                representations: [],
+              },
+            },
+          ],
+        }),
+      );
+    });
+
+    it("should throw BUFFER_APPEND_ERROR for generic Error", async () => {
+      const error = new Error("Generic error");
+      mockSegmentSink.pushChunk.mockRejectedValueOnce(error);
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(MediaError);
+    });
+
+    it("should throw BUFFER_APPEND_ERROR for unknown error type", async () => {
+      mockSegmentSink.pushChunk.mockRejectedValueOnce("string error");
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(MediaError);
+    });
+  });
+
+  describe("cancellation handling", () => {
+    it("should throw CancellationError on initial pushChunk if cancelled", async () => {
+      const cancellationError = new CancellationError("Test", "test");
+      mockTaskCanceller.cancel("test cancellation");
+      mockSegmentSink.pushChunk.mockRejectedValueOnce(cancellationError);
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(CancellationError);
+    });
+
+    it("should throw CancellationError during retry if cancelled", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      mockSegmentSink.pushChunk.mockRejectedValueOnce(bufferFullError);
+      mockTaskCanceller.cancel("test 523");
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(CancellationError);
+    });
+
+    it("should throw CancellationError if retry pushChunk is cancelled", async () => {
+      const bufferFullError = new SourceBufferError(
+        "BUFFER_FULL",
+        "Buffer is full",
+        true,
+      );
+
+      const cancellationError = new CancellationError("Test", "test");
+
+      mockSegmentSink.pushChunk
+        .mockRejectedValueOnce(bufferFullError)
+        .mockRejectedValueOnce(cancellationError);
+
+      await expect(
+        appendSegmentToBuffer(
+          mockPlaybackObserver,
+          mockSegmentSink,
+          mockDataInfos,
+          mockBufferGoal,
+          mockTaskCanceller.signal,
+        ),
+      ).rejects.toThrow(CancellationError);
+    });
+  });
+});

--- a/src/core/stream/representation/utils/__tests__/check_for_discontinuity.test.ts
+++ b/src/core/stream/representation/utils/__tests__/check_for_discontinuity.test.ts
@@ -1,0 +1,513 @@
+import { describe, it, expect, vi } from "vitest";
+import type { IBufferedChunk } from "../../../../segment_sinks";
+import checkForDiscontinuity from "../check_for_discontinuity";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+// Minimal type setup for tests
+interface TestContent {
+  adaptation: { type: string };
+  manifest: any;
+  period: { end?: number };
+  representation: {
+    index: {
+      checkDiscontinuity: (time: number) => number | null;
+      awaitSegmentBetween: (start: number, end: number) => boolean | undefined;
+    };
+  };
+}
+
+describe("checkForDiscontinuity", () => {
+  const createMockContent = (overrides?: Partial<TestContent>): any => ({
+    adaptation: { type: "video" },
+    manifest: {},
+    period: {},
+    representation: {
+      index: {
+        checkDiscontinuity: vi.fn(() => null),
+        awaitSegmentBetween: vi.fn(() => undefined),
+      },
+    },
+    ...overrides,
+  });
+
+  const createBufferedChunk = (
+    start: number,
+    end: number,
+    segmentTime: number,
+    segmentEnd: number,
+  ): IBufferedChunk =>
+    ({
+      bufferedStart: start,
+      bufferedEnd: end,
+      infos: {
+        segment: {
+          time: segmentTime,
+          end: segmentEnd,
+        },
+      },
+    }) as IBufferedChunk;
+
+  describe("when no segments are buffered in range", () => {
+    it("should return null when nextSegmentStart is provided", () => {
+      const content = createMockContent();
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 20 },
+        15, // nextSegmentStart
+        false,
+        [],
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return discontinuity to period end when finished loading and at period end", () => {
+      const content = createMockContent({
+        period: { end: 100 },
+      });
+      const result = checkForDiscontinuity(
+        content,
+        { start: 90, end: 105 },
+        null, // no next segment
+        true, // hasFinishedLoading
+        [],
+      );
+
+      expect(result).toEqual({ start: undefined, end: null });
+    });
+
+    it("should return manifest discontinuity when no next segment", () => {
+      const content = createMockContent({
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => 25),
+            awaitSegmentBetween: vi.fn(() => false),
+          },
+        },
+      });
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        false,
+        [],
+      );
+
+      expect(result).toEqual({ start: undefined, end: 25 });
+      expect(content.representation.index.checkDiscontinuity).toHaveBeenCalledWith(10);
+    });
+
+    it("should return discontinuity to Period's end when has finished loading without segment and range after Period's end", () => {
+      const content = createMockContent({
+        period: { end: 29 },
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => false),
+          },
+        },
+      });
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        true, // hasFinishedLoading
+        [],
+      );
+
+      expect(result).toEqual({ start: undefined, end: null });
+    });
+
+    it("should return discontinuity to Period's end when has finished loading without segment and range equal to Period's end", () => {
+      const content = createMockContent({
+        period: { end: 30 },
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => false),
+          },
+        },
+      });
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        true, // hasFinishedLoading
+        [],
+      );
+
+      expect(result).toEqual({ start: undefined, end: null });
+    });
+
+    it("should not return discontinuity when has finished loading without segment and range before Period's end", () => {
+      const content = createMockContent({
+        period: { end: 31 },
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => false),
+          },
+        },
+      });
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        true, // hasFinishedLoading
+        [],
+      );
+
+      expect(result).toEqual(null);
+    });
+  });
+
+  describe("when there's a hole before the first buffered segment", () => {
+    it("should detect discontinuity when hole won't be filled", () => {
+      const content = createMockContent();
+      const bufferedSegments = [createBufferedChunk(15, 20, 15, 20)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 25 },
+        null, // no next segment to fill the hole
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: undefined, end: 15 });
+    });
+
+    it("should detect discontinuity when next segment won't fill the hole", () => {
+      const content = createMockContent();
+      const bufferedSegments = [createBufferedChunk(15, 20, 15, 20)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 25 },
+        20, // nextSegmentStart is after the hole
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: undefined, end: 15 });
+    });
+
+    it("should return null when a segment is expected to fill the hole", () => {
+      const content = createMockContent();
+      const bufferedSegments = [createBufferedChunk(15, 20, 15, 20)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 25 },
+        10, // nextSegmentStart will fill the hole
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when awaiting segment between start and hole", () => {
+      const content = createMockContent({
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => true),
+          },
+        },
+      });
+      const bufferedSegments = [createBufferedChunk(15, 20, 15, 20)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 25 },
+        null,
+        false, // not finished loading
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+      expect(content.representation.index.awaitSegmentBetween).toHaveBeenCalledWith(
+        10,
+        15,
+      );
+    });
+  });
+
+  describe("when there's a hole between buffered segments", () => {
+    it("should detect discontinuity between consecutive segments", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        createBufferedChunk(10, 15, 10, 15),
+        createBufferedChunk(20, 25, 20, 25), // hole from 15 to 20
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null, // no segment to fill the hole
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: 15, end: 20 });
+    });
+
+    it("should detect discontinuity when next segment comes after the hole", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        createBufferedChunk(10, 15, 10, 15),
+        createBufferedChunk(20, 25, 20, 25),
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        25, // nextSegmentStart is after the hole
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: 15, end: 20 });
+    });
+
+    it("should return null when next segment will fill the hole", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        createBufferedChunk(10, 15, 10, 15),
+        createBufferedChunk(20, 25, 20, 25),
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        15, // nextSegmentStart will fill the hole
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when awaiting segment between holes", () => {
+      const content = createMockContent({
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => true),
+          },
+        },
+      });
+      const bufferedSegments = [
+        createBufferedChunk(10, 15, 10, 15),
+        createBufferedChunk(20, 25, 20, 25),
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        false, // not finished loading
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+      expect(content.representation.index.awaitSegmentBetween).toHaveBeenCalledWith(
+        15,
+        20,
+      );
+    });
+  });
+
+  describe("when checking for discontinuity at period end", () => {
+    it("should detect discontinuity when last segment ends before period end", () => {
+      const content = createMockContent({
+        period: { end: 100 },
+      });
+      const bufferedSegments = [
+        createBufferedChunk(80, 90, 80, 90), // ends before period end
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 80, end: 105 },
+        null,
+        true, // hasFinishedLoading
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: 90, end: null });
+    });
+
+    it("should return null when checked range doesn't reach period end", () => {
+      const content = createMockContent({
+        period: { end: 100 },
+      });
+      const bufferedSegments = [createBufferedChunk(80, 90, 80, 90)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 80, end: 95 }, // doesn't reach period end
+        null,
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null when last segment reaches period end", () => {
+      const content = createMockContent({
+        period: { end: 100 },
+      });
+      const bufferedSegments = [createBufferedChunk(80, 100, 80, 100)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 80, end: 105 },
+        null,
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when checking for manifest discontinuity at range end", () => {
+    it("should detect manifest discontinuity at end of range", () => {
+      const content = createMockContent({
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn((time) => (time === 50 ? 60 : null)),
+            awaitSegmentBetween: vi.fn(() => undefined),
+          },
+        },
+      });
+      const bufferedSegments = [createBufferedChunk(30, 40, 30, 40)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 30, end: 50 },
+        null,
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: 40, end: 60 });
+      expect(content.representation.index.checkDiscontinuity).toHaveBeenCalledWith(50);
+    });
+
+    it("should return null when no manifest discontinuity at range end", () => {
+      const content = createMockContent({
+        representation: {
+          index: {
+            checkDiscontinuity: vi.fn(() => null),
+            awaitSegmentBetween: vi.fn(() => false),
+          },
+        },
+      });
+      const bufferedSegments = [createBufferedChunk(30, 40, 30, 40)];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 30, end: 50 },
+        null,
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle segments with undefined bufferedStart", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        {
+          bufferedStart: undefined,
+          bufferedEnd: 15,
+          infos: { segment: { time: 10, end: 15 } },
+        } as IBufferedChunk,
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 20 },
+        null,
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle segments with undefined bufferedEnd", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        {
+          bufferedStart: 10,
+          bufferedEnd: undefined,
+          infos: { segment: { time: 10, end: 15 } },
+        } as IBufferedChunk,
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 20 },
+        null,
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle multiple segments where only some overlap with range", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        createBufferedChunk(5, 8, 5, 8), // before range
+        createBufferedChunk(10, 15, 10, 15), // in range
+        createBufferedChunk(20, 25, 20, 25), // in range
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        true,
+        bufferedSegments,
+      );
+
+      expect(result).toEqual({ start: 15, end: 20 });
+    });
+
+    it("should handle consecutive segments without gaps", () => {
+      const content = createMockContent();
+      const bufferedSegments = [
+        createBufferedChunk(10, 15, 10, 15),
+        createBufferedChunk(15, 20, 15, 20),
+        createBufferedChunk(20, 25, 20, 25),
+      ];
+
+      const result = checkForDiscontinuity(
+        content,
+        { start: 10, end: 30 },
+        null,
+        false,
+        bufferedSegments,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
+++ b/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import config from "../../../../../config";
+import getSegmentPriority from "../get_segment_priority";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+
+// Mock the config module
+vi.mock("../../../../../config", () => ({
+  default: {
+    getCurrent: vi.fn(),
+  },
+}));
+
+describe("getSegmentPriority", () => {
+  const mockGetCurrent = vi.mocked(config.getCurrent as any);
+
+  beforeEach(() => {
+    // Default configuration for most tests
+    mockGetCurrent.mockReturnValue({
+      SEGMENT_PRIORITIES_STEPS: [1, 5, 10, 20],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("priority based on distance from wanted timestamp", () => {
+    it("should return priority 0 for segments at the wanted timestamp", () => {
+      const result = getSegmentPriority(100, 100);
+      expect(result).toBe(0);
+    });
+
+    it("should return priority 0 for segments behind the wanted timestamp", () => {
+      const result = getSegmentPriority(50, 100);
+      expect(result).toBe(0);
+    });
+
+    it("should return priority 0 for segments slightly ahead (distance < first step)", () => {
+      const result = getSegmentPriority(100.5, 100);
+      expect(result).toBe(0);
+    });
+
+    it("should return priority 1 for distance within second step", () => {
+      // distance = 103 - 100 = 3, which is >= 1 but < 5
+      const result = getSegmentPriority(103, 100);
+      expect(result).toBe(1);
+    });
+
+    it("should return priority 2 for distance within third step", () => {
+      // distance = 107 - 100 = 7, which is >= 5 but < 10
+      const result = getSegmentPriority(107, 100);
+      expect(result).toBe(2);
+    });
+
+    it("should return priority 3 for distance within fourth step", () => {
+      // distance = 115 - 100 = 15, which is >= 10 but < 20
+      const result = getSegmentPriority(115, 100);
+      expect(result).toBe(3);
+    });
+
+    it("should return lowest priority (steps.length) for distance beyond all steps", () => {
+      // distance = 125 - 100 = 25, which is >= 20
+      const result = getSegmentPriority(125, 100);
+      expect(result).toBe(4); // SEGMENT_PRIORITIES_STEPS.length
+    });
+  });
+
+  describe("boundary conditions", () => {
+    it("should handle exact boundary values correctly", () => {
+      // distance exactly at step value should fall into next priority
+      expect(getSegmentPriority(101, 100)).toBe(1); // distance = 1
+      expect(getSegmentPriority(105, 100)).toBe(2); // distance = 5
+      expect(getSegmentPriority(110, 100)).toBe(3); // distance = 10
+      expect(getSegmentPriority(120, 100)).toBe(4); // distance = 20
+    });
+
+    it("should handle values just below boundaries", () => {
+      expect(getSegmentPriority(100.999, 100)).toBe(0); // distance = 0.999 < 1
+      expect(getSegmentPriority(104.999, 100)).toBe(1); // distance = 4.999 < 5
+      expect(getSegmentPriority(109.999, 100)).toBe(2); // distance = 9.999 < 10
+    });
+  });
+
+  describe("negative distances (segments behind wanted timestamp)", () => {
+    it("should always return priority 0 for any negative distance", () => {
+      expect(getSegmentPriority(50, 100)).toBe(0);
+      expect(getSegmentPriority(0, 100)).toBe(0);
+      expect(getSegmentPriority(99, 100)).toBe(0);
+    });
+  });
+
+  describe("different config values", () => {
+    it("should work with empty priority steps array", () => {
+      mockGetCurrent.mockReturnValue({
+        SEGMENT_PRIORITIES_STEPS: [],
+      });
+
+      const result = getSegmentPriority(100, 50);
+      expect(result).toBe(0); // steps.length = 0
+    });
+
+    it("should work with single priority step", () => {
+      mockGetCurrent.mockReturnValue({
+        SEGMENT_PRIORITIES_STEPS: [10],
+      });
+
+      expect(getSegmentPriority(105, 100)).toBe(0); // distance = 5 < 10
+      expect(getSegmentPriority(115, 100)).toBe(1); // distance = 15 >= 10
+    });
+
+    it("should work with different step values", () => {
+      mockGetCurrent.mockReturnValue({
+        SEGMENT_PRIORITIES_STEPS: [2, 10, 30, 60],
+      });
+
+      expect(getSegmentPriority(101, 100)).toBe(0); // distance = 1 < 2
+      expect(getSegmentPriority(105, 100)).toBe(1); // distance = 5, >= 2 but < 10
+      expect(getSegmentPriority(120, 100)).toBe(2); // distance = 20, >= 10 but < 30
+      expect(getSegmentPriority(145, 100)).toBe(3); // distance = 45, >= 30 but < 60
+      expect(getSegmentPriority(170, 100)).toBe(4); // distance = 70 >= 60
+    });
+  });
+
+  describe("config integration", () => {
+    it("should call config.getCurrent() to get priority steps", () => {
+      getSegmentPriority(100, 50);
+      expect(mockGetCurrent).toHaveBeenCalledOnce();
+    });
+
+    it("should get fresh config on each call", () => {
+      getSegmentPriority(100, 50);
+      getSegmentPriority(200, 150);
+      expect(mockGetCurrent).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/core/stream/representation/utils/__tests__/push_init_segment.test.ts
+++ b/src/core/stream/representation/utils/__tests__/push_init_segment.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import pushInitSegment from "../push_init_segment";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+const mockAppendSegmentToBuffer = vi.hoisted(() => vi.fn());
+
+vi.mock("../append_segment_to_buffer", () => ({
+  default: mockAppendSegmentToBuffer,
+}));
+
+describe("pushInitSegment", () => {
+  let mockPlaybackObserver: any;
+  let mockSegmentSink: any;
+  let mockBufferGoal: any;
+  let mockCancelSignal: any;
+  let mockContent: any;
+  let mockSegment: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockPlaybackObserver = {};
+
+    mockSegmentSink = {};
+
+    mockBufferGoal = {
+      getValue: vi.fn().mockReturnValue(30),
+    };
+
+    mockCancelSignal = {
+      signal: { aborted: false },
+      cancellationError: null,
+    };
+
+    mockContent = {
+      adaptation: { id: "adaptation-1" },
+      manifest: { id: "manifest-1" },
+      period: { id: "period-1" },
+      representation: {
+        id: "rep-1",
+        getMimeTypeString: vi.fn().mockReturnValue('video/mp4; codecs="avc1.42E01E"'),
+      },
+    };
+
+    mockSegment = {
+      id: "init-segment",
+      isInit: true,
+      time: 0,
+      duration: 0,
+    };
+  });
+
+  it("should call appendSegmentToBuffer with correct data structure", async () => {
+    mockAppendSegmentToBuffer.mockResolvedValue({
+      start: 0,
+      end: 10,
+    });
+
+    const initSegmentUniqueId = "unique-init-123";
+
+    await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId,
+        segmentData: null,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledTimes(1);
+
+    const callArgs = mockAppendSegmentToBuffer.mock.calls[0];
+    expect(callArgs[0]).toBe(mockPlaybackObserver);
+    expect(callArgs[1]).toBe(mockSegmentSink);
+    expect(callArgs[3]).toBe(mockBufferGoal);
+    expect(callArgs[4]).toBe(mockCancelSignal);
+
+    const { data, inventoryInfos } = callArgs[2];
+    expect(data).toEqual({
+      initSegmentUniqueId,
+      chunk: null,
+      timestampOffset: 0,
+      appendWindow: [undefined, undefined],
+      codec: 'video/mp4; codecs="avc1.42E01E"',
+    });
+
+    expect(inventoryInfos).toMatchObject({
+      segment: mockSegment,
+      chunkSize: undefined,
+      start: 0,
+      end: 0,
+      adaptation: mockContent.adaptation,
+      manifest: mockContent.manifest,
+      period: mockContent.period,
+      representation: mockContent.representation,
+    });
+  });
+
+  it("should return correct payload with buffered result", async () => {
+    const mockBuffered = { start: 0, end: 10 };
+    mockAppendSegmentToBuffer.mockResolvedValue(mockBuffered);
+
+    const result = await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId: "init-456",
+        segmentData: null,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    expect(result).toEqual({
+      content: mockContent,
+      segment: mockSegment,
+      buffered: mockBuffered,
+    });
+  });
+
+  it("should call getMimeTypeString on representation", async () => {
+    mockAppendSegmentToBuffer.mockResolvedValue({ start: 0, end: 0 });
+
+    await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId: "init-789",
+        segmentData: null,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockContent.representation.getMimeTypeString).toHaveBeenCalledTimes(1);
+  });
+
+  it("should set chunk to null for init segments", async () => {
+    mockAppendSegmentToBuffer.mockResolvedValue({});
+
+    await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId: "init-abc",
+        segmentData: { someData: "value" },
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    const { data } = mockAppendSegmentToBuffer.mock.calls[0][2];
+    expect(data.chunk).toBeNull();
+  });
+
+  it("should set timestampOffset to 0", async () => {
+    mockAppendSegmentToBuffer.mockResolvedValue({});
+
+    await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId: "init-def",
+        segmentData: null,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    const { data } = mockAppendSegmentToBuffer.mock.calls[0][2];
+    expect(data.timestampOffset).toBe(0);
+  });
+
+  it("should set appendWindow to [undefined, undefined]", async () => {
+    mockAppendSegmentToBuffer.mockResolvedValue({});
+
+    await pushInitSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        content: mockContent,
+        initSegmentUniqueId: "init-ghi",
+        segmentData: null,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+        bufferGoal: mockBufferGoal,
+      },
+      mockCancelSignal,
+    );
+
+    const { data } = mockAppendSegmentToBuffer.mock.calls[0][2];
+    expect(data.appendWindow).toEqual([undefined, undefined]);
+  });
+});

--- a/src/core/stream/representation/utils/__tests__/push_media_segment.test.ts
+++ b/src/core/stream/representation/utils/__tests__/push_media_segment.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CancellationSignal } from "../../../../../utils/task_canceller";
+import pushMediaSegment from "../push_media_segment";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+// Mock dependencies with vi.hoisted
+const mockGetCurrent = vi.hoisted(() => vi.fn());
+const mockObjectAssign = vi.hoisted(() => vi.fn());
+const mockAppendSegmentToBuffer = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../../../config", () => ({
+  default: {
+    getCurrent: mockGetCurrent,
+  },
+}));
+
+vi.mock("../../../../../utils/object_assign", () => ({
+  default: mockObjectAssign,
+}));
+
+vi.mock("../append_segment_to_buffer.ts", () => ({
+  default: mockAppendSegmentToBuffer,
+}));
+
+describe("pushMediaSegment", () => {
+  const mockPlaybackObserver = {} as any;
+  const mockBufferGoal = { getValue: () => 30 } as any;
+  const mockCancelSignal = {} as CancellationSignal;
+  const mockSegmentSink = {} as any;
+
+  const mockContent = {
+    adaptation: {} as any,
+    manifest: {} as any,
+    period: {} as any,
+    representation: {
+      getMimeTypeString: vi.fn(() => 'video/mp4; codecs="avc1.42E01E"'),
+    } as any,
+  };
+
+  const mockSegment = {
+    time: 10,
+    duration: 5,
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrent.mockReturnValue({
+      APPEND_WINDOW_SECURITIES: {
+        START: 0.1,
+        END: 0.2,
+      },
+    });
+    mockObjectAssign.mockImplementation((target, ...sources) =>
+      // eslint-disable-next-line no-restricted-properties
+      Object.assign(target, ...sources),
+    );
+  });
+
+  it("should return null when chunkData is null", async () => {
+    const parsedSegment: any = {
+      chunkData: null,
+      chunkInfos: null,
+      chunkOffset: 0,
+      chunkSize: 0,
+      appendWindow: [undefined, undefined] as [number | undefined, number | undefined],
+    };
+
+    const result = await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(result).toBeNull();
+    expect(mockAppendSegmentToBuffer).not.toHaveBeenCalled();
+  });
+
+  it("should append segment with basic data when chunkData is present", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: null,
+      chunkOffset: 2.5,
+      chunkSize: 1024,
+      appendWindow: [undefined, undefined] as [number | undefined, number | undefined],
+    };
+
+    const mockBuffered = [{ start: 10, end: 15 }];
+    mockAppendSegmentToBuffer.mockResolvedValue(mockBuffered);
+
+    const result = await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      mockPlaybackObserver,
+      mockSegmentSink,
+      {
+        data: {
+          initSegmentUniqueId: "init-123",
+          chunk: mockChunkData,
+          timestampOffset: 2.5,
+          appendWindow: [undefined, undefined],
+          codec: 'video/mp4; codecs="avc1.42E01E"',
+        },
+        inventoryInfos: expect.objectContaining({
+          segment: mockSegment,
+          chunkSize: 1024,
+          start: 10,
+          end: 15,
+        }),
+      },
+      mockBufferGoal,
+      mockCancelSignal,
+    );
+
+    expect(result).toEqual({
+      content: mockContent,
+      segment: mockSegment,
+      buffered: mockBuffered,
+    });
+  });
+
+  it("should use chunkInfos for time calculations when available", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: { time: 20, duration: 8 },
+      chunkOffset: 0,
+      chunkSize: 2048,
+      appendWindow: [undefined, undefined] as [number | undefined, number | undefined],
+    };
+
+    mockAppendSegmentToBuffer.mockResolvedValue([]);
+
+    await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: null,
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        inventoryInfos: expect.objectContaining({
+          start: 20,
+          end: 28,
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("should apply append window securities to start window", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: null,
+      chunkOffset: 0,
+      chunkSize: 1024,
+      appendWindow: [5, undefined] as [number | undefined, number | undefined],
+    };
+
+    mockAppendSegmentToBuffer.mockResolvedValue([]);
+
+    await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          appendWindow: [4.9, undefined], // 5 - 0.1
+        }),
+        inventoryInfos: expect.objectContaining({
+          start: 10, // max(10, 4.9)
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("should apply append window securities to end window", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: null,
+      chunkOffset: 0,
+      chunkSize: 1024,
+      appendWindow: [undefined, 20] as [number | undefined, number | undefined],
+    };
+
+    mockAppendSegmentToBuffer.mockResolvedValue([]);
+
+    await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          appendWindow: [undefined, 20.2], // 20 + 0.2
+        }),
+        inventoryInfos: expect.objectContaining({
+          end: 15, // min(15, 20.2)
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("should apply both start and end append windows", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: { time: 8, duration: 4 },
+      chunkOffset: 0,
+      chunkSize: 1024,
+      appendWindow: [9, 11] as [number | undefined, number | undefined],
+    };
+
+    mockAppendSegmentToBuffer.mockResolvedValue([]);
+
+    await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          appendWindow: [8.9, 11.2], // [9 - 0.1, 11 + 0.2]
+        }),
+        inventoryInfos: expect.objectContaining({
+          start: 8.9, // max(8, 8.9)
+          end: 11.2, // min(12, 11.2)
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("should not go below 0 for start append window", async () => {
+    const mockChunkData = new Uint8Array([1, 2, 3]);
+    const parsedSegment: any = {
+      chunkData: mockChunkData,
+      chunkInfos: null,
+      chunkOffset: 0,
+      chunkSize: 1024,
+      appendWindow: [0.05, undefined] as [number | undefined, number | undefined],
+    };
+
+    mockAppendSegmentToBuffer.mockResolvedValue([]);
+
+    await pushMediaSegment(
+      {
+        playbackObserver: mockPlaybackObserver,
+        bufferGoal: mockBufferGoal,
+        content: mockContent,
+        initSegmentUniqueId: "init-123",
+        parsedSegment,
+        segment: mockSegment,
+        segmentSink: mockSegmentSink,
+      },
+      mockCancelSignal,
+    );
+
+    expect(mockAppendSegmentToBuffer).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          appendWindow: [0, undefined], // max(0, 0.05 - 0.1)
+        }),
+      }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/src/manifest/classes/index.ts
+++ b/src/manifest/classes/index.ts
@@ -21,6 +21,7 @@ import Manifest from "./manifest";
 import Period from "./period";
 import type { IThumbnailTrack } from "./period";
 import Representation from "./representation";
+import type { IRepresentationProtectionData } from "./representation";
 import type {
   IMetaPlaylistPrivateInfos,
   IPrivateInfos,
@@ -41,6 +42,7 @@ export type {
   IManifestParsingOptions,
   IMetaPlaylistPrivateInfos,
   IRepresentationIndex,
+  IRepresentationProtectionData,
   IPrivateInfos,
   ISegment,
   IThumbnailTrack,


### PR DESCRIPTION
In an attempt to see how llm could be useful in a non-risky way, this mostly adds a lot of unit tests (I begin with this because we can just remove if it proves to be badly-written and/or hard to maintain).

I heavily looked at its output and updated them, and I did not open the "agentic" door yet. I just did a basic, one shot: "here's a file in isolation, try writing vitest unit tests for it, also, do you see issues in that original file?".
The tests it wrote were initially broken in interesting places, because it was almost always for cases where our code's semantic seems "unnatural" (e.g. `bufferGap` to `Infinity` being synonymous with `0`, where it does make more sense to mean the reverse when thinking about it without looking at the code).

I fixed them myself.

It did not see any issue for now.

---

I also updated the `RepresentationStream` a little by moving out a part of its code that was easily testable.
This one actually came from another refacto I was doing at the same time, but as it was minimal and easy to add unit tests for, I added it there. It shouldn't change the behavior.