### PR TITLE
cmcd: do not set deadline and rtp when <=0 playback rate. Better escaping

### DIFF
--- a/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
+++ b/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
@@ -392,6 +392,18 @@ describe("CmcdDataBuilder", () => {
       expect(sessionHeader).not.toContain("pr=");
     });
 
+    it("does not include pr when playback speed is negative", () => {
+      const builder = new CmcdDataBuilder({ communicationType: "headers" });
+      const observer = makePlaybackObserver({ speed: -1, rebuffering: null });
+      builder.startMonitoringPlayback(
+        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
+      );
+
+      const payload: any = builder.getCmcdDataForManifest("dash");
+      const sessionHeader = payload.value["CMCD-Session"];
+      expect(sessionHeader).not.toContain("pr=");
+    });
+
     it("includes su when rebuffering is active", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ rebuffering: { timestamp: 0 }, speed: 1 });

--- a/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
+++ b/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
@@ -403,6 +403,29 @@ describe("CmcdDataBuilder", () => {
       const requestHeader = payload.value["CMCD-Request"];
       expect(requestHeader).toContain("su");
     });
+
+    it("does not include dl or rtp when playback speed is 0", () => {
+      const builder = new CmcdDataBuilder({ communicationType: "headers" });
+      const observer = makePlaybackObserver({
+        buffered: {
+          video: [{ start: 5, end: 20 }],
+          audio: null,
+          text: null,
+        },
+        speed: 0,
+        rebuffering: null,
+      });
+      builder.startMonitoringPlayback(
+        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
+      );
+
+      const payload: any = builder.getCmcdDataForSegmentRequest(makeSegmentInfo());
+      const requestHeader = payload.value["CMCD-Request"];
+      const statusHeader = payload.value["CMCD-Status"];
+      expect(requestHeader).toContain("bl=10000");
+      expect(requestHeader).not.toContain("dl=");
+      expect(statusHeader).not.toContain("rtp=");
+    });
   });
 
   describe("stopMonitoringPlayback", () => {
@@ -459,6 +482,30 @@ describe("CmcdDataBuilder", () => {
           expect(val[val.length - 1]).not.toBe(",");
         }
       }
+    });
+
+    it("escapes all backslashes and quotes in header strings", () => {
+      const builder = new CmcdDataBuilder({
+        sessionId: 's\\"id\\tail',
+        contentId: 'c\\"id\\tail',
+        communicationType: "headers",
+      });
+      const payload: any = builder.getCmcdDataForManifest("dash");
+      const sessionHeader = payload.value["CMCD-Session"];
+      expect(sessionHeader).toContain('cid="c\\\\\\"id\\\\tail"');
+      expect(sessionHeader).toContain('sid="s\\\\\\"id\\\\tail"');
+    });
+
+    it("preserves all backslashes and quotes after query decoding", () => {
+      const builder = new CmcdDataBuilder({
+        sessionId: 's\\"id\\tail',
+        contentId: 'c\\"id\\tail',
+        communicationType: "query",
+      });
+      const payload: any = builder.getCmcdDataForManifest("dash");
+      const qs = decodeURIComponent(payload.value[0][1]);
+      expect(qs).toContain('cid="c\\\\\\"id\\\\tail"');
+      expect(qs).toContain('sid="s\\\\\\"id\\\\tail"');
     });
   });
 });

--- a/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
+++ b/src/core/cmcd/__tests__/cmcd_data_builder.test.ts
@@ -358,9 +358,7 @@ describe("CmcdDataBuilder", () => {
         speed: 1,
         rebuffering: null,
       });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForSegmentRequest(makeSegmentInfo());
       const requestHeader = payload.value["CMCD-Request"];
