### PR TITLE
Add unit tests for Core Entry and make code more testable

### DIFF
--- a/src/core/entry/__tests__/FreezeResolver.test.ts
+++ b/src/core/entry/__tests__/FreezeResolver.test.ts
@@ -85,7 +85,7 @@ describe("FreezeResolver", () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   describe("onNewObservation - No freeze scenarios", () => {

--- a/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
+++ b/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
@@ -90,13 +90,12 @@ describe("ContentTimeBoundariesObserver", () => {
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
     mockGetMinimumSafePosition.mockReturnValue(0);
     mockGetMaximumSafePosition.mockReturnValue(100);
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   describe("constructor", () => {

--- a/src/core/entry/__tests__/core_text_displayer_interface.test.ts
+++ b/src/core/entry/__tests__/core_text_displayer_interface.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import noop from "../../../utils/noop";
+import { CancellationError } from "../../../utils/task_canceller";
+import { CoreMessageType } from "../../types";
+import CoreTextDisplayerInterface from "../core_text_displayer_interface";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+const mockLogError = vi.hoisted(() => {
+  return vi.fn();
+});
+
+vi.mock("../../../log", () => ({
+  default: {
+    error: mockLogError,
+  },
+}));
+
+vi.mock("../../../utils/task_canceller", () => ({
+  CancellationError: class MockCancellationError extends Error {
+    constructor(name: string, reason: string) {
+      super(reason);
+      this.name = name;
+    }
+  },
+}));
+
+describe("CoreTextDisplayerInterface", () => {
+  let messageSender: any;
+  let cdi: CoreTextDisplayerInterface;
+  const CONTENT_ID = "test-content-id";
+
+  beforeEach(() => {
+    messageSender = vi.fn();
+    mockLogError.mockReset();
+    cdi = new CoreTextDisplayerInterface(CONTENT_ID, messageSender);
+  });
+
+  describe("constructor", () => {
+    it("should initialize with empty queues", () => {
+      expect(cdi._queues.pushTextData).toHaveLength(0);
+      expect(cdi._queues.remove).toHaveLength(0);
+    });
+  });
+
+  describe("pushTextData", () => {
+    it("should send a PushTextData message with contentId and infos", () => {
+      const infos = { data: "subtitle data" } as any;
+      cdi.pushTextData(infos);
+      expect(messageSender).toHaveBeenCalledOnce();
+      expect(messageSender).toHaveBeenCalledWith({
+        type: CoreMessageType.PushTextData,
+        contentId: CONTENT_ID,
+        value: infos,
+      });
+    });
+
+    it("should push a resolve/reject pair into pushTextData queue", () => {
+      cdi.pushTextData({} as any);
+      expect(cdi._queues.pushTextData).toHaveLength(1);
+      expect(cdi._queues.remove).toHaveLength(0);
+    });
+
+    it("should return a promise that resolves via onPushedTrackSuccess", async () => {
+      const ranges = [{ start: 0, end: 10 }];
+      const promise = cdi.pushTextData({} as any);
+      cdi.onPushedTrackSuccess(ranges);
+      await expect(promise).resolves.toEqual(ranges);
+    });
+
+    it("should return a promise that rejects via onPushedTrackError", async () => {
+      const error = new Error("push failed");
+      const promise = cdi.pushTextData({} as any);
+      cdi.onPushedTrackError(error);
+      await expect(promise).rejects.toThrow("push failed");
+    });
+  });
+
+  describe("remove", () => {
+    it("should send a RemoveTextData message with contentId, start, and end", () => {
+      cdi.remove(5, 20);
+      expect(messageSender).toHaveBeenCalledOnce();
+      expect(messageSender).toHaveBeenCalledWith({
+        type: CoreMessageType.RemoveTextData,
+        contentId: CONTENT_ID,
+        value: { start: 5, end: 20 },
+      });
+    });
+
+    it("should push a resolve/reject pair into remove queue", () => {
+      cdi.remove(0, 10);
+      expect(cdi._queues.remove).toHaveLength(1);
+      expect(cdi._queues.pushTextData).toHaveLength(0);
+    });
+
+    it("should return a promise that resolves via onRemoveSuccess", async () => {
+      const ranges = [{ start: 5, end: 20 }];
+      const promise = cdi.remove(5, 20);
+      cdi.onRemoveSuccess(ranges);
+      await expect(promise).resolves.toEqual(ranges);
+    });
+    it("should return a promise that rejects via onPushedTrackError", async () => {
+      const error = new Error("remove failed");
+      const promise = cdi.remove(5, 20);
+      cdi.onRemoveError(error);
+      await expect(promise).rejects.toThrow("remove failed");
+    });
+  });
+
+  describe("reset", () => {
+    it("should send a ResetTextDisplayer message", () => {
+      cdi.reset();
+      expect(messageSender).toHaveBeenCalledWith({
+        type: CoreMessageType.ResetTextDisplayer,
+        contentId: CONTENT_ID,
+        value: null,
+      });
+    });
+
+    it("should reject all pending pushTextData and remove promises", async () => {
+      const pushPromise = cdi.pushTextData({} as any);
+      const removePromise = cdi.remove(0, 10);
+      cdi.reset();
+      await expect(pushPromise).rejects.toBeInstanceOf(CancellationError);
+      await expect(removePromise).rejects.toBeInstanceOf(CancellationError);
+    });
+
+    it("should clear both queues after reset", () => {
+      cdi.pushTextData({} as any).catch(noop);
+      cdi.remove(0, 10).catch(noop);
+      cdi.reset();
+      expect(cdi._queues.pushTextData).toHaveLength(0);
+      expect(cdi._queues.remove).toHaveLength(0);
+    });
+  });
+
+  describe("stop", () => {
+    it("should send a StopTextDisplayer message", () => {
+      cdi.stop("user stopped");
+      expect(messageSender).toHaveBeenCalledWith({
+        type: CoreMessageType.StopTextDisplayer,
+        contentId: CONTENT_ID,
+        value: null,
+      });
+    });
+
+    it("should reject all pending promises with a CancellationError", async () => {
+      const pushPromise = cdi.pushTextData({} as any);
+      const removePromise = cdi.remove(0, 10);
+      cdi.stop("stopped for test");
+      await expect(pushPromise).rejects.toBeInstanceOf(CancellationError);
+      await expect(removePromise).rejects.toBeInstanceOf(CancellationError);
+    });
+
+    it("should use 'reset' as fallback reason when undefined is passed", async () => {
+      const pushPromise = cdi.pushTextData({} as any);
+      cdi.stop(undefined);
+      const err = await pushPromise.catch((e) => e);
+      expect(err.message).toBe("reset");
+    });
+  });
+
+  describe("onPushedTrackSuccess", () => {
+    it("should log an error and not throw when queue is empty", () => {
+      expect(() => cdi.onPushedTrackSuccess([])).not.toThrow();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it("should resolve operations in FIFO order", async () => {
+      const ranges1 = [{ start: 0, end: 1 }];
+      const ranges2 = [{ start: 2, end: 3 }];
+      const p1 = cdi.pushTextData({} as any);
+      const p2 = cdi.pushTextData({} as any);
+      cdi.onPushedTrackSuccess(ranges1);
+      cdi.onPushedTrackSuccess(ranges2);
+      await expect(p1).resolves.toEqual(ranges1);
+      await expect(p2).resolves.toEqual(ranges2);
+    });
+  });
+
+  describe("onPushedTrackError", () => {
+    it("should log an error and not throw when queue is empty", () => {
+      expect(() => cdi.onPushedTrackError(new Error())).not.toThrow();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+
+  describe("onRemoveSuccess", () => {
+    it("should log an error and not throw when queue is empty", () => {
+      expect(() => cdi.onRemoveSuccess([])).not.toThrow();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+
+  describe("onRemoveError", () => {
+    it("should log an error and not throw when queue is empty", () => {
+      expect(() => cdi.onRemoveError(new Error())).not.toThrow();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/core/entry/__tests__/get_buffered_data_per_media_buffer.test.ts
+++ b/src/core/entry/__tests__/get_buffered_data_per_media_buffer.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SourceBufferType } from "../../../mse";
+
+const mockArrayFind = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../utils/array_find", () => ({
+  default: mockArrayFind,
+}));
+
+import getBufferedDataPerMediaBuffer from "../get_buffered_data_per_media_buffer";
+
+describe("getBufferedDataPerMediaBuffer", () => {
+  beforeEach(() => {
+    mockArrayFind.mockReset();
+    // Default: mimic real arrayFind behavior
+    mockArrayFind.mockImplementation(
+      // eslint-disable-next-line no-restricted-properties
+      (arr: unknown[], predicate: (item: unknown) => boolean) => arr.find(predicate),
+    );
+  });
+
+  it("should return all nulls when both arguments are null", () => {
+    const result = getBufferedDataPerMediaBuffer(null, null);
+    expect(result).toEqual({ audio: null, video: null, text: null });
+  });
+
+  it("should return text ranges from textDisplayer when provided", () => {
+    const textRanges = [{ start: 0, end: 10 }];
+    const textDisplayer = { getBufferedRanges: vi.fn(() => textRanges) };
+    const result = getBufferedDataPerMediaBuffer(null, textDisplayer as never);
+    expect(result.text).toBe(textRanges);
+    expect(result.audio).toBeNull();
+    expect(result.video).toBeNull();
+  });
+
+  it("should return audio and video ranges from mediaSourceInterface", () => {
+    const audioRanges = [{ start: 0, end: 5 }];
+    const videoRanges = [{ start: 0, end: 8 }];
+
+    const audioSourceBuffer = {
+      type: SourceBufferType.Audio,
+      getBuffered: vi.fn(() => audioRanges),
+    };
+    const videoSourceBuffer = {
+      type: SourceBufferType.Video,
+      getBuffered: vi.fn(() => videoRanges),
+    };
+
+    mockArrayFind
+      .mockImplementationOnce(() => audioSourceBuffer)
+      .mockImplementationOnce(() => videoSourceBuffer);
+
+    const mediaSourceInterface = {
+      sourceBuffers: [audioSourceBuffer, videoSourceBuffer],
+    };
+    const result = getBufferedDataPerMediaBuffer(mediaSourceInterface as never, null);
+
+    expect(result.audio).toBe(audioRanges);
+    expect(result.video).toBe(videoRanges);
+    expect(result.text).toBeNull();
+  });
+
+  it("should keep audio/video as null if source buffers are not found", () => {
+    mockArrayFind.mockReturnValue(undefined);
+    const mediaSourceInterface = { sourceBuffers: [] };
+    const result = getBufferedDataPerMediaBuffer(mediaSourceInterface as never, null);
+    expect(result.audio).toBeNull();
+    expect(result.video).toBeNull();
+  });
+
+  it("should combine text displayer and mediaSourceInterface results", () => {
+    const textRanges = [{ start: 1, end: 3 }];
+    const audioRanges = [{ start: 0, end: 10 }];
+    const textDisplayer = { getBufferedRanges: vi.fn(() => textRanges) };
+
+    const audioSourceBuffer = {
+      type: SourceBufferType.Audio,
+      getBuffered: vi.fn(() => audioRanges),
+    };
+
+    mockArrayFind
+      .mockImplementationOnce(() => audioSourceBuffer)
+      .mockImplementationOnce(() => undefined);
+
+    const mediaSourceInterface = { sourceBuffers: [audioSourceBuffer] };
+    const result = getBufferedDataPerMediaBuffer(
+      mediaSourceInterface as never,
+      textDisplayer as never,
+    );
+
+    expect(result.text).toBe(textRanges);
+    expect(result.audio).toBe(audioRanges);
+    expect(result.video).toBeNull();
+  });
+});

--- a/src/core/entry/__tests__/track_choice_setter.test.ts
+++ b/src/core/entry/__tests__/track_choice_setter.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import TrackChoiceSetter from "../track_choice_setter";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+const mockLog = vi.hoisted(() => {
+  return { warn: vi.fn(), debug: vi.fn() };
+});
+
+vi.mock("../../../log", () => ({
+  default: mockLog,
+}));
+
+const mockIsNullOrUndefined = vi.hoisted(() => {
+  return vi.fn((val: unknown) => val === null || val === undefined);
+});
+
+vi.mock("../../../utils/is_null_or_undefined", () => ({
+  default: mockIsNullOrUndefined,
+}));
+
+const mockObjectAssign = vi.hoisted(() => {
+  return vi.fn((target: object, ...sources: object[]) =>
+    // eslint-disable-next-line no-restricted-properties
+    Object.assign(target, ...sources),
+  );
+});
+
+vi.mock("../../../utils/object_assign", () => ({
+  default: mockObjectAssign,
+}));
+
+// We need a real SharedReference-like implementation to make tests meaningful
+const MockSharedReference = vi.hoisted(() => {
+  return class MockedSharedReference<T> {
+    private _value: T;
+    public finish = vi.fn();
+
+    constructor(initialValue: T) {
+      this._value = initialValue;
+    }
+
+    getValue(): T {
+      return this._value;
+    }
+
+    setValue(val: T): void {
+      this._value = val;
+    }
+  };
+});
+
+vi.mock("../../../utils/reference", () => ({
+  default: MockSharedReference,
+}));
+
+function makeRef<T>(val: T): any {
+  return new MockSharedReference(val);
+}
+
+describe("TrackChoiceSetter", () => {
+  let setter: TrackChoiceSetter;
+
+  beforeEach(() => {
+    setter = new TrackChoiceSetter();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("addTrackSetter", () => {
+    it("should add a track setter without error for a new period/type", () => {
+      const ref = makeRef(null);
+      expect(() => setter.addTrackSetter("p1", "audio", ref)).not.toThrow();
+    });
+
+    it("should warn and finish old references if track setter already declared for same period/type", () => {
+      const ref1 = makeRef(null);
+      const ref2 = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref1);
+      setter.addTrackSetter("p1", "audio", ref2);
+      expect(mockLog.warn).toHaveBeenCalledOnce();
+      expect(ref1.finish).toHaveBeenCalled();
+    });
+
+    it("should handle a non-null initial value on the ref", () => {
+      const representationsRef = makeRef({
+        representationIds: ["r1"],
+        switchingMode: "direct",
+      });
+      const choice = {
+        adaptationId: "a1",
+        switchingMode: "direct",
+        representations: representationsRef,
+        relativeResumingPosition: undefined,
+      };
+      const ref = makeRef(choice);
+      setter.addTrackSetter("p1", "video", ref);
+      // objectAssign should have been called to replace representations with a SharedReference
+      expect(mockObjectAssign).toHaveBeenCalled();
+    });
+  });
+
+  describe("setTrack", () => {
+    it("should return false and log debug when periodId not found", () => {
+      const result = setter.setTrack("unknown", "audio", null);
+      expect(result).toBe(false);
+      expect(mockLog.debug).toHaveBeenCalled();
+    });
+
+    it("should return true and set null track choice", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.setTrack("p1", "audio", null);
+      expect(result).toBe(true);
+    });
+
+    it("should return true and set a valid track choice", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.setTrack("p1", "audio", {
+        adaptationId: "a1",
+        switchingMode: "direct",
+        initialRepresentations: {
+          representationIds: ["r1"],
+          switchingMode: "direct",
+        },
+        relativeResumingPosition: undefined,
+      });
+      expect(result).toBe(true);
+      const val = ref.getValue();
+      expect(val.adaptationId).toBe("a1");
+    });
+
+    it("should return false when bufferType not registered for a known period", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.setTrack("p1", "video", null);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("updateRepresentations", () => {
+    it("should return false when period not found", () => {
+      const result = setter.updateRepresentations("unknown", "a1", "audio", {
+        representationIds: [],
+        switchingMode: "direct",
+      });
+      expect(result).toBe(false);
+      expect(mockLog.debug).toHaveBeenCalled();
+    });
+
+    it("should return false when current trackReference value is null", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.updateRepresentations("p1", "a1", "audio", {
+        representationIds: [],
+        switchingMode: "direct",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("should return false when adaptationId is desynchronized", () => {
+      const representationsRef = makeRef({
+        representationIds: [],
+        switchingMode: "direct",
+      });
+      const ref = makeRef({
+        adaptationId: "a1",
+        switchingMode: "direct",
+        representations: representationsRef,
+        relativeResumingPosition: undefined,
+      });
+      setter.addTrackSetter("p1", "audio", ref);
+      // setTrack to ensure internal state is set
+      const result = setter.updateRepresentations("p1", "different-id", "audio", {
+        representationIds: [],
+        switchingMode: "direct",
+      });
+      expect(result).toBe(false);
+      expect(mockLog.debug).toHaveBeenCalled();
+    });
+
+    it("should return true and update representations when adaptationId matches", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      setter.setTrack("p1", "audio", {
+        adaptationId: "a1",
+        switchingMode: "direct",
+        initialRepresentations: {
+          representationIds: ["r1"],
+          switchingMode: "direct",
+        },
+        relativeResumingPosition: undefined,
+      });
+
+      const result = setter.updateRepresentations("p1", "a1", "audio", {
+        representationIds: ["r2"],
+        switchingMode: "direct",
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("removeTrackSetter", () => {
+    it("should return false and log debug when period not found", () => {
+      const result = setter.removeTrackSetter("unknown", "audio");
+      expect(result).toBe(false);
+      expect(mockLog.debug).toHaveBeenCalled();
+    });
+
+    it("should return false when bufferType not registered", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.removeTrackSetter("p1", "video");
+      expect(result).toBe(false);
+    });
+
+    it("should return true, finish references, and clean up on removal", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      const result = setter.removeTrackSetter("p1", "audio");
+      expect(result).toBe(true);
+      // trackReference.finish should have been called
+      expect(ref.finish).toHaveBeenCalled();
+    });
+
+    it("should allow re-adding after removal", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      setter.removeTrackSetter("p1", "audio");
+      const ref2 = makeRef(null);
+      expect(() => setter.addTrackSetter("p1", "audio", ref2)).not.toThrow();
+      expect(mockLog.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reset", () => {
+    it("should finish all references and clear state", () => {
+      const refAudio = makeRef(null);
+      const refVideo = makeRef(null);
+      setter.addTrackSetter("p1", "audio", refAudio);
+      setter.addTrackSetter("p1", "video", refVideo);
+      setter.reset();
+      // After reset, setting a track should return false (no period registered)
+      const result = setter.setTrack("p1", "audio", null);
+      expect(result).toBe(false);
+    });
+
+    it("should finish all SharedReferences on reset", () => {
+      const ref = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref);
+      setter.reset();
+      expect(ref.finish).toHaveBeenCalled();
+    });
+
+    it("should handle reset on empty setter without error", () => {
+      expect(() => setter.reset()).not.toThrow();
+    });
+  });
+
+  describe("multiple periods", () => {
+    it("should handle multiple periods independently", () => {
+      const ref1 = makeRef(null);
+      const ref2 = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref1);
+      setter.addTrackSetter("p2", "audio", ref2);
+
+      const r1 = setter.setTrack("p1", "audio", null);
+      const r2 = setter.setTrack("p2", "audio", null);
+      expect(r1).toBe(true);
+      expect(r2).toBe(true);
+    });
+
+    it("removing one period should not affect another", () => {
+      const ref1 = makeRef(null);
+      const ref2 = makeRef(null);
+      setter.addTrackSetter("p1", "audio", ref1);
+      setter.addTrackSetter("p2", "audio", ref2);
+      setter.removeTrackSetter("p1", "audio");
+      const result = setter.setTrack("p2", "audio", null);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/core/entry/__tests__/utils.test.ts
+++ b/src/core/entry/__tests__/utils.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  formatErrorForSender,
+  synchronizeSegmentSinksOnObservation,
+  updateCodecSupportInWorkerMode,
+  extractExternalPlugins,
+} from "../utils";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+const { mockFormatError, mockMediaSource_, mockCreateRepresentationFilter } = vi.hoisted(
+  () => {
+    return {
+      mockFormatError: vi.fn(),
+      mockMediaSource_: { isTypeSupported: vi.fn() },
+      mockCreateRepresentationFilter: vi.fn(),
+    };
+  },
+);
+vi.mock("../../../errors", () => ({
+  formatError: mockFormatError,
+}));
+vi.mock("../../../compat/browser_compatibility_types", () => ({
+  MediaSource_: mockMediaSource_,
+}));
+vi.mock("../../../manifest", () => ({
+  createRepresentationFilterFromFnString: mockCreateRepresentationFilter,
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("formatErrorForSender", () => {
+  it("should call formatError with the error and default options, then serialize", () => {
+    const mockSerialize = vi
+      .fn()
+      .mockReturnValue({ code: "NONE", message: "An unknown error" });
+    mockFormatError.mockReturnValue({ serialize: mockSerialize });
+
+    const result = formatErrorForSender(new Error("test"));
+
+    expect(mockFormatError).toHaveBeenCalledWith(new Error("test"), {
+      defaultCode: "NONE",
+      defaultReason: "An unknown error stopped content playback.",
+    });
+    expect(mockSerialize).toHaveBeenCalled();
+    expect(result).toEqual({ code: "NONE", message: "An unknown error" });
+  });
+});
+
+describe("synchronizeSegmentSinksOnObservation", () => {
+  it("should call synchronizeInventory for initialized segment sinks", () => {
+    const syncInventory = vi.fn();
+    const segmentSinksStore = {
+      getStatus: vi.fn((type: string) => {
+        if (type === "video") {
+          return { type: "initialized", value: { synchronizeInventory: syncInventory } };
+        }
+        return { type: "not-initialized" };
+      }),
+    } as any;
+
+    const observation = {
+      buffered: {
+        video: [{ start: 0, end: 10 }],
+        audio: [],
+        text: [],
+      },
+    } as any;
+
+    synchronizeSegmentSinksOnObservation(observation, segmentSinksStore);
+
+    expect(syncInventory).toHaveBeenCalledTimes(1);
+    expect(syncInventory).toHaveBeenCalledWith([{ start: 0, end: 10 }]);
+  });
+
+  it("should call synchronizeInventory for all initialized sinks with their buffered ranges", () => {
+    const videoSync = vi.fn();
+    const audioSync = vi.fn();
+    const textSync = vi.fn();
+
+    const segmentSinksStore = {
+      getStatus: vi.fn((type: string) => {
+        if (type === "video") {
+          return { type: "initialized", value: { synchronizeInventory: videoSync } };
+        }
+        if (type === "audio") {
+          return { type: "initialized", value: { synchronizeInventory: audioSync } };
+        }
+        if (type === "text") {
+          return { type: "initialized", value: { synchronizeInventory: textSync } };
+        }
+        return { type: "not-initialized" };
+      }),
+    } as any;
+
+    const observation = {
+      buffered: {
+        video: [{ start: 0, end: 5 }],
+        audio: [{ start: 1, end: 6 }],
+        text: undefined,
+      },
+    } as any;
+
+    synchronizeSegmentSinksOnObservation(observation, segmentSinksStore);
+
+    expect(videoSync).toHaveBeenCalledWith([{ start: 0, end: 5 }]);
+    expect(audioSync).toHaveBeenCalledWith([{ start: 1, end: 6 }]);
+    expect(textSync).toHaveBeenCalledWith([]); // undefined falls back to []
+  });
+});
+
+describe("updateCodecSupportInWorkerMode", () => {
+  it("should do nothing if MediaSource_ is null", async () => {
+    // Re-import with MediaSource_ as null - we test indirectly
+    // by checking that isTypeSupported is never called when MediaSource_ is null
+    // This test verifies the null-guard works via a manifest with no periods
+    const manifest = { periods: [] } as any;
+    // Since we can't easily change the module-level import, we verify normal flow
+    updateCodecSupportInWorkerMode(manifest);
+    expect(mockMediaSource_.isTypeSupported).not.toHaveBeenCalled();
+  });
+
+  it("should set isCodecSupportedInWebWorker based on isTypeSupported", () => {
+    mockMediaSource_.isTypeSupported.mockImplementation((codec: string) => {
+      // eslint-disable-next-line no-restricted-properties
+      return codec.includes("avc1");
+    });
+
+    const videoRep = {
+      mimeType: "video/mp4",
+      codecs: ["avc1.42E01E"],
+      isCodecSupportedInWebWorker: undefined,
+    };
+    const audioRep = {
+      mimeType: "audio/mp4",
+      codecs: ["mp4a.40.2"],
+      isCodecSupportedInWebWorker: undefined,
+    };
+
+    const manifest = {
+      periods: [
+        {
+          adaptations: {
+            video: [{ representations: [videoRep] }],
+            audio: [{ representations: [audioRep] }],
+          },
+        },
+      ],
+    } as any;
+
+    updateCodecSupportInWorkerMode(manifest);
+
+    expect(videoRep.isCodecSupportedInWebWorker).toBe(true);
+    expect(audioRep.isCodecSupportedInWebWorker).toBe(false);
+  });
+
+  it("should cache codec support results", () => {
+    mockMediaSource_.isTypeSupported.mockReturnValue(true);
+
+    const rep1 = {
+      mimeType: "video/mp4",
+      codecs: ["avc1.42E01E"],
+      isCodecSupportedInWebWorker: undefined,
+    };
+    const rep2 = {
+      mimeType: "video/mp4",
+      codecs: ["avc1.42E01E"],
+      isCodecSupportedInWebWorker: undefined,
+    };
+
+    const manifest = {
+      periods: [
+        {
+          adaptations: {
+            video: [{ representations: [rep1, rep2] }],
+            audio: [],
+          },
+        },
+      ],
+    } as any;
+
+    updateCodecSupportInWorkerMode(manifest);
+
+    expect(mockMediaSource_.isTypeSupported).toHaveBeenCalledTimes(1);
+    expect(rep1.isCodecSupportedInWebWorker).toBe(true);
+    expect(rep2.isCodecSupportedInWebWorker).toBe(true);
+  });
+});
+
+describe("extractExternalPlugins", () => {
+  const emptyCorePlugins = {
+    representationFilters: new Map(),
+    segmentLoaders: new Map(),
+    manifestLoaders: new Map(),
+  };
+
+  it("should return undefined for all when input has no loaders", () => {
+    const result = extractExternalPlugins(
+      {
+        manifestLoader: undefined,
+        segmentLoader: undefined,
+        representationFilter: undefined,
+      },
+      emptyCorePlugins,
+    );
+    expect(result).toEqual({
+      manifestLoader: undefined,
+      segmentLoader: undefined,
+      representationFilter: undefined,
+    });
+  });
+
+  it("should use fn directly when provided", () => {
+    const repFilter = vi.fn();
+    const manifestLoader = vi.fn();
+    const segmentLoader = vi.fn();
+
+    const result = extractExternalPlugins(
+      {
+        representationFilter: { fn: repFilter },
+        manifestLoader: { fn: manifestLoader },
+        segmentLoader: { fn: segmentLoader },
+      },
+      emptyCorePlugins,
+    );
+
+    expect(result.representationFilter).toBe(repFilter);
+    expect(result.manifestLoader).toBe(manifestLoader);
+    expect(result.segmentLoader).toBe(segmentLoader);
+  });
+
+  it("should use eval string for representationFilter", () => {
+    const createdFilter = vi.fn();
+    mockCreateRepresentationFilter.mockReturnValue(createdFilter);
+
+    const result = extractExternalPlugins(
+      {
+        representationFilter: { eval: "some code" },
+        manifestLoader: undefined,
+        segmentLoader: undefined,
+      },
+      emptyCorePlugins,
+    );
+
+    expect(mockCreateRepresentationFilter).toHaveBeenCalledWith("some code");
+    expect(result.representationFilter).toBe(createdFilter);
+  });
+
+  it("should look up workerId in corePlugins maps", () => {
+    const workerRepFilter = vi.fn();
+    const workerManifestLoader = vi.fn();
+    const workerSegmentLoader = vi.fn();
+
+    const corePlugins = {
+      representationFilters: new Map([["rf-id", workerRepFilter]]),
+      segmentLoaders: new Map([["sl-id", workerSegmentLoader]]),
+      manifestLoaders: new Map([["ml-id", workerManifestLoader]]),
+    };
+
+    const result = extractExternalPlugins(
+      {
+        representationFilter: { workerId: "rf-id" },
+        manifestLoader: { workerId: "ml-id" },
+        segmentLoader: { workerId: "sl-id" },
+      },
+      corePlugins,
+    );
+
+    expect(result.representationFilter).toBe(workerRepFilter);
+    expect(result.manifestLoader).toBe(workerManifestLoader);
+    expect(result.segmentLoader).toBe(workerSegmentLoader);
+  });
+
+  it("should return undefined when workerId is not found in maps", () => {
+    const result = extractExternalPlugins(
+      {
+        representationFilter: { workerId: "unknown" },
+        manifestLoader: { workerId: "unknown" },
+        segmentLoader: { workerId: "unknown" },
+      },
+      emptyCorePlugins,
+    );
+
+    expect(result.representationFilter).toBeUndefined();
+    expect(result.manifestLoader).toBeUndefined();
+    expect(result.segmentLoader).toBeUndefined();
+  });
+
+  it("should prefer fn over eval and workerId for representationFilter", () => {
+    const fnFilter = vi.fn();
+    mockCreateRepresentationFilter.mockReturnValue(vi.fn());
+
+    const result = extractExternalPlugins(
+      {
+        representationFilter: { fn: fnFilter, eval: "some code", workerId: "rf-id" },
+        manifestLoader: undefined,
+        segmentLoader: undefined,
+      },
+      emptyCorePlugins,
+    );
+
+    expect(result.representationFilter).toBe(fnFilter);
+    expect(mockCreateRepresentationFilter).not.toHaveBeenCalled();
+  });
+});

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -1,21 +1,12 @@
-import { MediaSource_ } from "../../compat/browser_compatibility_types";
 import features from "../../features";
 import log from "../../log";
 import type { IContentInitializationData } from "../../main_thread/types";
 import type { IManifest } from "../../manifest";
-import { createRepresentationFilterFromFnString } from "../../manifest";
-import type Manifest from "../../manifest/classes";
 import type { IMediaSourceInterface } from "../../mse";
 import MainMediaSourceInterface from "../../mse/main_media_source_interface";
 import WorkerMediaSourceInterface from "../../mse/worker_media_source_interface";
-import type {
-  IPlayerError,
-  IRepresentationFilter,
-  ISegmentLoader,
-  IManifestLoader,
-} from "../../public_types";
+import type { IPlayerError } from "../../public_types";
 import idGenerator from "../../utils/id_generator";
-import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import type { CancellationError, CancellationSignal } from "../../utils/task_canceller";
 import TaskCanceller from "../../utils/task_canceller";
 import type { IRepresentationEstimator } from "../adaptive";
@@ -33,7 +24,12 @@ import { CoreMessageType } from "../types";
 import CoreTextDisplayerInterface from "./core_text_displayer_interface";
 import FreezeResolver from "./FreezeResolver";
 import TrackChoiceSetter from "./track_choice_setter";
-import { formatErrorForSender } from "./utils";
+import type { ICorePlugins } from "./utils";
+import {
+  extractExternalPlugins,
+  formatErrorForSender,
+  updateCodecSupportInWorkerMode,
+} from "./utils";
 
 /** Function allowing to associate a unique identifier to all created `MediaSource` */
 const generateMediaSourceId = idGenerator();
@@ -463,12 +459,6 @@ export interface IPreparedContentData {
   useMseInWorker: boolean;
 }
 
-export interface ICorePlugins {
-  representationFilters: Map<string, IRepresentationFilter>;
-  segmentLoaders: Map<string, ISegmentLoader>;
-  manifestLoaders: Map<string, IManifestLoader>;
-}
-
 /**
  * @param {Function} sendMessage
  * @param {string} contentId
@@ -539,105 +529,4 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
   });
 
   return [mediaSourceInterface, segmentSinksStore, textSender];
-}
-
-/**
- * Set Representation.isCodecSupportedInWebWorker to true or false
- * If the codec is supported in the current context.
- * If MSE in worker is not available, the attribute is not set.
- */
-function updateCodecSupportInWorkerMode(manifestToUpdate: Manifest) {
-  if (isNullOrUndefined(MediaSource_)) {
-    return;
-  }
-
-  const codecsMap = new Map<string, boolean>();
-  for (const period of manifestToUpdate.periods) {
-    const checkedAdaptations = [
-      ...(period.adaptations.video ?? []),
-      ...(period.adaptations.audio ?? []),
-    ];
-    for (const adaptation of checkedAdaptations) {
-      for (const representation of adaptation.representations) {
-        const codec = `${representation.mimeType};codecs="${representation.codecs[0]}"`;
-        if (codecsMap.has(codec)) {
-          representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
-        } else {
-          const supported = MediaSource_.isTypeSupported(codec);
-          representation.isCodecSupportedInWebWorker = supported;
-          codecsMap.set(codec, supported);
-        }
-      }
-    }
-  }
-}
-
-/**
- * Some functions may be defined by the API, we call those "plugins".
- * This function parses and extract the actual function from the different
- * ways an application can provide it to us.
- * @param {Object} input - The API input
- * @param {Object} corePlugins - Context on what identified functions are
- * defined right now.
- * @returns {Function}
- */
-function extractExternalPlugins(
-  input: {
-    manifestLoader:
-      | {
-          fn?: IManifestLoader | undefined;
-          workerId?: string | undefined;
-        }
-      | undefined;
-    segmentLoader:
-      | {
-          fn?: ISegmentLoader | undefined;
-          workerId?: string | undefined;
-        }
-      | undefined;
-    representationFilter:
-      | undefined
-      | {
-          fn?: IRepresentationFilter | undefined;
-          eval?: string | undefined;
-          workerId?: string | undefined;
-        };
-  },
-  corePlugins: ICorePlugins,
-): {
-  manifestLoader: IManifestLoader | undefined;
-  segmentLoader: ISegmentLoader | undefined;
-  representationFilter: IRepresentationFilter | undefined;
-} {
-  let manifestLoader;
-  let segmentLoader;
-  let representationFilter;
-  if (typeof input.representationFilter?.fn === "function") {
-    representationFilter = input.representationFilter.fn;
-  } else if (typeof input.representationFilter?.eval === "string") {
-    representationFilter = createRepresentationFilterFromFnString(
-      input.representationFilter.eval,
-    );
-  } else if (typeof input.representationFilter?.workerId === "string") {
-    representationFilter = corePlugins.representationFilters.get(
-      input.representationFilter.workerId,
-    );
-  }
-
-  if (typeof input.manifestLoader?.fn === "function") {
-    manifestLoader = input.manifestLoader.fn;
-  } else if (typeof input.manifestLoader?.workerId === "string") {
-    manifestLoader = corePlugins.manifestLoaders.get(input.manifestLoader.workerId);
-  }
-
-  if (typeof input.segmentLoader?.fn === "function") {
-    segmentLoader = input.segmentLoader.fn;
-  } else if (typeof input.segmentLoader?.workerId === "string") {
-    segmentLoader = corePlugins.segmentLoaders.get(input.segmentLoader.workerId);
-  }
-  return {
-    manifestLoader,
-    segmentLoader,
-    representationFilter,
-  };
 }

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -36,13 +36,12 @@ import type {
 } from "../types";
 import { CoreMessageType } from "../types";
 import ContentPreparer from "./content_preparer";
-import type { ICorePlugins } from "./content_preparer";
 import createContentTimeBoundariesObserver from "./create_content_time_boundaries_observer";
 import type { IFreezeResolution } from "./FreezeResolver";
 import getBufferedDataPerMediaBuffer from "./get_buffered_data_per_media_buffer";
 import getThumbnailData from "./get_thumbnail_data";
-import synchronizeSegmentSinksOnObservation from "./synchronize_sinks_on_observation";
-import { formatErrorForSender } from "./utils";
+import type { ICorePlugins } from "./utils";
+import { formatErrorForSender, synchronizeSegmentSinksOnObservation } from "./utils";
 
 export type IMessageReceiverCallback = (evt: { data: IMainThreadMessage }) => void;
 

--- a/src/core/entry/core_text_displayer_interface.ts
+++ b/src/core/entry/core_text_displayer_interface.ts
@@ -104,9 +104,11 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
     this._queues.pushTextData.forEach((elt) => {
       elt.reject(error);
     });
+    this._queues.pushTextData.length = 0;
     this._queues.remove.forEach((elt) => {
       elt.reject(error);
     });
+    this._queues.remove.length = 0;
   }
 
   /**
@@ -149,7 +151,7 @@ export default class CoreTextDisplayerInterface implements ITextDisplayerInterfa
    * @param {unknown} err
    */
   public onRemoveError(err: Error): void {
-    const element = this._queues.pushTextData.shift();
+    const element = this._queues.remove.shift();
     if (element === undefined) {
       log.error("text", "pushTextData error for inexistant operation");
       return;

--- a/src/core/entry/index.ts
+++ b/src/core/entry/index.ts
@@ -2,4 +2,4 @@ import type { IMessageReceiverCallback } from "./core_entry";
 import initializeCoreEntry from "./core_entry";
 export default initializeCoreEntry;
 export type { IMessageReceiverCallback };
-export type { ICorePlugins } from "./content_preparer";
+export type { ICorePlugins } from "./utils";

--- a/src/core/entry/utils.ts
+++ b/src/core/entry/utils.ts
@@ -1,6 +1,36 @@
+import { MediaSource_ } from "../../compat/browser_compatibility_types";
 import { formatError } from "../../errors";
+import type { ICorePlaybackObservation } from "../../main_thread/init/utils/create_core_playback_observer";
+import { createRepresentationFilterFromFnString } from "../../manifest";
+import type Manifest from "../../manifest/classes";
+import type {
+  IManifestLoader,
+  IRepresentationFilter,
+  ISegmentLoader,
+} from "../../public_types";
+import isNullOrUndefined from "../../utils/is_null_or_undefined";
+import type SegmentSinksStore from "../segment_sinks";
 import type { ISentError } from "../types";
 
+/**
+ * "Plugins" are a specific kind of API where an application can define complex
+ * functions that the RxPlayer will call in some normally-core aspects of media
+ * playback: e.g. loading segments.
+ *
+ * This interface lists them.
+ */
+export interface ICorePlugins {
+  representationFilters: Map<string, IRepresentationFilter>;
+  segmentLoaders: Map<string, ISegmentLoader>;
+  manifestLoaders: Map<string, IManifestLoader>;
+}
+
+/**
+ * Format an error, which may be of any form, into an Object than can easily be
+ * serialized - e.g. to be communicated through a postMessage-like API.
+ * @param {*} error - The error to serialized
+ * @returns {Object} - A serialization-safe error format
+ */
 export function formatErrorForSender(error: unknown): ISentError {
   const formattedError = formatError(error, {
     defaultCode: "NONE",
@@ -8,4 +38,125 @@ export function formatErrorForSender(error: unknown): ISentError {
   });
 
   return formattedError.serialize();
+}
+
+/**
+ * Synchronize SegmentSinks with what has been buffered.
+ * @param {Object} observation - The just-received playback observation,
+ * including what has been buffered on lower-level buffers
+ * @param {Object} segmentSinksStore - Interface allowing to interact
+ * with `SegmentSink`s, so their inventory can be updated accordingly.
+ */
+export function synchronizeSegmentSinksOnObservation(
+  observation: ICorePlaybackObservation,
+  segmentSinksStore: SegmentSinksStore,
+): void {
+  // Synchronize SegmentSinks with what has been buffered.
+  ["video" as const, "audio" as const, "text" as const].forEach((tType) => {
+    const segmentSinkStatus = segmentSinksStore.getStatus(tType);
+    if (segmentSinkStatus.type === "initialized") {
+      segmentSinkStatus.value.synchronizeInventory(observation.buffered[tType] ?? []);
+    }
+  });
+}
+
+/**
+ * Set Representation.isCodecSupportedInWebWorker to true or false
+ * If the codec is supported in the current context.
+ * If MSE in worker is not available, the attribute is not set.
+ */
+export function updateCodecSupportInWorkerMode(manifestToUpdate: Manifest) {
+  if (isNullOrUndefined(MediaSource_)) {
+    return;
+  }
+
+  const codecsMap = new Map<string, boolean>();
+  for (const period of manifestToUpdate.periods) {
+    const checkedAdaptations = [
+      ...(period.adaptations.video ?? []),
+      ...(period.adaptations.audio ?? []),
+    ];
+    for (const adaptation of checkedAdaptations) {
+      for (const representation of adaptation.representations) {
+        const codec = `${representation.mimeType};codecs="${representation.codecs[0]}"`;
+        if (codecsMap.has(codec)) {
+          representation.isCodecSupportedInWebWorker = codecsMap.get(codec);
+        } else {
+          const supported = MediaSource_.isTypeSupported(codec);
+          representation.isCodecSupportedInWebWorker = supported;
+          codecsMap.set(codec, supported);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Some functions may be defined by the API, we call those "plugins".
+ * This function parses and extract the actual function from the different
+ * ways an application can provide it to us.
+ * @param {Object} input - The API input
+ * @param {Object} corePlugins - Context on what identified functions are
+ * defined right now.
+ * @returns {Function}
+ */
+export function extractExternalPlugins(
+  input: {
+    manifestLoader:
+      | {
+          fn?: IManifestLoader | undefined;
+          workerId?: string | undefined;
+        }
+      | undefined;
+    segmentLoader:
+      | {
+          fn?: ISegmentLoader | undefined;
+          workerId?: string | undefined;
+        }
+      | undefined;
+    representationFilter:
+      | undefined
+      | {
+          fn?: IRepresentationFilter | undefined;
+          eval?: string | undefined;
+          workerId?: string | undefined;
+        };
+  },
+  corePlugins: ICorePlugins,
+): {
+  manifestLoader: IManifestLoader | undefined;
+  segmentLoader: ISegmentLoader | undefined;
+  representationFilter: IRepresentationFilter | undefined;
+} {
+  let manifestLoader;
+  let segmentLoader;
+  let representationFilter;
+  if (typeof input.representationFilter?.fn === "function") {
+    representationFilter = input.representationFilter.fn;
+  } else if (typeof input.representationFilter?.eval === "string") {
+    representationFilter = createRepresentationFilterFromFnString(
+      input.representationFilter.eval,
+    );
+  } else if (typeof input.representationFilter?.workerId === "string") {
+    representationFilter = corePlugins.representationFilters.get(
+      input.representationFilter.workerId,
+    );
+  }
+
+  if (typeof input.manifestLoader?.fn === "function") {
+    manifestLoader = input.manifestLoader.fn;
+  } else if (typeof input.manifestLoader?.workerId === "string") {
+    manifestLoader = corePlugins.manifestLoaders.get(input.manifestLoader.workerId);
+  }
+
+  if (typeof input.segmentLoader?.fn === "function") {
+    segmentLoader = input.segmentLoader.fn;
+  } else if (typeof input.segmentLoader?.workerId === "string") {
+    segmentLoader = corePlugins.segmentLoaders.get(input.segmentLoader.workerId);
+  }
+  return {
+    manifestLoader,
+    segmentLoader,
+    representationFilter,
+  };
 }


### PR DESCRIPTION
This commit continues our efforts to add a lot of unit tests in the core logic of the RxPlayer.

This time for core entry, the entry point of our worker when running in multithreading mode (or just the entry point toward the core logic in monothreading mode).

The code has been lightly modified this time to make it more testable: this just means that some utilts functions have been moved to another file.

It also detected an issue, but thankfully I cannot find a single way in which it would create an actual bug: a typo in our `CoreTextDisplayer` meant an error from a `remove` call would reject the last `push` call instead of `remove`.

This should not be possible for now as I don't see a case for `remove` to throw currently, it is only a theoretical, resilience, situation.