### PR TITLE
fix(directfile): fix side effects for multiples instance of media element track store

### DIFF
--- a/src/main_thread/tracks_store/__tests__/media_element_tracks_store.test.ts
+++ b/src/main_thread/tracks_store/__tests__/media_element_tracks_store.test.ts
@@ -3,22 +3,62 @@ import type { IMediaElement } from "../../../compat/browser_compatibility_types"
 import assert from "../../../utils/assert";
 import MediaElementTracksStore from "../media_element_tracks_store";
 
-function createFakeMediaElement(): IMediaElement {
-  return {
-    audioTracks: [
-      { language: "en", enabled: false },
-      { language: "fr", enabled: true },
-      { language: "el", enabled: false },
-      { language: "pt-BR", enabled: false },
-    ],
-    textTracks: [
-      { language: "en", mode: "hidden" },
-      { language: "fr", mode: "showing" },
-      { language: "el", mode: "hidden" },
-      { language: "pt-BR", mode: "hidden" },
-    ],
-    videoTracks: [{ language: "", selected: true }],
-  } as unknown as IMediaElement;
+type TrackListEventName = "addtrack" | "removetrack" | "change";
+
+type FakeTrackList<TTrack, TEvent = Event> = TTrack[] & {
+  addEventListener(evt: TrackListEventName, fn: (evt: TEvent) => void): void;
+  removeEventListener(evt: TrackListEventName, fn: (evt: TEvent) => void): void;
+  trigger(evt: TrackListEventName, payload: TEvent): void;
+};
+
+type IFakeMediaElement = IMediaElement & {
+  readonly audioTracks: FakeTrackList<{ language: string; enabled: boolean }>;
+  readonly textTracks: FakeTrackList<TextTrack, TrackEvent>;
+  readonly videoTracks: FakeTrackList<{ language: string; selected: boolean }>;
+};
+
+function createFakeTrackList<TTrack, TEvent = Event>(
+  tracks: TTrack[],
+): FakeTrackList<TTrack, TEvent> {
+  const listeners: Record<TrackListEventName, Array<(evt: TEvent) => void>> = {
+    addtrack: [],
+    removetrack: [],
+    change: [],
+  };
+  const trackList = tracks as FakeTrackList<TTrack, TEvent>;
+  trackList.addEventListener = (evt, fn) => {
+    listeners[evt].push(fn);
+  };
+  trackList.removeEventListener = (evt, fn) => {
+    listeners[evt] = listeners[evt].filter((listener) => listener !== fn);
+  };
+  trackList.trigger = (evt, payload) => {
+    listeners[evt].forEach((listener) => listener(payload));
+  };
+  return trackList;
+}
+
+function createFakeMediaElement(): IFakeMediaElement {
+  const audioTracks = createFakeTrackList([
+    { language: "en", enabled: false },
+    { language: "fr", enabled: true },
+    { language: "el", enabled: false },
+    { language: "pt-BR", enabled: false },
+  ]);
+  const textTracks = createFakeTrackList<TextTrack, TrackEvent>([
+    { language: "en", mode: "hidden" },
+    { language: "fr", mode: "showing" },
+    { language: "el", mode: "hidden" },
+    { language: "pt-BR", mode: "hidden" },
+  ] as TextTrack[]);
+  const videoTracks = createFakeTrackList([{ language: "", selected: true }]);
+  const fakeMediaElement = {} as IFakeMediaElement;
+  Object.defineProperties(fakeMediaElement, {
+    audioTracks: { get: () => audioTracks },
+    textTracks: { get: () => textTracks },
+    videoTracks: { get: () => videoTracks },
+  });
+  return fakeMediaElement;
 }
 
 describe("API - MediaElementTracksStore", () => {
@@ -99,15 +139,11 @@ describe("API - MediaElementTracksStore", () => {
       });
 
       // Fake browser behavior
-      (fakeMediaElement.textTracks as unknown as TextTrack[]).unshift({
+      fakeMediaElement.textTracks.unshift({
         language: "es",
         mode: "hidden",
       } as TextTrack);
-      (
-        fakeMediaElement.textTracks as {
-          onaddtrack: ((arg: TrackEvent) => void) | undefined;
-        }
-      ).onaddtrack?.({} as TrackEvent);
+      fakeMediaElement.textTracks.trigger("addtrack", {} as TrackEvent);
     });
   });
 
@@ -123,14 +159,8 @@ describe("API - MediaElementTracksStore", () => {
       });
 
       // Fake browser behavior
-      const _elt = fakeMediaElement;
-      (
-        _elt.videoTracks as unknown as Array<{
-          language: string;
-          selected: boolean;
-        }>
-      ).unshift({ language: "en", selected: false });
-      _elt.videoTracks?.onaddtrack?.({} as TrackEvent);
+      fakeMediaElement.videoTracks.unshift({ language: "en", selected: false });
+      fakeMediaElement.videoTracks.trigger("addtrack", {} as Event);
     });
   });
 
