### PR TITLE
Harmonize --no-type-check flag

### DIFF
--- a/scripts/generate_build.mjs
+++ b/scripts/generate_build.mjs
@@ -181,7 +181,7 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
         devMode = true;
         break;
       case "-n":
-      case "--no-check":
+      case "--no-typecheck":
         noCheck = true;
         break;
       case "--no-wasm":
@@ -225,7 +225,7 @@ Usage: node generate_build.mjs [OPTIONS]
 Options:
   -h, --help             Display this help
   -d, --dev-mode         Build all files in development mode (more runtime checks, worker not minified)
-  -n, --no-check         Skip type checking for inputed files.
+  -n, --no-typecheck     Skip type checking for inputed files.
   --no-wasm              Skip WebAssembly file generation (avoid Rust toolchain installation).
                          WARNING: With this option, related JS exports will not be available.`,
   );

--- a/scripts/make_all_builds.sh
+++ b/scripts/make_all_builds.sh
@@ -39,7 +39,7 @@ npm run bundle
 npm run bundle:min
 
 if [[ -n "$NO_TYPECHECK" ]]; then
-  npm run build -- --no-check
+  npm run build -- --no-typecheck
 else
   npm run build
 fi


### PR DESCRIPTION
Some script (`make_all_builds.sh`) relied on a flag called `--no-typecheck`, another `generate_build.mjs` relied on `--no-check` for the same thing.

I here rely on `--no-type-check` for both to simplify.