### PR TITLE
Do not send two times a `streamEvent` when reloading while in it

### DIFF
--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -190,7 +190,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       manifest: null,
       mediaSourceInfo: null,
       rebufferingController: null,
-      streamEventsEmitter: null,
       initialTime: undefined,
       autoPlay: undefined,
       initialPlayPerformed: null,
@@ -2077,13 +2076,6 @@ export interface IMediaSourceContentInitializerContentInfos {
    * `null` if none is currently created for the content.
    */
   rebufferingController: RebufferingController | null;
-  /**
-   * Current `StreamEventsEmitter` linked to the content, allowing to
-   * send events found in the Manifest.
-   *
-   * `null` if none is currently created for the content.
-   */
-  streamEventsEmitter: StreamEventsEmitter | null;
   /**
    * The initial position to seek to in seconds once the content is loadeed.
    * `undefined` if unknown yet.

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -411,12 +411,32 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       contentInfo.contentDecryptor = contentDecryptor;
     }
 
+    const streamEventsEmitter = new StreamEventsEmitter(playbackObserver);
+    streamEventsEmitter.addEventListener(
+      "event",
+      (payload) => {
+        this.trigger("streamEvent", payload);
+      },
+      this._initCanceller.signal,
+    );
+    streamEventsEmitter.addEventListener(
+      "eventSkip",
+      (payload) => {
+        this.trigger("streamEventSkip", payload);
+      },
+      this._initCanceller.signal,
+    );
+    this._initCanceller.signal.register((err) => {
+      streamEventsEmitter.stop(err.reason);
+    });
+
     const playbackStartParams = {
       mediaElement,
       textDisplayer,
       playbackObserver,
       drmInitializationStatus,
       mediaSourceStatus,
+      streamEventsEmitter,
     };
     mediaSourceStatus.onUpdate(
       (msInitStatus, stopListeningMSStatus) => {
@@ -519,6 +539,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         textDisplayer,
         playbackObserver,
         mediaSourceStatus,
+        streamEventsEmitter,
         position,
         !isPaused,
       );
@@ -930,6 +951,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             return;
           }
           const manifest = msgData.value.manifest;
+          streamEventsEmitter.start(manifest);
           this._currentContentInfo.manifest = manifest;
           this._updateCodecSupport(manifest, mediaElement);
           this._startPlaybackIfReady(playbackStartParams);
@@ -957,8 +979,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
               msgData.value.updates,
             );
           }
-          this._currentContentInfo?.streamEventsEmitter?.onManifestUpdate(manifest);
-
+          streamEventsEmitter.onManifestUpdate(manifest);
           this._updateCodecSupport(manifest, mediaElement);
           this.trigger("manifestUpdate", msgData.value.updates);
           break;
@@ -1567,6 +1588,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     textDisplayer: ITextDisplayer | null,
     playbackObserver: IMediaElementPlaybackObserver,
     mediaSourceStatus: SharedReference<MediaSourceInitializationStatus>,
+    streamEventsEmitter: StreamEventsEmitter,
     position: number,
     autoPlay: boolean,
   ) {
@@ -1574,6 +1596,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     this._currentMediaSourceCanceller = new TaskCanceller("Init MediaSource");
     this._currentMediaSourceCanceller.linkToSignal(this._initCanceller.signal);
     mediaSourceStatus.setValue(MediaSourceInitializationStatus.AttachNow);
+    streamEventsEmitter.pause();
     this.trigger("reloadingMediaSource", { position, autoPlay });
 
     mediaSourceStatus.onUpdate(
@@ -1589,6 +1612,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
             mediaElement,
             textDisplayer,
             playbackObserver,
+            streamEventsEmitter,
           },
           this._currentMediaSourceCanceller.signal,
         );
@@ -1644,6 +1668,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       mediaElement: IMediaElement;
       textDisplayer: ITextDisplayer | null;
       playbackObserver: IMediaElementPlaybackObserver;
+      streamEventsEmitter: StreamEventsEmitter;
     },
     cancelSignal: CancellationSignal,
   ): IReadOnlyPlaybackObserver<ICorePlaybackObservation> | null {
@@ -1661,10 +1686,17 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
 
     const { manifest, mediaSourceInfo } = this._currentContentInfo;
     const { speed } = this._settings;
-    const { initialTime, autoPlay, mediaElement, textDisplayer, playbackObserver } =
-      parameters;
+    const {
+      initialTime,
+      autoPlay,
+      mediaElement,
+      textDisplayer,
+      playbackObserver,
+      streamEventsEmitter,
+    } = parameters;
     this._currentContentInfo.initialTime = initialTime;
     this._currentContentInfo.autoPlay = autoPlay;
+    streamEventsEmitter.pause(); // Only start polling events once ready to play
 
     const { autoPlayResult, initialPlayPerformed } = performInitialSeekAndPlay(
       {
@@ -1678,6 +1710,15 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       cancelSignal,
     );
     this._currentContentInfo.initialPlayPerformed = initialPlayPerformed;
+    initialPlayPerformed.onUpdate(
+      (isPerformed, stopListening) => {
+        if (isPerformed) {
+          stopListening();
+          streamEventsEmitter.resume(); // We can now start polling events
+        }
+      },
+      { clearSignal: cancelSignal, emitCurrentValue: true },
+    );
     const corePlaybackObserver = createCorePlaybackObserver(
       playbackObserver,
       {
@@ -1719,36 +1760,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     });
     rebufferingController.start();
     this._currentContentInfo.rebufferingController = rebufferingController;
-
-    const currentContentInfo = this._currentContentInfo;
-    initialPlayPerformed.onUpdate(
-      (isPerformed, stopListening) => {
-        if (isPerformed) {
-          stopListening();
-          const streamEventsEmitter = new StreamEventsEmitter(manifest, playbackObserver);
-          currentContentInfo.streamEventsEmitter = streamEventsEmitter;
-          streamEventsEmitter.addEventListener(
-            "event",
-            (payload) => {
-              this.trigger("streamEvent", payload);
-            },
-            cancelSignal,
-          );
-          streamEventsEmitter.addEventListener(
-            "eventSkip",
-            (payload) => {
-              this.trigger("streamEventSkip", payload);
-            },
-            cancelSignal,
-          );
-          streamEventsEmitter.start();
-          cancelSignal.register((err) => {
-            streamEventsEmitter.stop(err.reason);
-          });
-        }
-      },
-      { clearSignal: cancelSignal, emitCurrentValue: true },
-    );
 
     const _getSegmentSinkMetrics = async (): Promise<ISegmentSinkMetrics | undefined> => {
       this._awaitingRequests.nextRequestId++;
@@ -1864,6 +1875,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     playbackObserver: IMediaElementPlaybackObserver;
     drmInitializationStatus: IReadOnlySharedReference<IDrmInitializationStatus>;
     mediaSourceStatus: IReadOnlySharedReference<MediaSourceInitializationStatus>;
+    streamEventsEmitter: StreamEventsEmitter;
   }): boolean {
     if (this._currentContentInfo === null || this._currentContentInfo.manifest === null) {
       return false;
@@ -1893,6 +1905,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         mediaElement: parameters.mediaElement,
         textDisplayer: parameters.textDisplayer,
         playbackObserver: parameters.playbackObserver,
+        streamEventsEmitter: parameters.streamEventsEmitter,
       },
       this._currentMediaSourceCanceller.signal,
     );

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -353,21 +353,30 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     }
 
     let textDisplayer: ITextDisplayer | null = null;
-    if (
-      this._settings.textTrackOptions.textTrackMode === "html" &&
-      features.htmlTextDisplayer !== null
-    ) {
-      assert(this._hasTextBufferFeature());
-      textDisplayer = new features.htmlTextDisplayer(
-        mediaElement,
-        this._settings.textTrackOptions.textTrackElement,
+    try {
+      if (
+        this._settings.textTrackOptions.textTrackMode === "html" &&
+        features.htmlTextDisplayer !== null
+      ) {
+        assert(this._hasTextBufferFeature());
+        textDisplayer = new features.htmlTextDisplayer(
+          mediaElement,
+          this._settings.textTrackOptions.textTrackElement,
+        );
+      } else if (features.nativeTextDisplayer !== null) {
+        assert(this._hasTextBufferFeature());
+        textDisplayer = new features.nativeTextDisplayer(mediaElement);
+      } else {
+        assert(!this._hasTextBufferFeature());
+      }
+    } catch (err) {
+      log.error(
+        "Init",
+        "failed to initialize text displayer",
+        err instanceof Error ? err : "Unknown Error",
       );
-    } else if (features.nativeTextDisplayer !== null) {
-      assert(this._hasTextBufferFeature());
-      textDisplayer = new features.nativeTextDisplayer(mediaElement);
-    } else {
-      assert(!this._hasTextBufferFeature());
     }
+
     this._initCanceller.signal.register((err) => {
       textDisplayer?.stop(err.reason);
     });

--- a/src/main_thread/init/utils/__tests__/stream_events_emitter.test.ts
+++ b/src/main_thread/init/utils/__tests__/stream_events_emitter.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IManifestMetadata } from "../../../../manifest";
+import type {
+  IPlaybackObservation,
+  IReadOnlyPlaybackObserver,
+} from "../../../../playback_observer";
+import { SeekingState } from "../../../../playback_observer";
+import SharedReference from "../../../../utils/reference";
+import type { CancellationSignal } from "../../../../utils/task_canceller";
+import TaskCanceller from "../../../../utils/task_canceller";
+import StreamEventsEmitter from "../stream_events_emitter/stream_events_emitter";
+
+describe("init - StreamEventsEmitter", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should not send skipped events for positions crossed while the media is not ready", () => {
+    vi.useFakeTimers();
+
+    const observationRef = new SharedReference(generateObservation(4));
+    const playbackObserver = createPlaybackObserver(observationRef);
+    const streamEventsEmitter = new StreamEventsEmitter(playbackObserver);
+    const skippedEvents: unknown[] = [];
+    const regularEvents: unknown[] = [];
+    const stopCanceller = new TaskCanceller("test");
+
+    streamEventsEmitter.addEventListener(
+      "event",
+      (evt) => {
+        regularEvents.push(evt);
+      },
+      stopCanceller.signal,
+    );
+    streamEventsEmitter.addEventListener(
+      "eventSkip",
+      (evt) => {
+        skippedEvents.push(evt);
+      },
+      stopCanceller.signal,
+    );
+
+    streamEventsEmitter.start(generateManifest());
+    streamEventsEmitter.pause();
+
+    observationRef.setValue(generateObservation(9));
+    vi.advanceTimersByTime(200);
+
+    streamEventsEmitter.resume();
+    observationRef.setValue(generateObservation(9.1));
+    vi.advanceTimersByTime(200);
+
+    expect(regularEvents).toHaveLength(0);
+    expect(skippedEvents).toHaveLength(0);
+
+    streamEventsEmitter.stop("test end");
+    stopCanceller.cancel("test end");
+  });
+
+  it("should compare from the current position immediately after resuming", () => {
+    vi.useFakeTimers();
+
+    const observationRef = new SharedReference(generateObservation(4));
+    const playbackObserver = createPlaybackObserver(observationRef);
+    const streamEventsEmitter = new StreamEventsEmitter(playbackObserver);
+    const regularEvents: unknown[] = [];
+    const stopCanceller = new TaskCanceller("test");
+
+    streamEventsEmitter.addEventListener(
+      "event",
+      (evt) => {
+        regularEvents.push(evt);
+      },
+      stopCanceller.signal,
+    );
+
+    streamEventsEmitter.start(generateManifest());
+    streamEventsEmitter.pause();
+
+    observationRef.setValue(generateObservation(4.5));
+    streamEventsEmitter.resume();
+    observationRef.setValue(generateObservation(8.5));
+    vi.advanceTimersByTime(200);
+
+    expect(regularEvents).toHaveLength(1);
+
+    streamEventsEmitter.stop("test end");
+    stopCanceller.cancel("test end");
+  });
+});
+
+function createPlaybackObserver(
+  observationRef: SharedReference<IPlaybackObservation>,
+): IReadOnlyPlaybackObserver<IPlaybackObservation> {
+  return {
+    getCurrentTime() {
+      return observationRef.getValue().position.getPolled();
+    },
+    getPlaybackRate() {
+      return 1;
+    },
+    getReadyState() {
+      return 4;
+    },
+    getIsPaused() {
+      return false;
+    },
+    getReference() {
+      return observationRef;
+    },
+    listen(
+      cb: (observation: IPlaybackObservation, stopListening: () => void) => void,
+      options: {
+        includeLastObservation?: boolean | undefined;
+        clearSignal: CancellationSignal;
+      },
+    ) {
+      observationRef.onUpdate(cb, {
+        clearSignal: options.clearSignal,
+        emitCurrentValue: options.includeLastObservation,
+      });
+    },
+    deriveReadOnlyObserver() {
+      throw new Error("unused in this test");
+    },
+  } as unknown as IReadOnlyPlaybackObserver<IPlaybackObservation>;
+}
+
+function generateManifest(): IManifestMetadata {
+  return {
+    periods: [
+      {
+        start: 0,
+        streamEvents: [
+          {
+            start: 5,
+            end: 8,
+            id: "evt",
+            data: {
+              type: "dash-event-stream",
+              value: {
+                schemeIdUri: "urn:test",
+                timescale: 1,
+                xmlData: { data: "<Event />", namespaces: [] },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  } as unknown as IManifestMetadata;
+}
+
+function generateObservation(currentTime: number): IPlaybackObservation {
+  return {
+    event: "timeupdate",
+    seeking: SeekingState.None,
+    rebuffering: null,
+    freezing: null,
+    duration: 100,
+    ended: false,
+    paused: false,
+    playbackRate: 1,
+    readyState: 4,
+    bufferGap: 10,
+    fullyLoaded: false,
+    currentRange: { start: 0, end: 20 },
+    buffered: {} as TimeRanges,
+    position: {
+      getPolled() {
+        return currentTime;
+      },
+    } as IPlaybackObservation["position"],
+  };
+}

--- a/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
+++ b/src/main_thread/init/utils/stream_events_emitter/stream_events_emitter.ts
@@ -16,11 +16,11 @@
 
 import config from "../../../../config";
 import type { IManifestMetadata } from "../../../../manifest";
-import { SeekingState } from "../../../../playback_observer";
 import type {
   IPlaybackObservation,
   IReadOnlyPlaybackObserver,
 } from "../../../../playback_observer";
+import { SeekingState } from "../../../../playback_observer";
 import EventEmitter from "../../../../utils/event_emitter";
 import SharedReference from "../../../../utils/reference";
 import type { CancellationSignal } from "../../../../utils/task_canceller";
@@ -42,27 +42,34 @@ interface IStreamEventsEmitterEvent {
  * Get events from manifest and emit each time an event has to be emitted
  */
 export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitterEvent> {
-  private _manifest: IManifestMetadata;
+  /** Regularly emit playback metrics such as the position. */
   private _playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>;
+  /** Current stream events tracked for the whole content. */
   private _scheduledEventsRef: SharedReference<
     Array<IStreamEventPayload | INonFiniteStreamEventPayload>
   >;
+  /** Events currently considered active, to only emit their enter/exit once. */
   private _eventsBeingPlayed: WeakMap<
     IStreamEventPayload | INonFiniteStreamEventPayload,
     true
   >;
+  /** Whether event evaluation is temporarily suspended, e.g. during a reload. */
+  private _isPaused: boolean;
+  /** Last observation used as comparison point for the next event check. */
+  private _previousObservation: {
+    /** Media position that is being played. */
+    currentTime: number;
+    /** If `true`, we're currently seeking in the media. */
+    isSeeking: boolean;
+  } | null;
+  /** Cancels the current emitter lifecycle. */
   private _canceller: TaskCanceller | null;
 
   /**
-   * @param {Object} manifest
    * @param {Object} playbackObserver
    */
-  constructor(
-    manifest: IManifestMetadata,
-    playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>,
-  ) {
+  constructor(playbackObserver: IReadOnlyPlaybackObserver<IPlaybackObservation>) {
     super();
-    this._manifest = manifest;
     this._playbackObserver = playbackObserver;
     this._canceller = null;
     this._scheduledEventsRef = new SharedReference<
@@ -72,22 +79,36 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
       IStreamEventPayload | INonFiniteStreamEventPayload,
       true
     >();
+    this._isPaused = true;
+    this._previousObservation = null;
   }
 
-  public start(): void {
+  /**
+   * Initialize the emitter for the given content manifest.
+   *
+   * The emitter starts in a paused state so the caller can resume it only once
+   * the corresponding media instance is actually ready.
+   * @param {Object} manifest
+   */
+  public start(manifest: IManifestMetadata): void {
     if (this._canceller !== null) {
       return;
     }
     this._canceller = new TaskCanceller("StreamEventsEmitter");
 
     const cancelSignal = this._canceller.signal;
-    const playbackObserver = this._playbackObserver;
+    this._isPaused = true;
+    this._previousObservation = null;
+    this._eventsBeingPlayed = new WeakMap<
+      IStreamEventPayload | INonFiniteStreamEventPayload,
+      true
+    >();
 
     let isPollingEvents = false;
     let cancelCurrentPolling = new TaskCanceller("StreamEventsEmitter Polling");
     cancelCurrentPolling.linkToSignal(cancelSignal);
 
-    this._scheduledEventsRef.setValue(refreshScheduledEventsList([], this._manifest));
+    this._scheduledEventsRef.setValue(refreshScheduledEventsList([], manifest));
 
     this._scheduledEventsRef.onUpdate(
       ({ length: scheduledEventsLength }) => {
@@ -103,16 +124,22 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
           return;
         }
         isPollingEvents = true;
-        let oldObservation = constructObservation();
         const checkStreamEvents = () => {
-          const newObservation = constructObservation();
+          if (this._isPaused) {
+            return;
+          }
+          const newObservation = this._constructObservation();
+          if (this._previousObservation === null) {
+            this._previousObservation = newObservation;
+            return;
+          }
           this._emitStreamEvents(
             this._scheduledEventsRef.getValue(),
-            oldObservation,
+            this._previousObservation,
             newObservation,
             cancelCurrentPolling.signal,
           );
-          oldObservation = newObservation;
+          this._previousObservation = newObservation;
         };
 
         const { STREAM_EVENT_EMITTER_POLL_INTERVAL } = config.getCurrent();
@@ -120,7 +147,7 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
           checkStreamEvents,
           STREAM_EVENT_EMITTER_POLL_INTERVAL,
         );
-        playbackObserver.listen(checkStreamEvents, {
+        this._playbackObserver.listen(checkStreamEvents, {
           includeLastObservation: false,
           clearSignal: cancelCurrentPolling.signal,
         });
@@ -128,20 +155,34 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
         cancelCurrentPolling.signal.register(() => {
           clearInterval(intervalId);
         });
-
-        function constructObservation() {
-          const lastObservation = playbackObserver.getReference().getValue();
-          const currentTime =
-            playbackObserver.getCurrentTime() ??
-            playbackObserver.getReference().getValue().position.getPolled();
-          const isSeeking = lastObservation.seeking !== SeekingState.None;
-          return { currentTime, isSeeking };
-        }
       },
       { emitCurrentValue: true, clearSignal: cancelSignal },
     );
   }
 
+  /**
+   * Suspend event evaluation until `resume` has been called.
+   *
+   * To use when playback metrics should be temporarily ignored, for example
+   * while reloading a content.
+   */
+  public pause(): void {
+    this._isPaused = true;
+    this._previousObservation = null;
+  }
+
+  /**
+   * Resume event evaluation from the current playback state.
+   */
+  public resume(): void {
+    this._isPaused = false;
+
+    // Take a snapshot right now to avoid comparing a post-reload position
+    // with a stale pre-reload observation.
+    this._previousObservation = this._constructObservation();
+  }
+
+  /** Refresh the tracked stream-event list after a manifest update. */
   public onManifestUpdate(man: IManifestMetadata) {
     const prev = this._scheduledEventsRef.getValue();
     this._scheduledEventsRef.setValue(refreshScheduledEventsList(prev, man));
@@ -156,12 +197,35 @@ export default class StreamEventsEmitter extends EventEmitter<IStreamEventsEmitt
     if (this._canceller !== null) {
       this._canceller.cancel(reason ?? "StreamEventsEmitter stop");
       this._canceller = null;
+      this._previousObservation = null;
+      this._eventsBeingPlayed = new WeakMap<
+        IStreamEventPayload | INonFiniteStreamEventPayload,
+        true
+      >();
     }
   }
 
   /**
+   * Construct observation object relied on by the `StreamEventsEmitted` by
+   * generating it from this instance's `PlaybackObserver`.
+   */
+  private _constructObservation(): {
+    /** Current media position that is being played. */
+    currentTime: number;
+    /** If `true`, we're currently seeking in the media. */
+    isSeeking: boolean;
+  } {
+    const lastObservation = this._playbackObserver.getReference().getValue();
+    const currentTime =
+      this._playbackObserver.getCurrentTime() ??
+      this._playbackObserver.getReference().getValue().position.getPolled();
+    const isSeeking = lastObservation.seeking !== SeekingState.None;
+    return { currentTime, isSeeking };
+  }
+
+  /**
    * Examine playback situation from playback observations to emit stream events and
-   * prepare set onExit callbacks if needed.
+   * prepare `onExit` callbacks if needed.
    * @param {Array.<Object>} scheduledEvents
    * @param {Object} oldObservation
    * @param {Object} newObservation

--- a/tests/contents/static/DASH_static_SegmentTimeline/event-stream-audio-codec-switch.js
+++ b/tests/contents/static/DASH_static_SegmentTimeline/event-stream-audio-codec-switch.js
@@ -1,0 +1,23 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_static_SegmentTimeline/media/";
+
+const PERIOD_2_START = 101.568367;
+
+export default {
+  url: BASE_URL + "event-streams_audio_codec_switch.mpd",
+  transport: "dash",
+  crossingEvent: {
+    id: "5",
+    start: 100,
+    end: 110,
+    period2Start: PERIOD_2_START,
+  },
+  laterPeriodEvent: {
+    id: "1",
+    start: PERIOD_2_START + 20,
+  },
+};

--- a/tests/contents/static/DASH_static_SegmentTimeline/index.js
+++ b/tests/contents/static/DASH_static_SegmentTimeline/index.js
@@ -9,6 +9,7 @@ import segmentTemplateInheritanceASRep from "./segment_template_inheritance_as_r
 import segmentTemplateInheritancePeriodAS from "./segment_template_inheritance_period_as";
 import segmentTimelineEndNumber from "./segment_timeline_end_number";
 import streamEventsInfos from "./event-stream";
+import streamEventsAudioCodecSwitchInfos from "./event-stream-audio-codec-switch";
 import trickModeInfos from "./trickmode.js";
 
 export {
@@ -23,5 +24,6 @@ export {
   segmentTemplateInheritancePeriodAS,
   segmentTimelineEndNumber,
   streamEventsInfos,
+  streamEventsAudioCodecSwitchInfos,
   trickModeInfos,
 };

--- a/tests/contents/static/DASH_static_SegmentTimeline/media/event-streams_audio_codec_switch.mpd
+++ b/tests/contents/static/DASH_static_SegmentTimeline/media/event-streams_audio_codec_switch.mpd
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT3M35S"
+  maxSegmentDuration="PT5S"
+  minBufferTime="PT10S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period
+    id="1"
+    duration="PT1M41.568367S">
+
+    <EventStream schemeIdUri="urn:uuid:XYZY" timescale="10000" value="call">
+      <Event presentationTime="50000" duration="30000" id="0">
+        <data> 5 - 8 </data>
+      </Event>
+      <Event presentationTime="200000" id="1">
+        20
+      </Event>
+      <Event presentationTime="400000" duration="100000" id="2">
+        40 - 50
+      </Event>
+      <Event presentationTime="450000" duration="90000" id="3">
+        45 - 55
+      </Event>
+      <Event presentationTime="450000" duration="150000" id="6">
+        45 - 60
+      </Event>
+      <Event presentationTime="1000000" duration="100000" id="5">
+        <data>100 - 110</data>
+      </Event>
+    </EventStream>
+
+    <BaseURL>dash/</BaseURL>
+    <AdaptationSet group="1" contentType="audio" segmentAlignment="true" audioSamplingRate="44100" mimeType="audio/mp4" codecs="mp4a.40.2" startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+    <AdaptationSet group="2" contentType="video" par="40:17" minBandwidth="400000" maxBandwidth="1996000" maxWidth="2221" maxHeight="944" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive" />
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive" />
+      <Representation id="video=1193000" bandwidth="1193000" width="768" height="432" sar="45:34" codecs="avc1.42C01E" scanType="progressive" />
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive" />
+    </AdaptationSet>
+  </Period>
+
+  <Period
+    id="2"
+    duration="PT1M41.568367S">
+
+    <EventStream schemeIdUri="urn:uuid:XYZ" timescale="1000" value="call">
+      <Event id="foo" />
+      <Event presentationTime="0" id="bar">
+        <data>0</data>
+      </Event>
+      <Event presentationTime="4000" duration="5000" id="0">
+        <data>4 - 9</data>
+      </Event>
+      <Event presentationTime="20000" id="1">
+        20
+      </Event>
+      <Event presentationTime="40000" duration="3000" id="2">
+        40-43
+      </Event>
+      <Event presentationTime="60000" duration="1" id="4">
+        60-60.001
+      </Event>
+    </EventStream>
+
+    <BaseURL>dash/</BaseURL>
+    <AdaptationSet group="1" contentType="audio" segmentAlignment="true" audioSamplingRate="44100" mimeType="audio/mp4" codecs="ec-3" startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="44100" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="177152" />
+          <S d="176128" r="1" />
+          <S d="177152" />
+          <S d="176128" />
+          <S d="64512" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+    <AdaptationSet group="2" contentType="video" par="40:17" minBandwidth="400000" maxBandwidth="1996000" maxWidth="2221" maxHeight="944" segmentAlignment="true" mimeType="video/mp4" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate timescale="1000" initialization="ateam-$RepresentationID$.dash" media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline><S t="0" d="4004" r="24" /><S d="1376" /></SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video=400000" bandwidth="400000" width="220" height="124" sar="248:187" codecs="avc1.42C014" scanType="progressive" />
+      <Representation id="video=795000" bandwidth="795000" width="368" height="208" sar="520:391" codecs="avc1.42C014" scanType="progressive" />
+      <Representation id="video=1193000" bandwidth="1193000" width="768" height="432" sar="45:34" codecs="avc1.42C01E" scanType="progressive" />
+      <Representation id="video=1996000" bandwidth="1996000" width="1680" height="944" sar="472:357" codecs="avc1.640028" scanType="progressive" />
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/static/DASH_static_SegmentTimeline/urls.mjs
+++ b/tests/contents/static/DASH_static_SegmentTimeline/urls.mjs
@@ -100,6 +100,11 @@ export default [
     contentType: "application/dash+xml",
   },
   {
+    url: BASE_URL + "event-streams_audio_codec_switch.mpd",
+    path: path.join(currentDirectory, "media/event-streams_audio_codec_switch.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
     url: BASE_URL + "segment_template_inheritance_period_as.mpd",
     path: path.join(currentDirectory, "media/segment_template_inheritance_period_as.mpd"),
     contentType: "application/dash+xml",

--- a/tests/integration/scenarios/dash_stream-events_on_reload.test.js
+++ b/tests/integration/scenarios/dash_stream-events_on_reload.test.js
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import RxPlayer from "../../../dist/es2017";
+import DummyMediaElement from "../../../dist/es2017/experimental/tools/DummyMediaElement";
+import { streamEventsAudioCodecSwitchInfos } from "../../contents/static/DASH_static_SegmentTimeline";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
+import { waitForLoadedStateAfterLoadVideo } from "../../utils/waitForPlayerState";
+
+const MID_PERIOD_RELOAD_EVENT = {
+  id: "6",
+  start: 45,
+  end: 60,
+};
+
+describe("DASH Stream events on reload", function () {
+  const oldMediaSourceSupported = MediaSource.isTypeSupported;
+  let player;
+  let dummy;
+
+  beforeEach(() => {
+    MediaSource.isTypeSupported = () => true;
+    dummy = new DummyMediaElement();
+    player = new RxPlayer({ videoElement: dummy });
+    player.setWantedBufferAhead(10);
+  });
+
+  afterEach(() => {
+    MediaSource.isTypeSupported = oldMediaSourceSupported;
+    player.dispose();
+  });
+
+  async function loadContent(startAt) {
+    player.loadVideo({
+      url: streamEventsAudioCodecSwitchInfos.url,
+      transport: streamEventsAudioCodecSwitchInfos.transport,
+      autoPlay: true,
+      startAt: { position: startAt },
+      onCodecSwitch: "reload",
+    });
+    await waitForLoadedStateAfterLoadVideo(player);
+  }
+
+  async function waitForReloadAndPosition(
+    observedStates,
+    minimumPosition,
+    maxTimeMs = 20000,
+  ) {
+    await checkAfterSleepWithBackoff({ minTimeMs: 1000, stepMs: 100, maxTimeMs }, () => {
+      expect(player.getError()).toBe(null);
+      expect(observedStates).toContain("PLAYING");
+      expect(observedStates).toContain("RELOADING");
+      expect(player.getPosition()).toBeGreaterThan(minimumPosition);
+    });
+  }
+
+  it("should not send twice an event that stays active through an internal reload", async function () {
+    const { crossingEvent } = streamEventsAudioCodecSwitchInfos;
+    const receivedStreamEvents = [];
+    const observedStates = [];
+    player.addEventListener("streamEvent", (evt) => {
+      if (evt.data.value.element.getAttribute("id") === crossingEvent.id) {
+        receivedStreamEvents.push(evt);
+      }
+    });
+    player.addEventListener("playerStateChange", (state) => {
+      observedStates.push(state);
+    });
+
+    await loadContent(crossingEvent.start - 0.5);
+    await waitForReloadAndPosition(observedStates, crossingEvent.period2Start + 1);
+
+    expect(receivedStreamEvents).toHaveLength(1);
+  }, 30000);
+
+  it("should not emit a skip event for an event that stays active through an internal reload", async function () {
+    const { crossingEvent } = streamEventsAudioCodecSwitchInfos;
+    const receivedStreamEventSkips = [];
+    const observedStates = [];
+    player.addEventListener("streamEventSkip", (evt) => {
+      if (evt.data.value.element.getAttribute("id") === crossingEvent.id) {
+        receivedStreamEventSkips.push(evt);
+      }
+    });
+    player.addEventListener("playerStateChange", (state) => {
+      observedStates.push(state);
+    });
+
+    await loadContent(crossingEvent.start - 0.5);
+    await waitForReloadAndPosition(observedStates, crossingEvent.period2Start + 1);
+
+    expect(receivedStreamEventSkips).toHaveLength(0);
+  }, 30000);
+
+  it("should still emit later Period 2 events after the internal reload", async function () {
+    const { crossingEvent, laterPeriodEvent } = streamEventsAudioCodecSwitchInfos;
+    const receivedStreamEvents = [];
+    const observedStates = [];
+    player.addEventListener("streamEvent", (evt) => {
+      if (evt.data.value.element.getAttribute("id") === laterPeriodEvent.id) {
+        receivedStreamEvents.push(evt);
+      }
+    });
+    player.addEventListener("playerStateChange", (state) => {
+      observedStates.push(state);
+    });
+
+    await loadContent(crossingEvent.start - 0.5);
+    await waitForReloadAndPosition(observedStates, laterPeriodEvent.start + 1, 30000);
+
+    expect(receivedStreamEvents).toHaveLength(1);
+  }, 40000);
+
+  it("should not send twice an event that stays active through a mid-Period representation reload", async function () {
+    const receivedStreamEvents = [];
+    const observedStates = [];
+    let initialRepresentationId;
+    let targetRepresentationId;
+    player.addEventListener("streamEvent", (evt) => {
+      if (evt.data.value.element.getAttribute("id") === MID_PERIOD_RELOAD_EVENT.id) {
+        receivedStreamEvents.push(evt);
+      }
+    });
+    player.addEventListener("playerStateChange", (state) => {
+      observedStates.push(state);
+    });
+    player.addEventListener("newAvailablePeriods", (periods) => {
+      const period = periods[0];
+      const videoTrack = player.getVideoTrack(period.id);
+      expect(videoTrack).not.toBe(null);
+      expect(videoTrack.representations.length).toBeGreaterThan(1);
+      initialRepresentationId = videoTrack.representations[0].id;
+      targetRepresentationId = videoTrack.representations[1].id;
+      player.lockVideoRepresentations({
+        periodId: period.id,
+        representations: [initialRepresentationId],
+      });
+    });
+
+    player.loadVideo({
+      url: streamEventsAudioCodecSwitchInfos.url,
+      transport: streamEventsAudioCodecSwitchInfos.transport,
+      autoPlay: true,
+      startAt: { position: MID_PERIOD_RELOAD_EVENT.start - 0.5 },
+    });
+    await waitForLoadedStateAfterLoadVideo(player);
+
+    const initialPeriod = player.getCurrentPeriod();
+    await checkAfterSleepWithBackoff(
+      { minTimeMs: 100, stepMs: 100, maxTimeMs: 10000 },
+      () => {
+        expect(player.getError()).toBe(null);
+        expect(receivedStreamEvents).toHaveLength(1);
+        expect(observedStates).not.toContain("RELOADING");
+        expect(observedStates).toContain("LOADING");
+        expect(observedStates).toContain("PLAYING");
+        expect(player.getPosition()).toBeGreaterThan(46);
+        expect(initialRepresentationId).toBeDefined();
+        expect(targetRepresentationId).toBeDefined();
+      },
+    );
+
+    expect(player.getVideoRepresentation().id).toEqual(initialRepresentationId);
+    player.lockVideoRepresentations({
+      representations: [targetRepresentationId],
+      switchingMode: "reload",
+    });
+
+    await checkAfterSleepWithBackoff(
+      { minTimeMs: 200, stepMs: 100, maxTimeMs: 15000 },
+      () => {
+        expect(player.getError()).toBe(null);
+        const reloadIndex = observedStates.indexOf("RELOADING");
+        const lastPlayingIndex = observedStates.lastIndexOf("PLAYING");
+        expect(reloadIndex).toBeGreaterThanOrEqual(0);
+        expect(lastPlayingIndex).toBeGreaterThan(reloadIndex);
+        expect(player.getPlayerState()).toBe("PLAYING");
+        expect(player.getCurrentPeriod()?.id).toBe(initialPeriod?.id);
+        expect(player.getPosition()).toBeGreaterThanOrEqual(
+          MID_PERIOD_RELOAD_EVENT.start,
+        );
+        expect(player.getPosition()).toBeLessThan(MID_PERIOD_RELOAD_EVENT.end);
+        expect(player.getVideoRepresentation().id).toEqual(targetRepresentationId);
+      },
+    );
+
+    expect(receivedStreamEvents).toHaveLength(1);
+  }, 30000);
+});


### PR DESCRIPTION
  Based on #1827 (textTrackDisplayer resilience fix, relied on here to keep the tests simpler)

  We have a case in production where server-side teams complained that ads were sometimes acknowledged twice
  instead of once.

  ## Preamble: DASH `EventStream` and the RxPlayer event API

  Those contents rely on DASH's `EventStream` concept, which adds `<Event>` tags inside the MPD (DASH's
  manifest file) to indicate those acknowledgement events.

  Those `Event`s have a `start` in seconds and either no `duration`, in which case they correspond to a point
  in time, or also a `duration` in seconds, in which case they correspond to a time interval.

  The RxPlayer then triggers a `streamEvent` event at the right time, which is either when we pass that "point"
  or when we enter that time interval. It can also indicate an event exit (when there is a duration) or emit a
  `streamEventSkip` when the event is skipped over.

  ## Issue: events with a duration coupled to a reload

  The content on which the issue was observed has a second underlying issue: the ad is only available with AAC
  audio, whereas the regular content can play in DD+.

  On some devices, when encountering that codec switch, the RxPlayer needs to reset all media buffers from
  scratch, a process we call "reloading".

  When reloading, the `StreamEventsEmitter`, which is the module handling `EventStream`s, was also re-created,
  meaning that it lost the context it had before. For `<Event>`s with a duration, if they have very unlucky
  timings and include the timestamp at which we reload, this can lead to entering that event interval twice:
  once before the reload, and a second time after the reload when playback resumes.

  This is the problem that was observed.

  ## The fix: same `StreamEventsEmitter` instance for the whole content + `pause` / `resume` concepts

  To fix this, I chose to keep the same `StreamEventsEmitter` instance for the whole content instead of
  creating a new one on each reload, so it can preserve the context it had before the reload.

  Doing that required another behavior: it now has additional `pause` / `resume` APIs so it does not capture
  playback events while reloading is in progress, as playback metrics can be temporarily reset during that time
  and do not correspond to what we would consider "actual playback".

  ## Tests

  Most of the diff is tests.

  I added both unit tests for `StreamEventsEmitter`, to cover the new behavior, and integration tests with a
  new fake static content reproducing that issue.

  Those integration test fail before this fix and succeed after it.