### PR TITLE
TTML: Do not apply percentage line heights

### DIFF
--- a/scripts/canal-release.patch
+++ b/scripts/canal-release.patch
@@ -70,8 +70,8 @@ index 63c98bbfc..92a8796e0 100644
    const trimmedLineHeight = lineHeight.trim();
    const splittedLineHeight = trimmedLineHeight.split(" ");
  
-@@ -38,10 +37,10 @@ export default function applyLineHeight(element: HTMLElement, lineHeight: string
-     firstLineHeight[2] === "%" ||
+@@ -54,10 +53,10 @@ export default function applyLineHeight(element: HTMLElement, lineHeight: string
+     // firstLineHeight[2] === "%" ||
      firstLineHeight[2] === "em"
    ) {
 -    element.style.lineHeight = firstLineHeight[1] + firstLineHeight[2];

--- a/src/parsers/texttracks/ttml/html/apply_line_height.ts
+++ b/src/parsers/texttracks/ttml/html/apply_line_height.ts
@@ -35,7 +35,22 @@ export default function applyLineHeight(element: HTMLElement, lineHeight: string
   }
   if (
     firstLineHeight[2] === "px" ||
-    firstLineHeight[2] === "%" ||
+    // TODO: For now, we disable the percentage unit as its rules are complex to
+    // implement in our current logic:
+    // A percentage `lineHeight` depends on the `fontSize` computed at that point,
+    // yet a lineHeight applies to a `p` in TTML and `fontSize` applies to a `span`
+    // (below `p`) and our translation applies that same level of style: CSS `lineHeight`
+    // is set on the element defining it, but `fontSize` is set at the end on each cue.
+    //
+    // Thus we cannot easily just rely on CSS' similar behavior for percentage
+    // `lineHeight`s because the `fontSize` might not be known at that point by
+    // the CSS (yet it might be for TTML). Work-around tricks are not straightforward
+    // either (e.g. we cannot just repeat the `fontSize` at both places because
+    // the potential percentage values in which they are expressed could coumpound).
+    // Seeing other players, it also seems poorly supported, so for now I think
+    // we can just ignore those. In a perfect world, it should be implemented
+    // though!
+    // firstLineHeight[2] === "%" ||
     firstLineHeight[2] === "em"
   ) {
     element.style.lineHeight = firstLineHeight[1] + firstLineHeight[2];


### PR DESCRIPTION
We had an issue recently where TTML subtitles provided by some packagers had cue lines that were partially overlapping.

Checking it closely, it seems that the issue was in the RxPlayer, in our interpretation of the `lineHeight` style attribute (in TTML) when it is set in percentages.

Like in CSS, a percentage `lineHeight` attribute is computed from the known `fontSize` that applies at that point, so translating it from TTML to CSS (which is what we do with subtitles when we're in the `"html"` `textTrackMode`) should be straightforward.

But there was a caveat I did not think about: the elements on which TTML style attributes are applied might not be the same than the one on which it is applied in CSS: a `lineHeight` is applied on the element that declared it ([the TTML spec indicates that it applies to a `p`](https://www.w3.org/TR/2018/REC-ttml1-20181108/#style-attribute-lineHeight)) but a `fontSize` is applied on the cue itself ([the TTML spec indicates that it applies on a `span`](https://www.w3.org/TR/2018/REC-ttml1-20181108/#style-attribute-fontSize))

Thus CSS might not have the same computed `fontSize` when a `lineHeight` is encountered than the original TTML file. And thus, the computed `lineHeight` could be wrong.

It seems fixable, but simple fixes all breaks in subtle way or are just complex enough to not be straightforward to keep it maintainable (e.g. you cannot just repeat a `fontSize` on parent+child because if that `fontSize` is in percentage and is just given also as percentage to CSS, it would coumpound).

Instead, I looked at what others were doing, and saw multiple implementations (including e.g. the shaka-player) just skipping percentage lineHeights.

I decided to also go that route for now: it's usually not a core style attribute, the default is readable but our previous implementation could easily not be.

I left a pretty big TODO at its place, hoping to be descriptive enough.