### PR TITLE
MULTI_THREAD is not an experimental feature anymore

### DIFF
--- a/demo/scripts/modules/player/index.ts
+++ b/demo/scripts/modules/player/index.ts
@@ -17,12 +17,10 @@ import {
   HTML_TEXT_BUFFER,
   HTML_TTML_PARSER,
   HTML_VTT_PARSER,
+  MULTI_THREAD,
   SMOOTH,
 } from "../../../../src/features/list/index.ts";
-import {
-  METAPLAYLIST,
-  MULTI_THREAD,
-} from "../../../../src/experimental/features/index.ts";
+import { METAPLAYLIST } from "../../../../src/experimental/features/index.ts";
 import RxPlayer from "../../../../src/minimal.ts";
 import { linkPlayerEventsToState } from "./events.ts";
 import VideoThumbnailLoader, {

--- a/doc/Getting_Started/MultiThreading.md
+++ b/doc/Getting_Started/MultiThreading.md
@@ -81,22 +81,6 @@ If you do not encounter those situations, the advantages of "multithread" mode m
 evident. In any case, you may want to test that mode to see if it is improving your
 application.
 
-## About it being an "experimental" feature
-
-This "multithread" mode is added as an "experimental" feature.
-
-Like all other experimental features, it **is** considered stable enough to run in
-production. What we mean by "experimental" in the RxPlayer API is just that we may change
-its API at any RxPlayer version without impacting the RxPlayer's major version due to
-semantic versioning principles.
-
-For example, a new minor RxPlayer version could bring with it a complete API change
-regarding the corresponding `MULTI_THREAD` feature. Still, potential changes would be
-fully documented on that release's release note and changelog file.
-
-The choice of labeling this feature as experimental has been made so we can have more
-freedom if we find ways to provide sensible improvements to its API in the future.
-
 ## Quick start
 
 You can just test this feature quickly by running the following code:
@@ -106,13 +90,13 @@ You can just test this feature quickly by running the following code:
 // default import)
 import RxPlayer from "rx-player/minimal";
 
-// Import the MULTI_THREAD experimental feature
-import { MULTI_THREAD } from "rx-player/experimental/features";
+// Import the MULTI_THREAD feature
+import { MULTI_THREAD } from "rx-player/features";
 
 // To simplify this example, we'll directly import an "embedded" version of the
 // supplementary code loaded by the `MULTI_THREAD` feature.
 // We could also load it on demand through a URL
-import { EMBEDDED_WORKER } from "rx-player/experimental/features/embeds";
+import { EMBEDDED_WORKER } from "rx-player/features/embeds";
 
 // Add the MULTI_THREAD feature, like any other feature
 RxPlayer.addFeatures([MULTI_THREAD]);
@@ -219,7 +203,7 @@ for most cases:
 
   ```js
   import RxPlayer from "rx-player/minimal";
-  import { MULTI_THREAD } from "rx-player/experimental/features";
+  import { MULTI_THREAD } from "rx-player/features";
   import { DASH } from "rx-player/features";
 
   RxPlayer.addFeatures([
@@ -274,10 +258,10 @@ your application.
 You can find it at any of the following places:
 
 - The easiest way is to just import in your application its "embedded" version, exported
-  through the `"rx-player/experimental/features/embeds"` path:
+  through the `"rx-player/features/embeds"` path:
 
   ```js
-  import { EMBEDDED_WORKER } from "rx-player/experimental/features/embeds";
+  import { EMBEDDED_WORKER } from "rx-player/features/embeds";
   ```
 
   This allows to bypass the need to store and serve separately that file.
@@ -308,11 +292,10 @@ those "multithread" scenarios. Note that this is unneeded for most usages.
 To do this, you have to explicitly provide the corresponding WebAssembly file. Like for
 the worker file, it can either be found:
 
-- As an "embedded" version, exported through the
-  `"rx-player/experimental/features/embeds"` path:
+- As an "embedded" version, exported through the `"rx-player/features/embeds"` path:
 
   ```js
-  import { EMBEDDED_DASH_WASM } from "rx-player/experimental/features/embeds";
+  import { EMBEDDED_DASH_WASM } from "rx-player/features/embeds";
   ```
 
   Note however that the embedded version of this WebAssembly file is much bigger than the
@@ -327,15 +310,15 @@ the worker file, it can either be found:
 
 ### Step 2: importing the `MULTI_THREAD` feature and adding it
 
-The `MULTI_THREAD` feature, then needs to be imported through the
-`rx-player/experimental/features` path and added to the RxPlayer's **class** (and not an
-instance, `addFeatures` being a static method), like any other feature:
+The `MULTI_THREAD` feature then needs to be imported through the `rx-player/features` path
+and added to the RxPlayer's **class** (and not an instance, `addFeatures` being a static
+method), like any other feature:
 
 ```js
 // Import the RxPlayer
 // (here through the "minimal" build, though it doesn't change for other builds)
 import RxPlayer from "rx-player/minimal";
-import { MULTI_THREAD } from "rx-player/experimental/features";
+import { MULTI_THREAD } from "rx-player/features";
 
 RxPlayer.addFeatures([MULTI_THREAD]);
 ```

--- a/doc/api/Miscellaneous/DASH_WASM_Parser.md
+++ b/doc/api/Miscellaneous/DASH_WASM_Parser.md
@@ -62,7 +62,7 @@ import { DASH_WASM } from "rx-player/features";
 
 // For this example, we will include the "embedded version" of the WebAssembly file
 // You can also load it as a separate file for more efficiency
-import { EMBEDDED_DASH_WASM } from "rx-player/experimental/features/embeds";
+import { EMBEDDED_DASH_WASM } from "rx-player/features/embeds";
 
 // Link parser to the WebAssembly file.
 // This function can be called at any point in time.
@@ -93,10 +93,10 @@ parser.
 You can find it at any of the following places:
 
 - The easiest way is to just import in your application its "embedded" version, exported
-  through the `"rx-player/experimental/features/embeds"` path:
+  through the `"rx-player/features/embeds"` path:
 
   ```js
-  import { EMBEDDED_DASH_WASM } from "rx-player/experimental/features/embeds";
+  import { EMBEDDED_DASH_WASM } from "rx-player/features/embeds";
   ```
 
   This allows to bypass the need to store and serve this file separately. Note however

--- a/doc/api/MultiThread/attachWorker.md
+++ b/doc/api/MultiThread/attachWorker.md
@@ -38,13 +38,13 @@ This `attachWorker` method then returns a Promise which:
 // default import)
 import RxPlayer from "rx-player/minimal";
 
-// Import the MULTI_THREAD experimental feature
-import { MULTI_THREAD } from "rx-player/experimental/features";
+// Import the MULTI_THREAD feature
+import { MULTI_THREAD } from "rx-player/features";
 
 // To simplify this example, we'll directly import an "embedded" version of the
 // supplementary code loaded by the `MULTI_THREAD` feature.
 // We could also load it on demand through a URL
-import { EMBEDDED_WORKER } from "rx-player/experimental/features/embeds";
+import { EMBEDDED_WORKER } from "rx-player/features/embeds";
 
 // Add the MULTI_THREAD feature, like any other feature
 RxPlayer.addFeatures([MULTI_THREAD]);

--- a/doc/api/RxPlayer_Features.md
+++ b/doc/api/RxPlayer_Features.md
@@ -66,6 +66,7 @@ Here is the annotated exhaustive list (notes are at the bottom of the table):
 | `NATIVE_TTML_PARSER` [3] | Parse TTML text tracks for the `"native"` `textTrackMode` |
 | `NATIVE_SAMI_PARSER` [3] | Parse SAMI text tracks for the `"native"` `textTrackMode` |
 | `DEBUG_ELEMENT`          | Allows to use the `createDebugElement` RxPlayer method    |
+| `MULTI_THREAD` [7]       | Allows to run the RxPlayer's core logic in another thread |
 | `DASH_WASM` [1] [2] [5]  | Enable DASH playback using a WebAssembly-based MPD parser |
 | `LOCAL_MANIFEST` [4]     | Enable playback of "local" contents                       |
 | `METAPLAYLIST` [4]       | Enable playback of "metaplaylist" contents                |

--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
       "require": "./dist/commonjs/features/list/index.js",
       "default": "./dist/es2017/features/list/index.js"
     },
+    "./features/embeds": {
+      "import": "./dist/es2017/__GENERATED_CODE/index.js",
+      "require": "./dist/commonjs/__GENERATED_CODE/index.js",
+      "default": "./dist/es2017/__GENERATED_CODE/index.js"
+    },
     "./features/*": {
       "import": "./dist/es2017/features/list/*.js",
       "require": "./dist/commonjs/features/list/*.js",
@@ -123,6 +128,9 @@
       ],
       "features": [
         "./dist/es2017/features/list/index.d.ts"
+      ],
+      "features/embeds": [
+        "./dist/es2017/__GENERATED_CODE/index.d.ts"
       ],
       "features/*": [
         "./dist/es2017/features/list/*.d.ts"

--- a/src/experimental/features/multi_thread.ts
+++ b/src/experimental/features/multi_thread.ts
@@ -1,16 +1,19 @@
+import addStableMultiThreadFeature from "../../features/list/multi_thread.ts";
 import type { IFeaturesObject } from "../../features/types.ts";
-import { WorkerCoreInterface } from "../../main_thread/core_interface/multithread.ts";
-import MediaSourceContentInitializer from "../../main_thread/init/media_source_content_initializer.ts";
 
 /**
  * Add ability to run the RxPlayer's main buffering logic in a WebMultiThread.
  * @param {Object} features
  */
 function addMultiThreadFeature(features: IFeaturesObject): void {
-  features.multithread = {
-    init: MediaSourceContentInitializer,
-    coreInterface: WorkerCoreInterface,
-  };
+  /* eslint-disable-next-line no-console */
+  console.warn(
+    "RxPlayer: `MULTI_THREAD` is no longer experimental.\n" +
+      'You should now import it through the "rx-player/features" path. ' +
+      "If you also rely on embedded worker assets, you should now import them through " +
+      'the "rx-player/features/embeds" path.',
+  );
+  addStableMultiThreadFeature(features);
 }
 
 export { addMultiThreadFeature as MULTI_THREAD };

--- a/src/features/list/index.ts
+++ b/src/features/list/index.ts
@@ -25,6 +25,7 @@ export { HTML_TEXT_BUFFER } from "./html_text_buffer.ts";
 export { HTML_TTML_PARSER } from "./html_ttml_parser.ts";
 export { HTML_VTT_PARSER } from "./html_vtt_parser.ts";
 export { MEDIA_SOURCE_MAIN } from "./media_source_main.ts";
+export { MULTI_THREAD } from "./multi_thread.ts";
 export { NATIVE_SAMI_PARSER } from "./native_sami_parser.ts";
 export { NATIVE_SRT_PARSER } from "./native_srt_parser.ts";
 export { NATIVE_TEXT_BUFFER } from "./native_text_buffer.ts";

--- a/src/features/list/multi_thread.ts
+++ b/src/features/list/multi_thread.ts
@@ -1,0 +1,17 @@
+import { WorkerCoreInterface } from "../../main_thread/core_interface/multithread.ts";
+import MediaSourceContentInitializer from "../../main_thread/init/media_source_content_initializer.ts";
+import type { IFeaturesObject } from "../types.ts";
+
+/**
+ * Add ability to run the RxPlayer's main buffering logic in a WebWorker.
+ * @param {Object} features
+ */
+function addMultiThreadFeature(features: IFeaturesObject): void {
+  features.multithread = {
+    init: MediaSourceContentInitializer,
+    coreInterface: WorkerCoreInterface,
+  };
+}
+
+export { addMultiThreadFeature as MULTI_THREAD };
+export default addMultiThreadFeature;

--- a/tests/integration/scenarios/audio_tag.test.js
+++ b/tests/integration/scenarios/audio_tag.test.js
@@ -1,6 +1,6 @@
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
 import TestWorkerEmbed from "../../embedded_worker_bundle";
 import {

--- a/tests/integration/scenarios/dash_render_thumbnail.test.js
+++ b/tests/integration/scenarios/dash_render_thumbnail.test.js
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
 import thumbnailInfos from "../../contents/static/DASH_static_SegmentTimeline/thumbnails.js";
 import TestWorkerEmbed from "../../embedded_worker_bundle";

--- a/tests/integration/scenarios/idle.test.js
+++ b/tests/integration/scenarios/idle.test.js
@@ -1,5 +1,5 @@
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import {
   EMBEDDED_WORKER,
   EMBEDDED_DASH_WASM,

--- a/tests/integration/scenarios/initial_playback.test.js
+++ b/tests/integration/scenarios/initial_playback.test.js
@@ -15,7 +15,7 @@
  */
 
 import RxPlayer from "../../../src/index.ts";
-import { MULTI_THREAD } from "../../../src/experimental/features";
+import { MULTI_THREAD } from "../../../src/features/list/index.ts";
 import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
 import TestWorkerEmbed from "../../embedded_worker_bundle";
 import { manifestInfos } from "../../contents/static/DASH_static_SegmentTimeline";

--- a/tests/integration/scenarios/loadVideo_options.test.js
+++ b/tests/integration/scenarios/loadVideo_options.test.js
@@ -16,7 +16,7 @@
 
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
 import TestWorkerEmbed from "../../embedded_worker_bundle";
 import { manifestInfos } from "../../contents/static/DASH_static_SegmentTimeline";

--- a/tests/integration/utils/launch_tests_for_content.js
+++ b/tests/integration/utils/launch_tests_for_content.js
@@ -1,6 +1,6 @@
 import { describe, afterEach, beforeEach, it, expect } from "vitest";
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import { EMBEDDED_DASH_WASM } from "../../../dist/es2017/__GENERATED_CODE/index.js";
 import TestWorkerEmbed from "../../embedded_worker_bundle";
 import sleep from "../../utils/sleep.js";

--- a/tests/integration/utils/stop_on_event.js
+++ b/tests/integration/utils/stop_on_event.js
@@ -1,6 +1,6 @@
 import { describe, afterEach, beforeEach, it, expect } from "vitest";
 import RxPlayer from "../../../dist/es2017";
-import { MULTI_THREAD } from "../../../dist/es2017/experimental/features/index.js";
+import { MULTI_THREAD } from "../../../dist/es2017/features/list/index.js";
 import {
   EMBEDDED_WORKER,
   EMBEDDED_DASH_WASM,

--- a/tests/performance/src/main.js
+++ b/tests/performance/src/main.js
@@ -1,4 +1,5 @@
 import RxPlayer from "rx-player";
+// TODO: Remove `/experimental/` next release
 import { MULTI_THREAD } from "rx-player/experimental/features";
 import { EMBEDDED_WORKER } from "rx-player/experimental/features/embeds";
 import { multiAdaptationSetsInfos } from "../../contents/static/DASH_static_SegmentTimeline";

--- a/tests/unit/src/experimental/features/multi_thread.test.ts
+++ b/tests/unit/src/experimental/features/multi_thread.test.ts
@@ -1,13 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import addMultiThreadFeature from "../../../../../src/experimental/features/multi_thread.ts";
 import type { IFeaturesObject } from "../../../../../src/features/types.ts";
 import { WorkerCoreInterface } from "../../../../../src/main_thread/core_interface/multithread.ts";
 import MediaSourceContentInitializer from "../../../../../src/main_thread/init/media_source_content_initializer.ts";
 
-describe("Features list - EME", () => {
-  it("should add the ContentDecryptor in the current features", () => {
+describe("Experimental features - MULTI_THREAD compatibility alias", () => {
+  it("should warn and add the multi-thread implementation", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const featureObject: IFeaturesObject = {} as IFeaturesObject;
     addMultiThreadFeature(featureObject);
+    expect(warnSpy).toHaveBeenCalledOnce();
     expect(featureObject).toEqual({
       multithread: {
         init: MediaSourceContentInitializer,

--- a/tests/unit/src/features/list/index.test.ts
+++ b/tests/unit/src/features/list/index.test.ts
@@ -20,6 +20,7 @@ import {
   HTML_TEXT_BUFFER,
   HTML_TTML_PARSER,
   HTML_VTT_PARSER,
+  MULTI_THREAD,
   NATIVE_SAMI_PARSER,
   NATIVE_SRT_PARSER,
   NATIVE_TEXT_BUFFER,
@@ -27,6 +28,7 @@ import {
   NATIVE_VTT_PARSER,
   SMOOTH,
 } from "../../../../../src/features/list/index.ts";
+import { MULTI_THREAD as MULTI_THREAD_FEATURE } from "../../../../../src/features/list/multi_thread.ts";
 import { NATIVE_SAMI_PARSER as NATIVE_SAMI_PARSER_FEATURE } from "../../../../../src/features/list/native_sami_parser.ts";
 import { NATIVE_SRT_PARSER as NATIVE_SRT_PARSER_FEATURE } from "../../../../../src/features/list/native_srt_parser.ts";
 import { NATIVE_TEXT_BUFFER as NATIVE_TEXT_BUFFER_FEATURE } from "../../../../../src/features/list/native_text_buffer.ts";
@@ -45,6 +47,7 @@ describe("Features list", () => {
     expect(HTML_TEXT_BUFFER).toBe(HTML_TEXT_BUFFER_FEATURE);
     expect(HTML_TTML_PARSER).toBe(HTML_TTML_PARSER_FEATURE);
     expect(HTML_VTT_PARSER).toBe(HTML_VTT_PARSER_FEATURE);
+    expect(MULTI_THREAD).toBe(MULTI_THREAD_FEATURE);
     expect(NATIVE_SAMI_PARSER).toBe(NATIVE_SAMI_PARSER_FEATURE);
     expect(NATIVE_SRT_PARSER).toBe(NATIVE_SRT_PARSER_FEATURE);
     expect(NATIVE_TEXT_BUFFER).toBe(NATIVE_TEXT_BUFFER_FEATURE);

--- a/tests/unit/src/features/list/multi_thread.test.ts
+++ b/tests/unit/src/features/list/multi_thread.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import addMultiThreadFeature from "../../../../../src/features/list/multi_thread.ts";
+import type { IFeaturesObject } from "../../../../../src/features/types.ts";
+import { WorkerCoreInterface } from "../../../../../src/main_thread/core_interface/multithread.ts";
+import MediaSourceContentInitializer from "../../../../../src/main_thread/init/media_source_content_initializer.ts";
+
+describe("Features list - MULTI_THREAD", () => {
+  it("should add the multi-thread implementation to the current features", () => {
+    const featureObject: IFeaturesObject = {} as IFeaturesObject;
+    addMultiThreadFeature(featureObject);
+    expect(featureObject).toEqual({
+      multithread: {
+        init: MediaSourceContentInitializer,
+        coreInterface: WorkerCoreInterface,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What

This PR proposes to make the `MULTI_THREAD` feature not experimental anymore. An alias in `rx-player/experimental/` import paths will be kept to avoid breaking applications.

## History

We historically had some specific problems with e.g. the parsing of MPDs with a huge timeshift window and/or very heavy applications where the RxPlayer would have a visible negative performance impact on the UI and/or vice-versa.
We were also at the time working on low-latency DASH streaming and were afraid that those performance issues would be very noticeable with those contents (because low-latency contents don't allow for a large media buffer, making even brief buffering logic interruptions more risky).  

We first POCed the `MULTI_THREAD` feature 3 years ago (august 2023). It had some of the expected benefits, but also some surprises: on many constrained devices (e.g. smart TVs) the quality we ended up choosing was often higher, and that choice was much more stable than before (reason: quality-related logic is very time-sensitive, before `MULTI_THREAD`, a UI could artificially make those time measurements much larger just by doing a long synchronous task).

Moreover, some devices that were extremely slow before now were clearly more responsive in that mode.
So we continued our efforts on its integration in the RxPlayer. 

## About the "experimental" categorization

We finally officially released it under the "experimental API" categorization in our `v4.0.0` in february 2024.

We kept it for a long time under that "experimental" category not because it was unstable but mainly because we weren't totally sure about its API.

There were some unfinished edges (some callbacks like `segmentLoader` couldn't be used, you couldn't play Smooth Streaming content in-worker...) and we were afraid that issues/features we didn't think about at first could lead to API breakage.

Thus it was experimental mostly to indicate that the API itself was unstable and could change at any moment without leading to a new major RxPlayer version.

Yet our last release, the `v4.5.0` was mostly about resolving known `MULTI_THREAD` edge cases and its API was never broken, nor did I ever see a reason to change it.

## Now

So now from what we continue to see as results from the application-side, I would like to signal more clearly that the `MULTI_THREAD` feature generally leads to a better experience than the "regular" mono-threaded mode, by removing the `experimental` categorization from it.