### PR TITLE
Do not patch out `pssh` box on DStv's Streama STB

### DIFF
--- a/src/compat/__tests__/can_patch_out_pssh.test.ts
+++ b/src/compat/__tests__/can_patch_out_pssh.test.ts
@@ -1,0 +1,40 @@
+import { describe, beforeEach, it, expect, vi, afterEach } from "vitest";
+import configHandler from "../../config";
+import canPatchOutPssh from "../can_patch_out_pssh";
+import EnvDetector, { mockEnvironment, resetEnvironment } from "../env_detector";
+
+describe("compat - canPatchOutPssh", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+    resetEnvironment();
+  });
+
+  it("should return true if we are not on the DSTV Streama MDP 1001s STB", () => {
+    mockEnvironment(EnvDetector.BROWSERS.Other, EnvDetector.DEVICES.Tizen, false);
+    expect(canPatchOutPssh()).toBe(true);
+  });
+
+  it("should return false if we force it through the config", () => {
+    const oldConfig = configHandler.getCurrent();
+    vi.spyOn(configHandler, "getCurrent").mockImplementation(() => {
+      return {
+        ...oldConfig,
+        PREVENT_PSSH_PATCHING: true,
+      };
+    });
+    mockEnvironment(EnvDetector.BROWSERS.Other, EnvDetector.DEVICES.Tizen, false);
+    expect(canPatchOutPssh()).toBe(false);
+  });
+
+  it("should return false if we are on the DSTV Streama MDP 1001s STB", () => {
+    mockEnvironment(
+      EnvDetector.BROWSERS.Other,
+      EnvDetector.DEVICES.StreamaMdp1001S,
+      false,
+    );
+    expect(canPatchOutPssh()).toBe(false);
+  });
+});

