### PR TITLE
Add `core/entry` unit tests, fix rare scenario when an ended live audio content would not have its duration known until the end-of-stream

### DIFF
--- a/src/core/adaptive/__tests__/guess_based_chooser.test.ts
+++ b/src/core/adaptive/__tests__/guess_based_chooser.test.ts
@@ -593,7 +593,7 @@ describe("GuessBasedChooser", () => {
       });
 
       it("should stop guess when estimated bandwidth is too low", () => {
-        vi.mocked(mocks.estimateRequestBandwidth).mockReturnValue(700000); // 70% of bitrate
+        mocks.estimateRequestBandwidth.mockReturnValue(700000); // 70% of bitrate
 
         const requests = [createRequest("rep-3", 2, 9000, false)];
 

--- a/src/core/entry/FreezeResolver.ts
+++ b/src/core/entry/FreezeResolver.ts
@@ -1,4 +1,4 @@
-import { config } from "../../experimental";
+import config from "../../config";
 import log from "../../log";
 import type { IAdaptation, IPeriod, IRepresentation } from "../../manifest";
 import type {

--- a/src/core/entry/__tests__/FreezeResolver.test.ts
+++ b/src/core/entry/__tests__/FreezeResolver.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import type SegmentSinksStore from "../../segment_sinks";
+import type { IBufferedChunk } from "../../segment_sinks";
+import FreezeResolver from "../FreezeResolver";
+import type { IFreezeResolverObservation } from "../FreezeResolver";
+
+const {
+  mockGetCurrent,
+  mockLogInfo,
+  mockLogWarn,
+  mockLogDebug,
+  mockGetMonotonicTimeStamp,
+} = vi.hoisted(() => ({
+  mockGetCurrent: vi.fn(() => ({
+    UNFREEZING_SEEK_DELAY: 3000,
+    UNFREEZING_DELTA_POSITION: 0.001,
+    FREEZING_FLUSH_FAILURE_DELAY: {
+      MINIMUM: 1000,
+      MAXIMUM: 10000,
+      POSITION_DELTA: 0.1,
+    },
+  })),
+  mockLogInfo: vi.fn(),
+  mockLogWarn: vi.fn(),
+  mockLogDebug: vi.fn(),
+  mockGetMonotonicTimeStamp: vi.fn(),
+}));
+
+vi.mock("../../../config", () => ({
+  default: {
+    getCurrent: mockGetCurrent,
+  },
+}));
+
+vi.mock("../../../log", () => ({
+  default: {
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    debug: mockLogDebug,
+  },
+}));
+
+vi.mock("../../../utils/monotonic_timestamp", () => ({
+  default: mockGetMonotonicTimeStamp,
+}));
+
+describe("FreezeResolver", () => {
+  let freezeResolver: FreezeResolver;
+  let mockSegmentSinksStore: SegmentSinksStore;
+  let mockTimestamp: number;
+
+  const createMockObservation = (
+    overrides: Partial<IFreezeResolverObservation> = {},
+  ): IFreezeResolverObservation => ({
+    readyState: 4,
+    rebuffering: null,
+    freezing: null,
+    bufferGap: 10,
+    position: {
+      getPolled: () => 100,
+    } as any,
+    fullyLoaded: false,
+    ...overrides,
+  });
+
+  const createMockSegmentSinksStore = (): SegmentSinksStore =>
+    ({
+      getStatus: vi.fn(() => ({
+        type: "initialized",
+        value: {
+          getLastKnownInventory: vi.fn(() => []),
+        },
+      })),
+    }) as any;
+
+  beforeEach(() => {
+    mockTimestamp = 10000;
+    mockGetMonotonicTimeStamp.mockImplementation(() => mockTimestamp);
+    mockSegmentSinksStore = createMockSegmentSinksStore();
+    freezeResolver = new FreezeResolver(mockSegmentSinksStore);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("onNewObservation - No freeze scenarios", () => {
+    it("should return null when playback is not frozen", () => {
+      const observation = createMockObservation({
+        readyState: 4,
+        freezing: null,
+        rebuffering: null,
+      });
+      const result = freezeResolver.onNewObservation(observation);
+      expect(result).toBeNull();
+    });
+
+    it("should return null when readyState is 1 but buffer gap is too small", () => {
+      const observation = createMockObservation({
+        readyState: 1,
+        bufferGap: 3, // Less than MINIMUM_BUFFER_GAP_AT_READY_STATE_1_BEFORE_FREEZING (6)
+        freezing: null,
+        rebuffering: null,
+        fullyLoaded: false,
+      });
+      const result = freezeResolver.onNewObservation(observation);
+      expect(result).toBeNull();
+    });
+
+    it("should ignore freeze when within ignore period", () => {
+      const observation1 = createMockObservation({
+        freezing: { timestamp: mockTimestamp },
+      });
+
+      // First observation triggers a flush
+      mockTimestamp = 10000;
+      freezeResolver.onNewObservation(observation1);
+      mockTimestamp = 13100; // Within UNFREEZING_SEEK_DELAY
+
+      const result = freezeResolver.onNewObservation(observation1);
+      expect(result).not.toBeNull();
+
+      // Second observation within ignore period
+      mockTimestamp = 13200; // Still within MINIMUM_TIME_BETWEEN_FREEZE_HANDLING (6000ms from flush)
+      const observation2 = createMockObservation({
+        freezing: { timestamp: 13200 },
+      });
+
+      const result2 = freezeResolver.onNewObservation(observation2);
+      expect(result2).toBeNull();
+    });
+  });
+
+  describe("onNewObservation - Freeze detection", () => {
+    it("should detect freeze when freezing status is set", () => {
+      const observation = createMockObservation({
+        freezing: { timestamp: mockTimestamp - 4000 },
+        bufferGap: 10,
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+
+      expect(result).not.toBeNull();
+      expect(mockLogInfo).toHaveBeenCalledWith(
+        "Freeze",
+        "Freeze detected",
+        expect.any(Object),
+      );
+    });
+
+    it("should detect freeze when readyState is 1 with sufficient buffer", () => {
+      const observation = createMockObservation({
+        readyState: 1,
+        bufferGap: 8, // Greater than MINIMUM_BUFFER_GAP_AT_READY_STATE_1_BEFORE_FREEZING
+        rebuffering: {
+          timestamp: mockTimestamp - 4000,
+          reason: "not-ready",
+          position: undefined,
+        },
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+      expect(result).not.toBeNull();
+    });
+
+    it("should detect freeze when fully loaded with readyState 1", () => {
+      const observation = createMockObservation({
+        readyState: 1,
+        bufferGap: 2,
+        fullyLoaded: true,
+        rebuffering: {
+          timestamp: mockTimestamp - 4000,
+          reason: "not-ready",
+          position: undefined,
+        },
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+      expect(result).not.toBeNull();
+    });
+  });
+
+  describe("onNewObservation - Flush strategy", () => {
+    it("should return flush resolution after freeze delay", () => {
+      const freezeTimestamp = mockTimestamp - 4000;
+      const observation = createMockObservation({
+        freezing: { timestamp: freezeTimestamp },
+        position: { getPolled: () => 100 } as any,
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+
+      expect(result).toEqual({
+        type: "flush",
+        value: { relativeSeek: 0.001 },
+      });
+      expect(mockLogDebug).toHaveBeenCalledWith("Freeze", "Trying to flush to un-freeze");
+    });
+
+    it("should not flush before UNFREEZING_SEEK_DELAY has passed", () => {
+      const freezeTimestamp = mockTimestamp - 2000; // Less than UNFREEZING_SEEK_DELAY (3000)
+      const observation = createMockObservation({
+        freezing: { timestamp: freezeTimestamp },
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("onNewObservation - Decipherability checks", () => {
+    it("should reload when buffer has undecipherable data", () => {
+      const mockSegment: IBufferedChunk = {
+        infos: {
+          representation: {
+            decipherable: false,
+            uniqueId: "rep1",
+          } as any,
+        },
+        start: 90,
+        end: 110,
+      } as any;
+
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment]),
+            },
+          }) as any,
+      );
+
+      const observation = createMockObservation({
+        rebuffering: {
+          timestamp: mockTimestamp - 5000,
+          reason: "not-ready",
+          position: undefined,
+        },
+        readyState: 1,
+        bufferGap: 8,
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+
+      expect(result).toEqual({
+        type: "reload",
+        value: null,
+      });
+      expect(mockLogWarn).toHaveBeenCalledWith(
+        "Freeze",
+        expect.stringContaining("undecipherable segments"),
+      );
+    });
+
+    it("should first flush when frozen with only decipherable encrypted data", () => {
+      const mockSegment: IBufferedChunk = {
+        infos: {
+          representation: {
+            decipherable: true,
+            uniqueId: "rep1",
+          } as any,
+        },
+        start: 90,
+        end: 110,
+      } as any;
+
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment]),
+            },
+          }) as any,
+      );
+
+      const observation = createMockObservation({
+        rebuffering: {
+          timestamp: mockTimestamp - 5000,
+          reason: "not-ready",
+          position: undefined,
+        },
+        readyState: 1,
+        bufferGap: 8,
+      });
+
+      const result = freezeResolver.onNewObservation(observation);
+      expect(result).toEqual({
+        type: "flush",
+        value: {
+          relativeSeek: 0.001,
+        },
+      });
+    });
+  });
+
+  describe("onNewObservation - Failed flush handling", () => {
+    it("should reload when flush fails and no representation change detected", () => {
+      // First: trigger a flush
+      mockTimestamp = 10000;
+      const observation1 = createMockObservation({
+        freezing: { timestamp: 6000 },
+        position: { getPolled: () => 100 } as any,
+      });
+
+      const flushResult = freezeResolver.onNewObservation(observation1);
+      expect(flushResult?.type).toBe("flush");
+
+      // Second: still frozen after flush, need to wait beyond the ignore period
+      // MINIMUM_TIME_BETWEEN_FREEZE_HANDLING is 6000ms
+      mockTimestamp = 17500; // 7500ms after flush, beyond ignore period (16000 + 1500)
+      const observation2 = createMockObservation({
+        freezing: { timestamp: 17500 },
+        position: { getPolled: () => 100.001 } as any, // Very close to flush position
+      });
+
+      const result = freezeResolver.onNewObservation(observation2);
+
+      expect(result).toEqual({
+        type: "reload",
+        value: null,
+      });
+    });
+
+    it("should avoid representation when freeze happens on representation switch", () => {
+      const mockSegment1: IBufferedChunk = {
+        infos: {
+          representation: { uniqueId: "rep1", bitrate: 1000000 } as any,
+          adaptation: { id: "video-ada" } as any,
+          period: { id: "period1" } as any,
+        },
+        start: 90,
+        end: 100,
+        bufferedStart: 90,
+        bufferedEnd: 100,
+      } as any;
+
+      const mockSegment2: IBufferedChunk = {
+        infos: {
+          representation: { uniqueId: "rep2", bitrate: 2000000 } as any,
+          adaptation: { id: "video-ada" } as any,
+          period: { id: "period1" } as any,
+        },
+        start: 100,
+        end: 110,
+        bufferedStart: 100,
+        bufferedEnd: 110,
+      } as any;
+
+      // Build history with representation switch
+      mockTimestamp = 10000;
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment1]),
+            },
+          }) as any,
+      );
+      freezeResolver.onNewObservation(
+        createMockObservation({ position: { getPolled: () => 95 } as any }),
+      );
+
+      mockTimestamp = 11000;
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment2]),
+            },
+          }) as any,
+      );
+      freezeResolver.onNewObservation(
+        createMockObservation({ position: { getPolled: () => 105 } as any }),
+      );
+
+      // Trigger flush
+      mockTimestamp = 15000;
+      const observation1 = createMockObservation({
+        freezing: { timestamp: 11000 }, // Frozen for 4000ms
+        position: { getPolled: () => 105 } as any,
+      });
+      const flushResult = freezeResolver.onNewObservation(observation1);
+      expect(flushResult?.type).toBe("flush");
+
+      // Still frozen after flush, need to wait beyond ignore period (6000ms from flush at 15000 = 21000)
+      mockTimestamp = 22000;
+      const observation2 = createMockObservation({
+        freezing: { timestamp: 22000 },
+        position: { getPolled: () => 105.001 } as any,
+      });
+
+      const result = freezeResolver.onNewObservation(observation2);
+
+      expect(result).toEqual({
+        type: "avoid-representations",
+        value: expect.arrayContaining([
+          expect.objectContaining({
+            representation: expect.objectContaining({ uniqueId: "rep2" }),
+          }),
+        ]),
+      });
+    });
+
+    it("should reload when freeze happens on period switch", () => {
+      const mockSegment1: IBufferedChunk = {
+        infos: {
+          representation: { uniqueId: "rep1" } as any,
+          adaptation: { id: "video-ada" } as any,
+          period: { id: "period1" } as any,
+        },
+        start: 90,
+        end: 100,
+        bufferedStart: 90,
+        bufferedEnd: 100,
+      } as any;
+
+      const mockSegment2: IBufferedChunk = {
+        infos: {
+          representation: { uniqueId: "rep2" } as any,
+          adaptation: { id: "video-ada" } as any,
+          period: { id: "period2" } as any, // Different period
+        },
+        start: 100,
+        end: 110,
+        bufferedStart: 100,
+        bufferedEnd: 110,
+      } as any;
+
+      // Build history with period switch
+      mockTimestamp = 10000;
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment1]),
+            },
+          }) as any,
+      );
+      freezeResolver.onNewObservation(
+        createMockObservation({ position: { getPolled: () => 95 } as any }),
+      );
+
+      mockTimestamp = 11000;
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment2]),
+            },
+          }) as any,
+      );
+      freezeResolver.onNewObservation(
+        createMockObservation({ position: { getPolled: () => 105 } as any }),
+      );
+
+      // Trigger flush
+      mockTimestamp = 15000;
+      const flushResult = freezeResolver.onNewObservation(
+        createMockObservation({
+          freezing: { timestamp: 11000 }, // Frozen for 4000ms
+          position: { getPolled: () => 105 } as any,
+        }),
+      );
+      expect(flushResult?.type).toBe("flush");
+
+      // Still frozen after flush, need to wait beyond ignore period (6000ms from flush at 15000 = 21000)
+      mockTimestamp = 22000;
+      const result = freezeResolver.onNewObservation(
+        createMockObservation({
+          freezing: { timestamp: 22000 },
+          position: { getPolled: () => 105.001 } as any,
+        }),
+      );
+
+      expect(result).toEqual({
+        type: "reload",
+        value: null,
+      });
+    });
+  });
+
+  describe("History management", () => {
+    it("should maintain segment history for audio and video", () => {
+      const mockSegment: IBufferedChunk = {
+        infos: {
+          representation: { uniqueId: "rep1" } as any,
+        },
+        start: 90,
+        bufferedStart: 90,
+        end: 110,
+        bufferedEnd: 110,
+      } as any;
+
+      mockSegmentSinksStore.getStatus = vi.fn(
+        () =>
+          ({
+            type: "initialized",
+            value: {
+              getLastKnownInventory: vi.fn(() => [mockSegment]),
+            },
+          }) as any,
+      );
+
+      const observation = createMockObservation({
+        position: { getPolled: () => 100 } as any,
+      });
+
+      freezeResolver.onNewObservation(observation);
+
+      // Verify history is tracked (implicitly tested through representation avoidance)
+      expect(mockSegmentSinksStore.getStatus).toHaveBeenCalledWith("audio");
+      expect(mockSegmentSinksStore.getStatus).toHaveBeenCalledWith("video");
+    });
+
+    it("should limit history to 100 entries per track type", () => {
+      // Create many observations to exceed history limit
+      for (let i = 0; i < 150; i++) {
+        mockTimestamp += 100;
+        freezeResolver.onNewObservation(
+          createMockObservation({
+            position: { getPolled: () => i } as any,
+          }),
+        );
+      }
+
+      // The test passes if no errors are thrown
+      // History should be limited internally
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/src/core/entry/__tests__/FreezeResolver.test.ts
+++ b/src/core/entry/__tests__/FreezeResolver.test.ts
@@ -4,6 +4,10 @@ import type { IBufferedChunk } from "../../segment_sinks";
 import FreezeResolver from "../FreezeResolver";
 import type { IFreezeResolverObservation } from "../FreezeResolver";
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+
 const {
   mockGetCurrent,
   mockLogInfo,

--- a/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
+++ b/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
@@ -1,0 +1,880 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import ContentTimeBoundariesObserver from "../content_time_boundaries_observer";
+import { IBufferType } from "../../segment_sinks";
+
+// Hoisted mocks
+const {
+  mockTrigger,
+  mockCancellerSignal,
+  mockCanceller,
+  mockPlaybackObserverListen,
+  mockManifestEventListener,
+  mockGetMinimumSafePosition,
+  mockGetMaximumSafePosition,
+  mockGetLastAvailablePosition,
+  mockGetEnd,
+} = vi.hoisted(() => ({
+  mockTrigger: vi.fn(),
+  mockCancellerSignal: { isCancelled: vi.fn(() => false) },
+  mockCanceller: {
+    signal: { isCancelled: vi.fn(() => false) },
+    isUsed: vi.fn(() => false),
+    cancel: vi.fn(),
+  },
+  mockPlaybackObserverListen: vi.fn(),
+  mockManifestEventListener: vi.fn(),
+  mockGetMinimumSafePosition: vi.fn(() => 0),
+  mockGetMaximumSafePosition: vi.fn((): number | undefined => 100),
+  mockGetLastAvailablePosition: vi.fn(),
+  mockGetEnd: vi.fn(),
+}));
+
+vi.mock("../../../utils/event_emitter", () => ({
+  default: class EventEmitter {
+    trigger = mockTrigger;
+    removeEventListener = vi.fn();
+    addEventListener = vi.fn();
+  },
+}));
+
+vi.mock("../../../utils/task_canceller", () => ({
+  default: class TaskCanceller {
+    signal = mockCancellerSignal;
+    isUsed = mockCanceller.isUsed;
+    cancel = mockCanceller.cancel;
+  },
+}));
+
+vi.mock("../../../utils/queue_microtask", () => ({
+  default: (fn: () => void) => fn(),
+}));
+
+vi.mock("../../../utils/sorted_list", () => ({
+  default: class SortedList<T> {
+    private items: T[] = [];
+    constructor(private compareFn: (a: T, b: T) => number) {}
+    add(item: T) {
+      this.items.push(item);
+      this.items.sort(this.compareFn);
+    }
+    has(item: T) {
+      return this.items.includes(item);
+    }
+    removeElement(item: T) {
+      const index = this.items.indexOf(item);
+      if (index > -1) this.items.splice(index, 1);
+    }
+    toArray() {
+      return [...this.items];
+    }
+  },
+}));
+
+describe("ContentTimeBoundariesObserver", () => {
+  const createMockManifest = (overrides = {}): any => ({
+    periods: [],
+    isLastPeriodKnown: false,
+    isDynamic: false,
+    getMinimumSafePosition: mockGetMinimumSafePosition,
+    getMaximumSafePosition: mockGetMaximumSafePosition,
+    addEventListener: mockManifestEventListener,
+    ...overrides,
+  });
+
+  const createMockPlaybackObserver = (): any => ({
+    listen: mockPlaybackObserverListen,
+  });
+
+  const createMockPeriod = (id: string, start: number = 0): any => ({
+    id,
+    start,
+    duration: 10,
+    end: start + 10,
+  });
+
+  const createMockAdaptation = (representations: any[] = []): any => ({
+    id: "adaptation-1",
+    representations,
+  });
+
+  const createMockRepresentation = (): any => ({
+    id: "representation-1",
+    index: {
+      getLastAvailablePosition: mockGetLastAvailablePosition,
+      getEnd: mockGetEnd,
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMinimumSafePosition.mockReturnValue(0);
+    mockGetMaximumSafePosition.mockReturnValue(100);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("should initialize and set up playback observer", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const bufferTypes: IBufferType[] = ["audio", "video"];
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, bufferTypes);
+
+      expect(mockPlaybackObserverListen).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          includeLastObservation: false,
+          clearSignal: mockCancellerSignal,
+        }),
+      );
+    });
+
+    it("should set up manifest event listener", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+
+      expect(mockManifestEventListener).toHaveBeenCalledWith(
+        "manifestUpdate",
+        expect.any(Function),
+        mockCancellerSignal,
+      );
+    });
+
+    it("should trigger warning when position is before manifest minimum", () => {
+      mockGetMinimumSafePosition.mockReturnValue(10);
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+
+      const positionCallback = mockPlaybackObserverListen.mock.calls[0][0];
+      positionCallback({ position: { getWanted: () => 5 } });
+
+      expect(mockTrigger).toHaveBeenCalledWith("warning", expect.any(Object));
+      const warning = mockTrigger.mock.calls[0][1];
+      expect(warning.code).toBe("MEDIA_TIME_BEFORE_MANIFEST");
+    });
+
+    it("should trigger warning when position is after manifest maximum", () => {
+      mockGetMaximumSafePosition.mockReturnValue(100);
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+
+      const positionCallback = mockPlaybackObserverListen.mock.calls[0][0];
+      positionCallback({ position: { getWanted: () => 150 } });
+
+      expect(mockTrigger).toHaveBeenCalledWith("warning", expect.any(Object));
+      const warning = mockTrigger.mock.calls[0][1];
+      expect(warning.code).toBe("MEDIA_TIME_AFTER_MANIFEST");
+    });
+  });
+
+  describe("getCurrentEndingTime", () => {
+    it("should return ending position when manifest is not dynamic", () => {
+      mockGetMaximumSafePosition.mockReturnValue(100);
+      const manifest = createMockManifest({ isDynamic: false });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      const result = observer.getCurrentEndingTime();
+
+      expect(result).toEqual({
+        isEnd: true,
+        endingPosition: 100,
+      });
+    });
+
+    it("should return isEnd: true when ending position is determined for dynamic content", () => {
+      const representation = createMockRepresentation();
+      mockGetEnd.mockReturnValue(100);
+      const adaptation = createMockAdaptation([representation]);
+      const period = createMockPeriod("period-1");
+      const manifest = createMockManifest({
+        isDynamic: true,
+        isLastPeriodKnown: true,
+        periods: [period],
+      });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onAdaptationChange("audio", period, adaptation);
+
+      const result = observer.getCurrentEndingTime();
+
+      expect(result).toEqual({
+        isEnd: true,
+        endingPosition: 100,
+      });
+    });
+
+    it("should return isEnd: false when ending position is undetermined for non-dynamic content", () => {
+      mockGetMaximumSafePosition.mockReturnValue(undefined);
+      const manifest = createMockManifest({ isDynamic: false });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      const result = observer.getCurrentEndingTime();
+
+      expect(result).toEqual({
+        isEnd: false,
+        endingPosition: undefined,
+      });
+    });
+
+    it("should return isEnd: false when ending position is undetermined for dynamic content", () => {
+      const representation = createMockRepresentation();
+      mockGetEnd.mockReturnValue(100);
+      const adaptation = createMockAdaptation([representation]);
+      const period = createMockPeriod("period-1");
+      const manifest = createMockManifest({
+        isDynamic: true,
+        isLastPeriodKnown: false,
+        periods: [period],
+      });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onAdaptationChange("audio", period, adaptation);
+
+      const result = observer.getCurrentEndingTime();
+
+      expect(result).toEqual({
+        isEnd: false,
+        endingPosition: 100,
+      });
+    });
+  });
+
+  describe("onAdaptationChange", () => {
+    it("should trigger endingPositionChange for audio adaptation on last period", () => {
+      const representation = createMockRepresentation();
+      mockGetLastAvailablePosition.mockReturnValue(80);
+      const adaptation = createMockAdaptation([representation]);
+      const period = createMockPeriod("period-1");
+      const manifest = createMockManifest({
+        isLastPeriodKnown: true,
+        periods: [period],
+      });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onAdaptationChange("audio", period, adaptation);
+
+      expect(mockTrigger).toHaveBeenCalledWith(
+        "endingPositionChange",
+        expect.objectContaining({
+          endingPosition: expect.any(Number),
+        }),
+      );
+    });
+
+    it("should trigger endingPositionChange for video adaptation on last period", () => {
+      const representation = createMockRepresentation();
+      mockGetLastAvailablePosition.mockReturnValue(90);
+      const adaptation = createMockAdaptation([representation]);
+      const period = createMockPeriod("period-1");
+      const manifest = createMockManifest({
+        isLastPeriodKnown: true,
+        periods: [period],
+      });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "video",
+      ]);
+
+      observer.onAdaptationChange("video", period, adaptation);
+
+      expect(mockTrigger).toHaveBeenCalledWith(
+        "endingPositionChange",
+        expect.objectContaining({
+          endingPosition: expect.any(Number),
+        }),
+      );
+    });
+
+    it("should not trigger events after canceller is used", () => {
+      mockCanceller.isUsed.mockReturnValue(true);
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period = createMockPeriod("period-1");
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      mockTrigger.mockClear();
+      observer.onAdaptationChange("audio", period, null);
+
+      // Only manifestUpdate related triggers should have been called
+      const periodChangeCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "periodChange",
+      );
+      expect(periodChangeCalls).toHaveLength(0);
+    });
+
+    it("should calculate minimum of audio and video positions", () => {
+      const audioRep = createMockRepresentation();
+      const videoRep = createMockRepresentation();
+      let i = 0;
+      mockGetLastAvailablePosition.mockImplementation(() => {
+        i++;
+        return (10 - i) * 10;
+      });
+
+      const audioAdaptation = createMockAdaptation([audioRep]);
+      const videoAdaptation = createMockAdaptation([videoRep]);
+      const period = createMockPeriod("period-1");
+      const manifest = createMockManifest({
+        isLastPeriodKnown: true,
+        periods: [period],
+      });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+        "video",
+      ]);
+
+      observer.onAdaptationChange("audio", period, audioAdaptation);
+      observer.onAdaptationChange("video", period, videoAdaptation);
+
+      const result = observer.getCurrentEndingTime();
+
+      expect(result.endingPosition).toBe(60);
+      expect(i).toEqual(4);
+    });
+  });
+
+  describe("onRepresentationChange", () => {
+    it("should add period to active periods", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period1 = createMockPeriod("period-1", 0);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onRepresentationChange("audio", period1);
+
+      // Should trigger periodChange when period becomes active across all buffer types
+      expect(mockTrigger).toHaveBeenCalledWith("periodChange", period1);
+    });
+  });
+
+  describe("onPeriodCleared", () => {
+    it("should remove period from active periods", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period1 = createMockPeriod("period-1", 0);
+      const period2 = createMockPeriod("period-2", 10);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onRepresentationChange("audio", period1);
+      observer.onRepresentationChange("audio", period2);
+
+      mockTrigger.mockClear();
+
+      observer.onPeriodCleared("audio", period1);
+
+      // Should trigger periodChange for period2
+      expect(mockTrigger).toHaveBeenCalledWith("periodChange", period2);
+    });
+
+    it("should handle clearing non-existent period gracefully", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period1 = createMockPeriod("period-1", 0);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      // Should not throw
+      expect(() => {
+        observer.onPeriodCleared("audio", period1);
+      }).not.toThrow();
+    });
+  });
+
+  describe("periodChange event", () => {
+    it("should trigger periodChange only when period is active in all buffer types", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period = createMockPeriod("period-1", 0);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+        "video",
+      ]);
+
+      mockTrigger.mockClear();
+
+      observer.onRepresentationChange("audio", period);
+
+      // Should not trigger yet - not active in video
+      const periodChangeCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "periodChange",
+      );
+      expect(periodChangeCalls).toHaveLength(0);
+
+      observer.onRepresentationChange("video", period);
+
+      // Now should trigger
+      expect(mockTrigger).toHaveBeenCalledWith("periodChange", period);
+    });
+
+    it("should not trigger periodChange multiple times for same period", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period = createMockPeriod("period-1", 0);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onRepresentationChange("audio", period);
+
+      mockTrigger.mockClear();
+
+      observer.onRepresentationChange("audio", period);
+
+      const periodChangeCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "periodChange",
+      );
+      expect(periodChangeCalls).toHaveLength(0);
+    });
+
+    it("should trigger periodChange when switching to different period", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+      const period1 = createMockPeriod("period-1", 0);
+      const period2 = createMockPeriod("period-2", 10);
+      const adap1 = createMockAdaptation([]);
+      const adap2 = createMockAdaptation([]);
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onAdaptationChange("audio", period1, adap1);
+      observer.onRepresentationChange("audio", period1);
+      expect(mockTrigger).toHaveBeenCalledWith("periodChange", period1);
+      mockTrigger.mockClear();
+      observer.onPeriodCleared("audio", period1);
+      observer.onAdaptationChange("audio", period2, adap2);
+      observer.onRepresentationChange("audio", period2);
+      expect(mockTrigger).toHaveBeenCalledWith("periodChange", period2);
+    });
+  });
+
+  describe("onLastSegmentFinishedLoading", () => {
+    it("should trigger endOfStream when all buffer types finished loading", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: true });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+        "video",
+      ]);
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentFinishedLoading("audio");
+      observer.onLastSegmentFinishedLoading("video");
+
+      expect(mockTrigger).toHaveBeenCalledWith("endOfStream", null);
+    });
+
+    it("should not trigger endOfStream if not all buffer types finished", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: true });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+        "video",
+      ]);
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentFinishedLoading("audio");
+
+      const endOfStreamCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "endOfStream",
+      );
+      expect(endOfStreamCalls).toHaveLength(0);
+    });
+
+    it("should not trigger endOfStream if last period is not known", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: false });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentFinishedLoading("audio");
+
+      const endOfStreamCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "endOfStream",
+      );
+      expect(endOfStreamCalls).toHaveLength(0);
+    });
+
+    it("should not trigger multiple times for same buffer type", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: true });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onLastSegmentFinishedLoading("audio");
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentFinishedLoading("audio");
+
+      const endOfStreamCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "endOfStream",
+      );
+      expect(endOfStreamCalls).toHaveLength(0);
+    });
+  });
+
+  describe("onLastSegmentLoadingResume", () => {
+    it("should trigger resumeStream after endOfStream", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: true });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+        "video",
+      ]);
+
+      observer.onLastSegmentFinishedLoading("audio");
+      observer.onLastSegmentFinishedLoading("video");
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentLoadingResume("audio");
+
+      expect(mockTrigger).toHaveBeenCalledWith("resumeStream", null);
+    });
+
+    it("should not trigger if already in loading state", () => {
+      const manifest = createMockManifest({ isLastPeriodKnown: true });
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.onLastSegmentLoadingResume("audio");
+
+      mockTrigger.mockClear();
+
+      observer.onLastSegmentLoadingResume("audio");
+
+      const resumeStreamCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "resumeStream",
+      );
+      expect(resumeStreamCalls).toHaveLength(0);
+    });
+  });
+
+  describe("manifestUpdate event", () => {
+    it("should trigger endingPositionChange on manifest update", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+
+      const manifestUpdateCallback = mockManifestEventListener.mock.calls[0][1];
+
+      mockTrigger.mockClear();
+      manifestUpdateCallback();
+
+      expect(mockTrigger).toHaveBeenCalledWith(
+        "endingPositionChange",
+        expect.objectContaining({
+          endingPosition: expect.any(Number),
+          isEnd: expect.any(Boolean),
+        }),
+      );
+    });
+
+    it("should not trigger events if canceller is cancelled", () => {
+      mockCancellerSignal.isCancelled.mockReturnValue(true);
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+
+      const manifestUpdateCallback = mockManifestEventListener.mock.calls[0][1];
+
+      mockTrigger.mockClear();
+      manifestUpdateCallback();
+
+      // endingPositionChange should still be called, but endOfStream check skipped
+      const endOfStreamCalls = mockTrigger.mock.calls.filter(
+        (call) => call[0] === "endOfStream",
+      );
+      expect(endOfStreamCalls).toHaveLength(0);
+    });
+  });
+
+  describe("dispose", () => {
+    it("should cancel operations with provided reason", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.dispose("test reason");
+
+      expect(mockCanceller.cancel).toHaveBeenCalledWith("test reason");
+    });
+
+    it("should cancel operations with default reason when none provided", () => {
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+        "audio",
+      ]);
+
+      observer.dispose(undefined);
+
+      expect(mockCanceller.cancel).toHaveBeenCalledWith(
+        "ContentTimeBoundariesObserver dispose",
+      );
+    });
+  });
+
+  describe("MaximumPositionCalculator", () => {
+    describe("getMaximumAvailablePosition", () => {
+      it("should return manifest safe position for dynamic content", () => {
+        mockGetMaximumSafePosition.mockReturnValue(120);
+        const manifest = createMockManifest({ isDynamic: true });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+        ]);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(120);
+      });
+
+      it("should return manifest safe position when adaptations not set", () => {
+        mockGetMaximumSafePosition.mockReturnValue(100);
+        const manifest = createMockManifest({ isDynamic: false });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(100);
+      });
+
+      it("should handle null audio adaptation", () => {
+        const videoRep = createMockRepresentation();
+        mockGetLastAvailablePosition.mockReturnValue(90);
+        const videoAdaptation = createMockAdaptation([videoRep]);
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: false,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        observer.onAdaptationChange("audio", period, null);
+        observer.onAdaptationChange("video", period, videoAdaptation);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(90);
+      });
+
+      it("should handle null video adaptation", () => {
+        const audioRep = createMockRepresentation();
+        mockGetLastAvailablePosition.mockReturnValue(85);
+        const audioAdaptation = createMockAdaptation([audioRep]);
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: false,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        observer.onAdaptationChange("audio", period, audioAdaptation);
+        observer.onAdaptationChange("video", period, null);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(85);
+      });
+
+      it("should handle both adaptations being null", () => {
+        mockGetMaximumSafePosition.mockReturnValue(100);
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: false,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        observer.onAdaptationChange("audio", period, null);
+        observer.onAdaptationChange("video", period, null);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(100);
+      });
+
+      it("should fallback to manifest position when representation returns undefined", () => {
+        mockGetMaximumSafePosition.mockReturnValue(100);
+        const audioRep = createMockRepresentation();
+        mockGetLastAvailablePosition.mockReturnValue(undefined);
+        const audioAdaptation = createMockAdaptation([audioRep]);
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: false,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+        ]);
+
+        observer.onAdaptationChange("audio", period, audioAdaptation);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.endingPosition).toBe(100);
+      });
+    });
+
+    describe("getEndingPosition for dynamic content", () => {
+      it("should return undefined when adaptations not set", () => {
+        const manifest = createMockManifest({ isDynamic: true });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.isEnd).toBe(false);
+      });
+
+      it("should return ending position from audio when video is null", () => {
+        const audioRep = createMockRepresentation();
+        mockGetEnd.mockReturnValue(95);
+        const audioAdaptation = createMockAdaptation([audioRep]);
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: true,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        observer.onAdaptationChange("audio", period, audioAdaptation);
+        observer.onAdaptationChange("video", period, null);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result).toEqual({
+          isEnd: true,
+          endingPosition: 95,
+        });
+      });
+
+      it("should return undefined when both adaptations are null", () => {
+        const period = createMockPeriod("period-1");
+        const manifest = createMockManifest({
+          isDynamic: true,
+          isLastPeriodKnown: true,
+          periods: [period],
+        });
+        const playbackObserver = createMockPlaybackObserver();
+
+        const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
+          "audio",
+          "video",
+        ]);
+
+        observer.onAdaptationChange("audio", period, null);
+        observer.onAdaptationChange("video", period, null);
+
+        const result = observer.getCurrentEndingTime();
+
+        expect(result.isEnd).toBe(false);
+      });
+    });
+  });
+});

