### PR TITLE
consider HTTP 429 as retryable requests

### DIFF
--- a/src/core/fetchers/utils/schedule_request.ts
+++ b/src/core/fetchers/utils/schedule_request.ts
@@ -46,7 +46,8 @@ function shouldRetry(error: unknown): boolean {
         error.status === 415 || // some CDN seems to use that code when
         // requesting low-latency segments too much
         // in advance
-        error.status === 412
+        error.status === 412 ||
+        error.status === 429 // TODO: Handle optional Retry-After header
       );
     }
     return (
@@ -64,7 +65,8 @@ function shouldRetry(error: unknown): boolean {
         error.xhr.status === 415 || // some CDN seems to use that code when
         // requesting low-latency segments too much
         // in advance
-        error.xhr.status === 412
+        error.xhr.status === 412 ||
+        error.xhr.status === 429
       );
     }
     return false;


### PR DESCRIPTION
As indicated in #1857, "HTTP 429 Too many requests" seems to be a valid case for our segment+manifest retry heuristics, as that issue may resolve itself by just retrying the request later.

It is compatible to DASH specifications (which just tell us to follow HTTP semantics for received status codes).

HTTP 429 may be accompanied by a Retry-After header indicating the preferred minimal backoff time. For now this is not handled as it could be a more risky development when we are preparing our new 4.5.0 release. But it should also be handled in the future.

It makes sense also for license retries but those requests are entirely handled by the application anyway, which decides of the retry rules, so no diff needed there.