--- a/src/compat/can_patch_out_pssh.ts
+++ b/src/compat/can_patch_out_pssh.ts
@@ -1,0 +1,53 @@
+import config from "../config";
+import EnvDetector from "./env_detector";
+
+/**
+ * When talking about `ISOBMFF`/.mp4 metadata, the `pssh` is a box (a subpart of
+ * that file) containing protection-related metadata that is then used to
+ * interact with EME APIs.
+ *
+ * The idea in EME scenarios is that the EME player (here the RxPlayer) will
+ * take that data and communicate it to the browser's CDM (Content Decryption
+ * Module) through an EME API (generally `generateRequest`).
+ *
+ * There is a mechanism in place in browsers, presumably to facilitate that work
+ * which is that when the browser sees a `pssh` box in media data (either linked
+ * directly through a media element's `src` attribute or one communicated
+ * through MSE API) it can send an `encrypted` event so a JS player can then
+ * communicate it to the right EME API.
+ *
+ * However, in an MSE/EME player, we often are distrustful of letting the browser
+ * do work that can without issue be already done on our side (due to being
+ * burned too much time on some weird environment, where the spec isn't respected
+ * to the letter). So instead historically in MSE scenarios, the RxPlayer read the
+ * `pssh` itself, and then "patched it out" (replaced it with a `free` box,
+ * effectively a no-op for ISOBMFF metadata) from the segment before giving it to
+ * the browser's buffer so that we skip that now unnecessary browser round-trip
+ * (the `encrypted` event) and supplementary API surface that could be broken.
+ *
+ * Several years pass without issue, but in early 2026, we found out that one
+ * device, a "Streama" STB from DStv (owned by Multichoice) refuse to bufferise
+ * segments which had this "optimization" performed.
+ * We have no idea why, from our POV it's an issue on the browser integration side.
+ * They don't disagree but they cannot update that part of their device easily.
+ *
+ * So we decided to fix it player-side. When discussing about it, we hesitated
+ * between removing that "optimization" altogether or only for the specific device
+ * where we identified the issue. I chose (though far from everyone agreed!) the
+ * second solution (only for problematic device) because I feared changing
+ * behavior too much compared to most of our previous versions could break
+ * other devices, even if we saw that some other players such as the
+ * shaka-player did not do that same optimization.
+ *
+ * @returns {boolean}
+ */
+export default function canPatchOutPsshBox(): boolean {
+  const { PREVENT_PSSH_PATCHING } = config.getCurrent();
+  if (
+    PREVENT_PSSH_PATCHING ||
+    EnvDetector.device === EnvDetector.DEVICES.StreamaMdp1001S
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/src/compat/env_detector.ts
+++ b/src/compat/env_detector.ts
@@ -80,6 +80,8 @@ const DEVICES = {
   Xbox: 109,
   /** Another device that does not match with the others defined here. */
   Other: 110,
+  /** DSTtv's Streama STB MPD1001S, which is known to have some quirks. */
+  StreamaMdp1001S: 111,
 } as const;
 
 /** Interface giving information on the current environment where the RxPlayer runs. */
@@ -200,6 +202,8 @@ function resetEnvironment(): void {
     EnvDetector.device = DEVICES.PlayStation4;
   } else if (navigator.userAgent.indexOf("PlayStation 5") !== -1) {
     EnvDetector.device = DEVICES.PlayStation5;
+  } else if (navigator.userAgent.indexOf("DStv Streama, MDMP1001S") !== -1) {
+    EnvDetector.device = DEVICES.StreamaMdp1001S;
   } else if (/Tizen/.test(navigator.userAgent)) {
     EnvDetector.device = DEVICES.Tizen;
 

--- a/src/default_config.ts
+++ b/src/default_config.ts
@@ -1263,6 +1263,12 @@ const DEFAULT_CONFIG = {
   // Compatibility toggles:
 
   /**
+   * If set to `true`, we will not patch out a `pssh` box if found in an
+   * ISOBMFF segment.
+   */
+  PREVENT_PSSH_PATCHING: false,
+
+  /**
    * If set to `true`, we'll always try to check thoroughly that a
    * `MediaKeySystemAccess` can be relied on.
    */

--- a/src/parsers/containers/isobmff/__tests__/extract_pssh.test.ts
+++ b/src/parsers/containers/isobmff/__tests__/extract_pssh.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { concat } from "../../../../utils/byte_parsing";
+import extractPssh, { getPsshSystemID } from "../extract_pssh";
+
+const { mockCanPatchOutPsshBox, mockLog } = vi.hoisted(() => {
+  return {
+    mockCanPatchOutPsshBox: vi.fn(() => false),
+    mockLog: {
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      log: vi.fn(),
+      error: vi.fn(),
+    },
+  };
+});
+
+vi.mock("../../../../compat/can_patch_out_pssh", () => ({
+  default: mockCanPatchOutPsshBox,
+}));
+
+vi.mock("../../../../log", () => ({
+  default: mockLog,
+}));
+
+/** Build a minimal moov box wrapping `innerBytes`. */
+function buildMoovBox(innerBytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> {
+  const size = 8 + innerBytes.length;
+  const buf = new Uint8Array(size);
+  const view = new DataView(buf.buffer);
+  view.setUint32(0, size, false);
+  buf[4] = 0x6d;
+  buf[5] = 0x6f;
+  buf[6] = 0x6f;
+  buf[7] = 0x76; // "moov"
+  buf.set(innerBytes, 8);
+  return buf;
+}
+
+/**
+ * Build a pssh box.
+ *
+ * Layout (after size + name):
+ *   1 byte  version
+ *   3 bytes flags
+ *  16 bytes systemId
+ *   N bytes extra data
+ */
+function buildPsshBox(
+  systemId: Uint8Array<ArrayBuffer>,
+  version = 0,
+  extraData: Uint8Array<ArrayBuffer> = new Uint8Array(0),
+): Uint8Array<ArrayBuffer> {
+  // 8 (size+name) + 1 (version) + 3 (flags) + 16 (systemId) + extraData
+  const size = 8 + 1 + 3 + 16 + extraData.length;
+  const buf = new Uint8Array(size);
+  const view = new DataView(buf.buffer);
+  view.setUint32(0, size, false);
+  buf[4] = 0x70;
+  buf[5] = 0x73;
+  buf[6] = 0x73;
+  buf[7] = 0x68; // "pssh"
+  buf[8] = version; // version (bytes 0 of version+flags)
+  // flags stay 0x000000
+  buf.set(systemId, 12); // offset 8+4 = 12
+  buf.set(extraData, 28);
+  return buf;
+}
+
+const SYSTEM_ID_A = new Uint8Array([
+  0x10, 0x77, 0xef, 0xec, 0xc0, 0xb2, 0x4d, 0x02, 0xac, 0xe3, 0x3c, 0x1e, 0x52, 0xe2,
+  0xfb, 0x4b,
+]);
+const SYSTEM_ID_B = new Uint8Array([
+  0xed, 0xef, 0x8b, 0xa9, 0x79, 0xd6, 0x4a, 0xce, 0xa3, 0xc8, 0x27, 0xdc, 0xd5, 0x1d,
+  0x21, 0xed,
+]);
+
+const systemIdAHex = Array.from(SYSTEM_ID_A)
+  .map((b) => b.toString(16).padStart(2, "0"))
+  .join("");
+const systemIdBHex = Array.from(SYSTEM_ID_B)
+  .map((b) => b.toString(16).padStart(2, "0"))
+  .join("");
+
+describe("extractPssh", () => {
+  beforeEach(() => {
+    mockCanPatchOutPsshBox.mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns [] when there is no moov box", () => {
+    const data = new Uint8Array(32); // no moov, only `0`
+    expect(extractPssh(data)).toEqual([]);
+  });
+
+  it("returns [] when moov contains no pssh box", () => {
+    // An empty moov (just the 8-byte header, no inner boxes)
+    const data = buildMoovBox(new Uint8Array(0));
+    expect(extractPssh(data)).toEqual([]);
+  });
+
+  it("extracts a single pssh box", () => {
+    const pssh = buildPsshBox(SYSTEM_ID_A);
+    const data = buildMoovBox(pssh);
+    const result = extractPssh(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].systemId).toBe(systemIdAHex);
+  });
+
+  it("extracts multiple pssh boxes in order", () => {
+    const psshA = buildPsshBox(SYSTEM_ID_A);
+    const psshB = buildPsshBox(SYSTEM_ID_B);
+    const data = buildMoovBox(concat(psshA, psshB));
+    const result = extractPssh(data);
+    expect(result).toHaveLength(2);
+    expect(result[0].systemId).toBe(systemIdAHex);
+    expect(result[1].systemId).toBe(systemIdBHex);
+  });
+
+  it("skips a pssh whose systemId cannot be parsed and keeps going", () => {
+    // A pssh with version > 1 triggers the 'un-handled PSSH version' warn path,
+    // so getPsshSystemID returns undefined and the box is omitted.
+    const psshBad = buildPsshBox(SYSTEM_ID_A, 2 /* unsupported version */);
+    const psshGood = buildPsshBox(SYSTEM_ID_B);
+    const data = buildMoovBox(concat(psshBad, psshGood));
+    const result = extractPssh(data);
+    expect(result).toHaveLength(1);
+    expect(result[0].systemId).toBe(systemIdBHex);
+    expect(mockLog.warn).toHaveBeenCalledWith("isobmff", "un-handled PSSH version");
+  });
+
+  it("patches out pssh bytes when canPatchOutPsshBox returns true", () => {
+    mockCanPatchOutPsshBox.mockReturnValue(true);
+    const pssh = buildPsshBox(SYSTEM_ID_A);
+    const moov = buildMoovBox(pssh);
+    // The pssh box starts at offset 8 inside moov content (right after moov header).
+    // After patching, bytes 4–7 of the pssh box should be "free" (0x66 0x72 0x65 0x65).
+    extractPssh(moov);
+    // moov content starts at offset 8 of the full segment.
+    // pssh name is at moov_content[4..7] = segment[12..15]
+    expect(moov[12]).toBe(0x66); // 'f'
+    expect(moov[13]).toBe(0x72); // 'r'
+    expect(moov[14]).toBe(0x65); // 'e'
+    expect(moov[15]).toBe(0x65); // 'e'
+  });
+
+  it("does not patch bytes when canPatchOutPsshBox returns false", () => {
+    mockCanPatchOutPsshBox.mockReturnValue(false);
+    const pssh = buildPsshBox(SYSTEM_ID_A);
+    const originalNameByte1 = pssh[4]; // should be 0x70 ('p')
+    const originalNameByte2 = pssh[5]; // 's'
+    const originalNameByte3 = pssh[6]; // 's'
+    const originalNameByte4 = pssh[7]; // 'h'
+    const moov = buildMoovBox(pssh);
+    extractPssh(moov);
+    expect(moov[12]).toBe(originalNameByte1);
+    expect(moov[13]).toBe(originalNameByte2);
+    expect(moov[14]).toBe(originalNameByte3);
+    expect(moov[15]).toBe(originalNameByte4);
+  });
+});
+
+describe("getPsshSystemID", () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses a valid version-0 pssh and returns hex systemId", () => {
+    const pssh = buildPsshBox(SYSTEM_ID_A);
+    // initialDataOffset is the offset right after size (4) + name (4) = 8
+    const result = getPsshSystemID(pssh, 8);
+    expect(result).toBe(systemIdAHex);
+  });
+
+  it("parses a valid version-1 pssh", () => {
+    const pssh = buildPsshBox(SYSTEM_ID_B, 1);
+    const result = getPsshSystemID(pssh, 8);
+    expect(result).toBe(systemIdBHex);
+  });
+
+  it("returns undefined and warns for version > 1", () => {
+    const pssh = buildPsshBox(SYSTEM_ID_A, 2);
+    const result = getPsshSystemID(pssh, 8);
+    expect(result).toBeUndefined();
+    expect(mockLog.warn).toHaveBeenCalledWith("isobmff", "un-handled PSSH version");
+  });
+
+  it("returns undefined when buffer is too short to contain a full systemId", () => {
+    // Build a buffer that's big enough for the header (version + flags = 4 bytes)
+    // but lacks the 16-byte systemId.
+    const buf = new Uint8Array(8 + 4 + 10); // only 10 bytes where 16 are needed
+    const result = getPsshSystemID(buf, 8);
+    expect(result).toBeUndefined();
+    expect(mockLog.warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/parsers/containers/isobmff/extract_pssh.ts
+++ b/src/parsers/containers/isobmff/extract_pssh.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import canPatchOutPsshBox from "../../../compat/can_patch_out_pssh";
 import log from "../../../log";
 import sliceUint8Array from "../../../utils/slice_uint8array";
 import { bytesToHex } from "../../../utils/string_parsing";
@@ -28,15 +29,17 @@ export interface IISOBMFFPSSHInfo {
 }
 
 /**
- * Replace every PSSH box from an ISOBMFF segment by FREE boxes and returns the
- * removed PSSH in an array.
+ * Return every `pssh` box from an ISOBMFF segment.
+ *
+ * If the current device has no issue with it, also replace them by `free` boxes.
  * Useful to manually manage encryption while avoiding the round-trip with the
  * browser's encrypted event.
+ *
  * @param {Uint8Array} data - the ISOBMFF segment
  * @returns {Array.<Uint8Array>} - The extracted PSSH boxes. In the order they
  * are encountered.
  */
-export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSHInfo[] {
+export default function extractPssh(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSHInfo[] {
   const moovContent = getBoxContent(data, 0x6d6f6f76 /* moov */);
   if (moovContent === null) {
     return [];
@@ -49,7 +52,7 @@ export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSH
     try {
       psshOffsets = getBoxOffsets(remainingMoovContent, 0x70737368 /* pssh */);
     } catch (e) {
-      const err = e instanceof Error ? e : "";
+      const err = e instanceof Error ? e : new Error("Unknown ISOBMFF box reading error");
       log.warn("isobmff", "Error while removing PSSH from ISOBMFF", err);
       return psshBoxes;
     }
@@ -60,6 +63,13 @@ export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSH
     const systemId = getPsshSystemID(pssh, psshOffsets[1] - psshOffsets[0]);
     if (systemId !== undefined) {
       psshBoxes.push({ systemId, data: pssh });
+    }
+    if (canPatchOutPsshBox()) {
+      // replace by `free` box.
+      remainingMoovContent[psshOffsets[0] + 4] = 0x66;
+      remainingMoovContent[psshOffsets[0] + 5] = 0x72;
+      remainingMoovContent[psshOffsets[0] + 6] = 0x65;
+      remainingMoovContent[psshOffsets[0] + 7] = 0x65;
     }
     remainingMoovContent = remainingMoovContent.subarray(psshOffsets[2]);
   }

--- a/src/parsers/containers/isobmff/index.ts
+++ b/src/parsers/containers/isobmff/index.ts
@@ -15,9 +15,9 @@
  */
 
 import extractCompleteChunks, { extractInitSegment } from "./extract_complete_chunks";
+import extractPssh, { getPsshSystemID } from "./extract_pssh";
 import findCompleteBox from "./find_complete_box";
 import removeDolbyVisionConfigData from "./remove_dolby_vision_config_data";
-import takePSSHOut, { getPsshSystemID } from "./take_pssh_out";
 
 export { extractInitSegment };
 export { createBox, createBoxWithChildren } from "./create_box";
@@ -44,5 +44,5 @@ export {
   findCompleteBox,
   getPsshSystemID,
   removeDolbyVisionConfigData,
-  takePSSHOut,
+  extractPssh,
 };

--- a/src/parsers/containers/isobmff/take_pssh_out.ts
+++ b/src/parsers/containers/isobmff/take_pssh_out.ts
@@ -37,14 +37,13 @@ export interface IISOBMFFPSSHInfo {
  * are encountered.
  */
 export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSHInfo[] {
-  let i = 0;
-  const moov = getBoxContent(data, 0x6d6f6f76 /* moov */);
+  let moov = getBoxContent(data, 0x6d6f6f76 /* moov */);
   if (moov === null) {
     return [];
   }
 
   const psshBoxes: IISOBMFFPSSHInfo[] = [];
-  while (i < moov.length) {
+  while (moov.length !== 0) {
     let psshOffsets;
     try {
       psshOffsets = getBoxOffsets(moov, 0x70737368 /* pssh */);
@@ -63,11 +62,12 @@ export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSH
     }
 
     // replace by `free` box.
-    moov[psshOffsets[0] + 4] = 0x66;
-    moov[psshOffsets[0] + 5] = 0x72;
-    moov[psshOffsets[0] + 6] = 0x65;
-    moov[psshOffsets[0] + 7] = 0x65;
-    i = psshOffsets[2];
+    // moov[psshOffsets[0] + 4] = 0x66;
+    // moov[psshOffsets[0] + 5] = 0x72;
+    // moov[psshOffsets[0] + 6] = 0x65;
+    // moov[psshOffsets[0] + 7] = 0x65;
+    // i = psshOffsets[2];
+    moov = moov?.slice(psshOffsets[2]);
   }
   return psshBoxes;
 }

--- a/src/parsers/containers/isobmff/take_pssh_out.ts
+++ b/src/parsers/containers/isobmff/take_pssh_out.ts
@@ -37,16 +37,17 @@ export interface IISOBMFFPSSHInfo {
  * are encountered.
  */
 export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSHInfo[] {
-  let moov = getBoxContent(data, 0x6d6f6f76 /* moov */);
-  if (moov === null) {
+  const moovContent = getBoxContent(data, 0x6d6f6f76 /* moov */);
+  if (moovContent === null) {
     return [];
   }
 
   const psshBoxes: IISOBMFFPSSHInfo[] = [];
-  while (moov.length !== 0) {
+  let remainingMoovContent = moovContent;
+  while (remainingMoovContent.length > 0) {
     let psshOffsets;
     try {
-      psshOffsets = getBoxOffsets(moov, 0x70737368 /* pssh */);
+      psshOffsets = getBoxOffsets(remainingMoovContent, 0x70737368 /* pssh */);
     } catch (e) {
       const err = e instanceof Error ? e : "";
       log.warn("isobmff", "Error while removing PSSH from ISOBMFF", err);
@@ -55,19 +56,12 @@ export default function takePSSHOut(data: Uint8Array<ArrayBuffer>): IISOBMFFPSSH
     if (psshOffsets === null) {
       return psshBoxes;
     }
-    const pssh = sliceUint8Array(moov, psshOffsets[0], psshOffsets[2]);
+    const pssh = sliceUint8Array(remainingMoovContent, psshOffsets[0], psshOffsets[2]);
     const systemId = getPsshSystemID(pssh, psshOffsets[1] - psshOffsets[0]);
     if (systemId !== undefined) {
       psshBoxes.push({ systemId, data: pssh });
     }
-
-    // replace by `free` box.
-    // moov[psshOffsets[0] + 4] = 0x66;
-    // moov[psshOffsets[0] + 5] = 0x72;
-    // moov[psshOffsets[0] + 6] = 0x65;
-    // moov[psshOffsets[0] + 7] = 0x65;
-    // i = psshOffsets[2];
-    moov = moov?.slice(psshOffsets[2]);
+    remainingMoovContent = remainingMoovContent.subarray(psshOffsets[2]);
   }
   return psshBoxes;
 }

--- a/src/transports/dash/segment_parser.ts
+++ b/src/transports/dash/segment_parser.ts
@@ -19,7 +19,7 @@ import logger from "../../log";
 import {
   getMDHDTimescale,
   getSegmentsFromSidx,
-  takePSSHOut,
+  extractPssh,
   removeDolbyVisionConfigData,
 } from "../../parsers/containers/isobmff";
 import {
@@ -96,7 +96,7 @@ export default function generateAudioVideoSegmentParser({
 
     const protectionData: IProtectionDataInfo[] = [];
     if (seemsToBeMP4) {
-      const psshInfo = takePSSHOut(chunkData);
+      const psshInfo = extractPssh(chunkData);
       let keyId;
       if (segment.isInit) {
         keyId = getKeyIdFromInitSegment(chunkData) ?? undefined;

--- a/src/transports/local/segment_parser.ts
+++ b/src/transports/local/segment_parser.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getMDHDTimescale, takePSSHOut } from "../../parsers/containers/isobmff";
+import { getMDHDTimescale, extractPssh } from "../../parsers/containers/isobmff";
 import { getKeyIdFromInitSegment } from "../../parsers/containers/isobmff/utils";
 import { getTimeCodeScale } from "../../parsers/containers/matroska";
 import type {
@@ -68,7 +68,7 @@ export default function segmentParser(
   const seemsToBeMP4 = containerType === "mp4" || containerType === undefined;
   const protectionData: IProtectionDataInfo[] = [];
   if (seemsToBeMP4) {
-    const psshInfo = takePSSHOut(chunkData);
+    const psshInfo = extractPssh(chunkData);
     let keyId;
     if (segment.isInit) {
       keyId = getKeyIdFromInitSegment(chunkData) ?? undefined;


### PR DESCRIPTION

## Stop patching out the `pssh` on some Streama STB

_Copy-pasting here the JSDoc from the code for the PR's info, because I found that it summed it up well:_

When talking about `ISOBMFF`/.mp4 metadata, the `pssh` is a box (a subpart of that file) containing protection-related metadata that is then used to interact with EME APIs.

The idea in EME scenarios is that the EME player (here the RxPlayer) will take that data and communicate it to the browser's CDM (Content Decryption Module) through an EME API (generally `generateRequest`).

There is a mechanism in place in browsers, presumably to facilitate that work which is that when the browser sees a `pssh` box in media data (either linked directly through a media element's `src` attribute or one communicated
through MSE API) it can send an `encrypted` event so a JS player can then communicate it to the right EME API.

However, in an MSE/EME player, we often are distrustful of letting the browser do work that can without issue be already done on our side (due to being burned too much time on some weird environment, where the spec isn't respected to the letter). So instead historically in MSE scenarios, the RxPlayer read the `pssh` itself, and then "patched it out" (replaced it with a `free` box, effectively a no-op for ISOBMFF metadata) from the segment before giving it to the browser's buffer so that we skip that now unnecessary browser round-trip (the `encrypted` event) and supplementary API surface that could be broken.

Several years pass without issue, but in early 2026, we found out that one device, a "Streama" STB from DStv (owned by Multichoice) refuse to bufferise segments which had this "optimization" performed.
We have no idea why, from our POV it's an issue on the browser integration side. They don't disagree but they cannot update that part of their device easily.

So we decided to fix it player-side. When discussing about it, we hesitated between removing that "optimization" altogether or only for the specific device where we identified the issue. I chose (though far from everyone agreed!) the second solution (only for problematic device) because I feared changing behavior too much compared to most of our previous versions could break other devices, even if we saw that some other players such as the shaka-player did not do that same optimization.
