### PR TITLE
Centralize playback support detection in the API

### DIFF
--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -77,21 +77,23 @@ export default class ContentPreparer {
   private _currentMediaSourceCanceller: TaskCanceller;
 
   /** @see constructor */
-  private _hasVideo: boolean;
+  public videoTrack: boolean;
 
   /**
    * @param {Object} capabilities
-   * @param {boolean} capabilities.hasVideo - If `true`, we're playing on an
+   * @param {boolean} capabilities.videoTrack - If `true`, we're playing on an
    * element which has video capabilities.
    * If `false`, we're only able to play audio, optionally with subtitles.
    *
    * Typically this boolean is `true` for `<video>` HTMLElement and `false` for
    * `<audio>` HTMLElement.
+   * TODO: Why having it both on construction and in `initializeNewContent`'s
+   * context and not just the latter? To check.
    */
-  constructor({ hasVideo }: { hasVideo: boolean }) {
+  constructor(capabilities: { videoTrack: boolean }) {
     this._currentContent = null;
     this._currentMediaSourceCanceller = new TaskCanceller("ContentPreparer MediaSource");
-    this._hasVideo = hasVideo;
+    this.videoTrack = capabilities.videoTrack;
     const contentCanceller = new TaskCanceller("ContentPreparer");
     this._contentCanceller = contentCanceller;
   }
@@ -130,9 +132,8 @@ export default class ContentPreparer {
       const {
         contentId,
         url,
-        hasText,
+        capabilities,
         transportOptions,
-        useMseInWorker,
         enableRepresentationAvoidance,
         transport,
       } = context;
@@ -198,9 +199,9 @@ export default class ContentPreparer {
           sendMessage,
           contentId,
           {
-            useMseInWorker,
-            hasVideo: this._hasVideo,
-            hasText,
+            mseInWorker: capabilities.mseInWorker,
+            videoTrack: this.videoTrack,
+            textTrack: capabilities.textTrack,
           },
           currentMediaSourceCanceller.signal,
         );
@@ -219,7 +220,7 @@ export default class ContentPreparer {
         fetchThumbnailData,
         coreTextSender,
         trackChoiceSetter,
-        useMseInWorker,
+        mseInWorker: capabilities.mseInWorker,
       };
       mediaSource.addEventListener(
         "mediaSourceOpen",
@@ -344,9 +345,9 @@ export default class ContentPreparer {
         sendMessage,
         this._currentContent.contentId,
         {
-          useMseInWorker: this._currentContent.useMseInWorker,
-          hasVideo: this._hasVideo,
-          hasText: this._currentContent.coreTextSender !== null,
+          mseInWorker: this._currentContent.mseInWorker,
+          videoTrack: this.videoTrack,
+          textTrack: this._currentContent.coreTextSender !== null,
         },
         this._currentMediaSourceCanceller.signal,
       );
@@ -457,16 +458,16 @@ export interface IPreparedContentData {
    * WebWorker).
    * If `false`, they should be relied on on main thread.
    */
-  useMseInWorker: boolean;
+  mseInWorker: boolean;
 }
 
 /**
  * @param {Function} sendMessage
  * @param {string} contentId
  * @param {Object} capabilities
- * @param {boolean} capabilities.useMseInWorker
- * @param {boolean} capabilities.hasVideo
- * @param {boolean} capabilities.hasText
+ * @param {boolean} capabilities.mseInWorker
+ * @param {boolean} capabilities.videoTrack
+ * @param {boolean} capabilities.textTrack
  * @param {Object} cancelSignal
  * @returns {Array.<Object>}
  */
@@ -474,14 +475,14 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
   sendMessage: (msg: ICoreMessage, transferables?: Transferable[]) => void,
   contentId: string,
   capabilities: {
-    useMseInWorker: boolean;
-    hasVideo: boolean;
-    hasText: boolean;
+    mseInWorker: boolean;
+    videoTrack: boolean;
+    textTrack: boolean;
   },
   cancelSignal: CancellationSignal,
 ): [IMediaSourceInterface, SegmentSinksStore, CoreTextDisplayerInterface | null] {
   let mediaSourceInterface: IMediaSourceInterface;
-  if (capabilities.useMseInWorker) {
+  if (capabilities.mseInWorker) {
     if (BROWSER_GLOBALS.MediaSource_ === undefined) {
       throw new Error("ContentPreparer: Cannot use MSE-in-Worker: no MSE");
     }
@@ -521,13 +522,13 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
     );
   }
 
-  const textSender = capabilities.hasText
+  const textSender = capabilities.textTrack
     ? new CoreTextDisplayerInterface(contentId, sendMessage)
     : null;
-  const { hasVideo } = capabilities;
+  const { videoTrack } = capabilities;
   const segmentSinksStore = new SegmentSinksStore(
     mediaSourceInterface,
-    hasVideo,
+    videoTrack,
     textSender,
   );
   cancelSignal.register((err) => {

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -76,24 +76,9 @@ export default class ContentPreparer {
    */
   private _currentMediaSourceCanceller: TaskCanceller;
 
-  /** @see constructor */
-  public videoTrack: boolean;
-
-  /**
-   * @param {Object} capabilities
-   * @param {boolean} capabilities.videoTrack - If `true`, we're playing on an
-   * element which has video capabilities.
-   * If `false`, we're only able to play audio, optionally with subtitles.
-   *
-   * Typically this boolean is `true` for `<video>` HTMLElement and `false` for
-   * `<audio>` HTMLElement.
-   * TODO: Why having it both on construction and in `initializeNewContent`'s
-   * context and not just the latter? To check.
-   */
-  constructor(capabilities: { videoTrack: boolean }) {
+  constructor() {
     this._currentContent = null;
     this._currentMediaSourceCanceller = new TaskCanceller("ContentPreparer MediaSource");
-    this.videoTrack = capabilities.videoTrack;
     const contentCanceller = new TaskCanceller("ContentPreparer");
     this._contentCanceller = contentCanceller;
   }
@@ -200,7 +185,7 @@ export default class ContentPreparer {
           contentId,
           {
             mseInWorker: capabilities.mseInWorker,
-            videoTrack: this.videoTrack,
+            videoTrack: capabilities.videoTrack,
             textTrack: capabilities.textTrack,
           },
           currentMediaSourceCanceller.signal,
@@ -221,6 +206,8 @@ export default class ContentPreparer {
         coreTextSender,
         trackChoiceSetter,
         mseInWorker: capabilities.mseInWorker,
+        videoTrack: capabilities.videoTrack,
+        textTrack: capabilities.textTrack,
       };
       mediaSource.addEventListener(
         "mediaSourceOpen",
@@ -346,8 +333,8 @@ export default class ContentPreparer {
         this._currentContent.contentId,
         {
           mseInWorker: this._currentContent.mseInWorker,
-          videoTrack: this.videoTrack,
-          textTrack: this._currentContent.coreTextSender !== null,
+          videoTrack: this._currentContent.videoTrack,
+          textTrack: this._currentContent.textTrack,
         },
         this._currentMediaSourceCanceller.signal,
       );
@@ -459,6 +446,15 @@ export interface IPreparedContentData {
    * If `false`, they should be relied on on main thread.
    */
   mseInWorker: boolean;
+  /**
+   * If `true`, the current content should create and use a video buffer.
+   * If `false`, only audio should be buffered natively.
+   */
+  videoTrack: boolean;
+  /**
+   * If `true`, the current content should create and use text-track handling.
+   */
+  textTrack: boolean;
 }
 
 /**

--- a/src/core/entry/content_preparer.ts
+++ b/src/core/entry/content_preparer.ts
@@ -117,7 +117,7 @@ export default class ContentPreparer {
       const {
         contentId,
         url,
-        capabilities,
+        playbackSupport,
         transportOptions,
         enableRepresentationAvoidance,
         transport,
@@ -184,9 +184,9 @@ export default class ContentPreparer {
           sendMessage,
           contentId,
           {
-            mseInWorker: capabilities.mseInWorker,
-            videoTrack: capabilities.videoTrack,
-            textTrack: capabilities.textTrack,
+            mseInWorker: playbackSupport.mseInWorker,
+            videoTrack: playbackSupport.videoTrack,
+            textTrack: playbackSupport.textTrack,
           },
           currentMediaSourceCanceller.signal,
         );
@@ -205,9 +205,9 @@ export default class ContentPreparer {
         fetchThumbnailData,
         coreTextSender,
         trackChoiceSetter,
-        mseInWorker: capabilities.mseInWorker,
-        videoTrack: capabilities.videoTrack,
-        textTrack: capabilities.textTrack,
+        mseInWorker: playbackSupport.mseInWorker,
+        videoTrack: playbackSupport.videoTrack,
+        textTrack: playbackSupport.textTrack,
       };
       mediaSource.addEventListener(
         "mediaSourceOpen",
@@ -460,17 +460,17 @@ export interface IPreparedContentData {
 /**
  * @param {Function} sendMessage
  * @param {string} contentId
- * @param {Object} capabilities
- * @param {boolean} capabilities.mseInWorker
- * @param {boolean} capabilities.videoTrack
- * @param {boolean} capabilities.textTrack
+ * @param {Object} playbackSupport
+ * @param {boolean} playbackSupport.mseInWorker
+ * @param {boolean} playbackSupport.videoTrack
+ * @param {boolean} playbackSupport.textTrack
  * @param {Object} cancelSignal
  * @returns {Array.<Object>}
  */
 function createMediaSourceInterfaceAndSegmentSinksStore(
   sendMessage: (msg: ICoreMessage, transferables?: Transferable[]) => void,
   contentId: string,
-  capabilities: {
+  playbackSupport: {
     mseInWorker: boolean;
     videoTrack: boolean;
     textTrack: boolean;
@@ -478,7 +478,7 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
   cancelSignal: CancellationSignal,
 ): [IMediaSourceInterface, SegmentSinksStore, CoreTextDisplayerInterface | null] {
   let mediaSourceInterface: IMediaSourceInterface;
-  if (capabilities.mseInWorker) {
+  if (playbackSupport.mseInWorker) {
     if (BROWSER_GLOBALS.MediaSource_ === undefined) {
       throw new Error("ContentPreparer: Cannot use MSE-in-Worker: no MSE");
     }
@@ -518,10 +518,10 @@ function createMediaSourceInterfaceAndSegmentSinksStore(
     );
   }
 
-  const textSender = capabilities.textTrack
+  const textSender = playbackSupport.textTrack
     ? new CoreTextDisplayerInterface(contentId, sendMessage)
     : null;
-  const { videoTrack } = capabilities;
+  const { videoTrack } = playbackSupport;
   const segmentSinksStore = new SegmentSinksStore(
     mediaSourceInterface,
     videoTrack,

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -95,10 +95,8 @@ export default function initializeCoreEntry(
   /**
    * Abstraction allowing to prepare contents (fetching its manifest as
    * well as creating and reloading its MediaSource) for playback.
-   *
-   * Creating a default one which may change on initialization.
    */
-  let contentPreparer = new ContentPreparer({ videoTrack: true });
+  let contentPreparer = new ContentPreparer();
   /**
    * Object allowing to control the lifecycle of the current content (stop/reload etc.).
    * `null` if there's no content loaded currently.
@@ -158,12 +156,6 @@ export default function initializeCoreEntry(
         break;
 
       case MainThreadMessageType.PrepareContent:
-        if (msg.value.capabilities.videoTrack !== contentPreparer.videoTrack) {
-          contentPreparer.disposeCurrentContent("Received Prepare msg");
-          contentPreparer = new ContentPreparer({
-            videoTrack: msg.value.capabilities.videoTrack,
-          });
-        }
         prepareNewContent(sendMessage, contentPreparer, msg.value, refs, corePlugins);
         break;
 

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -96,7 +96,7 @@ export default function initializeCoreEntry(
    * Abstraction allowing to prepare contents (fetching its manifest as
    * well as creating and reloading its MediaSource) for playback.
    */
-  let contentPreparer = new ContentPreparer();
+  const contentPreparer = new ContentPreparer();
   /**
    * Object allowing to control the lifecycle of the current content (stop/reload etc.).
    * `null` if there's no content loaded currently.

--- a/src/core/entry/core_entry.ts
+++ b/src/core/entry/core_entry.ts
@@ -98,7 +98,7 @@ export default function initializeCoreEntry(
    *
    * Creating a default one which may change on initialization.
    */
-  let contentPreparer = new ContentPreparer({ hasVideo: true });
+  let contentPreparer = new ContentPreparer({ videoTrack: true });
   /**
    * Object allowing to control the lifecycle of the current content (stop/reload etc.).
    * `null` if there's no content loaded currently.
@@ -145,12 +145,6 @@ export default function initializeCoreEntry(
                 });
             }
           }
-
-          if (!msg.value.hasVideo) {
-            contentPreparer.disposeCurrentContent("Received Init msg");
-            contentPreparer = new ContentPreparer({ hasVideo: msg.value.hasVideo });
-          }
-
           sendMessage({ type: CoreMessageType.InitSuccess, value: null });
         }
         break;
@@ -164,6 +158,12 @@ export default function initializeCoreEntry(
         break;
 
       case MainThreadMessageType.PrepareContent:
+        if (msg.value.capabilities.videoTrack !== contentPreparer.videoTrack) {
+          contentPreparer.disposeCurrentContent("Received Prepare msg");
+          contentPreparer = new ContentPreparer({
+            videoTrack: msg.value.capabilities.videoTrack,
+          });
+        }
         prepareNewContent(sendMessage, contentPreparer, msg.value, refs, corePlugins);
         break;
 

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -650,7 +650,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           sendBackLogs: isDebugModeEnabled,
           date: Date.now(),
           timestamp: getMonotonicTimeStamp(),
-          hasVideo: canHandleVideoTracks(this.videoElement),
         },
       });
       log.addEventListener(
@@ -1034,6 +1033,9 @@ class Player extends EventEmitter<IPublicAPIEvent> {
 
     const isDirectFile = transport === "directfile";
 
+    const isTextHandled = canHandleTextTracks(options);
+    const isVideoHandled = canHandleVideoTracks(this.videoElement);
+
     /** Emit to stop the current content. */
     const currentContentCanceller = new TaskCanceller("API current content");
 
@@ -1204,7 +1206,6 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           type: MainThreadMessageType.Init,
           value: {
             dashWasmUrl: undefined,
-            hasVideo: canHandleVideoTracks(this.videoElement),
             logLevel: log.getLevel(),
             logFormat: log.getFormat(),
             sendBackLogs: false,
@@ -1230,7 +1231,11 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           startAt,
           textTrackOptions,
           url,
-          useMseInWorker: false,
+          capabilities: {
+            mseInWorker: false,
+            videoTrack: isVideoHandled,
+            textTrack: isTextHandled,
+          },
           MediaSourceClass,
         });
       } else {
@@ -1311,8 +1316,12 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           startAt,
           textTrackOptions,
           url,
-          useMseInWorker: hasMseInWorker,
           MediaSourceClass,
+          capabilities: {
+            mseInWorker: hasMseInWorker,
+            videoTrack: isVideoHandled,
+            textTrack: isTextHandled,
+          },
         });
       }
     } else {
@@ -1373,8 +1382,8 @@ class Player extends EventEmitter<IPublicAPIEvent> {
       mediaElementTracksStore,
       handledTrackTypes: {
         audio: true,
-        video: canHandleVideoTracks(this.videoElement),
-        text: canHandleTextTracks(options),
+        video: isVideoHandled,
+        text: isTextHandled,
       },
       useWorker,
       segmentSinkMetricsCallback: null,

--- a/src/main_thread/api/public_api.ts
+++ b/src/main_thread/api/public_api.ts
@@ -1231,7 +1231,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           startAt,
           textTrackOptions,
           url,
-          capabilities: {
+          playbackSupport: {
             mseInWorker: false,
             videoTrack: isVideoHandled,
             textTrack: isTextHandled,
@@ -1317,7 +1317,7 @@ class Player extends EventEmitter<IPublicAPIEvent> {
           textTrackOptions,
           url,
           MediaSourceClass,
-          capabilities: {
+          playbackSupport: {
             mseInWorker: hasMseInWorker,
             videoTrack: isVideoHandled,
             textTrack: isTextHandled,

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -178,8 +178,13 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       return;
     }
     const contentId = generateContentId();
-    const { adaptiveOptions, transport, transportOptions, capabilities, coreInterface } =
-      this._settings;
+    const {
+      adaptiveOptions,
+      transport,
+      transportOptions,
+      playbackSupport,
+      coreInterface,
+    } = this._settings;
     const { wantedBufferAhead, maxVideoBufferSize, maxBufferAhead, maxBufferBehind } =
       this._settings.bufferOptions;
     const initialVideoBitrate = adaptiveOptions.initialBitrates.video;
@@ -193,7 +198,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       initialTime: undefined,
       autoPlay: undefined,
       initialPlayPerformed: null,
-      useMseInWorker: capabilities.mseInWorker,
+      useMseInWorker: playbackSupport.mseInWorker,
     };
     coreInterface.sendMessage({
       type: MainThreadMessageType.PrepareContent,
@@ -202,7 +207,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         cmcd: this._settings.cmcd,
         enableRepresentationAvoidance: this._settings.enableRepresentationAvoidance,
         url: this._settings.url,
-        capabilities: this._settings.capabilities,
+        playbackSupport: this._settings.playbackSupport,
         transport,
         transportOptions,
         initialVideoBitrate,
@@ -2109,8 +2114,8 @@ export interface IInitializeArguments {
    * which cases message exchanging mechanisms would be different.
    */
   coreInterface: CoreInterface;
-  /** The capabilities of the current environment for this content. */
-  capabilities: {
+  /** The resolved playback support for this content. */
+  playbackSupport: {
     /**
      * If `true`, MSE API should be used in the core part of the RxPlayer (in the
      * WebWorker).

--- a/src/main_thread/init/media_source_content_initializer.ts
+++ b/src/main_thread/init/media_source_content_initializer.ts
@@ -178,13 +178,8 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       return;
     }
     const contentId = generateContentId();
-    const {
-      adaptiveOptions,
-      transport,
-      transportOptions,
-      useMseInWorker,
-      coreInterface,
-    } = this._settings;
+    const { adaptiveOptions, transport, transportOptions, capabilities, coreInterface } =
+      this._settings;
     const { wantedBufferAhead, maxVideoBufferSize, maxBufferAhead, maxBufferBehind } =
       this._settings.bufferOptions;
     const initialVideoBitrate = adaptiveOptions.initialBitrates.video;
@@ -198,7 +193,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
       initialTime: undefined,
       autoPlay: undefined,
       initialPlayPerformed: null,
-      useMseInWorker,
+      useMseInWorker: capabilities.mseInWorker,
     };
     coreInterface.sendMessage({
       type: MainThreadMessageType.PrepareContent,
@@ -207,7 +202,7 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
         cmcd: this._settings.cmcd,
         enableRepresentationAvoidance: this._settings.enableRepresentationAvoidance,
         url: this._settings.url,
-        hasText: canHandleTextTracks(this._settings.textTrackOptions),
+        capabilities: this._settings.capabilities,
         transport,
         transportOptions,
         initialVideoBitrate,
@@ -217,7 +212,6 @@ export default class MediaSourceContentInitializer extends ContentInitializer {
           lowLatencyMode: this._settings.lowLatencyMode,
         },
         segmentRetryOptions: this._settings.segmentRequestOptions,
-        useMseInWorker,
       },
     });
     this._initCanceller.signal.register(() => {
@@ -2115,16 +2109,30 @@ export interface IInitializeArguments {
    * which cases message exchanging mechanisms would be different.
    */
   coreInterface: CoreInterface;
-  /**
-   * If `true`, MSE API should be used in the core part of the RxPlayer (in the
-   * WebWorker).
-   * If `false`, they should be relied on on main thread.
-   *
-   * This might depend on both browser capabilities and preferences. It is
-   * assumed that the caller perform all those checks, the `ContentInitializer`
-   * won't check again the validity of this value.
-   */
-  useMseInWorker: boolean;
+  /** The capabilities of the current environment for this content. */
+  capabilities: {
+    /**
+     * If `true`, MSE API should be used in the core part of the RxPlayer (in the
+     * WebWorker).
+     * If `false`, they should be relied on on main thread.
+     *
+     * This might depend on both browser capabilities and preferences. It is
+     * assumed that the caller perform all those checks, the `ContentInitializer`
+     * won't check again the validity of this value.
+     */
+    mseInWorker: boolean;
+    /**
+     * If `true`, the right environment **and** features are present to be able
+     * to support text tracks.
+     */
+    textTrack: boolean;
+    /**
+     * If `true`, the right environment **and** features are present to be able
+     * to support video tracks.
+     * This includes a video element tag.
+     */
+    videoTrack: boolean;
+  };
   /** Options concerning the ABR logic. */
   adaptiveOptions: IAdaptiveRepresentationSelectorArguments;
   /** `true` if we should play when loaded. */

--- a/src/main_thread/types.ts
+++ b/src/main_thread/types.ts
@@ -103,8 +103,8 @@ export interface IContentInitializationData {
    * `undefined` if unknown.
    */
   url?: string | undefined;
-  /** The capabilities of the current environment for this content. */
-  capabilities: {
+  /** The resolved playback support for this content. */
+  playbackSupport: {
     /**
      * If `true`, MSE API should be used in the core part of the RxPlayer when
      * relying on a WebWorker.

--- a/src/main_thread/types.ts
+++ b/src/main_thread/types.ts
@@ -47,16 +47,6 @@ export interface IInitMessage {
   value: {
     /** Link to the DASH_WASM's feature WebAssembly file to parse DASH MPDs. */
     dashWasmUrl: string | undefined;
-    /**
-     * If `true` the final element on the current page displaying the content
-     * can display video content.
-     *
-     * If `false`, it cannot, but it can be assumed to be able to play audio
-     * content.
-     * An example where it would be set to `false` is for `HTMLAudioElement`
-     * elements (`<audio>` tags).
-     */
-    hasVideo: boolean;
     /** Initial logging level that should be set. */
     logLevel: ILoggerLevel;
     /** Intitial logger's log format that should be set. */
@@ -113,8 +103,30 @@ export interface IContentInitializationData {
    * `undefined` if unknown.
    */
   url?: string | undefined;
-  /** If `true`, text buffer (e.g. for subtitles) is enabled. */
-  hasText: boolean;
+  /** The capabilities of the current environment for this content. */
+  capabilities: {
+    /**
+     * If `true`, MSE API should be used in the core part of the RxPlayer when
+     * relying on a WebWorker.
+     * If `false`, they should be relied on on main thread.
+     *
+     * This might depend on both browser capabilities and preferences. It is
+     * assumed that the caller perform all those checks, the core won't check
+     * again the validity of this value.
+     */
+    mseInWorker: boolean;
+    /**
+     * If `true`, the right environment **and** features are present to be able
+     * to support text tracks.
+     */
+    textTrack: boolean;
+    /**
+     * If `true`, the right environment **and** features are present to be able
+     * to support video tracks.
+     * This includes a video element tag.
+     */
+    videoTrack: boolean;
+  };
   /**
    * The type of "transport" wanted, e.g. "dash" or "smooth".
    */
@@ -154,16 +166,6 @@ export interface IContentInitializationData {
   manifestRetryOptions: Omit<IManifestFetcherSettings, "cmcdDataBuilder">;
   /** Options relative to the fetching of media segments. */
   segmentRetryOptions: ISegmentQueueCreatorBackoffOptions;
-  /**
-   * If `true`, MSE API should be used in the core part of the RxPlayer when
-   * relying on a WebWorker.
-   * If `false`, they should be relied on on main thread.
-   *
-   * This might depend on both browser capabilities and preferences. It is
-   * assumed that the caller perform all those checks, the core won't check
-   * again the validity of this value.
-   */
-  useMseInWorker: boolean;
 }
 
 export interface ILogLevelUpdateMessage {


### PR DESCRIPTION
Based on #1777 (as it has a similar refacto).

This PR attempts to improve #1850, which fixed an issue where we would be waiting for a text track and video track even when playing without text track support and/or without a video element.

The fix added support checks at two places: our init (`src/main_thread/init`) and the API (`src/main_thread/api`).

I didn't like the fact that we had two different sources for it so I looked into if we could just check support once at `loadVideo`-time in the API, and then communicate this to the different modules that needs it.

I succeeded to do something that I like here.