@@ -371,9 +369,7 @@ describe("CmcdDataBuilder", () => {
     it("includes pr when playback speed is not 1", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ speed: 2, rebuffering: null });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForManifest("dash");
       const sessionHeader = payload.value["CMCD-Session"];
@@ -383,9 +379,7 @@ describe("CmcdDataBuilder", () => {
     it("does not include pr when speed is 1", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ speed: 1, rebuffering: null });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForManifest("dash");
       const sessionHeader = payload.value["CMCD-Session"];
@@ -395,9 +389,7 @@ describe("CmcdDataBuilder", () => {
     it("does not include pr when playback speed is negative", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ speed: -1, rebuffering: null });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForManifest("dash");
       const sessionHeader = payload.value["CMCD-Session"];
@@ -407,9 +399,7 @@ describe("CmcdDataBuilder", () => {
     it("includes su when rebuffering is active", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ rebuffering: { timestamp: 0 }, speed: 1 });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForManifest("dash");
       const requestHeader = payload.value["CMCD-Request"];
@@ -427,9 +417,7 @@ describe("CmcdDataBuilder", () => {
         speed: 0,
         rebuffering: null,
       });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
 
       const payload: any = builder.getCmcdDataForSegmentRequest(makeSegmentInfo());
       const requestHeader = payload.value["CMCD-Request"];
@@ -444,9 +432,7 @@ describe("CmcdDataBuilder", () => {
     it("clears the playback observer so subsequent calls work without observation data", () => {
       const builder = new CmcdDataBuilder({ communicationType: "headers" });
       const observer = makePlaybackObserver({ speed: 2, rebuffering: null });
-      builder.startMonitoringPlayback(
-        observer as Parameters<typeof builder.startMonitoringPlayback>[0],
-      );
+      builder.startMonitoringPlayback(observer);
       builder.stopMonitoringPlayback();
 
       const payload: any = builder.getCmcdDataForManifest("dash");

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -300,7 +300,10 @@ export default class CmcdDataBuilder {
     }
 
     const precizeDeadlineMs =
-      precizeBufferLengthMs === undefined || lastObservation === undefined
+      precizeBufferLengthMs === undefined ||
+      lastObservation === undefined ||
+      !isFinite(lastObservation.speed) ||
+      lastObservation.speed <= 0
         ? undefined
         : precizeBufferLengthMs / lastObservation.speed;
 
@@ -396,7 +399,7 @@ export default class CmcdDataBuilder {
     ): void => {
       const val = props[prop];
       if (val !== undefined) {
-        const formatted = `"${val.replace("\\", "\\\\").replace('"', '\\"')}"`;
+        const formatted = `"${val.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
         const toAdd = `${prop}=${formatted},`;
         addPayload(toAdd, headerName);
       }

--- a/src/core/cmcd/cmcd_data_builder.ts
+++ b/src/core/cmcd/cmcd_data_builder.ts
@@ -186,7 +186,10 @@ export default class CmcdDataBuilder {
 
     const lastObservation = this._playbackObserver?.getReference().getValue();
     props.pr =
-      lastObservation === undefined || lastObservation.speed === 1
+      lastObservation === undefined ||
+      !isFinite(lastObservation.speed) ||
+      lastObservation.speed < 0 ||
+      lastObservation.speed === 1
         ? undefined
         : lastObservation.speed;
     if (lastObservation !== undefined) {


### PR DESCRIPTION
While doing a code check before (at last) planning a new release, I saw some issues with a few CMCD edge cases:

- Both `dl` (for "deadline", ~ time remaining before rebuffering) and `rtp` (for "Requested maximum throughput", ~ proposed maximum throughput for the request) are indirectly dependent on the current playback rate (the current speed at which we play the content).

  Yet if we play at a playback rate equal to `0` or backwards (`0` could even lead to an `Infinity` value as there's a division going on, I don't even think it is a valid value here), the two concepts are difficult to determine.

  Instead of giving incorrect/meaningless value, I propose here to just not set them in that case (keys are optional).

- We had an escaping code for string values but due to what I guess was a typo only the first iteration was transformed.

- The CMCD v1/v2 specs are **heavily** unclear if negative playback rates are a legal value for their corresponding `pr` property: e.g. examples only talk about positive values, and nowhere in the spec the special theoretical case of reverse playback is mentioned.

  Yet technically (even if incredibly-poorly supported), the player's `playbackRate` can be negative.

  To take a safer route, I decided to just remove the optional `pr` property when the playback rate is negative.


I added unit tests to ensure that this is well fixed.