### PR TITLE
fix(drm): ignore empty encryption data

### DIFF
--- a/src/compat/eme/get_init_data.ts
+++ b/src/compat/eme/get_init_data.ts
@@ -150,7 +150,7 @@ export default function getInitData(
   encryptedEvent: IMediaEncryptedEvent,
 ): IEncryptedEventData | null {
   const { initData, initDataType, forceSessionRecreation } = encryptedEvent;
-  if (isNullOrUndefined(initData)) {
+  if (isNullOrUndefined(initData) || initData.byteLength === 0) {
     log.warn("DRM", "No init data found on media encrypted event.");
     return null;
   }

--- a/src/compat/eme/get_init_data.ts
+++ b/src/compat/eme/get_init_data.ts
@@ -150,8 +150,13 @@ export default function getInitData(
   encryptedEvent: IMediaEncryptedEvent,
 ): IEncryptedEventData | null {
   const { initData, initDataType, forceSessionRecreation } = encryptedEvent;
-  if (isNullOrUndefined(initData) || initData.byteLength === 0) {
+  if (isNullOrUndefined(initData)) {
     log.warn("DRM", "No init data found on media encrypted event.");
+    return null;
+  }
+
+  if (initData.byteLength === 0) {
+    log.warn("DRM", "Init data is empty on media encrypted event.");
     return null;
   }
 


### PR DESCRIPTION
Implementations of the "encrypted" event can differ across browsers.
On older WebKit versions, that event may be emitted with empty initialization data.
The RxPlayer does not support that case, which can lead to unnecessary processing of invalid data.

For compatibility, the proposed change explicitly checks that the initialization data is not empty before handling the event.

EME specs says: 

> If initData is empty, return a promise rejected with a newly created [TypeError](https://www.w3.org/TR/encrypted-media-2/#dfn-typeerror).

https://www.w3.org/TR/encrypted-media-2/#dom-mediakeysession-generaterequest


Related WebKit change:
[WebKit commit 63012055c2484807b56a146cf4a601dda27e4be5](https://github.com/WebKit/WebKit/commit/63012055c2484807b56a146cf4a601dda27e4be5)