### PR TITLE
adaptive: fix starvation emergency delay

### DIFF
--- a/src/core/adaptive/__tests__/network_analyzer.test.ts
+++ b/src/core/adaptive/__tests__/network_analyzer.test.ts
@@ -111,6 +111,23 @@ afterEach(() => {
   vi.resetAllMocks();
 });
 
+function createProgressEvents(
+  baseTime: number,
+  totalSize: number,
+  stepSize: number,
+  stepDurationMs: number,
+): Array<{ size: number; timestamp: number; totalSize: number }> {
+  const progress = [{ size: 0, timestamp: baseTime, totalSize }];
+  let size = 0;
+  let timestamp = baseTime;
+  while (size < totalSize) {
+    size = Math.min(size + stepSize, totalSize);
+    timestamp += stepDurationMs;
+    progress.push({ size, timestamp, totalSize });
+  }
+  return progress;
+}
+
 describe("estimateRequestBandwidth", () => {
   it("should return undefined if progress events are less than 5", () => {
     // eslint-disable-next-line no-restricted-properties
@@ -301,6 +318,41 @@ describe("NetworkAnalyzer", () => {
 
       // Should exit starvation mode and use regular factor
       expect(result.bitrateChosen).toBe(2000000 * 0.8);
+    });
+
+    it("should allow emergency estimate before 12s for short segments", () => {
+      const analyzer = new NetworkAnalyzer(1000000, false);
+      const bandwidthEstimator = createMockBandwidthEstimator(undefined);
+      const resetSpy = vi.spyOn(bandwidthEstimator, "reset");
+      const requestStart = 1000;
+      const now = 7000;
+      const performanceNowSpy = vi.spyOn(performance, "now").mockReturnValue(now);
+      const currentRepresentation = new DummyRepresentation({
+        bitrate: 1_200_000,
+      });
+      const currentRequests = [
+        createMockRequest(
+          10,
+          2,
+          requestStart,
+          createProgressEvents(requestStart, 1_000_000, 100_000, 100),
+          true,
+        ),
+      ];
+
+      const result = analyzer.getBandwidthEstimate(
+        createMockPlaybackInfo(1, 9),
+        bandwidthEstimator,
+        currentRepresentation,
+        currentRequests,
+        1_100_000,
+      );
+
+      expect(result.bandwidthEstimate).toBeDefined();
+      expect(result.bitrateChosen).toBeLessThan(currentRepresentation.bitrate);
+      expect(resetSpy).toHaveBeenCalled();
+      performanceNowSpy.mockRestore();
+      resetSpy.mockRestore();
     });
 
     it("should handle infinite buffer gap", () => {

--- a/src/core/adaptive/network_analyzer.ts
+++ b/src/core/adaptive/network_analyzer.ts
@@ -166,9 +166,9 @@ function estimateStarvationModeBitrate(
   const concernedRequest = concernedRequests[0];
   const now = getMonotonicTimeStamp();
 
-  let minimumRequestTime = concernedRequest.content.segment.duration * 1.5;
-  minimumRequestTime = Math.min(minimumRequestTime, 3000);
-  minimumRequestTime = Math.max(minimumRequestTime, 12000);
+  let minimumRequestTime = concernedRequest.content.segment.duration * 1500;
+  minimumRequestTime = Math.max(minimumRequestTime, 3000);
+  minimumRequestTime = Math.min(minimumRequestTime, 12000);
   if (now - concernedRequest.requestTimestamp < minimumRequestTime) {
     return undefined;
   }


### PR DESCRIPTION
"Starvation mode" is a special state in our ABR logic, which happens when the A/V buffer is empty or close to empty.

During that mode, we have an heuristic running which can trigger fall in quality if the current request hangs for too long.

We do not want it to trigger too early (we still want our ABR logic to be stable and reflect a long-term bandwidth), but we still want it to react fast enough when playback is already getting in danger of rebuffering.

Here that logic had two issues:
  1. it was defining the segment's duration in seconds, but then clamped its values as milliseconds
  2. the clamp was badly done, only going to the largest value instead.

So in the end we were always waiting 12 seconds before looking for such bandwidth falls.

For short (e.g. 2 seconds) segments, this is too long a time to wait.

This commit does not change the heuristic, but fix the clamping done so we begin checking for a bandwidth fall for between between 3 and 12 seconds after the request start.