### PR TITLE
fix(tracks): ignore unhandled runtime track types for period advertisement

### DIFF
--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -3939,7 +3939,7 @@ export interface IPublicApiContentInfos {
    * has no MediaElementTracksStore.
    */
   mediaElementTracksStore: IMediaElementTracksStore | null;
-  /** Track types for which this player instance can create dispatchers. */
+  /** Track types currently handled by the player for the loaded content. */
   handledTrackTypes: Record<ITrackType, boolean>;
   /**
    * If `true`, the RxPlayer's main logic is running in a WebWorker for this

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -133,6 +133,7 @@ import renderThumbnail from "../render_thumbnail";
 import type { IMediaElementTracksStore, ITSPeriodObject } from "../tracks_store";
 import TracksStore from "../tracks_store";
 import { MainThreadMessageType } from "../types";
+import { canHandleTextTracks, canHandleVideoTracks } from "../utils/media_capabilities";
 import type { IParsedLoadVideoOptions, IParsedStartAtOption } from "./option_utils";
 import {
   checkReloadOptions,
@@ -643,7 +644,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           sendBackLogs: isDebugModeEnabled,
           date: Date.now(),
           timestamp: getMonotonicTimeStamp(),
-          hasVideo: this.videoElement?.nodeName.toLowerCase() === "video",
+          hasVideo: canHandleVideoTracks(this.videoElement),
         },
       });
       log.addEventListener(
@@ -1191,7 +1192,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           type: MainThreadMessageType.Init,
           value: {
             dashWasmUrl: undefined,
-            hasVideo: this.videoElement?.nodeName.toLowerCase() === "video",
+            hasVideo: canHandleVideoTracks(this.videoElement),
             logLevel: log.getLevel(),
             logFormat: log.getFormat(),
             sendBackLogs: false,
@@ -1356,6 +1357,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       activeRepresentations: null,
       tracksStore: null,
       mediaElementTracksStore,
+      handledTrackTypes: {
+        audio: true,
+        video: canHandleVideoTracks(this.videoElement),
+        text: canHandleTextTracks(options),
+      },
       useWorker,
       segmentSinkMetricsCallback: null,
       fetchThumbnailDataCallback: null,
@@ -2981,6 +2987,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
     const tracksStore = new TracksStore({
       preferTrickModeTracks: this._priv_preferTrickModeTracks,
       defaultAudioTrackSwitchingMode: contentInfos.defaultAudioTrackSwitchingMode,
+      handledTrackTypes: contentInfos.handledTrackTypes,
       onTracksNotPlayableForType: {
         audio: contentInfos.onAudioTracksNotPlayable,
         video: contentInfos.onVideoTracksNotPlayable,
@@ -3932,6 +3939,8 @@ export interface IPublicApiContentInfos {
    * has no MediaElementTracksStore.
    */
   mediaElementTracksStore: IMediaElementTracksStore | null;
+  /** Track types for which this player instance can create dispatchers. */
+  handledTrackTypes: Record<ITrackType, boolean>;
   /**
    * If `true`, the RxPlayer's main logic is running in a WebWorker for this
    * content.

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -64,6 +64,7 @@ import type IContentDecryptor from "../decrypt";
 import { ContentDecryptorState, getKeySystemConfiguration } from "../decrypt";
 import type { ITextDisplayer } from "../text_displayer";
 import { MainThreadMessageType } from "../types";
+import { canHandleTextTracks } from "../utils/media_capabilities";
 import type { ITextDisplayerOptions } from "./types";
 import { ContentInitializer } from "./types";
 import type { ICorePlaybackObservation } from "./utils/create_core_playback_observer";
@@ -203,7 +204,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         cmcd: this._settings.cmcd,
         enableRepresentationAvoidance: this._settings.enableRepresentationAvoidance,
         url: this._settings.url,
-        hasText: this._hasTextBufferFeature(),
+        hasText: canHandleTextTracks(this._settings.textTrackOptions),
         transport,
         transportOptions,
         initialVideoBitrate,
@@ -358,16 +359,16 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         this._settings.textTrackOptions.textTrackMode === "html" &&
         features.htmlTextDisplayer !== null
       ) {
-        assert(this._hasTextBufferFeature());
+        assert(canHandleTextTracks(this._settings.textTrackOptions));
         textDisplayer = new features.htmlTextDisplayer(
           mediaElement,
           this._settings.textTrackOptions.textTrackElement,
         );
       } else if (features.nativeTextDisplayer !== null) {
-        assert(this._hasTextBufferFeature());
+        assert(canHandleTextTracks(this._settings.textTrackOptions));
         textDisplayer = new features.nativeTextDisplayer(mediaElement);
       } else {
-        assert(!this._hasTextBufferFeature());
+        assert(!canHandleTextTracks(this._settings.textTrackOptions));
       }
     } catch (err) {
       log.error(
@@ -1573,14 +1574,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
     } catch (err) {
       this._onFatalError(err);
     }
-  }
-
-  private _hasTextBufferFeature(): boolean {
-    return (
-      (this._settings.textTrackOptions.textTrackMode === "html" &&
-        features.htmlTextDisplayer !== null) ||
-      features.nativeTextDisplayer !== null
-    );
   }
 
   private _reload(

--- a/src/main_thread/tracks_store/__tests__/tracks_store.test.ts
+++ b/src/main_thread/tracks_store/__tests__/tracks_store.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { IAdaptationChoice } from "../../../core/types";
+import type {
+  IAdaptationMetadata,
+  IManifestMetadata,
+  IPeriodMetadata,
+} from "../../../manifest";
+import SharedReference from "../../../utils/reference";
+import TracksStore from "../tracks_store";
+
+describe("API - TracksStore", () => {
+  it("should advertise an audio-only period when video and text are not handled", () => {
+    const tracksStore = new TracksStore({
+      preferTrickModeTracks: false,
+      defaultAudioTrackSwitchingMode: undefined,
+      handledTrackTypes: {
+        audio: true,
+        video: false,
+        text: false,
+      },
+      onTracksNotPlayableForType: {
+        audio: "error",
+        video: "error",
+        text: "error",
+      },
+    });
+    const onNewAvailablePeriods = vi.fn();
+    tracksStore.addEventListener("newAvailablePeriods", onNewAvailablePeriods);
+
+    const period = createPeriodMetadata({
+      id: "period-1",
+      adaptations: {
+        audio: [createAdaptation("audio", "audio-adaptation")],
+      },
+    });
+
+    tracksStore.onManifestUpdate({
+      periods: [period],
+    } as unknown as IManifestMetadata);
+
+    expect(onNewAvailablePeriods).not.toHaveBeenCalled();
+
+    tracksStore.addTrackReference(
+      "audio",
+      period,
+      new SharedReference<IAdaptationChoice | null | undefined>(undefined),
+    );
+
+    expect(onNewAvailablePeriods).toHaveBeenCalledTimes(1);
+    expect(tracksStore.getAvailablePeriods()).toEqual([
+      { id: "period-1", start: 0, end: 10 },
+    ]);
+  });
+});
+
+function createAdaptation(
+  type: "audio" | "video" | "text",
+  id: string,
+): IAdaptationMetadata {
+  return {
+    id,
+    type,
+    normalizedLanguage: undefined,
+    isForcedSubtitles: false,
+    representations: [
+      {
+        id: `${id}-repr`,
+        decipherable: true,
+        isSupported: true,
+      },
+    ],
+    supportStatus: {
+      hasSupportedCodec: true,
+      hasCodecWithUndefinedSupport: false,
+      isDecipherable: true,
+    },
+  } as unknown as IAdaptationMetadata;
+}
+
+function createPeriodMetadata(args: {
+  id: string;
+  adaptations: Partial<IPeriodMetadata["adaptations"]>;
+}): IPeriodMetadata {
+  return {
+    id: args.id,
+    start: 0,
+    end: 10,
+    adaptations: args.adaptations,
+  } as unknown as IPeriodMetadata;
+}

--- a/src/main_thread/tracks_store/tracks_store.ts
+++ b/src/main_thread/tracks_store/tracks_store.ts
@@ -71,6 +71,9 @@ import TrackDispatcher from "./track_dispatcher";
  * @class TracksStore
  */
 export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
+  /** Track types for which the current runtime can create dispatchers. */
+  private _handledTrackTypes: Record<ITrackType, boolean>;
+
   /**
    * Store track selection information, per Period.
    * Sorted by Period's start time ascending
@@ -113,6 +116,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   constructor(args: {
     preferTrickModeTracks: boolean;
     defaultAudioTrackSwitchingMode: IAudioTrackSwitchingMode | undefined;
+    handledTrackTypes: Record<ITrackType, boolean>;
     onTracksNotPlayableForType: {
       audio: "error" | "continue";
       video: "error" | "continue";
@@ -120,6 +124,7 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
     };
   }) {
     super();
+    this._handledTrackTypes = args.handledTrackTypes;
     this._storedPeriodInfo = [];
     this._isDisposed = false;
     this._cachedPeriodInfo = new WeakMap();
@@ -1635,9 +1640,25 @@ export default class TracksStore extends EventEmitter<ITracksStoreEvents> {
   private _shouldAdvertisePeriod(periodObj: ITSPeriodObject): boolean {
     return (
       !periodObj.isPeriodAdvertised &&
-      periodObj.text.dispatcher !== null &&
-      periodObj.video.dispatcher !== null &&
-      periodObj.audio.dispatcher !== null
+      this._isPeriodTypeReadyForAdvertisement(periodObj, "text") &&
+      this._isPeriodTypeReadyForAdvertisement(periodObj, "video") &&
+      this._isPeriodTypeReadyForAdvertisement(periodObj, "audio")
+    );
+  }
+
+  /**
+   * Returns `true` if the given type is ready for Period advertisement.
+   *
+   * We only wait for dispatchers that can actually be created in the current
+   * runtime. Types disabled through feature selection or media element
+   * capabilities should not keep the Period hidden forever.
+   */
+  private _isPeriodTypeReadyForAdvertisement(
+    periodObj: ITSPeriodObject,
+    bufferType: ITrackType,
+  ): boolean {
+    return (
+      !this._handledTrackTypes[bufferType] || periodObj[bufferType].dispatcher !== null
     );
   }
 }

