### PR TITLE
Verify built npm package before publish

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,6 +53,10 @@ jobs:
         run: npm run types:unit_tests
       - name: Lint test files
         run: npm run lint:tests
+      - name: Build package for consumer checks
+        run: npm run build -- --no-wasm --no-typecheck
+      - name: Check package exports
+        run: node scripts/check_package_build.mjs
 
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -209,10 +209,10 @@ jobs:
           npm run build
           PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-dev-package"
           mkdir -p "$PACKAGE_DIRECTORY"
-          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_NAME=$(npm pack --ignore-scripts --pack-destination "$PACKAGE_DIRECTORY")
           PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
           node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
-          npm publish "$PACKAGE_PATH" --tag dev --provenance
+          npm publish "$PACKAGE_PATH" --ignore-scripts --tag dev --provenance
 
       - name: Apply Canal+ patch
         run: git apply ./scripts/canal-release.patch
@@ -225,10 +225,10 @@ jobs:
           npm run build
           PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-canal-package"
           mkdir -p "$PACKAGE_DIRECTORY"
-          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_NAME=$(npm pack --ignore-scripts --pack-destination "$PACKAGE_DIRECTORY")
           PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
           node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
-          npm publish "$PACKAGE_PATH" --tag canal --provenance
+          npm publish "$PACKAGE_PATH" --ignore-scripts --tag canal --provenance
 
   publish_official:
     if: needs.determine_release_type.outputs.release_type == 'official'
@@ -276,7 +276,7 @@ jobs:
           npm run build
           PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-official-package"
           mkdir -p "$PACKAGE_DIRECTORY"
-          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_NAME=$(npm pack --ignore-scripts --pack-destination "$PACKAGE_DIRECTORY")
           PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
           node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
           echo "PACKAGE_PATH=$PACKAGE_PATH" >> "$GITHUB_ENV"
@@ -308,4 +308,4 @@ jobs:
           git push origin stable
 
       - name: Publish official release
-        run: npm publish "$PACKAGE_PATH" --provenance
+        run: npm publish "$PACKAGE_PATH" --ignore-scripts --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,10 +204,15 @@ jobs:
       - name: Update version for dev release
         run: npm run update-version "${{ steps.get_version.outputs.version }}"
 
-      - name: Build and publish dev version
+      - name: Build, check and publish dev version
         run: |
           npm run build
-          npm publish --tag dev --provenance
+          PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-dev-package"
+          mkdir -p "$PACKAGE_DIRECTORY"
+          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
+          node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
+          npm publish "$PACKAGE_PATH" --tag dev --provenance
 
       - name: Apply Canal+ patch
         run: git apply ./scripts/canal-release.patch
@@ -215,10 +220,15 @@ jobs:
       - name: Update version for canal release
         run: npm run update-version "${{ steps.get_version.outputs.canal_version }}"
 
-      - name: Build and publish Canal version
+      - name: Build, check and publish Canal version
         run: |
           npm run build
-          npm publish --tag canal --provenance
+          PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-canal-package"
+          mkdir -p "$PACKAGE_DIRECTORY"
+          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
+          node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
+          npm publish "$PACKAGE_PATH" --tag canal --provenance
 
   publish_official:
     if: needs.determine_release_type.outputs.release_type == 'official'
@@ -261,6 +271,16 @@ jobs:
       - name: Install RxPlayer dependencies
         run: npm ci
 
+      - name: Build and check official package
+        run: |
+          npm run build
+          PACKAGE_DIRECTORY="$RUNNER_TEMP/rx-player-official-package"
+          mkdir -p "$PACKAGE_DIRECTORY"
+          PACKAGE_NAME=$(npm pack --silent --pack-destination "$PACKAGE_DIRECTORY")
+          PACKAGE_PATH="$PACKAGE_DIRECTORY/$PACKAGE_NAME"
+          node scripts/check_package_build.mjs --package "$PACKAGE_PATH"
+          echo "PACKAGE_PATH=$PACKAGE_PATH" >> "$GITHUB_ENV"
+
       - name: Merge on stable branch
         run: |
           git config user.name "github-actions[bot]"