@@ -149,14 +179,8 @@ describe("API - MediaElementTracksStore", () => {
       });
 
       // Fake browser behavior
-      const _elt = fakeMediaElement;
-      (
-        _elt.audioTracks as unknown as Array<{
-          language: string;
-          selected: boolean;
-        }>
-      ).unshift({ language: "en", selected: false });
-      _elt.audioTracks?.onaddtrack?.({} as TrackEvent);
+      fakeMediaElement.audioTracks.unshift({ language: "en", enabled: false });
+      fakeMediaElement.audioTracks.trigger("addtrack", {} as Event);
     });
   });
 
@@ -173,11 +197,7 @@ describe("API - MediaElementTracksStore", () => {
       trackManager.setTextTrackById("gen_text_en_1");
 
       // Fake browser behavior
-      (
-        fakeMediaElement.textTracks as {
-          onchange: ((arg: Event) => void) | undefined;
-        }
-      ).onchange?.(undefined as unknown as Event);
+      fakeMediaElement.textTracks.trigger("change", undefined as unknown as TrackEvent);
     });
   });
 });

--- a/src/main_thread/tracks_store/media_element_tracks_store.ts
+++ b/src/main_thread/tracks_store/media_element_tracks_store.ts
@@ -40,6 +40,7 @@ import type {
 import EventEmitter from "../../utils/event_emitter";
 import isNullOrUndefined from "../../utils/is_null_or_undefined";
 import normalizeLanguage from "../../utils/languages";
+import TaskCanceller from "../../utils/task_canceller";
 
 /** Events emitted by the MediaElementTracksStore. */
 interface IMediaElementTracksStoreEvents {
@@ -237,8 +238,14 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
    */
   private _videoTrackLockedOn: ICompatVideoTrack | undefined | null;
 
+  /** Task canceller that is cancel when the MediaTrackStore is disposed */
+  private taskCanceller: TaskCanceller;
+
   constructor(mediaElement: IMediaElement) {
     super();
+
+    this.taskCanceller = new TaskCanceller("media_element_track_store");
+
     // TODO In practice, the audio/video/text tracks API are not always implemented on
     // the media element, although Typescript HTMLMediaElement types tend to mean
     // that can't be undefined.
@@ -441,24 +448,7 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
    * Free the resources used by the MediaElementTracksStore.
    */
   public dispose(): void {
-    if (this._nativeVideoTracks !== undefined) {
-      this._nativeVideoTracks.onchange = null;
-      this._nativeVideoTracks.onaddtrack = null;
-      this._nativeVideoTracks.onremovetrack = null;
-    }
-
-    if (this._nativeAudioTracks !== undefined) {
-      this._nativeAudioTracks.onchange = null;
-      this._nativeAudioTracks.onaddtrack = null;
-      this._nativeAudioTracks.onremovetrack = null;
-    }
-
-    if (this._nativeTextTracks !== undefined) {
-      this._nativeTextTracks.onchange = null;
-      this._nativeTextTracks.onaddtrack = null;
-      this._nativeTextTracks.onremovetrack = null;
-    }
-
+    this.taskCanceller.cancel("disposed");
     this.removeEventListener();
   }
 
@@ -607,7 +597,7 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
    */
   private _handleNativeTracksCallbacks(): void {
     if (this._nativeAudioTracks !== undefined) {
-      this._nativeAudioTracks.onaddtrack = () => {
+      const onAddAudioTrack = () => {
         if (this._nativeAudioTracks !== undefined) {
           const newAudioTracks = createAudioTracks(this._nativeAudioTracks);
           if (areTrackArraysDifferent(this._audioTracks, newAudioTracks)) {
@@ -622,7 +612,12 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeAudioTracks.onremovetrack = () => {
+      this._nativeAudioTracks.addEventListener("addtrack", onAddAudioTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeAudioTracks?.removeEventListener("addtrack", onAddAudioTrack);
+      });
+
+      const onRemoveAudioTrack = () => {
         if (this._nativeAudioTracks !== undefined) {
           const newAudioTracks = createAudioTracks(this._nativeAudioTracks);
           if (areTrackArraysDifferent(this._audioTracks, newAudioTracks)) {
@@ -637,7 +632,13 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeAudioTracks.onchange = () => {
+
+      this._nativeAudioTracks.addEventListener("removetrack", onRemoveAudioTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeAudioTracks?.removeEventListener("removetrack", onRemoveAudioTrack);
+      });
+
+      const onAudioChange = () => {
         if (this._audioTracks !== undefined) {
           for (let i = 0; i < this._audioTracks.length; i++) {
             const { track, nativeTrack } = this._audioTracks[i];
@@ -656,10 +657,15 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
         }
         return;
       };
+
+      this._nativeAudioTracks.addEventListener("change", onAudioChange);
+      this.taskCanceller.signal.register(() => {
+        this._nativeAudioTracks?.removeEventListener("change", onAudioChange);
+      });
     }
 
     if (this._nativeTextTracks !== undefined) {
-      this._nativeTextTracks.onaddtrack = () => {
+      const onAddTextTrack = () => {
         if (this._nativeTextTracks !== undefined) {
           const newTextTracks = createTextTracks(this._nativeTextTracks);
           if (areTrackArraysDifferent(this._textTracks, newTextTracks)) {
@@ -674,7 +680,13 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeTextTracks.onremovetrack = () => {
+
+      this._nativeTextTracks.addEventListener("addtrack", onAddTextTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeTextTracks?.removeEventListener("addtrack", onAddTextTrack);
+      });
+
+      const onRemoveTextTrack = () => {
         if (this._nativeTextTracks !== undefined) {
           const newTextTracks = createTextTracks(this._nativeTextTracks);
           if (areTrackArraysDifferent(this._textTracks, newTextTracks)) {
@@ -689,7 +701,12 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeTextTracks.onchange = () => {
+      this._nativeTextTracks.addEventListener("removetrack", onRemoveTextTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeTextTracks?.removeEventListener("removetrack", onRemoveTextTrack);
+      });
+
+      const onTextChange = () => {
         if (this._textTracks !== undefined) {
           for (let i = 0; i < this._textTracks.length; i++) {
             const { track, nativeTrack } = this._textTracks[i];
@@ -708,10 +725,15 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
         }
         return;
       };
+
+      this._nativeTextTracks.addEventListener("change", onTextChange);
+      this.taskCanceller.signal.register(() => {
+        this._nativeTextTracks?.removeEventListener("change", onTextChange);
+      });
     }
 
     if (this._nativeVideoTracks !== undefined) {
-      this._nativeVideoTracks.onaddtrack = () => {
+      const onAddVideoTrack = () => {
         if (this._nativeVideoTracks !== undefined) {
           const newVideoTracks = createVideoTracks(this._nativeVideoTracks);
           if (areTrackArraysDifferent(this._videoTracks, newVideoTracks)) {
@@ -726,7 +748,13 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeVideoTracks.onremovetrack = () => {
+
+      this._nativeVideoTracks.addEventListener("addtrack", onAddVideoTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeVideoTracks?.removeEventListener("addtrack", onAddVideoTrack);
+      });
+
+      const onRemoveVideoTrack = () => {
         if (this._nativeVideoTracks !== undefined) {
           const newVideoTracks = createVideoTracks(this._nativeVideoTracks);
           if (areTrackArraysDifferent(this._videoTracks, newVideoTracks)) {
@@ -741,7 +769,13 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
           }
         }
       };
-      this._nativeVideoTracks.onchange = () => {
+
+      this._nativeVideoTracks.addEventListener("removetrack", onRemoveVideoTrack);
+      this.taskCanceller.signal.register(() => {
+        this._nativeVideoTracks?.removeEventListener("removetrack", onRemoveVideoTrack);
+      });
+
+      const onVideoChange = () => {
         if (this._videoTracks !== undefined) {
           for (let i = 0; i < this._videoTracks.length; i++) {
             const { track, nativeTrack } = this._videoTracks[i];
@@ -760,6 +794,11 @@ export default class MediaElementTracksStore extends EventEmitter<IMediaElementT
         }
         return;
       };
+
+      this._nativeVideoTracks.addEventListener("change", onVideoChange);
+      this.taskCanceller.signal.register(() => {
+        this._nativeVideoTracks?.removeEventListener("change", onVideoChange);
+      });
     }
   }
 


### PR DESCRIPTION
fix(directfile): fix side effects for multiples instance of media element track store
    
    having multiple instance of media element track store could mess up the
    state of videoElement.audioTracks by overwriting the 'onaddtrack' and
    'onremovetrack' event listeners