--- a/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
+++ b/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import sleep from "../../../utils/sleep";
+import type { IBufferType } from "../../segment_sinks";
 import ContentTimeBoundariesObserver from "../content_time_boundaries_observer";
-import { IBufferType } from "../../segment_sinks";
 
-// Hoisted mocks
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
 const {
   mockTrigger,
   mockCancellerSignal,
@@ -46,28 +51,7 @@ vi.mock("../../../utils/task_canceller", () => ({
 }));
 
 vi.mock("../../../utils/queue_microtask", () => ({
-  default: (fn: () => void) => fn(),
-}));
-
-vi.mock("../../../utils/sorted_list", () => ({
-  default: class SortedList<T> {
-    private items: T[] = [];
-    constructor(private compareFn: (a: T, b: T) => number) {}
-    add(item: T) {
-      this.items.push(item);
-      this.items.sort(this.compareFn);
-    }
-    has(item: T) {
-      return this.items.includes(item);
-    }
-    removeElement(item: T) {
-      const index = this.items.indexOf(item);
-      if (index > -1) this.items.splice(index, 1);
-    }
-    toArray() {
-      return [...this.items];
-    }
-  },
+  default: (fn: () => void) => Promise.resolve().then(() => fn()),
 }));
 
 describe("ContentTimeBoundariesObserver", () => {
@@ -116,13 +100,13 @@ describe("ContentTimeBoundariesObserver", () => {
   });
 
   describe("constructor", () => {
-    it("should initialize and set up playback observer", () => {
+    it("should initialize and set up playback observer", async () => {
       const manifest = createMockManifest();
       const playbackObserver = createMockPlaybackObserver();
       const bufferTypes: IBufferType[] = ["audio", "video"];
 
       new ContentTimeBoundariesObserver(manifest, playbackObserver, bufferTypes);
-
+      await sleep(0);
       expect(mockPlaybackObserverListen).toHaveBeenCalledWith(
         expect.any(Function),
         expect.objectContaining({
@@ -132,11 +116,12 @@ describe("ContentTimeBoundariesObserver", () => {
       );
     });
 
-    it("should set up manifest event listener", () => {
+    it("should set up manifest event listener", async () => {
       const manifest = createMockManifest();
       const playbackObserver = createMockPlaybackObserver();
 
       new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+      await sleep(0);
 
       expect(mockManifestEventListener).toHaveBeenCalledWith(
         "manifestUpdate",
@@ -145,12 +130,13 @@ describe("ContentTimeBoundariesObserver", () => {
       );
     });
 
-    it("should trigger warning when position is before manifest minimum", () => {
+    it("should trigger warning when position is before manifest minimum", async () => {
       mockGetMinimumSafePosition.mockReturnValue(10);
       const manifest = createMockManifest();
       const playbackObserver = createMockPlaybackObserver();
 
       new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+      await sleep(0);
 
       const positionCallback = mockPlaybackObserverListen.mock.calls[0][0];
       positionCallback({ position: { getWanted: () => 5 } });
@@ -160,12 +146,13 @@ describe("ContentTimeBoundariesObserver", () => {
       expect(warning.code).toBe("MEDIA_TIME_BEFORE_MANIFEST");
     });
 
-    it("should trigger warning when position is after manifest maximum", () => {
+    it("should trigger warning when position is after manifest maximum", async () => {
       mockGetMaximumSafePosition.mockReturnValue(100);
       const manifest = createMockManifest();
       const playbackObserver = createMockPlaybackObserver();
 
       new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+      await sleep(0);
 
       const positionCallback = mockPlaybackObserverListen.mock.calls[0][0];
       positionCallback({ position: { getWanted: () => 150 } });
@@ -177,7 +164,7 @@ describe("ContentTimeBoundariesObserver", () => {
   });
 
   describe("getCurrentEndingTime", () => {
-    it("should return ending position when manifest is not dynamic", () => {
+    it("should return ending position when manifest is not dynamic", async () => {
       mockGetMaximumSafePosition.mockReturnValue(100);
       const manifest = createMockManifest({ isDynamic: false });
       const playbackObserver = createMockPlaybackObserver();
@@ -185,6 +172,7 @@ describe("ContentTimeBoundariesObserver", () => {
       const observer = new ContentTimeBoundariesObserver(manifest, playbackObserver, [
         "audio",
       ]);
+      await sleep(0);
 
       const result = observer.getCurrentEndingTime();
 

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -27,6 +27,7 @@ import type {
 } from "../../manifest";
 import type { IReadOnlyPlaybackObserver } from "../../playback_observer";
 import type { IPlayerError } from "../../public_types";
+import arrayIncludes from "../../utils/array_includes";
 import EventEmitter from "../../utils/event_emitter";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import queueMicrotask from "../../utils/queue_microtask";
@@ -92,6 +93,15 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
      * whole content.
      */
     const maximumPositionCalculator = new MaximumPositionCalculator(manifest);
+
+    // Indicate directly that no Adaptation of a particular type will be set
+    if (!arrayIncludes(this._allBufferTypes, "video")) {
+      maximumPositionCalculator.updateLastVideoAdaptation(null);
+    }
+    if (!arrayIncludes(this._allBufferTypes, "audio")) {
+      maximumPositionCalculator.updateLastAudioAdaptation(null);
+    }
+
     this._maximumPositionCalculator = maximumPositionCalculator;
 
     const cancelSignal = this._canceller.signal;

--- a/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
+++ b/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
@@ -1,11 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import getSegmentPriority from "../get_segment_priority";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/unbound-method */
-
 const mockGetCurrentConfig = vi.hoisted(() => vi.fn());
 vi.mock("../../../../../config", () => ({
   default: {

--- a/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
+++ b/src/core/stream/representation/utils/__tests__/get_segment_priority.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import config from "../../../../../config";
 import getSegmentPriority from "../get_segment_priority";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -7,19 +6,17 @@ import getSegmentPriority from "../get_segment_priority";
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/unbound-method */
 
-// Mock the config module
+const mockGetCurrentConfig = vi.hoisted(() => vi.fn());
 vi.mock("../../../../../config", () => ({
   default: {
-    getCurrent: vi.fn(),
+    getCurrent: mockGetCurrentConfig,
   },
 }));
 
 describe("getSegmentPriority", () => {
-  const mockGetCurrent = vi.mocked(config.getCurrent as any);
-
   beforeEach(() => {
     // Default configuration for most tests
-    mockGetCurrent.mockReturnValue({
+    mockGetCurrentConfig.mockReturnValue({
       SEGMENT_PRIORITIES_STEPS: [1, 5, 10, 20],
     });
   });
@@ -95,7 +92,7 @@ describe("getSegmentPriority", () => {
 
   describe("different config values", () => {
     it("should work with empty priority steps array", () => {
-      mockGetCurrent.mockReturnValue({
+      mockGetCurrentConfig.mockReturnValue({
         SEGMENT_PRIORITIES_STEPS: [],
       });
 
@@ -104,7 +101,7 @@ describe("getSegmentPriority", () => {
     });
 
     it("should work with single priority step", () => {
-      mockGetCurrent.mockReturnValue({
+      mockGetCurrentConfig.mockReturnValue({
         SEGMENT_PRIORITIES_STEPS: [10],
       });
 
@@ -113,7 +110,7 @@ describe("getSegmentPriority", () => {
     });
 
     it("should work with different step values", () => {
-      mockGetCurrent.mockReturnValue({
+      mockGetCurrentConfig.mockReturnValue({
         SEGMENT_PRIORITIES_STEPS: [2, 10, 30, 60],
       });
 
@@ -128,13 +125,13 @@ describe("getSegmentPriority", () => {
   describe("config integration", () => {
     it("should call config.getCurrent() to get priority steps", () => {
       getSegmentPriority(100, 50);
-      expect(mockGetCurrent).toHaveBeenCalledOnce();
+      expect(mockGetCurrentConfig).toHaveBeenCalledOnce();
     });
 
     it("should get fresh config on each call", () => {
       getSegmentPriority(100, 50);
       getSegmentPriority(200, 150);
-      expect(mockGetCurrent).toHaveBeenCalledTimes(2);
+      expect(mockGetCurrentConfig).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
This continues the effort started with #1794 of writing new unit tests / checking issues by giving source files through an LLM in one shot and seeing what it thought the tested code's behavior was.

This time for a few modules in `core/entry`.

Very interestingly it at last found an issue, yet a very minor one: when playing a live audio content on an `<audio>` element (this is not advertised much yet supported by the RxPlayer), whose end is already known, the `<audio>` element `duration` property won't be set until the last audio segment has been pushed (whereas on a `<video>` element, it would have been set as soon as that live's manifest duration is known).

This is because our `ContentTimeBoundariesObserver`, whose role is to check that we're playing within the content's announced time boundaries and which also advertises the content's currently-known duration, awaited the RxPlayer's choice for a video quality even when the current media element was an HTMLAudioElement - and thus won't have any video chosen.

That module already knows which type of buffer exists, so fixing it was very straightforward.

---

What's very interesting about all this is that the LLM just saw the module source file, wrote that test that ended up broken, yet without seeing there was an issue.
So it correctly implied what the role of that module was yet didn't see that a test it wrote would fail - a good thing as if it had it might not have written that test or written it in a different way, and I may not have thought about adding a test for such a niche case.