### PR TITLE
feat: add time info for time out of bounds errors

### DIFF
--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -253,7 +253,8 @@ That property is set for:
 
 When present, `timeInfo` is an object with the following properties:
 
-- `position` (`number`): The current media position that triggered the warning or error.
+- `position` (`number`): The considered playback position that triggered the warning or
+  error.
 
 - `minPosition` (`number`): The minimum safe position currently known by the player for
   that content.

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -95,8 +95,8 @@ supplementary `tracksInfo` property, describing the track(s) related to the issu
 format of that property is decribed in the chapter below listed codes, and the codes for
 which it is set are indicated in the corresponding code's description below.
 
-Depending on its `code` property, a `MEDIA_ERROR` may also have a supplementary
-`timeInfo` property, describing the position-related bounds linked to the issue.
+Depending on its `code` property, a `MEDIA_ERROR` may also have a supplementary `timeInfo`
+property, describing the position-related bounds linked to the issue.
 
 #### codes
 

--- a/doc/api/Player_Errors.md
+++ b/doc/api/Player_Errors.md
@@ -95,6 +95,9 @@ supplementary `tracksInfo` property, describing the track(s) related to the issu
 format of that property is decribed in the chapter below listed codes, and the codes for
 which it is set are indicated in the corresponding code's description below.
 
+Depending on its `code` property, a `MEDIA_ERROR` may also have a supplementary
+`timeInfo` property, describing the position-related bounds linked to the issue.
+
 #### codes
 
 An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
@@ -172,10 +175,16 @@ An error of `type` `MEDIA_ERROR` can have the following codes (`code` property):
   lead to stalling indefinitely as the player won't be able to download new segments
   arround the current time.
 
