### PR TITLE
fix: precision difference triggers content boundaries warnings

### DIFF
--- a/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
+++ b/src/core/entry/__tests__/content_time_boundaries_observer.test.ts
@@ -150,6 +150,20 @@ describe("ContentTimeBoundariesObserver", () => {
       });
     });
 
+    it("should not trigger warning when position is within epsilon of manifest minimum", async () => {
+      mockGetMinimumSafePosition.mockReturnValue(10);
+      const manifest = createMockManifest();
+      const playbackObserver = createMockPlaybackObserver();
+
+      new ContentTimeBoundariesObserver(manifest, playbackObserver, ["audio"]);
+      await sleep(0);
+
+      const positionCallback = mockPlaybackObserverListen.mock.calls[0][0];
+      positionCallback({ position: { getWanted: () => 9.9995 } });
+
+      expect(mockTrigger).not.toHaveBeenCalled();
+    });
+
     it("should trigger warning when position is after manifest maximum", async () => {
       mockGetMaximumSafePosition.mockReturnValue(100);
       const manifest = createMockManifest();

--- a/src/core/entry/content_time_boundaries_observer.ts
+++ b/src/core/entry/content_time_boundaries_observer.ts
@@ -47,6 +47,12 @@ import TaskCanceller from "../../utils/task_canceller";
  *     Manifest range.
  * @class ContentTimeBoundariesObserver
  */
+
+// `HTMLMediaElement.currentTime` can be off by a very small amount from the
+// Manifest-derived boundaries. We keep an epsilon so those rounding
+// differences do not trigger spurious boundary warnings.
+const EPSILON = 1e-3;
+
 export default class ContentTimeBoundariesObserver extends EventEmitter<IContentTimeBoundariesObserverEvent> {
   /** Allows to interrupt everything the `ContentTimeBoundariesObserver` is doing. */
   private _canceller: TaskCanceller;
@@ -115,7 +121,11 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
           const wantedPosition = position.getWanted();
           const minimumPosition = manifest.getMinimumSafePosition();
           const maximumPosition = maximumPositionCalculator.getMaximumAvailablePosition();
-          if (wantedPosition < minimumPosition) {
+
+          // Only report "before manifest" when the position is meaningfully
+          // behind the minimum, not when `<video>.currentTime` and the
+          // Manifest disagree by a tiny floating-point delta.
+          if (wantedPosition < minimumPosition - EPSILON) {
             const warning = new MediaError(
               "MEDIA_TIME_BEFORE_MANIFEST",
               "The current position is behind the " +
@@ -129,7 +139,7 @@ export default class ContentTimeBoundariesObserver extends EventEmitter<IContent
               },
             );
             this.trigger("warning", warning);
-          } else if (wantedPosition > maximumPosition) {
+          } else if (wantedPosition > maximumPosition + EPSILON) {
             const warning = new MediaError(
               "MEDIA_TIME_AFTER_MANIFEST",
               "The current position is after the latest " +


### PR DESCRIPTION
## Description

This PR fixes spurious `MEDIA_TIME_BEFORE_MANIFEST` and `MEDIA_TIME_AFTER_MANIFEST` warnings triggered when the wanted playback position is only marginally outside of the Manifest time boundaries.

Those tiny differences can happen because of floating-point precision discrepancies between the media element current time and Manifest-derived boundaries. The `ContentTimeBoundariesObserver` now applies a small epsilon (`1e-3`) when comparing the wanted position against the minimum and maximum available positions, so warnings are only emitted when the position is meaningfully outside of the playable range.

## Changes

- Add a precision margin when checking whether the wanted position is before the Manifest minimum.
- Apply the same margin when checking whether it is after the Manifest maximum.
- Add a unit test ensuring no warning is emitted when the position is within that margin near the Manifest minimum.

## Tests

- `npm run test:unit -- src/core/entry/__tests__/content_time_boundaries_observer.test.ts`