### PR TITLE
init: continue playback if text displayer fail to initialize

### DIFF
--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -353,21 +353,30 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     }
 
     let textDisplayer: ITextDisplayer | null = null;
-    if (
-      this._settings.textTrackOptions.textTrackMode === "html" &&
-      features.htmlTextDisplayer !== null
-    ) {
-      assert(this._hasTextBufferFeature());
-      textDisplayer = new features.htmlTextDisplayer(
-        mediaElement,
-        this._settings.textTrackOptions.textTrackElement,
+    try {
+      if (
+        this._settings.textTrackOptions.textTrackMode === "html" &&
+        features.htmlTextDisplayer !== null
+      ) {
+        assert(this._hasTextBufferFeature());
+        textDisplayer = new features.htmlTextDisplayer(
+          mediaElement,
+          this._settings.textTrackOptions.textTrackElement,
+        );
+      } else if (features.nativeTextDisplayer !== null) {
+        assert(this._hasTextBufferFeature());
+        textDisplayer = new features.nativeTextDisplayer(mediaElement);
+      } else {
+        assert(!this._hasTextBufferFeature());
+      }
+    } catch (err) {
+      log.error(
+        "Init",
+        "failed to initialize text displayer",
+        err instanceof Error ? err : "Unknown Error",
       );
-    } else if (features.nativeTextDisplayer !== null) {
-      assert(this._hasTextBufferFeature());
-      textDisplayer = new features.nativeTextDisplayer(mediaElement);
-    } else {
-      assert(!this._hasTextBufferFeature());
     }
+
     this._initCanceller.signal.register((err) => {
       textDisplayer?.stop(err.reason);
     });


### PR DESCRIPTION
I was working on a new development which added some integration tests relying on our mock DummyMediaElement (mocking HTML5+MSE+EME for test envs).

That mock fails to perform a few operation including adding a `<track>` element for text-tracks. We don't care much about native track element in those tests for now, so it wasn't necessary to implement it until now.

Yet it made me see an issue inside the RxPlayer: in the unlikely event where that API would not be implemented, the RxPlayer would just hang indefinitely in a LOADING state, instead of just continuing without displaying subtitles.

I don't know about a single actual case for now where it would fail, and most applications rely on the `"html"` `textTrackMode` anyway which does not have this issue, but nonetheless I thought it was a quick resilience win to just continue playback when it happens.