+  For those errors, the `timeInfo` property is set. It indicates which position was
+  considered too low and the corresponding manifest bounds.
+
 - `"MEDIA_TIME_AFTER_MANIFEST"`: The current time in the media is after what is currently
   declared in the [Manifest](../Getting_Started/Glossary.md#manifest). This can lead to
   stalling indefinitely as the player won't be able to download new segments arround the
   current time.
+
+  For those errors, the `timeInfo` property is set. It indicates which position was
+  considered too high and the corresponding manifest bounds.
 
 - `"DISCONTINUITY_ENCOUNTERED"`: A discontinuity (i.e. a hole in the media buffer) has
   been encontered and seeked over.
@@ -231,6 +240,26 @@ Each object has two sub-properties:
 
 - `track`: Characteristics of the track. Its format depends on the `type` property and is
   described below.
+
+#### `timeInfo` property
+
+As described in the corresponding code's documentation, a supplementary `timeInfo`
+property may be set on `MEDIA_ERROR` for some time-related errors.
+
+That property is set for:
+
+- `"MEDIA_TIME_BEFORE_MANIFEST"`
+- `"MEDIA_TIME_AFTER_MANIFEST"`
+
+When present, `timeInfo` is an object with the following properties:
+
+- `position` (`number`): The current media position that triggered the warning or error.
+
+- `minPosition` (`number`): The minimum safe position currently known by the player for
+  that content.
+
+- `maxPosition` (`number`): The maximum safe position currently known by the player for
+  that content.
 
 ##### For video tracks
 

--- a/doc/api/Typescript_Types.md
+++ b/doc/api/Typescript_Types.md
@@ -548,3 +548,49 @@ function logKeyStatuses(keyStatuses: IEncryptedMediaErrorKeyStatusObject): void 
   console.log(keyStatuses);
 }
 ```
+
+### MediaError's `timeInfo` property
+
+Some `MediaError` values thrown by the RxPlayer may have a `timeInfo` property set. This
+property is set on `MEDIA_TIME_BEFORE_MANIFEST` and `MEDIA_TIME_AFTER_MANIFEST` errors.
+
+That property has the following shape:
+
+```ts
+interface IMediaErrorTimeInfo {
+  position: number;
+  minPosition: number;
+  maxPosition: number;
+}
+```
+
+This property gives access to the out-of-bounds position and to the corresponding manifest
+bounds:
+
+```ts
+// the type wanted
+import { IPlayerError } from "rx-player/types";
+
+rxPlayer.addEventListener("warning", (err: Error | IPlayerError) => {
+  if (
+    err.type === "MEDIA_ERROR" &&
+    (err.code === "MEDIA_TIME_BEFORE_MANIFEST" ||
+      err.code === "MEDIA_TIME_AFTER_MANIFEST") &&
+    err.timeInfo !== undefined
+  ) {
+    handleOutOfBoundsPosition(err.timeInfo);
+  }
+});
+
+function handleOutOfBoundsPosition(timeInfo: {
+  position: number;
+  minPosition: number;
+  maxPosition: number;
+}): void {
+  if (timeInfo.position < timeInfo.minPosition) {
+    // Application-specific handling
+  } else if (timeInfo.position > timeInfo.maxPosition) {
+    // Application-specific handling
+  }
+}
+```

--- a/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
+++ b/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
@@ -143,6 +143,11 @@ describe("ContentTimeBoundariesObserver", () => {
       expect(mockTrigger).toHaveBeenCalledWith("warning", expect.any(Object));
       const warning = mockTrigger.mock.calls[0][1];
       expect(warning.code).toBe("MEDIA_TIME_BEFORE_MANIFEST");
+      expect(warning.timeInfo).toEqual({
+        position: 5,
+        minPosition: 10,
+        maxPosition: 100,
+      });
     });
 
     it("should trigger warning when position is after manifest maximum", async () => {

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -113,11 +113,20 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
       playbackObserver.listen(
         ({ position }) => {
           const wantedPosition = position.getWanted();
-          if (wantedPosition < manifest.getMinimumSafePosition()) {
+          const minimumPosition = manifest.getMinimumSafePosition();
+          const maximumPosition = manifest.getMaximumSafePosition();
+          if (wantedPosition < minimumPosition) {
             const warning = new MediaError(
               "MEDIA_TIME_BEFORE_MANIFEST",
               "The current position is behind the " +
                 "earliest time announced in the Manifest.",
+              {
+                timeInfo: {
+                  position: wantedPosition,
+                  minPosition: minimumPosition,
+                  maxPosition: maximumPosition,
+                },
+              },
             );
             this.trigger("warning", warning);
           } else if (
@@ -127,6 +136,13 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
               "MEDIA_TIME_AFTER_MANIFEST",
               "The current position is after the latest " +
                 "time announced in the Manifest.",
+              {
+                timeInfo: {
+                  position: wantedPosition,
+                  minPosition: minimumPosition,
+                  maxPosition: maximumPosition,
+                },
+              },
             );
             this.trigger("warning", warning);
           }

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -114,7 +114,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
         ({ position }) => {
           const wantedPosition = position.getWanted();
           const minimumPosition = manifest.getMinimumSafePosition();
-          const maximumPosition = manifest.getMaximumSafePosition();
+          const maximumPosition = maximumPositionCalculator.getMaximumAvailablePosition();
           if (wantedPosition < minimumPosition) {
             const warning = new MediaError(
               "MEDIA_TIME_BEFORE_MANIFEST",
@@ -129,9 +129,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
               },
             );
             this.trigger("warning", warning);
-          } else if (
-            wantedPosition > maximumPositionCalculator.getMaximumAvailablePosition()
-          ) {
+          } else if (wantedPosition > maximumPosition) {
             const warning = new MediaError(
               "MEDIA_TIME_AFTER_MANIFEST",
               "The current position is after the latest " +

--- a/src/errors/__tests__/media_error.test.ts
+++ b/src/errors/__tests__/media_error.test.ts
@@ -4,7 +4,9 @@ import MediaError from "../media_error";
 describe("errors - MediaError", () => {
   it("should format a MediaError", () => {
     const reason = "test";
-    const mediaError = new MediaError("MEDIA_TIME_BEFORE_MANIFEST", reason);
+    const mediaError = new MediaError("MEDIA_TIME_BEFORE_MANIFEST", reason, {
+      timeInfo: { position: 5, minPosition: 10, maxPosition: 100 },
+    });
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
     expect(mediaError.type).toBe("MEDIA_ERROR");
@@ -15,7 +17,9 @@ describe("errors - MediaError", () => {
 
   it("should be able to set it as fatal", () => {
     const reason = "test";
-    const mediaError = new MediaError("MEDIA_TIME_AFTER_MANIFEST", reason);
+    const mediaError = new MediaError("MEDIA_TIME_AFTER_MANIFEST", reason, {
+      timeInfo: { position: 5, minPosition: 10, maxPosition: 100 },
+    });
     mediaError.fatal = true;
     expect(mediaError).toBeInstanceOf(Error);
     expect(mediaError.name).toBe("MediaError");
@@ -35,5 +39,33 @@ describe("errors - MediaError", () => {
     expect(mediaError.code).toBe("MEDIA_ERR_NETWORK");
     expect(mediaError.fatal).toBe(true);
     expect(mediaError.message).toBe("MEDIA_ERR_NETWORK: test");
+  });
+
+  it("should expose and serialize custom position metadata", () => {
+    const mediaError = new MediaError("MEDIA_TIME_BEFORE_MANIFEST", "test", {
+      timeInfo: {
+        position: 3,
+        minPosition: 10,
+        maxPosition: 20,
+      },
+    });
+
+    expect(mediaError.timeInfo).toEqual({
+      position: 3,
+      minPosition: 10,
+      maxPosition: 20,
+    });
+    expect(mediaError.serialize()).toEqual({
+      isSerializedError: true,
+      name: "MediaError",
+      code: "MEDIA_TIME_BEFORE_MANIFEST",
+      reason: "test",
+      tracks: undefined,
+      timeInfo: {
+        position: 3,
+        minPosition: 10,
+        maxPosition: 20,
+      },
+    });
   });
 });

--- a/src/errors/__tests__/media_error.test.ts
+++ b/src/errors/__tests__/media_error.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import MediaError from "../media_error";
+import type { ISerializedMediaError } from "../media_error";
+import MediaError, { deserializeMediaError } from "../media_error";
 
 describe("errors - MediaError", () => {
   it("should format a MediaError", () => {
@@ -67,5 +68,75 @@ describe("errors - MediaError", () => {
         maxPosition: 20,
       },
     });
+  });
+
+  it("should deserialize a serialized MediaError with timeInfo", () => {
+    const serializedError: ISerializedMediaError = {
+      isSerializedError: true,
+      name: "MediaError",
+      code: "MEDIA_TIME_BEFORE_MANIFEST",
+      reason: "test",
+      tracks: undefined,
+      timeInfo: {
+        position: 3,
+        minPosition: 10,
+        maxPosition: 20,
+      },
+    };
+
+    const mediaError = deserializeMediaError(serializedError);
+
+    expect(mediaError).toBeInstanceOf(MediaError);
+    expect(mediaError.code).toBe("MEDIA_TIME_BEFORE_MANIFEST");
+    expect(mediaError.message).toBe("MEDIA_TIME_BEFORE_MANIFEST: test");
+    expect(mediaError.timeInfo).toEqual(serializedError.timeInfo);
+  });
+
+  it("should deserialize a serialized MediaError with tracks", () => {
+    const serializedError: ISerializedMediaError = {
+      isSerializedError: true,
+      name: "MediaError",
+      code: "BUFFER_APPEND_ERROR",
+      reason: "test",
+      tracks: [
+        {
+          type: "audio",
+          track: {
+            id: "fra1",
+            audioDescription: false,
+            language: "fra",
+            normalized: "fra",
+            representations: [],
+          },
+        },
+      ],
+      timeInfo: undefined,
+    };
+
+    const mediaError = deserializeMediaError(serializedError);
+
+    expect(mediaError).toBeInstanceOf(MediaError);
+    expect(mediaError.code).toBe("BUFFER_APPEND_ERROR");
+    expect(mediaError.message).toBe("BUFFER_APPEND_ERROR: test");
+    expect(mediaError.tracksInfo).toEqual(serializedError.tracks);
+  });
+
+  it("should deserialize a serialized MediaError without metadata", () => {
+    const serializedError = {
+      isSerializedError: true as const,
+      name: "MediaError" as const,
+      code: "MEDIA_ERR_NETWORK" as const,
+      reason: "test",
+      tracks: undefined,
+      timeInfo: undefined,
+    };
+
+    const mediaError = deserializeMediaError(serializedError);
+
+    expect(mediaError).toBeInstanceOf(MediaError);
+    expect(mediaError.code).toBe("MEDIA_ERR_NETWORK");
+    expect(mediaError.message).toBe("MEDIA_ERR_NETWORK: test");
+    expect(mediaError.timeInfo).toBeUndefined();
+    expect(mediaError.tracksInfo).toBeUndefined();
   });
 });

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -22,7 +22,7 @@ import { ErrorCodes, ErrorTypes, NetworkErrorTypes } from "./error_codes";
 import formatError from "./format_error";
 import isKnownError from "./is_known_error";
 import type { ISerializedMediaError } from "./media_error";
-import MediaError from "./media_error";
+import MediaError, { deserializeMediaError } from "./media_error";
 import type { ISerializedNetworkError } from "./network_error";
 import NetworkError from "./network_error";
 import type { ISerializedOtherError } from "./other_error";
@@ -46,6 +46,7 @@ export {
   ErrorTypes,
   formatError,
   MediaError,
+  deserializeMediaError,
   NetworkError,
   OtherError,
   NetworkErrorTypes,

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -19,13 +19,13 @@ import type { IMediaErrorCode } from "./error_codes";
 import { ErrorTypes } from "./error_codes";
 import errorMessage from "./error_message";
 
-type ICodeWithAdaptationType =
+export type ICodeWithAdaptationType =
   | "BUFFER_APPEND_ERROR"
   | "BUFFER_FULL_ERROR"
   | "NO_PLAYABLE_REPRESENTATION"
   | "MANIFEST_INCOMPATIBLE_CODECS_ERROR";
 
-type ICodeWithManifestPositionError =
+export type ICodeWithManifestPositionError =
   | "MEDIA_TIME_BEFORE_MANIFEST"
   | "MEDIA_TIME_AFTER_MANIFEST";
 
@@ -120,6 +120,41 @@ export default class MediaError extends Error {
       timeInfo: this.timeInfo,
     };
   }
+}
+
+/**
+ * Re-create a `MediaError` from a serialized representation.
+ * @param {Object} serializedMediaError
+ * @returns {MediaError}
+ */
+export function deserializeMediaError(
+  serializedMediaError: ISerializedMediaError,
+): MediaError {
+  if (serializedMediaError.timeInfo !== undefined) {
+    return new MediaError(
+      serializedMediaError.code as ICodeWithManifestPositionError,
+      serializedMediaError.reason,
+      {
+        timeInfo: serializedMediaError.timeInfo,
+      },
+    );
+  }
+  if (serializedMediaError.tracks !== undefined) {
+    return new MediaError(
+      serializedMediaError.code as ICodeWithAdaptationType,
+      serializedMediaError.reason,
+      {
+        tracks: serializedMediaError.tracks,
+      },
+    );
+  }
+  return new MediaError(
+    serializedMediaError.code as Exclude<
+      IMediaErrorCode,
+      ICodeWithAdaptationType | ICodeWithManifestPositionError
+    >,
+    serializedMediaError.reason,
+  );
 }
 
 /** Serializable object which allows to create a `MediaError` later. */

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -25,6 +25,16 @@ type ICodeWithAdaptationType =
   | "NO_PLAYABLE_REPRESENTATION"
   | "MANIFEST_INCOMPATIBLE_CODECS_ERROR";
 
+type ICodeWithManifestPositionError =
+  | "MEDIA_TIME_BEFORE_MANIFEST"
+  | "MEDIA_TIME_AFTER_MANIFEST";
+
+interface ITimeInfo {
+  position: number;
+  minPosition: number;
+  maxPosition: number;
+}
+
 /**
  * Error linked to the media Playback.
  *
@@ -36,6 +46,7 @@ export default class MediaError extends Error {
   public readonly type: "MEDIA_ERROR";
   public readonly code: IMediaErrorCode;
   public readonly tracksInfo: ITaggedTrack[] | undefined;
+  public readonly timeInfo: ITimeInfo | undefined;
   public fatal: boolean;
   private _originalMessage: string;
 
@@ -52,13 +63,18 @@ export default class MediaError extends Error {
     },
   );
   constructor(
-    code: Exclude<IMediaErrorCode, ICodeWithAdaptationType>,
+    code: ICodeWithManifestPositionError,
     reason: string,
-    context?:
-      | {
-          tracks?: undefined;
-        }
-      | undefined,
+    context: {
+      timeInfo: ITimeInfo;
+    },
+  );
+  constructor(
+    code: Exclude<
+      IMediaErrorCode,
+      ICodeWithAdaptationType | ICodeWithManifestPositionError
+    >,
+    reason: string,
   );
   constructor(
     code: IMediaErrorCode,
@@ -66,6 +82,7 @@ export default class MediaError extends Error {
     context?:
       | {
           tracks?: ITaggedTrack[] | undefined;
+          timeInfo?: ITimeInfo;
         }
       | undefined,
   ) {
@@ -82,6 +99,9 @@ export default class MediaError extends Error {
     if (context?.tracks !== undefined && context?.tracks.length > 0) {
       this.tracksInfo = context.tracks;
     }
+    if (context?.timeInfo !== undefined) {
+      this.timeInfo = context.timeInfo;
+    }
   }
 
   /**
@@ -97,6 +117,7 @@ export default class MediaError extends Error {
       code: this.code,
       reason: this._originalMessage,
       tracks: this.tracksInfo,
+      timeInfo: this.timeInfo,
     };
   }
 }
@@ -108,4 +129,5 @@ export interface ISerializedMediaError {
   code: IMediaErrorCode;
   reason: string;
   tracks: ITaggedTrack[] | undefined;
+  timeInfo?: ITimeInfo | undefined;
 }

--- a/src/errors/media_error.ts
+++ b/src/errors/media_error.ts
@@ -15,6 +15,7 @@
  */
 
 import type { ITaggedTrack } from "../manifest";
+import assert from "../utils/assert";
 import type { IMediaErrorCode } from "./error_codes";
 import { ErrorTypes } from "./error_codes";
 import errorMessage from "./error_message";
@@ -130,31 +131,29 @@ export default class MediaError extends Error {
 export function deserializeMediaError(
   serializedMediaError: ISerializedMediaError,
 ): MediaError {
-  if (serializedMediaError.timeInfo !== undefined) {
-    return new MediaError(
-      serializedMediaError.code as ICodeWithManifestPositionError,
-      serializedMediaError.reason,
-      {
-        timeInfo: serializedMediaError.timeInfo,
-      },
+  if (
+    serializedMediaError.code === "MEDIA_TIME_BEFORE_MANIFEST" ||
+    serializedMediaError.code === "MEDIA_TIME_AFTER_MANIFEST"
+  ) {
+    assert(
+      serializedMediaError.timeInfo !== undefined,
+      `The MediaError with code ${serializedMediaError.code} does not provide "timeinfo"`,
     );
+    return new MediaError(serializedMediaError.code, serializedMediaError.reason, {
+      timeInfo: serializedMediaError.timeInfo,
+    });
   }
-  if (serializedMediaError.tracks !== undefined) {
-    return new MediaError(
-      serializedMediaError.code as ICodeWithAdaptationType,
-      serializedMediaError.reason,
-      {
-        tracks: serializedMediaError.tracks,
-      },
-    );
+  if (
+    serializedMediaError.code === "BUFFER_APPEND_ERROR" ||
+    serializedMediaError.code === "BUFFER_FULL_ERROR" ||
+    serializedMediaError.code === "NO_PLAYABLE_REPRESENTATION" ||
+    serializedMediaError.code === "MANIFEST_INCOMPATIBLE_CODECS_ERROR"
+  ) {
+    return new MediaError(serializedMediaError.code, serializedMediaError.reason, {
+      tracks: serializedMediaError.tracks,
+    });
   }
-  return new MediaError(
-    serializedMediaError.code as Exclude<
-      IMediaErrorCode,
-      ICodeWithAdaptationType | ICodeWithManifestPositionError
-    >,
-    serializedMediaError.reason,
-  );
+  return new MediaError(serializedMediaError.code, serializedMediaError.reason);
 }
 
 /** Serializable object which allows to create a `MediaError` later. */

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -15,9 +15,10 @@ import type {
   ISentLogValue,
 } from "../../core/types";
 import { CoreMessageType } from "../../core/types";
+import type { MediaError } from "../../errors";
 import {
+  deserializeMediaError,
   EncryptedMediaError,
-  MediaError,
   NetworkError,
   OtherError,
   SourceBufferError,
@@ -2292,20 +2293,7 @@ function formatCoreError(sentError: ISentError): IPlayerError {
         ),
       );
     case "MediaError":
-      if (sentError.timeInfo !== undefined) {
-        // eslint-disable-next-line
-        return new MediaError(sentError.code as any, sentError.reason, {
-          timeInfo: sentError.timeInfo,
-        });
-      }
-      if (sentError.tracks !== undefined) {
-        // eslint-disable-next-line
-        return new MediaError(sentError.code as any, sentError.reason, {
-          tracks: sentError.tracks,
-        });
-      }
-      // eslint-disable-next-line
-      return new MediaError(sentError.code as any, sentError.reason);
+      return deserializeMediaError(sentError);
     case "EncryptedMediaError":
       // We assume that everything have already been checked Worker-side here
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -2292,10 +2292,20 @@ function formatCoreError(sentError: ISentError): IPlayerError {
         ),
       );
     case "MediaError":
+      if (sentError.timeInfo !== undefined) {
+        // eslint-disable-next-line
+        return new MediaError(sentError.code as any, sentError.reason, {
+          timeInfo: sentError.timeInfo,
+        });
+      }
+      if (sentError.tracks !== undefined) {
+        // eslint-disable-next-line
+        return new MediaError(sentError.code as any, sentError.reason, {
+          tracks: sentError.tracks,
+        });
+      }
       // eslint-disable-next-line
-      return new MediaError(sentError.code as any, sentError.reason, {
-        tracks: sentError.tracks,
-      });
+      return new MediaError(sentError.code as any, sentError.reason);
     case "EncryptedMediaError":
       // We assume that everything have already been checked Worker-side here
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument


### PR DESCRIPTION
When the player throws a `MediaError` with the `"MEDIA_TIME_BEFORE_MANIFEST"` or
`"MEDIA_TIME_AFTER_MANIFEST"` code, it is not easy for an application to determine
which position the player attempted to play and failed to handle.

The RxPlayer exposes APIs such as `getWallClockTime`, but that API is tied to the
currentTime of the `video` element, whereas this `MediaError` can be raised independently
from the media element's current state.

This PR adds the position information that triggered the `MediaError`.
It also adds the minimum and maximum playable positions.
Applications can use this information to handle the error appropriately.