### PR TITLE
fix(safari): seek explicitly to 0 because native HLS player will start at live position

### DIFF
--- a/src/compat/should_seek_at_zero.ts
+++ b/src/compat/should_seek_at_zero.ts
@@ -1,0 +1,23 @@
+import config from "../config";
+import EnvDetector from "./env_detector";
+
+/**
+ * Determines whether the player should perform an explicit initial seek to 0.
+ *
+ * In most cases, a media element starts at position 0 and no initial seek is
+ * needed. The exception is Safari when playing HLS streams: the native player
+ * may start at the live position instead of 0, so performing an explicit seek
+ * ensures the player starts from the intended initial position.
+ *
+ * @returns {boolean} `true` if an explicit initial seek to 0 should be performed.
+ */
+export default function shouldPerformInitialSeekToZero(): boolean {
+  const { FORCE_INITIAL_SEEK_TO_ZERO } = config.getCurrent();
+  if (FORCE_INITIAL_SEEK_TO_ZERO) {
+    return FORCE_INITIAL_SEEK_TO_ZERO;
+  }
+  return (
+    EnvDetector.browser === EnvDetector.BROWSERS.SafariDesktop ||
+    EnvDetector.browser === EnvDetector.BROWSERS.SafariMobile
+  );
+}

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1333,6 +1333,12 @@ const DEFAULT_CONFIG = {
    * announcing the content as loaded.
    */
   FORCE_WAIT_FOR_HAVE_ENOUGH_DATA: false,
+
+  /**
+   * If `true`, forces an initial seek to 0. Mainly needed for Safari HLS,
+   * where the player may start at the live position instead of 0.
+   */
+  FORCE_INITIAL_SEEK_TO_ZERO: false,
 };
 
 export type IDefaultConfig = typeof DEFAULT_CONFIG;

--- a/src/main_thread/init/utils/initial_seek_and_play.ts
+++ b/src/main_thread/init/utils/initial_seek_and_play.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IMediaElement } from "../../../compat/browser_compatibility_types";
+import shouldPerformInitialSeekToZero from "../../../compat/should_seek_at_zero";
 import shouldValidateMetadata from "../../../compat/should_validate_metadata";
 import { MediaError } from "../../../errors";
 import log from "../../../log";
@@ -145,7 +146,10 @@ export default function performInitialSeekAndPlay(
             }
             if (obs.readyState >= 1) {
               stopListening();
-              if (initiallySeekedTime !== 0 && initiallySeekedTime !== undefined) {
+              if (
+                initiallySeekedTime !== undefined &&
+                (initiallySeekedTime !== 0 || shouldPerformInitialSeekToZero())
+              ) {
                 performInitialSeek(initiallySeekedTime);
               } else {
                 playbackObserver.unblockSeeking();


### PR DESCRIPTION
When using the RxPlayer on Safari in "directfile" mode with an HLS live playlist, Safari sets the currentTime to the live position instead of 0.

Previously, we assumed that a newly created videoElement always started at 0, so we did not perform an initial seek.
This PR adds support for Safari to explicitly perform an initial seek to 0 in this case.