### PR TITLE
feat: add `getMaximumPosition` and `getMinimumPosition` support when using directfile with HLS playlist on safari

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2825,6 +2825,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     if (isDirectFile) {
       if (this.videoElement === null) {
+        log.error("API", "getMaximumPosition() called on a disposed player");
         return null;
       }
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2825,7 +2825,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     if (isDirectFile) {
       if (this.videoElement === null) {
-        throw new Error("Disposed player");
+        return null;
       }
 
       if (this.videoElement.seekable.length > 0) {

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2820,6 +2820,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (this.videoElement === null) {
         throw new Error("Disposed player");
       }
+
+      if (this.videoElement.seekable.length > 0) {
+        return this.videoElement.seekable.end(this.videoElement.seekable.length - 1);
+      }
+      // if for some reason seekable has no entry, fallback on duration
       return this.videoElement.duration;
     }
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -3526,6 +3526,22 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       if (startDate !== undefined) {
         positionData.wallClockTime = startDate + observation.position.getPolled();
       }
+
+      let directFileMaximumPosition;
+      if (this.videoElement.seekable.length > 0) {
+        directFileMaximumPosition = this.videoElement.seekable.end(
+          this.videoElement.seekable.length - 1,
+        );
+      }
+
+      if (directFileMaximumPosition !== undefined && !isNaN(directFileMaximumPosition)) {
+        positionData.maximumPosition = directFileMaximumPosition;
+        // infinity duration means the content is live
+        if (this.videoElement.duration === Infinity) {
+          positionData.liveGap =
+            directFileMaximumPosition - this.videoElement.currentTime;
+        }
+      }
     }
     this.trigger("positionUpdate", positionData);
   }

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -2772,6 +2772,13 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     }
 
     if (this._priv_contentInfos.isDirectFile) {
+      if (this.videoElement === null) {
+        log.error("API", "getMinimumPosition() called on a disposed player");
+        return 0;
+      }
+      if (this.videoElement.seekable.length > 0) {
+        return this.videoElement.seekable.start(0);
+      }
       return 0;
     }
 


### PR DESCRIPTION
add `getMaximumPosition` and `getMinimumPosition` support when using directfile with HLS playlist on safari
this also add `maximumPosition` and `liveGap` in the `positionUpdate` event.