--- a/src/main_thread/utils/media_capabilities.ts
+++ b/src/main_thread/utils/media_capabilities.ts
@@ -1,0 +1,14 @@
+import type { IMediaElement } from "../../compat/browser_compatibility_types";
+import features from "../../features";
+import type { ITextDisplayerOptions } from "../init/types";
+
+export function canHandleVideoTracks(mediaElement: IMediaElement | null): boolean {
+  return mediaElement?.nodeName.toLowerCase() === "video";
+}
+
+export function canHandleTextTracks(textTrackOptions: ITextDisplayerOptions): boolean {
+  return (
+    (textTrackOptions.textTrackMode === "html" && features.htmlTextDisplayer !== null) ||
+    features.nativeTextDisplayer !== null
+  );
+}

--- a/tests/contents/static/DASH_static_audio_tag/audio_only.js
+++ b/tests/contents/static/DASH_static_audio_tag/audio_only.js
@@ -1,0 +1,63 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_static_audio_tag/media/";
+
+export default {
+  url: BASE_URL + "audio_only.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 530621 / 44100,
+  minimumPosition: 0,
+  maximumPosition: 530621 / 44100,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 530621 / 44100,
+      adaptations: {
+        audio: [
+          {
+            id: "audio-audio-mp4a.40.2-audio/mp4",
+            representations: [
+              {
+                id: "audio=128000",
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 177341 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-0.dash",
+                    },
+                    {
+                      time: 177341 / 44100,
+                      duration: 176128 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-177341.dash",
+                    },
+                    {
+                      time: 353469 / 44100,
+                      duration: 177152 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-353469.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/static/DASH_static_audio_tag/audio_video.js
+++ b/tests/contents/static/DASH_static_audio_tag/audio_video.js
@@ -1,0 +1,103 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_static_audio_tag/media/";
+
+export default {
+  url: BASE_URL + "audio_video.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 530621 / 44100,
+  minimumPosition: 0,
+  maximumPosition: 530621 / 44100,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 530621 / 44100,
+      adaptations: {
+        audio: [
+          {
+            id: "audio-audio-mp4a.40.2-audio/mp4",
+            representations: [
+              {
+                id: "audio=128000",
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 177341 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-0.dash",
+                    },
+                    {
+                      time: 177341 / 44100,
+                      duration: 176128 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-177341.dash",
+                    },
+                    {
+                      time: 353469 / 44100,
+                      duration: 177152 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-353469.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        video: [
+          {
+            id: "video-video-video/mp4",
+            representations: [
+              {
+                id: "video=400000",
+                bitrate: 400000,
+                height: 124,
+                width: 220,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-0.dash",
+                    },
+                    {
+                      time: 4004 / 1000,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-4004.dash",
+                    },
+                    {
+                      time: 8008 / 1000,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-8008.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/static/DASH_static_audio_tag/index.js
+++ b/tests/contents/static/DASH_static_audio_tag/index.js
@@ -1,0 +1,4 @@
+import audioOnlyManifestInfos from "./audio_only.js";
+import audioVideoManifestInfos from "./audio_video.js";
+
+export { audioOnlyManifestInfos, audioVideoManifestInfos };

--- a/tests/contents/static/DASH_static_audio_tag/media/audio_only.mpd
+++ b/tests/contents/static/DASH_static_audio_tag/media/audio_only.mpd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT12.032222S"
+  minBufferTime="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT12.032222S">
+    <BaseURL>/DASH_static_SegmentTimeline/media/dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="44100"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/static/DASH_static_audio_tag/media/audio_video.mpd
+++ b/tests/contents/static/DASH_static_audio_tag/media/audio_video.mpd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT12.032222S"
+  minBufferTime="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT12.032222S">
+    <BaseURL>/DASH_static_SegmentTimeline/media/dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="44100"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="1000"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="4004" />
+          <S d="4004" />
+          <S d="4004" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video=400000"
+        bandwidth="400000"
+        width="220"
+        height="124"
+        sar="248:187"
+        codecs="avc1.42C014"
+        scanType="progressive" />
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/static/DASH_static_audio_tag/urls.mjs
+++ b/tests/contents/static/DASH_static_audio_tag/urls.mjs
@@ -1,0 +1,20 @@
+/* eslint-env node */
+
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const BASE_URL = "/DASH_static_audio_tag/media/";
+
+export default [
+  {
+    url: BASE_URL + "audio_only.mpd",
+    path: path.join(currentDirectory, "media/audio_only.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "audio_video.mpd",
+    path: path.join(currentDirectory, "media/audio_video.mpd"),
+    contentType: "application/dash+xml",
+  },
+];

--- a/tests/contents/static/urls.mjs
+++ b/tests/contents/static/urls.mjs
@@ -16,6 +16,7 @@ import urls11 from "./DASH_static_number_based_SegmentTimeline/urls.mjs";
 import urls12 from "./DASH_DRM_static_SegmentTemplate/urls.mjs";
 import urls13 from "./DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs";
 import urls14 from "./imagetracks/urls.mjs";
+import urls15 from "./DASH_static_audio_tag/urls.mjs";
 
 export default [
   ...urls1,
@@ -32,4 +33,5 @@ export default [
   ...urls12,
   ...urls13,
   ...urls14,
+  ...urls15,
 ];

--- a/tests/integration/scenarios/audio_tag.test.js
+++ b/tests/integration/scenarios/audio_tag.test.js
@@ -1,0 +1,104 @@
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import RxPlayer from "../../../dist/es2017";
+import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
+import TestWorkerEmbed from "../../embedded_worker_bundle";
+import {
+  audioOnlyManifestInfos,
+  audioVideoManifestInfos,
+} from "../../contents/static/DASH_static_audio_tag";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
+import { lockLowestBitrates } from "../../utils/bitrates";
+import { waitForLoadedStateAfterLoadVideo } from "../../utils/waitForPlayerState";
+
+runAudioTagTests();
+runAudioTagTests({ multithread: true });
+
+function runAudioTagTests({ multithread } = {}) {
+  let title = "playback through an audio element";
+  if (multithread === true) {
+    RxPlayer.addFeatures([MULTI_THREAD]);
+    title = "playback through an audio element with worker";
+  }
+
+  describe(title, function () {
+    let audioElement;
+    let player;
+
+    beforeEach(() => {
+      audioElement = document.createElement("audio");
+      document.body.appendChild(audioElement);
+      player = new RxPlayer({ videoElement: audioElement });
+      if (multithread === true) {
+        player.attachWorker({
+          workerUrl: TestWorkerEmbed,
+          dashWasmUrl: EMBEDDED_DASH_WASM,
+        });
+      }
+    });
+
+    afterEach(() => {
+      player.dispose();
+      audioElement.remove();
+    });
+
+    it("should play audio-only content on an audio element", async function () {
+      lockLowestBitrates(player);
+      player.loadVideo({
+        url: audioOnlyManifestInfos.url,
+        transport: audioOnlyManifestInfos.transport,
+        autoPlay: true,
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      expect(player.getVideoElement().nodeName).to.equal("AUDIO");
+
+      await player.play();
+      await checkAfterSleepWithBackoff({ stepMs: 100, maxTimeMs: 10000 }, () => {
+        expect(player.getPosition()).to.be.above(0);
+        expect(player.getCurrentBufferGap()).to.be.above(0);
+        expect(player.getVideoElement().buffered.start(0)).to.be.at.most(
+          player.getPosition(),
+        );
+      });
+    });
+
+    it("should ignore video data and play audio on an audio element", async function () {
+      lockLowestBitrates(player);
+      const requestedSegments = [];
+      const videoInitSegmentUrl =
+        audioVideoManifestInfos.periods[0].adaptations.video[0].representations[0].index
+          .init.url;
+
+      if (multithread === true) {
+        const workerInterface = player.getWorkerInterface();
+        expect(workerInterface).not.toBeNull();
+        workerInterface.addMessageListener("segment-loader", (info) => {
+          requestedSegments.push(info.url);
+        });
+      }
+
+      player.loadVideo({
+        url: audioVideoManifestInfos.url,
+        transport: audioVideoManifestInfos.transport,
+        autoPlay: true,
+        segmentLoader: {
+          fn: (info, callbacks) => {
+            requestedSegments.push(info.url);
+            callbacks.fallback();
+          },
+          workerId: "default-segment-loader",
+        },
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      expect(player.getVideoElement().nodeName).to.equal("AUDIO");
+      expect(requestedSegments).not.toContain(videoInitSegmentUrl);
+
+      await player.play();
+      await checkAfterSleepWithBackoff({ stepMs: 100, maxTimeMs: 10000 }, () => {
+        expect(player.getPosition()).to.be.above(0);
+        expect(player.getCurrentBufferGap()).to.be.above(0);
+        expect(requestedSegments).not.toContain(videoInitSegmentUrl);
+      });
+    });
+  });
+}


### PR DESCRIPTION
fix issue #1847 

Stop waiting for track dispatchers that cannot be created in the current runtime configuration when deciding whether a Period can be advertised. This prevents audio-only playback from getting stuck when video or text track handling is intentionally disabled by the media element or the selected feature set.