### PR TITLE
feat: add support for new nagra keysystem "com.tvkey.drm"

### DIFF
--- a/src/main_thread/decrypt/utils/get_drm_system_id.ts
+++ b/src/main_thread/decrypt/utils/get_drm_system_id.ts
@@ -34,7 +34,7 @@ export default function getDrmSystemId(keySystem: string): string | undefined {
   if (startsWith(keySystem, "com.apple.fps")) {
     return "94ce86fb07ff4f43adb893d2fa968ca2";
   }
-  if (startsWith(keySystem, "com.nagra.")) {
+  if (startsWith(keySystem, "com.nagra.") || startsWith(keySystem, "com.tvkey.")) {
     return "adb41c242dbf4a6d958b4457c0d27b95";
   }
   return undefined;

--- a/src/main_thread/decrypt/utils/get_drm_system_id.ts
+++ b/src/main_thread/decrypt/utils/get_drm_system_id.ts
@@ -34,7 +34,9 @@ export default function getDrmSystemId(keySystem: string): string | undefined {
   if (startsWith(keySystem, "com.apple.fps")) {
     return "94ce86fb07ff4f43adb893d2fa968ca2";
   }
-  if (startsWith(keySystem, "com.nagra.") || startsWith(keySystem, "com.tvkey.")) {
+
+  // @see https://docs.nagra.vision/connect-player-sdk-5-for-browsers/5.28.x/Default/drm-preferences-and-security-levels
+  if (startsWith(keySystem, "com.nagra.") || keySystem === "com.tvkey.drm") {
     return "adb41c242dbf4a6d958b4457c0d27b95";
   }
   return undefined;


### PR DESCRIPTION
New Samsung TV from 2026 supports a Nagra keySystem called `"com.tvkey.drm"`.

This PR detect that this new keysystem is a Nagra keysystem and send the appropriate PSSH to the device.