### PR TITLE
Add integration tests

### DIFF
--- a/tests/contents/static/DASH_static_audio_tag/audio_only.js
+++ b/tests/contents/static/DASH_static_audio_tag/audio_only.js
@@ -1,0 +1,63 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_static_audio_tag/media/";
+
+export default {
+  url: BASE_URL + "audio_only.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 530621 / 44100,
+  minimumPosition: 0,
+  maximumPosition: 530621 / 44100,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 530621 / 44100,
+      adaptations: {
+        audio: [
+          {
+            id: "audio-audio-mp4a.40.2-audio/mp4",
+            representations: [
+              {
+                id: "audio=128000",
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 177341 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-0.dash",
+                    },
+                    {
+                      time: 177341 / 44100,
+                      duration: 176128 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-177341.dash",
+                    },
+                    {
+                      time: 353469 / 44100,
+                      duration: 177152 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-353469.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/static/DASH_static_audio_tag/audio_video.js
+++ b/tests/contents/static/DASH_static_audio_tag/audio_video.js
@@ -1,0 +1,103 @@
+const BASE_URL =
+  "http://" +
+  __TEST_CONTENT_SERVER__.URL +
+  ":" +
+  __TEST_CONTENT_SERVER__.PORT +
+  "/DASH_static_audio_tag/media/";
+
+export default {
+  url: BASE_URL + "audio_video.mpd",
+  transport: "dash",
+  isDynamic: false,
+  isLive: false,
+  duration: 530621 / 44100,
+  minimumPosition: 0,
+  maximumPosition: 530621 / 44100,
+  availabilityStartTime: 0,
+  periods: [
+    {
+      start: 0,
+      duration: 530621 / 44100,
+      adaptations: {
+        audio: [
+          {
+            id: "audio-audio-mp4a.40.2-audio/mp4",
+            representations: [
+              {
+                id: "audio=128000",
+                bitrate: 128000,
+                codec: "mp4a.40.2",
+                mimeType: "audio/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 177341 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-0.dash",
+                    },
+                    {
+                      time: 177341 / 44100,
+                      duration: 176128 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-177341.dash",
+                    },
+                    {
+                      time: 353469 / 44100,
+                      duration: 177152 / 44100,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-audio=128000-353469.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+        video: [
+          {
+            id: "video-video-video/mp4",
+            representations: [
+              {
+                id: "video=400000",
+                bitrate: 400000,
+                height: 124,
+                width: 220,
+                codec: "avc1.42C014",
+                mimeType: "video/mp4",
+                index: {
+                  init: {
+                    url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000.dash",
+                  },
+                  segments: [
+                    {
+                      time: 0,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-0.dash",
+                    },
+                    {
+                      time: 4004 / 1000,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-4004.dash",
+                    },
+                    {
+                      time: 8008 / 1000,
+                      duration: 4004 / 1000,
+                      timescale: 1,
+                      url: "/DASH_static_SegmentTimeline/media/dash/ateam-video=400000-8008.dash",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/tests/contents/static/DASH_static_audio_tag/index.js
+++ b/tests/contents/static/DASH_static_audio_tag/index.js
@@ -1,0 +1,4 @@
+import audioOnlyManifestInfos from "./audio_only.js";
+import audioVideoManifestInfos from "./audio_video.js";
+
+export { audioOnlyManifestInfos, audioVideoManifestInfos };

--- a/tests/contents/static/DASH_static_audio_tag/media/audio_only.mpd
+++ b/tests/contents/static/DASH_static_audio_tag/media/audio_only.mpd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT12.032222S"
+  minBufferTime="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT12.032222S">
+    <BaseURL>/DASH_static_SegmentTimeline/media/dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="44100"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/static/DASH_static_audio_tag/media/audio_video.mpd
+++ b/tests/contents/static/DASH_static_audio_tag/media/audio_video.mpd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT12.032222S"
+  minBufferTime="PT2S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="1" duration="PT12.032222S">
+    <BaseURL>/DASH_static_SegmentTimeline/media/dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="44100"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="177341" />
+          <S d="176128" />
+          <S d="177152" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio=128000" bandwidth="128000" />
+    </AdaptationSet>
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      par="40:17"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="1000"
+        initialization="ateam-$RepresentationID$.dash"
+        media="ateam-$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="0" d="4004" />
+          <S d="4004" />
+          <S d="4004" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video=400000"
+        bandwidth="400000"
+        width="220"
+        height="124"
+        sar="248:187"
+        codecs="avc1.42C014"
+        scanType="progressive" />
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/contents/static/DASH_static_audio_tag/urls.mjs
+++ b/tests/contents/static/DASH_static_audio_tag/urls.mjs
@@ -1,0 +1,20 @@
+/* eslint-env node */
+
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const BASE_URL = "/DASH_static_audio_tag/media/";
+
+export default [
+  {
+    url: BASE_URL + "audio_only.mpd",
+    path: path.join(currentDirectory, "media/audio_only.mpd"),
+    contentType: "application/dash+xml",
+  },
+  {
+    url: BASE_URL + "audio_video.mpd",
+    path: path.join(currentDirectory, "media/audio_video.mpd"),
+    contentType: "application/dash+xml",
+  },
+];

--- a/tests/contents/static/urls.mjs
+++ b/tests/contents/static/urls.mjs
@@ -16,6 +16,7 @@ import urls11 from "./DASH_static_number_based_SegmentTimeline/urls.mjs";
 import urls12 from "./DASH_DRM_static_SegmentTemplate/urls.mjs";
 import urls13 from "./DASH_dynamic_SegmentTemplate_UnsupportedAudio/urls.mjs";
 import urls14 from "./imagetracks/urls.mjs";
+import urls15 from "./DASH_static_audio_tag/urls.mjs";
 
 export default [
   ...urls1,
@@ -32,4 +33,5 @@ export default [
   ...urls12,
   ...urls13,
   ...urls14,
+  ...urls15,
 ];

--- a/tests/integration/scenarios/audio_tag.test.js
+++ b/tests/integration/scenarios/audio_tag.test.js
@@ -1,0 +1,104 @@
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import RxPlayer from "../../../dist/es2017";
+import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
+import TestWorkerEmbed from "../../embedded_worker_bundle";
+import {
+  audioOnlyManifestInfos,
+  audioVideoManifestInfos,
+} from "../../contents/static/DASH_static_audio_tag";
+import { checkAfterSleepWithBackoff } from "../../utils/checkAfterSleepWithBackoff.js";
+import { lockLowestBitrates } from "../../utils/bitrates";
+import { waitForLoadedStateAfterLoadVideo } from "../../utils/waitForPlayerState";
+
+runAudioTagTests();
+runAudioTagTests({ multithread: true });
+
+function runAudioTagTests({ multithread } = {}) {
+  let title = "playback through an audio element";
+  if (multithread === true) {
+    RxPlayer.addFeatures([MULTI_THREAD]);
+    title = "playback through an audio element with worker";
+  }
+
+  describe(title, function () {
+    let audioElement;
+    let player;
+
+    beforeEach(() => {
+      audioElement = document.createElement("audio");
+      document.body.appendChild(audioElement);
+      player = new RxPlayer({ videoElement: audioElement });
+      if (multithread === true) {
+        player.attachWorker({
+          workerUrl: TestWorkerEmbed,
+          dashWasmUrl: EMBEDDED_DASH_WASM,
+        });
+      }
+    });
+
+    afterEach(() => {
+      player.dispose();
+      audioElement.remove();
+    });
+
+    it("should play audio-only content on an audio element", async function () {
+      lockLowestBitrates(player);
+      player.loadVideo({
+        url: audioOnlyManifestInfos.url,
+        transport: audioOnlyManifestInfos.transport,
+        autoPlay: true,
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      expect(player.getVideoElement().nodeName).to.equal("AUDIO");
+
+      await player.play();
+      await checkAfterSleepWithBackoff({ stepMs: 100, maxTimeMs: 10000 }, () => {
+        expect(player.getPosition()).to.be.above(0);
+        expect(player.getCurrentBufferGap()).to.be.above(0);
+        expect(player.getVideoElement().buffered.start(0)).to.be.at.most(
+          player.getPosition(),
+        );
+      });
+    });
+
+    it("should ignore video data and play audio on an audio element", async function () {
+      lockLowestBitrates(player);
+      const requestedSegments = [];
+      const videoInitSegmentUrl =
+        audioVideoManifestInfos.periods[0].adaptations.video[0].representations[0].index
+          .init.url;
+
+      if (multithread === true) {
+        const workerInterface = player.getWorkerInterface();
+        expect(workerInterface).not.toBeNull();
+        workerInterface.addMessageListener("segment-loader", (info) => {
+          requestedSegments.push(info.url);
+        });
+      }
+
+      player.loadVideo({
+        url: audioVideoManifestInfos.url,
+        transport: audioVideoManifestInfos.transport,
+        autoPlay: true,
+        segmentLoader: {
+          fn: (info, callbacks) => {
+            requestedSegments.push(info.url);
+            callbacks.fallback();
+          },
+          workerId: "default-segment-loader",
+        },
+      });
+      await waitForLoadedStateAfterLoadVideo(player);
+      expect(player.getVideoElement().nodeName).to.equal("AUDIO");
+      expect(requestedSegments).not.toContain(videoInitSegmentUrl);
+
+      await player.play();
+      await checkAfterSleepWithBackoff({ stepMs: 100, maxTimeMs: 10000 }, () => {
+        expect(player.getPosition()).to.be.above(0);
+        expect(player.getCurrentBufferGap()).to.be.above(0);
+        expect(requestedSegments).not.toContain(videoInitSegmentUrl);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Webdriverio is yet again broken on my machine, this time, both chrome and firefox are not able to be launched. This is routine with that dependency sadly.
Because we don't have much time to look into this and because CI seems to be able to run those, I do just this PR to run integration tests - which shouldn't pass as they prove the bug in #1850 