@@ -287,7 +307,5 @@ jobs:
           git checkout stable # go back to stable for publish
           git push origin stable
 
-      - name: Build and publish official release
-        run: |
-          npm run build
-          npm publish --provenance
+      - name: Publish official release
+        run: npm publish "$PACKAGE_PATH" --provenance

--- a/scripts/check_package_build.mjs
+++ b/scripts/check_package_build.mjs
@@ -29,6 +29,14 @@ import { fileURLToPath, pathToFileURL } from "url";
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.join(currentDirectory, "..");
+const UNSUPPORTED_PACKAGE_LIFECYCLE_SCRIPTS = [
+  "prepack",
+  "prepare",
+  "postpack",
+  "prepublishOnly",
+  "publish",
+  "postpublish",
+];
 
 /**
  * @typedef {Object} ICheckPackageBuildOptions
@@ -43,7 +51,7 @@ const ROOT_DIR = path.join(currentDirectory, "..");
  */
 export default async function checkPackageBuild(options = {}) {
   const temporaryDirectory = await fs.mkdtemp(
-    path.join(os.tmpdir(), "rx-player-package-"),
+    path.join(os.tmpdir(), "package-build-check"),
   );
   try {
     const packagePath =
@@ -88,6 +96,7 @@ export default async function checkPackageBuild(options = {}) {
         'The installed package should have a name and an object "exports" field.',
       );
     }
+    checkPublishLifecycleScripts(packageJson);
 
     const installedPackageDirectory = path.dirname(
       packagePathForConsumer(consumerDirectory),
@@ -121,6 +130,33 @@ export default async function checkPackageBuild(options = {}) {
 }
 
 /**
+ * Package builds and releases ignore npm lifecycle scripts so that every step
+ * affecting the published archive stays explicit in the release workflow.
+ * Reject those scripts so that they cannot be silently ignored.
+ * @param {Record<string, unknown>} packageJson
+ */
+function checkPublishLifecycleScripts(packageJson) {
+  if (
+    packageJson.scripts === null ||
+    typeof packageJson.scripts !== "object" ||
+    Array.isArray(packageJson.scripts)
+  ) {
+    return;
+  }
+  const scripts = /** @type {Record<string, unknown>} */ (packageJson.scripts);
+  const skippedScripts = UNSUPPORTED_PACKAGE_LIFECYCLE_SCRIPTS.filter(
+    (scriptName) => typeof scripts[scriptName] === "string",
+  );
+  if (skippedScripts.length > 0) {
+    throw new Error(
+      "Package builds and releases do not run the following npm lifecycle " +
+        `scripts: ${skippedScripts.join(", ")}. Update the release workflow ` +
+        "to handle them explicitly before allowing those scripts.",
+    );
+  }
+}
+
+/**
  * Pack the current project into the given directory.
  * @param {string} destinationDirectory
  * @returns {Promise<string>}
@@ -140,7 +176,7 @@ async function packCurrentProject(destinationDirectory) {
     "npm",
     [
       "pack",
-      "--silent",
+      "--ignore-scripts",
       "--cache",
       path.join(destinationDirectory, "npm-cache"),
       "--pack-destination",

--- a/scripts/check_package_build.mjs
+++ b/scripts/check_package_build.mjs
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+
+/**
+ * # check_package_build.mjs
+ *
+ * This file checks that the RxPlayer package can be consumed through both its
+ * ES module and CommonJS entry points.
+ *
+ * It packs the current project (or uses the package archive given through the
+ * `--package` option), installs it in an isolated temporary project and then:
+ *   - type-checks all public JavaScript exports from ES module and CommonJS
+ *     TypeScript consumers;
+ *   - loads those exports through both `import` and `require`, checking that
+ *     they expose the same names.
+ *
+ * The RxPlayer should be built before this script is called.
+ *
+ * You can either run it directly as a script or import its default export and
+ * call it.
+ */
+
+// @ts-check
+
+import { spawn } from "child_process";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath, pathToFileURL } from "url";
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.join(currentDirectory, "..");
+
+/**
+ * @typedef {Object} ICheckPackageBuildOptions
+ * @property {string|undefined} [packagePath] - Path to an already-packed npm
+ * package. If unset, the current project is packed and checked.
+ */
+
+/**
+ * Check the package's ES module and CommonJS entry points.
+ * @param {ICheckPackageBuildOptions} [options]
+ * @returns {Promise.<void>}
+ */
+export default async function checkPackageBuild(options = {}) {
+  const temporaryDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "rx-player-package-"),
+  );
+  try {
+    const packagePath =
+      options.packagePath === undefined
+        ? await packCurrentProject(temporaryDirectory)
+        : path.resolve(options.packagePath);
+    await ensureFileExists(packagePath, `Package archive not found: "${packagePath}"`);
+
+    const consumerDirectory = path.join(temporaryDirectory, "consumer");
+    await fs.mkdir(consumerDirectory);
+    await fs.writeFile(
+      path.join(consumerDirectory, "package.json"),
+      '{\n  "name": "rx-player-package-check",\n  "private": true,\n  "type": "module"\n}\n',
+    );
+
+    console.log(" 📦 Installing package in an isolated project...");
+    await runCommand(
+      "npm",
+      [
+        "install",
+        "--silent",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        "--cache",
+        path.join(temporaryDirectory, "npm-cache"),
+        packagePath,
+      ],
+      consumerDirectory,
+    );
+
+    const packageJson = JSON.parse(
+      await fs.readFile(packagePathForConsumer(consumerDirectory), "utf8"),
+    );
+    if (
+      typeof packageJson.name !== "string" ||
+      packageJson.exports === null ||
+      typeof packageJson.exports !== "object" ||
+      Array.isArray(packageJson.exports)
+    ) {
+      throw new Error(
+        'The installed package should have a name and an object "exports" field.',
+      );
+    }
+
+    const installedPackageDirectory = path.dirname(
+      packagePathForConsumer(consumerDirectory),
+    );
+    const publicSpecifiers = await listPublicJavaScriptSpecifiers(
+      installedPackageDirectory,
+      packageJson.name,
+      packageJson.exports,
+    );
+    if (publicSpecifiers.length === 0) {
+      throw new Error("No public JavaScript export was found in the installed package.");
+    }
+
+    console.log(` 🧪 Type-checking ${publicSpecifiers.length} public exports...`);
+    await writeTypeScriptConsumers(consumerDirectory, publicSpecifiers);
+    await runCommand(
+      "npm",
+      ["exec", "--offline", "--", "tsc", "--project", consumerDirectory],
+      ROOT_DIR,
+    );
+
+    console.log(" 🔎 Comparing ES module and CommonJS runtime exports...");
+    const runtimeCheckPath = path.join(consumerDirectory, "check_runtime_exports.mjs");
+    await fs.writeFile(runtimeCheckPath, createRuntimeCheckSource(publicSpecifiers));
+    await runCommand(process.execPath, [runtimeCheckPath], consumerDirectory);
+  } finally {
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+  }
+
+  console.log(" 🙌 SUCCESS!");
+}
+
+/**
+ * Pack the current project into the given directory.
+ * @param {string} destinationDirectory
+ * @returns {Promise<string>}
+ */
+async function packCurrentProject(destinationDirectory) {
+  await ensureFileExists(
+    path.join(ROOT_DIR, "dist", "es2017", "index.js"),
+    'No ES module build found. Run "npm run build" before this script.',
+  );
+  await ensureFileExists(
+    path.join(ROOT_DIR, "dist", "commonjs", "index.js"),
+    'No CommonJS build found. Run "npm run build" before this script.',
+  );
+
+  console.log(" 📦 Packing the current project...");
+  await runCommand(
+    "npm",
+    [
+      "pack",
+      "--silent",
+      "--cache",
+      path.join(destinationDirectory, "npm-cache"),
+      "--pack-destination",
+      destinationDirectory,
+      ROOT_DIR,
+    ],
+    ROOT_DIR,
+  );
+  const archiveNames = (await fs.readdir(destinationDirectory)).filter((name) =>
+    name.endsWith(".tgz"),
+  );
+  if (archiveNames.length !== 1) {
+    throw new Error(
+      `Expected npm pack to create one archive, but found ${archiveNames.length}.`,
+    );
+  }
+  return path.join(destinationDirectory, archiveNames[0]);
+}
+
+/**
+ * Return the installed package.json path for the fixture project.
+ * @param {string} consumerDirectory
+ * @returns {string}
+ */
+function packagePathForConsumer(consumerDirectory) {
+  return path.join(consumerDirectory, "node_modules", "rx-player", "package.json");
+}
+
+/**
+ * List all concrete public JavaScript specifiers from a package export map.
+ * Wildcard exports are expanded from the files present in the installed
+ * package.
+ * @param {string} packageDirectory
+ * @param {string} packageName
+ * @param {Record<string, unknown>} exportsMap
+ * @returns {Promise<string[]>}
+ */
+async function listPublicJavaScriptSpecifiers(packageDirectory, packageName, exportsMap) {
+  const files = await listFilesRecursively(packageDirectory);
+  const specifiers = new Set();
+
+  for (const [exportName, exportDefinition] of Object.entries(exportsMap)) {
+    if (exportName === "./package.json") {
+      continue;
+    }
+    const importTarget = findExportTarget(exportDefinition, "import");
+    const requireTarget = findExportTarget(exportDefinition, "require");
+    if (importTarget === undefined) {
+      throw new Error(`No import target found for export "${exportName}".`);
+    }
+    if (requireTarget === undefined) {
+      throw new Error(`No require target found for export "${exportName}".`);
+    }
+
+    const wildcardOffset = exportName.indexOf("*");
+    if (wildcardOffset < 0) {
+      specifiers.add(toPackageSpecifier(packageName, exportName));
+      continue;
+    }
+    if (exportName.indexOf("*", wildcardOffset + 1) >= 0) {
+      throw new Error(`Multiple wildcards are unsupported in export "${exportName}".`);
+    }
+
+    const targetMatcher = createWildcardMatcher(importTarget);
+    for (const file of files) {
+      const match = targetMatcher.exec("./" + file.split(path.sep).join("/"));
+      if (match !== null) {
+        specifiers.add(
+          toPackageSpecifier(packageName, exportName.replace("*", match[1])),
+        );
+      }
+    }
+  }
+
+  return [...specifiers].sort();
+}
+
+/**
+ * Find a string target for the wanted condition in an export definition.
+ * @param {unknown} exportDefinition
+ * @param {"import"|"require"} condition
+ * @returns {string|undefined}
+ */
+function findExportTarget(exportDefinition, condition) {
+  if (typeof exportDefinition === "string") {
+    return exportDefinition;
+  }
+  if (
+    exportDefinition !== null &&
+    typeof exportDefinition === "object" &&
+    !Array.isArray(exportDefinition)
+  ) {
+    const conditions = /** @type {Record<string, unknown>} */ (exportDefinition);
+    const target = conditions[condition] ?? conditions.default;
+    return typeof target === "string" ? target : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Create a regular expression capturing the value of a target's wildcard.
+ * @param {string} target
+ * @returns {RegExp}
+ */
+function createWildcardMatcher(target) {
+  const wildcardOffset = target.indexOf("*");
+  if (wildcardOffset < 0 || target.indexOf("*", wildcardOffset + 1) >= 0) {
+    throw new Error(`Expected exactly one wildcard in export target "${target}".`);
+  }
+  const beforeWildcard = escapeRegularExpression(target.slice(0, wildcardOffset));
+  const afterWildcard = escapeRegularExpression(target.slice(wildcardOffset + 1));
+  return new RegExp("^" + beforeWildcard + "(.+)" + afterWildcard + "$");
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeRegularExpression(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} exportName
+ * @returns {string}
+ */
+function toPackageSpecifier(packageName, exportName) {
+  return exportName === "." ? packageName : packageName + exportName.slice(1);
+}
+
+/**
+ * @param {string} directory
+ * @returns {Promise<string[]>}
+ */
+async function listFilesRecursively(directory) {
+  const files = [];
+  const entries = await fs.readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      const childFiles = await listFilesRecursively(entryPath);
+      for (const childFile of childFiles) {
+        files.push(path.join(entry.name, childFile));
+      }
+    } else if (entry.isFile()) {
+      files.push(entry.name);
+    }
+  }
+  return files;
+}
+
+/**
+ * Write ES module and CommonJS TypeScript consumers for every public export.
+ * @param {string} consumerDirectory
+ * @param {string[]} publicSpecifiers
+ * @returns {Promise<void>}
+ */
+async function writeTypeScriptConsumers(consumerDirectory, publicSpecifiers) {
+  const esModuleImports = publicSpecifiers
+    .map(
+      (specifier, index) =>
+        `import * as publicExport${index} from ${JSON.stringify(specifier)};\n` +
+        `void publicExport${index};`,
+    )
+    .join("\n");
+  const commonJsImports = publicSpecifiers
+    .map(
+      (specifier, index) =>
+        `import publicExport${index} = require(${JSON.stringify(specifier)});\n` +
+        `void publicExport${index};`,
+    )
+    .join("\n");
+  await Promise.all([
+    fs.writeFile(path.join(consumerDirectory, "consumer.mts"), esModuleImports + "\n"),
+    fs.writeFile(path.join(consumerDirectory, "consumer.cts"), commonJsImports + "\n"),
+    fs.writeFile(
+      path.join(consumerDirectory, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            exactOptionalPropertyTypes: true,
+            lib: ["ES2022", "DOM"],
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            noEmit: true,
+            skipLibCheck: false,
+            strict: true,
+            target: "ES2022",
+          },
+          files: ["consumer.mts", "consumer.cts"],
+        },
+        null,
+        2,
+      ) + "\n",
+    ),
+  ]);
+}
+
+/**
+ * Create the JavaScript source comparing runtime exports.
+ * @param {string[]} publicSpecifiers
+ * @returns {string}
+ */
+function createRuntimeCheckSource(publicSpecifiers) {
+  return `import { createRequire } from "node:module";
+import { isDeepStrictEqual } from "node:util";
+
+const require = createRequire(import.meta.url);
+const publicSpecifiers = ${JSON.stringify(publicSpecifiers, null, 2)};
+
+for (const specifier of publicSpecifiers) {
+  const esmExports = await import(specifier);
+  const commonJsExports = require(specifier);
+  const esmNames = Object.keys(esmExports).sort();
+  const commonJsNames = Object.keys(commonJsExports)
+    .filter((name) => name !== "__esModule")
+    .sort();
+  if (!isDeepStrictEqual(esmNames, commonJsNames)) {
+    throw new Error(
+      specifier + ": ES module exports " + JSON.stringify(esmNames) +
+        " differ from CommonJS exports " + JSON.stringify(commonJsNames) + ".",
+    );
+  }
+}
+`;
+}
+
+/**
+ * Reject if the given file does not exist.
+ * @param {string} filePath
+ * @param {string} errorMessage
+ * @returns {Promise<void>}
+ */
+async function ensureFileExists(filePath, errorMessage) {
+  try {
+    await fs.access(filePath);
+  } catch {
+    throw new Error(errorMessage);
+  }
+}
+
+/**
+ * Run a command and reject if it exits with a non-zero status.
+ * @param {string} command
+ * @param {string[]} args
+ * @param {string} cwd
+ * @returns {Promise<void>}
+ */
+function runCommand(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const childProcess = spawn(command, args, { cwd, stdio: "inherit" });
+    childProcess.on("error", reject);
+    childProcess.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Command "${command}" exited with code ${code}.`));
+      }
+    });
+  });
+}
+
+// If true, this script is called directly
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const args = process.argv.slice(2);
+  let packagePath;
+  for (let argOffset = 0; argOffset < args.length; argOffset++) {
+    const currentArg = args[argOffset];
+    switch (currentArg) {
+      case "-h":
+      case "--help":
+        displayHelp();
+        process.exit(0);
+        break;
+      case "-p":
+      case "--package":
+        argOffset++;
+        packagePath = args[argOffset];
+        if (packagePath === undefined) {
+          console.error("ERROR: no package archive provided\n");
+          displayHelp();
+          process.exit(1);
+        }
+        break;
+      case "--":
+        argOffset = args.length;
+        break;
+      default:
+        console.error('ERROR: unknown option: "' + currentArg + '"\n');
+        displayHelp();
+        process.exit(1);
+    }
+  }
+
+  checkPackageBuild({ packagePath }).catch((err) => {
+    console.error("Fatal error:", err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}
+
+/**
+ * Display through `console.log` a help message relative to how to run this
+ * script.
+ */
+function displayHelp() {
+  console.log(
+    `check_package_build.mjs: Check the packaged RxPlayer's ES module and CommonJS exports.
+
+Usage: node check_package_build.mjs [OPTIONS]
+
+The RxPlayer should be built before running this script. By default, the
+current project is packed and installed in an isolated temporary project.
+
+Options:
+  -h, --help              Display this help.
+  -p, --package <path>    Check an existing npm package archive instead of
+                          packing the current project.`,
+  );
+}


### PR DESCRIPTION
Based on #1876 

#1876 brought a change in how builds are done: TypeScript produces our default ES2017 build like before and the commonjs+ES5 build is then produced from it by swc.

It shouldn't break anything from my tests, but I still was afraid of a slight change that could break API users, maybe not now but later as we bring an unrelated change breaking in a non-obvious manner that workflow.

So I finally did what I thought we always had to do: more thoroughly validate packages published on npm: both ES2017 and commonjs builds, their typings etc.

---

This is what this PR does:
1. on PR and releases CI workflows, we produce the npm package (the same one that would be done on `publish`) locally and then check that all its commonjs/es2017 exports are there, provide the same exported names, and are type-checkable if an application imports one or the other
2. Release CI workflows now use that tested local package on `publish`, where before `publish` did the package itself.

Though I had to add a few restrictions to ensure all goes well:
- Lifecycle npm scripts, specifically `prepublishOnly`, could be running before a `publish`, and often have the semantics in the mind of developers of a "last minute build generation". Here this wouldn't work, the package has already been done and validated once `publish` is called, by an `npm pack` call.

   So to be safer I just forbid all npm lifecycle scripts that could have such a gotcha from poor assumptions: `pack` and `publish`-related ones. I also ignore them in `npm pack` and `npm publish` through the `--ignore-scripts` flag.
   
   I've been broad here (e.g. even `postPublish` is forbidden and our script will throw if one is declared) as a clear signal that such lifecycle scripts are assumed to not be used in the rx-player, simplifying our mental model
   
 - There are many ways to indicate export/import paths in `npm` depending on the bundler/node versions etc.

   For now I focused on the `exports` key from the `package.json` which should realistically replicate the use case of a great majority of our users (`exports` is the main key looked at by node and bundlers since 2020).