### PR TITLE
adaptive: Fix off by one error in RepresentationScoreCalculator (For low-latency contents)

### DIFF
--- a/src/core/adaptive/utils/__tests__/representation_score_calculator.test.ts
+++ b/src/core/adaptive/utils/__tests__/representation_score_calculator.test.ts
@@ -119,7 +119,7 @@ describe("RepresentationScoreCalculator", () => {
       expect(estimate).toBeUndefined();
     });
 
-    it("should return LOW confidence when less than 5 segments loaded", () => {
+    it("should return LOW confidence when less than 6 segments loaded", () => {
       calculator.addSample(mockRepresentation1, 2, 4);
       calculator.addSample(mockRepresentation1, 2, 4);
 
@@ -128,8 +128,8 @@ describe("RepresentationScoreCalculator", () => {
     });
 
     it("should return LOW confidence when loaded duration is less than 10 seconds", () => {
-      // Add 5 segments but with short duration
-      for (let i = 0; i < 5; i++) {
+      // Add 6 segments but with short duration
+      for (let i = 0; i < 6; i++) {
         calculator.addSample(mockRepresentation1, 1, 1);
       }
 
@@ -137,8 +137,7 @@ describe("RepresentationScoreCalculator", () => {
       expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.LOW);
     });
 
-    it("should return HIGH confidence when > 5 segments and >= 10 seconds loaded", () => {
-      // Add 5 segments with 2 seconds each (total 10 seconds)
+    it("should return HIGH confidence when 6 segments and >= 10 seconds loaded", () => {
       for (let i = 0; i < 6; i++) {
         calculator.addSample(mockRepresentation1, 1, 2);
       }
@@ -147,8 +146,8 @@ describe("RepresentationScoreCalculator", () => {
       expect(estimate?.confidenceLevel).toBe(ScoreConfidenceLevel.HIGH);
     });
 
-    it("should return HIGH confidence when > 5 segments and > 10 seconds loaded", () => {
-      // Add 5 segments with 3 seconds each (total 15 seconds)
+    it("should return HIGH confidence when > 6 segments and > 10 seconds loaded", () => {
+      // Add 6 segments with 3 seconds each (total 15 seconds)
       for (let i = 0; i < 6; i++) {
         calculator.addSample(mockRepresentation1, 1, 3);
       }

--- a/src/core/adaptive/utils/representation_score_calculator.ts
+++ b/src/core/adaptive/utils/representation_score_calculator.ts
@@ -110,7 +110,7 @@ export default class RepresentationScoreCalculator {
         representation,
         ewma: currentEWMA,
         loadedDuration: segmentDuration,
-        loadedSegments: 0,
+        loadedSegments: 1,
       };
     }
 
@@ -143,7 +143,7 @@ export default class RepresentationScoreCalculator {
     const { ewma, loadedSegments, loadedDuration } = this._currentRepresentationData;
     const estimate = ewma.getEstimate();
     const confidenceLevel =
-      loadedSegments >= 5 && loadedDuration >= 10
+      loadedSegments >= 6 && loadedDuration >= 10
         ? ScoreConfidenceLevel.HIGH
         : ScoreConfidenceLevel.LOW;
 


### PR DESCRIPTION
Low-latency contents may rely on a very specific ABR algorithm, that just look at the ability to sustain recent segment requests.

The code intended to wait for 5 segments but manifestly looking at the logic, we waited for 6 segments instead.

The 6 segments seems to be what we tested the most, so I now more explicitely wait for 6 segments. 

As such, this sould not change the actual logic.